### PR TITLE
add #[inline] to folder / visitors

### DIFF
--- a/common/src/fold.rs
+++ b/common/src/fold.rs
@@ -10,6 +10,7 @@ pub trait Fold<T> {
     fn fold(&mut self, node: T) -> T;
 
     /// Creates a folder which applies `folder` after `self`.
+    #[inline(always)]
     fn then<F>(self, folder: F) -> AndThen<Self, F>
     where
         Self: Sized,
@@ -29,6 +30,7 @@ pub trait Visit<T> {
     fn visit(&mut self, node: &T);
 
     /// Creates a folder which applies `folder` after `self`.
+    #[inline(always)]
     fn then<F>(self, visitor: F) -> AndThen<Self, F>
     where
         Self: Sized,
@@ -46,6 +48,7 @@ where
     T: FoldWith<Self>,
     F: Fold<T>,
 {
+    #[inline(always)]
     fn fold(&mut self, node: T) -> T {
         (**self).fold(node)
     }
@@ -56,6 +59,7 @@ where
     T: VisitWith<Self>,
     F: Visit<T>,
 {
+    #[inline(always)]
     fn visit(&mut self, node: &T) {
         (**self).visit(node)
     }
@@ -66,6 +70,7 @@ where
     T: FoldWith<Self>,
     F: Fold<T>,
 {
+    #[inline(always)]
     fn fold(&mut self, node: T) -> T {
         (**self).fold(node)
     }
@@ -76,6 +81,7 @@ where
     T: VisitWith<Self>,
     F: Visit<T>,
 {
+    #[inline(always)]
     fn visit(&mut self, node: &T) {
         (**self).visit(node)
     }
@@ -85,6 +91,7 @@ impl<T, F> Fold<T> for F
 where
     T: FoldWith<F>,
 {
+    #[inline(always)]
     default fn fold(&mut self, t: T) -> T {
         t.fold_children(self)
     }
@@ -94,6 +101,7 @@ impl<T, F> Visit<T> for F
 where
     T: VisitWith<F>,
 {
+    #[inline(always)]
     default fn visit(&mut self, t: &T) {
         t.visit_children(self)
     }
@@ -111,6 +119,7 @@ where
     F1: Fold<T>,
     F2: Fold<T>,
 {
+    #[inline]
     fn fold(&mut self, node: T) -> T {
         let node = self.first.fold(node);
         self.second.fold(node)
@@ -123,6 +132,7 @@ where
     F1: Visit<T>,
     F2: Visit<T>,
 {
+    #[inline]
     fn visit(&mut self, node: &T) {
         self.first.visit(node);
         self.second.visit(node);
@@ -147,6 +157,7 @@ pub trait FoldWith<F>: Sized {
     /// Call `f.fold(self)`.
     ///
     /// This bypasses a type inference bug which is caused by specialization.
+    #[inline(always)]
     fn fold_with(self, f: &mut F) -> Self {
         f.fold(self)
     }
@@ -170,6 +181,7 @@ pub trait VisitWith<F> {
     /// Call `f.visit(self)`.
     ///
     /// This bypasses a type inference bug which is caused by specialization.
+    #[inline(always)]
     fn visit_with(&self, f: &mut F)
     where
         Self: Sized,
@@ -182,18 +194,21 @@ impl<'a, T, F> VisitWith<F> for &'a T
 where
     F: Visit<T>,
 {
+    #[inline(always)]
     fn visit_children(&self, f: &mut F) {
         f.visit(*self)
     }
 }
 
 impl<F> FoldWith<F> for ! {
+    #[inline(always)]
     fn fold_children(self, _: &mut F) -> Self {
         self
     }
 }
 
 impl<F> VisitWith<F> for ! {
+    #[inline(always)]
     fn visit_children(&self, _: &mut F) {}
 }
 
@@ -201,6 +216,7 @@ impl<T, F> FoldWith<F> for Box<T>
 where
     F: Fold<T>,
 {
+    #[inline(always)]
     fn fold_children(self, f: &mut F) -> Self {
         box f.fold(*self)
     }
@@ -210,6 +226,7 @@ impl<T, F> VisitWith<F> for Box<T>
 where
     F: Visit<T>,
 {
+    #[inline(always)]
     fn visit_children(&self, f: &mut F) {
         f.visit(&**self)
     }
@@ -219,6 +236,7 @@ impl<T, F> FoldWith<F> for Vec<T>
 where
     F: Fold<T>,
 {
+    #[inline]
     fn fold_children(self, f: &mut F) -> Self {
         self.into_iter().map(|it| f.fold(it)).collect()
     }
@@ -228,6 +246,7 @@ impl<T, F> VisitWith<F> for Vec<T>
 where
     F: Visit<T>,
 {
+    #[inline]
     fn visit_children(&self, f: &mut F) {
         self.iter().for_each(|node| f.visit(node))
     }
@@ -237,6 +256,7 @@ impl<T, F> VisitWith<F> for [T]
 where
     F: Visit<T>,
 {
+    #[inline]
     fn visit_children(&self, f: &mut F) {
         self.iter().for_each(|node| f.visit(node))
     }
@@ -246,6 +266,7 @@ impl<T, F> FoldWith<F> for Option<T>
 where
     F: Fold<T>,
 {
+    #[inline(always)]
     fn fold_children(self, f: &mut F) -> Self {
         self.map(|t| f.fold(t))
     }
@@ -255,6 +276,7 @@ impl<T, F> VisitWith<F> for Option<T>
 where
     F: Visit<T>,
 {
+    #[inline(always)]
     fn visit_children(&self, f: &mut F) {
         if let Some(ref node) = *self {
             f.visit(node)
@@ -264,6 +286,7 @@ where
 
 impl<F> FoldWith<F> for String {
     /// No op.
+    #[inline(always)]
     fn fold_children(self, _: &mut F) -> Self {
         self
     }
@@ -271,11 +294,13 @@ impl<F> FoldWith<F> for String {
 
 impl<F> VisitWith<F> for String {
     /// No op.
+    #[inline(always)]
     fn visit_children(&self, _: &mut F) {}
 }
 
 impl<F, S: StaticAtomSet> FoldWith<F> for Atom<S> {
     /// No op.
+    #[inline(always)]
     fn fold_children(self, _: &mut F) -> Self {
         self
     }
@@ -283,6 +308,7 @@ impl<F, S: StaticAtomSet> FoldWith<F> for Atom<S> {
 
 impl<F, S: StaticAtomSet> VisitWith<F> for Atom<S> {
     /// No op.
+    #[inline(always)]
     fn visit_children(&self, _: &mut F) {}
 }
 
@@ -290,6 +316,7 @@ impl<A, B, F> FoldWith<F> for Either<A, B>
 where
     F: Fold<A> + Fold<B>,
 {
+    #[inline(always)]
     fn fold_children(self, f: &mut F) -> Self {
         match self {
             Either::Left(a) => Either::Left(Fold::<A>::fold(f, a)),
@@ -302,6 +329,7 @@ impl<A, B, F> VisitWith<F> for Either<A, B>
 where
     F: Visit<A> + Visit<B>,
 {
+    #[inline(always)]
     fn visit_children(&self, f: &mut F) {
         match *self {
             Either::Left(ref a) => f.visit(a),


### PR DESCRIPTION
This is to improve performance.
`#[inline(always)]` is applied to noop / constructor / box, ref related methods.