### PR TITLE
Improve performance of serialization and deserialization

### DIFF
--- a/ecmascript/parser/tests/jsx/basic/1/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/1/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 5,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 5
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 5,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 5
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 2,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "a",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 5,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 5
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": true,

--- a/ecmascript/parser/tests/jsx/basic/10/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/10/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 32,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 32
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 32,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 32
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 2,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "a",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 3,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 3
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": false,
@@ -83,17 +43,7 @@
             "span": {
               "start": 27,
               "end": 27,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 27
-                },
-                "end": {
-                  "line": 1,
-                  "column": 27
-                }
-              }
+              "ctxt": 0
             }
           }
         }
@@ -103,34 +53,14 @@
         "span": {
           "start": 30,
           "end": 32,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 30
-            },
-            "end": {
-              "line": 1,
-              "column": 32
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 30,
             "end": 31,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 30
-              },
-              "end": {
-                "line": 1,
-                "column": 31
-              }
-            }
+            "ctxt": 0
           },
           "value": "a",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/11/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/11/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 24,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 24
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 24,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 24
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 4,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 4
-              }
-            }
+            "ctxt": 0
           },
           "value": "div",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 5,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 5
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": false,
@@ -81,17 +41,7 @@
           "span": {
             "start": 5,
             "end": 18,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 5
-              },
-              "end": {
-                "line": 1,
-                "column": 18
-              }
-            }
+            "ctxt": 0
           },
           "value": "@test content",
           "raw": "@test content"
@@ -102,34 +52,14 @@
         "span": {
           "start": 20,
           "end": 24,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 20
-            },
-            "end": {
-              "line": 1,
-              "column": 24
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 20,
             "end": 23,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 20
-              },
-              "end": {
-                "line": 1,
-                "column": 23
-              }
-            }
+            "ctxt": 0
           },
           "value": "div",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/12/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/12/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 41,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 41
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 41,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 41
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 4,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 4
-              }
-            }
+            "ctxt": 0
           },
           "value": "div",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 5,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 5
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": false,
@@ -81,17 +41,7 @@
           "span": {
             "start": 5,
             "end": 11,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 5
-              },
-              "end": {
-                "line": 1,
-                "column": 11
-              }
-            }
+            "ctxt": 0
           },
           "opening": {
             "type": "JSXOpeningElement",
@@ -100,17 +50,7 @@
               "span": {
                 "start": 6,
                 "end": 8,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 6
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 8
-                  }
-                }
+                "ctxt": 0
               },
               "value": "br",
               "typeAnnotation": null,
@@ -119,17 +59,7 @@
             "span": {
               "start": 6,
               "end": 11,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1,
-                  "column": 11
-                }
-              }
+              "ctxt": 0
             },
             "attributes": [],
             "selfClosing": true,
@@ -143,17 +73,7 @@
           "span": {
             "start": 11,
             "end": 35,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 11
-              },
-              "end": {
-                "line": 1,
-                "column": 35
-              }
-            }
+            "ctxt": 0
           },
           "value": "7x invalid-js-identifier",
           "raw": "7x invalid-js-identifier"
@@ -164,34 +84,14 @@
         "span": {
           "start": 37,
           "end": 41,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 37
-            },
-            "end": {
-              "line": 1,
-              "column": 41
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 37,
             "end": 40,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 37
-              },
-              "end": {
-                "line": 1,
-                "column": 40
-              }
-            }
+            "ctxt": 0
           },
           "value": "div",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/13/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/13/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 57,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 57
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 57,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 57
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 10,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 10
-              }
-            }
+            "ctxt": 0
           },
           "value": "LeftRight",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 57,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 57
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [
           {
@@ -77,34 +37,14 @@
             "span": {
               "start": 11,
               "end": 21,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 11
-                },
-                "end": {
-                  "line": 1,
-                  "column": 21
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 11,
                 "end": 15,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 11
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 15
-                  }
-                }
+                "ctxt": 0
               },
               "value": "left",
               "typeAnnotation": null,
@@ -115,17 +55,7 @@
               "span": {
                 "start": 16,
                 "end": 21,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 16
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 21
-                  }
-                }
+                "ctxt": 0
               },
               "opening": {
                 "type": "JSXOpeningElement",
@@ -134,17 +64,7 @@
                   "span": {
                     "start": 17,
                     "end": 18,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 1,
-                        "column": 17
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 18
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "a",
                   "typeAnnotation": null,
@@ -153,17 +73,7 @@
                 "span": {
                   "start": 17,
                   "end": 21,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 17
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 21
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "attributes": [],
                 "selfClosing": true,
@@ -178,34 +88,14 @@
             "span": {
               "start": 22,
               "end": 54,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 22
-                },
-                "end": {
-                  "line": 1,
-                  "column": 54
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 22,
                 "end": 27,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 22
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 27
-                  }
-                }
+                "ctxt": 0
               },
               "value": "right",
               "typeAnnotation": null,
@@ -216,17 +106,7 @@
               "span": {
                 "start": 28,
                 "end": 54,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 28
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 54
-                  }
-                }
+                "ctxt": 0
               },
               "opening": {
                 "type": "JSXOpeningElement",
@@ -235,17 +115,7 @@
                   "span": {
                     "start": 29,
                     "end": 30,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 1,
-                        "column": 29
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 30
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "b",
                   "typeAnnotation": null,
@@ -254,17 +124,7 @@
                 "span": {
                   "start": 29,
                   "end": 31,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 29
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 31
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "attributes": [],
                 "selfClosing": false,
@@ -276,17 +136,7 @@
                   "span": {
                     "start": 31,
                     "end": 50,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 1,
-                        "column": 31
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 50
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "monkeys /> gorillas",
                   "raw": "monkeys /> gorillas"
@@ -297,34 +147,14 @@
                 "span": {
                   "start": 52,
                   "end": 54,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 52
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 54
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
                     "start": 52,
                     "end": 53,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 1,
-                        "column": 52
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 53
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "b",
                   "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/14/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/14/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 11,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 11
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 11,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 11
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -42,17 +22,7 @@
             "span": {
               "start": 1,
               "end": 2,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 1
-                },
-                "end": {
-                  "line": 1,
-                  "column": 2
-                }
-              }
+              "ctxt": 0
             },
             "value": "a",
             "typeAnnotation": null,
@@ -63,17 +33,7 @@
             "span": {
               "start": 3,
               "end": 4,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 3
-                },
-                "end": {
-                  "line": 1,
-                  "column": 4
-                }
-              }
+              "ctxt": 0
             },
             "value": "b",
             "typeAnnotation": null,
@@ -83,17 +43,7 @@
         "span": {
           "start": 1,
           "end": 5,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 5
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": false,
@@ -105,17 +55,7 @@
         "span": {
           "start": 7,
           "end": 11,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 7
-            },
-            "end": {
-              "line": 1,
-              "column": 11
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "JSXMemberExpression",
@@ -124,17 +64,7 @@
             "span": {
               "start": 7,
               "end": 8,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 7
-                },
-                "end": {
-                  "line": 1,
-                  "column": 8
-                }
-              }
+              "ctxt": 0
             },
             "value": "a",
             "typeAnnotation": null,
@@ -145,17 +75,7 @@
             "span": {
               "start": 9,
               "end": 10,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 9
-                },
-                "end": {
-                  "line": 1,
-                  "column": 10
-                }
-              }
+              "ctxt": 0
             },
             "value": "b",
             "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/15/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/15/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 15,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 15
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 15,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 15
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -44,17 +24,7 @@
               "span": {
                 "start": 1,
                 "end": 2,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 1
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 2
-                  }
-                }
+                "ctxt": 0
               },
               "value": "a",
               "typeAnnotation": null,
@@ -65,17 +35,7 @@
               "span": {
                 "start": 3,
                 "end": 4,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 3
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 4
-                  }
-                }
+                "ctxt": 0
               },
               "value": "b",
               "typeAnnotation": null,
@@ -87,17 +47,7 @@
             "span": {
               "start": 5,
               "end": 6,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 5
-                },
-                "end": {
-                  "line": 1,
-                  "column": 6
-                }
-              }
+              "ctxt": 0
             },
             "value": "c",
             "typeAnnotation": null,
@@ -107,17 +57,7 @@
         "span": {
           "start": 1,
           "end": 7,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 7
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": false,
@@ -129,17 +69,7 @@
         "span": {
           "start": 9,
           "end": 15,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 9
-            },
-            "end": {
-              "line": 1,
-              "column": 15
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "JSXMemberExpression",
@@ -150,17 +80,7 @@
               "span": {
                 "start": 9,
                 "end": 10,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 10
-                  }
-                }
+                "ctxt": 0
               },
               "value": "a",
               "typeAnnotation": null,
@@ -171,17 +91,7 @@
               "span": {
                 "start": 11,
                 "end": 12,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 11
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 12
-                  }
-                }
+                "ctxt": 0
               },
               "value": "b",
               "typeAnnotation": null,
@@ -193,17 +103,7 @@
             "span": {
               "start": 13,
               "end": 14,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 13
-                },
-                "end": {
-                  "line": 1,
-                  "column": 14
-                }
-              }
+              "ctxt": 0
             },
             "value": "c",
             "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/16/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/16/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 14,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 14
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 13,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 13
-          }
-        }
+        "ctxt": 0
       },
       "operator": "<",
       "left": {
@@ -39,34 +19,14 @@
         "span": {
           "start": 0,
           "end": 9,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 0
-            },
-            "end": {
-              "line": 1,
-              "column": 9
-            }
-          }
+          "ctxt": 0
         },
         "expression": {
           "type": "JSXElement",
           "span": {
             "start": 1,
             "end": 8,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 8
-              }
-            }
+            "ctxt": 0
           },
           "opening": {
             "type": "JSXOpeningElement",
@@ -75,17 +35,7 @@
               "span": {
                 "start": 2,
                 "end": 5,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 2
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 5
-                  }
-                }
+                "ctxt": 0
               },
               "value": "div",
               "typeAnnotation": null,
@@ -94,17 +44,7 @@
             "span": {
               "start": 2,
               "end": 8,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 2
-                },
-                "end": {
-                  "line": 1,
-                  "column": 8
-                }
-              }
+              "ctxt": 0
             },
             "attributes": [],
             "selfClosing": true,
@@ -119,17 +59,7 @@
         "span": {
           "start": 12,
           "end": 13,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 12
-            },
-            "end": {
-              "line": 1,
-              "column": 13
-            }
-          }
+          "ctxt": 0
         },
         "value": "x",
         "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/17/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/17/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 18,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 18
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 18,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 18
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 4,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 4
-              }
-            }
+            "ctxt": 0
           },
           "value": "div",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 18,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 18
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [
           {
@@ -77,34 +37,14 @@
             "spread": {
               "start": 6,
               "end": 9,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1,
-                  "column": 9
-                }
-              }
+              "ctxt": 0
             },
             "arguments": {
               "type": "Identifier",
               "span": {
                 "start": 9,
                 "end": 14,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 14
-                  }
-                }
+                "ctxt": 0
               },
               "value": "props",
               "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/18/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/18/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 35,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 35
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 35,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 35
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 4,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 4
-              }
-            }
+            "ctxt": 0
           },
           "value": "div",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 35,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 35
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [
           {
@@ -77,34 +37,14 @@
             "spread": {
               "start": 6,
               "end": 9,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1,
-                  "column": 9
-                }
-              }
+              "ctxt": 0
             },
             "arguments": {
               "type": "Identifier",
               "span": {
                 "start": 9,
                 "end": 14,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 14
-                  }
-                }
+                "ctxt": 0
               },
               "value": "props",
               "typeAnnotation": null,
@@ -116,34 +56,14 @@
             "span": {
               "start": 16,
               "end": 32,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 16
-                },
-                "end": {
-                  "line": 1,
-                  "column": 32
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 16,
                 "end": 20,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 16
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 20
-                  }
-                }
+                "ctxt": 0
               },
               "value": "post",
               "typeAnnotation": null,
@@ -154,17 +74,7 @@
               "span": {
                 "start": 21,
                 "end": 32,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 21
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 32
-                  }
-                }
+                "ctxt": 0
               },
               "value": "attribute",
               "hasEscape": false

--- a/ecmascript/parser/tests/jsx/basic/19/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/19/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 53,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 53
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 53,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 53
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 4,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 4
-              }
-            }
+            "ctxt": 0
           },
           "value": "div",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 47,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 47
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [
           {
@@ -77,34 +37,14 @@
             "span": {
               "start": 5,
               "end": 18,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 5
-                },
-                "end": {
-                  "line": 1,
-                  "column": 18
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 5,
                 "end": 8,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 5
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 8
-                  }
-                }
+                "ctxt": 0
               },
               "value": "pre",
               "typeAnnotation": null,
@@ -115,17 +55,7 @@
               "span": {
                 "start": 9,
                 "end": 18,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 18
-                  }
-                }
+                "ctxt": 0
               },
               "value": "leading",
               "hasEscape": false
@@ -136,34 +66,14 @@
             "span": {
               "start": 19,
               "end": 35,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 19
-                },
-                "end": {
-                  "line": 1,
-                  "column": 35
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 19,
                 "end": 23,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 19
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 23
-                  }
-                }
+                "ctxt": 0
               },
               "value": "pre2",
               "typeAnnotation": null,
@@ -174,17 +84,7 @@
               "span": {
                 "start": 24,
                 "end": 35,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 24
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 35
-                  }
-                }
+                "ctxt": 0
               },
               "value": "attribute",
               "hasEscape": false
@@ -195,34 +95,14 @@
             "spread": {
               "start": 37,
               "end": 40,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 37
-                },
-                "end": {
-                  "line": 1,
-                  "column": 40
-                }
-              }
+              "ctxt": 0
             },
             "arguments": {
               "type": "Identifier",
               "span": {
                 "start": 40,
                 "end": 45,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 40
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 45
-                  }
-                }
+                "ctxt": 0
               },
               "value": "props",
               "typeAnnotation": null,
@@ -239,34 +119,14 @@
         "span": {
           "start": 49,
           "end": 53,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 49
-            },
-            "end": {
-              "line": 1,
-              "column": 53
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 49,
             "end": 52,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 49
-              },
-              "end": {
-                "line": 1,
-                "column": 52
-              }
-            }
+            "ctxt": 0
           },
           "value": "div",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/2/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/2/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 11,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 11
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 11,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 11
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -42,17 +22,7 @@
             "span": {
               "start": 1,
               "end": 2,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 1
-                },
-                "end": {
-                  "line": 1,
-                  "column": 2
-                }
-              }
+              "ctxt": 0
             },
             "value": "n",
             "typeAnnotation": null,
@@ -63,17 +33,7 @@
             "span": {
               "start": 3,
               "end": 4,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 3
-                },
-                "end": {
-                  "line": 1,
-                  "column": 4
-                }
-              }
+              "ctxt": 0
             },
             "value": "a",
             "typeAnnotation": null,
@@ -83,17 +43,7 @@
         "span": {
           "start": 1,
           "end": 11,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 11
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [
           {
@@ -101,17 +51,7 @@
             "span": {
               "start": 5,
               "end": 8,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 5
-                },
-                "end": {
-                  "line": 1,
-                  "column": 8
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "JSXNamespacedName",
@@ -120,17 +60,7 @@
                 "span": {
                   "start": 5,
                   "end": 6,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 5
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 6
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "value": "n",
                 "typeAnnotation": null,
@@ -141,17 +71,7 @@
                 "span": {
                   "start": 7,
                   "end": 8,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 7
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 8
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "value": "v",
                 "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/20/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/20/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 52,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 52
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 52,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 52
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 2,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "A",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 31,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 31
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [
           {
@@ -77,34 +37,14 @@
             "span": {
               "start": 3,
               "end": 16,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 3
-                },
-                "end": {
-                  "line": 1,
-                  "column": 16
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 3,
                 "end": 5,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 3
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 5
-                  }
-                }
+                "ctxt": 0
               },
               "value": "aa",
               "typeAnnotation": null,
@@ -115,51 +55,21 @@
               "span": {
                 "start": 7,
                 "end": 15,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 7
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 15
-                  }
-                }
+                "ctxt": 0
               },
               "object": {
                 "type": "MemberExpression",
                 "span": {
                   "start": 7,
                   "end": 12,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 7
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 12
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "object": {
                   "type": "Identifier",
                   "span": {
                     "start": 7,
                     "end": 9,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 1,
-                        "column": 7
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 9
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "aa",
                   "typeAnnotation": null,
@@ -170,17 +80,7 @@
                   "span": {
                     "start": 10,
                     "end": 12,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 1,
-                        "column": 10
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 12
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "bb",
                   "typeAnnotation": null,
@@ -193,17 +93,7 @@
                 "span": {
                   "start": 13,
                   "end": 15,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 13
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 15
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "value": "cc",
                 "typeAnnotation": null,
@@ -217,34 +107,14 @@
             "span": {
               "start": 17,
               "end": 30,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 17
-                },
-                "end": {
-                  "line": 1,
-                  "column": 30
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 17,
                 "end": 19,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 17
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 19
-                  }
-                }
+                "ctxt": 0
               },
               "value": "bb",
               "typeAnnotation": null,
@@ -255,51 +125,21 @@
               "span": {
                 "start": 21,
                 "end": 29,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 21
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 29
-                  }
-                }
+                "ctxt": 0
               },
               "object": {
                 "type": "MemberExpression",
                 "span": {
                   "start": 21,
                   "end": 26,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 21
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 26
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "object": {
                   "type": "Identifier",
                   "span": {
                     "start": 21,
                     "end": 23,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 1,
-                        "column": 21
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 23
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "bb",
                   "typeAnnotation": null,
@@ -310,17 +150,7 @@
                   "span": {
                     "start": 24,
                     "end": 26,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 1,
-                        "column": 24
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 26
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "cc",
                   "typeAnnotation": null,
@@ -333,17 +163,7 @@
                 "span": {
                   "start": 27,
                   "end": 29,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 27
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 29
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "value": "dd",
                 "typeAnnotation": null,
@@ -362,17 +182,7 @@
           "span": {
             "start": 31,
             "end": 48,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 31
-              },
-              "end": {
-                "line": 1,
-                "column": 48
-              }
-            }
+            "ctxt": 0
           },
           "opening": {
             "type": "JSXOpeningElement",
@@ -381,17 +191,7 @@
               "span": {
                 "start": 32,
                 "end": 35,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 32
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 35
-                  }
-                }
+                "ctxt": 0
               },
               "value": "div",
               "typeAnnotation": null,
@@ -400,17 +200,7 @@
             "span": {
               "start": 32,
               "end": 36,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 32
-                },
-                "end": {
-                  "line": 1,
-                  "column": 36
-                }
-              }
+              "ctxt": 0
             },
             "attributes": [],
             "selfClosing": false,
@@ -424,34 +214,14 @@
                 "span": {
                   "start": 37,
                   "end": 41,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 37
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 41
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "object": {
                   "type": "Identifier",
                   "span": {
                     "start": 37,
                     "end": 39,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 1,
-                        "column": 37
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 39
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "aa",
                   "typeAnnotation": null,
@@ -462,17 +232,7 @@
                   "span": {
                     "start": 40,
                     "end": 41,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 1,
-                        "column": 40
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 41
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "b",
                   "typeAnnotation": null,
@@ -487,34 +247,14 @@
             "span": {
               "start": 44,
               "end": 48,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 44
-                },
-                "end": {
-                  "line": 1,
-                  "column": 48
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 44,
                 "end": 47,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 44
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 47
-                  }
-                }
+                "ctxt": 0
               },
               "value": "div",
               "typeAnnotation": null,
@@ -528,34 +268,14 @@
         "span": {
           "start": 50,
           "end": 52,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 50
-            },
-            "end": {
-              "line": 1,
-              "column": 52
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 50,
             "end": 51,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 50
-              },
-              "end": {
-                "line": 1,
-                "column": 51
-              }
-            }
+            "ctxt": 0
           },
           "value": "A",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/21/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/21/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 41,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 41
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 41,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 41
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 4,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 4
-              }
-            }
+            "ctxt": 0
           },
           "value": "div",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 12,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 12
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [
           {
@@ -77,34 +37,14 @@
             "spread": {
               "start": 6,
               "end": 9,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1,
-                  "column": 9
-                }
-              }
+              "ctxt": 0
             },
             "arguments": {
               "type": "Identifier",
               "span": {
                 "start": 9,
                 "end": 10,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 10
-                  }
-                }
+                "ctxt": 0
               },
               "value": "c",
               "typeAnnotation": null,
@@ -121,17 +61,7 @@
           "span": {
             "start": 12,
             "end": 13,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 12
-              },
-              "end": {
-                "line": 1,
-                "column": 13
-              }
-            }
+            "ctxt": 0
           },
           "value": " ",
           "raw": " "
@@ -143,17 +73,7 @@
             "span": {
               "start": 17,
               "end": 25,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 17
-                },
-                "end": {
-                  "line": 1,
-                  "column": 25
-                }
-              }
+              "ctxt": 0
             },
             "value": "children",
             "typeAnnotation": null,
@@ -167,17 +87,7 @@
             "span": {
               "start": 27,
               "end": 28,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 27
-                },
-                "end": {
-                  "line": 1,
-                  "column": 28
-                }
-              }
+              "ctxt": 0
             },
             "value": "a",
             "typeAnnotation": null,
@@ -191,17 +101,7 @@
             "span": {
               "start": 33,
               "end": 34,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 33
-                },
-                "end": {
-                  "line": 1,
-                  "column": 34
-                }
-              }
+              "ctxt": 0
             },
             "value": "b",
             "typeAnnotation": null,
@@ -214,34 +114,14 @@
         "span": {
           "start": 37,
           "end": 41,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 37
-            },
-            "end": {
-              "line": 1,
-              "column": 41
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 37,
             "end": 40,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 37
-              },
-              "end": {
-                "line": 1,
-                "column": 40
-              }
-            }
+            "ctxt": 0
           },
           "value": "div",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/3/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/3/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 40,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 40
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 40,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 40
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 2,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "a",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 15,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 15
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [
           {
@@ -77,17 +37,7 @@
             "span": {
               "start": 3,
               "end": 14,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 3
-                },
-                "end": {
-                  "line": 1,
-                  "column": 14
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "JSXNamespacedName",
@@ -96,17 +46,7 @@
                 "span": {
                   "start": 3,
                   "end": 4,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 3
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 4
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "value": "n",
                 "typeAnnotation": null,
@@ -117,17 +57,7 @@
                 "span": {
                   "start": 5,
                   "end": 8,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 5
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 8
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "value": "foo",
                 "typeAnnotation": null,
@@ -139,17 +69,7 @@
               "span": {
                 "start": 9,
                 "end": 14,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 14
-                  }
-                }
+                "ctxt": 0
               },
               "value": "bar",
               "hasEscape": false
@@ -165,17 +85,7 @@
           "span": {
             "start": 15,
             "end": 16,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 15
-              },
-              "end": {
-                "line": 1,
-                "column": 16
-              }
-            }
+            "ctxt": 0
           },
           "value": " ",
           "raw": " "
@@ -187,17 +97,7 @@
             "span": {
               "start": 17,
               "end": 22,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 17
-                },
-                "end": {
-                  "line": 1,
-                  "column": 22
-                }
-              }
+              "ctxt": 0
             },
             "value": "value",
             "typeAnnotation": null,
@@ -209,17 +109,7 @@
           "span": {
             "start": 23,
             "end": 24,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 23
-              },
-              "end": {
-                "line": 1,
-                "column": 24
-              }
-            }
+            "ctxt": 0
           },
           "value": " ",
           "raw": " "
@@ -229,17 +119,7 @@
           "span": {
             "start": 24,
             "end": 36,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 24
-              },
-              "end": {
-                "line": 1,
-                "column": 36
-              }
-            }
+            "ctxt": 0
           },
           "opening": {
             "type": "JSXOpeningElement",
@@ -248,17 +128,7 @@
               "span": {
                 "start": 25,
                 "end": 26,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 25
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 26
-                  }
-                }
+                "ctxt": 0
               },
               "value": "b",
               "typeAnnotation": null,
@@ -267,17 +137,7 @@
             "span": {
               "start": 25,
               "end": 27,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 25
-                },
-                "end": {
-                  "line": 1,
-                  "column": 27
-                }
-              }
+              "ctxt": 0
             },
             "attributes": [],
             "selfClosing": false,
@@ -289,17 +149,7 @@
               "span": {
                 "start": 27,
                 "end": 32,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 27
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 32
-                  }
-                }
+                "ctxt": 0
               },
               "opening": {
                 "type": "JSXOpeningElement",
@@ -308,17 +158,7 @@
                   "span": {
                     "start": 28,
                     "end": 29,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 1,
-                        "column": 28
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 29
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "c",
                   "typeAnnotation": null,
@@ -327,17 +167,7 @@
                 "span": {
                   "start": 28,
                   "end": 32,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 28
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 32
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "attributes": [],
                 "selfClosing": true,
@@ -352,34 +182,14 @@
             "span": {
               "start": 34,
               "end": 36,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 34
-                },
-                "end": {
-                  "line": 1,
-                  "column": 36
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 34,
                 "end": 35,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 34
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 35
-                  }
-                }
+                "ctxt": 0
               },
               "value": "b",
               "typeAnnotation": null,
@@ -393,34 +203,14 @@
         "span": {
           "start": 38,
           "end": 40,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 38
-            },
-            "end": {
-              "line": 1,
-              "column": 40
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 38,
             "end": 39,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 38
-              },
-              "end": {
-                "line": 1,
-                "column": 39
-              }
-            }
+            "ctxt": 0
           },
           "value": "a",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/4/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/4/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 40,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 40
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 40,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 40
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 2,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "a",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 40,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 40
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [
           {
@@ -77,34 +37,14 @@
             "span": {
               "start": 3,
               "end": 10,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 3
-                },
-                "end": {
-                  "line": 1,
-                  "column": 10
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 3,
                 "end": 4,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 3
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 4
-                  }
-                }
+                "ctxt": 0
               },
               "value": "b",
               "typeAnnotation": null,
@@ -115,17 +55,7 @@
               "span": {
                 "start": 6,
                 "end": 9,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 6
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 9
-                  }
-                }
+                "ctxt": 0
               },
               "value": " ",
               "hasEscape": false
@@ -136,34 +66,14 @@
             "span": {
               "start": 11,
               "end": 16,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 11
-                },
-                "end": {
-                  "line": 1,
-                  "column": 16
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 11,
                 "end": 12,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 11
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 12
-                  }
-                }
+                "ctxt": 0
               },
               "value": "c",
               "typeAnnotation": null,
@@ -174,17 +84,7 @@
               "span": {
                 "start": 13,
                 "end": 16,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 13
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 16
-                  }
-                }
+                "ctxt": 0
               },
               "value": " ",
               "hasEscape": false
@@ -195,34 +95,14 @@
             "span": {
               "start": 17,
               "end": 26,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 17
-                },
-                "end": {
-                  "line": 1,
-                  "column": 26
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 17,
                 "end": 18,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 17
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 18
-                  }
-                }
+                "ctxt": 0
               },
               "value": "d",
               "typeAnnotation": null,
@@ -233,17 +113,7 @@
               "span": {
                 "start": 19,
                 "end": 26,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 19
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 26
-                  }
-                }
+                "ctxt": 0
               },
               "value": "&",
               "hasEscape": false
@@ -254,34 +124,14 @@
             "span": {
               "start": 27,
               "end": 37,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 27
-                },
-                "end": {
-                  "line": 1,
-                  "column": 37
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 27,
                 "end": 28,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 27
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 28
-                  }
-                }
+                "ctxt": 0
               },
               "value": "e",
               "typeAnnotation": null,
@@ -292,17 +142,7 @@
               "span": {
                 "start": 29,
                 "end": 37,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 29
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 37
-                  }
-                }
+                "ctxt": 0
               },
               "value": "&ampr;",
               "hasEscape": false

--- a/ecmascript/parser/tests/jsx/basic/5/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/5/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 6,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 2,
-        "column": 2
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 6,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 2,
-            "column": 2
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 2,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "a",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 6,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 2,
-              "column": 2
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": true,

--- a/ecmascript/parser/tests/jsx/basic/6/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/6/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 23,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 17
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 23,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 17
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 10,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 7
-              }
-            }
+            "ctxt": 0
           },
           "value": "日本語",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 11,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 8
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": false,
@@ -81,34 +41,14 @@
         "span": {
           "start": 13,
           "end": 23,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 10
-            },
-            "end": {
-              "line": 1,
-              "column": 17
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 13,
             "end": 22,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 10
-              },
-              "end": {
-                "line": 1,
-                "column": 16
-              }
-            }
+            "ctxt": 0
           },
           "value": "日本語",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/7/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/7/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 55,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 5,
-        "column": 10
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 55,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 5,
-            "column": 10
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 8,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 8
-              }
-            }
+            "ctxt": 0
           },
           "value": "AbC-def",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 33,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 2,
-              "column": 23
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [
           {
@@ -77,34 +37,14 @@
             "span": {
               "start": 12,
               "end": 32,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 2,
-                  "column": 2
-                },
-                "end": {
-                  "line": 2,
-                  "column": 22
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 12,
                 "end": 16,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 2,
-                    "column": 2
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 6
-                  }
-                }
+                "ctxt": 0
               },
               "value": "test",
               "typeAnnotation": null,
@@ -115,17 +55,7 @@
               "span": {
                 "start": 17,
                 "end": 32,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 2,
-                    "column": 7
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 22
-                  }
-                }
+                "ctxt": 0
               },
               "value": "&&",
               "hasEscape": false
@@ -141,17 +71,7 @@
           "span": {
             "start": 33,
             "end": 45,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 2,
-                "column": 23
-              },
-              "end": {
-                "line": 5,
-                "column": 0
-              }
-            }
+            "ctxt": 0
           },
           "value": "\n\r\nbar\n\r\nbaz\n\r\n",
           "raw": "\n\r\nbar\n\r\nbaz\n\r\n"
@@ -162,34 +82,14 @@
         "span": {
           "start": 47,
           "end": 55,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 5,
-              "column": 2
-            },
-            "end": {
-              "line": 5,
-              "column": 10
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 47,
             "end": 54,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 5,
-                "column": 2
-              },
-              "end": {
-                "line": 5,
-                "column": 9
-              }
-            }
+            "ctxt": 0
           },
           "value": "AbC-def",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/8/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/8/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 27,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 27
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 27,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 27
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 2,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "a",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 27,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 27
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [
           {
@@ -77,34 +37,14 @@
             "span": {
               "start": 3,
               "end": 24,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 3
-                },
-                "end": {
-                  "line": 1,
-                  "column": 24
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 3,
                 "end": 4,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 3
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 4
-                  }
-                }
+                "ctxt": 0
               },
               "value": "b",
               "typeAnnotation": null,
@@ -115,34 +55,14 @@
               "span": {
                 "start": 6,
                 "end": 23,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 6
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 23
-                  }
-                }
+                "ctxt": 0
               },
               "test": {
                 "type": "Identifier",
                 "span": {
                   "start": 6,
                   "end": 7,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 6
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 7
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "value": "x",
                 "typeAnnotation": null,
@@ -153,17 +73,7 @@
                 "span": {
                   "start": 10,
                   "end": 15,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 10
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 15
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "opening": {
                   "type": "JSXOpeningElement",
@@ -172,17 +82,7 @@
                     "span": {
                       "start": 11,
                       "end": 12,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 1,
-                          "column": 11
-                        },
-                        "end": {
-                          "line": 1,
-                          "column": 12
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "value": "c",
                     "typeAnnotation": null,
@@ -191,17 +91,7 @@
                   "span": {
                     "start": 11,
                     "end": 15,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 1,
-                        "column": 11
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 15
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "attributes": [],
                   "selfClosing": true,
@@ -215,17 +105,7 @@
                 "span": {
                   "start": 18,
                   "end": 23,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 18
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 23
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "opening": {
                   "type": "JSXOpeningElement",
@@ -234,17 +114,7 @@
                     "span": {
                       "start": 19,
                       "end": 20,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 1,
-                          "column": 19
-                        },
-                        "end": {
-                          "line": 1,
-                          "column": 20
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "value": "d",
                     "typeAnnotation": null,
@@ -253,17 +123,7 @@
                   "span": {
                     "start": 19,
                     "end": 23,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 1,
-                        "column": 19
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 23
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "attributes": [],
                   "selfClosing": true,

--- a/ecmascript/parser/tests/jsx/basic/asi/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/asi/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 37,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 4,
-        "column": 1
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -23,17 +13,7 @@
         "span": {
           "start": 9,
           "end": 10,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 9
-            },
-            "end": {
-              "line": 1,
-              "column": 10
-            }
-          }
+          "ctxt": 0
         },
         "value": "x",
         "typeAnnotation": null,
@@ -45,34 +25,14 @@
       "span": {
         "start": 0,
         "end": 37,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 4,
-            "column": 1
-          }
-        }
+        "ctxt": 0
       },
       "body": {
         "type": "BlockStatement",
         "span": {
           "start": 13,
           "end": 37,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 13
-            },
-            "end": {
-              "line": 4,
-              "column": 1
-            }
-          }
+          "ctxt": 0
         },
         "stmts": [
           {
@@ -80,17 +40,7 @@
             "span": {
               "start": 18,
               "end": 23,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 2,
-                  "column": 2
-                },
-                "end": {
-                  "line": 2,
-                  "column": 7
-                }
-              }
+              "ctxt": 0
             },
             "kind": "let",
             "declare": false,
@@ -100,34 +50,14 @@
                 "span": {
                   "start": 22,
                   "end": 23,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 2,
-                      "column": 6
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 7
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "id": {
                   "type": "Identifier",
                   "span": {
                     "start": 22,
                     "end": 23,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 2,
-                        "column": 6
-                      },
-                      "end": {
-                        "line": 2,
-                        "column": 7
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "x",
                   "typeAnnotation": null,
@@ -143,17 +73,7 @@
             "span": {
               "start": 27,
               "end": 34,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 3,
-                  "column": 2
-                },
-                "end": {
-                  "line": 3,
-                  "column": 9
-                }
-              }
+              "ctxt": 0
             },
             "opening": {
               "type": "JSXOpeningElement",
@@ -162,17 +82,7 @@
                 "span": {
                   "start": 28,
                   "end": 31,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 3,
-                      "column": 3
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 6
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "value": "div",
                 "typeAnnotation": null,
@@ -181,17 +91,7 @@
               "span": {
                 "start": 28,
                 "end": 34,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 3,
-                    "column": 3
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 9
-                  }
-                }
+                "ctxt": 0
               },
               "attributes": [],
               "selfClosing": true,

--- a/ecmascript/parser/tests/jsx/basic/custom/tpl-space/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/custom/tpl-space/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 14,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 14
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 14,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 14
-          }
-        }
+        "ctxt": 0
       },
       "expressions": [
         {
@@ -39,17 +19,7 @@
           "span": {
             "start": 3,
             "end": 6,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 3
-              },
-              "end": {
-                "line": 1,
-                "column": 6
-              }
-            }
+            "ctxt": 0
           },
           "value": "foo",
           "typeAnnotation": null,
@@ -62,17 +32,7 @@
           "span": {
             "start": 1,
             "end": 1,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 1
-              }
-            }
+            "ctxt": 0
           },
           "tail": false,
           "cooked": {
@@ -80,17 +40,7 @@
             "span": {
               "start": 1,
               "end": 1,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 1
-                },
-                "end": {
-                  "line": 1,
-                  "column": 1
-                }
-              }
+              "ctxt": 0
             },
             "value": "",
             "hasEscape": false
@@ -100,17 +50,7 @@
             "span": {
               "start": 1,
               "end": 1,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 1
-                },
-                "end": {
-                  "line": 1,
-                  "column": 1
-                }
-              }
+              "ctxt": 0
             },
             "value": "",
             "hasEscape": false
@@ -121,17 +61,7 @@
           "span": {
             "start": 7,
             "end": 13,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 7
-              },
-              "end": {
-                "line": 1,
-                "column": 13
-              }
-            }
+            "ctxt": 0
           },
           "tail": true,
           "cooked": {
@@ -139,17 +69,7 @@
             "span": {
               "start": 7,
               "end": 13,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 7
-                },
-                "end": {
-                  "line": 1,
-                  "column": 13
-                }
-              }
+              "ctxt": 0
             },
             "value": " <bar>",
             "hasEscape": false
@@ -159,17 +79,7 @@
             "span": {
               "start": 7,
               "end": 13,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 7
-                },
-                "end": {
-                  "line": 1,
-                  "column": 13
-                }
-              }
+              "ctxt": 0
             },
             "value": " <bar>",
             "hasEscape": false

--- a/ecmascript/parser/tests/jsx/basic/custom/tpl/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/custom/tpl/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 13,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 13
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 13,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 13
-          }
-        }
+        "ctxt": 0
       },
       "expressions": [
         {
@@ -39,17 +19,7 @@
           "span": {
             "start": 3,
             "end": 6,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 3
-              },
-              "end": {
-                "line": 1,
-                "column": 6
-              }
-            }
+            "ctxt": 0
           },
           "value": "foo",
           "typeAnnotation": null,
@@ -62,17 +32,7 @@
           "span": {
             "start": 1,
             "end": 1,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 1
-              }
-            }
+            "ctxt": 0
           },
           "tail": false,
           "cooked": {
@@ -80,17 +40,7 @@
             "span": {
               "start": 1,
               "end": 1,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 1
-                },
-                "end": {
-                  "line": 1,
-                  "column": 1
-                }
-              }
+              "ctxt": 0
             },
             "value": "",
             "hasEscape": false
@@ -100,17 +50,7 @@
             "span": {
               "start": 1,
               "end": 1,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 1
-                },
-                "end": {
-                  "line": 1,
-                  "column": 1
-                }
-              }
+              "ctxt": 0
             },
             "value": "",
             "hasEscape": false
@@ -121,17 +61,7 @@
           "span": {
             "start": 7,
             "end": 12,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 7
-              },
-              "end": {
-                "line": 1,
-                "column": 12
-              }
-            }
+            "ctxt": 0
           },
           "tail": true,
           "cooked": {
@@ -139,17 +69,7 @@
             "span": {
               "start": 7,
               "end": 12,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 7
-                },
-                "end": {
-                  "line": 1,
-                  "column": 12
-                }
-              }
+              "ctxt": 0
             },
             "value": "<bar>",
             "hasEscape": false
@@ -159,17 +79,7 @@
             "span": {
               "start": 7,
               "end": 12,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 7
-                },
-                "end": {
-                  "line": 1,
-                  "column": 12
-                }
-              }
+              "ctxt": 0
             },
             "value": "<bar>",
             "hasEscape": false

--- a/ecmascript/parser/tests/jsx/basic/custom/unary-paren/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/custom/unary-paren/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 318,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 19,
-        "column": 19
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 26,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 26
-          }
-        }
+        "ctxt": 0
       },
       "specifiers": [
         {
@@ -39,34 +19,14 @@
           "span": {
             "start": 7,
             "end": 12,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 7
-              },
-              "end": {
-                "line": 1,
-                "column": 12
-              }
-            }
+            "ctxt": 0
           },
           "local": {
             "type": "Identifier",
             "span": {
               "start": 7,
               "end": 12,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 7
-                },
-                "end": {
-                  "line": 1,
-                  "column": 12
-                }
-              }
+              "ctxt": 0
             },
             "value": "React",
             "typeAnnotation": null,
@@ -79,17 +39,7 @@
         "span": {
           "start": 18,
           "end": 26,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 18
-            },
-            "end": {
-              "line": 1,
-              "column": 26
-            }
-          }
+          "ctxt": 0
         },
         "value": "react",
         "hasEscape": false
@@ -102,17 +52,7 @@
         "span": {
           "start": 39,
           "end": 42,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 3,
-              "column": 9
-            },
-            "end": {
-              "line": 3,
-              "column": 12
-            }
-          }
+          "ctxt": 0
         },
         "value": "App",
         "typeAnnotation": null,
@@ -124,34 +64,14 @@
       "span": {
         "start": 30,
         "end": 295,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 3,
-            "column": 0
-          },
-          "end": {
-            "line": 17,
-            "column": 1
-          }
-        }
+        "ctxt": 0
       },
       "body": {
         "type": "BlockStatement",
         "span": {
           "start": 45,
           "end": 295,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 3,
-              "column": 15
-            },
-            "end": {
-              "line": 17,
-              "column": 1
-            }
-          }
+          "ctxt": 0
         },
         "stmts": [
           {
@@ -159,17 +79,7 @@
             "span": {
               "start": 50,
               "end": 73,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 4,
-                  "column": 2
-                },
-                "end": {
-                  "line": 4,
-                  "column": 25
-                }
-              }
+              "ctxt": 0
             },
             "kind": "const",
             "declare": false,
@@ -179,34 +89,14 @@
                 "span": {
                   "start": 56,
                   "end": 72,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 4,
-                      "column": 8
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 24
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "id": {
                   "type": "Identifier",
                   "span": {
                     "start": 56,
                     "end": 65,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 4,
-                        "column": 8
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 17
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "isLoading",
                   "typeAnnotation": null,
@@ -217,17 +107,7 @@
                   "span": {
                     "start": 68,
                     "end": 72,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 4,
-                        "column": 20
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 24
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": true
                 },
@@ -240,51 +120,21 @@
             "span": {
               "start": 77,
               "end": 292,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 5,
-                  "column": 2
-                },
-                "end": {
-                  "line": 16,
-                  "column": 4
-                }
-              }
+              "ctxt": 0
             },
             "argument": {
               "type": "ParenthesisExpression",
               "span": {
                 "start": 84,
                 "end": 291,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 5,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 3
-                  }
-                }
+                "ctxt": 0
               },
               "expression": {
                 "type": "JSXElement",
                 "span": {
                   "start": 91,
                   "end": 286,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 6,
-                      "column": 4
-                    },
-                    "end": {
-                      "line": 15,
-                      "column": 10
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "opening": {
                   "type": "JSXOpeningElement",
@@ -293,17 +143,7 @@
                     "span": {
                       "start": 92,
                       "end": 95,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 6,
-                          "column": 5
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 8
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "value": "div",
                     "typeAnnotation": null,
@@ -312,17 +152,7 @@
                   "span": {
                     "start": 92,
                     "end": 96,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 6,
-                        "column": 5
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 9
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "attributes": [],
                   "selfClosing": false,
@@ -334,17 +164,7 @@
                     "span": {
                       "start": 96,
                       "end": 104,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 6,
-                          "column": 9
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 6
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "value": "\n\r\n      ",
                     "raw": "\n\r\n      "
@@ -354,17 +174,7 @@
                     "span": {
                       "start": 104,
                       "end": 119,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 7,
-                          "column": 6
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 21
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "opening": {
                       "type": "JSXOpeningElement",
@@ -373,17 +183,7 @@
                         "span": {
                           "start": 105,
                           "end": 107,
-                          "ctxt": 0,
-                          "loc": {
-                            "start": {
-                              "line": 7,
-                              "column": 7
-                            },
-                            "end": {
-                              "line": 7,
-                              "column": 9
-                            }
-                          }
+                          "ctxt": 0
                         },
                         "value": "h1",
                         "typeAnnotation": null,
@@ -392,17 +192,7 @@
                       "span": {
                         "start": 105,
                         "end": 108,
-                        "ctxt": 0,
-                        "loc": {
-                          "start": {
-                            "line": 7,
-                            "column": 7
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 10
-                          }
-                        }
+                        "ctxt": 0
                       },
                       "attributes": [],
                       "selfClosing": false,
@@ -414,17 +204,7 @@
                         "span": {
                           "start": 108,
                           "end": 114,
-                          "ctxt": 0,
-                          "loc": {
-                            "start": {
-                              "line": 7,
-                              "column": 10
-                            },
-                            "end": {
-                              "line": 7,
-                              "column": 16
-                            }
-                          }
+                          "ctxt": 0
                         },
                         "value": "works ",
                         "raw": "works "
@@ -435,34 +215,14 @@
                       "span": {
                         "start": 116,
                         "end": 119,
-                        "ctxt": 0,
-                        "loc": {
-                          "start": {
-                            "line": 7,
-                            "column": 18
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 21
-                          }
-                        }
+                        "ctxt": 0
                       },
                       "name": {
                         "type": "Identifier",
                         "span": {
                           "start": 116,
                           "end": 118,
-                          "ctxt": 0,
-                          "loc": {
-                            "start": {
-                              "line": 7,
-                              "column": 18
-                            },
-                            "end": {
-                              "line": 7,
-                              "column": 20
-                            }
-                          }
+                          "ctxt": 0
                         },
                         "value": "h1",
                         "typeAnnotation": null,
@@ -475,17 +235,7 @@
                     "span": {
                       "start": 119,
                       "end": 127,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 7,
-                          "column": 21
-                        },
-                        "end": {
-                          "line": 8,
-                          "column": 6
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "value": "\n\r\n      ",
                     "raw": "\n\r\n      "
@@ -497,34 +247,14 @@
                       "span": {
                         "start": 138,
                         "end": 265,
-                        "ctxt": 0,
-                        "loc": {
-                          "start": {
-                            "line": 9,
-                            "column": 8
-                          },
-                          "end": {
-                            "line": 13,
-                            "column": 11
-                          }
-                        }
+                        "ctxt": 0
                       },
                       "test": {
                         "type": "Identifier",
                         "span": {
                           "start": 138,
                           "end": 147,
-                          "ctxt": 0,
-                          "loc": {
-                            "start": {
-                              "line": 9,
-                              "column": 8
-                            },
-                            "end": {
-                              "line": 9,
-                              "column": 17
-                            }
-                          }
+                          "ctxt": 0
                         },
                         "value": "isLoading",
                         "typeAnnotation": null,
@@ -535,34 +265,14 @@
                         "span": {
                           "start": 150,
                           "end": 193,
-                          "ctxt": 0,
-                          "loc": {
-                            "start": {
-                              "line": 9,
-                              "column": 20
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 9
-                            }
-                          }
+                          "ctxt": 0
                         },
                         "expression": {
                           "type": "JSXElement",
                           "span": {
                             "start": 163,
                             "end": 182,
-                            "ctxt": 0,
-                            "loc": {
-                              "start": {
-                                "line": 10,
-                                "column": 10
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 29
-                              }
-                            }
+                            "ctxt": 0
                           },
                           "opening": {
                             "type": "JSXOpeningElement",
@@ -571,17 +281,7 @@
                               "span": {
                                 "start": 164,
                                 "end": 167,
-                                "ctxt": 0,
-                                "loc": {
-                                  "start": {
-                                    "line": 10,
-                                    "column": 11
-                                  },
-                                  "end": {
-                                    "line": 10,
-                                    "column": 14
-                                  }
-                                }
+                                "ctxt": 0
                               },
                               "value": "div",
                               "typeAnnotation": null,
@@ -590,17 +290,7 @@
                             "span": {
                               "start": 164,
                               "end": 168,
-                              "ctxt": 0,
-                              "loc": {
-                                "start": {
-                                  "line": 10,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 10,
-                                  "column": 15
-                                }
-                              }
+                              "ctxt": 0
                             },
                             "attributes": [],
                             "selfClosing": false,
@@ -612,17 +302,7 @@
                               "span": {
                                 "start": 168,
                                 "end": 176,
-                                "ctxt": 0,
-                                "loc": {
-                                  "start": {
-                                    "line": 10,
-                                    "column": 15
-                                  },
-                                  "end": {
-                                    "line": 10,
-                                    "column": 23
-                                  }
-                                }
+                                "ctxt": 0
                               },
                               "value": "loading ",
                               "raw": "loading "
@@ -633,34 +313,14 @@
                             "span": {
                               "start": 178,
                               "end": 182,
-                              "ctxt": 0,
-                              "loc": {
-                                "start": {
-                                  "line": 10,
-                                  "column": 25
-                                },
-                                "end": {
-                                  "line": 10,
-                                  "column": 29
-                                }
-                              }
+                              "ctxt": 0
                             },
                             "name": {
                               "type": "Identifier",
                               "span": {
                                 "start": 178,
                                 "end": 181,
-                                "ctxt": 0,
-                                "loc": {
-                                  "start": {
-                                    "line": 10,
-                                    "column": 25
-                                  },
-                                  "end": {
-                                    "line": 10,
-                                    "column": 28
-                                  }
-                                }
+                                "ctxt": 0
                               },
                               "value": "div",
                               "typeAnnotation": null,
@@ -674,34 +334,14 @@
                         "span": {
                           "start": 196,
                           "end": 265,
-                          "ctxt": 0,
-                          "loc": {
-                            "start": {
-                              "line": 11,
-                              "column": 12
-                            },
-                            "end": {
-                              "line": 13,
-                              "column": 11
-                            }
-                          }
+                          "ctxt": 0
                         },
                         "expression": {
                           "type": "JSXElement",
                           "span": {
                             "start": 211,
                             "end": 252,
-                            "ctxt": 0,
-                            "loc": {
-                              "start": {
-                                "line": 12,
-                                "column": 12
-                              },
-                              "end": {
-                                "line": 12,
-                                "column": 53
-                              }
-                            }
+                            "ctxt": 0
                           },
                           "opening": {
                             "type": "JSXOpeningElement",
@@ -710,17 +350,7 @@
                               "span": {
                                 "start": 212,
                                 "end": 215,
-                                "ctxt": 0,
-                                "loc": {
-                                  "start": {
-                                    "line": 12,
-                                    "column": 13
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 16
-                                  }
-                                }
+                                "ctxt": 0
                               },
                               "value": "div",
                               "typeAnnotation": null,
@@ -729,17 +359,7 @@
                             "span": {
                               "start": 212,
                               "end": 216,
-                              "ctxt": 0,
-                              "loc": {
-                                "start": {
-                                  "line": 12,
-                                  "column": 13
-                                },
-                                "end": {
-                                  "line": 12,
-                                  "column": 17
-                                }
-                              }
+                              "ctxt": 0
                             },
                             "attributes": [],
                             "selfClosing": false,
@@ -751,17 +371,7 @@
                               "span": {
                                 "start": 216,
                                 "end": 246,
-                                "ctxt": 0,
-                                "loc": {
-                                  "start": {
-                                    "line": 12,
-                                    "column": 17
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 47
-                                  }
-                                }
+                                "ctxt": 0
                               },
                               "value": "naaaaaaaaaaaaffffffffffffffff ",
                               "raw": "naaaaaaaaaaaaffffffffffffffff "
@@ -772,34 +382,14 @@
                             "span": {
                               "start": 248,
                               "end": 252,
-                              "ctxt": 0,
-                              "loc": {
-                                "start": {
-                                  "line": 12,
-                                  "column": 49
-                                },
-                                "end": {
-                                  "line": 12,
-                                  "column": 53
-                                }
-                              }
+                              "ctxt": 0
                             },
                             "name": {
                               "type": "Identifier",
                               "span": {
                                 "start": 248,
                                 "end": 251,
-                                "ctxt": 0,
-                                "loc": {
-                                  "start": {
-                                    "line": 12,
-                                    "column": 49
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 52
-                                  }
-                                }
+                                "ctxt": 0
                               },
                               "value": "div",
                               "typeAnnotation": null,
@@ -815,17 +405,7 @@
                     "span": {
                       "start": 274,
                       "end": 280,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 14,
-                          "column": 7
-                        },
-                        "end": {
-                          "line": 15,
-                          "column": 4
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "value": "\n\r\n    ",
                     "raw": "\n\r\n    "
@@ -836,34 +416,14 @@
                   "span": {
                     "start": 282,
                     "end": 286,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 15,
-                        "column": 6
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 10
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
                       "start": 282,
                       "end": 285,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 15,
-                          "column": 6
-                        },
-                        "end": {
-                          "line": 15,
-                          "column": 9
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "value": "div",
                     "typeAnnotation": null,
@@ -885,34 +445,14 @@
       "span": {
         "start": 299,
         "end": 318,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 19,
-            "column": 0
-          },
-          "end": {
-            "line": 19,
-            "column": 19
-          }
-        }
+        "ctxt": 0
       },
       "expression": {
         "type": "Identifier",
         "span": {
           "start": 314,
           "end": 317,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 19,
-              "column": 15
-            },
-            "end": {
-              "line": 19,
-              "column": 18
-            }
-          }
+          "ctxt": 0
         },
         "value": "App",
         "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/custom/unary/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/custom/unary/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 266,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 15,
-        "column": 19
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 26,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 26
-          }
-        }
+        "ctxt": 0
       },
       "specifiers": [
         {
@@ -39,34 +19,14 @@
           "span": {
             "start": 7,
             "end": 12,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 7
-              },
-              "end": {
-                "line": 1,
-                "column": 12
-              }
-            }
+            "ctxt": 0
           },
           "local": {
             "type": "Identifier",
             "span": {
               "start": 7,
               "end": 12,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 7
-                },
-                "end": {
-                  "line": 1,
-                  "column": 12
-                }
-              }
+              "ctxt": 0
             },
             "value": "React",
             "typeAnnotation": null,
@@ -79,17 +39,7 @@
         "span": {
           "start": 18,
           "end": 26,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 18
-            },
-            "end": {
-              "line": 1,
-              "column": 26
-            }
-          }
+          "ctxt": 0
         },
         "value": "react",
         "hasEscape": false
@@ -102,17 +52,7 @@
         "span": {
           "start": 39,
           "end": 42,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 3,
-              "column": 9
-            },
-            "end": {
-              "line": 3,
-              "column": 12
-            }
-          }
+          "ctxt": 0
         },
         "value": "App",
         "typeAnnotation": null,
@@ -124,34 +64,14 @@
       "span": {
         "start": 30,
         "end": 243,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 3,
-            "column": 0
-          },
-          "end": {
-            "line": 13,
-            "column": 1
-          }
-        }
+        "ctxt": 0
       },
       "body": {
         "type": "BlockStatement",
         "span": {
           "start": 45,
           "end": 243,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 3,
-              "column": 15
-            },
-            "end": {
-              "line": 13,
-              "column": 1
-            }
-          }
+          "ctxt": 0
         },
         "stmts": [
           {
@@ -159,17 +79,7 @@
             "span": {
               "start": 50,
               "end": 73,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 4,
-                  "column": 2
-                },
-                "end": {
-                  "line": 4,
-                  "column": 25
-                }
-              }
+              "ctxt": 0
             },
             "kind": "const",
             "declare": false,
@@ -179,34 +89,14 @@
                 "span": {
                   "start": 56,
                   "end": 72,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 4,
-                      "column": 8
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 24
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "id": {
                   "type": "Identifier",
                   "span": {
                     "start": 56,
                     "end": 65,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 4,
-                        "column": 8
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 17
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "isLoading",
                   "typeAnnotation": null,
@@ -217,17 +107,7 @@
                   "span": {
                     "start": 68,
                     "end": 72,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 4,
-                        "column": 20
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 24
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": true
                 },
@@ -240,51 +120,21 @@
             "span": {
               "start": 77,
               "end": 240,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 5,
-                  "column": 2
-                },
-                "end": {
-                  "line": 12,
-                  "column": 4
-                }
-              }
+              "ctxt": 0
             },
             "argument": {
               "type": "ParenthesisExpression",
               "span": {
                 "start": 84,
                 "end": 239,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 5,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 12,
-                    "column": 3
-                  }
-                }
+                "ctxt": 0
               },
               "expression": {
                 "type": "JSXElement",
                 "span": {
                   "start": 91,
                   "end": 234,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 6,
-                      "column": 4
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 10
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "opening": {
                   "type": "JSXOpeningElement",
@@ -293,17 +143,7 @@
                     "span": {
                       "start": 92,
                       "end": 95,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 6,
-                          "column": 5
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 8
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "value": "div",
                     "typeAnnotation": null,
@@ -312,17 +152,7 @@
                   "span": {
                     "start": 92,
                     "end": 96,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 6,
-                        "column": 5
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 9
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "attributes": [],
                   "selfClosing": false,
@@ -334,17 +164,7 @@
                     "span": {
                       "start": 96,
                       "end": 104,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 6,
-                          "column": 9
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 6
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "value": "\n\r\n      ",
                     "raw": "\n\r\n      "
@@ -354,17 +174,7 @@
                     "span": {
                       "start": 104,
                       "end": 119,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 7,
-                          "column": 6
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 21
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "opening": {
                       "type": "JSXOpeningElement",
@@ -373,17 +183,7 @@
                         "span": {
                           "start": 105,
                           "end": 107,
-                          "ctxt": 0,
-                          "loc": {
-                            "start": {
-                              "line": 7,
-                              "column": 7
-                            },
-                            "end": {
-                              "line": 7,
-                              "column": 9
-                            }
-                          }
+                          "ctxt": 0
                         },
                         "value": "h1",
                         "typeAnnotation": null,
@@ -392,17 +192,7 @@
                       "span": {
                         "start": 105,
                         "end": 108,
-                        "ctxt": 0,
-                        "loc": {
-                          "start": {
-                            "line": 7,
-                            "column": 7
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 10
-                          }
-                        }
+                        "ctxt": 0
                       },
                       "attributes": [],
                       "selfClosing": false,
@@ -414,17 +204,7 @@
                         "span": {
                           "start": 108,
                           "end": 114,
-                          "ctxt": 0,
-                          "loc": {
-                            "start": {
-                              "line": 7,
-                              "column": 10
-                            },
-                            "end": {
-                              "line": 7,
-                              "column": 16
-                            }
-                          }
+                          "ctxt": 0
                         },
                         "value": "works ",
                         "raw": "works "
@@ -435,34 +215,14 @@
                       "span": {
                         "start": 116,
                         "end": 119,
-                        "ctxt": 0,
-                        "loc": {
-                          "start": {
-                            "line": 7,
-                            "column": 18
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 21
-                          }
-                        }
+                        "ctxt": 0
                       },
                       "name": {
                         "type": "Identifier",
                         "span": {
                           "start": 116,
                           "end": 118,
-                          "ctxt": 0,
-                          "loc": {
-                            "start": {
-                              "line": 7,
-                              "column": 18
-                            },
-                            "end": {
-                              "line": 7,
-                              "column": 20
-                            }
-                          }
+                          "ctxt": 0
                         },
                         "value": "h1",
                         "typeAnnotation": null,
@@ -475,17 +235,7 @@
                     "span": {
                       "start": 119,
                       "end": 127,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 7,
-                          "column": 21
-                        },
-                        "end": {
-                          "line": 8,
-                          "column": 6
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "value": "\n\r\n      ",
                     "raw": "\n\r\n      "
@@ -497,34 +247,14 @@
                       "span": {
                         "start": 138,
                         "end": 213,
-                        "ctxt": 0,
-                        "loc": {
-                          "start": {
-                            "line": 9,
-                            "column": 8
-                          },
-                          "end": {
-                            "line": 9,
-                            "column": 83
-                          }
-                        }
+                        "ctxt": 0
                       },
                       "test": {
                         "type": "Identifier",
                         "span": {
                           "start": 138,
                           "end": 147,
-                          "ctxt": 0,
-                          "loc": {
-                            "start": {
-                              "line": 9,
-                              "column": 8
-                            },
-                            "end": {
-                              "line": 9,
-                              "column": 17
-                            }
-                          }
+                          "ctxt": 0
                         },
                         "value": "isLoading",
                         "typeAnnotation": null,
@@ -535,17 +265,7 @@
                         "span": {
                           "start": 150,
                           "end": 169,
-                          "ctxt": 0,
-                          "loc": {
-                            "start": {
-                              "line": 9,
-                              "column": 20
-                            },
-                            "end": {
-                              "line": 9,
-                              "column": 39
-                            }
-                          }
+                          "ctxt": 0
                         },
                         "opening": {
                           "type": "JSXOpeningElement",
@@ -554,17 +274,7 @@
                             "span": {
                               "start": 151,
                               "end": 154,
-                              "ctxt": 0,
-                              "loc": {
-                                "start": {
-                                  "line": 9,
-                                  "column": 21
-                                },
-                                "end": {
-                                  "line": 9,
-                                  "column": 24
-                                }
-                              }
+                              "ctxt": 0
                             },
                             "value": "div",
                             "typeAnnotation": null,
@@ -573,17 +283,7 @@
                           "span": {
                             "start": 151,
                             "end": 155,
-                            "ctxt": 0,
-                            "loc": {
-                              "start": {
-                                "line": 9,
-                                "column": 21
-                              },
-                              "end": {
-                                "line": 9,
-                                "column": 25
-                              }
-                            }
+                            "ctxt": 0
                           },
                           "attributes": [],
                           "selfClosing": false,
@@ -595,17 +295,7 @@
                             "span": {
                               "start": 155,
                               "end": 163,
-                              "ctxt": 0,
-                              "loc": {
-                                "start": {
-                                  "line": 9,
-                                  "column": 25
-                                },
-                                "end": {
-                                  "line": 9,
-                                  "column": 33
-                                }
-                              }
+                              "ctxt": 0
                             },
                             "value": "loading ",
                             "raw": "loading "
@@ -616,34 +306,14 @@
                           "span": {
                             "start": 165,
                             "end": 169,
-                            "ctxt": 0,
-                            "loc": {
-                              "start": {
-                                "line": 9,
-                                "column": 35
-                              },
-                              "end": {
-                                "line": 9,
-                                "column": 39
-                              }
-                            }
+                            "ctxt": 0
                           },
                           "name": {
                             "type": "Identifier",
                             "span": {
                               "start": 165,
                               "end": 168,
-                              "ctxt": 0,
-                              "loc": {
-                                "start": {
-                                  "line": 9,
-                                  "column": 35
-                                },
-                                "end": {
-                                  "line": 9,
-                                  "column": 38
-                                }
-                              }
+                              "ctxt": 0
                             },
                             "value": "div",
                             "typeAnnotation": null,
@@ -656,17 +326,7 @@
                         "span": {
                           "start": 172,
                           "end": 213,
-                          "ctxt": 0,
-                          "loc": {
-                            "start": {
-                              "line": 9,
-                              "column": 42
-                            },
-                            "end": {
-                              "line": 9,
-                              "column": 83
-                            }
-                          }
+                          "ctxt": 0
                         },
                         "opening": {
                           "type": "JSXOpeningElement",
@@ -675,17 +335,7 @@
                             "span": {
                               "start": 173,
                               "end": 176,
-                              "ctxt": 0,
-                              "loc": {
-                                "start": {
-                                  "line": 9,
-                                  "column": 43
-                                },
-                                "end": {
-                                  "line": 9,
-                                  "column": 46
-                                }
-                              }
+                              "ctxt": 0
                             },
                             "value": "div",
                             "typeAnnotation": null,
@@ -694,17 +344,7 @@
                           "span": {
                             "start": 173,
                             "end": 177,
-                            "ctxt": 0,
-                            "loc": {
-                              "start": {
-                                "line": 9,
-                                "column": 43
-                              },
-                              "end": {
-                                "line": 9,
-                                "column": 47
-                              }
-                            }
+                            "ctxt": 0
                           },
                           "attributes": [],
                           "selfClosing": false,
@@ -716,17 +356,7 @@
                             "span": {
                               "start": 177,
                               "end": 207,
-                              "ctxt": 0,
-                              "loc": {
-                                "start": {
-                                  "line": 9,
-                                  "column": 47
-                                },
-                                "end": {
-                                  "line": 9,
-                                  "column": 77
-                                }
-                              }
+                              "ctxt": 0
                             },
                             "value": "naaaaaaaaaaaaffffffffffffffff ",
                             "raw": "naaaaaaaaaaaaffffffffffffffff "
@@ -737,34 +367,14 @@
                           "span": {
                             "start": 209,
                             "end": 213,
-                            "ctxt": 0,
-                            "loc": {
-                              "start": {
-                                "line": 9,
-                                "column": 79
-                              },
-                              "end": {
-                                "line": 9,
-                                "column": 83
-                              }
-                            }
+                            "ctxt": 0
                           },
                           "name": {
                             "type": "Identifier",
                             "span": {
                               "start": 209,
                               "end": 212,
-                              "ctxt": 0,
-                              "loc": {
-                                "start": {
-                                  "line": 9,
-                                  "column": 79
-                                },
-                                "end": {
-                                  "line": 9,
-                                  "column": 82
-                                }
-                              }
+                              "ctxt": 0
                             },
                             "value": "div",
                             "typeAnnotation": null,
@@ -779,17 +389,7 @@
                     "span": {
                       "start": 222,
                       "end": 228,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 10,
-                          "column": 7
-                        },
-                        "end": {
-                          "line": 11,
-                          "column": 4
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "value": "\n\r\n    ",
                     "raw": "\n\r\n    "
@@ -800,34 +400,14 @@
                   "span": {
                     "start": 230,
                     "end": 234,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 11,
-                        "column": 6
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 10
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
                       "start": 230,
                       "end": 233,
-                      "ctxt": 0,
-                      "loc": {
-                        "start": {
-                          "line": 11,
-                          "column": 6
-                        },
-                        "end": {
-                          "line": 11,
-                          "column": 9
-                        }
-                      }
+                      "ctxt": 0
                     },
                     "value": "div",
                     "typeAnnotation": null,
@@ -849,34 +429,14 @@
       "span": {
         "start": 247,
         "end": 266,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 15,
-            "column": 0
-          },
-          "end": {
-            "line": 15,
-            "column": 19
-          }
-        }
+        "ctxt": 0
       },
       "expression": {
         "type": "Identifier",
         "span": {
           "start": 262,
           "end": 265,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 15,
-              "column": 15
-            },
-            "end": {
-              "line": 15,
-              "column": 18
-            }
-          }
+          "ctxt": 0
         },
         "value": "App",
         "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/empty-expression-container/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/empty-expression-container/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 9,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 9
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 9,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 9
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 2,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "a",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 3,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 3
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": false,
@@ -83,17 +43,7 @@
             "span": {
               "start": 4,
               "end": 4,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 4
-                },
-                "end": {
-                  "line": 1,
-                  "column": 4
-                }
-              }
+              "ctxt": 0
             }
           }
         }
@@ -103,34 +53,14 @@
         "span": {
           "start": 7,
           "end": 9,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 7
-            },
-            "end": {
-              "line": 1,
-              "column": 9
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 7,
             "end": 8,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 7
-              },
-              "end": {
-                "line": 1,
-                "column": 8
-              }
-            }
+            "ctxt": 0
           },
           "value": "a",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/entity/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/entity/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 16,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 16
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 16,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 16
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 2,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "A",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 3,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 3
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": false,
@@ -81,17 +41,7 @@
           "span": {
             "start": 3,
             "end": 12,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 3
-              },
-              "end": {
-                "line": 1,
-                "column": 12
-              }
-            }
+            "ctxt": 0
           },
           "value": "💩",
           "raw": "💩"
@@ -102,34 +52,14 @@
         "span": {
           "start": 14,
           "end": 16,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 14
-            },
-            "end": {
-              "line": 1,
-              "column": 16
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 14,
             "end": 15,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 14
-              },
-              "end": {
-                "line": 1,
-                "column": 15
-              }
-            }
+            "ctxt": 0
           },
           "value": "A",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/fragment-1/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/fragment-1/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 5,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 5
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,34 +11,14 @@
       "span": {
         "start": 0,
         "end": 5,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 5
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningFragment",
         "span": {
           "start": 1,
           "end": 2,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 2
-            }
-          }
+          "ctxt": 0
         }
       },
       "children": [],
@@ -57,17 +27,7 @@
         "span": {
           "start": 4,
           "end": 5,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 4
-            },
-            "end": {
-              "line": 1,
-              "column": 5
-            }
-          }
+          "ctxt": 0
         }
       }
     }

--- a/ecmascript/parser/tests/jsx/basic/fragment-2/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/fragment-2/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 22,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 22
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,34 +11,14 @@
       "span": {
         "start": 0,
         "end": 22,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 22
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningFragment",
         "span": {
           "start": 1,
           "end": 2,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 2
-            }
-          }
+          "ctxt": 0
         }
       },
       "children": [
@@ -57,17 +27,7 @@
           "span": {
             "start": 2,
             "end": 19,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 2
-              },
-              "end": {
-                "line": 1,
-                "column": 19
-              }
-            }
+            "ctxt": 0
           },
           "value": "Hi, I'm a string!",
           "raw": "Hi, I'm a string!"
@@ -78,17 +38,7 @@
         "span": {
           "start": 21,
           "end": 22,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 21
-            },
-            "end": {
-              "line": 1,
-              "column": 22
-            }
-          }
+          "ctxt": 0
         }
       }
     }

--- a/ecmascript/parser/tests/jsx/basic/fragment-3/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/fragment-3/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 55,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 6,
-        "column": 3
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,34 +11,14 @@
       "span": {
         "start": 0,
         "end": 55,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 6,
-            "column": 3
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningFragment",
         "span": {
           "start": 2,
           "end": 3,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 2
-            },
-            "end": {
-              "line": 1,
-              "column": 3
-            }
-          }
+          "ctxt": 0
         }
       },
       "children": [
@@ -57,17 +27,7 @@
           "span": {
             "start": 3,
             "end": 7,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 3
-              },
-              "end": {
-                "line": 2,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "\n\r\n  ",
           "raw": "\n\r\n  "
@@ -77,17 +37,7 @@
           "span": {
             "start": 7,
             "end": 32,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 2,
-                "column": 2
-              },
-              "end": {
-                "line": 4,
-                "column": 9
-              }
-            }
+            "ctxt": 0
           },
           "opening": {
             "type": "JSXOpeningElement",
@@ -96,17 +46,7 @@
               "span": {
                 "start": 8,
                 "end": 12,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 2,
-                    "column": 3
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 7
-                  }
-                }
+                "ctxt": 0
               },
               "value": "span",
               "typeAnnotation": null,
@@ -115,17 +55,7 @@
             "span": {
               "start": 8,
               "end": 13,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 2,
-                  "column": 3
-                },
-                "end": {
-                  "line": 2,
-                  "column": 8
-                }
-              }
+              "ctxt": 0
             },
             "attributes": [],
             "selfClosing": false,
@@ -137,17 +67,7 @@
               "span": {
                 "start": 13,
                 "end": 25,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 2,
-                    "column": 8
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 2
-                  }
-                }
+                "ctxt": 0
               },
               "value": "\n\r\n    hi\n\r\n  ",
               "raw": "\n\r\n    hi\n\r\n  "
@@ -158,34 +78,14 @@
             "span": {
               "start": 27,
               "end": 32,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 4,
-                  "column": 4
-                },
-                "end": {
-                  "line": 4,
-                  "column": 9
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 27,
                 "end": 31,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 4,
-                    "column": 4
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 8
-                  }
-                }
+                "ctxt": 0
               },
               "value": "span",
               "typeAnnotation": null,
@@ -198,17 +98,7 @@
           "span": {
             "start": 32,
             "end": 36,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 4,
-                "column": 9
-              },
-              "end": {
-                "line": 5,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "\n\r\n  ",
           "raw": "\n\r\n  "
@@ -218,17 +108,7 @@
           "span": {
             "start": 36,
             "end": 50,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 5,
-                "column": 2
-              },
-              "end": {
-                "line": 5,
-                "column": 16
-              }
-            }
+            "ctxt": 0
           },
           "opening": {
             "type": "JSXOpeningElement",
@@ -237,17 +117,7 @@
               "span": {
                 "start": 37,
                 "end": 40,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 5,
-                    "column": 3
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 6
-                  }
-                }
+                "ctxt": 0
               },
               "value": "div",
               "typeAnnotation": null,
@@ -256,17 +126,7 @@
             "span": {
               "start": 37,
               "end": 41,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 5,
-                  "column": 3
-                },
-                "end": {
-                  "line": 5,
-                  "column": 7
-                }
-              }
+              "ctxt": 0
             },
             "attributes": [],
             "selfClosing": false,
@@ -278,17 +138,7 @@
               "span": {
                 "start": 41,
                 "end": 44,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 5,
-                    "column": 7
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 10
-                  }
-                }
+                "ctxt": 0
               },
               "value": "bye",
               "raw": "bye"
@@ -299,34 +149,14 @@
             "span": {
               "start": 46,
               "end": 50,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 5,
-                  "column": 12
-                },
-                "end": {
-                  "line": 5,
-                  "column": 16
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 46,
                 "end": 49,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 5,
-                    "column": 12
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 15
-                  }
-                }
+                "ctxt": 0
               },
               "value": "div",
               "typeAnnotation": null,
@@ -339,17 +169,7 @@
           "span": {
             "start": 50,
             "end": 52,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 5,
-                "column": 16
-              },
-              "end": {
-                "line": 6,
-                "column": 0
-              }
-            }
+            "ctxt": 0
           },
           "value": "\n\r\n",
           "raw": "\n\r\n"
@@ -360,17 +180,7 @@
         "span": {
           "start": 54,
           "end": 55,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 6,
-              "column": 2
-            },
-            "end": {
-              "line": 6,
-              "column": 3
-            }
-          }
+          "ctxt": 0
         }
       }
     }

--- a/ecmascript/parser/tests/jsx/basic/fragment-4/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/fragment-4/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 55,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 7,
-        "column": 3
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,34 +11,14 @@
       "span": {
         "start": 0,
         "end": 55,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 7,
-            "column": 3
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningFragment",
         "span": {
           "start": 1,
           "end": 2,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 2
-            }
-          }
+          "ctxt": 0
         }
       },
       "children": [
@@ -57,17 +27,7 @@
           "span": {
             "start": 2,
             "end": 6,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 2
-              },
-              "end": {
-                "line": 2,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "\n\r\n  ",
           "raw": "\n\r\n  "
@@ -77,34 +37,14 @@
           "span": {
             "start": 6,
             "end": 50,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 2,
-                "column": 2
-              },
-              "end": {
-                "line": 6,
-                "column": 5
-              }
-            }
+            "ctxt": 0
           },
           "opening": {
             "type": "JSXOpeningFragment",
             "span": {
               "start": 7,
               "end": 8,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 2,
-                  "column": 3
-                },
-                "end": {
-                  "line": 2,
-                  "column": 4
-                }
-              }
+              "ctxt": 0
             }
           },
           "children": [
@@ -113,17 +53,7 @@
               "span": {
                 "start": 8,
                 "end": 14,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 2,
-                    "column": 4
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 4
-                  }
-                }
+                "ctxt": 0
               },
               "value": "\n\r\n    ",
               "raw": "\n\r\n    "
@@ -133,34 +63,14 @@
               "span": {
                 "start": 14,
                 "end": 43,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 3,
-                    "column": 4
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 7
-                  }
-                }
+                "ctxt": 0
               },
               "opening": {
                 "type": "JSXOpeningFragment",
                 "span": {
                   "start": 15,
                   "end": 16,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 3,
-                      "column": 5
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 6
-                    }
-                  }
+                  "ctxt": 0
                 }
               },
               "children": [
@@ -169,17 +79,7 @@
                   "span": {
                     "start": 16,
                     "end": 40,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 3,
-                        "column": 6
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 4
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "\n\r\n      super deep\n\r\n    ",
                   "raw": "\n\r\n      super deep\n\r\n    "
@@ -190,17 +90,7 @@
                 "span": {
                   "start": 42,
                   "end": 43,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 5,
-                      "column": 6
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 7
-                    }
-                  }
+                  "ctxt": 0
                 }
               }
             },
@@ -209,17 +99,7 @@
               "span": {
                 "start": 43,
                 "end": 47,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 5,
-                    "column": 7
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 2
-                  }
-                }
+                "ctxt": 0
               },
               "value": "\n\r\n  ",
               "raw": "\n\r\n  "
@@ -230,17 +110,7 @@
             "span": {
               "start": 49,
               "end": 50,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 6,
-                  "column": 4
-                },
-                "end": {
-                  "line": 6,
-                  "column": 5
-                }
-              }
+              "ctxt": 0
             }
           }
         },
@@ -249,17 +119,7 @@
           "span": {
             "start": 50,
             "end": 52,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 6,
-                "column": 5
-              },
-              "end": {
-                "line": 7,
-                "column": 0
-              }
-            }
+            "ctxt": 0
           },
           "value": "\n\r\n",
           "raw": "\n\r\n"
@@ -270,17 +130,7 @@
         "span": {
           "start": 54,
           "end": 55,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 7,
-              "column": 2
-            },
-            "end": {
-              "line": 7,
-              "column": 3
-            }
-          }
+          "ctxt": 0
         }
       }
     }

--- a/ecmascript/parser/tests/jsx/basic/fragment-5/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/fragment-5/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 68,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 7,
-        "column": 3
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,34 +11,14 @@
       "span": {
         "start": 0,
         "end": 68,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 7,
-            "column": 3
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningFragment",
         "span": {
           "start": 32,
           "end": 33,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 4,
-              "column": 0
-            },
-            "end": {
-              "line": 4,
-              "column": 1
-            }
-          }
+          "ctxt": 0
         }
       },
       "children": [
@@ -57,17 +27,7 @@
           "span": {
             "start": 33,
             "end": 37,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 4,
-                "column": 1
-              },
-              "end": {
-                "line": 5,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "\n\r\n  ",
           "raw": "\n\r\n  "
@@ -77,17 +37,7 @@
           "span": {
             "start": 37,
             "end": 48,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 5,
-                "column": 2
-              },
-              "end": {
-                "line": 5,
-                "column": 13
-              }
-            }
+            "ctxt": 0
           },
           "opening": {
             "type": "JSXOpeningElement",
@@ -96,17 +46,7 @@
               "span": {
                 "start": 38,
                 "end": 41,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 5,
-                    "column": 3
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 6
-                  }
-                }
+                "ctxt": 0
               },
               "value": "div",
               "typeAnnotation": null,
@@ -115,17 +55,7 @@
             "span": {
               "start": 38,
               "end": 42,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 5,
-                  "column": 3
-                },
-                "end": {
-                  "line": 5,
-                  "column": 7
-                }
-              }
+              "ctxt": 0
             },
             "attributes": [],
             "selfClosing": false,
@@ -137,34 +67,14 @@
             "span": {
               "start": 44,
               "end": 48,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 5,
-                  "column": 9
-                },
-                "end": {
-                  "line": 5,
-                  "column": 13
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 44,
                 "end": 47,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 5,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 12
-                  }
-                }
+                "ctxt": 0
               },
               "value": "div",
               "typeAnnotation": null,
@@ -177,17 +87,7 @@
           "span": {
             "start": 48,
             "end": 52,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 5,
-                "column": 13
-              },
-              "end": {
-                "line": 6,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "\n\r\n  ",
           "raw": "\n\r\n  "
@@ -197,17 +97,7 @@
           "span": {
             "start": 52,
             "end": 63,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 6,
-                "column": 2
-              },
-              "end": {
-                "line": 6,
-                "column": 13
-              }
-            }
+            "ctxt": 0
           },
           "opening": {
             "type": "JSXOpeningElement",
@@ -216,17 +106,7 @@
               "span": {
                 "start": 53,
                 "end": 56,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 6,
-                    "column": 3
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 6
-                  }
-                }
+                "ctxt": 0
               },
               "value": "div",
               "typeAnnotation": null,
@@ -235,17 +115,7 @@
             "span": {
               "start": 53,
               "end": 57,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 6,
-                  "column": 3
-                },
-                "end": {
-                  "line": 6,
-                  "column": 7
-                }
-              }
+              "ctxt": 0
             },
             "attributes": [],
             "selfClosing": false,
@@ -257,34 +127,14 @@
             "span": {
               "start": 59,
               "end": 63,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 6,
-                  "column": 9
-                },
-                "end": {
-                  "line": 6,
-                  "column": 13
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 59,
                 "end": 62,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 6,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 12
-                  }
-                }
+                "ctxt": 0
               },
               "value": "div",
               "typeAnnotation": null,
@@ -297,17 +147,7 @@
           "span": {
             "start": 63,
             "end": 65,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 6,
-                "column": 13
-              },
-              "end": {
-                "line": 7,
-                "column": 0
-              }
-            }
+            "ctxt": 0
           },
           "value": "\n\r\n",
           "raw": "\n\r\n"
@@ -318,17 +158,7 @@
         "span": {
           "start": 67,
           "end": 68,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 7,
-              "column": 2
-            },
-            "end": {
-              "line": 7,
-              "column": 3
-            }
-          }
+          "ctxt": 0
         }
       }
     }

--- a/ecmascript/parser/tests/jsx/basic/fragment-6/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/fragment-6/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 59,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 59
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,34 +11,14 @@
       "span": {
         "start": 0,
         "end": 59,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 59
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningFragment",
         "span": {
           "start": 1,
           "end": 2,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 2
-            }
-          }
+          "ctxt": 0
         }
       },
       "children": [
@@ -57,17 +27,7 @@
           "span": {
             "start": 2,
             "end": 23,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 2
-              },
-              "end": {
-                "line": 1,
-                "column": 23
-              }
-            }
+            "ctxt": 0
           },
           "opening": {
             "type": "JSXOpeningElement",
@@ -76,17 +36,7 @@
               "span": {
                 "start": 3,
                 "end": 6,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 3
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 6
-                  }
-                }
+                "ctxt": 0
               },
               "value": "div",
               "typeAnnotation": null,
@@ -95,17 +45,7 @@
             "span": {
               "start": 3,
               "end": 7,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 3
-                },
-                "end": {
-                  "line": 1,
-                  "column": 7
-                }
-              }
+              "ctxt": 0
             },
             "attributes": [],
             "selfClosing": false,
@@ -117,17 +57,7 @@
               "span": {
                 "start": 7,
                 "end": 17,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 7
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 17
-                  }
-                }
+                "ctxt": 0
               },
               "value": "JSXElement",
               "raw": "JSXElement"
@@ -138,34 +68,14 @@
             "span": {
               "start": 19,
               "end": 23,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 19
-                },
-                "end": {
-                  "line": 1,
-                  "column": 23
-                }
-              }
+              "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
                 "start": 19,
                 "end": 22,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 19
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 22
-                  }
-                }
+                "ctxt": 0
               },
               "value": "div",
               "typeAnnotation": null,
@@ -178,17 +88,7 @@
           "span": {
             "start": 23,
             "end": 30,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 23
-              },
-              "end": {
-                "line": 1,
-                "column": 30
-              }
-            }
+            "ctxt": 0
           },
           "value": "JSXText",
           "raw": "JSXText"
@@ -200,17 +100,7 @@
             "span": {
               "start": 31,
               "end": 55,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 31
-                },
-                "end": {
-                  "line": 1,
-                  "column": 55
-                }
-              }
+              "ctxt": 0
             },
             "value": "JSXExpressionContainer",
             "hasEscape": false
@@ -222,17 +112,7 @@
         "span": {
           "start": 58,
           "end": 59,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 58
-            },
-            "end": {
-              "line": 1,
-              "column": 59
-            }
-          }
+          "ctxt": 0
         }
       }
     }

--- a/ecmascript/parser/tests/jsx/basic/keyword-tag/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/keyword-tag/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 12,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 12
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 11,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 11
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 4,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 4
-              }
-            }
+            "ctxt": 0
           },
           "value": "var",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 5,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 5
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": false,
@@ -81,34 +41,14 @@
         "span": {
           "start": 7,
           "end": 11,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 7
-            },
-            "end": {
-              "line": 1,
-              "column": 11
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 7,
             "end": 10,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 7
-              },
-              "end": {
-                "line": 1,
-                "column": 10
-              }
-            }
+            "ctxt": 0
           },
           "value": "var",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/namespace-tag/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/namespace-tag/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 33,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 2,
-        "column": 19
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 11,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 11
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -42,17 +22,7 @@
             "span": {
               "start": 1,
               "end": 4,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 1
-                },
-                "end": {
-                  "line": 1,
-                  "column": 4
-                }
-              }
+              "ctxt": 0
             },
             "value": "Foo",
             "typeAnnotation": null,
@@ -63,17 +33,7 @@
             "span": {
               "start": 5,
               "end": 8,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 5
-                },
-                "end": {
-                  "line": 1,
-                  "column": 8
-                }
-              }
+              "ctxt": 0
             },
             "value": "Bar",
             "typeAnnotation": null,
@@ -83,17 +43,7 @@
         "span": {
           "start": 1,
           "end": 11,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 11
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": true,
@@ -107,17 +57,7 @@
       "span": {
         "start": 14,
         "end": 33,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 2,
-            "column": 0
-          },
-          "end": {
-            "line": 2,
-            "column": 19
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -128,17 +68,7 @@
             "span": {
               "start": 15,
               "end": 18,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 2,
-                  "column": 1
-                },
-                "end": {
-                  "line": 2,
-                  "column": 4
-                }
-              }
+              "ctxt": 0
             },
             "value": "Foo",
             "typeAnnotation": null,
@@ -149,17 +79,7 @@
             "span": {
               "start": 19,
               "end": 22,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 2,
-                  "column": 5
-                },
-                "end": {
-                  "line": 2,
-                  "column": 8
-                }
-              }
+              "ctxt": 0
             },
             "value": "Bar",
             "typeAnnotation": null,
@@ -169,17 +89,7 @@
         "span": {
           "start": 15,
           "end": 23,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 2,
-              "column": 1
-            },
-            "end": {
-              "line": 2,
-              "column": 9
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": false,
@@ -191,17 +101,7 @@
         "span": {
           "start": 25,
           "end": 33,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 2,
-              "column": 11
-            },
-            "end": {
-              "line": 2,
-              "column": 19
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "JSXNamespacedName",
@@ -210,17 +110,7 @@
             "span": {
               "start": 25,
               "end": 28,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 2,
-                  "column": 11
-                },
-                "end": {
-                  "line": 2,
-                  "column": 14
-                }
-              }
+              "ctxt": 0
             },
             "value": "Foo",
             "typeAnnotation": null,
@@ -231,17 +121,7 @@
             "span": {
               "start": 29,
               "end": 32,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 2,
-                  "column": 15
-                },
-                "end": {
-                  "line": 2,
-                  "column": 18
-                }
-              }
+              "ctxt": 0
             },
             "value": "Bar",
             "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/nonentity-decimal/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/nonentity-decimal/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 15,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 15
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 15,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 15
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 2,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "A",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 3,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 3
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": false,
@@ -81,17 +41,7 @@
           "span": {
             "start": 3,
             "end": 11,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 3
-              },
-              "end": {
-                "line": 1,
-                "column": 11
-              }
-            }
+            "ctxt": 0
           },
           "value": "&#1f4a9;",
           "raw": "&#1f4a9;"
@@ -102,34 +52,14 @@
         "span": {
           "start": 13,
           "end": 15,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 13
-            },
-            "end": {
-              "line": 1,
-              "column": 15
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 13,
             "end": 14,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 13
-              },
-              "end": {
-                "line": 1,
-                "column": 14
-              }
-            }
+            "ctxt": 0
           },
           "value": "A",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/nonentity/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/nonentity/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 16,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 1,
-        "column": 16
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -21,17 +11,7 @@
       "span": {
         "start": 0,
         "end": 16,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 1,
-            "column": 16
-          }
-        }
+        "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningElement",
@@ -40,17 +20,7 @@
           "span": {
             "start": 1,
             "end": 2,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 1
-              },
-              "end": {
-                "line": 1,
-                "column": 2
-              }
-            }
+            "ctxt": 0
           },
           "value": "A",
           "typeAnnotation": null,
@@ -59,17 +29,7 @@
         "span": {
           "start": 1,
           "end": 3,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 3
-            }
-          }
+          "ctxt": 0
         },
         "attributes": [],
         "selfClosing": false,
@@ -81,17 +41,7 @@
           "span": {
             "start": 3,
             "end": 12,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 3
-              },
-              "end": {
-                "line": 1,
-                "column": 12
-              }
-            }
+            "ctxt": 0
           },
           "value": "&#x1g4q9;",
           "raw": "&#x1g4q9;"
@@ -102,34 +52,14 @@
         "span": {
           "start": 14,
           "end": 16,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 14
-            },
-            "end": {
-              "line": 1,
-              "column": 16
-            }
-          }
+          "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
             "start": 14,
             "end": 15,
-            "ctxt": 0,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 14
-              },
-              "end": {
-                "line": 1,
-                "column": 15
-              }
-            }
+            "ctxt": 0
           },
           "value": "A",
           "typeAnnotation": null,

--- a/ecmascript/parser/tests/jsx/basic/yield-tag/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/yield-tag/input.js.json
@@ -3,17 +3,7 @@
   "span": {
     "start": 0,
     "end": 37,
-    "ctxt": 0,
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 3,
-        "column": 1
-      }
-    }
+    "ctxt": 0
   },
   "body": [
     {
@@ -23,17 +13,7 @@
         "span": {
           "start": 9,
           "end": 11,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 9
-            },
-            "end": {
-              "line": 1,
-              "column": 11
-            }
-          }
+          "ctxt": 0
         },
         "value": "it",
         "typeAnnotation": null,
@@ -45,34 +25,14 @@
       "span": {
         "start": 0,
         "end": 37,
-        "ctxt": 0,
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 0
-          },
-          "end": {
-            "line": 3,
-            "column": 1
-          }
-        }
+        "ctxt": 0
       },
       "body": {
         "type": "BlockStatement",
         "span": {
           "start": 13,
           "end": 37,
-          "ctxt": 0,
-          "loc": {
-            "start": {
-              "line": 1,
-              "column": 13
-            },
-            "end": {
-              "line": 3,
-              "column": 1
-            }
-          }
+          "ctxt": 0
         },
         "stmts": [
           {
@@ -80,34 +40,14 @@
             "span": {
               "start": 20,
               "end": 33,
-              "ctxt": 0,
-              "loc": {
-                "start": {
-                  "line": 2,
-                  "column": 4
-                },
-                "end": {
-                  "line": 2,
-                  "column": 17
-                }
-              }
+              "ctxt": 0
             },
             "argument": {
               "type": "JSXElement",
               "span": {
                 "start": 26,
                 "end": 33,
-                "ctxt": 0,
-                "loc": {
-                  "start": {
-                    "line": 2,
-                    "column": 10
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 17
-                  }
-                }
+                "ctxt": 0
               },
               "opening": {
                 "type": "JSXOpeningElement",
@@ -116,17 +56,7 @@
                   "span": {
                     "start": 27,
                     "end": 28,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 2,
-                        "column": 11
-                      },
-                      "end": {
-                        "line": 2,
-                        "column": 12
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "a",
                   "typeAnnotation": null,
@@ -135,17 +65,7 @@
                 "span": {
                   "start": 27,
                   "end": 29,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 2,
-                      "column": 11
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 13
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "attributes": [],
                 "selfClosing": false,
@@ -157,34 +77,14 @@
                 "span": {
                   "start": 31,
                   "end": 33,
-                  "ctxt": 0,
-                  "loc": {
-                    "start": {
-                      "line": 2,
-                      "column": 15
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 17
-                    }
-                  }
+                  "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
                     "start": 31,
                     "end": 32,
-                    "ctxt": 0,
-                    "loc": {
-                      "start": {
-                        "line": 2,
-                        "column": 15
-                      },
-                      "end": {
-                        "line": 2,
-                        "column": 16
-                      }
-                    }
+                    "ctxt": 0
                   },
                   "value": "a",
                   "typeAnnotation": null,


### PR DESCRIPTION
Before:


```
[parse]
  parse x 1,955 ops/sec ±0.59% (88 runs sampled)
  parse + print x 418 ops/sec ±0.38% (86 runs sampled)
```

After: 

```
[plugin]
  parse x 3,156 ops/sec ±0.43% (89 runs sampled)
  parse + print x 740 ops/sec ±0.35% (88 runs sampled)
  parse + transform x 734 ops/sec ±0.22% (88 runs sampled)
  plugin x 720 ops/sec ±0.32% (87 runs sampled)
[transform]
  swc (es3) x 761 ops/sec ±0.23% (89 runs sampled)
  swc (es2015) x 800 ops/sec ±1.02% (87 runs sampled)
  swc (es2016) x 2,123 ops/sec ±0.84% (88 runs sampled)
  swc (es2017) x 2,131 ops/sec ±1.13% (90 runs sampled)
  swc (es2018) x 2,981 ops/sec ±0.25% (90 runs sampled)
  swc-optimize (es3) x 712 ops/sec ±0.21% (86 runs sampled)
Browserslist: caniuse-lite is outdated. Please run next command `npm update caniuse-lite browserslist`
  babel (es5) x 41.75 ops/sec ±8.07% (56 runs sampled)
[typescript]
  swc (es3) x 646 ops/sec ±2.25% (87 runs sampled)
  swc (es5) x 703 ops/sec ±0.55% (89 runs sampled)
  swc (es2015) x 708 ops/sec ±0.26% (87 runs sampled)
  swc (es2016) x 1,656 ops/sec ±0.17% (90 runs sampled)
  swc (es2017) x 1,661 ops/sec ±0.33% (91 runs sampled)
  swc (es2018) x 2,135 ops/sec ±0.25% (88 runs sampled)
  swc-optimize (es3) x 631 ops/sec ±0.13% (88 runs sampled)
  babel (es5) x 41.89 ops/sec ±4.62% (54 runs sampled)
```