### PR TITLE
Simplify: `left.rhs * right` is only safe when operators are the same

### DIFF
--- a/ecmascript/transforms/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/src/simplify/expr/mod.rs
@@ -443,9 +443,8 @@ fn fold_bin(
                     op: left_op,
                     right: left_rhs,
                 }) => {
-                    let v = perform_arithmetic_op(op, &left_rhs, &right);
-                    match v {
-                        Known(value) => {
+                    if left_op == op {
+                        if let Known(value) = perform_arithmetic_op(op, &left_rhs, &right) {
                             return Expr::Bin(BinExpr {
                                 span,
                                 left: left_lhs,
@@ -453,15 +452,13 @@ fn fold_bin(
                                 right: box Expr::Lit(Lit::Num(Number { value, span })),
                             });
                         }
-                        _ => {
-                            left = box Expr::Bin(BinExpr {
-                                left: left_lhs,
-                                op: left_op,
-                                span: left_span,
-                                right: left_rhs,
-                            })
-                        }
                     }
+                    left = box Expr::Bin(BinExpr {
+                        left: left_lhs,
+                        op: left_op,
+                        span: left_span,
+                        right: left_rhs,
+                    })
                 }
                 _ => {}
             }


### PR DESCRIPTION
Some counterexamples:
```js
var x = 2**32 - 1;
var y = x & ~3;

(x * 2) & 2; // 2
x * (2 & 2); // 8589934590

(y & 1) | 2; // 2
y & (1 | 2); // 0

(y | 1) & 2; // 0
y | (1 & 2); // -4
```