### PR TITLE
WIP: A Rudimentary Plugin System

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ swc_atoms = { path = "./atoms" }
 swc_common = { path = "./common" }
 swc_ecmascript = { path = "./ecmascript" }
 swc_macros = { path = "./macros" }
+swc_plugins = { path = "./plugins" }
 rayon = "0.9"
 slog = "2"
 slog-envlogger = "2.1"

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -7,3 +7,6 @@ authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
 swc_common = { path = "../common" }
 anymap = "0.12.1"
 libloading = "0.5.0"
+
+[dev-dependencies]
+dummy_plugin = { path = "tests/dummy_plugin" }

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
 [dependencies]
 swc_common = { path = "../common" }
 anymap = "0.12.1"
+libloading = "0.5.0"

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "swc_plugins"
+version = "0.1.0"
+authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
+
+[dependencies]
+swc_common = { path = "../common" }
+anymap = "0.12.1"

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -11,19 +11,17 @@ extern crate swc_common;
 macro_rules! register_plugin {
     ($register:expr) => {
         #[doc(hidden)]
-        pub mod __swc_plugins {
-            #[no_mangle]
-            pub extern "C" fn swc_register_plugin(registrar: &mut $crate::Registrar) {
-                let register: fn(&mut $crate::Registrar) = $register;
+        #[no_mangle]
+        pub extern "C" fn swc_register_plugin(registrar: &mut $crate::Registrar) {
+            let register: fn(&mut $crate::Registrar) = $register;
 
+            register(registrar);
+        }
 
-                register(registrar);
-            }
-
-            #[no_mangle]
-            pub extern "C" fn swg_plugin_library_version() -> &'static str {
-                $crate::SWC_PLUGIN_VERSION
-            }
+        #[doc(hidden)]
+        #[no_mangle]
+        pub extern "C" fn swg_plugin_library_version() -> String {
+            $crate::SWC_PLUGIN_VERSION.to_string()
         }
     };
 }

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -1,0 +1,96 @@
+extern crate anymap;
+extern crate swc_common;
+
+use anymap::AnyMap;
+use swc_common::{Fold};
+
+/// Declare a SWC plugin.
+/// 
+/// # Note
+/// 
+/// This macro can only be invoked once per crate.
+#[macro_export]
+macro_rules! register_plugin {
+    ($register:expr) => {
+        #[doc(hidden)]
+        pub mod __swc_plugins {
+            #[no_mangle]
+            pub extern "C" fn swc_register_plugin(registrar: &mut $crate::PluginRegistrar) {
+                // enforce the desired function signature
+                let register: fn(&mut $crate::PluginRegistrar) = $register;
+
+                register(registrar);
+            }
+        }
+    };
+}
+
+#[derive(Debug)]
+pub struct PluginRegistrar {
+    folders: AnyMap,
+}
+
+impl PluginRegistrar {
+    pub fn new() -> PluginRegistrar {
+        PluginRegistrar {
+            folders: AnyMap::new(),
+        }
+    }
+
+    pub fn register<A, F>(&mut self, folder: F) -> &mut Self
+    where F: Fold<A> + 'static,
+          A: 'static,
+    {
+
+        self.folders.entry::<Vec<Box<dyn Fold<A>>>>()
+            .or_insert_with(Vec::new)
+            .push(Box::new(folder));
+
+        self
+    }
+
+    pub fn get<A: 'static>(&self) -> &[Box<dyn Fold<A>>] {
+        self.folders.get::<Vec<Box<dyn Fold<A>>>>()
+            .map(|folders| folders.as_slice())
+            .unwrap_or(&[])
+    }
+
+    pub fn len(&self) -> usize {
+        self.folders.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.folders.is_empty()
+    }
+}
+
+impl Default for PluginRegistrar {
+    fn default() -> PluginRegistrar {
+        PluginRegistrar::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Foo;
+    
+    impl Fold<usize> for Foo {
+        fn fold(&mut self, node: usize) -> usize {
+            node
+        }
+    }
+
+    #[test]
+    fn insert_a_folder_and_get_it_back() {
+        let mut registrar = PluginRegistrar::new();
+        assert!(registrar.is_empty());
+
+        registrar.register::<usize, _>(Foo);
+        assert_eq!(registrar.len(), 1);
+
+        let got = registrar.get::<usize>();
+        assert_eq!(got.len(), 1);
+    }
+}

--- a/plugins/src/loader.rs
+++ b/plugins/src/loader.rs
@@ -1,0 +1,67 @@
+use swc_common::Fold;
+use super::{Registrar, PluginError};
+use libloading::Library;
+use std::ffi::OsStr;
+
+/// A plugin loader.
+#[derive(Debug, Default)]
+pub struct Loader {
+    libraries: Vec<Library>,
+    registrar: Registrar,
+}
+
+impl Loader {
+    pub fn new() -> Loader {
+        Loader::default()
+    }
+
+    pub fn load_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> Result<(), PluginError> {
+        let path = path.as_ref();
+        let lib = Library::new(path)?;
+
+        let symbol_name = "swg_plugin_library_version\0";
+
+        let compiled_swc_plugin_version = unsafe { 
+            match lib.get(symbol_name.as_bytes()) {
+                // extract the raw function pointer. This is safe because we're
+                // only ever going to use it while "lib" is alive.
+                Ok(symbol) => *symbol,
+                Err(_) => return Err(PluginError::MissingSymbol(&symbol_name[..symbol_name.len()-2])),
+            }
+        };
+
+        validate_library_version(compiled_swc_plugin_version)?;
+
+        unimplemented!()
+    }
+
+    pub fn get_mut<A: 'static>(&mut self) -> &mut [Box<dyn Fold<A>>] {
+        self.registrar.get_mut()
+    }
+}
+
+fn validate_library_version(func: extern "C" fn() -> &'static str) -> Result<(), PluginError> {
+    if func() == super::SWC_PLUGIN_VERSION {
+        Ok(())
+    } else {
+        Err(PluginError::MismatchedLibraryVersion)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // pretend this crate is a plugin for testing purposes. This gives us 
+    // access to the generated code so we can manually verify the happy path.
+    register_plugin!(|_| {});
+
+    #[test]
+    fn generated_version_is_always_compatible() {
+        let generated = __swc_plugins::swg_plugin_library_version;
+
+        // the generated function should always return the correct library 
+        // version because we *are* the swc_plugins crate
+        assert!(validate_library_version(generated).is_ok());
+    }
+}

--- a/plugins/src/registrar.rs
+++ b/plugins/src/registrar.rs
@@ -38,6 +38,10 @@ impl Registrar {
     pub fn is_empty(&self) -> bool {
         self.folders.is_empty()
     }
+
+    pub(crate) fn clear(&mut self) {
+        self.folders.clear();
+    }
 }
 
 impl Default for Registrar {

--- a/plugins/src/registrar.rs
+++ b/plugins/src/registrar.rs
@@ -1,6 +1,7 @@
 use anymap::AnyMap;
 use swc_common::{Fold};
 
+/// Something you can use to register 3rd party plugins.
 #[derive(Debug)]
 pub struct Registrar {
     folders: AnyMap,

--- a/plugins/src/registrar.rs
+++ b/plugins/src/registrar.rs
@@ -1,0 +1,71 @@
+use anymap::AnyMap;
+use swc_common::{Fold};
+
+#[derive(Debug)]
+pub struct Registrar {
+    folders: AnyMap,
+}
+
+impl Registrar {
+    pub fn new() -> Registrar {
+        Registrar {
+            folders: AnyMap::new(),
+        }
+    }
+
+    pub fn register<A, F>(&mut self, folder: F) -> &mut Self
+    where F: Fold<A> + 'static,
+          A: 'static,
+    {
+        self.folders.entry::<Vec<Box<dyn Fold<A>>>>()
+            .or_insert_with(Vec::new)
+            .push(Box::new(folder));
+
+        self
+    }
+
+    pub(crate) fn get_mut<A: 'static>(&mut self) -> &mut [Box<dyn Fold<A>>] {
+        self.folders.get_mut::<Vec<Box<dyn Fold<A>>>>()
+            .map(|folders| folders.as_mut_slice())
+            .unwrap_or(&mut [])
+    }
+
+    pub fn len(&self) -> usize {
+        self.folders.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.folders.is_empty()
+    }
+}
+
+impl Default for Registrar {
+    fn default() -> Registrar {
+        Registrar::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Foo;
+    
+    impl Fold<usize> for Foo {
+        fn fold(&mut self, node: usize) -> usize {
+            node
+        }
+    }
+
+    #[test]
+    fn insert_a_folder_and_get_it_back() {
+        let mut registrar = Registrar::new();
+        assert!(registrar.is_empty());
+
+        registrar.register::<usize, _>(Foo);
+        assert_eq!(registrar.len(), 1);
+
+        let got = registrar.get_mut::<usize>();
+        assert_eq!(got.len(), 1);
+    }
+}

--- a/plugins/tests/dummy_plugin/Cargo.toml
+++ b/plugins/tests/dummy_plugin/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "dummy_plugin"
+version = "0.1.0"
+authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
+
+[dependencies]
+swc_plugins = { path = "../.." }
+swc_common = { path = "../../../common" }
+lazy_static = "1.0"
+
+[lib]
+path = "./lib.rs"
+crate-type = ["cdylib"]

--- a/plugins/tests/dummy_plugin/lib.rs
+++ b/plugins/tests/dummy_plugin/lib.rs
@@ -1,0 +1,21 @@
+#[macro_use]
+extern crate swc_plugins;
+extern crate swc_common;
+
+use swc_common::Fold;
+use swc_plugins::Registrar;
+
+register_plugin!(register);
+
+pub struct Increment;
+
+impl Fold<u32> for Increment {
+    #[no_mangle]
+    fn fold(&mut self, n: u32) -> u32 {
+        n + 1
+    }
+}
+
+fn register(reg: &mut Registrar) {
+    reg.register::<u32, _>(Increment);
+}

--- a/plugins/tests/integration_test.rs
+++ b/plugins/tests/integration_test.rs
@@ -1,0 +1,51 @@
+extern crate swc_plugins;
+extern crate swc_common;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use swc_plugins::Loader;
+
+#[test]
+fn run_the_dummy_plugin() {
+    let library = compile_dummy_plugin();
+    let mut loader = Loader::new();
+
+    assert!(loader.registrar().is_empty());
+    loader.load_plugin(&library).unwrap();
+    assert_eq!(loader.registrar().len(), 1);
+
+    let plugins = loader.get_mut::<u32>();
+    assert_eq!(plugins.len(), 1);
+
+    let plugin = &mut plugins[0];
+    let original = 42;
+    let got = plugin.fold(original);
+    assert_eq!(got, original + 1);
+}
+
+fn compile_dummy_plugin() -> PathBuf {
+    let plugins = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dummy_plugin = plugins.join("tests").join("dummy_plugin");
+
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build");
+
+    #[cfg(not(debug_assertions))]
+    cmd.arg("--release");
+
+    let status = cmd
+        .current_dir(&dummy_plugin)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let debug = plugins.parent()
+        .unwrap()
+        .join("target")
+        .join("debug");
+
+    let lib = debug.join("libdummy_plugin.so");
+    assert!(lib.exists());
+
+    lib
+}

--- a/plugins/tests/integration_test.rs
+++ b/plugins/tests/integration_test.rs
@@ -39,13 +39,25 @@ fn compile_dummy_plugin() -> PathBuf {
         .unwrap();
     assert!(status.success());
 
-    let debug = plugins.parent()
+    let target_dir = plugins.parent()
         .unwrap()
-        .join("target")
-        .join("debug");
+        .join("target");
 
-    let lib = debug.join("libdummy_plugin.so");
+    let target_dir = if cfg!(debug_assertions) {
+        target_dir.join("debug")
+    } else {
+        target_dir.join("release")
+    };
+
+    let lib = target_dir.join(LIB_DUMMY);
     assert!(lib.exists());
 
     lib
 }
+
+#[cfg(unix)]
+const LIB_DUMMY: &str = "libdummy_plugin.so";
+#[cfg(windows)]
+const LIB_DUMMY: &str = "dummy_plugin.dll";
+#[cfg(not(any(unix, windows)))]
+compile_error!("What file name does this platform use for DLLs?");


### PR DESCRIPTION
This adds the basic infrastructure for a binary plugin system. We essentially use `LibLoading` or `dlopen` to load a DLL at runtime and execute a couple well known symbols to register a plugin.

Later on we may want to create a small utility which can download a plugin repo (e.g. from GitHub), compile it, then copy the DLL to some user-specific plugins directory. We'd also need some sort of plugin discovery mechanism (e.g. a `SWC_PLUGIN_PATH` environment variable which defaults to the plugin directory) to know where to look when loading plugins as part of the build process. 

Outstanding questions:

- What should a plugin look like? Does it implement a special `Plugin` trait, is it just an implementation of `Fold<T>`, etc? This probably ties in with #41.
- `rustc` doesn't guarantee ABI compatibility between versions, meaning each plugin would have to be compiled with *exactly* the same version of `rustc` as `swc`
- How do you declare a plugin? Should we have an equivalent of `.babelrc`, or maybe take a different approach?
- Do we want to support writing plugins in other languages?
- How will the rest of the system want to use loaded plugins?

This works towards #18.