### PR TITLE
Link to docs, people need to know how it works!

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Make the web (development) faster.
 
 swc is rust port of [babel][] and [closure compiler][].
 
+# Documentation
+
+Check out the documentation [in the website](https://swc-project.github.io/docs/introduction).
+
 
 # Installation
 


### PR DESCRIPTION
By the way, I think the "Docs" menu link on the top bar of the website isn't bringing you to a very useful page. You have to click the 4-arrows icon in the top left to find the rest of the documentation. Can we fix it?