### PR TITLE
readme: Fix npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ swc is rust port of [babel][] and [closure compiler][].
 Currently this requires nightly version of [rust][].
 
 ```sh
-npm i -SD swc
+npm i -D swc
 ```
 or 
 ```sh


### PR DESCRIPTION
Hi. Super tiny PR, but useful, perhaps. 

If you want to install the dev package you need to use `--save-dev` or just `-D`.

Thanks