### PR TITLE
es2015::destructuring pass

### DIFF
--- a/ecmascript/transforms/src/compat/es2015/destructuring/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/destructuring/mod.rs
@@ -696,7 +696,12 @@ fn make_ref_ident(decls: &mut Vec<VarDeclarator>, init: Option<Box<Expr>>) -> Id
     }
 }
 
-fn make_ref_prop_expr(ref_ident: &Ident, prop: Box<Expr>, computed: bool) -> Expr {
+fn make_ref_prop_expr(ref_ident: &Ident, prop: Box<Expr>, mut computed: bool) -> Expr {
+    computed |= match *prop {
+        Expr::Lit(Lit::Num(..)) => true,
+        _ => false,
+    };
+
     Expr::Member(MemberExpr {
         span: DUMMY_SP,
         obj: ExprOrSuper::Expr(box ref_ident.clone().into()),

--- a/ecmascript/transforms/src/compat/es2015/destructuring/tests.rs
+++ b/ecmascript/transforms/src/compat/es2015/destructuring/tests.rs
@@ -484,3 +484,32 @@ test!(
     return false;
 }"#
 );
+
+test!(
+    ::swc_ecma_parser::Syntax::default(),
+    |_| tr(),
+    issue_311,
+    "const Foo = 'foo';
+
+const bar = {
+  [Foo]: {
+    qux: 'baz'
+  }
+};
+
+const {
+  [Foo]: {
+    qux
+  }
+} = bar;",
+    "
+const Foo = 'foo';
+const bar = {
+    [Foo]: {
+        qux: 'baz'
+    }
+};
+const ref = bar ? bar : _throw(new TypeError(\"Cannot destructure 'undefined' or 'null'\")), \
+     _ref$Foo = ref[Foo], ref1 = _ref$Foo ? _ref$Foo : _throw(new TypeError(\"Cannot destructure \
+     'undefined' or 'null'\")), qux = ref1.qux;"
+);


### PR DESCRIPTION
 - es2015::destructuring pass now uses computed member if necessary.

Fixes #311.