### PR TITLE
Make rls work.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ target/
 core
 *.log
 Cargo.lock
+
+/.vscode
+/.idea
+*.iml

--- a/ecmascript/ast/src/class.rs
+++ b/ecmascript/ast/src/class.rs
@@ -6,8 +6,8 @@ use swc_macros::ast_node;
 pub struct Class {
     pub span: Span,
 
-    pub super_class: Option<Box<Expr>>,
     pub body: Vec<ClassMethod>,
+    pub super_class: Option<(Box<Expr>)>,
 }
 
 #[ast_node]

--- a/ecmascript/ast/src/decl.rs
+++ b/ecmascript/ast/src/decl.rs
@@ -59,5 +59,5 @@ pub struct VarDeclarator {
 
     pub name: Pat,
     /// Initialization expresion.
-    pub init: Option<Box<Expr>>,
+    pub init: Option<(Box<Expr>)>,
 }

--- a/ecmascript/ast/src/expr.rs
+++ b/ecmascript/ast/src/expr.rs
@@ -79,7 +79,7 @@ pub enum ExprKind {
 /// Array literal.
 #[ast_node]
 pub struct ArrayLit {
-    pub elems: Vec<Option<ExprOrSpread>>,
+    pub elems: Vec<(Option<ExprOrSpread>)>,
 }
 
 /// Object literal.
@@ -156,11 +156,12 @@ pub struct CallExpr {
 #[ast_node]
 pub struct NewExpr {
     pub callee: Box<Expr>,
-    pub args: Option<Vec<ExprOrSpread>>,
+    // #[code = "$( $( $args ),* )?"]
+    pub args: Option<(Vec<ExprOrSpread>)>,
 }
 #[ast_node]
 pub struct SeqExpr {
-    pub exprs: Vec<Box<Expr>>,
+    pub exprs: Vec<(Box<Expr>)>,
 }
 #[ast_node]
 pub struct ArrowExpr {
@@ -173,7 +174,7 @@ pub struct ArrowExpr {
 
 #[ast_node]
 pub struct YieldExpr {
-    pub arg: Option<Box<Expr>>,
+    pub arg: Option<(Box<Expr>)>,
     pub delegate: bool,
 }
 #[ast_node]
@@ -188,9 +189,9 @@ pub struct AwaitExpr {
 
 #[ast_node]
 pub struct TplLit {
-    pub tag: Option<Box<Expr>>,
+    pub tag: Option<(Box<Expr>)>,
 
-    pub exprs: Vec<Box<Expr>>,
+    pub exprs: Vec<(Box<Expr>)>,
 
     pub quasis: Vec<TplElement>,
 }

--- a/ecmascript/ast/src/lib.rs
+++ b/ecmascript/ast/src/lib.rs
@@ -10,18 +10,26 @@ extern crate swc_common;
 #[macro_use]
 extern crate swc_macros;
 
-pub use self::class::*;
-pub use self::decl::*;
-pub use self::expr::*;
-pub use self::function::*;
-pub use self::lit::*;
-pub use self::module::*;
-pub use self::module_decl::*;
-pub use self::operators::*;
-pub use self::pat::*;
-pub use self::prop::*;
-pub use self::stmt::*;
+pub use self::class::{Class, ClassMethod, ClassMethodKind};
+pub use self::decl::{ClassDecl, Decl, FnDecl, VarDecl, VarDeclKind, VarDeclarator};
+pub use self::expr::{ArrayLit, ArrowExpr, AssignExpr, AwaitExpr, BinExpr, BlockStmtOrExpr,
+                     CallExpr, ClassExpr, CondExpr, Expr, ExprKind, ExprOrSpread, ExprOrSuper,
+                     FnExpr, MemberExpr, MetaPropExpr, NewExpr, ObjectLit, PatOrExpr, SeqExpr,
+                     TplElement, TplLit, UnaryExpr, UpdateExpr, YieldExpr};
+pub use self::function::Function;
+pub use self::lit::{Lit, Number, Regex, RegexFlags};
+pub use self::module::{Module, ModuleItem};
+pub use self::module_decl::{ExportDefaultDecl, ExportSpecifier, ImportSpecifier,
+                            ImportSpecifierKind, ModuleDecl, ModuleDeclKind};
+pub use self::operators::{AssignOp, BinaryOp, UnaryOp, UpdateOp};
+pub use self::pat::{ObjectPatProp, Pat, PatKind};
+pub use self::prop::{Prop, PropKind, PropName};
+pub use self::stmt::{BlockStmt, BreakStmt, CatchClause, ContinueStmt, DoWhileStmt, ForInStmt,
+                     ForOfStmt, ForStmt, IfStmt, LabeledStmt, ReturnStmt, Stmt, StmtKind,
+                     SwitchCase, SwitchStmt, ThrowStmt, TryStmt, VarDeclOrExpr, VarDeclOrPat,
+                     WhileStmt, WithStmt};
 use std::fmt::{self, Debug, Display, Formatter};
+use std::io;
 use swc_atoms::JsWord;
 use swc_common::{Span, Spanned};
 use swc_macros::AstNode;

--- a/ecmascript/ast/src/pat.rs
+++ b/ecmascript/ast/src/pat.rs
@@ -18,7 +18,7 @@ impl Spanned<PatKind> for Pat {
 pub enum PatKind {
     Ident(Ident),
 
-    Array(Vec<Option<Pat>>),
+    Array(Vec<(Option<Pat>)>),
 
     Rest(Box<Pat>),
 
@@ -41,7 +41,7 @@ pub enum ObjectPatProp {
     Assign {
         key: Ident,
 
-        value: Option<Box<Expr>>,
+        value: Option<(Box<Expr>)>,
     },
 }
 

--- a/ecmascript/ast/src/stmt.rs
+++ b/ecmascript/ast/src/stmt.rs
@@ -9,6 +9,15 @@ pub struct Stmt {
     pub node: StmtKind,
 }
 
+impl From<(Box<Expr>)> for Stmt {
+    fn from(t: Box<Expr>) -> Self {
+        Stmt {
+            span: t.span,
+            node: StmtKind::Expr(t),
+        }
+    }
+}
+
 impl From<Decl> for Stmt {
     fn from(decl: Decl) -> Self {
         Stmt {
@@ -25,7 +34,7 @@ impl Spanned<StmtKind> for Stmt {
 }
 
 /// Use when only block statements are allowed.
-#[ast_node]
+#[derive(AstNode, Fold, Clone, Debug, PartialEq, Default)]
 pub struct BlockStmt {
     /// Span of brace.
     pub span: Span,
@@ -89,7 +98,7 @@ pub struct WithStmt {
 
 #[ast_node]
 pub struct ReturnStmt {
-    pub arg: Option<Box<Expr>>,
+    pub arg: Option<(Box<Expr>)>,
 }
 
 #[ast_node]
@@ -109,7 +118,7 @@ pub struct ContinueStmt {
 pub struct IfStmt {
     pub test: Box<Expr>,
     pub cons: Box<Stmt>,
-    pub alt: Option<Box<Stmt>>,
+    pub alt: Option<(Box<Stmt>)>,
 }
 #[ast_node]
 pub struct SwitchStmt {
@@ -139,8 +148,8 @@ pub struct DoWhileStmt {
 #[ast_node]
 pub struct ForStmt {
     pub init: Option<VarDeclOrExpr>,
-    pub test: Option<Box<Expr>>,
-    pub update: Option<Box<Expr>>,
+    pub test: Option<(Box<Expr>)>,
+    pub update: Option<(Box<Expr>)>,
     pub body: Box<Stmt>,
 }
 #[ast_node]
@@ -160,7 +169,7 @@ pub struct ForOfStmt {
 pub struct SwitchCase {
     // pub span: Span,
     /// None for `default:`
-    pub test: Option<Box<Expr>>,
+    pub test: Option<(Box<Expr>)>,
 
     pub cons: Vec<Stmt>,
 }


### PR DESCRIPTION
rust-analysis chokes with `Option<Box<Expr>>` style fields.
Rls only shows a warning on the crate with that fields, but ICEs on
dependent crates.
This can be workarounded by using `Option<(Box<Expr>)>`.

Also, using multiple glob imports is bad for rls.
So this commit deglobs them.