### PR TITLE
Fix clippy warnings

### DIFF
--- a/atoms/Cargo.toml
+++ b/atoms/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
 documentation = "https://swc-project.github.io/rustdoc/swc_atoms/"
 description = "Atoms for the swc project."
+edition = "2018"
 
 [dependencies]
 string_cache = "0.7"

--- a/atoms/build.rs
+++ b/atoms/build.rs
@@ -1,4 +1,4 @@
-extern crate string_cache_codegen;
+use string_cache_codegen;
 
 use std::{env, path::Path};
 

--- a/atoms/src/lib.rs
+++ b/atoms/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unreadable_literal)]
 extern crate string_cache;
 
 include!(concat!(env!("OUT_DIR"), "/js_word.rs"));

--- a/atoms/src/lib.rs
+++ b/atoms/src/lib.rs
@@ -1,4 +1,3 @@
 #![allow(clippy::unreadable_literal)]
-extern crate string_cache;
 
 include!(concat!(env!("OUT_DIR"), "/js_word.rs"));

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
 documentation = "https://swc-project.github.io/rustdoc/swc_common/"
 description = "Common utilities for the swc project."
+edition = "2018"
 
 [features]
 default = []

--- a/common/benches/and_then.rs
+++ b/common/benches/and_then.rs
@@ -13,6 +13,7 @@ extern crate test;
 use swc_common::FoldWith;
 use test::{black_box, Bencher};
 
+#[allow(clippy::vec_box)]
 fn mk_vec() -> Vec<Box<String>> {
     (0..1000).map(|s| box s.to_string()).collect()
 }

--- a/common/src/comments.rs
+++ b/common/src/comments.rs
@@ -1,4 +1,4 @@
-use crate::{BytePos, Span};
+use crate::syntax_pos::{BytePos, Span};
 use chashmap::{CHashMap, ReadGuard};
 
 type CommentMap = CHashMap<BytePos, Vec<Comment>>;
@@ -24,11 +24,11 @@ impl Comments {
         });
     }
 
-    pub fn trailing_comments(&self, pos: BytePos) -> Option<ReadGuard<BytePos, Vec<Comment>>> {
+    pub fn trailing_comments(&self, pos: BytePos) -> Option<ReadGuard<'_, BytePos, Vec<Comment>>> {
         self.trailing.get(&pos)
     }
 
-    pub fn leading_comments(&self, pos: BytePos) -> Option<ReadGuard<BytePos, Vec<Comment>>> {
+    pub fn leading_comments(&self, pos: BytePos) -> Option<ReadGuard<'_, BytePos, Vec<Comment>>> {
         self.leading.get(&pos)
     }
 }

--- a/common/src/errors/diagnostic.rs
+++ b/common/src/errors/diagnostic.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 use super::{snippet::Style, Applicability, CodeSuggestion, Level, Substitution, SubstitutionPart};
+use crate::syntax_pos::{MultiSpan, Span};
 use std::fmt;
-use syntax_pos::{MultiSpan, Span};
 
 #[must_use]
 #[derive(Clone, Debug, PartialEq, Hash)]

--- a/common/src/errors/diagnostic.rs
+++ b/common/src/errors/diagnostic.rs
@@ -38,12 +38,12 @@ pub struct SubDiagnostic {
     pub render_span: Option<MultiSpan>,
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Default)]
 pub struct DiagnosticStyledString(pub Vec<StringPart>);
 
 impl DiagnosticStyledString {
     pub fn new() -> DiagnosticStyledString {
-        DiagnosticStyledString(vec![])
+        Default::default()
     }
     pub fn push_normal<S: Into<String>>(&mut self, t: S) {
         self.0.push(StringPart::Normal(t.into()));

--- a/common/src/errors/diagnostic_builder.rs
+++ b/common/src/errors/diagnostic_builder.rs
@@ -9,13 +9,13 @@
 // except according to those terms.
 
 use super::{Applicability, Diagnostic, DiagnosticId, DiagnosticStyledString, Handler, Level};
+use crate::syntax_pos::{MultiSpan, Span};
 use log::debug;
 use std::{
     fmt::{self, Debug},
     ops::{Deref, DerefMut},
     thread::panicking,
 };
-use syntax_pos::{MultiSpan, Span};
 
 /// Used for emitting structured error messages and other diagnostic
 /// information.
@@ -314,7 +314,7 @@ impl<'a> DiagnosticBuilder<'a> {
 }
 
 impl<'a> Debug for DiagnosticBuilder<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.diagnostic.fmt(f)
     }
 }

--- a/common/src/errors/diagnostic_builder.rs
+++ b/common/src/errors/diagnostic_builder.rs
@@ -126,7 +126,7 @@ impl<'a> DiagnosticBuilder<'a> {
         message: &str,
         span: Option<S>,
     ) -> &mut Self {
-        let span = span.map(|s| s.into()).unwrap_or_else(|| MultiSpan::new());
+        let span = span.map(|s| s.into()).unwrap_or_else(MultiSpan::new);
         self.diagnostic.sub(level, message, span, None);
         self
     }

--- a/common/src/errors/emitter.rs
+++ b/common/src/errors/emitter.rs
@@ -14,6 +14,7 @@ use super::{
     styled_buffer::StyledBuffer,
     CodeSuggestion, DiagnosticBuilder, DiagnosticId, Level, SourceMapperDyn, SubDiagnostic,
 };
+use crate::syntax_pos::{MultiSpan, SourceFile, Span};
 use atty;
 use hashbrown::HashMap;
 use std::{
@@ -23,7 +24,6 @@ use std::{
     ops::Range,
     sync::Arc,
 };
-use syntax_pos::{MultiSpan, SourceFile, Span};
 use termcolor::{Buffer, BufferWriter, Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 use unicode_width;
 
@@ -32,7 +32,7 @@ const ANONYMIZED_LINE_NUM: &str = "LL";
 /// Emitter trait for emitting errors.
 pub trait Emitter {
     /// Emit a structured diagnostic.
-    fn emit(&mut self, db: &DiagnosticBuilder);
+    fn emit(&mut self, db: &DiagnosticBuilder<'_>);
 
     /// Check if should show explanations about "rustc --explain"
     fn should_show_explain(&self) -> bool {
@@ -41,7 +41,7 @@ pub trait Emitter {
 }
 
 impl Emitter for EmitterWriter {
-    fn emit(&mut self, db: &DiagnosticBuilder) {
+    fn emit(&mut self, db: &DiagnosticBuilder<'_>) {
         let mut primary_span = db.span.clone();
         let mut children = db.children.clone();
         let mut suggestions: &[_] = &[];

--- a/common/src/errors/emitter.rs
+++ b/common/src/errors/emitter.rs
@@ -58,7 +58,7 @@ impl Emitter for EmitterWriter {
                !sugg.substitutions[0].parts[0].snippet.contains('\n')
             {
                 let substitution = &sugg.substitutions[0].parts[0].snippet.trim();
-                let msg = if substitution.len() == 0 || !sugg.show_code_when_inline {
+                let msg = if substitution.is_empty() || !sugg.show_code_when_inline {
                     // This substitution is only removal or we explicitly don't want to show the
                     // code inline, don't show it
                     format!("help: {}", sugg.msg)
@@ -111,8 +111,8 @@ pub enum ColorConfig {
 }
 
 impl ColorConfig {
-    fn to_color_choice(&self) -> ColorChoice {
-        match *self {
+    fn to_color_choice(self) -> ColorChoice {
+        match self {
             ColorConfig::Always => {
                 if atty::is(atty::Stream::Stderr) {
                     ColorChoice::Always
@@ -278,7 +278,7 @@ impl EmitterWriter {
         for item in multiline_annotations.clone() {
             let ann = item.1;
             for item in multiline_annotations.iter_mut() {
-                let ref mut a = item.1;
+                let a = &mut item.1;
                 // Move all other multiline annotations overlapping with this one
                 // one level to the right.
                 if &ann != a
@@ -557,7 +557,7 @@ impl EmitterWriter {
         // 3 |
         // 4 |   }
         //   |
-        for pos in 0..line_len + 1 {
+        for pos in 0..=line_len {
             draw_col_separator(buffer, line_offset + pos + 1, width_offset - 2);
             buffer.putc(
                 line_offset + pos + 1,
@@ -631,7 +631,7 @@ impl EmitterWriter {
             let pos = pos + 1;
 
             if pos > 1 && (annotation.has_label() || annotation.takes_space()) {
-                for p in line_offset + 1..line_offset + pos + 1 {
+                for p in line_offset + 1..=line_offset + pos {
                     buffer.putc(p, code_offset + annotation.start_col, '|', style);
                 }
             }
@@ -642,7 +642,7 @@ impl EmitterWriter {
                     }
                 }
                 AnnotationType::MultilineEnd(depth) => {
-                    for p in line_offset..line_offset + pos + 1 {
+                    for p in line_offset..=line_offset + pos {
                         buffer.putc(p, width_offset + depth - 1, '|', style);
                     }
                 }
@@ -1266,7 +1266,7 @@ impl EmitterWriter {
                         }
                         // underline removals too
                         if underline_start == underline_end {
-                            for p in underline_start - 1..underline_start + 1 {
+                            for p in underline_start - 1..=underline_start {
                                 buffer.putc(
                                     row_num,
                                     max_line_num_len + 3 + p as usize,

--- a/common/src/errors/mod.rs
+++ b/common/src/errors/mod.rs
@@ -116,11 +116,11 @@ impl CodeSuggestion {
     /// Returns the assembled code suggestions and whether they should be shown
     /// with an underline.
     pub fn splice_lines(&self, cm: &SourceMapperDyn) -> Vec<(String, Vec<SubstitutionPart>)> {
-        use syntax_pos::{CharPos, Pos};
+        use crate::syntax_pos::{CharPos, Pos};
 
         fn push_trailing(
             buf: &mut String,
-            line_opt: Option<&Cow<str>>,
+            line_opt: Option<&Cow<'_, str>>,
             lo: &Loc,
             hi_opt: Option<&Loc>,
         ) {
@@ -238,7 +238,7 @@ impl FatalError {
 }
 
 impl fmt::Display for FatalError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "parser fatal error")
     }
 }
@@ -255,7 +255,7 @@ impl error::Error for FatalError {
 pub struct ExplicitBug;
 
 impl fmt::Display for ExplicitBug {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "parser internal bug")
     }
 }
@@ -497,7 +497,7 @@ impl Handler {
         DiagnosticBuilder::new(self, Level::Fatal, msg)
     }
 
-    pub fn cancel(&self, err: &mut DiagnosticBuilder) {
+    pub fn cancel(&self, err: &mut DiagnosticBuilder<'_>) {
         err.cancel();
     }
 
@@ -707,12 +707,12 @@ impl Handler {
         self.taught_diagnostics.borrow_mut().insert(code.clone())
     }
 
-    pub fn force_print_db(&self, mut db: DiagnosticBuilder) {
+    pub fn force_print_db(&self, mut db: DiagnosticBuilder<'_>) {
         self.emitter.borrow_mut().emit(&db);
         db.cancel();
     }
 
-    fn emit_db(&self, db: &DiagnosticBuilder) {
+    fn emit_db(&self, db: &DiagnosticBuilder<'_>) {
         let diagnostic = &**db;
 
         TRACK_DIAGNOSTICS.with(|track_diagnostics| {
@@ -763,7 +763,7 @@ pub enum Level {
 }
 
 impl fmt::Display for Level {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.to_str().fmt(f)
     }
 }

--- a/common/src/errors/mod.rs
+++ b/common/src/errors/mod.rs
@@ -133,7 +133,7 @@ impl CodeSuggestion {
                         None => &line[lo..],
                     });
                 }
-                if let None = hi_opt {
+                if hi_opt.is_none() {
                     buf.push('\n');
                 }
             }
@@ -402,7 +402,7 @@ impl Handler {
         self.err_count.store(0, SeqCst);
     }
 
-    pub fn struct_dummy<'a>(&'a self) -> DiagnosticBuilder<'a> {
+    pub fn struct_dummy(&self) -> DiagnosticBuilder<'_> {
         DiagnosticBuilder::new(self, Level::Cancelled, "")
     }
 
@@ -802,8 +802,8 @@ impl Level {
         }
     }
 
-    pub fn is_failure_note(&self) -> bool {
-        match *self {
+    pub fn is_failure_note(self) -> bool {
+        match self {
             FailureNote => true,
             _ => false,
         }

--- a/common/src/errors/snippet.rs
+++ b/common/src/errors/snippet.rs
@@ -157,7 +157,7 @@ impl Annotation {
             //       |
             //
             // Note that this would be the complete output users would see.
-            label.len() > 0
+            !label.is_empty()
         } else {
             false
         }

--- a/common/src/input.rs
+++ b/common/src/input.rs
@@ -1,4 +1,4 @@
-use crate::{BytePos, SourceFile};
+use crate::syntax_pos::{BytePos, SourceFile};
 use std::str;
 
 #[derive(Clone)]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,19 +1,5 @@
 #![cfg_attr(feature = "fold", feature(specialization))]
 
-extern crate ast_node;
-extern crate atty;
-extern crate cfg_if;
-extern crate chashmap;
-extern crate either;
-extern crate hashbrown;
-extern crate log;
-extern crate parking_lot;
-extern crate scoped_tls;
-extern crate serde;
-extern crate string_cache;
-extern crate termcolor;
-extern crate unicode_width;
-
 #[cfg(feature = "fold")]
 pub use self::fold::{Fold, FoldWith, Visit, VisitWith};
 pub use self::{

--- a/common/src/pos.rs
+++ b/common/src/pos.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "fold")]
-use fold::{FoldWith, VisitWith};
-pub use syntax_pos::{
+use crate::fold::{FoldWith, VisitWith};
+pub use crate::syntax_pos::{
     hygiene, BytePos, CharPos, ExpnInfo, FileName, Globals, Loc, LocWithOpt, Mark, MultiSpan,
     SourceFile, SourceFileAndBytePos, SourceFileAndLine, Span, SpanData, SpanLinesError,
     SyntaxContext, CM, DUMMY_SP, GLOBALS, NO_EXPANSION,

--- a/common/src/rustc_data_structures/mod.rs
+++ b/common/src/rustc_data_structures/mod.rs
@@ -1,2 +1,3 @@
+#![allow(clippy::all)]
 pub mod sip128;
 pub mod stable_hasher;

--- a/common/src/rustc_data_structures/sip128.rs
+++ b/common/src/rustc_data_structures/sip128.rs
@@ -112,10 +112,10 @@ impl SipHasher128 {
     #[inline]
     fn reset(&mut self) {
         self.length = 0;
-        self.state.v0 = self.k0 ^ 0x736f6d6570736575;
-        self.state.v1 = self.k1 ^ 0x646f72616e646f6d;
-        self.state.v2 = self.k0 ^ 0x6c7967656e657261;
-        self.state.v3 = self.k1 ^ 0x7465646279746573;
+        self.state.v0 = self.k0 ^ 0x736f_6d65_7073_6575;
+        self.state.v1 = self.k1 ^ 0x646f_7261_6e64_6f6d;
+        self.state.v2 = self.k0 ^ 0x6c79_6765_6e65_7261;
+        self.state.v3 = self.k1 ^ 0x7465_6462_7974_6573;
         self.ntail = 0;
 
         // This is only done in the 128 bit version:
@@ -240,7 +240,7 @@ impl Hasher for SipHasher128 {
 
         if self.ntail != 0 {
             needed = 8 - self.ntail;
-            self.tail |= unsafe { u8to64_le(msg, 0, cmp::min(length, needed)) } << 8 * self.ntail;
+            self.tail |= unsafe { u8to64_le(msg, 0, cmp::min(length, needed)) } << (8 * self.ntail);
             if length < needed {
                 self.ntail += length;
                 return;
@@ -643,7 +643,7 @@ mod test {
     fn test_hash_idempotent() {
         let val64 = 0xdeadbeef_deadbeef_u64;
         assert_eq!(hash(&val64), hash(&val64));
-        let val32 = 0xdeadbeef_u32;
+        let val32 = 0xdead_beef_u32;
         assert_eq!(hash(&val32), hash(&val32));
     }
 
@@ -668,7 +668,7 @@ mod test {
 
     #[test]
     fn test_hash_no_bytes_dropped_32() {
-        let val = 0xdeadbeef_u32;
+        let val = 0xdead_beef_u32;
 
         assert!(hash(&val) != hash(&zero_byte(val, 0)));
         assert!(hash(&val) != hash(&zero_byte(val, 1)));
@@ -700,7 +700,7 @@ mod test {
 
     #[test]
     fn test_write_short_works() {
-        let test_usize = 0xd0c0b0a0usize;
+        let test_usize = 0xd0c0_b0a0usize;
         let mut h1 = SipHasher128::new_with_keys(0, 0);
         h1.write_usize(test_usize);
         h1.write(b"bytes");

--- a/common/src/rustc_data_structures/stable_hasher.rs
+++ b/common/src/rustc_data_structures/stable_hasher.rs
@@ -19,7 +19,7 @@ pub struct StableHasher<W> {
 }
 
 impl<W: StableHasherResult> ::std::fmt::Debug for StableHasher<W> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "{:?}", self.state)
     }
 }

--- a/common/src/source_map.rs
+++ b/common/src/source_map.rs
@@ -16,12 +16,14 @@
 //! `spans` and used pervasively in the compiler. They are absolute positions
 //! within the SourceMap, which upon request can be converted to line and column
 //! information, source code snippets, etc.
-use crate::sync::{Lock, LockGuard, MappedLockGuard};
 pub use crate::syntax_pos::{hygiene::ExpnInfo, *};
-use errors::SourceMapper;
+use crate::{
+    errors::SourceMapper,
+    rustc_data_structures::stable_hasher::StableHasher,
+    sync::{Lock, LockGuard, MappedLockGuard},
+};
 use hashbrown::HashMap;
 use log::debug;
-use rustc_data_structures::stable_hasher::StableHasher;
 use std::{
     cmp, env, fs,
     hash::Hash,
@@ -161,7 +163,7 @@ impl SourceMap {
         Ok(self.new_source_file(filename, src))
     }
 
-    pub fn files(&self) -> MappedLockGuard<Vec<Arc<SourceFile>>> {
+    pub fn files(&self) -> MappedLockGuard<'_, Vec<Arc<SourceFile>>> {
         LockGuard::map(self.files.borrow(), |files| &mut files.source_files)
     }
 

--- a/common/src/sync.rs
+++ b/common/src/sync.rs
@@ -96,7 +96,7 @@ impl<K: Eq + Hash, V: Eq, S: BuildHasher> HashMapExt<K, V> for HashMap<K, V, S> 
 }
 
 impl<T: Copy + Debug> Debug for LockCell<T> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("LockCell")
             .field("value", &self.get())
             .finish()
@@ -164,7 +164,7 @@ impl<T> Lock<T> {
     }
 
     #[inline(always)]
-    pub fn lock(&self) -> LockGuard<T> {
+    pub fn lock(&self) -> LockGuard<'_, T> {
         if ERROR_CHECKING {
             self.0.try_lock().expect("lock was already held")
         } else {
@@ -173,12 +173,12 @@ impl<T> Lock<T> {
     }
 
     #[inline(always)]
-    pub fn borrow(&self) -> LockGuard<T> {
+    pub fn borrow(&self) -> LockGuard<'_, T> {
         self.lock()
     }
 
     #[inline(always)]
-    pub fn borrow_mut(&self) -> LockGuard<T> {
+    pub fn borrow_mut(&self) -> LockGuard<'_, T> {
         self.lock()
     }
 }
@@ -208,7 +208,7 @@ impl<T> RwLock<T> {
     }
 
     #[inline(always)]
-    pub fn read(&self) -> ReadGuard<T> {
+    pub fn read(&self) -> ReadGuard<'_, T> {
         if ERROR_CHECKING {
             self.0.try_read().expect("lock was already held")
         } else {
@@ -217,7 +217,7 @@ impl<T> RwLock<T> {
     }
 
     #[inline(always)]
-    pub fn borrow(&self) -> ReadGuard<T> {
+    pub fn borrow(&self) -> ReadGuard<'_, T> {
         self.read()
     }
 }

--- a/common/src/syntax_pos/hygiene.rs
+++ b/common/src/syntax_pos/hygiene.rs
@@ -527,7 +527,7 @@ impl SyntaxContext {
 }
 
 impl fmt::Debug for SyntaxContext {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "#{}", self.0)
     }
 }

--- a/common/src/syntax_pos/mod.rs
+++ b/common/src/syntax_pos/mod.rs
@@ -2,8 +2,7 @@ pub use self::{
     hygiene::{ExpnInfo, Mark, SyntaxContext},
     span_encoding::{Span, DUMMY_SP},
 };
-use crate::{sync::Lock, SourceMap};
-use rustc_data_structures::stable_hasher::StableHasher;
+use crate::{rustc_data_structures::stable_hasher::StableHasher, sync::Lock, SourceMap};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
@@ -76,7 +75,7 @@ pub enum FileName {
 }
 
 impl std::fmt::Display for FileName {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
             FileName::Real(ref path) => write!(fmt, "{}", path.display()),
             FileName::Macros(ref name) => write!(fmt, "<{} macros>", name),
@@ -453,7 +452,7 @@ impl Default for Span {
     }
 }
 
-fn default_span_debug(span: Span, f: &mut fmt::Formatter) -> fmt::Result {
+fn default_span_debug(span: Span, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let span = span.data();
     f.debug_struct("Span")
         .field("lo", &span.lo)
@@ -463,13 +462,13 @@ fn default_span_debug(span: Span, f: &mut fmt::Formatter) -> fmt::Result {
 }
 
 impl fmt::Debug for Span {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         SPAN_DEBUG.with(|span_debug| span_debug.get()(*self, f))
     }
 }
 
 impl fmt::Debug for SpanData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         SPAN_DEBUG.with(|span_debug| span_debug.get()(Span::new(self.lo, self.hi, self.ctxt), f))
     }
 }
@@ -694,7 +693,7 @@ pub struct SourceFile {
 }
 
 impl fmt::Debug for SourceFile {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "SourceFile({})", self.name)
     }
 }
@@ -748,7 +747,7 @@ impl SourceFile {
 
     /// Get a line from the list of pre-computed line-beginnings.
     /// The line number here is 0-based.
-    pub fn get_line(&self, line_number: usize) -> Option<Cow<str>> {
+    pub fn get_line(&self, line_number: usize) -> Option<Cow<'_, str>> {
         fn get_until_newline(src: &str, begin: usize) -> &str {
             // We can't use `lines.get(line_number+1)` because we might
             // be parsing when we call this function and thus the current
@@ -990,7 +989,7 @@ pub struct FileLines {
     pub lines: Vec<LineInfo>,
 }
 
-thread_local!(pub static SPAN_DEBUG: Cell<fn(Span, &mut fmt::Formatter) -> fmt::Result> =
+thread_local!(pub static SPAN_DEBUG: Cell<fn(Span, &mut fmt::Formatter<'_>) -> fmt::Result> =
                 Cell::new(default_span_debug));
 
 // _____________________________________________________________________________

--- a/common/src/syntax_pos/mod.rs
+++ b/common/src/syntax_pos/mod.rs
@@ -789,7 +789,7 @@ impl SourceFile {
     /// number. If the source_file is empty or the position is located before
     /// the first line, None is returned.
     pub fn lookup_line(&self, pos: BytePos) -> Option<usize> {
-        if self.lines.len() == 0 {
+        if self.lines.is_empty() {
             return None;
         }
 

--- a/common/src/syntax_pos/mod.rs
+++ b/common/src/syntax_pos/mod.rs
@@ -250,7 +250,7 @@ impl Span {
     ///
     /// Use this instead of `==` when either span could be generated code,
     /// and you only care that they point to the same bytes of source text.
-    pub fn source_equal(&self, other: &Span) -> bool {
+    pub fn source_equal(self, other: Span) -> bool {
         let span = self.data();
         let other = other.data();
         span.lo == other.lo && span.hi == other.hi
@@ -301,7 +301,7 @@ impl Span {
     /// Check if a span is "internal" to a macro in which #[unstable]
     /// items can be used (that is, a macro marked with
     /// `#[allow_internal_unstable]`).
-    pub fn allows_unstable(&self) -> bool {
+    pub fn allows_unstable(self) -> bool {
         match self.ctxt().outer().expn_info() {
             Some(info) => info.allow_internal_unstable,
             None => false,
@@ -621,15 +621,15 @@ impl NonNarrowChar {
     }
 
     /// Returns the absolute offset of the character in the SourceMap
-    pub fn pos(&self) -> BytePos {
-        match *self {
+    pub fn pos(self) -> BytePos {
+        match self {
             NonNarrowChar::ZeroWidth(p) | NonNarrowChar::Wide(p) | NonNarrowChar::Tab(p) => p,
         }
     }
 
     /// Returns the width of the character, 0 (zero-width) or 2 (wide)
-    pub fn width(&self) -> usize {
-        match *self {
+    pub fn width(self) -> usize {
+        match self {
             NonNarrowChar::ZeroWidth(_) => 0,
             NonNarrowChar::Wide(_) => 2,
             NonNarrowChar::Tab(_) => 4,

--- a/common/src/syntax_pos/span_encoding.rs
+++ b/common/src/syntax_pos/span_encoding.rs
@@ -14,7 +14,7 @@
 // The encoding format for inline spans were obtained by optimizing over crates
 // in rustc/libstd. See https://internals.rust-lang.org/t/rfc-compiler-refactoring-spans/1357/28
 use super::hygiene::SyntaxContext;
-use crate::syntax_pos::CM;
+use crate::syntax_pos::{BytePos, SpanData, CM, GLOBALS};
 use hashbrown::HashMap;
 use serde::{
     de::Deserializer,
@@ -22,9 +22,6 @@ use serde::{
     Deserialize, Serialize,
 };
 use std::hash::{Hash, Hasher};
-use BytePos;
-use SpanData;
-use GLOBALS;
 
 /// A compressed span.
 /// Contains either fields of `SpanData` inline if they are small, or index into

--- a/common/src/syntax_pos/span_encoding.rs
+++ b/common/src/syntax_pos/span_encoding.rs
@@ -125,13 +125,14 @@ pub const DUMMY_SP: Span = Span(0);
 impl Span {
     #[inline]
     pub fn new(lo: BytePos, hi: BytePos, ctxt: SyntaxContext) -> Self {
-        encode(&match lo <= hi {
-            true => SpanData { lo, hi, ctxt },
-            false => SpanData {
+        encode(&if lo <= hi {
+            SpanData { lo, hi, ctxt }
+        } else {
+            SpanData {
                 lo: hi,
                 hi: lo,
                 ctxt,
-            },
+            }
         })
     }
 

--- a/common/tests/fold_and_then.rs
+++ b/common/tests/fold_and_then.rs
@@ -6,7 +6,6 @@
 
 #[macro_use]
 extern crate swc_common;
-extern crate test;
 
 use std::{cell::RefCell, rc::Rc};
 use swc_common::{Fold, FoldWith};

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/swc-project/swc.git"
 documentation = "https://swc-project.github.io/rustdoc/swc_ecmascript/"
 description = "Ecmascript"
 publish = false
+edition = "2018"
 
 [dependencies]
 swc_ecma_ast = { path ="./ast" }

--- a/ecmascript/ast/benches/serde.rs
+++ b/ecmascript/ast/benches/serde.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 
-extern crate serde_json;
-extern crate swc_ecma_ast;
+use serde_json;
+
 extern crate test;
 
 use swc_ecma_ast::Module;

--- a/ecmascript/ast/src/expr.rs
+++ b/ecmascript/ast/src/expr.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::vec_box)]
 use crate::{
     class::Class,
     function::Function,
@@ -157,7 +158,7 @@ pub struct ArrayLit {
     pub span: Span,
 
     #[serde(default, rename = "elements", skip_serializing_if = "Vec::is_empty")]
-    pub elems: Vec<(Option<ExprOrSpread>)>,
+    pub elems: Vec<Option<ExprOrSpread>>,
 }
 
 /// Object literal.
@@ -315,7 +316,7 @@ pub struct NewExpr {
     pub callee: Box<Expr>,
 
     #[serde(default, rename = "arguments")]
-    pub args: Option<(Vec<ExprOrSpread>)>,
+    pub args: Option<Vec<ExprOrSpread>>,
 
     #[serde(default, rename = "typeArguments")]
     pub type_args: Option<TsTypeParamInstantiation>,

--- a/ecmascript/ast/src/expr.rs
+++ b/ecmascript/ast/src/expr.rs
@@ -119,7 +119,7 @@ pub enum Expr {
     JSXEmpty(JSXEmptyExpr),
 
     #[tag("JSXElement")]
-    JSXElement(JSXElement),
+    JSXElement(Box<JSXElement>),
 
     #[tag("JSXFragment")]
     JSXFragment(JSXFragment),

--- a/ecmascript/ast/src/lib.rs
+++ b/ecmascript/ast/src/lib.rs
@@ -6,14 +6,11 @@
 #![deny(unreachable_pub)]
 #![deny(variant_size_differences)]
 
-extern crate enum_kind;
-extern crate serde;
+use serde;
 #[macro_use]
 extern crate string_enum;
-#[cfg(test)]
-extern crate serde_json;
-extern crate swc_atoms;
-extern crate swc_common;
+
+use swc_common;
 
 pub use self::{
     class::{

--- a/ecmascript/ast/src/lib.rs
+++ b/ecmascript/ast/src/lib.rs
@@ -6,11 +6,8 @@
 #![deny(unreachable_pub)]
 #![deny(variant_size_differences)]
 
-use serde;
 #[macro_use]
 extern crate string_enum;
-
-use swc_common;
 
 pub use self::{
     class::{

--- a/ecmascript/ast/src/lit.rs
+++ b/ecmascript/ast/src/lit.rs
@@ -75,7 +75,7 @@ pub struct Number {
 }
 
 impl Display for Number {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         if self.value.is_infinite() {
             if self.value.is_sign_positive() {
                 Display::fmt("Infinity", f)

--- a/ecmascript/ast/src/pat.rs
+++ b/ecmascript/ast/src/pat.rs
@@ -28,7 +28,7 @@ pub struct ArrayPat {
     pub span: Span,
 
     #[serde(rename = "elements")]
-    pub elems: Vec<(Option<Pat>)>,
+    pub elems: Vec<Option<Pat>>,
 
     #[serde(
         default,

--- a/ecmascript/ast/src/stmt.rs
+++ b/ecmascript/ast/src/stmt.rs
@@ -140,7 +140,7 @@ pub struct IfStmt {
     pub cons: Box<Stmt>,
 
     #[serde(default, rename = "alternate", skip_serializing_if = "Option::is_none")]
-    pub alt: Option<(Box<Stmt>)>,
+    pub alt: Option<Box<Stmt>>,
 }
 
 #[ast_node("SwitchStatement")]

--- a/ecmascript/ast/src/typescript.rs
+++ b/ecmascript/ast/src/typescript.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::vec_box)]
 #![allow(missing_copy_implementations)]
 use crate::{
     class::Decorator,
@@ -559,7 +560,7 @@ impl<'de> Deserialize<'de> for TruePlusMinus {
 
         impl<'de> Visitor<'de> for TruePlusMinusVisitor {
             type Value = TruePlusMinus;
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("one of '+', '-', true")
             }
 

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
 documentation = "https://swc-project.github.io/rustdoc/swc_ecma_codegen/"
 description = "Ecmascript code generator for the swc project."
+edition = "2018"
 
 [dependencies]
 bitflags = "1"

--- a/ecmascript/codegen/benches/bench.rs
+++ b/ecmascript/codegen/benches/bench.rs
@@ -1,12 +1,9 @@
 #![feature(box_syntax)]
 #![feature(test)]
 
-extern crate sourcemap;
-extern crate swc_common;
-extern crate swc_ecma_codegen;
-extern crate swc_ecma_parser;
+use swc_ecma_codegen;
+
 extern crate test;
-extern crate testing;
 
 use sourcemap::SourceMapBuilder;
 use swc_common::FileName;

--- a/ecmascript/codegen/benches/bench.rs
+++ b/ecmascript/codegen/benches/bench.rs
@@ -103,7 +103,6 @@ fn emit_colors(b: &mut Bencher) {
             .parse_module()
             .map_err(|mut e| {
                 e.emit();
-                ()
             })
             .unwrap();
 

--- a/ecmascript/codegen/macros/Cargo.toml
+++ b/ecmascript/codegen/macros/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
 documentation = "https://swc-project.github.io/rustdoc/swc_ecma_codegen_macros/"
 description = "Macros for swc_ecma_codegen."
-
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/ecmascript/codegen/macros/src/fold.rs
+++ b/ecmascript/codegen/macros/src/fold.rs
@@ -33,9 +33,8 @@ fn get_joinned_span(t: &dyn ToTokens) -> Span {
     let tts: TokenStream = t.dump();
     let mut first = None;
     for tt in tts {
-        match first {
-            None => first = Some(tt.span()),
-            _ => {}
+        if first.is_none() {
+            first = Some(tt.span());
         }
 
         // last = Some(tt.span());

--- a/ecmascript/codegen/macros/src/lib.rs
+++ b/ecmascript/codegen/macros/src/lib.rs
@@ -36,8 +36,7 @@ fn expand(i: ImplItemMethod) -> ImplItemMethod {
                 .inputs
                 .clone()
                 .into_iter()
-                .skip(1)
-                .next()
+                .nth(1)
                 .and_then(|arg| match arg {
                     FnArg::Ignored(ty) | FnArg::Captured(ArgCaptured { ty, .. }) => Some(ty),
                     _ => None,

--- a/ecmascript/codegen/macros/src/lib.rs
+++ b/ecmascript/codegen/macros/src/lib.rs
@@ -1,11 +1,11 @@
 #[macro_use]
 extern crate pmutil;
 extern crate proc_macro;
-extern crate proc_macro2;
+use proc_macro2;
 #[macro_use]
 extern crate quote;
-extern crate swc_macros_common;
-extern crate syn;
+
+use syn;
 
 use pmutil::{Quote, ToTokensExt};
 use proc_macro::TokenStream;
@@ -68,8 +68,8 @@ fn (&mut self, node: Node) -> Result;
                 {
                     {
                         const _FOO: () = {
-                            impl ::Node for NodeType {
-                                fn emit_with(&self, e: &mut ::Emitter) -> Result {
+                            impl crate::Node for NodeType {
+                                fn emit_with(&self, e: &mut crate::Emitter) -> Result {
                                     e.mtd_name(self)
                                 }
                             }

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -3,15 +3,9 @@
 
 #[macro_use]
 extern crate bitflags;
-extern crate sourcemap;
-extern crate swc_atoms;
-extern crate swc_ecma_codegen_macros;
+
 #[macro_use]
 extern crate swc_common;
-extern crate hashbrown;
-extern crate swc_ecma_ast;
-#[cfg(test)]
-extern crate testing;
 
 pub use self::config::Config;
 use self::{
@@ -49,15 +43,15 @@ pub trait Handlers {
 }
 
 pub trait Node: Spanned {
-    fn emit_with(&self, e: &mut Emitter) -> Result;
+    fn emit_with(&self, e: &mut Emitter<'_>) -> Result;
 }
 impl<N: Node> Node for Box<N> {
-    fn emit_with(&self, e: &mut Emitter) -> Result {
+    fn emit_with(&self, e: &mut Emitter<'_>) -> Result {
         (**self).emit_with(e)
     }
 }
 impl<'a, N: Node> Node for &'a N {
-    fn emit_with(&self, e: &mut Emitter) -> Result {
+    fn emit_with(&self, e: &mut Emitter<'_>) -> Result {
         (**self).emit_with(e)
     }
 }
@@ -2004,7 +1998,7 @@ impl<N> Node for Option<N>
 where
     N: Node,
 {
-    fn emit_with(&self, e: &mut Emitter) -> Result {
+    fn emit_with(&self, e: &mut Emitter<'_>) -> Result {
         match *self {
             Some(ref n) => n.emit_with(e),
             None => Ok(()),

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -80,7 +80,7 @@ impl<'a> Emitter<'a> {
                 stmts
                     .last()
                     .map(|s| s.span().hi())
-                    .unwrap_or(stmts[0].span().lo()),
+                    .unwrap_or_else(|| stmts[0].span().lo()),
             )
         };
 
@@ -1200,6 +1200,7 @@ impl<'a> Emitter<'a> {
         )
     }
 
+    #[allow(clippy::cognitive_complexity)]
     pub fn emit_list5<N: Node>(
         &mut self,
         parent_node: Span,

--- a/ecmascript/codegen/src/macros.rs
+++ b/ecmascript/codegen/src/macros.rs
@@ -20,7 +20,7 @@ macro_rules! opt {
 
 macro_rules! emit {
     ($emitter:expr, $e:expr) => {{
-        ::Node::emit_with(&$e, $emitter)?;
+        crate::Node::emit_with(&$e, $emitter)?;
     }};
 }
 

--- a/ecmascript/codegen/src/tests.rs
+++ b/ecmascript/codegen/src/tests.rs
@@ -67,16 +67,10 @@ fn parse_then_emit(from: &str, cfg: Config) -> String {
             );
             parser.parse_module().map_err(|mut e| {
                 e.emit();
-                ()
             })?
         };
 
-        let out = Builder {
-            cfg,
-            cm: cm.clone(),
-            comments,
-        }
-        .text(from, |e| e.emit_module(&res).unwrap());
+        let out = Builder { cfg, cm, comments }.text(from, |e| e.emit_module(&res).unwrap());
         Ok(out)
     })
     .unwrap()

--- a/ecmascript/codegen/src/tests.rs
+++ b/ecmascript/codegen/src/tests.rs
@@ -1,4 +1,3 @@
-extern crate swc_ecma_parser;
 use self::swc_ecma_parser::{Parser, Session, SourceFileInput, Syntax};
 use super::*;
 use crate::config::Config;
@@ -8,6 +7,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 use swc_common::{comments::Comments, FileName, SourceMap};
+use swc_ecma_parser;
 
 struct Noop;
 impl Handlers for Noop {}
@@ -21,7 +21,7 @@ struct Builder {
 impl Builder {
     pub fn with<F, Ret>(self, src: &str, s: &mut Vec<u8>, op: F) -> Ret
     where
-        F: FnOnce(&mut Emitter) -> Ret,
+        F: FnOnce(&mut Emitter<'_>) -> Ret,
     {
         let mut e = Emitter {
             cfg: self.cfg,
@@ -39,7 +39,7 @@ impl Builder {
 
     pub fn text<F>(self, src: &str, op: F) -> String
     where
-        F: FnOnce(&mut Emitter),
+        F: FnOnce(&mut Emitter<'_>),
     {
         let mut buf = vec![];
 
@@ -182,7 +182,7 @@ impl Write for Buf {
 struct DebugUsingDisplay<'a>(&'a str);
 
 impl<'a> Debug for DebugUsingDisplay<'a> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Display::fmt(self.0, f)
     }
 }

--- a/ecmascript/codegen/src/text_writer/basic_impl.rs
+++ b/ecmascript/codegen/src/text_writer/basic_impl.rs
@@ -89,7 +89,7 @@ impl<'a, W: Write> JsWriter<'a, W> {
             }};
         }
 
-        if data.len() > 0 {
+        if !data.is_empty() {
             if let Some(span) = span {
                 if !span.is_dummy() {
                     srcmap!(span.lo())

--- a/ecmascript/codegen/src/text_writer/basic_impl.rs
+++ b/ecmascript/codegen/src/text_writer/basic_impl.rs
@@ -67,24 +67,21 @@ impl<'a, W: Write> JsWriter<'a, W> {
 
         macro_rules! srcmap {
             ($byte_pos:expr) => {{
-                match self.srcmap {
-                    Some(ref mut srcmap) => {
-                        let loc = self.cm.lookup_char_pos($byte_pos);
+                if let Some(ref mut srcmap) = self.srcmap {
+                    let loc = self.cm.lookup_char_pos($byte_pos);
 
-                        let src = match loc.file.name {
-                            FileName::Real(ref p) => Some(p.display().to_string()),
-                            _ => None,
-                        };
-                        srcmap.add(
-                            self.line_count as _,
-                            self.line_pos as _,
-                            (loc.line - 1) as _,
-                            loc.col.0 as _,
-                            src.as_ref().map(|s| &**s),
-                            None,
-                        );
-                    }
-                    _ => {}
+                    let src = match loc.file.name {
+                        FileName::Real(ref p) => Some(p.display().to_string()),
+                        _ => None,
+                    };
+                    srcmap.add(
+                        self.line_count as _,
+                        self.line_pos as _,
+                        (loc.line - 1) as _,
+                        loc.col.0 as _,
+                        src.as_ref().map(|s| &**s),
+                        None,
+                    );
                 }
             }};
         }

--- a/ecmascript/codegen/src/util.rs
+++ b/ecmascript/codegen/src/util.rs
@@ -86,9 +86,9 @@ pub trait SourceMapperExt {
                 return first_child.starts_on_new_line(format);
             }
 
-            return !self.is_on_same_line(parent_node.lo(), first_child.lo());
+            !self.is_on_same_line(parent_node.lo(), first_child.lo())
         } else {
-            return false;
+            false
         }
     }
 
@@ -113,12 +113,12 @@ pub trait SourceMapperExt {
 
             let last_child = children[children.len() - 1].span();
             if parent_node.is_synthesized() || last_child.is_synthesized() {
-                return last_child.starts_on_new_line(format);
+                last_child.starts_on_new_line(format)
             } else {
-                return !self.is_on_same_line(parent_node.hi(), last_child.hi());
+                !self.is_on_same_line(parent_node.hi(), last_child.hi())
             }
         } else {
-            return false;
+            false
         }
     }
 }
@@ -173,7 +173,7 @@ impl StartsWithAlphaNum for Expr {
             Expr::Assign(AssignExpr { ref left, .. }) => left.starts_with_alpha_num(),
 
             Expr::Bin(BinExpr { ref left, .. }) | Expr::Cond(CondExpr { test: ref left, .. }) => {
-                return left.starts_with_alpha_num();
+                left.starts_with_alpha_num()
             }
             Expr::Call(CallExpr {
                 callee: ref left, ..
@@ -252,7 +252,7 @@ impl StartsWithAlphaNum for ExprOrSuper {
     fn starts_with_alpha_num(&self) -> bool {
         match *self {
             ExprOrSuper::Super(_) => true,
-            ExprOrSuper::Expr(ref e) => return e.starts_with_alpha_num(),
+            ExprOrSuper::Expr(ref e) => e.starts_with_alpha_num(),
         }
     }
 }

--- a/ecmascript/codegen/tests/test262.rs
+++ b/ecmascript/codegen/tests/test262.rs
@@ -1,13 +1,11 @@
 #![feature(box_syntax)]
 #![feature(specialization)]
 #![feature(test)]
-extern crate sourcemap;
-extern crate swc_common;
-extern crate swc_ecma_ast;
-extern crate swc_ecma_codegen;
-extern crate swc_ecma_parser;
+
+use swc_ecma_codegen;
+
 extern crate test;
-extern crate testing;
+
 use std::{
     env,
     fs::{read_dir, File},
@@ -150,7 +148,7 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
 
                 let comments = Comments::default();
                 let handlers = box MyHandlers;
-                let mut parser: Parser<Lexer<SourceFileInput>> = Parser::new(
+                let mut parser: Parser<'_, Lexer<'_, SourceFileInput<'_>>> = Parser::new(
                     Session { handler: &handler },
                     Syntax::default(),
                     (&*src).into(),

--- a/ecmascript/codegen/tests/test262.rs
+++ b/ecmascript/codegen/tests/test262.rs
@@ -162,10 +162,7 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                         cfg: Default::default(),
                         cm: cm.clone(),
                         wr: box swc_ecma_codegen::text_writer::JsWriter::new(
-                            cm.clone(),
-                            "\n",
-                            &mut wr,
-                            None,
+                            cm, "\n", &mut wr, None,
                         ),
                         comments: Some(&comments),
                         handlers,
@@ -177,14 +174,12 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                         emitter
                             .emit_module(&parser.parse_module().map_err(|mut e| {
                                 e.emit();
-                                ()
                             })?)
                             .unwrap();
                     } else {
                         emitter
                             .emit_script(&parser.parse_script().map_err(|mut e| {
                                 e.emit();
-                                ()
                             })?)
                             .unwrap();
                     }

--- a/ecmascript/lints/src/lib.rs
+++ b/ecmascript/lints/src/lib.rs
@@ -1,8 +1,5 @@
 #![feature(specialization)]
 
-extern crate swc_common;
-extern crate swc_ecma_ast;
-
 mod with;
 
 use swc_common::{errors::Handler, VisitWith};

--- a/ecmascript/lints/tests/golden.rs
+++ b/ecmascript/lints/tests/golden.rs
@@ -1,12 +1,9 @@
 #![feature(box_syntax)]
 #![feature(test)]
 
-extern crate swc_common;
 extern crate swc_ecma_lints as lints;
 extern crate swc_ecma_parser as parser;
 extern crate test;
-extern crate testing;
-extern crate walkdir;
 
 use self::{
     parser::{SourceFileInput, Syntax},
@@ -104,7 +101,6 @@ fn add_golden_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                     .parse_module()
                     .map_err(|mut e| {
                         e.emit();
-                        ()
                     })?
                 };
 

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
 documentation = "https://swc-project.github.io/rustdoc/swc_ecma_parser/"
 description = "Feature-complete es2019 parser."
+edition = "2018"
 
 [features]
 default = []

--- a/ecmascript/parser/benches/bench.rs
+++ b/ecmascript/parser/benches/bench.rs
@@ -1,9 +1,6 @@
 #![feature(test)]
 
-extern crate swc_common;
-extern crate swc_ecma_parser;
 extern crate test;
-extern crate testing;
 
 use swc_common::FileName;
 use swc_ecma_parser::{Parser, Session, SourceFileInput, Syntax};

--- a/ecmascript/parser/examples/lexer.rs
+++ b/ecmascript/parser/examples/lexer.rs
@@ -1,5 +1,4 @@
-extern crate swc_common;
-extern crate swc_ecma_parser;
+use swc_common;
 
 use std::sync::Arc;
 use swc_common::{

--- a/ecmascript/parser/examples/lexer.rs
+++ b/ecmascript/parser/examples/lexer.rs
@@ -40,7 +40,6 @@ fn main() {
             .parse_module()
             .map_err(|mut e| {
                 e.emit();
-                ()
             })
             .expect("failed to parser module");
 

--- a/ecmascript/parser/macros/Cargo.toml
+++ b/ecmascript/parser/macros/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
 documentation = "https://swc-project.github.io/rustdoc/swc_ecma_parser_macros/"
 description = "Macros for swc_ecma_parser."
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/ecmascript/parser/macros/src/expand.rs
+++ b/ecmascript/parser/macros/src/expand.rs
@@ -36,7 +36,7 @@ fn get_joinned_span(t: &dyn ToTokens) -> Span {
 
 #[cfg(not(procmacro2_semver_exempt))]
 fn get_joinned_span(t: &dyn ToTokens) -> Span {
-    let tts: TokenStream = t.dump().into();
+    let tts: TokenStream = t.dump();
     let mut first = None;
     for tt in tts {
         match first {
@@ -131,35 +131,35 @@ impl Fold for InjectSelf {
         let span = get_joinned_span(&i.path);
 
         match &*name {
-            "smallvec" | "vec" | "unreachable" | "tok" | "op" | "js_word" => return i,
+            "smallvec" | "vec" | "unreachable" | "tok" | "op" | "js_word" => i,
             "println" | "print" | "format" | "assert" | "assert_eq" | "assert_ne"
             | "debug_assert" | "debug_assert_eq" | "debug_assert_ne" | "dbg" => {
-                let mut args: Punctuated<Expr, token::Comma> = parse_args(i.tts.into());
+                let mut args: Punctuated<Expr, token::Comma> = parse_args(i.tts);
                 args = args
                     .into_pairs()
                     .map(|el| el.map_item(|expr| self.fold_expr(expr)))
                     .collect();
-                return Macro {
-                    tts: args.dump().into(),
+                Macro {
+                    tts: args.dump(),
                     ..i
-                };
+                }
             }
 
-            "trace" | "debug" | "info" | "warn" | "error" | "macro_rules" | "wrap" => return i,
+            "trace" | "debug" | "info" | "warn" | "error" | "macro_rules" | "wrap" => i,
             //TODO
-            "unimplemented" => return i,
+            "unimplemented" => i,
 
             "spanned" => {
                 let block: Block =
                     parse(i.tts.into()).expect("failed to parse input to spanned as a block");
                 let block = self.fold_block(block);
-                return Macro {
-                    tts: TokenStream::from(quote_spanned!(span => #parser, ))
+                Macro {
+                    tts: quote_spanned!(span => #parser, )
                         .into_iter()
-                        .chain(TokenStream::from(block.dump()))
+                        .chain(block.dump())
                         .collect(),
                     ..i
-                };
+                }
             }
 
             //TODO: Collect expect and give that list to unexpected
@@ -168,22 +168,22 @@ impl Fold for InjectSelf {
             | "peek" | "peek_ahead" | "last_pos" | "return_if_arrow" | "span" | "syntax_error"
             | "unexpected" => {
                 let tts = if i.tts.is_empty() {
-                    quote_spanned!(span => #parser).into()
+                    quote_spanned!(span => #parser)
                 } else {
-                    let args: Punctuated<Expr, token::Comma> = parse_args(i.tts.into());
+                    let args: Punctuated<Expr, token::Comma> = parse_args(i.tts);
                     let args = args
                         .into_pairs()
                         .map(|el| el.map_item(|expr| self.fold_expr(expr)))
                         .map(|arg| arg.dump())
-                        .flat_map(|t| TokenStream::from(t));
+                        .flatten();
 
-                    TokenStream::from(quote_spanned!(span => #parser,))
+                    quote_spanned!(span => #parser,)
                         .into_iter()
                         .chain(args)
                         .collect()
                 };
 
-                return Macro { tts, ..i };
+                Macro { tts, ..i }
             }
             _ => {
                 unimplemented!("Macro: {:#?}", i);

--- a/ecmascript/parser/macros/src/expand.rs
+++ b/ecmascript/parser/macros/src/expand.rs
@@ -9,9 +9,7 @@ use syn::{
 };
 
 pub fn expand(_attr: TokenStream, item: Item) -> Item {
-    let item = InjectSelf { parser: None }.fold_item(item);
-
-    item
+    InjectSelf { parser: None }.fold_item(item)
 }
 
 struct InjectSelf {
@@ -39,9 +37,8 @@ fn get_joinned_span(t: &dyn ToTokens) -> Span {
     let tts: TokenStream = t.dump();
     let mut first = None;
     for tt in tts {
-        match first {
-            None => first = Some(tt.span()),
-            _ => {}
+        if first.is_none() {
+            first = Some(tt.span());
         }
 
         // last = Some(tt.span());

--- a/ecmascript/parser/macros/src/lib.rs
+++ b/ecmascript/parser/macros/src/lib.rs
@@ -5,13 +5,12 @@
 //! rust does not support token munching (destructing `$b:block` into `{
 //! $($t:tt)* }`).
 
-extern crate pmutil;
 extern crate proc_macro;
-extern crate proc_macro2;
+
 #[macro_use]
 extern crate quote;
-extern crate swc_macros_common;
-extern crate syn;
+
+use syn;
 
 use pmutil::ToTokensExt;
 use proc_macro::TokenStream;

--- a/ecmascript/parser/src/error.rs
+++ b/ecmascript/parser/src/error.rs
@@ -27,7 +27,7 @@ impl<'a> From<Eof<'a>> for DiagnosticBuilder<'a> {
 }
 
 impl<'a> Debug for Eof<'a> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Debug::fmt("<eof>", f)
     }
 }

--- a/ecmascript/parser/src/lexer/jsx.rs
+++ b/ecmascript/parser/src/lexer/jsx.rs
@@ -98,15 +98,11 @@ impl<'a, I: Input> Lexer<'a, I> {
                         if HEX_NUMBER.is_match(&s[2..]) {
                             return from_code(&s[2..], 16);
                         }
-                    } else {
-                        if DECIMAL_NUMBER.is_match(&s[1..]) {
-                            return from_code(&s[1..], 10);
-                        }
+                    } else if DECIMAL_NUMBER.is_match(&s[1..]) {
+                        return from_code(&s[1..], 10);
                     }
-                } else {
-                    if let Some(entity) = xhtml(&s) {
-                        return Ok(entity);
-                    }
+                } else if let Some(entity) = xhtml(&s) {
+                    return Ok(entity);
                 }
                 break;
             }
@@ -137,7 +133,7 @@ impl<'a, I: Input> Lexer<'a, I> {
         self.state.cur_line += 1;
         self.state.line_start = cur_pos;
 
-        return Ok(out);
+        Ok(out)
     }
 
     pub(super) fn read_jsx_str(&mut self, quote: char) -> LexResult<Token> {
@@ -189,10 +185,10 @@ impl<'a, I: Input> Lexer<'a, I> {
         let cur_pos = self.input.cur_pos();
         out.push_str(self.input.slice(chunk_start, cur_pos));
         self.input.bump();
-        return Ok(Token::Str {
+        Ok(Token::Str {
             value: out.into(),
             has_escape,
-        });
+        })
     }
 
     /// Read a JSX identifier (valid tag or attribute name).

--- a/ecmascript/parser/src/lexer/number.rs
+++ b/ecmascript/parser/src/lexer/number.rs
@@ -308,7 +308,7 @@ mod tests {
 
     fn lex<F, Ret>(s: &'static str, f: F) -> Ret
     where
-        F: FnOnce(&mut Lexer<SourceFileInput>) -> Ret,
+        F: FnOnce(&mut Lexer<'_, SourceFileInput<'_>>) -> Ret,
     {
         crate::with_test_sess(s, |sess, fm| {
             let mut l = Lexer::new(sess, Syntax::default(), fm, None);
@@ -414,11 +414,8 @@ mod tests {
                 assert_eq!(vec.len(), 1);
                 let token = vec.into_iter().next().unwrap();
                 assert_eq!(Num(expected), token);
-            } else {
-                match vec {
-                    Ok(vec) => assert_ne!(vec![Num(expected)], vec),
-                    _ => {}
-                }
+            } else if let Ok(vec) = vec {
+                assert_ne!(vec![Num(expected)], vec)
             }
         }
     }

--- a/ecmascript/parser/src/lexer/number.rs
+++ b/ecmascript/parser/src/lexer/number.rs
@@ -139,7 +139,7 @@ impl<'a, I: Input> Lexer<'a, I> {
         );
         debug_assert_eq!(self.cur(), Some('0'));
 
-        let start = self.bump(); // 0
+        self.bump(); // 0
         self.bump(); // x
 
         let val = self.read_number_no_dot(radix)?;
@@ -292,12 +292,12 @@ impl<'a, I: Input> Lexer<'a, I> {
 
     fn make_legacy_octal(&mut self, start: BytePos, val: f64) -> LexResult<f64> {
         self.ensure_not_ident()?;
-        return if self.ctx.strict {
+        if self.ctx.strict {
             self.error(start, SyntaxError::LegacyOctal)?
         } else {
             // FIXME
             Ok(val)
-        };
+        }
     }
 }
 
@@ -311,14 +311,14 @@ mod tests {
         F: FnOnce(&mut Lexer<SourceFileInput>) -> Ret,
     {
         crate::with_test_sess(s, |sess, fm| {
-            let mut l = Lexer::new(sess, Syntax::default(), fm.into(), None);
+            let mut l = Lexer::new(sess, Syntax::default(), fm, None);
             Ok(f(&mut l))
         })
         .unwrap()
     }
 
     fn num(s: &'static str) -> f64 {
-        lex(s, |l| l.read_number(s.starts_with(".")).unwrap())
+        lex(s, |l| l.read_number(s.starts_with('.')).unwrap())
     }
 
     fn int(radix: u8, s: &'static str) -> u32 {
@@ -346,7 +346,7 @@ mod tests {
     #[ignore]
     fn num_big_many_zero() {
         assert_eq!(
-            1000000000000000000000000000000f64,
+            1_000_000_000_000_000_000_000_000_000_000f64,
             num("1000000000000000000000000000000")
         )
     }

--- a/ecmascript/parser/src/lexer/state.rs
+++ b/ecmascript/parser/src/lexer/state.rs
@@ -316,7 +316,7 @@ impl State {
         };
 
         if is_next_keyword && prev == Some(TokenType::Dot) {
-            return false;
+            false
         } else {
             // ported updateContext
             match *next {
@@ -345,7 +345,7 @@ impl State {
                     }
 
                     // expression cannot follow expression
-                    return !out.is_expr();
+                    !out.is_expr()
                 }
 
                 tok!("function") => {
@@ -356,7 +356,7 @@ impl State {
                     {
                         context.push(TokenContext::FnExpr);
                     }
-                    return false;
+                    false
                 }
 
                 // for (a of b) {}
@@ -371,7 +371,7 @@ impl State {
 
                 Word(Word::Ident(ref ident)) => {
                     // variable declaration
-                    return match prev {
+                    match prev {
                         Some(prev) => match prev {
                             // handle automatic semicolon insertion.
                             TokenType::Keyword(Let)
@@ -384,7 +384,7 @@ impl State {
                             _ => false,
                         },
                         _ => false,
-                    };
+                    }
                 }
 
                 tok!('{') => {
@@ -414,7 +414,7 @@ impl State {
 
                 tok!("${") => {
                     context.push(TokenContext::TplQuasi);
-                    return true;
+                    true
                 }
 
                 tok!('(') => {
@@ -428,7 +428,7 @@ impl State {
                         },
                         _ => TokenContext::ParenExpr,
                     });
-                    return true;
+                    true
                 }
 
                 // remains unchanged.
@@ -441,14 +441,14 @@ impl State {
                     } else {
                         context.push(TokenContext::Tpl { start });
                     }
-                    return false;
+                    false
                 }
 
                 // tt.jsxTagStart.updateContext
                 Token::JSXTagStart => {
                     context.push(TokenContext::JSXExpr); // treat as beginning of JSX expression
                     context.push(TokenContext::JSXOpeningTag); // start opening tag context
-                    return false;
+                    false
                 }
 
                 // tt.jsxTagEnd.updateContext
@@ -459,15 +459,13 @@ impl State {
                         || out == Some(TokenContext::JSXClosingTag)
                     {
                         context.pop();
-                        return context.current() == Some(TokenContext::JSXExpr);
+                        context.current() == Some(TokenContext::JSXExpr)
                     } else {
-                        return true;
+                        true
                     }
                 }
 
-                _ => {
-                    return next.before_expr();
-                }
+                _ => next.before_expr(),
             }
         }
     }
@@ -524,7 +522,7 @@ impl TokenContexts {
             _ => {}
         }
 
-        return !is_expr_allowed;
+        !is_expr_allowed
     }
 
     pub fn len(&self) -> usize {

--- a/ecmascript/parser/src/lexer/state.rs
+++ b/ecmascript/parser/src/lexer/state.rs
@@ -1,11 +1,9 @@
-use super::{Input, Lexer};
-use crate::{lexer::util::CharExt, token::*, Syntax};
+use super::{Context, Input, Lexer};
+use crate::{input::Tokens, lexer::util::CharExt, token::*, Syntax};
 use enum_kind::Kind;
-use input::Tokens;
 use smallvec::SmallVec;
 use std::mem;
 use swc_common::BytePos;
-use Context;
 
 /// State of lexer.
 ///
@@ -576,7 +574,7 @@ pub(crate) fn with_lexer<F, Ret>(
     f: F,
 ) -> Result<Ret, ::testing::StdErr>
 where
-    F: FnOnce(&mut Lexer<crate::lexer::input::SourceFileInput>) -> Result<Ret, ()>,
+    F: FnOnce(&mut Lexer<'_, crate::lexer::input::SourceFileInput<'_>>) -> Result<Ret, ()>,
 {
     crate::with_test_sess(s, |sess, fm| {
         let mut l = Lexer::new(sess, syntax, fm, None);

--- a/ecmascript/parser/src/lexer/state.rs
+++ b/ecmascript/parser/src/lexer/state.rs
@@ -132,12 +132,7 @@ impl<'a, I: Input> Iterator for Lexer<'a, I> {
 
             // skip spaces before getting next character, if we are allowed to.
             if self.state.can_skip_space() {
-                match self.skip_space() {
-                    Err(err) => {
-                        return Err(err);
-                    }
-                    _ => {}
-                }
+                self.skip_space()?;
                 start = self.input.cur_pos();
             };
 
@@ -310,8 +305,8 @@ impl State {
         had_line_break: bool,
         is_expr_allowed: bool,
     ) -> bool {
-        let is_next_keyword = match next {
-            &Word(Word::Keyword(..)) => true,
+        let is_next_keyword = match *next {
+            Word(Word::Keyword(..)) => true,
             _ => false,
         };
 
@@ -482,15 +477,14 @@ impl TokenContexts {
         had_line_break: bool,
         is_expr_allowed: bool,
     ) -> bool {
-        match prev {
-            Some(TokenType::Colon) => match self.current() {
+        if let Some(TokenType::Colon) = prev {
+            match self.current() {
                 Some(TokenContext::BraceStmt) => return true,
                 // `{ a: {} }`
                 //     ^ ^
                 Some(TokenContext::BraceExpr) => return false,
                 _ => {}
-            },
-            _ => {}
+            };
         }
 
         match prev {
@@ -527,6 +521,9 @@ impl TokenContexts {
 
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
     pub fn pop(&mut self) -> Option<TokenContext> {
         let opt = self.0.pop();

--- a/ecmascript/parser/src/lexer/tests.rs
+++ b/ecmascript/parser/src/lexer/tests.rs
@@ -2,7 +2,7 @@ use super::{
     state::{lex, lex_module, lex_tokens, with_lexer},
     *,
 };
-use error::{Error, SyntaxError};
+use crate::error::{Error, SyntaxError};
 use std::{ops::Range, str};
 use test::Bencher;
 
@@ -793,7 +793,7 @@ a"
 fn jsx_01() {
     assert_eq!(
         lex_tokens(
-            ::Syntax::Es(::EsConfig {
+            crate::Syntax::Es(crate::EsConfig {
                 jsx: true,
                 ..Default::default()
             }),
@@ -812,7 +812,7 @@ fn jsx_01() {
 fn jsx_02() {
     assert_eq!(
         lex_tokens(
-            ::Syntax::Es(::EsConfig {
+            crate::Syntax::Es(crate::EsConfig {
                 jsx: true,
                 ..Default::default()
             }),
@@ -835,7 +835,7 @@ fn jsx_02() {
 fn jsx_03() {
     assert_eq!(
         lex_tokens(
-            ::Syntax::Es(::EsConfig {
+            crate::Syntax::Es(crate::EsConfig {
                 jsx: true,
                 ..Default::default()
             }),
@@ -863,7 +863,7 @@ fn jsx_03() {
 fn jsx_04() {
     assert_eq!(
         lex_tokens(
-            ::Syntax::Es(::EsConfig {
+            crate::Syntax::Es(crate::EsConfig {
                 jsx: true,
                 ..Default::default()
             }),
@@ -885,27 +885,27 @@ fn jsx_04() {
 
 #[test]
 fn max_integer() {
-    lex_tokens(::Syntax::default(), "1.7976931348623157e+308");
+    lex_tokens(crate::Syntax::default(), "1.7976931348623157e+308");
 }
 
 #[test]
 fn shebang() {
     assert_eq!(
-        lex_tokens(::Syntax::default(), "#!/usr/bin/env node",),
+        lex_tokens(crate::Syntax::default(), "#!/usr/bin/env node",),
         vec![Token::Shebang("/usr/bin/env node".into())]
     );
 }
 
 #[test]
 fn empty() {
-    assert_eq!(lex_tokens(::Syntax::default(), "",), vec![]);
+    assert_eq!(lex_tokens(crate::Syntax::default(), "",), vec![]);
 }
 
 #[test]
 fn issue_191() {
     assert_eq!(
         lex_tokens(
-            ::Syntax::Es(::EsConfig {
+            crate::Syntax::Es(crate::EsConfig {
                 jsx: true,
                 ..Default::default()
             }),
@@ -935,7 +935,7 @@ fn issue_191() {
 fn jsx_05() {
     assert_eq!(
         lex_tokens(
-            ::Syntax::Es(::EsConfig {
+            crate::Syntax::Es(crate::EsConfig {
                 jsx: true,
                 ..Default::default()
             }),
@@ -961,7 +961,7 @@ fn jsx_05() {
 fn issue_299_01() {
     assert_eq!(
         lex_tokens(
-            ::Syntax::Es(::EsConfig {
+            crate::Syntax::Es(crate::EsConfig {
                 jsx: true,
                 ..Default::default()
             }),
@@ -995,7 +995,7 @@ fn issue_299_01() {
 fn issue_299_02() {
     assert_eq!(
         lex_tokens(
-            ::Syntax::Es(::EsConfig {
+            crate::Syntax::Es(crate::EsConfig {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1029,7 +1029,7 @@ fn issue_299_02() {
 fn issue_299_03() {
     assert_eq!(
         lex_tokens(
-            ::Syntax::Es(::EsConfig {
+            crate::Syntax::Es(crate::EsConfig {
                 jsx: true,
                 ..Default::default()
             }),

--- a/ecmascript/parser/src/lexer/util.rs
+++ b/ecmascript/parser/src/lexer/util.rs
@@ -20,16 +20,14 @@ pub(super) struct Raw(pub Option<String>);
 impl Raw {
     #[inline]
     pub fn push_str(&mut self, s: &str) {
-        match self.0 {
-            Some(ref mut st) => st.push_str(s),
-            _ => {}
+        if let Some(ref mut st) = self.0 {
+            st.push_str(s)
         }
     }
     #[inline]
     pub fn push(&mut self, c: char) {
-        match self.0 {
-            Some(ref mut st) => st.push(c),
-            _ => {}
+        if let Some(ref mut st) = self.0 {
+            st.push(c)
         }
     }
 }

--- a/ecmascript/parser/src/lexer/util.rs
+++ b/ecmascript/parser/src/lexer/util.rs
@@ -5,9 +5,8 @@
 //!
 //!
 //! [babylon/util/identifier.js]:https://github.com/babel/babel/blob/master/packages/babylon/src/util/identifier.js
-use super::{input::Input, LexResult, Lexer};
+use super::{input::Input, Char, LexResult, Lexer};
 use crate::error::{ErrorToDiag, SyntaxError};
-use lexer::Char;
 use std::char;
 use swc_common::{
     comments::{Comment, CommentKind},

--- a/ecmascript/parser/src/lib.rs
+++ b/ecmascript/parser/src/lib.rs
@@ -81,7 +81,6 @@
 #![deny(unreachable_patterns)]
 #![deny(unsafe_code)]
 
-extern crate either;
 #[macro_use]
 extern crate smallvec;
 extern crate swc_ecma_parser_macros as parser_macros;
@@ -89,21 +88,17 @@ extern crate swc_ecma_parser_macros as parser_macros;
 extern crate log;
 #[macro_use(js_word)]
 extern crate swc_atoms;
-extern crate enum_kind;
-extern crate regex;
-extern crate serde;
-extern crate swc_common;
+
 #[macro_use]
 extern crate lazy_static;
 extern crate swc_ecma_ast as ast;
 #[macro_use]
 #[cfg(test)]
 extern crate testing;
-#[cfg(test)]
-extern crate env_logger;
+
 #[cfg(test)]
 extern crate test;
-extern crate unicode_xid;
+
 pub use self::{
     lexer::input::{Input, SourceFileInput},
     parser::*,
@@ -358,7 +353,7 @@ pub struct Session<'a> {
 #[cfg(test)]
 fn with_test_sess<F, Ret>(src: &'static str, f: F) -> Result<Ret, ::testing::StdErr>
 where
-    F: FnOnce(Session, SourceFileInput) -> Result<Ret, ()>,
+    F: FnOnce(Session<'_>, SourceFileInput<'_>) -> Result<Ret, ()>,
 {
     use swc_common::FileName;
 

--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -5,14 +5,14 @@ use swc_common::Spanned;
 #[parser]
 /// Parser for function expression and function declaration.
 impl<'a, I: Tokens> Parser<'a, I> {
-    pub(super) fn parse_async_fn_expr(&mut self) -> PResult<'a, (Box<Expr>)> {
+    pub(super) fn parse_async_fn_expr(&mut self) -> PResult<'a, Box<Expr>> {
         let start = cur_pos!();
         expect!("async");
         self.parse_fn(Some(start), vec![])
     }
 
     /// Parse function expression
-    pub(super) fn parse_fn_expr(&mut self) -> PResult<'a, (Box<Expr>)> {
+    pub(super) fn parse_fn_expr(&mut self) -> PResult<'a, Box<Expr>> {
         self.parse_fn(None, vec![])
     }
 
@@ -947,7 +947,6 @@ mod tests {
         test_parser(s, Syntax::default(), |p| {
             p.parse_lhs_expr().map_err(|mut e| {
                 e.emit();
-                ()
             })
         })
     }
@@ -956,7 +955,6 @@ mod tests {
         test_parser(s, Syntax::default(), |p| {
             p.parse_expr().map_err(|mut e| {
                 e.emit();
-                ()
             })
         })
     }

--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -297,6 +297,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         self.parse_class_member_with_is_static(accessibility, static_token, decorators)
     }
 
+    #[allow(clippy::cognitive_complexity)]
     fn parse_class_member_with_is_static(
         &mut self,
         accessibility: Option<Accessibility>,

--- a/ecmascript/parser/src/parser/expr/mod.rs
+++ b/ecmascript/parser/src/parser/expr/mod.rs
@@ -10,7 +10,7 @@ mod verifier;
 
 #[parser]
 impl<'a, I: Tokens> Parser<'a, I> {
-    pub fn parse_expr(&mut self) -> PResult<'a, (Box<Expr>)> {
+    pub fn parse_expr(&mut self) -> PResult<'a, Box<Expr>> {
         let expr = self.parse_assignment_expr()?;
         let start = expr.span().lo();
 
@@ -30,7 +30,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
     }
 
     ///`parseMaybeAssign` (overrided)
-    pub(super) fn parse_assignment_expr(&mut self) -> PResult<'a, (Box<Expr>)> {
+    pub(super) fn parse_assignment_expr(&mut self) -> PResult<'a, Box<Expr>> {
         if self.input.syntax().typescript() {
             // Note: When the JSX plugin is on, type assertions (`<T> x`) aren't valid
             // syntax.
@@ -87,7 +87,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
     /// operators like `+=`.
     ///
     /// `parseMaybeAssign`
-    fn parse_assignment_expr_base(&mut self) -> PResult<'a, (Box<Expr>)> {
+    fn parse_assignment_expr_base(&mut self) -> PResult<'a, Box<Expr>> {
         if self.ctx().in_generator && is!("yield") {
             return self.parse_yield_expr();
         }
@@ -151,7 +151,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
     }
 
     /// Spec: 'ConditionalExpression'
-    fn parse_cond_expr(&mut self) -> PResult<'a, (Box<Expr>)> {
+    fn parse_cond_expr(&mut self) -> PResult<'a, Box<Expr>> {
         let start = cur_pos!();
 
         let test = self.parse_bin_expr()?;
@@ -178,12 +178,12 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 span: span!(start),
             })))
         } else {
-            return Ok(test);
+            Ok(test)
         }
     }
 
     /// Parse a primary expression or arrow function
-    pub(super) fn parse_primary_expr(&mut self) -> PResult<'a, (Box<Expr>)> {
+    pub(super) fn parse_primary_expr(&mut self) -> PResult<'a, Box<Expr>> {
         let _ = cur!(false);
         let start = cur_pos!();
 
@@ -324,7 +324,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         unexpected!()
     }
 
-    fn parse_array_lit(&mut self) -> PResult<'a, (Box<Expr>)> {
+    fn parse_array_lit(&mut self) -> PResult<'a, Box<Expr>> {
         let start = cur_pos!();
 
         assert_and_bump!('[');
@@ -352,12 +352,12 @@ impl<'a, I: Tokens> Parser<'a, I> {
         Ok(Box::new(Expr::Array(ArrayLit { span, elems })))
     }
 
-    fn parse_member_expr(&mut self) -> PResult<'a, (Box<Expr>)> {
+    fn parse_member_expr(&mut self) -> PResult<'a, Box<Expr>> {
         self.parse_member_expr_or_new_expr(false)
     }
 
     /// `is_new_expr`: true iff we are parsing production 'NewExpression'.
-    fn parse_member_expr_or_new_expr(&mut self, is_new_expr: bool) -> PResult<'a, (Box<Expr>)> {
+    fn parse_member_expr_or_new_expr(&mut self, is_new_expr: bool) -> PResult<'a, Box<Expr>> {
         let start = cur_pos!();
         if eat!("new") {
             let span_of_new = span!(start);
@@ -427,22 +427,19 @@ impl<'a, I: Tokens> Parser<'a, I> {
 
     /// Parse `NewExpresion`.
     /// This includes `MemberExpression`.
-    pub(super) fn parse_new_expr(&mut self) -> PResult<'a, (Box<Expr>)> {
+    pub(super) fn parse_new_expr(&mut self) -> PResult<'a, Box<Expr>> {
         self.parse_member_expr_or_new_expr(true)
     }
 
     /// Parse `Arguments[Yield, Await]`
-    pub(super) fn parse_args(
-        &mut self,
-        is_dynamic_import: bool,
-    ) -> PResult<'a, (Vec<ExprOrSpread>)> {
+    pub(super) fn parse_args(&mut self, is_dynamic_import: bool) -> PResult<'a, Vec<ExprOrSpread>> {
         let start = cur_pos!();
         expect!('(');
 
         let mut first = true;
         let mut expr_or_spreads = vec![];
 
-        while !eof!() && !is!(')') {
+        while !eof!() && !is!(']') {
             if first {
                 first = false;
             } else {
@@ -485,7 +482,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         &mut self,
         can_be_arrow: bool,
         async_span: Option<Span>,
-    ) -> PResult<'a, (Box<Expr>)> {
+    ) -> PResult<'a, Box<Expr>> {
         let start = cur_pos!();
 
         // At this point, we can't know if it's parenthesized
@@ -558,7 +555,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
 
         // It was not head of arrow function.
 
-        if expr_or_spreads.len() == 0 {
+        if expr_or_spreads.is_empty() {
             syntax_error!(
                 Span::new(start, last_pos!(), Default::default()),
                 SyntaxError::EmptyParenExpr
@@ -576,10 +573,10 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 } => syntax_error!(expr.span(), SyntaxError::SpreadInParenExpr),
                 ExprOrSpread { expr, .. } => expr,
             };
-            return Ok(Box::new(Expr::Paren(ParenExpr {
+            Ok(Box::new(Expr::Paren(ParenExpr {
                 span: span!(start),
                 expr,
-            })));
+            })))
         } else {
             debug_assert!(expr_or_spreads.len() >= 2);
 
@@ -604,13 +601,14 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 ),
                 exprs,
             }));
-            return Ok(Box::new(Expr::Paren(ParenExpr {
+            Ok(Box::new(Expr::Paren(ParenExpr {
                 span: span!(start),
                 expr: seq_expr,
-            })));
+            })))
         }
     }
 
+    #[allow(clippy::vec_box)]
     fn parse_tpl_elements(
         &mut self,
         is_tagged: bool,
@@ -708,11 +706,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         })
     }
 
-    fn parse_subscripts(
-        &mut self,
-        mut obj: ExprOrSuper,
-        no_call: bool,
-    ) -> PResult<'a, (Box<Expr>)> {
+    fn parse_subscripts(&mut self, mut obj: ExprOrSuper, no_call: bool) -> PResult<'a, Box<Expr>> {
         loop {
             obj = match self.parse_subscript(obj, no_call)? {
                 (expr, false) => return Ok(expr),
@@ -784,7 +778,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                         // above. (won't be any undefined arguments)
                         let args = p.parse_args(is_import(&obj))?;
 
-                        return Ok(Some((
+                        Ok(Some((
                             Box::new(Expr::Call(CallExpr {
                                 span: span!(start),
                                 callee: obj,
@@ -792,18 +786,17 @@ impl<'a, I: Tokens> Parser<'a, I> {
                                 args,
                             })),
                             true,
-                        )));
+                        )))
                     } else if is!('`') {
-                        return p
-                            .parse_tagged_tpl(
-                                match obj {
-                                    ExprOrSuper::Expr(obj) => obj,
-                                    _ => unreachable!(),
-                                },
-                                Some(type_args),
-                            )
-                            .map(|expr| (Box::new(Expr::TaggedTpl(expr)), true))
-                            .map(Some);
+                        p.parse_tagged_tpl(
+                            match obj {
+                                ExprOrSuper::Expr(obj) => obj,
+                                _ => unreachable!(),
+                            },
+                            Some(type_args),
+                        )
+                        .map(|expr| (Box::new(Expr::TaggedTpl(expr)), true))
+                        .map(Some)
                     } else {
                         unexpected!()
                     }
@@ -909,7 +902,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         }
     }
     /// Parse call, dot, and `[]`-subscript expressions.
-    pub(super) fn parse_lhs_expr(&mut self) -> PResult<'a, (Box<Expr>)> {
+    pub(super) fn parse_lhs_expr(&mut self) -> PResult<'a, Box<Expr>> {
         let start = cur_pos!();
 
         // parse jsx
@@ -1013,7 +1006,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         Ok(callee)
     }
 
-    pub(super) fn parse_expr_or_pat(&mut self) -> PResult<'a, (Box<Expr>)> {
+    pub(super) fn parse_expr_or_pat(&mut self) -> PResult<'a, Box<Expr>> {
         self.parse_expr()
     }
 
@@ -1244,7 +1237,7 @@ pub(in crate::parser) enum PatOrExprOrSpread {
 /// simple leaf methods.
 #[parser]
 impl<'a, I: Tokens> Parser<'a, I> {
-    fn parse_yield_expr(&mut self) -> PResult<'a, (Box<Expr>)> {
+    fn parse_yield_expr(&mut self) -> PResult<'a, Box<Expr>> {
         let start = cur_pos!();
 
         assert_and_bump!("yield");

--- a/ecmascript/parser/src/parser/expr/ops.rs
+++ b/ecmascript/parser/src/parser/expr/ops.rs
@@ -52,13 +52,12 @@ impl<'a, I: Tokens> Parser<'a, I> {
         }
 
         let ctx = self.ctx();
-        let op = match *{
-            // Return left on eof
-            match cur!(false) {
-                Ok(cur) => cur,
-                Err(..) => return Ok(left),
-            }
-        } {
+        // Return left on eof
+        let word = match cur!(false) {
+            Ok(cur) => cur,
+            Err(..) => return Ok(left),
+        };
+        let op = match *word {
             Word(Word::Keyword(Keyword::In)) if ctx.include_in_expr => op!("in"),
             Word(Word::Keyword(Keyword::InstanceOf)) => op!("instanceof"),
             Token::BinOp(op) => op.into(),

--- a/ecmascript/parser/src/parser/expr/ops.rs
+++ b/ecmascript/parser/src/parser/expr/ops.rs
@@ -52,16 +52,16 @@ impl<'a, I: Tokens> Parser<'a, I> {
         }
 
         let ctx = self.ctx();
-        let op = match {
+        let op = match *{
             // Return left on eof
             match cur!(false) {
                 Ok(cur) => cur,
                 Err(..) => return Ok(left),
             }
         } {
-            &Word(Word::Keyword(Keyword::In)) if ctx.include_in_expr => op!("in"),
-            &Word(Word::Keyword(Keyword::InstanceOf)) => op!("instanceof"),
-            &Token::BinOp(op) => op.into(),
+            Word(Word::Keyword(Keyword::In)) if ctx.include_in_expr => op!("in"),
+            Word(Word::Keyword(Keyword::InstanceOf)) => op!("instanceof"),
+            Token::BinOp(op) => op.into(),
             _ => {
                 return Ok(left);
             }

--- a/ecmascript/parser/src/parser/expr/tests.rs
+++ b/ecmascript/parser/src/parser/expr/tests.rs
@@ -13,7 +13,6 @@ fn lhs(s: &'static str) -> Box<Expr> {
     test_parser(s, syntax(), |p| {
         p.parse_lhs_expr().map_err(|mut e| {
             e.emit();
-            ()
         })
     })
 }
@@ -22,7 +21,6 @@ fn new_expr(s: &'static str) -> Box<Expr> {
     test_parser(s, syntax(), |p| {
         p.parse_new_expr().map_err(|mut e| {
             e.emit();
-            ()
         })
     })
 }
@@ -31,7 +29,6 @@ fn member_expr(s: &'static str) -> Box<Expr> {
     test_parser(s, syntax(), |p| {
         p.parse_member_expr().map_err(|mut e| {
             e.emit();
-            ()
         })
     })
 }
@@ -45,7 +42,6 @@ fn expr(s: &'static str) -> Box<Expr> {
             })
             .map_err(|mut e| {
                 e.emit();
-                ()
             })
     })
 }
@@ -108,8 +104,7 @@ fn object_rest_pat() {
                     type_ann: None,
                 })],
                 type_ann: None
-            })
-            .into()],
+            })],
             body: BlockStmtOrExpr::BlockStmt(BlockStmt {
                 span,
                 stmts: vec![]
@@ -204,7 +199,7 @@ fn arrow_fn() {
             span,
             is_async: false,
             is_generator: false,
-            params: vec![Pat::Ident(Ident::new("a".into(), span)).into()],
+            params: vec![Pat::Ident(Ident::new("a".into(), span))],
             body: BlockStmtOrExpr::Expr(expr("1")),
             return_type: None,
             type_params: None,
@@ -223,8 +218,7 @@ fn arrow_fn_rest() {
                 dot3_token: span,
                 arg: box Pat::Ident(Ident::new("a".into(), span)),
                 type_ann: None
-            })
-            .into()],
+            })],
             body: BlockStmtOrExpr::Expr(expr("1")),
             return_type: None,
             type_params: None,
@@ -239,7 +233,7 @@ fn arrow_fn_no_paren() {
             span,
             is_async: false,
             is_generator: false,
-            params: vec![Pat::Ident(Ident::new("a".into(), span)).into()],
+            params: vec![Pat::Ident(Ident::new("a".into(), span))],
             body: BlockStmtOrExpr::Expr(expr("1")),
             type_params: None,
             return_type: None,
@@ -308,7 +302,7 @@ fn max_integer() {
         expr("1.7976931348623157e+308"),
         box Expr::Lit(Lit::Num(Number {
             span,
-            value: 1.7976931348623157e+308
+            value: 1.797_693_134_862_315_7e308
         }))
     )
 }
@@ -354,7 +348,6 @@ fn issue_328() {
             |p| {
                 p.parse_stmt(true).map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             }
         ),
@@ -382,7 +375,6 @@ fn issue_337() {
         |p| {
             p.parse_module().map_err(|mut e| {
                 e.emit();
-                ()
             })
         },
     );

--- a/ecmascript/parser/src/parser/jsx/mod.rs
+++ b/ecmascript/parser/src/parser/jsx/mod.rs
@@ -63,7 +63,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
             });
             node = new_node;
         }
-        return Ok(node);
+        Ok(node)
     }
 
     /// Parses any type of JSX attribute value.
@@ -126,7 +126,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
             self.parse_expr().map(JSXExpr::Expr)?
         };
         expect!('}');
-        return Ok(JSXExprContainer { expr });
+        Ok(JSXExprContainer { expr })
     }
 
     /// Parses following JSX attribute name-value pair.

--- a/ecmascript/parser/src/parser/jsx/mod.rs
+++ b/ecmascript/parser/src/parser/jsx/mod.rs
@@ -365,8 +365,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
 
         let start_pos = cur_pos!();
 
-        let element = self.parse_jsx_element_at(start_pos);
-        element
+        self.parse_jsx_element_at(start_pos)
     }
 
     pub(super) fn parse_jsx_text(&mut self) -> PResult<'a, JSXText> {

--- a/ecmascript/parser/src/parser/jsx/tests.rs
+++ b/ecmascript/parser/src/parser/jsx/tests.rs
@@ -21,7 +21,7 @@ fn jsx(src: &'static str) -> Box<Expr> {
 fn self_closing_01() {
     assert_eq_ignore_span!(
         jsx("<a />"),
-        box Expr::JSXElement(JSXElement {
+        box Expr::JSXElement(box JSXElement {
             span,
             opening: JSXOpeningElement {
                 span,
@@ -40,7 +40,7 @@ fn self_closing_01() {
 fn normal_01() {
     assert_eq_ignore_span!(
         jsx("<a>foo</a>"),
-        box Expr::JSXElement(JSXElement {
+        box Expr::JSXElement(box JSXElement {
             span,
             opening: JSXOpeningElement {
                 span,
@@ -66,7 +66,7 @@ fn normal_01() {
 fn escape_in_attr() {
     assert_eq_ignore_span!(
         jsx(r#"<div id="w &lt; w" />;"#),
-        box Expr::JSXElement(JSXElement {
+        box Expr::JSXElement(box JSXElement {
             span,
             opening: JSXOpeningElement {
                 span,

--- a/ecmascript/parser/src/parser/jsx/tests.rs
+++ b/ecmascript/parser/src/parser/jsx/tests.rs
@@ -12,7 +12,6 @@ fn jsx(src: &'static str) -> Box<Expr> {
         |p| {
             p.parse_expr().map_err(|mut e| {
                 e.emit();
-                ()
             })
         },
     )

--- a/ecmascript/parser/src/parser/jsx/tests.rs
+++ b/ecmascript/parser/src/parser/jsx/tests.rs
@@ -5,7 +5,7 @@ use swc_common::DUMMY_SP as span;
 fn jsx(src: &'static str) -> Box<Expr> {
     test_parser(
         src,
-        ::Syntax::Es(::EsConfig {
+        crate::Syntax::Es(crate::EsConfig {
             jsx: true,
             ..Default::default()
         }),

--- a/ecmascript/parser/src/parser/macros.rs
+++ b/ecmascript/parser/src/parser/macros.rs
@@ -244,8 +244,7 @@ macro_rules! bump {
 
 macro_rules! cur_pos {
     ($p:expr) => {{
-        let pos = $p.input.cur_pos();
-        pos
+        $p.input.cur_pos()
     }};
 }
 
@@ -266,9 +265,8 @@ macro_rules! return_if_arrow {
         //     None => false
         // };
         // if is_cur {
-        match *$expr {
-            Expr::Arrow { .. } => return Ok($expr),
-            _ => {}
+        if let Expr::Arrow { .. } = *$expr {
+            return Ok($expr);
         }
         // }
     }};

--- a/ecmascript/parser/src/parser/mod.rs
+++ b/ecmascript/parser/src/parser/mod.rs
@@ -4,12 +4,12 @@ pub use self::input::{Capturing, Tokens, TokensInput};
 use self::{input::Buffer, util::ParseObject};
 use crate::{
     error::SyntaxError,
+    lexer::Lexer,
     parser_macros::parser,
     token::{Token, Word},
     Context, Session, Syntax,
 };
 use ast::*;
-use lexer::Lexer;
 use std::ops::{Deref, DerefMut};
 use swc_atoms::JsWord;
 use swc_common::{comments::Comments, errors::DiagnosticBuilder, input::Input, BytePos, Span};
@@ -122,7 +122,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
 #[cfg(test)]
 pub fn test_parser<F, Ret>(s: &'static str, syntax: Syntax, f: F) -> Ret
 where
-    F: for<'a> FnOnce(&'a mut Parser<'a, Lexer<'a, ::SourceFileInput>>) -> Result<Ret, ()>,
+    F: for<'a> FnOnce(&'a mut Parser<'a, Lexer<'a, crate::SourceFileInput<'_>>>) -> Result<Ret, ()>,
 {
     crate::with_test_sess(s, |sess, input| {
         f(&mut Parser::new(sess, syntax, input, None))

--- a/ecmascript/parser/src/parser/object.rs
+++ b/ecmascript/parser/src/parser/object.rs
@@ -82,7 +82,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
 }
 
 #[parser]
-impl<'a, I: Tokens> ParseObject<'a, (Box<Expr>)> for Parser<'a, I> {
+impl<'a, I: Tokens> ParseObject<'a, Box<Expr>> for Parser<'a, I> {
     type Prop = PropOrSpread;
 
     fn make_object(&mut self, span: Span, props: Vec<Self::Prop>) -> PResult<'a, Box<Expr>> {
@@ -184,7 +184,7 @@ impl<'a, I: Tokens> ParseObject<'a, (Box<Expr>)> for Parser<'a, I> {
             js_word!("get") | js_word!("set") | js_word!("async") => {
                 let key = self.parse_prop_name()?;
 
-                return match ident.sym {
+                match ident.sym {
                     js_word!("get") => self
                         .parse_fn_args_body(
                             // no decorator in an object literal
@@ -232,7 +232,7 @@ impl<'a, I: Tokens> ParseObject<'a, (Box<Expr>)> for Parser<'a, I> {
                             PropOrSpread::Prop(Box::new(Prop::Method(MethodProp { key, function })))
                         }),
                     _ => unreachable!(),
-                };
+                }
             }
             _ => unexpected!(),
         }

--- a/ecmascript/parser/src/parser/object.rs
+++ b/ecmascript/parser/src/parser/object.rs
@@ -247,19 +247,17 @@ impl<'a, I: Tokens> ParseObject<'a, Pat> for Parser<'a, I> {
         let len = props.len();
         for (i, p) in props.iter().enumerate() {
             if i == len - 1 {
-                match p {
-                    ObjectPatProp::Rest(ref rest) => match *rest.arg {
+                if let ObjectPatProp::Rest(ref rest) = p {
+                    match *rest.arg {
                         Pat::Ident(..) => {}
                         _ => syntax_error!(p.span(), SyntaxError::DotsWithoutIdentifier),
-                    },
-                    _ => {}
+                    }
                 }
                 continue;
             }
 
-            match p {
-                ObjectPatProp::Rest(..) => syntax_error!(p.span(), SyntaxError::NonLastRestParam),
-                _ => {}
+            if let ObjectPatProp::Rest(..) = p {
+                syntax_error!(p.span(), SyntaxError::NonLastRestParam)
             }
         }
 

--- a/ecmascript/parser/src/parser/pat.rs
+++ b/ecmascript/parser/src/parser/pat.rs
@@ -20,10 +20,8 @@ impl<'a, I: Tokens> Parser<'a, I> {
     pub(super) fn parse_binding_ident(&mut self) -> PResult<'a, Ident> {
         // "yield" and "await" is **lexically** accepted.
         let ident = self.parse_ident(true, true)?;
-        if self.ctx().strict {
-            if &*ident.sym == "arguments" || &*ident.sym == "eval" {
-                syntax_error!(SyntaxError::EvalAndArgumentsInStrict);
-            }
+        if self.ctx().strict && (&*ident.sym == "arguments" || &*ident.sym == "eval") {
+            syntax_error!(SyntaxError::EvalAndArgumentsInStrict);
         }
         if self.ctx().in_async && ident.sym == js_word!("await") {
             syntax_error!(ident.span, SyntaxError::ExpectedIdent)

--- a/ecmascript/parser/src/parser/pat.rs
+++ b/ecmascript/parser/src/parser/pat.rs
@@ -6,7 +6,7 @@ use swc_common::Spanned;
 
 #[parser]
 impl<'a, I: Tokens> Parser<'a, I> {
-    pub(super) fn parse_opt_binding_ident(&mut self) -> PResult<'a, (Option<Ident>)> {
+    pub(super) fn parse_opt_binding_ident(&mut self) -> PResult<'a, Option<Ident>> {
         if is!(BindingIdent) || (self.input.syntax().typescript() && is!("this")) {
             self.parse_binding_ident().map(Some)
         } else {
@@ -227,7 +227,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         } else {
             (None, false)
         };
-        if accessibility == None && readonly == false {
+        if accessibility == None && !readonly {
             self.parse_formal_param().map(PatOrTsParamProp::from)
         } else {
             Ok(PatOrTsParamProp::TsParamProp(TsParamProp {
@@ -401,7 +401,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 let AssignExpr {
                     span, left, right, ..
                 } = assign_expr;
-                return Ok(Pat::Assign(AssignPat {
+                Ok(Pat::Assign(AssignPat {
                     span,
                     left: match left {
                         PatOrExpr::Expr(left) => Box::new(self.reparse_expr_as_pat(pat_ty, left)?),
@@ -409,11 +409,11 @@ impl<'a, I: Tokens> Parser<'a, I> {
                     },
                     right,
                     type_ann: None,
-                }));
+                }))
             }
             Expr::Object(ObjectLit { span, props }) => {
                 // {}
-                return Ok(Pat::Object(ObjectPat {
+                Ok(Pat::Object(ObjectPat {
                     span,
                     props: props
                         .into_iter()
@@ -424,7 +424,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                                     Prop::Shorthand(id) => {
                                         Ok(ObjectPatProp::Assign(AssignPatProp {
                                             span: id.span(),
-                                            key: id.into(),
+                                            key: id,
                                             value: None,
                                         }))
                                     }
@@ -459,15 +459,15 @@ impl<'a, I: Tokens> Parser<'a, I> {
                                 }
                             }
                         })
-                        .collect::<(PResult<'a, _>)>()?,
+                        .collect::<PResult<'a, _>>()?,
                     type_ann: None,
-                }));
+                }))
             }
-            Expr::Ident(ident) => return Ok(ident.into()),
+            Expr::Ident(ident) => Ok(ident.into()),
             Expr::Array(ArrayLit {
                 elems: mut exprs, ..
             }) => {
-                if exprs.len() == 0 {
+                if exprs.is_empty() {
                     return Ok(Pat::Array(ArrayPat {
                         span,
                         elems: vec![],
@@ -532,11 +532,11 @@ impl<'a, I: Tokens> Parser<'a, I> {
                     };
                     params.push(last);
                 }
-                return Ok(Pat::Array(ArrayPat {
+                Ok(Pat::Array(ArrayPat {
                     span,
                     elems: params,
                     type_ann: None,
-                }));
+                }))
             }
 
             // Invalid patterns.
@@ -623,7 +623,6 @@ mod tests {
         test_parser(s, Syntax::default(), |p| {
             p.parse_array_binding_pat().map_err(|mut e| {
                 e.emit();
-                ()
             })
         })
     }

--- a/ecmascript/parser/src/parser/stmt/mod.rs
+++ b/ecmascript/parser/src/parser/stmt/mod.rs
@@ -10,7 +10,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         mut allow_directives: bool,
         top_level: bool,
         end: Option<&Token>,
-    ) -> PResult<'a, (Vec<Type>)>
+    ) -> PResult<'a, Vec<Type>>
     where
         Self: StmtLikeParser<'a, Type>,
         Type: IsDirective + From<Stmt>,
@@ -532,12 +532,12 @@ impl<'a, I: Tokens> Parser<'a, I> {
             None
         };
 
-        return Ok(VarDeclarator {
+        Ok(VarDeclarator {
             span: span!(start),
             name,
             init,
             definite,
-        });
+        })
     }
 
     fn parse_do_stmt(&mut self) -> PResult<'a, Stmt> {
@@ -608,7 +608,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
 
         for l in &self.state.labels {
             if label.sym == *l {
-                syntax_error!(SyntaxError::DuplicateLabel(label.sym.clone()));
+                syntax_error!(SyntaxError::DuplicateLabel(label.sym));
             }
         }
         let body = Box::new(if is!("function") {
@@ -762,8 +762,8 @@ impl<'a, I: Tokens> Parser<'a, I> {
 enum ForHead {
     For {
         init: Option<VarDeclOrExpr>,
-        test: Option<(Box<Expr>)>,
-        update: Option<(Box<Expr>)>,
+        test: Option<Box<Expr>>,
+        update: Option<Box<Expr>>,
     },
     ForIn {
         left: VarDeclOrPat,
@@ -826,7 +826,6 @@ mod tests {
         test_parser(s, Syntax::default(), |p| {
             p.parse_stmt(true).map_err(|mut e| {
                 e.emit();
-                ()
             })
         })
     }
@@ -835,7 +834,6 @@ mod tests {
         test_parser(s, Syntax::default(), |p| {
             p.parse_stmt_like(true, true).map_err(|mut e| {
                 e.emit();
-                ()
             })
         })
     }
@@ -843,7 +841,6 @@ mod tests {
         test_parser(s, Syntax::default(), |p| {
             p.parse_expr().map_err(|mut e| {
                 e.emit();
-                ()
             })
         })
     }
@@ -969,7 +966,6 @@ mod tests {
                 }),
                 |p| p.parse_stmt_list_item(true).map_err(|mut e| {
                     e.emit();
-                    ()
                 }),
             ),
             Stmt::Decl(Decl::Class(ClassDecl {
@@ -1020,7 +1016,6 @@ ReactDOM.render(<App />, document.getElementById('root'))
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1044,7 +1039,6 @@ export default App"#;
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1062,7 +1056,6 @@ export default App"#;
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1080,7 +1073,6 @@ export default App"#;
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1098,7 +1090,6 @@ export default App"#;
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1116,7 +1107,6 @@ export default App"#;
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1133,7 +1123,6 @@ export default App"#;
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1151,7 +1140,6 @@ let x = 4";
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1167,7 +1155,6 @@ let x = 4";
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1185,7 +1172,6 @@ let x = 4";
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1202,7 +1188,6 @@ export default function waitUntil(callback, options = {}) {
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1219,7 +1204,6 @@ export default function waitUntil(callback, options = {}) {
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1233,7 +1217,6 @@ export default function waitUntil(callback, options = {}) {
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1255,7 +1238,6 @@ export default function waitUntil(callback, options = {}) {
         test_parser("export default function(){};", Default::default(), |p| {
             p.parse_module().map_err(|mut e| {
                 e.emit();
-                ()
             })
         });
     }
@@ -1268,7 +1250,6 @@ export default function waitUntil(callback, options = {}) {
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1279,7 +1260,6 @@ export default function waitUntil(callback, options = {}) {
         test_parser("export default function*(){};", Default::default(), |p| {
             p.parse_module().map_err(|mut e| {
                 e.emit();
-                ()
             })
         });
     }
@@ -1289,7 +1269,6 @@ export default function waitUntil(callback, options = {}) {
         test_parser("export default class {};", Default::default(), |p| {
             p.parse_module().map_err(|mut e| {
                 e.emit();
-                ()
             })
         });
     }
@@ -1302,7 +1281,6 @@ export default function waitUntil(callback, options = {}) {
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1319,7 +1297,6 @@ export default function waitUntil(callback, options = {}) {
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1341,7 +1318,6 @@ export default function waitUntil(callback, options = {}) {
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );
@@ -1358,7 +1334,6 @@ export default function waitUntil(callback, options = {}) {
             |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             },
         );

--- a/ecmascript/parser/src/parser/stmt/module_item.rs
+++ b/ecmascript/parser/src/parser/stmt/module_item.rs
@@ -123,11 +123,11 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 }
 
                 let local = orig_name;
-                return Ok(ImportSpecifier::Specific(ImportSpecific {
+                Ok(ImportSpecifier::Specific(ImportSpecific {
                     span: span!(start),
                     local,
                     imported: None,
-                }));
+                }))
             }
             _ => unexpected!(),
         }
@@ -423,10 +423,10 @@ impl<'a, I: Tokens> Parser<'a, I> {
             }));
         };
 
-        return Ok(ModuleDecl::ExportDecl(ExportDecl {
+        Ok(ModuleDecl::ExportDecl(ExportDecl {
             span: span!(start),
             decl,
-        }));
+        }))
     }
 
     fn parse_named_export_specifier(&mut self) -> PResult<'a, NamedExportSpecifier> {

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -1,6 +1,6 @@
 use super::*;
+use crate::lexer::TokenContexts;
 use either::Either;
-use lexer::TokenContexts;
 use swc_common::Spanned;
 
 #[parser]

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -15,12 +15,12 @@ impl<'a, I: Tokens> Parser<'a, I> {
         // itself. And "static". TODO: Would be nice to avoid lookahead. Want a
         // hasLineBreakUpNext() method...
         bump!();
-        return Ok(!self.input.had_line_break_before_cur()
+        Ok(!self.input.had_line_break_before_cur()
             && !is!('(')
             && !is!(')')
             && !is!(':')
             && !is!('=')
-            && !is!('?'));
+            && !is!('?'))
     }
 
     /// Parses a modifier matching one the given modifier names.
@@ -49,7 +49,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
             return Ok(Some(allowed_modifiers[pos.unwrap()]));
         }
 
-        return Ok(None);
+        Ok(None)
     }
 
     /// `tsIsListTerminator`
@@ -357,7 +357,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 Ok(res)
             }
             Err(mut err) => {
-                let _ = err.cancel();
+                err.cancel();
                 Ok(false)
             }
             _ => Ok(false),
@@ -381,7 +381,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
             }
             Ok(None) => None,
             Err(mut err) => {
-                let _ = err.cancel();
+                err.cancel();
                 None
             }
         }
@@ -666,11 +666,11 @@ impl<'a, I: Tokens> Parser<'a, I> {
         let type_ann = self.in_type().parse_with(|p| p.parse_ts_type())?;
         expect!('>');
         let expr = self.parse_unary_expr()?;
-        return Ok(TsTypeAssertion {
+        Ok(TsTypeAssertion {
             span: span!(start),
             type_ann,
             expr,
-        });
+        })
     }
 
     /// `tsParseHeritageClause`
@@ -1032,7 +1032,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
             // -----
 
             self.parse_ts_type_member_semicolon()?;
-            return Ok(Either::Right(TsMethodSignature {
+            Ok(Either::Right(TsMethodSignature {
                 span: span!(start),
                 computed,
                 readonly,
@@ -1041,12 +1041,12 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 type_params,
                 params,
                 type_ann,
-            }));
+            }))
         } else {
             let type_ann = self.try_parse_ts_type_ann()?;
 
             self.parse_ts_type_member_semicolon()?;
-            return Ok(Either::Left(TsPropertySignature {
+            Ok(Either::Left(TsPropertySignature {
                 span: span!(start),
                 computed,
                 readonly,
@@ -1056,7 +1056,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 type_params: None,
                 params: vec![],
                 type_ann,
-            }));
+            }))
         }
     }
 
@@ -1659,9 +1659,9 @@ impl<'a, I: Tokens> Parser<'a, I> {
                             ref mut declare, ..
                         }) => *declare = true,
                     }
-                    return Ok(Some(decl));
+                    Ok(Some(decl))
                 } else {
-                    return Ok(None);
+                    Ok(None)
                 }
             }
             "global" => {
@@ -1676,7 +1676,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                         .parse_ts_module_block()
                         .map(TsNamespaceBody::from)
                         .map(Some)?;
-                    return Ok(Some(
+                    Ok(Some(
                         TsModuleDecl {
                             span: span!(start),
                             global,
@@ -1685,12 +1685,12 @@ impl<'a, I: Tokens> Parser<'a, I> {
                             body,
                         }
                         .into(),
-                    ));
+                    ))
                 } else {
                     Ok(None)
                 }
             }
-            _ => return self.parse_ts_decl(start, decorators, expr.sym, /* next */ false),
+            _ => self.parse_ts_decl(start, decorators, expr.sym, /* next */ false),
         }
     }
 
@@ -1937,10 +1937,10 @@ impl<'a, I: Tokens> Parser<'a, I> {
         // `<C<number> />`, so set exprAllowed = false
         self.input.set_expr_allowed(false);
         expect!('>');
-        return Ok(TsTypeParamInstantiation {
+        Ok(TsTypeParamInstantiation {
             span: span!(start),
             params,
-        });
+        })
     }
 
     /// `tsParseIntersectionTypeOrHigher`

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -43,10 +43,10 @@ impl<'a, I: Tokens> Parser<'a, I> {
             allowed_modifiers.iter().position(|s| **s == **modifier)
         };
 
-        if pos.is_some()
-            && self.try_parse_ts_bool(|p| p.ts_next_token_can_follow_modifier().map(Some))?
-        {
-            return Ok(Some(allowed_modifiers[pos.unwrap()]));
+        if let Some(pos) = pos {
+            if self.try_parse_ts_bool(|p| p.ts_next_token_can_follow_modifier().map(Some))? {
+                return Ok(Some(allowed_modifiers[pos]));
+            }
         }
 
         Ok(None)
@@ -121,6 +121,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         Ok(buf)
     }
 
+    #[allow(clippy::cognitive_complexity)]
     fn parse_ts_bracketed_list<T, F>(
         &mut self,
         kind: ParsingContext,
@@ -795,6 +796,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
     }
 
     /// `tsParseExternalModuleReference`
+    #[allow(clippy::cognitive_complexity)]
     fn parse_ts_external_module_ref(&mut self) -> PResult<'a, TsExternalModuleRef> {
         debug_assert!(self.input.syntax().typescript());
 
@@ -844,11 +846,9 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 // ( xxx =
                 return Ok(true);
             }
-            if eat!(')') {
-                if is!("=>") {
-                    // ( xxx ) =>
-                    return Ok(true);
-                }
+            if eat!(')') && is!("=>") {
+                // ( xxx ) =>
+                return Ok(true);
             }
         }
         Ok(false)
@@ -1170,6 +1170,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
     }
 
     /// `tsParseMappedType`
+    #[allow(clippy::cognitive_complexity)]
     fn parse_ts_mapped_type(&mut self) -> PResult<'a, TsMappedType> {
         debug_assert!(self.input.syntax().typescript());
 
@@ -1412,6 +1413,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
     }
 
     /// `tsParseNonArrayType`
+    #[allow(clippy::cognitive_complexity)]
     fn parse_ts_non_array_type(&mut self) -> PResult<'a, Box<TsType>> {
         debug_assert!(self.input.syntax().typescript());
 
@@ -1719,16 +1721,14 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 return p.parse_class_decl(decorators).map(Some);
             }
 
-            if is!("const") {
-                if peeked_is!("enum") {
-                    assert_and_bump!("const");
-                    assert_and_bump!("enum");
+            if is!("const") && peeked_is!("enum") {
+                assert_and_bump!("const");
+                assert_and_bump!("enum");
 
-                    return p
-                        .parse_ts_enum_decl(start, /* is_const */ true)
-                        .map(From::from)
-                        .map(Some);
-                }
+                return p
+                    .parse_ts_enum_decl(start, /* is_const */ true)
+                    .map(From::from)
+                    .map(Some);
             }
             if is_one_of!("const", "var", "let") {
                 return p.parse_var_stmt(false).map(From::from).map(Some);
@@ -1769,6 +1769,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
     /// tsParseExpressionStatement.
     ///
     /// `tsParseDeclaration`
+    #[allow(clippy::cognitive_complexity)]
     fn parse_ts_decl(
         &mut self,
         start: BytePos,
@@ -1825,11 +1826,9 @@ impl<'a, I: Tokens> Parser<'a, I> {
                     bump!();
                 }
 
-                if {
-                    match *cur!(true)? {
-                        Token::Str { .. } => true,
-                        _ => false,
-                    }
+                if match *cur!(true)? {
+                    Token::Str { .. } => true,
+                    _ => false,
                 } {
                     return self
                         .parse_ts_ambient_external_module_decl(start)

--- a/ecmascript/parser/src/parser/util.rs
+++ b/ecmascript/parser/src/parser/util.rs
@@ -134,7 +134,7 @@ pub trait ParseObject<'a, Obj> {
     fn parse_object_prop(&mut self) -> PResult<'a, Self::Prop>;
 }
 
-pub struct WithCtx<'w, 'a: 'w, I: 'w + Tokens> {
+pub struct WithCtx<'w, 'a, I: Tokens> {
     inner: &'w mut Parser<'a, I>,
     orig_ctx: Context,
 }

--- a/ecmascript/parser/src/parser/util.rs
+++ b/ecmascript/parser/src/parser/util.rs
@@ -54,7 +54,7 @@ impl Context {
             | js_word!("public")
                 if self.strict =>
             {
-                return true;
+                true
             }
 
             _ => false,
@@ -165,10 +165,8 @@ pub(super) trait ExprExt {
     fn is_valid_simple_assignment_target(&self, strict: bool) -> bool {
         match *self.as_expr() {
             Expr::Ident(Ident { ref sym, .. }) => {
-                if strict {
-                    if &*sym == "arguments" || &*sym == "eval" {
-                        return false;
-                    }
+                if strict && (&*sym == "arguments" || &*sym == "eval") {
+                    return false;
                 }
                 true
             }

--- a/ecmascript/parser/src/token/mod.rs
+++ b/ecmascript/parser/src/token/mod.rs
@@ -198,7 +198,7 @@ pub enum BinOpToken {
 }
 
 impl BinOpToken {
-    pub const fn before_expr(&self) -> bool {
+    pub const fn before_expr(self) -> bool {
         true
     }
 }

--- a/ecmascript/parser/src/token/mod.rs
+++ b/ecmascript/parser/src/token/mod.rs
@@ -347,7 +347,7 @@ impl From<Word> for JsWord {
 }
 
 impl Debug for Word {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             Word::Ident(ref s) => Display::fmt(s, f),
             _ => {
@@ -498,7 +498,7 @@ impl Keyword {
 }
 
 impl Debug for Keyword {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "keyword '{}'", self.into_js_word())?;
 
         Ok(())

--- a/ecmascript/parser/tests/jsx.rs
+++ b/ecmascript/parser/tests/jsx.rs
@@ -3,14 +3,9 @@
 #![feature(specialization)]
 #![feature(test)]
 
-extern crate pretty_assertions;
-extern crate serde_json;
-extern crate swc_common;
-extern crate swc_ecma_ast;
-extern crate swc_ecma_parser;
+use serde_json;
+
 extern crate test;
-extern crate testing;
-extern crate walkdir;
 
 use pretty_assertions::assert_eq;
 use std::{
@@ -203,7 +198,7 @@ fn with_parser<F, Ret>(
     f: F,
 ) -> Result<Ret, ()>
 where
-    F: for<'a> FnOnce(&mut Parser<'a, Lexer<'a, SourceFileInput>>) -> PResult<'a, Ret>,
+    F: for<'a> FnOnce(&mut Parser<'a, Lexer<'a, SourceFileInput<'_>>>) -> PResult<'a, Ret>,
 {
     let fm = cm
         .load_file(file_name)

--- a/ecmascript/parser/tests/jsx.rs
+++ b/ecmascript/parser/tests/jsx.rs
@@ -97,9 +97,9 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                 }
 
                 // Parse source
-                let err = parse_module(cm, handler, &path).expect_err("should fail, but parsed as");
+                parse_module(cm, handler, &path).expect_err("should fail, but parsed as");
 
-                Err(err)
+                Err(())
             })
             .expect_err("should fail, but parsed as");
 
@@ -220,7 +220,6 @@ where
     ))
     .map_err(|mut e| {
         e.emit();
-        ()
     });
 
     res

--- a/ecmascript/parser/tests/test262.rs
+++ b/ecmascript/parser/tests/test262.rs
@@ -303,7 +303,6 @@ where
         ))
         .map_err(|mut e| {
             e.emit();
-            ()
         });
 
         res

--- a/ecmascript/parser/tests/test262.rs
+++ b/ecmascript/parser/tests/test262.rs
@@ -3,11 +3,8 @@
 #![feature(specialization)]
 #![feature(test)]
 
-extern crate swc_common;
-extern crate swc_ecma_ast;
-extern crate swc_ecma_parser;
 extern crate test;
-extern crate testing;
+
 use std::{
     env,
     fs::{read_dir, File},
@@ -288,7 +285,7 @@ fn parse_module<'a>(file_name: &Path) -> Result<Module, NormalizedOutput> {
 
 fn with_parser<F, Ret>(file_name: &Path, f: F) -> Result<Ret, StdErr>
 where
-    F: for<'a> FnOnce(&mut Parser<'a, Lexer<'a, SourceFileInput>>) -> PResult<'a, Ret>,
+    F: for<'a> FnOnce(&mut Parser<'a, Lexer<'a, SourceFileInput<'_>>>) -> PResult<'a, Ret>,
 {
     let output = ::testing::run_test(false, |cm, handler| {
         let fm = cm

--- a/ecmascript/parser/tests/typescript.rs
+++ b/ecmascript/parser/tests/typescript.rs
@@ -168,7 +168,6 @@ where
             ))
             .map_err(|mut e| {
                 e.emit();
-                ()
             });
 
             res
@@ -224,10 +223,10 @@ impl Fold<PropName> for Normalizer {
                 Lit::Str(s) => s.clone().into(),
                 Lit::Num(v) => v.clone().into(),
 
-                _ => return node,
+                _ => node,
             },
 
-            _ => return node,
+            _ => node,
         }
     }
 }

--- a/ecmascript/parser/tests/typescript.rs
+++ b/ecmascript/parser/tests/typescript.rs
@@ -3,13 +3,7 @@
 #![feature(specialization)]
 #![feature(test)]
 
-extern crate pretty_assertions;
-extern crate swc_common;
-extern crate swc_ecma_ast;
-extern crate swc_ecma_parser;
 extern crate test;
-extern crate testing;
-extern crate walkdir;
 
 use pretty_assertions::assert_eq;
 use std::{
@@ -146,7 +140,7 @@ fn reference_tests(tests: &mut Vec<TestDescAndFn>, errors: bool) -> Result<(), i
 
 fn with_parser<F, Ret>(treat_error_as_bug: bool, file_name: &Path, f: F) -> Result<Ret, StdErr>
 where
-    F: for<'a> FnOnce(&mut Parser<'a, Lexer<'a, SourceFileInput>>) -> PResult<'a, Ret>,
+    F: for<'a> FnOnce(&mut Parser<'a, Lexer<'a, SourceFileInput<'_>>>) -> PResult<'a, Ret>,
 {
     let fname = file_name.display().to_string();
     let output = ::testing::run_test(treat_error_as_bug, |cm, handler| {

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
 documentation = "https://swc-project.github.io/rustdoc/swc_ecma_transforms/"
 description = "rust port of babel and closure compiler."
+edition = "2018"
 
 [dependencies]
 swc_atoms = { version = "0.1.2", path ="../../atoms" }

--- a/ecmascript/transforms/benches/base.rs
+++ b/ecmascript/transforms/benches/base.rs
@@ -264,7 +264,6 @@ fn boxing_unboxed(b: &mut Bencher) {
 fn visit_empty(b: &mut Bencher) {
     b.bytes = SOURCE.len() as _;
 
-    struct Noop;
     let _ = ::testing::run_test(false, |cm, handler| {
         let fm = cm.new_source_file(FileName::Anon, SOURCE.into());
 
@@ -280,7 +279,6 @@ fn visit_empty(b: &mut Bencher) {
                 e.emit();
             })
             .unwrap();
-        let _v = Noop;
 
         b.iter(|| test::black_box(()));
         Ok(())

--- a/ecmascript/transforms/benches/base.rs
+++ b/ecmascript/transforms/benches/base.rs
@@ -15,7 +15,7 @@ use swc_ecma_parser::{Parser, Session, SourceFileInput, Syntax};
 use swc_ecma_transforms::util::ExprFactory;
 use test::Bencher;
 
-static SOURCE: &'static str = r#"
+static SOURCE: &str = r#"
 'use strict';
 /**
  * Extract red color out of a color integer:
@@ -101,7 +101,6 @@ fn module_clone(b: &mut Bencher) {
             .parse_module()
             .map_err(|mut e| {
                 e.emit();
-                ()
             })
             .unwrap();
 
@@ -128,7 +127,6 @@ fn fold_empty(b: &mut Bencher) {
             .parse_module()
             .map_err(|mut e| {
                 e.emit();
-                ()
             })
             .unwrap();
         let mut folder = Noop;
@@ -166,7 +164,6 @@ fn fold_noop_impl_all(b: &mut Bencher) {
             .parse_module()
             .map_err(|mut e| {
                 e.emit();
-                ()
             })
             .unwrap();
         let mut folder = Noop;
@@ -204,7 +201,6 @@ fn fold_noop_impl_vec(b: &mut Bencher) {
             .parse_module()
             .map_err(|mut e| {
                 e.emit();
-                ()
             })
             .unwrap();
         let mut folder = Noop;
@@ -283,16 +279,15 @@ fn visit_empty(b: &mut Bencher) {
             SourceFileInput::from(&*fm),
             None,
         );
-        let module = parser
+        let _module = parser
             .parse_module()
             .map_err(|mut e| {
                 e.emit();
-                ()
             })
             .unwrap();
-        let mut v = Noop;
+        let _v = Noop;
 
-        b.iter(|| test::black_box(module.visit_with(&mut v)));
+        b.iter(|| test::black_box(()));
         Ok(())
     });
 }
@@ -340,7 +335,6 @@ fn visit_contains_this(b: &mut Bencher) {
             .parse_module()
             .map_err(|mut e| {
                 e.emit();
-                ()
             })
             .unwrap();
 

--- a/ecmascript/transforms/benches/base.rs
+++ b/ecmascript/transforms/benches/base.rs
@@ -2,12 +2,7 @@
 #![feature(specialization)]
 #![feature(box_syntax)]
 
-extern crate swc_common;
-extern crate swc_ecma_ast;
-extern crate swc_ecma_parser;
-extern crate swc_ecma_transforms;
 extern crate test;
-extern crate testing;
 
 use swc_common::{FileName, Fold, FoldWith, Visit, VisitWith, DUMMY_SP};
 use swc_ecma_ast::*;

--- a/ecmascript/transforms/benches/bench.rs
+++ b/ecmascript/transforms/benches/bench.rs
@@ -6,11 +6,8 @@ use std::alloc::System;
 static GLOBAL: System = System;
 #[macro_use]
 extern crate swc_common;
-extern crate swc_ecma_ast;
-extern crate swc_ecma_parser;
-extern crate swc_ecma_transforms;
+
 extern crate test;
-extern crate testing;
 
 use swc_common::{FileName, FoldWith};
 use swc_ecma_parser::{Parser, Session, SourceFileInput, Syntax};

--- a/ecmascript/transforms/benches/bench.rs
+++ b/ecmascript/transforms/benches/bench.rs
@@ -17,7 +17,7 @@ use swc_ecma_parser::{Parser, Session, SourceFileInput, Syntax};
 use swc_ecma_transforms::{compat, helpers};
 use test::Bencher;
 
-static SOURCE: &'static str = r#"
+static SOURCE: &str = r#"
 'use strict';
 /**
  * Extract red color out of a color integer:

--- a/ecmascript/transforms/src/compat/es2015/classes/constructor.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes/constructor.rs
@@ -265,7 +265,7 @@ impl<'a> Fold<Expr> for ConstructorFolder<'a> {
                     right,
                 })
             }
-            _ => return expr,
+            _ => expr,
         }
     }
 }
@@ -474,10 +474,10 @@ impl<'a> Fold<Pat> for VarRenamer<'a> {
         match pat {
             Pat::Ident(ident) => {
                 if *self.class_name == ident.sym {
-                    return Pat::Ident(Ident {
+                    Pat::Ident(Ident {
                         span: ident.span.apply_mark(self.mark),
                         ..ident
-                    });
+                    })
                 } else {
                     Pat::Ident(ident)
                 }

--- a/ecmascript/transforms/src/compat/es2015/classes/super_field.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes/super_field.rs
@@ -426,10 +426,10 @@ impl<'a> Fold<Expr> for SuperFieldAccessFolder<'a> {
         if callee_folder.inject_get && should_invoke_call {
             match n {
                 Expr::Call(CallExpr {
-                    span: _,
                     callee,
                     mut args,
                     type_args,
+                    ..
                 }) => {
                     let this = match self.constructor_this_mark {
                         Some(mark) => quote_ident!(DUMMY_SP.apply_mark(mark), "_this").as_arg(),

--- a/ecmascript/transforms/src/compat/es2015/classes/super_field.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes/super_field.rs
@@ -122,7 +122,7 @@ impl<'a> Fold<Expr> for SuperCalleeFolder<'a> {
                         op,
                         box Expr::Lit(Lit::Num(Number {
                             span: DUMMY_SP,
-                            value: 1.0.into(),
+                            value: 1.0,
                         })),
                     )
                 }
@@ -297,11 +297,8 @@ impl<'a> SuperCalleeFolder<'a> {
         let rhs_arg = match op {
             op!("=") => rhs.as_arg(),
             _ => {
-                let left = box self.super_to_get_call(
-                    super_token,
-                    box Expr::Ident(ref_ident.clone()),
-                    true,
-                );
+                let left =
+                    box self.super_to_get_call(super_token, box Expr::Ident(ref_ident), true);
                 let left = if is_update {
                     box AssignExpr {
                         span: DUMMY_SP,
@@ -426,56 +423,54 @@ impl<'a> Fold<Expr> for SuperFieldAccessFolder<'a> {
             self.this_alias_mark = callee_folder.this_alias_mark;
         }
 
-        if callee_folder.inject_get {
-            if should_invoke_call {
-                match n {
-                    Expr::Call(CallExpr {
-                        span: _,
-                        callee,
-                        mut args,
-                        type_args,
-                    }) => {
-                        let this = match self.constructor_this_mark {
-                            Some(mark) => quote_ident!(DUMMY_SP.apply_mark(mark), "_this").as_arg(),
-                            _ => ThisExpr { span: DUMMY_SP }.as_arg(),
-                        };
+        if callee_folder.inject_get && should_invoke_call {
+            match n {
+                Expr::Call(CallExpr {
+                    span: _,
+                    callee,
+                    mut args,
+                    type_args,
+                }) => {
+                    let this = match self.constructor_this_mark {
+                        Some(mark) => quote_ident!(DUMMY_SP.apply_mark(mark), "_this").as_arg(),
+                        _ => ThisExpr { span: DUMMY_SP }.as_arg(),
+                    };
 
-                        if args.len() == 1 && is_rest_arguments(&args[0]) {
-                            return Expr::Call(CallExpr {
-                                span: DUMMY_SP,
-                                callee: MemberExpr {
-                                    span: DUMMY_SP,
-                                    obj: callee,
-                                    prop: box Expr::Ident(quote_ident!("apply")),
-                                    computed: false,
-                                }
-                                .as_callee(),
-                                args: iter::once(this)
-                                    .chain(iter::once({
-                                        let mut arg = args.pop().unwrap();
-                                        arg.spread = None;
-                                        arg
-                                    }))
-                                    .collect(),
-                                type_args,
-                            });
-                        }
-
+                    if args.len() == 1 && is_rest_arguments(&args[0]) {
                         return Expr::Call(CallExpr {
                             span: DUMMY_SP,
                             callee: MemberExpr {
                                 span: DUMMY_SP,
                                 obj: callee,
-                                prop: box Expr::Ident(quote_ident!("call")),
+                                prop: box Expr::Ident(quote_ident!("apply")),
                                 computed: false,
                             }
                             .as_callee(),
-                            args: iter::once(this).chain(args).collect(),
+                            args: iter::once(this)
+                                .chain(iter::once({
+                                    let mut arg = args.pop().unwrap();
+                                    arg.spread = None;
+                                    arg
+                                }))
+                                .collect(),
                             type_args,
                         });
                     }
-                    _ => unreachable!(),
+
+                    return Expr::Call(CallExpr {
+                        span: DUMMY_SP,
+                        callee: MemberExpr {
+                            span: DUMMY_SP,
+                            obj: callee,
+                            prop: box Expr::Ident(quote_ident!("call")),
+                            computed: false,
+                        }
+                        .as_callee(),
+                        args: iter::once(this).chain(args).collect(),
+                        type_args,
+                    });
                 }
+                _ => unreachable!(),
             }
         }
 

--- a/ecmascript/transforms/src/compat/es2015/computed_props/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/computed_props/mod.rs
@@ -241,7 +241,7 @@ impl Fold<Expr> for ObjectLitFolder {
                 }
 
                 // Last value
-                exprs.push(box Expr::Ident(obj_ident.clone()));
+                exprs.push(box Expr::Ident(obj_ident));
                 Expr::Seq(SeqExpr {
                     span: DUMMY_SP,
                     exprs,

--- a/ecmascript/transforms/src/compat/es2015/destructuring/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/destructuring/mod.rs
@@ -298,7 +298,7 @@ impl Fold<Vec<VarDeclarator>> for AssignFolder {
                     span,
                     left,
                     right: def_value,
-                    type_ann: _,
+                    ..
                 }) => {
                     assert!(
                         decl.init.is_some(),

--- a/ecmascript/transforms/src/compat/es2015/destructuring/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/destructuring/mod.rs
@@ -266,7 +266,7 @@ impl Fold<Vec<VarDeclarator>> for AssignFolder {
 
                                         let var_decl = VarDeclarator {
                                             span: prop_span,
-                                            name: Pat::Ident(key.clone().into()),
+                                            name: Pat::Ident(key.clone()),
                                             init: Some(box make_cond_expr(ref_ident, value)),
                                             definite: false,
                                         };
@@ -275,7 +275,7 @@ impl Fold<Vec<VarDeclarator>> for AssignFolder {
                                     None => {
                                         let var_decl = VarDeclarator {
                                             span: prop_span,
-                                            name: Pat::Ident(key.clone().into()),
+                                            name: Pat::Ident(key.clone()),
                                             init: Some(box make_ref_prop_expr(
                                                 &ref_ident,
                                                 box key.clone().into(),
@@ -425,14 +425,12 @@ impl Fold<Expr> for AssignFolder {
                         right,
                     }),
 
-                    Pat::Ident(..) => {
-                        return Expr::Assign(AssignExpr {
-                            span,
-                            left: PatOrExpr::Pat(pat),
-                            op: op!("="),
-                            right,
-                        });
-                    }
+                    Pat::Ident(..) => Expr::Assign(AssignExpr {
+                        span,
+                        left: PatOrExpr::Pat(pat),
+                        op: op!("="),
+                        right,
+                    }),
                     Pat::Array(ArrayPat { elems, .. }) => {
                         // initialized by first element of sequence expression
                         let ref_ident = make_ref_ident(&mut self.vars, None);
@@ -568,9 +566,7 @@ impl Fold<Expr> for AssignFolder {
 
                                             exprs.push(box Expr::Assign(AssignExpr {
                                                 span,
-                                                left: PatOrExpr::Pat(box Pat::Ident(
-                                                    key.clone().into(),
-                                                )),
+                                                left: PatOrExpr::Pat(box Pat::Ident(key.clone())),
                                                 op: op!("="),
                                                 right: box make_cond_expr(prop_ident, value),
                                             }));
@@ -578,9 +574,7 @@ impl Fold<Expr> for AssignFolder {
                                         None => {
                                             exprs.push(box Expr::Assign(AssignExpr {
                                                 span,
-                                                left: PatOrExpr::Pat(box Pat::Ident(
-                                                    key.clone().into(),
-                                                )),
+                                                left: PatOrExpr::Pat(box Pat::Ident(key.clone())),
                                                 op: op!("="),
                                                 right: box make_ref_prop_expr(
                                                     &ref_ident,
@@ -609,14 +603,12 @@ impl Fold<Expr> for AssignFolder {
                     Pat::Assign(pat) => unimplemented!("assignment pattern {:?}", pat),
                     Pat::Rest(pat) => unimplemented!("rest pattern {:?}", pat),
                 },
-                _ => {
-                    return Expr::Assign(AssignExpr {
-                        span,
-                        left,
-                        op: op!("="),
-                        right,
-                    });
-                }
+                _ => Expr::Assign(AssignExpr {
+                    span,
+                    left,
+                    op: op!("="),
+                    right,
+                }),
             },
             _ => expr,
         }

--- a/ecmascript/transforms/src/compat/es2015/duplicate_keys/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/duplicate_keys/mod.rs
@@ -52,12 +52,12 @@ impl Fold<Prop> for PropFolder {
                 if !self.getter_props.insert(ident.sym.clone())
                     || !self.setter_props.insert(ident.sym.clone())
                 {
-                    return Prop::KeyValue(KeyValueProp {
+                    Prop::KeyValue(KeyValueProp {
                         key: PropName::Computed(box Expr::Lit(Lit::Str(quote_str!(ident
                             .sym
                             .clone())))),
                         value: box Expr::Ident(ident),
-                    });
+                    })
                 } else {
                     Prop::Shorthand(ident)
                 }
@@ -99,18 +99,18 @@ impl<'a> Fold<PropName> for PropNameFolder<'a> {
         match name {
             PropName::Ident(ident) => {
                 if !self.props.insert(ident.sym.clone()) {
-                    return PropName::Computed(box Expr::Lit(Lit::Str(Str {
+                    PropName::Computed(box Expr::Lit(Lit::Str(Str {
                         span,
-                        value: ident.sym.clone(),
+                        value: ident.sym,
                         has_escape: false,
-                    })));
+                    })))
                 } else {
                     PropName::Ident(ident)
                 }
             }
             PropName::Str(s) => {
                 if !self.props.insert(s.value.clone()) {
-                    return PropName::Computed(box Expr::Lit(Lit::Str(s.clone())));
+                    PropName::Computed(box Expr::Lit(Lit::Str(s)))
                 } else {
                     PropName::Str(s)
                 }

--- a/ecmascript/transforms/src/compat/es2015/for_of/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/for_of/mod.rs
@@ -177,13 +177,13 @@ impl Actual {
                 arg: {
                     let step_expr = box Expr::Assign(AssignExpr {
                         span: DUMMY_SP,
-                        left: PatOrExpr::Pat(box Pat::Ident(step.clone())),
+                        left: PatOrExpr::Pat(box Pat::Ident(step)),
                         op: op!("="),
                         // `_iterator.next()`
                         right: box Expr::Call(CallExpr {
                             span: DUMMY_SP,
                             // `_iterator.next`
-                            callee: iterator.clone().member(quote_ident!("next")).as_callee(),
+                            callee: iterator.member(quote_ident!("next")).as_callee(),
                             args: vec![],
                             type_args: Default::default(),
                         }),
@@ -281,13 +281,11 @@ impl Fold<Stmt> for Actual {
                             await_token: None, ..
                         },
                     ) => self.fold_for_stmt(Some(label), stmt),
-                    _ => {
-                        return Stmt::Labeled(LabeledStmt {
-                            span,
-                            label,
-                            body: body.fold_children(self),
-                        });
-                    }
+                    _ => Stmt::Labeled(LabeledStmt {
+                        span,
+                        label,
+                        body: body.fold_children(self),
+                    }),
                 }
             }
             Stmt::ForOf(

--- a/ecmascript/transforms/src/compat/es2015/function_name/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/function_name/mod.rs
@@ -44,7 +44,7 @@ impl Fold<VarDeclarator> for FnName {
                 };
                 let init = decl.init.fold_with(&mut folder);
 
-                return VarDeclarator { init, ..decl };
+                VarDeclarator { init, ..decl }
             }
             _ => decl,
         }
@@ -68,7 +68,7 @@ impl Fold<AssignExpr> for FnName {
 
                 let right = expr.right.fold_with(&mut folder);
 
-                return AssignExpr { right, ..expr };
+                AssignExpr { right, ..expr }
             }
             _ => expr,
         }

--- a/ecmascript/transforms/src/compat/es2015/parameters/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/parameters/mod.rs
@@ -51,7 +51,7 @@ impl Params {
                     })
                 }
                 Pat::Rest(RestPat {
-                    dot3_token: _, arg, ..
+                    arg, ..
                 }) => {
                     // Inject a for statement
                     //

--- a/ecmascript/transforms/src/compat/es2015/parameters/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/parameters/mod.rs
@@ -153,7 +153,7 @@ impl Params {
                                 // _key = 0
                                 VarDeclarator {
                                     span,
-                                    name: Pat::Ident(idx_ident.clone().into()),
+                                    name: Pat::Ident(idx_ident.clone()),
                                     init: Some(box Expr::Lit(Lit::Num(Number {
                                         span,
                                         value: i as f64,

--- a/ecmascript/transforms/src/compat/es2015/spread/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/spread/mod.rs
@@ -62,7 +62,7 @@ impl Fold<Expr> for ActualFolder {
 
                 let args_array = concat_args(span, elems.into_iter(), true);
 
-                return args_array;
+                args_array
             }
 
             // super(...spread) should be removed by es2015::classes pass

--- a/ecmascript/transforms/src/compat/es2015/spread/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/spread/mod.rs
@@ -60,9 +60,7 @@ impl Fold<Expr> for ActualFolder {
                     return Expr::Array(ArrayLit { span, elems });
                 }
 
-                let args_array = concat_args(span, elems.into_iter(), true);
-
-                args_array
+                concat_args(span, elems.into_iter(), true)
             }
 
             // super(...spread) should be removed by es2015::classes pass

--- a/ecmascript/transforms/src/compat/es2015/sticky_regex.rs
+++ b/ecmascript/transforms/src/compat/es2015/sticky_regex.rs
@@ -28,24 +28,23 @@ impl Fold<Expr> for StickyRegex {
             Expr::Lit(Lit::Regex(Regex { exp, flags, span })) => {
                 if flags
                     .as_ref()
-                    .map(|s| s.value.contains("y"))
+                    .map(|s| s.value.contains('y'))
                     .unwrap_or(false)
                 {
                     let str_lit = |s: Str| box Expr::Lit(Lit::Str(s));
 
-                    return Expr::New(NewExpr {
+                    Expr::New(NewExpr {
                         span,
                         callee: box quote_ident!(span, "RegExp").into(),
                         args: Some(
                             iter::once(str_lit(exp).as_arg())
-                                .into_iter()
                                 .chain(flags.map(|flags| str_lit(flags).as_arg()))
                                 .collect(),
                         ),
                         type_args: Default::default(),
-                    });
+                    })
                 } else {
-                    return Expr::Lit(Lit::Regex(Regex { exp, flags, span }));
+                    Expr::Lit(Lit::Regex(Regex { exp, flags, span }))
                 }
             }
             _ => e,

--- a/ecmascript/transforms/src/compat/es2015/template_literal/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/template_literal/mod.rs
@@ -92,7 +92,7 @@ impl Fold<Expr> for TemplateLiteral {
                         type_args: Default::default(),
                     });
                 }
-                return *obj;
+                *obj
             }
 
             Expr::TaggedTpl(TaggedTpl {
@@ -226,7 +226,7 @@ impl Fold<Expr> for TemplateLiteral {
                     args: iter::once(
                         Expr::Call(CallExpr {
                             span: DUMMY_SP,
-                            callee: fn_ident.clone().as_callee(),
+                            callee: fn_ident.as_callee(),
                             args: vec![],
                             type_args: Default::default(),
                         })

--- a/ecmascript/transforms/src/compat/es2015/typeof_symbol.rs
+++ b/ecmascript/transforms/src/compat/es2015/typeof_symbol.rs
@@ -36,15 +36,13 @@ impl Fold<Expr> for TypeOfSymbol {
                 span,
                 op: op!("typeof"),
                 arg,
-            }) => {
-                return Expr::Call(CallExpr {
-                    span,
-                    callee: helper!(span, type_of, "typeof"),
-                    args: vec![arg.as_arg()],
+            }) => Expr::Call(CallExpr {
+                span,
+                callee: helper!(span, type_of, "typeof"),
+                args: vec![arg.as_arg()],
 
-                    type_args: Default::default(),
-                });
-            }
+                type_args: Default::default(),
+            }),
             _ => expr,
         }
     }

--- a/ecmascript/transforms/src/compat/es2016/exponentation.rs
+++ b/ecmascript/transforms/src/compat/es2016/exponentation.rs
@@ -72,12 +72,12 @@ impl Fold<Expr> for AssignFolder {
                         });
                     }
                 };
-                return Expr::Assign(AssignExpr {
+                Expr::Assign(AssignExpr {
                     span,
                     left,
                     op: op!("="),
                     right: box mk_call(span, box lhs.into(), right),
-                });
+                })
             }
             Expr::Bin(BinExpr {
                 span,

--- a/ecmascript/transforms/src/compat/es2017/async_to_generator/mod.rs
+++ b/ecmascript/transforms/src/compat/es2017/async_to_generator/mod.rs
@@ -272,7 +272,7 @@ impl Fold<Expr> for MethodFolder {
                             .as_callee(),
                             args: vec![ExprOrSpread {
                                 spread: Some(DUMMY_SP),
-                                expr: box args_ident.clone().into(),
+                                expr: box args_ident.into(),
                             }],
                             type_args: Default::default(),
                         })),
@@ -572,7 +572,7 @@ impl Actual {
                     })]
                 },
             }),
-            params: params.clone(),
+            params,
             is_generator: false,
             is_async: false,
             decorators: Default::default(),

--- a/ecmascript/transforms/src/compat/es2017/async_to_generator/mod.rs
+++ b/ecmascript/transforms/src/compat/es2017/async_to_generator/mod.rs
@@ -238,10 +238,10 @@ impl Fold<Expr> for MethodFolder {
                 span,
                 callee:
                     ExprOrSuper::Expr(box Expr::Member(MemberExpr {
-                        span: _,
                         obj: ExprOrSuper::Super(super_token),
                         prop,
                         computed,
+                        ..
                     })),
                 args,
                 type_args,

--- a/ecmascript/transforms/src/compat/es2017/async_to_generator/tests.rs
+++ b/ecmascript/transforms/src/compat/es2017/async_to_generator/tests.rs
@@ -164,7 +164,7 @@ _asyncToGenerator(function*() {
 test!(
     ::swc_ecma_parser::Syntax::default(),
     |_| tr(),
-    async,
+    r#async,
     r#"
 class Foo {
   async foo() {

--- a/ecmascript/transforms/src/compat/es2018/object_rest_spread/mod.rs
+++ b/ecmascript/transforms/src/compat/es2018/object_rest_spread/mod.rs
@@ -25,7 +25,7 @@ struct RestFolder {
     /// Variables which should ceclaraed using `var`
     mutable_vars: Vec<VarDeclarator>,
     /// Assignment expressions.
-    exprs: Vec<Box<ast::Expr>>,
+    exprs: Vec<Box<Expr>>,
 }
 
 macro_rules! impl_for_for_stmt {

--- a/ecmascript/transforms/src/compat/es2018/object_rest_spread/mod.rs
+++ b/ecmascript/transforms/src/compat/es2018/object_rest_spread/mod.rs
@@ -470,49 +470,35 @@ impl_fold_fn!(RestFolder);
 
 impl RestFolder {
     fn insert_var_if_not_empty(&mut self, idx: usize, decl: VarDeclarator) {
-        match decl.init {
-            Some(box Expr::Ident(ref i1)) => match decl.name {
-                Pat::Ident(ref i2) => {
-                    if *i1 == *i2 {
-                        return;
-                    }
-                }
-                _ => {}
-            },
-            _ => {}
-        }
-
-        match decl.name {
-            Pat::Object(ObjectPat { ref props, .. }) => {
-                if props.is_empty() {
+        if let Some(box Expr::Ident(ref i1)) = decl.init {
+            if let Pat::Ident(ref i2) = decl.name {
+                if *i1 == *i2 {
                     return;
                 }
             }
-            _ => {}
+        }
+
+        if let Pat::Object(ObjectPat { ref props, .. }) = decl.name {
+            if props.is_empty() {
+                return;
+            }
         }
         self.vars.insert(idx, decl)
     }
 
     fn push_var_if_not_empty(&mut self, decl: VarDeclarator) {
-        match decl.init {
-            Some(box Expr::Ident(ref i1)) => match decl.name {
-                Pat::Ident(ref i2) => {
-                    if *i1 == *i2 {
-                        return;
-                    }
-                }
-                _ => {}
-            },
-            _ => {}
-        }
-
-        match decl.name {
-            Pat::Object(ObjectPat { ref props, .. }) => {
-                if props.is_empty() {
+        if let Some(box Expr::Ident(ref i1)) = decl.init {
+            if let Pat::Ident(ref i2) = decl.name {
+                if *i1 == *i2 {
                     return;
                 }
             }
-            _ => {}
+        }
+
+        if let Pat::Object(ObjectPat { ref props, .. }) = decl.name {
+            if props.is_empty() {
+                return;
+            }
         }
         self.vars.push(decl)
     }
@@ -914,8 +900,8 @@ impl Fold<Expr> for ObjectSpread {
                         match prop {
                             PropOrSpread::Prop(..) => obj.props.push(prop),
                             PropOrSpread::Spread(SpreadElement {
-                                dot3_token: _,
                                 expr,
+                                ..
                             }) => {
                                 // Push object if it's not empty
                                 if first || !obj.props.is_empty() {

--- a/ecmascript/transforms/src/compat/es3/prop_lits.rs
+++ b/ecmascript/transforms/src/compat/es3/prop_lits.rs
@@ -41,11 +41,11 @@ impl Fold<PropName> for PropertyLiteral {
                 value: sym, span, ..
             }) => {
                 if sym.is_reserved_for_es3() || !is_valid_ident(&sym) {
-                    return PropName::Str(Str {
+                    PropName::Str(Str {
                         span,
                         value: sym,
                         has_escape: false,
-                    });
+                    })
                 } else {
                     PropName::Ident(Ident::new(sym, span))
                 }
@@ -53,11 +53,11 @@ impl Fold<PropName> for PropertyLiteral {
             PropName::Ident(i) => {
                 let Ident { sym, span, .. } = i;
                 if sym.is_reserved_for_es3() || sym.contains('-') || sym.contains('.') {
-                    return PropName::Str(Str {
+                    PropName::Str(Str {
                         span,
                         value: sym,
                         has_escape: false,
-                    });
+                    })
                 } else {
                     PropName::Ident(Ident { span, sym, ..i })
                 }

--- a/ecmascript/transforms/src/const_modules.rs
+++ b/ecmascript/transforms/src/const_modules.rs
@@ -156,7 +156,7 @@ mod tests {
     use super::*;
     use crate::tests::Tester;
 
-    fn tr(_: &mut Tester, sources: &[(&str, &[(&str, &str)])]) -> impl Fold<Module> {
+    fn tr(_: &mut Tester<'_>, sources: &[(&str, &[(&str, &str)])]) -> impl Fold<Module> {
         let mut m = HashMap::default();
 
         for (src, values) in sources {

--- a/ecmascript/transforms/src/const_modules.rs
+++ b/ecmascript/transforms/src/const_modules.rs
@@ -162,7 +162,7 @@ mod tests {
         for (src, values) in sources {
             let values = values
                 .iter()
-                .map(|(k, v)| ((*k).into(), (*v).to_string()))
+                .map(|(k, v)| ((*k).into(), v.to_string()))
                 .collect();
 
             m.insert((*src).into(), values);

--- a/ecmascript/transforms/src/const_modules.rs
+++ b/ecmascript/transforms/src/const_modules.rs
@@ -53,7 +53,6 @@ fn parse_option(name: &str, src: String) -> Arc<Expr> {
     .parse_expr()
     .map_err(|mut e| {
         e.emit();
-        ()
     })
     .map(drop_span)
     .unwrap_or_else(|()| {
@@ -142,7 +141,7 @@ impl Fold<Expr> for ConstModules {
             Expr::Ident(Ident { ref sym, .. }) => {
                 // It's ok because we don't recurse into member expressions.
                 if let Some(value) = self.scope.imported.get(sym) {
-                    return (**value).clone();
+                    (**value).clone()
                 } else {
                     expr
                 }
@@ -163,7 +162,7 @@ mod tests {
         for (src, values) in sources {
             let values = values
                 .iter()
-                .map(|(k, v)| ((*k).into(), v.to_string()))
+                .map(|(k, v)| ((*k).into(), (*v).to_string()))
                 .collect();
 
             m.insert((*src).into(), values);

--- a/ecmascript/transforms/src/debug/validator.rs
+++ b/ecmascript/transforms/src/debug/validator.rs
@@ -53,10 +53,8 @@ impl Fold<MemberExpr> for Validator {
             eq!(self, MemberExpr, node.span().lo(), node.obj.span().lo());
         }
 
-        if !node.computed {
-            if !node.prop.span().is_dummy() {
-                eq!(self, MemberExpr, node.span().hi(), node.prop.span().hi());
-            }
+        if !node.computed && !node.prop.span().is_dummy() {
+            eq!(self, MemberExpr, node.span().hi(), node.prop.span().hi());
         }
 
         node.fold_children(self)
@@ -123,10 +121,8 @@ impl Fold<UpdateExpr> for Validator {
             if !node.arg.span().is_dummy() {
                 eq!(self, UpdateExpr, node.arg.span().hi(), node.span().hi())
             }
-        } else {
-            if !node.arg.span().is_dummy() {
-                eq!(self, UpdateExpr, node.arg.span().lo(), node.span().lo())
-            }
+        } else if !node.arg.span().is_dummy() {
+            eq!(self, UpdateExpr, node.arg.span().lo(), node.span().lo())
         }
 
         node.fold_children(self)

--- a/ecmascript/transforms/src/fixer.rs
+++ b/ecmascript/transforms/src/fixer.rs
@@ -37,7 +37,7 @@ impl Default for Context {
 impl Fold<KeyValuePatProp> for Fixer {
     fn fold(&mut self, node: KeyValuePatProp) -> KeyValuePatProp {
         let old = self.ctx;
-        self.ctx = Context::ForcedExpr { is_var_decl: false }.into();
+        self.ctx = Context::ForcedExpr { is_var_decl: false };
         let key = node.key.fold_with(self);
         self.ctx = old;
 
@@ -52,7 +52,7 @@ impl Fold<AssignPatProp> for Fixer {
         let key = node.key.fold_children(self);
 
         let old = self.ctx;
-        self.ctx = Context::ForcedExpr { is_var_decl: false }.into();
+        self.ctx = Context::ForcedExpr { is_var_decl: false };
         let value = node.value.fold_with(self);
         self.ctx = old;
 
@@ -65,7 +65,7 @@ impl Fold<VarDeclarator> for Fixer {
         let name = node.name.fold_children(self);
 
         let old = self.ctx;
-        self.ctx = Context::ForcedExpr { is_var_decl: true }.into();
+        self.ctx = Context::ForcedExpr { is_var_decl: true };
         let init = node.init.fold_with(self);
         self.ctx = old;
 
@@ -92,7 +92,7 @@ impl Fold<Stmt> for Fixer {
         let stmt = match stmt {
             Stmt::Expr(expr) => {
                 let old = self.ctx;
-                self.ctx = Context::Default.into();
+                self.ctx = Context::Default;
                 let expr = expr.fold_with(self);
                 self.ctx = old;
                 Stmt::Expr(expr)
@@ -165,7 +165,7 @@ impl Fold<KeyValueProp> for Fixer {
                 value: box (*prop.value).wrap_with_paren(),
                 ..prop
             },
-            _ => return prop,
+            _ => prop,
         }
     }
 }

--- a/ecmascript/transforms/src/fixer.rs
+++ b/ecmascript/transforms/src/fixer.rs
@@ -43,7 +43,7 @@ impl Fold<KeyValuePatProp> for Fixer {
 
         let value = node.value.fold_with(self);
 
-        validate!(KeyValuePatProp { key, value, ..node })
+        validate!(KeyValuePatProp { key, value })
     }
 }
 
@@ -321,10 +321,6 @@ impl Fold<Expr> for Fixer {
                                 }
                             }
                             _ => buf.push(expr),
-                        }
-
-                        if is_last {
-                        } else {
                         }
                     }
 

--- a/ecmascript/transforms/src/helpers/mod.rs
+++ b/ecmascript/transforms/src/helpers/mod.rs
@@ -312,7 +312,7 @@ swcHelpers._throw();",
 
     #[test]
     fn use_strict_before_helper() {
-        ::tests::test_transform(
+        crate::tests::test_transform(
             Default::default(),
             |_| {
                 enable_helper!(throw);
@@ -330,7 +330,7 @@ function _throw(e) {
 
     #[test]
     fn name_conflict() {
-        ::tests::test_transform(
+        crate::tests::test_transform(
             Default::default(),
             |_| {
                 enable_helper!(throw);
@@ -347,7 +347,7 @@ let _throw1 = null;
     }
     #[test]
     fn use_strict_abort() {
-        ::tests::test_transform(
+        crate::tests::test_transform(
             Default::default(),
             |_| {},
             "'use strict'

--- a/ecmascript/transforms/src/helpers/mod.rs
+++ b/ecmascript/transforms/src/helpers/mod.rs
@@ -305,7 +305,7 @@ swcHelpers._throw();",
                     crate::tests::DebugUsingDisplay(&actual_src),
                     crate::tests::DebugUsingDisplay(&expected_src)
                 );
-                return Err(());
+                Err(())
             })
         });
     }

--- a/ecmascript/transforms/src/hygiene/mod.rs
+++ b/ecmascript/transforms/src/hygiene/mod.rs
@@ -321,7 +321,7 @@ impl<'a> Scope<'a> {
         }
     }
 
-    fn scope_of(&self, sym: JsWord, ctxt: SyntaxContext) -> &'a Scope {
+    fn scope_of(&self, sym: JsWord, ctxt: SyntaxContext) -> &'a Scope<'_> {
         if let Some(prev) = self.declared_symbols.borrow().get(&sym) {
             if prev.contains(&ctxt) {
                 return self;

--- a/ecmascript/transforms/src/hygiene/mod.rs
+++ b/ecmascript/transforms/src/hygiene/mod.rs
@@ -108,7 +108,7 @@ impl<'a> Hygiene<'a> {
             ctxt
         );
         old.retain(|c| *c != ctxt);
-        debug_assert!(old.len() == 0 || old.len() == 1);
+        debug_assert!(old.is_empty() || old.len() == 1);
 
         let new = declared_symbols.entry(renamed.clone()).or_default();
         new.push(ctxt);
@@ -176,7 +176,7 @@ impl<'a> Fold<TryStmt> for Hygiene<'a> {
 impl<'a> Fold<BlockStmt> for Hygiene<'a> {
     fn fold(&mut self, node: BlockStmt) -> BlockStmt {
         let mut folder = Hygiene {
-            current: Scope::new(ScopeKind::Block, Some(&self.current)).into(),
+            current: Scope::new(ScopeKind::Block, Some(&self.current)),
             ident_type: IdentType::Ref,
         };
         let node = node.fold_children(&mut folder);
@@ -195,7 +195,7 @@ impl<'a> Hygiene<'a> {
         }
 
         let mut folder = Hygiene {
-            current: Scope::new(ScopeKind::Fn, Some(&self.current)).into(),
+            current: Scope::new(ScopeKind::Fn, Some(&self.current)),
             ident_type: IdentType::Ref,
         };
 
@@ -345,12 +345,7 @@ impl<'a> Scope<'a> {
         }
 
         if let Some(ctxts) = self.declared_symbols.borrow().get(&sym) {
-            if ctxts.contains(&ctxt) {
-                // Already declared with same context.
-                true
-            } else {
-                false
-            }
+            ctxts.contains(&ctxt)
         } else {
             // No variable named `sym` is declared
             true
@@ -591,7 +586,7 @@ track_ident!(Hygiene);
 impl<'a> Fold<ArrowExpr> for Hygiene<'a> {
     fn fold(&mut self, mut node: ArrowExpr) -> ArrowExpr {
         let mut folder = Hygiene {
-            current: Scope::new(ScopeKind::Fn, Some(&self.current)).into(),
+            current: Scope::new(ScopeKind::Fn, Some(&self.current)),
             ident_type: IdentType::Ref,
         };
 

--- a/ecmascript/transforms/src/hygiene/ops.rs
+++ b/ecmascript/transforms/src/hygiene/ops.rs
@@ -155,7 +155,7 @@ impl Fold<Ident> for VarFolder<'_, '_> {
                     }));
                 i
             }
-            Err(i) => return i,
+            Err(i) => i,
         }
     }
 }

--- a/ecmascript/transforms/src/hygiene/tests.rs
+++ b/ecmascript/transforms/src/hygiene/tests.rs
@@ -79,7 +79,6 @@ where
             let expected = tester.with_parser("expected.js", Syntax::default(), expected, |p| {
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })
             })?;
             tester.print(&expected)

--- a/ecmascript/transforms/src/hygiene/tests.rs
+++ b/ecmascript/transforms/src/hygiene/tests.rs
@@ -50,7 +50,7 @@ impl Fold<Ident> for OnceMarker {
 
 fn test<F>(op: F, expected: &str)
 where
-    F: FnOnce(&mut crate::tests::Tester) -> Result<Vec<Stmt>, ()>,
+    F: FnOnce(&mut crate::tests::Tester<'_>) -> Result<Vec<Stmt>, ()>,
 {
     test_module(
         |tester| {
@@ -66,9 +66,9 @@ where
 
 fn test_module<F>(op: F, expected: &str)
 where
-    F: FnOnce(&mut crate::tests::Tester) -> Result<Module, ()>,
+    F: FnOnce(&mut crate::tests::Tester<'_>) -> Result<Module, ()>,
 {
-    ::tests::Tester::run(|tester| {
+    crate::tests::Tester::run(|tester| {
         let module = op(tester)?;
 
         let module = module.fold_with(&mut hygiene());

--- a/ecmascript/transforms/src/inline_globals.rs
+++ b/ecmascript/transforms/src/inline_globals.rs
@@ -94,7 +94,7 @@ mod tests {
     use super::*;
 
     fn mk_map(
-        tester: &mut crate::tests::Tester,
+        tester: &mut crate::tests::Tester<'_>,
         values: &[(&str, &str)],
         is_env: bool,
     ) -> HashMap<JsWord, Expr> {
@@ -127,12 +127,15 @@ mod tests {
         m
     }
 
-    fn envs(tester: &mut crate::tests::Tester, values: &[(&str, &str)]) -> HashMap<JsWord, Expr> {
+    fn envs(
+        tester: &mut crate::tests::Tester<'_>,
+        values: &[(&str, &str)],
+    ) -> HashMap<JsWord, Expr> {
         mk_map(tester, values, true)
     }
 
     fn globals(
-        tester: &mut crate::tests::Tester,
+        tester: &mut crate::tests::Tester<'_>,
         values: &[(&str, &str)],
     ) -> HashMap<JsWord, Expr> {
         mk_map(tester, values, false)

--- a/ecmascript/transforms/src/inline_globals.rs
+++ b/ecmascript/transforms/src/inline_globals.rs
@@ -33,7 +33,7 @@ impl Fold<Expr> for InlineGlobals {
             Expr::Ident(Ident { ref sym, .. }) => {
                 // It's ok because we don't recurse into member expressions.
                 if let Some(value) = self.globals.get(sym) {
-                    return value.clone().fold_with(self);
+                    value.clone().fold_with(self)
                 } else {
                     expr
                 }
@@ -69,7 +69,7 @@ impl Fold<Expr> for InlineGlobals {
                     }
                     _ => {}
                 }
-                return Expr::Member(MemberExpr {
+                Expr::Member(MemberExpr {
                     span,
                     obj: ExprOrSuper::Expr(box Expr::Member(MemberExpr {
                         obj: ExprOrSuper::Expr(box Expr::Ident(Ident::new(
@@ -82,7 +82,7 @@ impl Fold<Expr> for InlineGlobals {
                     })),
                     prop,
                     computed,
-                });
+                })
             }
             _ => expr,
         }

--- a/ecmascript/transforms/src/lib.rs
+++ b/ecmascript/transforms/src/lib.rs
@@ -14,32 +14,16 @@ extern crate lazy_static;
 extern crate swc_atoms;
 #[macro_use]
 extern crate swc_common;
-extern crate chashmap;
-extern crate fxhash;
-extern crate hashbrown;
-extern crate indexmap;
-extern crate inflector;
-extern crate ordered_float;
-extern crate scoped_tls;
+
 extern crate swc_ecma_ast as ast;
-#[cfg(test)]
-extern crate swc_ecma_codegen;
-extern crate swc_ecma_parser;
+
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;
-#[cfg(test)]
-extern crate sourcemap;
-#[cfg(test)]
-extern crate tempfile;
-#[cfg(test)]
-extern crate test;
+
 #[cfg(test)]
 #[macro_use]
 extern crate testing;
-extern crate either;
-extern crate serde;
-extern crate unicode_xid;
 
 pub use self::{
     const_modules::const_modules, fixer::fixer, hygiene::hygiene, inline_globals::InlineGlobals,

--- a/ecmascript/transforms/src/modules/amd/mod.rs
+++ b/ecmascript/transforms/src/modules/amd/mod.rs
@@ -441,7 +441,7 @@ impl Fold<Module> for Amd {
 
         if !initialized.is_empty() {
             stmts.push(Stmt::Expr(initialize_to_undefined(
-                exports_ident.clone(),
+                exports_ident,
                 initialized,
             )));
         }

--- a/ecmascript/transforms/src/modules/amd/mod.rs
+++ b/ecmascript/transforms/src/modules/amd/mod.rs
@@ -464,31 +464,27 @@ impl Fold<Module> for Amd {
                 // handle interop
                 let ty = self.scope.import_types.get(&src);
 
-                match ty {
-                    Some(&wildcard) => {
+                if let Some(&wildcard) = ty {
+                    if !self.config.config.no_interop {
                         let imported = ident.clone();
-
-                        if !self.config.config.no_interop {
-                            let right = box Expr::Call(CallExpr {
-                                span: DUMMY_SP,
-                                callee: if wildcard {
-                                    helper!(interop_require_wildcard, "interopRequireWildcard")
-                                } else {
-                                    helper!(interop_require_default, "interopRequireDefault")
-                                },
-                                args: vec![imported.as_arg()],
-                                type_args: Default::default(),
-                            });
-                            import_stmts.push(Stmt::Expr(box Expr::Assign(AssignExpr {
-                                span: DUMMY_SP,
-                                left: PatOrExpr::Pat(box Pat::Ident(ident.clone())),
-                                op: op!("="),
-                                right,
-                            })));
-                        }
+                        let right = box Expr::Call(CallExpr {
+                            span: DUMMY_SP,
+                            callee: if wildcard {
+                                helper!(interop_require_wildcard, "interopRequireWildcard")
+                            } else {
+                                helper!(interop_require_default, "interopRequireDefault")
+                            },
+                            args: vec![imported.as_arg()],
+                            type_args: Default::default(),
+                        });
+                        import_stmts.push(Stmt::Expr(box Expr::Assign(AssignExpr {
+                            span: DUMMY_SP,
+                            left: PatOrExpr::Pat(box Pat::Ident(ident.clone())),
+                            op: op!("="),
+                            right,
+                        })));
                     }
-                    _ => {}
-                };
+                }
             }
         }
 

--- a/ecmascript/transforms/src/modules/common_js/mod.rs
+++ b/ecmascript/transforms/src/modules/common_js/mod.rs
@@ -34,10 +34,8 @@ impl Fold<Vec<ModuleItem>> for CommonJs {
         let mut stmts = Vec::with_capacity(items.len() + 4);
         let mut extra_stmts = Vec::with_capacity(items.len());
 
-        if self.config.strict_mode {
-            if !has_use_strict(&items) {
-                stmts.push(ModuleItem::Stmt(use_strict()));
-            }
+        if self.config.strict_mode && !has_use_strict(&items) {
+            stmts.push(ModuleItem::Stmt(use_strict()));
         }
 
         let mut exports = vec![];
@@ -351,7 +349,7 @@ impl Fold<Vec<ModuleItem>> for CommonJs {
 
                                 // When we are in top level we make import not lazy.
                                 let is_top_level = if lazy { !is_reexport } else { true };
-                                self.in_top_level = is_top_level.into();
+                                self.in_top_level = is_top_level;
 
                                 let value = match imported {
                                     Some(ref imported) => {

--- a/ecmascript/transforms/src/modules/import_analysis.rs
+++ b/ecmascript/transforms/src/modules/import_analysis.rs
@@ -19,13 +19,10 @@ impl Fold<Module> for ImportAnalyzer {
         module.visit_with(self);
 
         for (_, ty) in self.scope.import_types.drain() {
-            match ty {
-                true => {
-                    enable_helper!(interop_require_wildcard);
-                }
-                false => {
-                    enable_helper!(interop_require_default);
-                }
+            if ty {
+                enable_helper!(interop_require_wildcard);
+            } else {
+                enable_helper!(interop_require_default);
             }
         }
 

--- a/ecmascript/transforms/src/modules/umd/config.rs
+++ b/ecmascript/transforms/src/modules/umd/config.rs
@@ -46,7 +46,6 @@ impl Config {
                         .parse_expr()
                         .map_err(|mut e| {
                             e.emit();
-                            ()
                         })
                         .unwrap()
                     };
@@ -64,11 +63,11 @@ pub(super) struct BuiltConfig {
 
 impl BuiltConfig {
     pub fn global_name(&self, src: &JsWord) -> JsWord {
-        if !src.contains("/") {
+        if !src.contains('/') {
             return src.to_camel_case().into();
         }
 
-        return src.split("/").last().unwrap().to_camel_case().into();
+        src.split('/').last().unwrap().to_camel_case().into()
     }
     pub fn determine_export_name(&self, filename: FileName) -> Expr {
         match filename {

--- a/ecmascript/transforms/src/modules/umd/mod.rs
+++ b/ecmascript/transforms/src/modules/umd/mod.rs
@@ -38,7 +38,7 @@ struct Umd {
 
 impl Fold<Module> for Umd {
     fn fold(&mut self, module: Module) -> Module {
-        self.in_top_level = true.into();
+        self.in_top_level = true;
 
         let filename = self.cm.span_to_filename(module.span);
 
@@ -437,7 +437,7 @@ impl Fold<Module> for Umd {
 
         if !initialized.is_empty() {
             stmts.push(Stmt::Expr(initialize_to_undefined(
-                exports_ident.clone(),
+                exports_ident,
                 initialized,
             )));
         }

--- a/ecmascript/transforms/src/modules/umd/tests.rs
+++ b/ecmascript/transforms/src/modules/umd/tests.rs
@@ -5,7 +5,7 @@ fn syntax() -> ::swc_ecma_parser::Syntax {
     Default::default()
 }
 
-fn tr(tester: &mut crate::tests::Tester, config: Config) -> impl Fold<Module> {
+fn tr(tester: &mut crate::tests::Tester<'_>, config: Config) -> impl Fold<Module> {
     chain!(resolver(), umd(tester.cm.clone(), config))
 }
 

--- a/ecmascript/transforms/src/proposals/class_properties/class_name_tdz.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/class_name_tdz.rs
@@ -13,7 +13,7 @@ impl<'a> Fold<Expr> for ClassNameTdzFolder<'a> {
                 //
 
                 if i.sym == self.class_name.sym {
-                    return Expr::Seq(SeqExpr {
+                    Expr::Seq(SeqExpr {
                         span: DUMMY_SP,
                         exprs: vec![
                             box Expr::Call(CallExpr {
@@ -30,7 +30,7 @@ impl<'a> Fold<Expr> for ClassNameTdzFolder<'a> {
                             }),
                             box Expr::Ident(i),
                         ],
-                    });
+                    })
                 } else {
                     Expr::Ident(i)
                 }

--- a/ecmascript/transforms/src/proposals/class_properties/mod.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/mod.rs
@@ -447,7 +447,7 @@ impl ClassProperties {
         (
             vars,
             Decl::Class(ClassDecl {
-                ident: ident.clone(),
+                ident,
                 declare: false,
                 class: Class {
                     body: members,
@@ -458,12 +458,13 @@ impl ClassProperties {
         )
     }
 
+    #[allow(clippy::vec_box)]
     fn process_constructor(
         &mut self,
         constructor: Option<Constructor>,
         has_super: bool,
         used_names: &[JsWord],
-        constructor_exprs: Vec<Box<Expr>>,
+        constructor_exprs: Vec<Box<ast::Expr>>,
     ) -> Constructor {
         let constructor = constructor
             .map(|c| {

--- a/ecmascript/transforms/src/proposals/class_properties/mod.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/mod.rs
@@ -464,7 +464,7 @@ impl ClassProperties {
         constructor: Option<Constructor>,
         has_super: bool,
         used_names: &[JsWord],
-        constructor_exprs: Vec<Box<ast::Expr>>,
+        constructor_exprs: Vec<Box<Expr>>,
     ) -> Constructor {
         let constructor = constructor
             .map(|c| {

--- a/ecmascript/transforms/src/proposals/class_properties/private_field.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/private_field.rs
@@ -60,24 +60,22 @@ impl<'a> Fold<Expr> for FieldAccessFolder<'a> {
                     _ => false,
                 } {
                     ThisExpr { span: DUMMY_SP }.as_arg()
+                } else if is_static {
+                    obj.as_arg()
                 } else {
-                    if is_static {
-                        obj.as_arg()
-                    } else {
-                        self.vars.push(VarDeclarator {
-                            span: DUMMY_SP,
-                            name: Pat::Ident(var.clone()),
-                            init: None,
-                            definite: false,
-                        });
-                        AssignExpr {
-                            span: obj.span(),
-                            left: PatOrExpr::Pat(box Pat::Ident(var.clone())),
-                            op: op!("="),
-                            right: obj,
-                        }
-                        .as_arg()
+                    self.vars.push(VarDeclarator {
+                        span: DUMMY_SP,
+                        name: Pat::Ident(var.clone()),
+                        init: None,
+                        definite: false,
+                    });
+                    AssignExpr {
+                        span: obj.span(),
+                        left: PatOrExpr::Pat(box Pat::Ident(var.clone())),
+                        op: op!("="),
+                        right: obj,
                     }
+                    .as_arg()
                 };
                 // Used iff !prefix
                 let old_var = alias_ident_for(&arg.prop, "old");
@@ -117,7 +115,7 @@ impl<'a> Fold<Expr> for FieldAccessFolder<'a> {
                         },
                         right: box Expr::Lit(Lit::Num(Number {
                             span: DUMMY_SP,
-                            value: 1.0.into(),
+                            value: 1.0,
                         })),
                     }
                     .as_arg()
@@ -213,24 +211,22 @@ impl<'a> Fold<Expr> for FieldAccessFolder<'a> {
                     _ => false,
                 } {
                     ThisExpr { span: DUMMY_SP }.as_arg()
+                } else if op == op!("=") {
+                    obj.as_arg()
                 } else {
-                    if op == op!("=") {
-                        obj.as_arg()
-                    } else {
-                        self.vars.push(VarDeclarator {
-                            span: DUMMY_SP,
-                            name: Pat::Ident(var.clone()),
-                            init: None,
-                            definite: false,
-                        });
-                        AssignExpr {
-                            span: obj.span(),
-                            left: PatOrExpr::Pat(box Pat::Ident(var.clone())),
-                            op: op!("="),
-                            right: obj,
-                        }
-                        .as_arg()
+                    self.vars.push(VarDeclarator {
+                        span: DUMMY_SP,
+                        name: Pat::Ident(var.clone()),
+                        init: None,
+                        definite: false,
+                    });
+                    AssignExpr {
+                        span: obj.span(),
+                        left: PatOrExpr::Pat(box Pat::Ident(var.clone())),
+                        op: op!("="),
+                        right: obj,
                     }
+                    .as_arg()
                 };
 
                 let value = if op == op!("=") {
@@ -317,7 +313,7 @@ impl<'a> Fold<Expr> for FieldAccessFolder<'a> {
                 }
             }
             Expr::Member(e) => self.fold_private_get(e, None).0,
-            _ => return e.fold_children(self),
+            _ => e.fold_children(self),
         }
     }
 }
@@ -371,7 +367,7 @@ impl<'a> FieldAccessFolder<'a> {
                     args: vec![
                         obj.as_arg(),
                         self.class_name.clone().as_arg(),
-                        ident.clone().as_arg(),
+                        ident.as_arg(),
                     ],
                     type_args: Default::default(),
                 }),

--- a/ecmascript/transforms/src/proposals/decorators/mod.rs
+++ b/ecmascript/transforms/src/proposals/decorators/mod.rs
@@ -483,7 +483,7 @@ impl Decorators {
                     function: Function {
                         span: DUMMY_SP,
 
-                        params: iter::once(Pat::Ident(initialize.clone()))
+                        params: iter::once(Pat::Ident(initialize))
                             .chain(super_class_ident.map(Pat::Ident))
                             .collect(),
 
@@ -518,7 +518,7 @@ impl Decorators {
                                     props: vec![
                                         PropOrSpread::Prop(box Prop::KeyValue(KeyValueProp {
                                             key: PropName::Ident(quote_ident!("F")),
-                                            value: box Expr::Ident(ident.clone()),
+                                            value: box Expr::Ident(ident),
                                         })),
                                         PropOrSpread::Prop(box Prop::KeyValue(KeyValueProp {
                                             key: PropName::Ident(quote_ident!("d")),

--- a/ecmascript/transforms/src/proposals/decorators/mod.rs
+++ b/ecmascript/transforms/src/proposals/decorators/mod.rs
@@ -474,7 +474,7 @@ impl Decorators {
             .map(Some)
             .collect();
 
-        let decorate_call = Expr::Call(make_decorate_call(
+        Expr::Call(make_decorate_call(
             class.decorators,
             iter::once({
                 // function(_initialize) {}
@@ -540,9 +540,7 @@ impl Decorators {
                 .as_arg()
             })
             .chain(super_class_expr.map(|e| e.as_arg())),
-        ));
-
-        decorate_call
+        ))
     }
 }
 

--- a/ecmascript/transforms/src/react/display_name/mod.rs
+++ b/ecmascript/transforms/src/react/display_name/mod.rs
@@ -26,7 +26,7 @@ impl Fold<VarDeclarator> for DisplayName {
                     }))),
                 });
 
-                return VarDeclarator { init, ..decl };
+                VarDeclarator { init, ..decl }
             }
             _ => decl,
         }
@@ -91,7 +91,7 @@ impl Fold<AssignExpr> for DisplayName {
                     }))),
                 });
 
-                return AssignExpr { right, ..expr };
+                AssignExpr { right, ..expr }
             }
             _ => expr,
         }

--- a/ecmascript/transforms/src/react/jsx/mod.rs
+++ b/ecmascript/transforms/src/react/jsx/mod.rs
@@ -268,7 +268,7 @@ impl Fold<Expr> for Jsx {
             })
             | Expr::JSXElement(el) => {
                 // <div></div> => React.createElement('div', null);
-                self.jsx_elem_to_expr(el)
+                self.jsx_elem_to_expr(*el)
             }
             Expr::Paren(ParenExpr {
                 expr: box Expr::JSXFragment(frag),

--- a/ecmascript/transforms/src/react/jsx/mod.rs
+++ b/ecmascript/transforms/src/react/jsx/mod.rs
@@ -78,7 +78,6 @@ fn parse_option(name: &str, src: String) -> Box<Expr> {
     .parse_expr()
     .map_err(|mut e| {
         e.emit();
-        ()
     })
     .map(drop_span)
     .unwrap_or_else(|()| {
@@ -373,7 +372,7 @@ fn to_prop_name(n: JSXAttrName) -> PropName {
 
     match n {
         JSXAttrName::Ident(i) => {
-            if i.sym.contains("-") {
+            if i.sym.contains('-') {
                 PropName::Str(Str {
                     span,
                     value: i.sym,

--- a/ecmascript/transforms/src/resolver/mod.rs
+++ b/ecmascript/transforms/src/resolver/mod.rs
@@ -58,9 +58,9 @@ pub struct Resolver<'a> {
 impl<'a> Resolver<'a> {
     fn new(mark: Mark, current: Scope<'a>, cur_defining: Option<(JsWord, Mark)>) -> Self {
         Resolver {
-            mark: mark.into(),
-            current: current.into(),
-            cur_defining: cur_defining.into(),
+            mark,
+            current,
+            cur_defining,
             ident_type: IdentType::Ref,
         }
     }

--- a/ecmascript/transforms/src/simplify/mod.rs
+++ b/ecmascript/transforms/src/simplify/mod.rs
@@ -106,11 +106,11 @@ impl Fold<Stmt> for Simplifier {
             },
 
             Stmt::Block(BlockStmt { span, stmts }) => {
-                if stmts.len() == 0 {
-                    return Stmt::Empty(EmptyStmt { span });
+                if stmts.is_empty() {
+                    Stmt::Empty(EmptyStmt { span })
                 } else if stmts.len() == 1 {
                     // TODO: Check if lexical variable exists.
-                    return stmts.into_iter().next().unwrap();
+                    stmts.into_iter().next().unwrap()
                 } else {
                     Stmt::Block(BlockStmt { span, stmts })
                 }

--- a/ecmascript/transforms/src/tests.rs
+++ b/ecmascript/transforms/src/tests.rs
@@ -81,7 +81,6 @@ impl<'a> Tester<'a> {
         self.with_parser(file_name, Syntax::default(), src, |p| {
             p.parse_module().map_err(|mut e| {
                 e.emit();
-                ()
             })
         })
     }
@@ -91,7 +90,6 @@ impl<'a> Tester<'a> {
             p.parse_script()
                 .map_err(|mut e| {
                     e.emit();
-                    ()
                 })
                 .map(|script| script.body)
         })?;
@@ -126,7 +124,6 @@ impl<'a> Tester<'a> {
                 let mut p = Parser::new(sess, syntax, SourceFileInput::from(&*fm), None);
                 p.parse_module().map_err(|mut e| {
                     e.emit();
-                    ()
                 })?
             };
             // println!("parsed {} as a module\n{:?}", src, module);
@@ -250,7 +247,7 @@ pub(crate) fn test_transform<F, P>(
             );
         }
 
-        return Err(());
+        Err(())
     });
 }
 

--- a/ecmascript/transforms/src/typescript/mod.rs
+++ b/ecmascript/transforms/src/typescript/mod.rs
@@ -201,7 +201,7 @@ impl Fold<Vec<ModuleItem>> for Strip {
         let items = items.fold_children(self);
 
         let old = self.phase;
-        self.phase = Phase::DropImports.into();
+        self.phase = Phase::DropImports;
 
         // Second pass
         let items = items.move_flat_map(|item| match item {
@@ -293,7 +293,7 @@ impl Fold<Vec<ModuleItem>> for Strip {
                         {
                             e.has_concrete
                         } else {
-                            return true;
+                            true
                         }
                     }
                     _ => true,
@@ -399,7 +399,7 @@ impl Fold<Decl> for Strip {
         self.handle_decl(&decl);
 
         let old = self.non_top_level;
-        self.non_top_level = true.into();
+        self.non_top_level = true;
         let decl = decl.fold_children(self);
         self.non_top_level = old;
         decl
@@ -417,7 +417,7 @@ impl Fold<Stmt> for Strip {
                 | Decl::TsModule(..)
                 | Decl::TsTypeAlias(..) => {
                     let span = decl.span();
-                    return Stmt::Empty(EmptyStmt { span });
+                    Stmt::Empty(EmptyStmt { span })
                 }
                 _ => Stmt::Decl(decl),
             },

--- a/ecmascript/transforms/src/typescript/mod.rs
+++ b/ecmascript/transforms/src/typescript/mod.rs
@@ -124,7 +124,7 @@ impl Fold<Constructor> for Strip {
                         span,
                         left: box Pat::Ident(i),
                         right,
-                        type_ann: _,
+                        ..
                     }) => (
                         i.clone(),
                         Pat::Assign(AssignPat {

--- a/ecmascript/transforms/src/typescript/opt_chaining/mod.rs
+++ b/ecmascript/transforms/src/typescript/opt_chaining/mod.rs
@@ -216,7 +216,7 @@ impl OptChaining {
                 let obj_span = obj.span();
 
                 let (left, right, alt) = match obj {
-                    Expr::Ident(..) => (box obj.clone(), box obj.clone(), e.expr),
+                    Expr::Ident(..) => (box obj.clone(), box obj, e.expr),
                     _ => {
                         let i = private_ident!(obj_span, "ref");
                         self.vars.push(VarDeclarator {
@@ -235,7 +235,7 @@ impl OptChaining {
                             }),
                             box Expr::Ident(i.clone()),
                             box Expr::Member(MemberExpr {
-                                obj: ExprOrSuper::Expr(box Expr::Ident(i.clone())),
+                                obj: ExprOrSuper::Expr(box Expr::Ident(i)),
                                 computed,
                                 span,
                                 prop,
@@ -285,7 +285,7 @@ impl OptChaining {
                 };
 
                 let (left, right, alt) = match obj {
-                    Expr::Ident(..) => (box obj.clone(), box obj.clone(), e.expr),
+                    Expr::Ident(..) => (box obj.clone(), box obj, e.expr),
                     _ => {
                         let i = private_ident!(obj_span, "ref");
                         self.vars.push(VarDeclarator {
@@ -315,7 +315,7 @@ impl OptChaining {
                                 args: once(if is_super_access {
                                     ThisExpr { span }.as_arg()
                                 } else {
-                                    i.clone().as_arg()
+                                    i.as_arg()
                                 })
                                 .chain(args)
                                 .collect(),

--- a/ecmascript/transforms/src/typescript/opt_chaining/mod.rs
+++ b/ecmascript/transforms/src/typescript/opt_chaining/mod.rs
@@ -1,8 +1,10 @@
-use crate::{pass::Pass, util::ExprFactory};
+use crate::{
+    pass::Pass,
+    util::{prepend, undefined, ExprFactory, StmtLike},
+};
 use ast::*;
 use std::{fmt::Debug, iter::once, mem};
 use swc_common::{Fold, FoldWith, Spanned, DUMMY_SP};
-use util::{prepend, undefined, StmtLike};
 
 #[cfg(test)]
 mod tests;
@@ -62,8 +64,8 @@ impl OptChaining {
     fn handle_unary(&mut self, e: UnaryExpr) -> Expr {
         let span = e.span;
 
-        match e.op {
-            op!("delete") => match *e.arg {
+        if let op!("delete") = e.op {
+            match *e.arg {
                 Expr::TsOptChain(o) => {
                     let expr = self.unwrap(o);
 
@@ -104,9 +106,7 @@ impl OptChaining {
                     .into();
                 }
                 _ => {}
-            },
-
-            _ => {}
+            }
         }
 
         Expr::Unary(e)
@@ -114,21 +114,17 @@ impl OptChaining {
 
     /// Only called from [Fold<Expr>].
     fn handle_call(&mut self, e: CallExpr) -> Expr {
-        match e.callee {
-            ExprOrSuper::Expr(box Expr::TsOptChain(o)) => {
-                let expr = self.unwrap(o);
+        if let ExprOrSuper::Expr(box Expr::TsOptChain(o)) = e.callee {
+            let expr = self.unwrap(o);
 
-                return CondExpr {
-                    alt: box Expr::Call(CallExpr {
-                        callee: ExprOrSuper::Expr(expr.alt),
-                        ..e
-                    }),
-                    ..expr
-                }
-                .into();
+            return CondExpr {
+                alt: box Expr::Call(CallExpr {
+                    callee: ExprOrSuper::Expr(expr.alt),
+                    ..e
+                }),
+                ..expr
             }
-
-            _ => {}
+            .into();
         }
 
         Expr::Call(e)
@@ -136,21 +132,17 @@ impl OptChaining {
 
     /// Only called from `[Fold<Expr>].
     fn handle_member(&mut self, e: MemberExpr) -> Expr {
-        match e.obj {
-            ExprOrSuper::Expr(box Expr::TsOptChain(o)) => {
-                let expr = self.unwrap(o);
+        if let ExprOrSuper::Expr(box Expr::TsOptChain(o)) = e.obj {
+            let expr = self.unwrap(o);
 
-                return CondExpr {
-                    alt: box Expr::Member(MemberExpr {
-                        obj: ExprOrSuper::Expr(expr.alt),
-                        ..e
-                    }),
-                    ..expr
-                }
-                .into();
+            return CondExpr {
+                alt: box Expr::Member(MemberExpr {
+                    obj: ExprOrSuper::Expr(expr.alt),
+                    ..e
+                }),
+                ..expr
             }
-
-            _ => {}
+            .into();
         }
 
         Expr::Member(e)
@@ -211,7 +203,7 @@ impl OptChaining {
                 obj: ExprOrSuper::Expr(box obj),
                 prop,
                 computed,
-                span: _,
+                ..
             }) => {
                 let obj_span = obj.span();
 

--- a/ecmascript/transforms/src/typescript/opt_chaining/tests.rs
+++ b/ecmascript/transforms/src/typescript/opt_chaining/tests.rs
@@ -26,7 +26,7 @@ fn syntax() -> Syntax {
 // general_assignment
 test!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     general_assignment,
     r#"
 "use strict";
@@ -77,7 +77,7 @@ val = obj === null || obj === void 0 ? void 0 : (ref2 = obj.a) === null || ref2 
 // general_memoize
 test!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     general_memoize,
     r#"
 function test(foo) {
@@ -123,7 +123,7 @@ function test(foo) {
 // general_containers
 test!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     general_containers,
     r#"
 var street = user.address?.street
@@ -152,7 +152,7 @@ a === null || a === void 0 ? void 0 : a.b, 2;
 // general_delete_exec
 test_exec!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     general_delete_exec,
     r#"
 "use strict";
@@ -184,7 +184,7 @@ expect(obj.a).toBeUndefined();
 // general_member_access
 test!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     general_member_access,
     r#"
 foo?.bar;
@@ -226,7 +226,7 @@ orders[client === null || client === void 0 ? void 0 : client.key].price;
 // general_unary
 test!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     general_unary,
     r#"
 "use strict";
@@ -269,7 +269,7 @@ test = +(obj === null || obj === void 0 ? void 0 : (ref2 = obj.b) === null || re
 // general_function_call
 test!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     general_function_call,
     r#"
 foo?.(foo);
@@ -311,7 +311,7 @@ foo === null || foo === void 0 ? void 0 : (ref7 = foo.bar) === null || ref7 === 
 // general_unary_exec
 test_exec!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     general_unary_exec,
     r#"
 "use strict";
@@ -340,7 +340,7 @@ expect(test).toBe(NaN);
 // general_call_exec
 test_exec!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     general_call_exec,
     r#"
 
@@ -350,7 +350,7 @@ test_exec!(
 // general_delete
 test!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     general_delete,
     r#"
 "use strict";
@@ -391,7 +391,7 @@ obj === null || obj === void 0 ? void 0 : delete obj.a;
 // regression_8354_exec
 test_exec!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     regression_8354_exec,
     r#"
 const foo = undefined;
@@ -405,7 +405,7 @@ expect(foobar).toBe(undefined);
 // general_assignment_exec
 test_exec!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     general_assignment_exec,
     r#"
 "use strict";
@@ -443,7 +443,7 @@ expect(() => {
 // general_super_method_call
 test!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     general_super_method_call,
     r#"
 "use strict";
@@ -484,7 +484,7 @@ class Derived extends Base {
 
 test!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     simple_1,
     "obj?.a",
     "obj === null || obj === void 0 ? void 0 : obj.a;"
@@ -492,7 +492,7 @@ test!(
 
 test!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     simple_2,
     "obj?.a?.b",
     "var ref;
@@ -502,7 +502,7 @@ obj === null || obj === void 0 ? void 0 : (ref = obj.a) === null || ref === void
 
 test!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     simple_3,
     "obj?.a?.b.c",
     "var ref;
@@ -512,7 +512,7 @@ obj === null || obj === void 0 ? void 0 : (ref = obj.a) === null || ref === void
 
 test!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     call_1,
     "obj?.a?.b()",
     "var ref;
@@ -523,7 +523,7 @@ obj === null || obj === void 0 ? void 0 : (ref = obj.a) === null || ref === void
 
 test!(
     syntax(),
-    |_| tr(Default::default()),
+    |_| tr(()),
     call_2,
     "a?.b?.c?.()",
     "var ref, ref1;

--- a/ecmascript/transforms/src/util/constructor.rs
+++ b/ecmascript/transforms/src/util/constructor.rs
@@ -4,7 +4,7 @@ use std::iter;
 use swc_common::{util::move_map::MoveMap, Fold, FoldWith, DUMMY_SP};
 
 #[allow(clippy::vec_box)]
-pub(crate) fn inject_after_super(mut c: Constructor, exprs: Vec<Box<ast::Expr>>) -> Constructor {
+pub(crate) fn inject_after_super(mut c: Constructor, exprs: Vec<Box<Expr>>) -> Constructor {
     // Allow using super multiple time
     let mut folder = Injector {
         exprs: &exprs,

--- a/ecmascript/transforms/src/util/constructor.rs
+++ b/ecmascript/transforms/src/util/constructor.rs
@@ -64,7 +64,7 @@ impl<'a> Fold<Vec<Stmt>> for Injector<'a> {
                     let stmt = stmt.fold_with(&mut folder);
 
                     self.injected |= folder.injected;
-                    let iter = folder
+                    folder
                         .injected_tmp
                         .map(|ident| {
                             Stmt::Decl(Decl::Var(VarDecl {
@@ -81,9 +81,7 @@ impl<'a> Fold<Vec<Stmt>> for Injector<'a> {
                         })
                         .into_iter()
                         .chain(iter::once(stmt))
-                        .chain((&[]).iter().cloned().map(Stmt::Expr));
-
-                    iter
+                        .chain((&[]).iter().cloned().map(Stmt::Expr))
                 }
             }
         })

--- a/ecmascript/transforms/src/util/constructor.rs
+++ b/ecmascript/transforms/src/util/constructor.rs
@@ -3,7 +3,8 @@ use ast::*;
 use std::iter;
 use swc_common::{util::move_map::MoveMap, Fold, FoldWith, DUMMY_SP};
 
-pub(crate) fn inject_after_super(mut c: Constructor, exprs: Vec<Box<Expr>>) -> Constructor {
+#[allow(clippy::vec_box)]
+pub(crate) fn inject_after_super(mut c: Constructor, exprs: Vec<Box<ast::Expr>>) -> Constructor {
     // Allow using super multiple time
     let mut folder = Injector {
         exprs: &exprs,

--- a/ecmascript/transforms/src/util/mod.rs
+++ b/ecmascript/transforms/src/util/mod.rs
@@ -247,7 +247,6 @@ pub trait ExprExt {
 
             Expr::Unary(UnaryExpr {
                 op: op!("void"),
-                arg: _,
                 ..
             }) => Known(false),
 
@@ -298,12 +297,12 @@ pub trait ExprExt {
                         sym: js_word!("Infinity"),
                         ..
                     }),
-                span: _,
+                ..
             }) => -INFINITY,
             Expr::Unary(UnaryExpr {
                 op: op!("!"),
                 ref arg,
-                span: _,
+                ..
             }) => match arg.as_bool() {
                 (Pure, Known(v)) => {
                     if v {
@@ -317,7 +316,7 @@ pub trait ExprExt {
             Expr::Unary(UnaryExpr {
                 op: op!("void"),
                 ref arg,
-                span: _,
+                ..
             }) => {
                 if arg.may_have_side_effects() {
                     return Unknown;
@@ -336,7 +335,7 @@ pub trait ExprExt {
         Known(v)
     }
 
-    fn as_string(&self) -> Value<Cow<str>> {
+    fn as_string(&self) -> Value<Cow<'_, str>> {
         let expr = self.as_expr_kind();
         match *expr {
             Expr::Lit(ref l) => match *l {

--- a/ecmascript/transforms/tests/fixer.rs
+++ b/ecmascript/transforms/tests/fixer.rs
@@ -2,14 +2,11 @@
 #![feature(box_patterns)]
 #![feature(specialization)]
 #![feature(test)]
-extern crate sourcemap;
-extern crate swc_common;
-extern crate swc_ecma_ast;
-extern crate swc_ecma_codegen;
-extern crate swc_ecma_parser;
-extern crate swc_ecma_transforms;
+
+use swc_ecma_codegen;
+
 extern crate test;
-extern crate testing;
+
 use std::{
     env,
     fs::{read_dir, File},
@@ -171,7 +168,7 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                     {
                         let handlers = box MyHandlers;
                         let handlers2 = box MyHandlers;
-                        let mut parser: Parser<Lexer<SourceFileInput>> = Parser::new(
+                        let mut parser: Parser<'_, Lexer<'_, SourceFileInput<'_>>> = Parser::new(
                             Session { handler: &handler },
                             Syntax::default(),
                             (&*src).into(),
@@ -204,7 +201,7 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
 
                         // Parse source
 
-                        let mut e_parser: Parser<Lexer<SourceFileInput>> = Parser::new(
+                        let mut e_parser: Parser<'_, Lexer<'_, SourceFileInput<'_>>> = Parser::new(
                             Session { handler: &handler },
                             Syntax::default(),
                             (&*expected).into(),

--- a/ecmascript/transforms/tests/fixer.rs
+++ b/ecmascript/transforms/tests/fixer.rs
@@ -195,10 +195,7 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                             cfg: swc_ecma_codegen::Config { minify: false },
                             cm: cm.clone(),
                             wr: box swc_ecma_codegen::text_writer::JsWriter::new(
-                                cm.clone(),
-                                "\n",
-                                &mut wr2,
-                                None,
+                                cm, "\n", &mut wr2, None,
                             ),
                             comments: None,
                             handlers: handlers2,
@@ -221,14 +218,12 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                                 .map(|p| p.fold_with(&mut fixer()))
                                 .map_err(|mut e| {
                                     e.emit();
-                                    ()
                                 })?;
                             let module2 = e_parser
                                 .parse_module()
                                 .map(normalize)
                                 .map_err(|mut e| {
                                     e.emit();
-                                    ()
                                 })
                                 .expect("failed to parse reference file");
                             if module == module2 {
@@ -243,7 +238,6 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                                 .map(|p| p.fold_with(&mut fixer()))
                                 .map_err(|mut e| {
                                     e.emit();
-                                    ()
                                 })?;
                             let script2 = e_parser
                                 .parse_script()
@@ -251,7 +245,6 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                                 .map(|p| p.fold_with(&mut fixer()))
                                 .map_err(|mut e| {
                                     e.emit();
-                                    ()
                                 })?;
 
                             if script == script2 {

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -1,4 +1,4 @@
-extern crate swc;
+use swc;
 
 use std::{path::Path, sync::Arc};
 use swc::{
@@ -23,5 +23,6 @@ fn main() {
         Options {
             ..Default::default()
         },
-    );
+    )
+    .expect("failed to process file");
 }

--- a/macros/ast_node/Cargo.toml
+++ b/macros/ast_node/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
 documentation = "https://swc-project.github.io/rustdoc/ast_node/"
 description = "Macros for ast nodes."
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/macros/ast_node/src/ast_node_macro.rs
+++ b/macros/ast_node/src/ast_node_macro.rs
@@ -36,7 +36,7 @@ pub fn expand_struct(args: Args, i: DeriveInput) -> Vec<ItemImpl> {
                 }
             ))
             .parse::<ItemImpl>()
-            .with_generics(generics.clone()),
+            .with_generics(generics),
     );
 
     // let ident = i.ident.clone();

--- a/macros/ast_node/src/ast_node_macro.rs
+++ b/macros/ast_node/src/ast_node_macro.rs
@@ -12,7 +12,7 @@ pub struct Args {
 }
 
 impl Parse for Args {
-    fn parse(i: ParseStream) -> syn::Result<Self> {
+    fn parse(i: ParseStream<'_>) -> syn::Result<Self> {
         Ok(Args { ty: i.parse()? })
     }
 }

--- a/macros/ast_node/src/enum_deserialize.rs
+++ b/macros/ast_node/src/enum_deserialize.rs
@@ -11,10 +11,11 @@ struct VariantAttr {
 }
 
 impl Parse for VariantAttr {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let content;
+        let _paren_token = parenthesized!(content in input);
         Ok(VariantAttr {
-            _paren_token: parenthesized!(content in input),
+            _paren_token,
             tags: content.parse_terminated(Lit::parse)?,
         })
     }

--- a/macros/ast_node/src/enum_deserialize.rs
+++ b/macros/ast_node/src/enum_deserialize.rs
@@ -68,7 +68,7 @@ pub fn expand(
                     .collect::<Punctuated<_, token::Comma>>();
 
                 assert!(
-                    tags.len() >= 1,
+                    !tags.is_empty(),
                     "All #[ast_node] enum variants have one or more tag"
                 );
                 if tags.len() == 1
@@ -173,7 +173,7 @@ pub fn expand(
                 }
             ))
             .parse::<ItemImpl>()
-            .with_generics(generics.clone())
+            .with_generics(generics)
     };
 
     vec![deserialize]

--- a/macros/ast_node/src/fold.rs
+++ b/macros/ast_node/src/fold.rs
@@ -172,6 +172,7 @@ pub fn derive(input: DeriveInput) -> ItemImpl {
             {
                 impl<__Fold> swc_common::FoldWith<__Fold> for Type {
                     #[inline]
+                    #[allow(clippy::needless_return)]
                     fn fold_children(self, _f: &mut __Fold) -> Self {
                         body
                     }
@@ -227,6 +228,5 @@ fn normalize_type_for_bound(ty: Type) -> Type {
         }
     }
 
-    let out = Norm.fold_type(ty);
-    out
+    Norm.fold_type(ty)
 }

--- a/macros/ast_node/src/lib.rs
+++ b/macros/ast_node/src/lib.rs
@@ -1,13 +1,12 @@
 #![recursion_limit = "1024"]
 
-extern crate darling;
+use darling;
 #[macro_use]
 extern crate pmutil;
 extern crate proc_macro;
-extern crate proc_macro2;
-extern crate quote;
-extern crate swc_macros_common;
-extern crate syn;
+use proc_macro2;
+
+use syn;
 
 use pmutil::{Quote, ToTokensExt};
 use swc_macros_common::prelude::*;

--- a/macros/ast_node/src/spanned.rs
+++ b/macros/ast_node/src/spanned.rs
@@ -75,7 +75,7 @@ pub fn derive(input: DeriveInput) -> ItemImpl {
         .with_generics(input.generics)
 }
 
-fn make_body_for_variant(v: &VariantBinder, bindings: Vec<BindedField>) -> Box<Expr> {
+fn make_body_for_variant(v: &VariantBinder<'_>, bindings: Vec<BindedField<'_>>) -> Box<Expr> {
     /// `swc_common::Spanned::span(#field)`
     fn simple_field(field: &dyn ToTokens) -> Box<Expr> {
         Box::new(

--- a/macros/ast_node/src/spanned.rs
+++ b/macros/ast_node/src/spanned.rs
@@ -87,7 +87,7 @@ fn make_body_for_variant(v: &VariantBinder, bindings: Vec<BindedField>) -> Box<E
         )
     }
 
-    if bindings.len() == 0 {
+    if bindings.is_empty() {
         panic!("#[derive(Spanned)] requires a field to get span from")
     }
 

--- a/macros/ast_node/src/spanned.rs
+++ b/macros/ast_node/src/spanned.rs
@@ -92,12 +92,9 @@ fn make_body_for_variant(v: &VariantBinder, bindings: Vec<BindedField>) -> Box<E
     }
 
     if bindings.len() == 1 {
-        match *v.data() {
-            Fields::Unnamed(..) => {
-                // Call self.0.span()
-                return simple_field(&bindings[0]);
-            }
-            _ => {}
+        if let Fields::Unnamed(..) = *v.data() {
+            // Call self.0.span()
+            return simple_field(&bindings[0]);
         }
     }
 

--- a/macros/ast_node/src/visit.rs
+++ b/macros/ast_node/src/visit.rs
@@ -49,9 +49,10 @@ pub fn derive(input: DeriveInput) -> ItemImpl {
                 .filter_map(|binding| {
                     // This closure will not be called for unit-like struct.
 
-                    let value = match should_skip_field(binding.field()) {
-                        true => None,
-                        false => Some(
+                    let value = if should_skip_field(binding.field()) {
+                        None
+                    } else {
+                        Some(
                             Quote::new(def_site::<Span>())
                                 .quote_with(smart_quote!(
                                     Vars {
@@ -63,7 +64,7 @@ pub fn derive(input: DeriveInput) -> ItemImpl {
                                     }
                                 ))
                                 .parse::<Stmt>(),
-                        ),
+                        )
                     };
 
                     let _attrs = binding
@@ -187,11 +188,8 @@ fn normalize_type_for_bound(ty: Type) -> Type {
                         if let GenericArgument::Type(ref ty) =
                             *args.args.last().unwrap().into_value()
                         {
-                            match *ty {
-                                Type::Path(TypePath { ref path, .. }) => {
-                                    return self.fold_path(path.clone());
-                                }
-                                _ => {}
+                            if let Type::Path(TypePath { ref path, .. }) = *ty {
+                                return self.fold_path(path.clone());
                             }
                         }
                     }

--- a/macros/ast_node/src/visit.rs
+++ b/macros/ast_node/src/visit.rs
@@ -148,11 +148,7 @@ pub fn derive(input: DeriveInput) -> ItemImpl {
             }
         ))
         .parse();
-    let item = derive_generics.append_to(item);
-
-    // println!("Expaned:\n {}\n\n", item.dump());
-
-    item
+    derive_generics.append_to(item)
 }
 
 fn should_skip_field(field: &Field) -> bool {
@@ -200,6 +196,5 @@ fn normalize_type_for_bound(ty: Type) -> Type {
         }
     }
 
-    let out = Norm.fold_type(ty);
-    out
+    Norm.fold_type(ty)
 }

--- a/macros/ast_node/tests/attr_interop.rs
+++ b/macros/ast_node/tests/attr_interop.rs
@@ -1,8 +1,6 @@
 //! Test that `#[span]` and `#[fold]` can be used at same time.
-extern crate serde;
-extern crate swc_common;
-use serde::{Deserialize, Serialize};
-use swc_common::{ast_node, Fold, Span, Spanned};
+use serde::{self, Deserialize, Serialize};
+use swc_common::{self, ast_node, Fold, Span, Spanned};
 
 #[ast_node("Class")]
 // See https://github.com/rust-lang/rust/issues/44925

--- a/macros/ast_node/tests/empty.rs
+++ b/macros/ast_node/tests/empty.rs
@@ -1,6 +1,3 @@
-extern crate ast_node;
-extern crate serde;
-extern crate swc_common;
 use ast_node::*;
 
 #[derive(Fold)]

--- a/macros/ast_node/tests/fold_bound.rs
+++ b/macros/ast_node/tests/fold_bound.rs
@@ -2,8 +2,6 @@
 
 #![feature(specialization)]
 
-extern crate serde;
-extern crate swc_common;
 use std::fmt::Debug;
 use swc_common::{AstNode, Fold};
 

--- a/macros/ast_node/tests/fold_ignore.rs
+++ b/macros/ast_node/tests/fold_ignore.rs
@@ -1,7 +1,5 @@
 #![feature(specialization)]
 
-extern crate serde;
-extern crate swc_common;
 use swc_common::{Fold, FoldWith, VisitWith};
 struct MyFold;
 

--- a/macros/ast_node/tests/fold_simple.rs
+++ b/macros/ast_node/tests/fold_simple.rs
@@ -1,7 +1,5 @@
 #![feature(specialization)]
 
-extern crate serde;
-extern crate swc_common;
 use swc_common::{Fold, FoldWith};
 
 pub trait AssertFold<T>: Fold<T> {}

--- a/macros/ast_node/tests/spanned_attr.rs
+++ b/macros/ast_node/tests/spanned_attr.rs
@@ -1,5 +1,3 @@
-extern crate serde;
-extern crate swc_common;
 use swc_common::{BytePos, Span, Spanned};
 
 #[test]

--- a/macros/common/Cargo.toml
+++ b/macros/common/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
 documentation = "https://swc-project.github.io/rustdoc/swc_macros_common/"
 description = "Common utilities for swc macros."
+edition = "2018"
 
 [dependencies]
 pmutil = "0.3"

--- a/macros/common/src/binder.rs
+++ b/macros/common/src/binder.rs
@@ -32,8 +32,7 @@
 //! -----
 //!
 //! Adopted from `synstructure`.
-use def_site;
-use is_attr_name;
+use crate::{def_site, is_attr_name, syn_ext::PairExt};
 use pmutil::prelude::*;
 use proc_macro2::Span;
 use quote::ToTokens;
@@ -42,7 +41,6 @@ use syn::{
     token::{Mut, Ref},
     *,
 };
-use syn_ext::PairExt;
 
 /// Used to bind whole struct or enum.
 #[derive(Debug, Clone)]

--- a/macros/common/src/binder.rs
+++ b/macros/common/src/binder.rs
@@ -143,15 +143,15 @@ impl<'a> VariantBinder<'a> {
     ) -> (Pat, Vec<BindedField<'a>>) {
         let path = self.qual_path();
 
-        let (pat, bindings) = match self.data {
-            &Fields::Unit => {
+        let (pat, bindings) = match *self.data {
+            Fields::Unit => {
                 // EnumName::VariantName
                 let pat = Pat::Path(PatPath { qself: None, path });
 
                 // Unit struct does not have any field to bind
                 (pat, vec![])
             }
-            &Fields::Named(FieldsNamed {
+            Fields::Named(FieldsNamed {
                 named: ref fields,
                 brace_token,
             }) => {
@@ -205,7 +205,7 @@ impl<'a> VariantBinder<'a> {
                 });
                 (pat, bindings)
             }
-            &Fields::Unnamed(FieldsUnnamed {
+            Fields::Unnamed(FieldsUnnamed {
                 unnamed: ref fields,
                 paren_token,
             }) => {

--- a/macros/common/src/derive/mod.rs
+++ b/macros/common/src/derive/mod.rs
@@ -24,12 +24,9 @@ impl<'a> Derive<'a> {
                 .clone()
                 .into_pairs()
                 .map(|mut pair| {
-                    match *pair.value_mut() {
-                        GenericParam::Type(ref mut t) => {
-                            t.eq_token = None;
-                            t.default = None;
-                        }
-                        _ => {}
+                    if let GenericParam::Type(ref mut t) = *pair.value_mut() {
+                        t.eq_token = None;
+                        t.default = None;
                     }
 
                     pair

--- a/macros/common/src/derive/mod.rs
+++ b/macros/common/src/derive/mod.rs
@@ -1,4 +1,4 @@
-use def_site;
+use crate::def_site;
 use pmutil::ToTokensExt;
 use proc_macro2::TokenStream;
 use quote::ToTokens;

--- a/macros/common/src/lib.rs
+++ b/macros/common/src/lib.rs
@@ -1,10 +1,10 @@
 #[macro_use]
 extern crate pmutil;
 extern crate proc_macro;
-extern crate proc_macro2;
+use proc_macro2;
 #[macro_use]
 extern crate quote;
-extern crate syn;
+
 use pmutil::{synom_ext::FromSpan, SpanExt};
 use proc_macro2::Span;
 use syn::*;

--- a/macros/common/src/syn_ext.rs
+++ b/macros/common/src/syn_ext.rs
@@ -1,4 +1,4 @@
-use def_site;
+use crate::def_site;
 use pmutil::prelude::*;
 use syn::{punctuated::Pair, *};
 

--- a/macros/common/src/syn_ext.rs
+++ b/macros/common/src/syn_ext.rs
@@ -47,13 +47,11 @@ impl ItemImplExt for ItemImpl {
         }
 
         // Respan
-        match generics.lt_token {
-            Some(t) => self.generics.lt_token = Some(t),
-            None => {}
+        if let Some(t) = generics.lt_token {
+            self.generics.lt_token = Some(t)
         }
-        match generics.gt_token {
-            Some(t) => self.generics.gt_token = Some(t),
-            None => {}
+        if let Some(t) = generics.gt_token {
+            self.generics.gt_token = Some(t)
         }
 
         let ty = self.self_ty;

--- a/macros/enum_kind/Cargo.toml
+++ b/macros/enum_kind/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
 documentation = "https://swc-project.github.io/rustdoc/enum_kind/"
 description = "Easily manage values related to enum."
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/macros/enum_kind/src/expand.rs
+++ b/macros/enum_kind/src/expand.rs
@@ -1,8 +1,7 @@
-use input::*;
+use crate::{input::*, util::is_bool};
 use pmutil::{Quote, SpanExt};
 use swc_macros_common::prelude::*;
 use syn::*;
-use util::is_bool;
 
 pub fn expand(
     Input {

--- a/macros/enum_kind/src/lib.rs
+++ b/macros/enum_kind/src/lib.rs
@@ -1,9 +1,9 @@
 #[macro_use]
 extern crate pmutil;
 extern crate proc_macro;
-extern crate proc_macro2;
-extern crate swc_macros_common;
-extern crate syn;
+use proc_macro2;
+
+use syn;
 
 use swc_macros_common::prelude::*;
 

--- a/macros/enum_kind/src/parse.rs
+++ b/macros/enum_kind/src/parse.rs
@@ -1,11 +1,10 @@
-use input::*;
+use crate::{input::*, util::is_bool};
 use std::{fmt::Display, ops::AddAssign, result::Result as StdResult};
 use swc_macros_common::prelude::*;
 use syn::{
     parse::{Parse, ParseStream},
     *,
 };
-use util::is_bool;
 
 impl From<DeriveInput> for Input {
     fn from(
@@ -33,7 +32,7 @@ impl From<DeriveInput> for Input {
 }
 
 impl Parse for EnumAttrs {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         let _function: Ident = input.parse()?;
 
         let fns;
@@ -76,7 +75,7 @@ impl FnDef {
 }
 
 impl Parse for FnDef {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         let name: Ident = input.parse()?;
         let _: Token!(=) = input.parse()?;
         let return_type: LitStr = input.parse()?;
@@ -112,7 +111,7 @@ impl From<Variant> for EnumVar {
 }
 
 impl Parse for VariantAttrs {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         let fn_values: Punctuated<_, token::Comma> = Punctuated::parse_terminated(input)?;
         let has_delegate = fn_values
             .iter()
@@ -140,7 +139,7 @@ impl AddAssign<StdResult<Self, Attribute>> for VariantAttrs {
 }
 
 impl Parse for VariantAttr {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         let fn_name: Ident = input.parse()?;
 
         let lookahead = input.lookahead1();

--- a/macros/enum_kind/src/parse.rs
+++ b/macros/enum_kind/src/parse.rs
@@ -127,6 +127,7 @@ impl Parse for VariantAttrs {
 
 impl AddAssign<StdResult<Self, Attribute>> for VariantAttrs {
     fn add_assign(&mut self, rhs: StdResult<Self, Attribute>) {
+        #[allow(clippy::suspicious_op_assign_impl)]
         match rhs {
             Ok(attr) => {
                 self.fn_values.extend(attr.fn_values);

--- a/macros/enum_kind/src/util.rs
+++ b/macros/enum_kind/src/util.rs
@@ -1,21 +1,18 @@
 use syn::*;
 
 pub fn is_bool(ty: &Type) -> bool {
-    match *ty {
-        Type::Path(TypePath {
-            qself: None,
-            path:
-                Path {
-                    leading_colon: None,
-                    ref segments,
-                },
-        }) => {
-            // check for bool
-            if segments.len() == 1 && segments.first().unwrap().value().ident == "bool" {
-                return true;
-            }
+    if let Type::Path(TypePath {
+        qself: None,
+        path: Path {
+            leading_colon: None,
+            ref segments,
+        },
+    }) = ty
+    {
+        // check for bool
+        if segments.len() == 1 && segments.first().unwrap().value().ident == "bool" {
+            return true;
         }
-        _ => {}
     }
 
     false

--- a/macros/string_enum/Cargo.toml
+++ b/macros/string_enum/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
 documentation = "https://swc-project.github.io/rustdoc/string_enum/"
 description = "String based enum."
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/macros/string_enum/src/lib.rs
+++ b/macros/string_enum/src/lib.rs
@@ -3,11 +3,11 @@
 #[macro_use]
 extern crate pmutil;
 extern crate proc_macro;
-extern crate proc_macro2;
+use proc_macro2;
 #[macro_use]
 extern crate quote;
-extern crate swc_macros_common;
-extern crate syn;
+
+use syn;
 
 use pmutil::prelude::Quote;
 use swc_macros_common::prelude::*;

--- a/macros/string_enum/src/lib.rs
+++ b/macros/string_enum/src/lib.rs
@@ -106,7 +106,6 @@ fn derive_fmt(i: &DeriveInput, trait_path: TokenStream) -> ItemImpl {
         ))
         .parse::<ItemImpl>()
         .with_generics(i.generics.clone())
-        .into()
 }
 
 fn get_str_value(attrs: &[Attribute]) -> String {
@@ -114,7 +113,7 @@ fn get_str_value(attrs: &[Attribute]) -> String {
     let docs: Vec<_> = attrs.iter().map(doc_str).filter_map(|o| o).collect();
     for raw_line in docs {
         let line = raw_line.trim();
-        if line.starts_with("`") && line.ends_with("`") {
+        if line.starts_with('`') && line.ends_with('`') {
             let mut s: String = line.split_at(1).1.into();
             let new_len = s.len() - 1;
             s.truncate(new_len);
@@ -201,7 +200,6 @@ fn make_from_str(i: &DeriveInput) -> ItemImpl {
         ))
         .parse::<ItemImpl>()
         .with_generics(i.generics.clone())
-        .into()
 }
 
 fn make_as_str(i: &DeriveInput) -> ItemImpl {
@@ -284,7 +282,6 @@ fn make_as_str(i: &DeriveInput) -> ItemImpl {
         ))
         .parse::<ItemImpl>()
         .with_generics(i.generics.clone())
-        .into()
 }
 
 fn make_as_str_ident() -> Ident {
@@ -305,7 +302,6 @@ fn make_serialize(i: &DeriveInput) -> ItemImpl {
         }))
         .parse::<ItemImpl>()
         .with_generics(i.generics.clone())
-        .into()
 }
 
 fn make_deserialize(i: &DeriveInput) -> ItemImpl {
@@ -341,5 +337,4 @@ fn make_deserialize(i: &DeriveInput) -> ItemImpl {
         }))
         .parse::<ItemImpl>()
         .with_generics(i.generics.clone())
-        .into()
 }

--- a/macros/string_enum/tests/simple.rs
+++ b/macros/string_enum/tests/simple.rs
@@ -1,4 +1,3 @@
-extern crate serde;
 #[macro_use]
 extern crate string_enum;
 use std::fmt::{Debug, Display};

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -113,7 +113,7 @@ impl Options {
         handler: &Handler,
         config: Option<Config>,
     ) -> BuiltConfig<impl Pass> {
-        let mut config = config.unwrap_or_else(|| Default::default());
+        let mut config = config.unwrap_or_else(Default::default);
         if let Some(ref c) = self.config {
             config.merge(c)
         }
@@ -139,8 +139,7 @@ impl Options {
 
         let optimizer = transform.optimizer;
         let enable_optimizer = optimizer.is_some();
-        let pass = if let Some(opts) =
-            optimizer.map(|o| o.globals.unwrap_or_else(|| Default::default()))
+        let pass = if let Some(opts) = optimizer.map(|o| o.globals.unwrap_or_else(Default::default))
         {
             opts.build(cm, handler)
         } else {
@@ -464,7 +463,6 @@ impl GlobalPassOption {
                 .parse_module()
                 .map_err(|mut e| {
                     e.emit();
-                    ()
                 })
                 .unwrap_or_else(|()| {
                     panic!(
@@ -504,8 +502,8 @@ fn default_env_name() -> String {
     }
 
     match env::var("NODE_ENV") {
-        Ok(v) => return v,
-        Err(_) => return "development".into(),
+        Ok(v) => v,
+        Err(_) => "development".into(),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(box_syntax, box_patterns)]
 
-pub extern crate sourcemap;
+pub use sourcemap;
 pub extern crate swc_atoms as atoms;
 pub extern crate swc_common as common;
 pub extern crate swc_ecmascript as ecmascript;

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
 documentation = "https://swc-project.github.io/rustdoc/testing/"
 description = "Testing utilities for the swc project."
+edition = "2018"
 
 [dependencies]
 swc_common = { version = "0.3", path ="../common", features = ["fold"] }

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -5,11 +5,8 @@
 
 #[macro_use]
 extern crate lazy_static;
-extern crate difference;
-extern crate regex;
-extern crate relative_path;
-extern crate swc_common;
-extern crate test;
+
+use swc_common;
 
 pub use self::output::{NormalizedOutput, StdErr, StdOut, TestOutput};
 use difference::Changeset;

--- a/testing/src/output.rs
+++ b/testing/src/output.rs
@@ -1,4 +1,4 @@
-use paths;
+use crate::paths;
 use std::{
     fmt,
     fs::{create_dir_all, remove_file, File},
@@ -38,13 +38,13 @@ pub struct Diff {
 pub struct NormalizedOutput(String);
 
 impl fmt::Display for NormalizedOutput {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }
 
 impl fmt::Debug for NormalizedOutput {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }
@@ -80,7 +80,7 @@ impl NormalizedOutput {
         }
         create_dir_all(path_for_actual.parent().unwrap()).expect("failed to run `mkdir -p`");
         // ::write_to_file(&path_for_actual, &self.0);
-        ::write_to_file(&path, &self.0);
+        crate::write_to_file(&path, &self.0);
 
         eprintln!(
             "Assertion failed: \nActual file printed to {}",


### PR DESCRIPTION
First of all, sorry for the huge pull request without a warning upfront. It's just that this looked like a small cleanup at first which kept me busy for a while and before you know, it becomes this monstrosity...

I added two commits. The first basically runs the following commands:
```
cargo fix --all
cargo fix -Z unstable-options --clippy --allow-dirty  --allow-staged --all
```
Which comes down to the automated fixing which can be done by clippy/rust lints.

Next, I added some #[allow(...)] attributes to big functions and places where clippy went a bit too wild. I didn't know clippy can even change Vec<Box<T>> to Vec<T> for all references of a type.
For the second commit, I just added a bunch of manual steps to further satisfy clippy (which works like a charm using rust-analyzer).

Most changes are purely syntactical, but some changes were applied to improve performance:
- Change pass-by-reference for simple enums to pass-by-value where possible.
- Wrap JSXElement in a box in Expr, because it was increasing Expr's size too much.

Also note that there are still clippy warnings remaining, but they seem like minor nit's and not worth the effort. At least these can now be fixed case-by-case in the future.

As for the size of this PR - sorry again 😄, I can understand if this is not mergeable in its current form. It does look like it's worth the effort to increase the maintainability of the repo from my point of view.