### PR TITLE
Fixing the Wasm blocker for Parser - try 2

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -11,15 +11,15 @@ edition = "2018"
 [features]
 default = []
 # Requires nightly.
-fold = ["swc_common/fold", "ast/fold"]
+fold = ["swc_common/fold", "swc_ecma_ast/fold"]
 # Verify that expression is valid. Requires nightly.
 verify = ["fold"]
 
 [dependencies]
 swc_atoms = { version = "0.2", path ="../../atoms" }
 swc_common = { version = "0.4.0", path ="../../common" }
-ast = { package = "swc_ecma_ast", version = "0.10.0", path ="../ast" }
-parser_macros = { package = "swc_ecma_parser_macros", version = "0.4", path ="./macros" }
+swc_ecma_ast = { version = "0.10.0", path ="../ast" }
+swc_ecma_parser_macros = { package = "swc_ecma_parser_macros", version = "0.4", path ="./macros" }
 enum_kind = { version = "0.2", path ="../../macros/enum_kind" }
 unicode-xid = "0.2"
 log = { version = "0.4", features = ["release_max_level_debug"] }

--- a/ecmascript/parser/src/lexer.rs
+++ b/ecmascript/parser/src/lexer.rs
@@ -15,7 +15,7 @@ use crate::{
     Context, JscTarget, Session, Syntax,
 };
 
-use ast::Str;
+use swc_ecma_ast::Str;
 use smallvec::{smallvec, SmallVec};
 use std::{char, iter::FusedIterator};
 use swc_atoms::JsWord;

--- a/ecmascript/parser/src/lexer.rs
+++ b/ecmascript/parser/src/lexer.rs
@@ -15,7 +15,6 @@ use crate::{
     Context, JscTarget, Session, Syntax,
 };
 
-use swc_ecma_ast::Str;
 use smallvec::{smallvec, SmallVec};
 use std::{char, iter::FusedIterator};
 use swc_atoms::JsWord;
@@ -23,6 +22,7 @@ use swc_common::{
     comments::{Comment, Comments},
     BytePos, Span,
 };
+use swc_ecma_ast::Str;
 
 pub mod input;
 mod jsx;

--- a/ecmascript/parser/src/parser.rs
+++ b/ecmascript/parser/src/parser.rs
@@ -8,11 +8,11 @@ use crate::{
     token::{Token, Word},
     Context, JscTarget, Session, Syntax,
 };
-use swc_ecma_ast::*;
-use swc_ecma_parser_macros::parser;
 use std::ops::{Deref, DerefMut};
 use swc_atoms::JsWord;
 use swc_common::{comments::Comments, errors::DiagnosticBuilder, input::Input, BytePos, Span};
+use swc_ecma_ast::*;
+use swc_ecma_parser_macros::parser;
 #[cfg(test)]
 extern crate test;
 #[cfg(test)]

--- a/ecmascript/parser/src/parser.rs
+++ b/ecmascript/parser/src/parser.rs
@@ -8,8 +8,8 @@ use crate::{
     token::{Token, Word},
     Context, JscTarget, Session, Syntax,
 };
-use ast::*;
-use parser_macros::parser;
+use swc_ecma_ast::*;
+use swc_ecma_parser_macros::parser;
 use std::ops::{Deref, DerefMut};
 use swc_atoms::JsWord;
 use swc_common::{comments::Comments, errors::DiagnosticBuilder, input::Input, BytePos, Span};

--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -1,7 +1,7 @@
 use super::{ident::MaybeOptionalIdentParser, *};
 use crate::{error::SyntaxError, Tokens};
 use either::Either;
-use parser_macros::parser;
+use swc_ecma_parser_macros::parser;
 use swc_atoms::js_word;
 use swc_common::Spanned;
 

--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -1,9 +1,9 @@
 use super::{ident::MaybeOptionalIdentParser, *};
 use crate::{error::SyntaxError, Tokens};
 use either::Either;
-use swc_ecma_parser_macros::parser;
 use swc_atoms::js_word;
 use swc_common::Spanned;
+use swc_ecma_parser_macros::parser;
 
 #[parser]
 /// Parser for function expression and function declaration.

--- a/ecmascript/parser/src/parser/ident.rs
+++ b/ecmascript/parser/src/parser/ident.rs
@@ -2,8 +2,8 @@
 use super::*;
 use crate::token::Keyword;
 use either::Either;
-use swc_ecma_parser_macros::parser;
 use swc_atoms::js_word;
+use swc_ecma_parser_macros::parser;
 
 #[parser]
 impl<'a, I: Tokens> Parser<'a, I> {

--- a/ecmascript/parser/src/parser/ident.rs
+++ b/ecmascript/parser/src/parser/ident.rs
@@ -2,7 +2,7 @@
 use super::*;
 use crate::token::Keyword;
 use either::Either;
-use parser_macros::parser;
+use swc_ecma_parser_macros::parser;
 use swc_atoms::js_word;
 
 #[parser]

--- a/ecmascript/parser/src/token.rs
+++ b/ecmascript/parser/src/token.rs
@@ -3,8 +3,6 @@
 //! [babel/bablyon]:https://github.com/babel/babel/blob/2d378d076eb0c5fe63234a8b509886005c01d7ee/packages/babylon/src/tokenizer/types.js
 pub(crate) use self::{AssignOpToken::*, BinOpToken::*, Keyword::*, Token::*};
 use crate::error::Error;
-pub(crate) use swc_ecma_ast::AssignOp as AssignOpToken;
-use swc_ecma_ast::{BinaryOp, Str};
 use enum_kind::Kind;
 use std::{
     borrow::Cow,
@@ -14,6 +12,8 @@ use swc_atoms::{js_word, JsWord};
 #[cfg(feature = "fold")]
 use swc_common::Fold;
 use swc_common::Span;
+pub(crate) use swc_ecma_ast::AssignOp as AssignOpToken;
+use swc_ecma_ast::{BinaryOp, Str};
 
 #[derive(Kind, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "fold", derive(Fold))]

--- a/ecmascript/parser/src/token.rs
+++ b/ecmascript/parser/src/token.rs
@@ -3,8 +3,8 @@
 //! [babel/bablyon]:https://github.com/babel/babel/blob/2d378d076eb0c5fe63234a8b509886005c01d7ee/packages/babylon/src/tokenizer/types.js
 pub(crate) use self::{AssignOpToken::*, BinOpToken::*, Keyword::*, Token::*};
 use crate::error::Error;
-pub(crate) use ast::AssignOp as AssignOpToken;
-use ast::{BinaryOp, Str};
+pub(crate) use swc_ecma_ast::AssignOp as AssignOpToken;
+use swc_ecma_ast::{BinaryOp, Str};
 use enum_kind::Kind;
 use std::{
     borrow::Cow,

--- a/ecmascript/parser/tests/jsx.rs
+++ b/ecmascript/parser/tests/jsx.rs
@@ -5,7 +5,7 @@
 
 extern crate test;
 
-use ast::*;
+use swc_ecma_ast::*;
 use pretty_assertions::assert_eq;
 use serde_json;
 use std::{

--- a/ecmascript/parser/tests/jsx.rs
+++ b/ecmascript/parser/tests/jsx.rs
@@ -5,7 +5,6 @@
 
 extern crate test;
 
-use swc_ecma_ast::*;
 use pretty_assertions::assert_eq;
 use serde_json;
 use std::{
@@ -16,6 +15,7 @@ use std::{
     sync::Arc,
 };
 use swc_common::{errors::Handler, Fold, FoldWith, SourceMap, CM};
+use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, PResult, Parser, Session, SourceFileInput};
 use test::{
     test_main, DynTestFn, Options, ShouldPanic::No, TestDesc, TestDescAndFn, TestName, TestType,

--- a/ecmascript/parser/tests/test262.rs
+++ b/ecmascript/parser/tests/test262.rs
@@ -5,7 +5,6 @@
 
 extern crate test;
 
-use swc_ecma_ast::*;
 use std::{
     env,
     fs::{read_dir, File},
@@ -13,6 +12,7 @@ use std::{
     path::Path,
 };
 use swc_common::{Fold, FoldWith, Span};
+use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, PResult, Parser, Session, SourceFileInput, Syntax};
 use test::{
     test_main, DynTestFn, Options, ShouldPanic::No, TestDesc, TestDescAndFn, TestName, TestType,

--- a/ecmascript/parser/tests/test262.rs
+++ b/ecmascript/parser/tests/test262.rs
@@ -5,7 +5,7 @@
 
 extern crate test;
 
-use ast::*;
+use swc_ecma_ast::*;
 use std::{
     env,
     fs::{read_dir, File},

--- a/ecmascript/parser/tests/typescript.rs
+++ b/ecmascript/parser/tests/typescript.rs
@@ -5,7 +5,6 @@
 
 extern crate test;
 
-use swc_ecma_ast::*;
 use pretty_assertions::assert_eq;
 use std::{
     env,
@@ -14,6 +13,7 @@ use std::{
     path::Path,
 };
 use swc_common::{Fold, FoldWith, CM};
+use swc_ecma_ast::*;
 use swc_ecma_parser::{
     lexer::Lexer, JscTarget, PResult, Parser, Session, SourceFileInput, Syntax, TsConfig,
 };

--- a/ecmascript/parser/tests/typescript.rs
+++ b/ecmascript/parser/tests/typescript.rs
@@ -5,7 +5,7 @@
 
 extern crate test;
 
-use ast::*;
+use swc_ecma_ast::*;
 use pretty_assertions::assert_eq;
 use std::{
     env,


### PR DESCRIPTION
Rust has a [bug](https://github.com/rust-lang/rust/issues/64450) when compiling a project for Wasm (with `--target wasm32-unknown-unknown` flag), these changes are a workaround.

These changes are only supposed to fix the SWC Parser, not the whole SWC project. This is because I only need the Parser at the moment, also fixing the whole SWC Project would be a nightmare for me, a newbie in SWC. Maybe later.