### PR TITLE
fix build error

### DIFF
--- a/ecmascript/transforms/src/lib.rs
+++ b/ecmascript/transforms/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(core_intrinsics)]
 #![feature(nll)]
 #![feature(trace_macros)]
+#![feature(split_ascii_whitespace)]
 #![cfg_attr(test, feature(test))]
 #![recursion_limit = "1024"]
 


### PR DESCRIPTION
System: macOS
Cargo: cargo 1.33.0-nightly (2cf1f5dda 2018-12-11)
Rustc: rustc 1.33.0-nightly (adbfec229 2018-12-17)

```
error[E0658]: use of unstable library feature 'split_ascii_whitespace' (see issue #48656)
   --> /Users/abc/.cargo/git/checkouts/swc-594f88c93b4170b2/c647cf1/ecmascript/transforms/src/react/jsx/mod.rs:357:35
    |
357 |     for s in t.replace("\n", " ").split_ascii_whitespace() {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(split_ascii_whitespace)] to the crate attributes to enable

error: aborting due to previous error

For more information about this error, try `rustc --explain E0658`.
error: Could not compile `swc_ecma_transforms`.

To learn more, run the command again with --verbose.
neon ERR! cargo build failed

Error: cargo build failed
    at Target.<anonymous> (/usr/local/lib/node_modules/neon-cli/lib/target.js:121:35)
    at step (/usr/local/lib/node_modules/neon-cli/lib/target.js:32:23)
    at Object.next (/usr/local/lib/node_modules/neon-cli/lib/target.js:13:53)
    at fulfilled (/usr/local/lib/node_modules/neon-cli/lib/target.js:4:58)
    at processTicksAndRejections (internal/process/next_tick.js:81:5)
```
