### PR TITLE
Fix old proc_macros2 dep breaking compile and fix line endings in atoms

### DIFF
--- a/atoms/build.rs
+++ b/atoms/build.rs
@@ -3,7 +3,7 @@ extern crate string_cache_codegen;
 use std::{env, path::Path};
 
 fn main() {
-    let strs = include_str!("words.txt").split("\n").collect::<Vec<_>>();
+    let strs = include_str!("words.txt").lines().map(|l| l.trim()).collect::<Vec<_>>();
     gen("js_word", "JsWord", &strs);
 }
 

--- a/ecmascript/parser/macros/Cargo.toml
+++ b/ecmascript/parser/macros/Cargo.toml
@@ -12,7 +12,7 @@ proc-macro = true
 
 [dependencies]
 swc_macros_common = { version = "0.1", path ="../../../macros/common" }
-proc-macro2 = "0.4.4"
+proc-macro2 = "0.4.24"
 
 [dependencies.syn]
 version = "0.14.1"


### PR DESCRIPTION
When trying to compile swc, I came across an issue with [proc_macro2::Span::join(&self, other: Span) -> Option\<Span\>](https://docs.rs/proc-macro2/0.4.24/proc_macro2/struct.Span.html#method.join) not existing. Easily fixed by updating the dependency from `0.4.4` to `0.4.24`.

Another major issue I came across when compiling the crate involved the `js_word!` macro throwing an error due to not accepting any parameters. After digging around, I noticed that the `js_word.rs` file that is generated by `atoms`' `build.rs` contained trailing `\r`s. As it turns out, the call to `::split(&'static str)` was allowing carriage returns to propagate to the aforementioned `js_word.rs` file. Replaced with a call to `::lines()` and a `map` to trim the words, just in case.