### PR TITLE
Fix test imports for latest nightly

### DIFF
--- a/ecmascript/codegen/tests/test262.rs
+++ b/ecmascript/codegen/tests/test262.rs
@@ -18,7 +18,7 @@ use std::{
 use swc_common::comments::Comments;
 use swc_ecma_codegen::Emitter;
 use swc_ecma_parser::{Parser, Session, SourceFileInput, Syntax};
-use test::{test_main, Options, ShouldPanic::No, TestDesc, TestDescAndFn, TestFn, TestName};
+use test::{test_main, Options, ShouldPanic::No, TestDesc, TestDescAndFn, DynTestFn, TestName};
 use testing::NormalizedOutput;
 
 const IGNORED_PASS_TESTS: &[&str] = &[
@@ -83,7 +83,7 @@ fn add_test<F: FnOnce() + Send + 'static>(
             should_panic: No,
             allow_fail: false,
         },
-        testfn: TestFn::DynTestFn(box f),
+        testfn: DynTestFn(box f),
     });
 }
 

--- a/ecmascript/lints/tests/golden.rs
+++ b/ecmascript/lints/tests/golden.rs
@@ -10,7 +10,7 @@ extern crate walkdir;
 
 use self::{
     parser::{SourceFileInput, Syntax},
-    test::{test_main, Options, ShouldPanic::No, TestDesc, TestDescAndFn, TestFn, TestName},
+    test::{test_main, Options, ShouldPanic::No, TestDesc, TestDescAndFn, DynTestFn, TestName},
 };
 use std::{
     env,
@@ -34,7 +34,7 @@ fn add_test<F: FnOnce() + Send + 'static>(
             should_panic: No,
             allow_fail: false,
         },
-        testfn: TestFn::DynTestFn(box f),
+        testfn: DynTestFn(box f),
     });
 }
 

--- a/ecmascript/parser/tests/jsx.rs
+++ b/ecmascript/parser/tests/jsx.rs
@@ -23,7 +23,7 @@ use std::{
 use swc_common::{errors::Handler, Fold, FoldWith, SourceMap};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{PResult, Parser, Session, SourceFileInput};
-use test::{test_main, Options, ShouldPanic::No, TestDesc, TestDescAndFn, TestFn, TestName};
+use test::{test_main, Options, ShouldPanic::No, TestDesc, TestDescAndFn, DynTestFn, TestName};
 use testing::{run_test, StdErr};
 use walkdir::WalkDir;
 
@@ -40,7 +40,7 @@ fn add_test<F: FnOnce() + Send + 'static>(
             should_panic: No,
             allow_fail: false,
         },
-        testfn: TestFn::DynTestFn(box f),
+        testfn: DynTestFn(box f),
     });
 }
 

--- a/ecmascript/parser/tests/test262.rs
+++ b/ecmascript/parser/tests/test262.rs
@@ -17,7 +17,7 @@ use std::{
 use swc_common::{Fold, FoldWith, Span};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{PResult, Parser, Session, SourceFileInput, Syntax};
-use test::{test_main, Options, ShouldPanic::No, TestDesc, TestDescAndFn, TestFn, TestName};
+use test::{test_main, Options, ShouldPanic::No, TestDesc, TestDescAndFn, DynTestFn, TestName};
 use testing::{NormalizedOutput, StdErr};
 
 const IGNORED_PASS_TESTS: &[&str] = &[
@@ -82,7 +82,7 @@ fn add_test<F: FnOnce() + Send + 'static>(
             should_panic: No,
             allow_fail: false,
         },
-        testfn: TestFn::DynTestFn(box f),
+        testfn: DynTestFn(box f),
     });
 }
 

--- a/ecmascript/parser/tests/typescript.rs
+++ b/ecmascript/parser/tests/typescript.rs
@@ -21,7 +21,7 @@ use std::{
 use swc_common::{Fold, FoldWith};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{PResult, Parser, Session, SourceFileInput, Syntax, TsConfig};
-use test::{test_main, Options, ShouldPanic::No, TestDesc, TestDescAndFn, TestFn, TestName};
+use test::{test_main, Options, ShouldPanic::No, TestDesc, TestDescAndFn, DynTestFn, TestName};
 use testing::StdErr;
 use walkdir::WalkDir;
 
@@ -41,7 +41,7 @@ fn add_test<F: FnOnce() + Send + 'static>(
             should_panic: No,
             allow_fail: false,
         },
-        testfn: TestFn::DynTestFn(box f),
+        testfn: DynTestFn(box f),
     });
 }
 

--- a/ecmascript/transforms/tests/fixer.rs
+++ b/ecmascript/transforms/tests/fixer.rs
@@ -22,7 +22,7 @@ use swc_ecma_ast::*;
 use swc_ecma_codegen::Emitter;
 use swc_ecma_parser::{Parser, Session, SourceFileInput, Syntax};
 use swc_ecma_transforms::fixer;
-use test::{test_main, Options, ShouldPanic::No, TestDesc, TestDescAndFn, TestFn, TestName};
+use test::{test_main, Options, ShouldPanic::No, TestDesc, TestDescAndFn, DynTestFn, TestName};
 
 const IGNORED_PASS_TESTS: &[&str] = &[
     // TODO: uningnore
@@ -105,7 +105,7 @@ fn add_test<F: FnOnce() + Send + 'static>(
             should_panic: No,
             allow_fail: false,
         },
-        testfn: TestFn::DynTestFn(box f),
+        testfn: DynTestFn(box f),
     });
 }
 


### PR DESCRIPTION
Because the `TestFn` enum is no longer exported.

Closes #354 