### PR TITLE
Make rls work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ target/
 core
 *.log
 Cargo.lock
+
+/.vscode
+/.idea
+*.iml

--- a/common/src/errors/handler.rs
+++ b/common/src/errors/handler.rs
@@ -1,5 +1,4 @@
 use super::Diagnostic;
-use Span;
 use rustc_errors::{CodeMapper, ColorConfig, Diagnostic as RustcDiagnostic,
                    Handler as RustcHandler, HandlerFlags, Level};
 use std::rc::Rc;

--- a/ecmascript/ast/src/class.rs
+++ b/ecmascript/ast/src/class.rs
@@ -1,13 +1,13 @@
 use super::{Expr, Function, PropName};
-use swc_common::{FoldWith, Span};
+use swc_common::Span;
 use swc_macros::ast_node;
 
 #[ast_node]
 pub struct Class {
     pub span: Span,
 
-    pub super_class: Option<Box<Expr>>,
     pub body: Vec<ClassMethod>,
+    pub super_class: Option<(Box<Expr>)>,
 }
 
 #[ast_node]
@@ -22,16 +22,10 @@ pub struct ClassMethod {
     pub is_static: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Fold)]
 pub enum ClassMethodKind {
     Constructor,
     Method,
     Getter,
     Setter,
-}
-
-impl<F> FoldWith<F> for ClassMethodKind {
-    fn fold_children(self, _: &mut F) -> Self {
-        self
-    }
 }

--- a/ecmascript/ast/src/decl.rs
+++ b/ecmascript/ast/src/decl.rs
@@ -59,5 +59,5 @@ pub struct VarDeclarator {
 
     pub name: Pat,
     /// Initialization expresion.
-    pub init: Option<Box<Expr>>,
+    pub init: Option<(Box<Expr>)>,
 }

--- a/ecmascript/ast/src/expr.rs
+++ b/ecmascript/ast/src/expr.rs
@@ -79,7 +79,7 @@ pub enum ExprKind {
 /// Array literal.
 #[ast_node]
 pub struct ArrayLit {
-    pub elems: Vec<Option<ExprOrSpread>>,
+    pub elems: Vec<(Option<ExprOrSpread>)>,
 }
 
 /// Object literal.
@@ -156,11 +156,12 @@ pub struct CallExpr {
 #[ast_node]
 pub struct NewExpr {
     pub callee: Box<Expr>,
-    pub args: Option<Vec<ExprOrSpread>>,
+    // #[code = "$( $( $args ),* )?"]
+    pub args: Option<(Vec<ExprOrSpread>)>,
 }
 #[ast_node]
 pub struct SeqExpr {
-    pub exprs: Vec<Box<Expr>>,
+    pub exprs: Vec<(Box<Expr>)>,
 }
 #[ast_node]
 pub struct ArrowExpr {
@@ -173,7 +174,7 @@ pub struct ArrowExpr {
 
 #[ast_node]
 pub struct YieldExpr {
-    pub arg: Option<Box<Expr>>,
+    pub arg: Option<(Box<Expr>)>,
     pub delegate: bool,
 }
 #[ast_node]
@@ -188,9 +189,9 @@ pub struct AwaitExpr {
 
 #[ast_node]
 pub struct TplLit {
-    pub tag: Option<Box<Expr>>,
+    pub tag: Option<(Box<Expr>)>,
 
-    pub exprs: Vec<Box<Expr>>,
+    pub exprs: Vec<(Box<Expr>)>,
 
     pub quasis: Vec<TplElement>,
 }

--- a/ecmascript/ast/src/lib.rs
+++ b/ecmascript/ast/src/lib.rs
@@ -10,21 +10,28 @@ extern crate swc_common;
 #[macro_use]
 extern crate swc_macros;
 
-pub use self::class::*;
-pub use self::decl::*;
-pub use self::expr::*;
-pub use self::function::*;
-pub use self::lit::*;
-pub use self::module::*;
-pub use self::module_decl::*;
-pub use self::operators::*;
-pub use self::pat::*;
-pub use self::prop::*;
-pub use self::stmt::*;
+pub use self::class::{Class, ClassMethod, ClassMethodKind};
+pub use self::decl::{ClassDecl, Decl, FnDecl, VarDecl, VarDeclKind, VarDeclarator};
+pub use self::expr::{ArrayLit, ArrowExpr, AssignExpr, AwaitExpr, BinExpr, BlockStmtOrExpr,
+                     CallExpr, ClassExpr, CondExpr, Expr, ExprKind, ExprOrSpread, ExprOrSuper,
+                     FnExpr, MemberExpr, MetaPropExpr, NewExpr, ObjectLit, PatOrExpr, SeqExpr,
+                     TplElement, TplLit, UnaryExpr, UpdateExpr, YieldExpr};
+pub use self::function::Function;
+pub use self::lit::{Lit, Number, Regex, RegexFlags};
+pub use self::module::{Module, ModuleItem};
+pub use self::module_decl::{ExportDefaultDecl, ExportSpecifier, ImportSpecifier,
+                            ImportSpecifierKind, ModuleDecl, ModuleDeclKind};
+pub use self::operators::{AssignOp, BinaryOp, UnaryOp, UpdateOp};
+pub use self::pat::{ObjectPatProp, Pat, PatKind};
+pub use self::prop::{Prop, PropKind, PropName};
+pub use self::stmt::{BlockStmt, BreakStmt, CatchClause, ContinueStmt, DoWhileStmt, ForInStmt,
+                     ForOfStmt, ForStmt, IfStmt, LabeledStmt, ReturnStmt, Stmt, StmtKind,
+                     SwitchCase, SwitchStmt, ThrowStmt, TryStmt, VarDeclOrExpr, VarDeclOrPat,
+                     WhileStmt, WithStmt};
 use std::fmt::{self, Debug, Display, Formatter};
 use swc_atoms::JsWord;
 use swc_common::{Span, Spanned};
-use swc_macros::AstNode;
+use swc_macros::{AstNode, Fold};
 
 mod macros;
 mod class;
@@ -40,7 +47,7 @@ mod prop;
 mod stmt;
 
 /// Ident with span.
-#[derive(AstNode, Clone, PartialEq)]
+#[derive(AstNode, Fold, Clone, PartialEq)]
 pub struct Ident {
     pub span: Span,
     #[fold(ignore)]

--- a/ecmascript/ast/src/operators.rs
+++ b/ecmascript/ast/src/operators.rs
@@ -1,6 +1,6 @@
-use swc_macros::{AstNode, Kind};
+use swc_macros::{AstNode, Fold, Kind};
 
-#[derive(Kind, AstNode, Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[derive(Kind, AstNode, Fold, Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
 #[kind(function(precedence = "u8"))]
 pub enum BinaryOp {
     /// `==`
@@ -83,7 +83,7 @@ pub enum BinaryOp {
     Exp,
 }
 
-#[derive(AstNode, Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[derive(AstNode, Fold, Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub enum AssignOp {
     /// `=`
     Assign,
@@ -114,7 +114,7 @@ pub enum AssignOp {
     ExpAssign,
 }
 
-#[derive(AstNode, Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[derive(AstNode, Fold, Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub enum UpdateOp {
     /// `++`
     PlusPlus,
@@ -122,7 +122,7 @@ pub enum UpdateOp {
     MinusMinus,
 }
 
-#[derive(AstNode, Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[derive(AstNode, Fold, Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub enum UnaryOp {
     /// `-`
     Minus,

--- a/ecmascript/ast/src/pat.rs
+++ b/ecmascript/ast/src/pat.rs
@@ -18,7 +18,7 @@ impl Spanned<PatKind> for Pat {
 pub enum PatKind {
     Ident(Ident),
 
-    Array(Vec<Option<Pat>>),
+    Array(Vec<(Option<Pat>)>),
 
     Rest(Box<Pat>),
 
@@ -41,7 +41,7 @@ pub enum ObjectPatProp {
     Assign {
         key: Ident,
 
-        value: Option<Box<Expr>>,
+        value: Option<(Box<Expr>)>,
     },
 }
 

--- a/ecmascript/ast/src/stmt.rs
+++ b/ecmascript/ast/src/stmt.rs
@@ -9,6 +9,15 @@ pub struct Stmt {
     pub node: StmtKind,
 }
 
+impl From<(Box<Expr>)> for Stmt {
+    fn from(t: Box<Expr>) -> Self {
+        Stmt {
+            span: t.span,
+            node: StmtKind::Expr(t),
+        }
+    }
+}
+
 impl From<Decl> for Stmt {
     fn from(decl: Decl) -> Self {
         Stmt {
@@ -25,7 +34,7 @@ impl Spanned<StmtKind> for Stmt {
 }
 
 /// Use when only block statements are allowed.
-#[ast_node]
+#[derive(AstNode, Fold, Clone, Debug, PartialEq, Default)]
 pub struct BlockStmt {
     /// Span of brace.
     pub span: Span,
@@ -89,7 +98,7 @@ pub struct WithStmt {
 
 #[ast_node]
 pub struct ReturnStmt {
-    pub arg: Option<Box<Expr>>,
+    pub arg: Option<(Box<Expr>)>,
 }
 
 #[ast_node]
@@ -109,7 +118,7 @@ pub struct ContinueStmt {
 pub struct IfStmt {
     pub test: Box<Expr>,
     pub cons: Box<Stmt>,
-    pub alt: Option<Box<Stmt>>,
+    pub alt: Option<(Box<Stmt>)>,
 }
 #[ast_node]
 pub struct SwitchStmt {
@@ -139,8 +148,8 @@ pub struct DoWhileStmt {
 #[ast_node]
 pub struct ForStmt {
     pub init: Option<VarDeclOrExpr>,
-    pub test: Option<Box<Expr>>,
-    pub update: Option<Box<Expr>>,
+    pub test: Option<(Box<Expr>)>,
+    pub update: Option<(Box<Expr>)>,
     pub body: Box<Stmt>,
 }
 #[ast_node]
@@ -160,7 +169,7 @@ pub struct ForOfStmt {
 pub struct SwitchCase {
     // pub span: Span,
     /// None for `default:`
-    pub test: Option<Box<Expr>>,
+    pub test: Option<(Box<Expr>)>,
 
     pub cons: Vec<Stmt>,
 }

--- a/macros/ast_node/Cargo.toml
+++ b/macros/ast_node/Cargo.toml
@@ -10,6 +10,7 @@ proc-macro = true
 swc_macros_common = { path = "../common" }
 pmutil = "0.1"
 proc-macro2 = "0.2"
+quote = "0.4"
 
 [dependencies.syn]
 version = "0.12"

--- a/macros/ast_node/src/fold.rs
+++ b/macros/ast_node/src/fold.rs
@@ -1,7 +1,7 @@
 use common::prelude::*;
 
-pub fn derive_fold(input: &DeriveInput) -> ItemImpl {
-    let mut derive_generics = Derive::new(input);
+pub fn derive(input: DeriveInput) -> ItemImpl {
+    let mut derive_generics = Derive::new(&input);
 
     let preds = derive_generics
         .all_generic_fields()
@@ -17,13 +17,13 @@ pub fn derive_fold(input: &DeriveInput) -> ItemImpl {
             Quote::new_call_site()
                 .quote_with(smart_quote!(
                     Vars { Type: &ty },
-                    (Type: ::swc_common::FoldWith<__Folder>)
+                    (Type: swc_common::FoldWith<__Folder>)
                 ))
                 .parse()
         });
     derive_generics.add_where_predicates(preds);
 
-    let arms = Binder::new_from(input)
+    let arms = Binder::new_from(&input)
         .variants()
         .into_iter()
         .map(|v| {
@@ -61,7 +61,7 @@ pub fn derive_fold(input: &DeriveInput) -> ItemImpl {
                                 FieldType: &binding.field().ty,
                                 binded_field: binding.name(),
                             },
-                            { ::swc_common::Folder::<FieldType>::fold(__folder, binded_field,) }
+                            { swc_common::Folder::<FieldType>::fold(__folder, binded_field,) }
                         )),
                     };
 
@@ -141,7 +141,7 @@ pub fn derive_fold(input: &DeriveInput) -> ItemImpl {
                 body,
             },
             {
-                impl<__Folder> ::swc_common::FoldWith<__Folder> for Type {
+                impl<__Folder> swc_common::FoldWith<__Folder> for Type {
                     fn fold_children(self, __folder: &mut __Folder) -> Self {
                         body
                     }

--- a/macros/ast_node/src/lib.rs
+++ b/macros/ast_node/src/lib.rs
@@ -4,49 +4,77 @@
 extern crate pmutil;
 extern crate proc_macro;
 extern crate proc_macro2;
+extern crate quote;
 extern crate swc_macros_common as common;
 extern crate syn;
 
-use self::fold::derive_fold;
 use common::prelude::*;
 
 mod fold;
 
-#[proc_macro_derive(AstNode, attributes(fold))]
-pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+#[proc_macro_derive(Fold, attributes(fold))]
+pub fn derive_fold(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse::<DeriveInput>(input).expect("failed to parse input as DeriveInput");
+    let type_name = input.ident.clone();
+
+    let item = self::fold::derive(input);
+
+    wrap_in_const(&format!("DERIVE_FOLD_FOR_{}", type_name), item.dump())
+}
+
+#[proc_macro_derive(AstNode)]
+pub fn derive_ast_node(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::<DeriveInput>(input).expect("failed to parse input as DeriveInput");
     let type_name = &input.ident;
 
-    let mut tokens = Tokens::new();
-    derive_fold(&input).to_tokens(&mut tokens);
-
-    let item = Quote::new_call_site()
+    let item = Quote::new(Span::call_site())
         .quote_with(smart_quote!(Vars { Type: type_name }, {
-            impl ::swc_common::AstNode for Type {}
+            impl swc_common::AstNode for Type {}
         }))
         .parse::<ItemImpl>()
         .with_generics(input.generics);
-    item.to_tokens(&mut tokens);
 
-    print("derive(AstNode)", tokens)
+    wrap_in_const(&format!("DERIVE_AST_NODE_FOR_{}", type_name), item.dump())
 }
 
 /// Alias for
 /// `#[derive(Clone, Debug, PartialEq, AstNode)]`
 #[proc_macro_attribute]
 pub fn ast_node(
-    _attr: proc_macro::TokenStream,
-    s: proc_macro::TokenStream,
+    args: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let item: Item = syn::parse(s).expect("failed to parse tokens as an item");
+    if !args.is_empty() {
+        panic!("#[ast_node] takes no arguments");
+    }
 
-    // With proc_macro feature enabled, only attributes for first derive works.
-    // https://github.com/rust-lang/rust/issues/44925
-    let tokens = pmutil::Quote::new_call_site().quote_with(smart_quote!(Vars { item }, {
-        #[derive(::swc_macros::AstNode)]
-        #[derive(Clone, Debug, PartialEq)]
+    let item: DeriveInput = parse(input).expect("failed to parse input as a DeriveInput");
+
+    // If we use call_site with proc_macro feature enabled,
+    // only attributes for first derive works.
+    // https://github.com/rust-lang/rust/issues/46489
+    let item = Quote::new(Span::def_site()).quote_with(smart_quote!(Vars { item }, {
+        #[derive(AstNode, Fold, Clone, Debug, PartialEq)]
         item
     }));
 
-    print("ast_node", tokens)
+    print("ast_node", item)
+}
+
+/// Workarounds https://github.com/rust-lang/rust/issues/44925
+fn wrap_in_const<T: Into<TokenStream>>(const_name: &str, item: T) -> proc_macro::TokenStream {
+    let item = Quote::new(Span::call_site()).quote_with(smart_quote!(
+        Vars {
+            item: item.into(),
+            CONST_NAME: Ident::new(const_name, call_site()),
+        },
+        {
+            #[allow(dead_code, non_upper_case_globals)]
+            const CONST_NAME: () = {
+                extern crate swc_common;
+                item
+            };
+        }
+    ));
+    item.into()
 }

--- a/macros/ast_node/tests/attribute.rs
+++ b/macros/ast_node/tests/attribute.rs
@@ -7,6 +7,7 @@ use swc_macros::ast_node;
 #[ast_node]
 // See https://github.com/rust-lang/rust/issues/44925
 pub struct Class {
+    #[fold(ignore)]
     pub s: String,
 }
 


### PR DESCRIPTION
rust-analysis chokes with `Option<Box<Expr>>` style fields.
Rls only shows a warning on the crate with that fields, but ICEs on
dependent crates.
This can be workarounded by using `Option<(Box<Expr>)>`.

Also, using multiple glob imports is bad for rls.
So this commit deglobs them.