### PR TITLE
Parser: respect jsc.target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
   - npm i -g jest
 
 script:
+  - RUST_BACKTRACE=full cargo check --color always --all --all-features --all-targets
   - RUST_BACKTRACE=full cargo test --color always --all --all-features
 
 before_deploy:

--- a/common/benches/and_then.rs
+++ b/common/benches/and_then.rs
@@ -6,7 +6,9 @@
 #![feature(specialization)]
 #![feature(test)]
 
-use swc_common::FoldWith;
+extern crate test;
+
+use swc_common::{chain, FoldWith};
 use test::{black_box, Bencher};
 
 #[allow(clippy::vec_box)]

--- a/ecmascript/ast/benches/serde.rs
+++ b/ecmascript/ast/benches/serde.rs
@@ -1,5 +1,7 @@
 #![feature(test)]
 
+extern crate test;
+
 use serde_json;
 use swc_ecma_ast::Module;
 use test::Bencher;

--- a/ecmascript/codegen/benches/bench.rs
+++ b/ecmascript/codegen/benches/bench.rs
@@ -1,6 +1,8 @@
 #![feature(box_syntax)]
 #![feature(test)]
 
+extern crate test;
+
 use sourcemap::SourceMapBuilder;
 use swc_common::FileName;
 use swc_ecma_codegen::{self, Emitter};

--- a/ecmascript/codegen/tests/test262.rs
+++ b/ecmascript/codegen/tests/test262.rs
@@ -146,12 +146,15 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
 
                 let comments = Comments::default();
                 let handlers = box MyHandlers;
-                let mut parser: Parser<'_, Lexer<'_, SourceFileInput<'_>>> = Parser::new(
+                let lexer = Lexer::new(
                     Session { handler: &handler },
                     Syntax::default(),
+                    Default::default(),
                     (&*src).into(),
                     Some(&comments),
                 );
+                let mut parser: Parser<'_, Lexer<'_, SourceFileInput<'_>>> =
+                    Parser::new_from(Session { handler: &handler }, lexer);
 
                 {
                     let mut emitter = Emitter {

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/parser/benches/parser.rs
+++ b/ecmascript/parser/benches/parser.rs
@@ -3,7 +3,7 @@
 extern crate test;
 
 use swc_common::FileName;
-use swc_ecma_parser::{Parser, Session, SourceFileInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, Parser, Session, SourceFileInput, Syntax};
 use test::Bencher;
 
 #[bench]
@@ -153,7 +153,14 @@ fn bench_module(b: &mut Bencher, syntax: Syntax, src: &'static str) {
 
         b.iter(|| {
             let _ = test::black_box({
-                let mut parser = Parser::new(session, syntax, SourceFileInput::from(&*fm), None);
+                let lexer = Lexer::new(
+                    session,
+                    syntax,
+                    Default::default(),
+                    SourceFileInput::from(&*fm),
+                    None,
+                );
+                let mut parser = Parser::new_from(session, lexer);
                 parser.parse_module()
             });
         });

--- a/ecmascript/parser/src/parser.rs
+++ b/ecmascript/parser/src/parser.rs
@@ -50,6 +50,7 @@ struct State {
 }
 
 impl<'a, I: Input> Parser<'a, Lexer<'a, I>> {
+    #[deprecated(since = "0.12.3", note = "Please use new_from instead")]
     pub fn new(
         session: Session<'a>,
         syntax: Syntax,
@@ -66,10 +67,6 @@ impl<'a, I: Input> Parser<'a, Lexer<'a, I>> {
 #[parser]
 impl<'a, I: Tokens> Parser<'a, I> {
     pub fn new_from(session: Session<'a>, input: I) -> Self {
-        Self::new_with(session, input)
-    }
-
-    pub fn new_with(session: Session<'a>, input: I) -> Self {
         Parser {
             session,
             input: Buffer::new(input),

--- a/ecmascript/parser/src/parser.rs
+++ b/ecmascript/parser/src/parser.rs
@@ -50,7 +50,7 @@ struct State {
 }
 
 impl<'a, I: Input> Parser<'a, Lexer<'a, I>> {
-    #[deprecated(since = "0.12.3", note = "Please use new_from instead")]
+    //    #[deprecated(since = "0.12.3", note = "Please use new_from instead")]
     pub fn new(
         session: Session<'a>,
         syntax: Syntax,
@@ -168,7 +168,8 @@ where
     F: for<'a> FnOnce(&'a mut Parser<'a, Lexer<'a, crate::SourceFileInput<'_>>>) -> Result<Ret, ()>,
 {
     crate::with_test_sess(s, |sess, input| {
-        f(&mut Parser::new(sess, syntax, input, None))
+        let lexer = Lexer::new(sess, Syntax::default(), Default::default(), input, None);
+        f(&mut Parser::new_from(sess, lexer))
     })
     .unwrap_or_else(|output| panic!("test_parser(): failed to parse \n{}\n{}", s, output))
 }
@@ -182,7 +183,14 @@ where
 
     let _ = crate::with_test_sess(s, |sess, input| {
         b.iter(|| {
-            let _ = f(&mut Parser::new(sess, syntax, input.clone(), None)).map_err(|mut err| {
+            let lexer = Lexer::new(
+                sess,
+                Syntax::default(),
+                Default::default(),
+                input.clone(),
+                None,
+            );
+            let _ = f(&mut Parser::new_from(sess, lexer)).map_err(|mut err| {
                 err.emit();
             });
         });

--- a/ecmascript/parser/src/parser.rs
+++ b/ecmascript/parser/src/parser.rs
@@ -168,7 +168,7 @@ where
     F: for<'a> FnOnce(&'a mut Parser<'a, Lexer<'a, crate::SourceFileInput<'_>>>) -> Result<Ret, ()>,
 {
     crate::with_test_sess(s, |sess, input| {
-        let lexer = Lexer::new(sess, Syntax::default(), Default::default(), input, None);
+        let lexer = Lexer::new(sess, syntax, Default::default(), input, None);
         f(&mut Parser::new_from(sess, lexer))
     })
     .unwrap_or_else(|output| panic!("test_parser(): failed to parse \n{}\n{}", s, output))
@@ -183,13 +183,7 @@ where
 
     let _ = crate::with_test_sess(s, |sess, input| {
         b.iter(|| {
-            let lexer = Lexer::new(
-                sess,
-                Syntax::default(),
-                Default::default(),
-                input.clone(),
-                None,
-            );
+            let lexer = Lexer::new(sess, syntax, Default::default(), input.clone(), None);
             let _ = f(&mut Parser::new_from(sess, lexer)).map_err(|mut err| {
                 err.emit();
             });

--- a/ecmascript/parser/tests/jsx/basic/5/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/5/input.js.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 5,
+    "end": 6,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "JSXElement",
       "span": {
         "start": 0,
-        "end": 5,
+        "end": 6,
         "ctxt": 0
       },
       "opening": {
@@ -28,7 +28,7 @@
         },
         "span": {
           "start": 1,
-          "end": 5,
+          "end": 6,
           "ctxt": 0
         },
         "attributes": [],

--- a/ecmascript/parser/tests/jsx/basic/7/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/7/input.js.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 51,
+    "end": 55,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "JSXElement",
       "span": {
         "start": 0,
-        "end": 51,
+        "end": 55,
         "ctxt": 0
       },
       "opening": {
@@ -28,22 +28,22 @@
         },
         "span": {
           "start": 1,
-          "end": 32,
+          "end": 33,
           "ctxt": 0
         },
         "attributes": [
           {
             "type": "JSXAttribute",
             "span": {
-              "start": 11,
-              "end": 31,
+              "start": 12,
+              "end": 32,
               "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
-                "start": 11,
-                "end": 15,
+                "start": 12,
+                "end": 16,
                 "ctxt": 0
               },
               "value": "test",
@@ -53,8 +53,8 @@
             "value": {
               "type": "StringLiteral",
               "span": {
-                "start": 16,
-                "end": 31,
+                "start": 17,
+                "end": 32,
                 "ctxt": 0
               },
               "value": "&&",
@@ -69,26 +69,26 @@
         {
           "type": "JSXText",
           "span": {
-            "start": 32,
-            "end": 41,
+            "start": 33,
+            "end": 45,
             "ctxt": 0
           },
-          "value": "\n\nbar\n\nbaz\n\n",
-          "raw": "\n\nbar\n\nbaz\n\n"
+          "value": "\n\r\nbar\n\r\nbaz\n\r\n",
+          "raw": "\n\r\nbar\n\r\nbaz\n\r\n"
         }
       ],
       "closing": {
         "type": "JSXClosingElement",
         "span": {
-          "start": 43,
-          "end": 51,
+          "start": 47,
+          "end": 55,
           "ctxt": 0
         },
         "name": {
           "type": "Identifier",
           "span": {
-            "start": 43,
-            "end": 50,
+            "start": 47,
+            "end": 54,
             "ctxt": 0
           },
           "value": "AbC-def",

--- a/ecmascript/parser/tests/jsx/basic/asi/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/asi/input.js.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 34,
+    "end": 37,
     "ctxt": 0
   },
   "body": [
@@ -24,22 +24,22 @@
       "decorators": [],
       "span": {
         "start": 0,
-        "end": 34,
+        "end": 37,
         "ctxt": 0
       },
       "body": {
         "type": "BlockStatement",
         "span": {
           "start": 13,
-          "end": 34,
+          "end": 37,
           "ctxt": 0
         },
         "stmts": [
           {
             "type": "VariableDeclaration",
             "span": {
-              "start": 17,
-              "end": 22,
+              "start": 18,
+              "end": 23,
               "ctxt": 0
             },
             "kind": "let",
@@ -48,15 +48,15 @@
               {
                 "type": "VariableDeclarator",
                 "span": {
-                  "start": 21,
-                  "end": 22,
+                  "start": 22,
+                  "end": 23,
                   "ctxt": 0
                 },
                 "id": {
                   "type": "Identifier",
                   "span": {
-                    "start": 21,
-                    "end": 22,
+                    "start": 22,
+                    "end": 23,
                     "ctxt": 0
                   },
                   "value": "x",
@@ -71,8 +71,8 @@
           {
             "type": "JSXElement",
             "span": {
-              "start": 25,
-              "end": 32,
+              "start": 27,
+              "end": 34,
               "ctxt": 0
             },
             "opening": {
@@ -80,8 +80,8 @@
               "name": {
                 "type": "Identifier",
                 "span": {
-                  "start": 26,
-                  "end": 29,
+                  "start": 28,
+                  "end": 31,
                   "ctxt": 0
                 },
                 "value": "div",
@@ -89,8 +89,8 @@
                 "optional": false
               },
               "span": {
-                "start": 26,
-                "end": 32,
+                "start": 28,
+                "end": 34,
                 "ctxt": 0
               },
               "attributes": [],

--- a/ecmascript/parser/tests/jsx/basic/custom/unary-paren/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/custom/unary-paren/input.js.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 300,
+    "end": 318,
     "ctxt": 0
   },
   "body": [
@@ -50,8 +50,8 @@
       "identifier": {
         "type": "Identifier",
         "span": {
-          "start": 37,
-          "end": 40,
+          "start": 39,
+          "end": 42,
           "ctxt": 0
         },
         "value": "App",
@@ -62,23 +62,23 @@
       "params": [],
       "decorators": [],
       "span": {
-        "start": 28,
-        "end": 279,
+        "start": 30,
+        "end": 295,
         "ctxt": 0
       },
       "body": {
         "type": "BlockStatement",
         "span": {
-          "start": 43,
-          "end": 279,
+          "start": 45,
+          "end": 295,
           "ctxt": 0
         },
         "stmts": [
           {
             "type": "VariableDeclaration",
             "span": {
-              "start": 47,
-              "end": 70,
+              "start": 50,
+              "end": 73,
               "ctxt": 0
             },
             "kind": "const",
@@ -87,15 +87,15 @@
               {
                 "type": "VariableDeclarator",
                 "span": {
-                  "start": 53,
-                  "end": 69,
+                  "start": 56,
+                  "end": 72,
                   "ctxt": 0
                 },
                 "id": {
                   "type": "Identifier",
                   "span": {
-                    "start": 53,
-                    "end": 62,
+                    "start": 56,
+                    "end": 65,
                     "ctxt": 0
                   },
                   "value": "isLoading",
@@ -105,8 +105,8 @@
                 "init": {
                   "type": "BooleanLiteral",
                   "span": {
-                    "start": 65,
-                    "end": 69,
+                    "start": 68,
+                    "end": 72,
                     "ctxt": 0
                   },
                   "value": true
@@ -118,22 +118,22 @@
           {
             "type": "ReturnStatement",
             "span": {
-              "start": 73,
-              "end": 277,
+              "start": 77,
+              "end": 292,
               "ctxt": 0
             },
             "argument": {
               "type": "ParenthesisExpression",
               "span": {
-                "start": 80,
-                "end": 276,
+                "start": 84,
+                "end": 291,
                 "ctxt": 0
               },
               "expression": {
                 "type": "JSXElement",
                 "span": {
-                  "start": 86,
-                  "end": 272,
+                  "start": 91,
+                  "end": 286,
                   "ctxt": 0
                 },
                 "opening": {
@@ -141,8 +141,8 @@
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 87,
-                      "end": 90,
+                      "start": 92,
+                      "end": 95,
                       "ctxt": 0
                     },
                     "value": "div",
@@ -150,8 +150,8 @@
                     "optional": false
                   },
                   "span": {
-                    "start": 87,
-                    "end": 91,
+                    "start": 92,
+                    "end": 96,
                     "ctxt": 0
                   },
                   "attributes": [],
@@ -162,18 +162,18 @@
                   {
                     "type": "JSXText",
                     "span": {
-                      "start": 91,
-                      "end": 98,
+                      "start": 96,
+                      "end": 104,
                       "ctxt": 0
                     },
-                    "value": "\n\n      ",
-                    "raw": "\n\n      "
+                    "value": "\n\r\n      ",
+                    "raw": "\n\r\n      "
                   },
                   {
                     "type": "JSXElement",
                     "span": {
-                      "start": 98,
-                      "end": 113,
+                      "start": 104,
+                      "end": 119,
                       "ctxt": 0
                     },
                     "opening": {
@@ -181,8 +181,8 @@
                       "name": {
                         "type": "Identifier",
                         "span": {
-                          "start": 99,
-                          "end": 101,
+                          "start": 105,
+                          "end": 107,
                           "ctxt": 0
                         },
                         "value": "h1",
@@ -190,8 +190,8 @@
                         "optional": false
                       },
                       "span": {
-                        "start": 99,
-                        "end": 102,
+                        "start": 105,
+                        "end": 108,
                         "ctxt": 0
                       },
                       "attributes": [],
@@ -202,8 +202,8 @@
                       {
                         "type": "JSXText",
                         "span": {
-                          "start": 102,
-                          "end": 108,
+                          "start": 108,
+                          "end": 114,
                           "ctxt": 0
                         },
                         "value": "works ",
@@ -213,15 +213,15 @@
                     "closing": {
                       "type": "JSXClosingElement",
                       "span": {
-                        "start": 110,
-                        "end": 113,
+                        "start": 116,
+                        "end": 119,
                         "ctxt": 0
                       },
                       "name": {
                         "type": "Identifier",
                         "span": {
-                          "start": 110,
-                          "end": 112,
+                          "start": 116,
+                          "end": 118,
                           "ctxt": 0
                         },
                         "value": "h1",
@@ -233,27 +233,27 @@
                   {
                     "type": "JSXText",
                     "span": {
-                      "start": 113,
-                      "end": 120,
+                      "start": 119,
+                      "end": 127,
                       "ctxt": 0
                     },
-                    "value": "\n\n      ",
-                    "raw": "\n\n      "
+                    "value": "\n\r\n      ",
+                    "raw": "\n\r\n      "
                   },
                   {
                     "type": "JSXExpressionContainer",
                     "expression": {
                       "type": "ConditionalExpression",
                       "span": {
-                        "start": 130,
-                        "end": 253,
+                        "start": 138,
+                        "end": 265,
                         "ctxt": 0
                       },
                       "test": {
                         "type": "Identifier",
                         "span": {
-                          "start": 130,
-                          "end": 139,
+                          "start": 138,
+                          "end": 147,
                           "ctxt": 0
                         },
                         "value": "isLoading",
@@ -263,15 +263,15 @@
                       "consequent": {
                         "type": "ParenthesisExpression",
                         "span": {
-                          "start": 142,
-                          "end": 183,
+                          "start": 150,
+                          "end": 193,
                           "ctxt": 0
                         },
                         "expression": {
                           "type": "JSXElement",
                           "span": {
-                            "start": 154,
-                            "end": 173,
+                            "start": 163,
+                            "end": 182,
                             "ctxt": 0
                           },
                           "opening": {
@@ -279,8 +279,8 @@
                             "name": {
                               "type": "Identifier",
                               "span": {
-                                "start": 155,
-                                "end": 158,
+                                "start": 164,
+                                "end": 167,
                                 "ctxt": 0
                               },
                               "value": "div",
@@ -288,8 +288,8 @@
                               "optional": false
                             },
                             "span": {
-                              "start": 155,
-                              "end": 159,
+                              "start": 164,
+                              "end": 168,
                               "ctxt": 0
                             },
                             "attributes": [],
@@ -300,8 +300,8 @@
                             {
                               "type": "JSXText",
                               "span": {
-                                "start": 159,
-                                "end": 167,
+                                "start": 168,
+                                "end": 176,
                                 "ctxt": 0
                               },
                               "value": "loading ",
@@ -311,15 +311,15 @@
                           "closing": {
                             "type": "JSXClosingElement",
                             "span": {
-                              "start": 169,
-                              "end": 173,
+                              "start": 178,
+                              "end": 182,
                               "ctxt": 0
                             },
                             "name": {
                               "type": "Identifier",
                               "span": {
-                                "start": 169,
-                                "end": 172,
+                                "start": 178,
+                                "end": 181,
                                 "ctxt": 0
                               },
                               "value": "div",
@@ -332,15 +332,15 @@
                       "alternate": {
                         "type": "ParenthesisExpression",
                         "span": {
-                          "start": 186,
-                          "end": 253,
+                          "start": 196,
+                          "end": 265,
                           "ctxt": 0
                         },
                         "expression": {
                           "type": "JSXElement",
                           "span": {
-                            "start": 200,
-                            "end": 241,
+                            "start": 211,
+                            "end": 252,
                             "ctxt": 0
                           },
                           "opening": {
@@ -348,8 +348,8 @@
                             "name": {
                               "type": "Identifier",
                               "span": {
-                                "start": 201,
-                                "end": 204,
+                                "start": 212,
+                                "end": 215,
                                 "ctxt": 0
                               },
                               "value": "div",
@@ -357,8 +357,8 @@
                               "optional": false
                             },
                             "span": {
-                              "start": 201,
-                              "end": 205,
+                              "start": 212,
+                              "end": 216,
                               "ctxt": 0
                             },
                             "attributes": [],
@@ -369,8 +369,8 @@
                             {
                               "type": "JSXText",
                               "span": {
-                                "start": 205,
-                                "end": 235,
+                                "start": 216,
+                                "end": 246,
                                 "ctxt": 0
                               },
                               "value": "naaaaaaaaaaaaffffffffffffffff ",
@@ -380,15 +380,15 @@
                           "closing": {
                             "type": "JSXClosingElement",
                             "span": {
-                              "start": 237,
-                              "end": 241,
+                              "start": 248,
+                              "end": 252,
                               "ctxt": 0
                             },
                             "name": {
                               "type": "Identifier",
                               "span": {
-                                "start": 237,
-                                "end": 240,
+                                "start": 248,
+                                "end": 251,
                                 "ctxt": 0
                               },
                               "value": "div",
@@ -403,26 +403,26 @@
                   {
                     "type": "JSXText",
                     "span": {
-                      "start": 261,
-                      "end": 266,
+                      "start": 274,
+                      "end": 280,
                       "ctxt": 0
                     },
-                    "value": "\n\n    ",
-                    "raw": "\n\n    "
+                    "value": "\n\r\n    ",
+                    "raw": "\n\r\n    "
                   }
                 ],
                 "closing": {
                   "type": "JSXClosingElement",
                   "span": {
-                    "start": 268,
-                    "end": 272,
+                    "start": 282,
+                    "end": 286,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 268,
-                      "end": 271,
+                      "start": 282,
+                      "end": 285,
                       "ctxt": 0
                     },
                     "value": "div",
@@ -443,15 +443,15 @@
     {
       "type": "ExportDefaultExpression",
       "span": {
-        "start": 281,
-        "end": 300,
+        "start": 299,
+        "end": 318,
         "ctxt": 0
       },
       "expression": {
         "type": "Identifier",
         "span": {
-          "start": 296,
-          "end": 299,
+          "start": 314,
+          "end": 317,
           "ctxt": 0
         },
         "value": "App",

--- a/ecmascript/parser/tests/jsx/basic/custom/unary/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/custom/unary/input.js.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 252,
+    "end": 266,
     "ctxt": 0
   },
   "body": [
@@ -50,8 +50,8 @@
       "identifier": {
         "type": "Identifier",
         "span": {
-          "start": 37,
-          "end": 40,
+          "start": 39,
+          "end": 42,
           "ctxt": 0
         },
         "value": "App",
@@ -62,23 +62,23 @@
       "params": [],
       "decorators": [],
       "span": {
-        "start": 28,
-        "end": 231,
+        "start": 30,
+        "end": 243,
         "ctxt": 0
       },
       "body": {
         "type": "BlockStatement",
         "span": {
-          "start": 43,
-          "end": 231,
+          "start": 45,
+          "end": 243,
           "ctxt": 0
         },
         "stmts": [
           {
             "type": "VariableDeclaration",
             "span": {
-              "start": 47,
-              "end": 70,
+              "start": 50,
+              "end": 73,
               "ctxt": 0
             },
             "kind": "const",
@@ -87,15 +87,15 @@
               {
                 "type": "VariableDeclarator",
                 "span": {
-                  "start": 53,
-                  "end": 69,
+                  "start": 56,
+                  "end": 72,
                   "ctxt": 0
                 },
                 "id": {
                   "type": "Identifier",
                   "span": {
-                    "start": 53,
-                    "end": 62,
+                    "start": 56,
+                    "end": 65,
                     "ctxt": 0
                   },
                   "value": "isLoading",
@@ -105,8 +105,8 @@
                 "init": {
                   "type": "BooleanLiteral",
                   "span": {
-                    "start": 65,
-                    "end": 69,
+                    "start": 68,
+                    "end": 72,
                     "ctxt": 0
                   },
                   "value": true
@@ -118,22 +118,22 @@
           {
             "type": "ReturnStatement",
             "span": {
-              "start": 73,
-              "end": 229,
+              "start": 77,
+              "end": 240,
               "ctxt": 0
             },
             "argument": {
               "type": "ParenthesisExpression",
               "span": {
-                "start": 80,
-                "end": 228,
+                "start": 84,
+                "end": 239,
                 "ctxt": 0
               },
               "expression": {
                 "type": "JSXElement",
                 "span": {
-                  "start": 86,
-                  "end": 224,
+                  "start": 91,
+                  "end": 234,
                   "ctxt": 0
                 },
                 "opening": {
@@ -141,8 +141,8 @@
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 87,
-                      "end": 90,
+                      "start": 92,
+                      "end": 95,
                       "ctxt": 0
                     },
                     "value": "div",
@@ -150,8 +150,8 @@
                     "optional": false
                   },
                   "span": {
-                    "start": 87,
-                    "end": 91,
+                    "start": 92,
+                    "end": 96,
                     "ctxt": 0
                   },
                   "attributes": [],
@@ -162,18 +162,18 @@
                   {
                     "type": "JSXText",
                     "span": {
-                      "start": 91,
-                      "end": 98,
+                      "start": 96,
+                      "end": 104,
                       "ctxt": 0
                     },
-                    "value": "\n\n      ",
-                    "raw": "\n\n      "
+                    "value": "\n\r\n      ",
+                    "raw": "\n\r\n      "
                   },
                   {
                     "type": "JSXElement",
                     "span": {
-                      "start": 98,
-                      "end": 113,
+                      "start": 104,
+                      "end": 119,
                       "ctxt": 0
                     },
                     "opening": {
@@ -181,8 +181,8 @@
                       "name": {
                         "type": "Identifier",
                         "span": {
-                          "start": 99,
-                          "end": 101,
+                          "start": 105,
+                          "end": 107,
                           "ctxt": 0
                         },
                         "value": "h1",
@@ -190,8 +190,8 @@
                         "optional": false
                       },
                       "span": {
-                        "start": 99,
-                        "end": 102,
+                        "start": 105,
+                        "end": 108,
                         "ctxt": 0
                       },
                       "attributes": [],
@@ -202,8 +202,8 @@
                       {
                         "type": "JSXText",
                         "span": {
-                          "start": 102,
-                          "end": 108,
+                          "start": 108,
+                          "end": 114,
                           "ctxt": 0
                         },
                         "value": "works ",
@@ -213,15 +213,15 @@
                     "closing": {
                       "type": "JSXClosingElement",
                       "span": {
-                        "start": 110,
-                        "end": 113,
+                        "start": 116,
+                        "end": 119,
                         "ctxt": 0
                       },
                       "name": {
                         "type": "Identifier",
                         "span": {
-                          "start": 110,
-                          "end": 112,
+                          "start": 116,
+                          "end": 118,
                           "ctxt": 0
                         },
                         "value": "h1",
@@ -233,27 +233,27 @@
                   {
                     "type": "JSXText",
                     "span": {
-                      "start": 113,
-                      "end": 120,
+                      "start": 119,
+                      "end": 127,
                       "ctxt": 0
                     },
-                    "value": "\n\n      ",
-                    "raw": "\n\n      "
+                    "value": "\n\r\n      ",
+                    "raw": "\n\r\n      "
                   },
                   {
                     "type": "JSXExpressionContainer",
                     "expression": {
                       "type": "ConditionalExpression",
                       "span": {
-                        "start": 130,
-                        "end": 205,
+                        "start": 138,
+                        "end": 213,
                         "ctxt": 0
                       },
                       "test": {
                         "type": "Identifier",
                         "span": {
-                          "start": 130,
-                          "end": 139,
+                          "start": 138,
+                          "end": 147,
                           "ctxt": 0
                         },
                         "value": "isLoading",
@@ -263,8 +263,8 @@
                       "consequent": {
                         "type": "JSXElement",
                         "span": {
-                          "start": 142,
-                          "end": 161,
+                          "start": 150,
+                          "end": 169,
                           "ctxt": 0
                         },
                         "opening": {
@@ -272,8 +272,8 @@
                           "name": {
                             "type": "Identifier",
                             "span": {
-                              "start": 143,
-                              "end": 146,
+                              "start": 151,
+                              "end": 154,
                               "ctxt": 0
                             },
                             "value": "div",
@@ -281,8 +281,8 @@
                             "optional": false
                           },
                           "span": {
-                            "start": 143,
-                            "end": 147,
+                            "start": 151,
+                            "end": 155,
                             "ctxt": 0
                           },
                           "attributes": [],
@@ -293,8 +293,8 @@
                           {
                             "type": "JSXText",
                             "span": {
-                              "start": 147,
-                              "end": 155,
+                              "start": 155,
+                              "end": 163,
                               "ctxt": 0
                             },
                             "value": "loading ",
@@ -304,15 +304,15 @@
                         "closing": {
                           "type": "JSXClosingElement",
                           "span": {
-                            "start": 157,
-                            "end": 161,
+                            "start": 165,
+                            "end": 169,
                             "ctxt": 0
                           },
                           "name": {
                             "type": "Identifier",
                             "span": {
-                              "start": 157,
-                              "end": 160,
+                              "start": 165,
+                              "end": 168,
                               "ctxt": 0
                             },
                             "value": "div",
@@ -324,8 +324,8 @@
                       "alternate": {
                         "type": "JSXElement",
                         "span": {
-                          "start": 164,
-                          "end": 205,
+                          "start": 172,
+                          "end": 213,
                           "ctxt": 0
                         },
                         "opening": {
@@ -333,8 +333,8 @@
                           "name": {
                             "type": "Identifier",
                             "span": {
-                              "start": 165,
-                              "end": 168,
+                              "start": 173,
+                              "end": 176,
                               "ctxt": 0
                             },
                             "value": "div",
@@ -342,8 +342,8 @@
                             "optional": false
                           },
                           "span": {
-                            "start": 165,
-                            "end": 169,
+                            "start": 173,
+                            "end": 177,
                             "ctxt": 0
                           },
                           "attributes": [],
@@ -354,8 +354,8 @@
                           {
                             "type": "JSXText",
                             "span": {
-                              "start": 169,
-                              "end": 199,
+                              "start": 177,
+                              "end": 207,
                               "ctxt": 0
                             },
                             "value": "naaaaaaaaaaaaffffffffffffffff ",
@@ -365,15 +365,15 @@
                         "closing": {
                           "type": "JSXClosingElement",
                           "span": {
-                            "start": 201,
-                            "end": 205,
+                            "start": 209,
+                            "end": 213,
                             "ctxt": 0
                           },
                           "name": {
                             "type": "Identifier",
                             "span": {
-                              "start": 201,
-                              "end": 204,
+                              "start": 209,
+                              "end": 212,
                               "ctxt": 0
                             },
                             "value": "div",
@@ -387,26 +387,26 @@
                   {
                     "type": "JSXText",
                     "span": {
-                      "start": 213,
-                      "end": 218,
+                      "start": 222,
+                      "end": 228,
                       "ctxt": 0
                     },
-                    "value": "\n\n    ",
-                    "raw": "\n\n    "
+                    "value": "\n\r\n    ",
+                    "raw": "\n\r\n    "
                   }
                 ],
                 "closing": {
                   "type": "JSXClosingElement",
                   "span": {
-                    "start": 220,
-                    "end": 224,
+                    "start": 230,
+                    "end": 234,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 220,
-                      "end": 223,
+                      "start": 230,
+                      "end": 233,
                       "ctxt": 0
                     },
                     "value": "div",
@@ -427,15 +427,15 @@
     {
       "type": "ExportDefaultExpression",
       "span": {
-        "start": 233,
-        "end": 252,
+        "start": 247,
+        "end": 266,
         "ctxt": 0
       },
       "expression": {
         "type": "Identifier",
         "span": {
-          "start": 248,
-          "end": 251,
+          "start": 262,
+          "end": 265,
           "ctxt": 0
         },
         "value": "App",

--- a/ecmascript/parser/tests/jsx/basic/fragment-3/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/fragment-3/input.js.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 50,
+    "end": 55,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "JSXFragment",
       "span": {
         "start": 0,
-        "end": 50,
+        "end": 55,
         "ctxt": 0
       },
       "opening": {
@@ -26,17 +26,17 @@
           "type": "JSXText",
           "span": {
             "start": 3,
-            "end": 6,
+            "end": 7,
             "ctxt": 0
           },
-          "value": "\n\n  ",
-          "raw": "\n\n  "
+          "value": "\n\r\n  ",
+          "raw": "\n\r\n  "
         },
         {
           "type": "JSXElement",
           "span": {
-            "start": 6,
-            "end": 29,
+            "start": 7,
+            "end": 32,
             "ctxt": 0
           },
           "opening": {
@@ -44,8 +44,8 @@
             "name": {
               "type": "Identifier",
               "span": {
-                "start": 7,
-                "end": 11,
+                "start": 8,
+                "end": 12,
                 "ctxt": 0
               },
               "value": "span",
@@ -53,8 +53,8 @@
               "optional": false
             },
             "span": {
-              "start": 7,
-              "end": 12,
+              "start": 8,
+              "end": 13,
               "ctxt": 0
             },
             "attributes": [],
@@ -65,26 +65,26 @@
             {
               "type": "JSXText",
               "span": {
-                "start": 12,
-                "end": 22,
+                "start": 13,
+                "end": 25,
                 "ctxt": 0
               },
-              "value": "\n\n    hi\n\n  ",
-              "raw": "\n\n    hi\n\n  "
+              "value": "\n\r\n    hi\n\r\n  ",
+              "raw": "\n\r\n    hi\n\r\n  "
             }
           ],
           "closing": {
             "type": "JSXClosingElement",
             "span": {
-              "start": 24,
-              "end": 29,
+              "start": 27,
+              "end": 32,
               "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
-                "start": 24,
-                "end": 28,
+                "start": 27,
+                "end": 31,
                 "ctxt": 0
               },
               "value": "span",
@@ -96,18 +96,18 @@
         {
           "type": "JSXText",
           "span": {
-            "start": 29,
-            "end": 32,
+            "start": 32,
+            "end": 36,
             "ctxt": 0
           },
-          "value": "\n\n  ",
-          "raw": "\n\n  "
+          "value": "\n\r\n  ",
+          "raw": "\n\r\n  "
         },
         {
           "type": "JSXElement",
           "span": {
-            "start": 32,
-            "end": 46,
+            "start": 36,
+            "end": 50,
             "ctxt": 0
           },
           "opening": {
@@ -115,8 +115,8 @@
             "name": {
               "type": "Identifier",
               "span": {
-                "start": 33,
-                "end": 36,
+                "start": 37,
+                "end": 40,
                 "ctxt": 0
               },
               "value": "div",
@@ -124,8 +124,8 @@
               "optional": false
             },
             "span": {
-              "start": 33,
-              "end": 37,
+              "start": 37,
+              "end": 41,
               "ctxt": 0
             },
             "attributes": [],
@@ -136,8 +136,8 @@
             {
               "type": "JSXText",
               "span": {
-                "start": 37,
-                "end": 40,
+                "start": 41,
+                "end": 44,
                 "ctxt": 0
               },
               "value": "bye",
@@ -147,15 +147,15 @@
           "closing": {
             "type": "JSXClosingElement",
             "span": {
-              "start": 42,
-              "end": 46,
+              "start": 46,
+              "end": 50,
               "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
-                "start": 42,
-                "end": 45,
+                "start": 46,
+                "end": 49,
                 "ctxt": 0
               },
               "value": "div",
@@ -167,19 +167,19 @@
         {
           "type": "JSXText",
           "span": {
-            "start": 46,
-            "end": 47,
+            "start": 50,
+            "end": 52,
             "ctxt": 0
           },
-          "value": "\n\n",
-          "raw": "\n\n"
+          "value": "\n\r\n",
+          "raw": "\n\r\n"
         }
       ],
       "closing": {
         "type": "JSXClosingFragment",
         "span": {
-          "start": 49,
-          "end": 50,
+          "start": 54,
+          "end": 55,
           "ctxt": 0
         }
       }

--- a/ecmascript/parser/tests/jsx/basic/fragment-4/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/fragment-4/input.js.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 49,
+    "end": 55,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "JSXFragment",
       "span": {
         "start": 0,
-        "end": 49,
+        "end": 55,
         "ctxt": 0
       },
       "opening": {
@@ -26,24 +26,24 @@
           "type": "JSXText",
           "span": {
             "start": 2,
-            "end": 5,
+            "end": 6,
             "ctxt": 0
           },
-          "value": "\n\n  ",
-          "raw": "\n\n  "
+          "value": "\n\r\n  ",
+          "raw": "\n\r\n  "
         },
         {
           "type": "JSXFragment",
           "span": {
-            "start": 5,
-            "end": 45,
+            "start": 6,
+            "end": 50,
             "ctxt": 0
           },
           "opening": {
             "type": "JSXOpeningFragment",
             "span": {
-              "start": 6,
-              "end": 7,
+              "start": 7,
+              "end": 8,
               "ctxt": 0
             }
           },
@@ -51,25 +51,25 @@
             {
               "type": "JSXText",
               "span": {
-                "start": 7,
-                "end": 12,
+                "start": 8,
+                "end": 14,
                 "ctxt": 0
               },
-              "value": "\n\n    ",
-              "raw": "\n\n    "
+              "value": "\n\r\n    ",
+              "raw": "\n\r\n    "
             },
             {
               "type": "JSXFragment",
               "span": {
-                "start": 12,
-                "end": 39,
+                "start": 14,
+                "end": 43,
                 "ctxt": 0
               },
               "opening": {
                 "type": "JSXOpeningFragment",
                 "span": {
-                  "start": 13,
-                  "end": 14,
+                  "start": 15,
+                  "end": 16,
                   "ctxt": 0
                 }
               },
@@ -77,19 +77,19 @@
                 {
                   "type": "JSXText",
                   "span": {
-                    "start": 14,
-                    "end": 36,
+                    "start": 16,
+                    "end": 40,
                     "ctxt": 0
                   },
-                  "value": "\n\n      super deep\n\n    ",
-                  "raw": "\n\n      super deep\n\n    "
+                  "value": "\n\r\n      super deep\n\r\n    ",
+                  "raw": "\n\r\n      super deep\n\r\n    "
                 }
               ],
               "closing": {
                 "type": "JSXClosingFragment",
                 "span": {
-                  "start": 38,
-                  "end": 39,
+                  "start": 42,
+                  "end": 43,
                   "ctxt": 0
                 }
               }
@@ -97,19 +97,19 @@
             {
               "type": "JSXText",
               "span": {
-                "start": 39,
-                "end": 42,
+                "start": 43,
+                "end": 47,
                 "ctxt": 0
               },
-              "value": "\n\n  ",
-              "raw": "\n\n  "
+              "value": "\n\r\n  ",
+              "raw": "\n\r\n  "
             }
           ],
           "closing": {
             "type": "JSXClosingFragment",
             "span": {
-              "start": 44,
-              "end": 45,
+              "start": 49,
+              "end": 50,
               "ctxt": 0
             }
           }
@@ -117,19 +117,19 @@
         {
           "type": "JSXText",
           "span": {
-            "start": 45,
-            "end": 46,
+            "start": 50,
+            "end": 52,
             "ctxt": 0
           },
-          "value": "\n\n",
-          "raw": "\n\n"
+          "value": "\n\r\n",
+          "raw": "\n\r\n"
         }
       ],
       "closing": {
         "type": "JSXClosingFragment",
         "span": {
-          "start": 48,
-          "end": 49,
+          "start": 54,
+          "end": 55,
           "ctxt": 0
         }
       }

--- a/ecmascript/parser/tests/jsx/basic/fragment-5/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/fragment-5/input.js.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 62,
+    "end": 68,
     "ctxt": 0
   },
   "body": [
@@ -10,14 +10,14 @@
       "type": "JSXFragment",
       "span": {
         "start": 0,
-        "end": 62,
+        "end": 68,
         "ctxt": 0
       },
       "opening": {
         "type": "JSXOpeningFragment",
         "span": {
-          "start": 29,
-          "end": 30,
+          "start": 32,
+          "end": 33,
           "ctxt": 0
         }
       },
@@ -25,78 +25,18 @@
         {
           "type": "JSXText",
           "span": {
-            "start": 30,
-            "end": 33,
-            "ctxt": 0
-          },
-          "value": "\n\n  ",
-          "raw": "\n\n  "
-        },
-        {
-          "type": "JSXElement",
-          "span": {
             "start": 33,
-            "end": 44,
+            "end": 37,
             "ctxt": 0
           },
-          "opening": {
-            "type": "JSXOpeningElement",
-            "name": {
-              "type": "Identifier",
-              "span": {
-                "start": 34,
-                "end": 37,
-                "ctxt": 0
-              },
-              "value": "div",
-              "typeAnnotation": null,
-              "optional": false
-            },
-            "span": {
-              "start": 34,
-              "end": 38,
-              "ctxt": 0
-            },
-            "attributes": [],
-            "selfClosing": false,
-            "typeArguments": null
-          },
-          "children": [],
-          "closing": {
-            "type": "JSXClosingElement",
-            "span": {
-              "start": 40,
-              "end": 44,
-              "ctxt": 0
-            },
-            "name": {
-              "type": "Identifier",
-              "span": {
-                "start": 40,
-                "end": 43,
-                "ctxt": 0
-              },
-              "value": "div",
-              "typeAnnotation": null,
-              "optional": false
-            }
-          }
-        },
-        {
-          "type": "JSXText",
-          "span": {
-            "start": 44,
-            "end": 47,
-            "ctxt": 0
-          },
-          "value": "\n\n  ",
-          "raw": "\n\n  "
+          "value": "\n\r\n  ",
+          "raw": "\n\r\n  "
         },
         {
           "type": "JSXElement",
           "span": {
-            "start": 47,
-            "end": 58,
+            "start": 37,
+            "end": 48,
             "ctxt": 0
           },
           "opening": {
@@ -104,8 +44,8 @@
             "name": {
               "type": "Identifier",
               "span": {
-                "start": 48,
-                "end": 51,
+                "start": 38,
+                "end": 41,
                 "ctxt": 0
               },
               "value": "div",
@@ -113,8 +53,8 @@
               "optional": false
             },
             "span": {
-              "start": 48,
-              "end": 52,
+              "start": 38,
+              "end": 42,
               "ctxt": 0
             },
             "attributes": [],
@@ -125,15 +65,15 @@
           "closing": {
             "type": "JSXClosingElement",
             "span": {
-              "start": 54,
-              "end": 58,
+              "start": 44,
+              "end": 48,
               "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
-                "start": 54,
-                "end": 57,
+                "start": 44,
+                "end": 47,
                 "ctxt": 0
               },
               "value": "div",
@@ -145,19 +85,79 @@
         {
           "type": "JSXText",
           "span": {
-            "start": 58,
-            "end": 59,
+            "start": 48,
+            "end": 52,
             "ctxt": 0
           },
-          "value": "\n\n",
-          "raw": "\n\n"
+          "value": "\n\r\n  ",
+          "raw": "\n\r\n  "
+        },
+        {
+          "type": "JSXElement",
+          "span": {
+            "start": 52,
+            "end": 63,
+            "ctxt": 0
+          },
+          "opening": {
+            "type": "JSXOpeningElement",
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 53,
+                "end": 56,
+                "ctxt": 0
+              },
+              "value": "div",
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "span": {
+              "start": 53,
+              "end": 57,
+              "ctxt": 0
+            },
+            "attributes": [],
+            "selfClosing": false,
+            "typeArguments": null
+          },
+          "children": [],
+          "closing": {
+            "type": "JSXClosingElement",
+            "span": {
+              "start": 59,
+              "end": 63,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 59,
+                "end": 62,
+                "ctxt": 0
+              },
+              "value": "div",
+              "typeAnnotation": null,
+              "optional": false
+            }
+          }
+        },
+        {
+          "type": "JSXText",
+          "span": {
+            "start": 63,
+            "end": 65,
+            "ctxt": 0
+          },
+          "value": "\n\r\n",
+          "raw": "\n\r\n"
         }
       ],
       "closing": {
         "type": "JSXClosingFragment",
         "span": {
-          "start": 61,
-          "end": 62,
+          "start": 67,
+          "end": 68,
           "ctxt": 0
         }
       }

--- a/ecmascript/parser/tests/jsx/basic/namespace-tag/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/namespace-tag/input.js.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 32,
+    "end": 33,
     "ctxt": 0
   },
   "body": [
@@ -55,8 +55,8 @@
     {
       "type": "JSXElement",
       "span": {
-        "start": 13,
-        "end": 32,
+        "start": 14,
+        "end": 33,
         "ctxt": 0
       },
       "opening": {
@@ -66,8 +66,8 @@
           "namespace": {
             "type": "Identifier",
             "span": {
-              "start": 14,
-              "end": 17,
+              "start": 15,
+              "end": 18,
               "ctxt": 0
             },
             "value": "Foo",
@@ -77,8 +77,8 @@
           "name": {
             "type": "Identifier",
             "span": {
-              "start": 18,
-              "end": 21,
+              "start": 19,
+              "end": 22,
               "ctxt": 0
             },
             "value": "Bar",
@@ -87,8 +87,8 @@
           }
         },
         "span": {
-          "start": 14,
-          "end": 22,
+          "start": 15,
+          "end": 23,
           "ctxt": 0
         },
         "attributes": [],
@@ -99,8 +99,8 @@
       "closing": {
         "type": "JSXClosingElement",
         "span": {
-          "start": 24,
-          "end": 32,
+          "start": 25,
+          "end": 33,
           "ctxt": 0
         },
         "name": {
@@ -108,8 +108,8 @@
           "namespace": {
             "type": "Identifier",
             "span": {
-              "start": 24,
-              "end": 27,
+              "start": 25,
+              "end": 28,
               "ctxt": 0
             },
             "value": "Foo",
@@ -119,8 +119,8 @@
           "name": {
             "type": "Identifier",
             "span": {
-              "start": 28,
-              "end": 31,
+              "start": 29,
+              "end": 32,
               "ctxt": 0
             },
             "value": "Bar",

--- a/ecmascript/parser/tests/jsx/basic/yield-tag/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/yield-tag/input.js.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 35,
+    "end": 37,
     "ctxt": 0
   },
   "body": [
@@ -24,29 +24,29 @@
       "decorators": [],
       "span": {
         "start": 0,
-        "end": 35,
+        "end": 37,
         "ctxt": 0
       },
       "body": {
         "type": "BlockStatement",
         "span": {
           "start": 13,
-          "end": 35,
+          "end": 37,
           "ctxt": 0
         },
         "stmts": [
           {
             "type": "YieldExpression",
             "span": {
-              "start": 19,
-              "end": 32,
+              "start": 20,
+              "end": 33,
               "ctxt": 0
             },
             "argument": {
               "type": "JSXElement",
               "span": {
-                "start": 25,
-                "end": 32,
+                "start": 26,
+                "end": 33,
                 "ctxt": 0
               },
               "opening": {
@@ -54,8 +54,8 @@
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 26,
-                    "end": 27,
+                    "start": 27,
+                    "end": 28,
                     "ctxt": 0
                   },
                   "value": "a",
@@ -63,8 +63,8 @@
                   "optional": false
                 },
                 "span": {
-                  "start": 26,
-                  "end": 28,
+                  "start": 27,
+                  "end": 29,
                   "ctxt": 0
                 },
                 "attributes": [],
@@ -75,15 +75,15 @@
               "closing": {
                 "type": "JSXClosingElement",
                 "span": {
-                  "start": 30,
-                  "end": 32,
+                  "start": 31,
+                  "end": 33,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 30,
-                    "end": 31,
+                    "start": 31,
+                    "end": 32,
                     "ctxt": 0
                   },
                   "value": "a",

--- a/ecmascript/parser/tests/typescript/arrow-function/async-generic-false-positive/input.ts.json
+++ b/ecmascript/parser/tests/typescript/arrow-function/async-generic-false-positive/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 27,
+    "end": 28,
     "ctxt": 0
   },
   "body": [
@@ -38,23 +38,23 @@
     {
       "type": "BinaryExpression",
       "span": {
-        "start": 11,
-        "end": 26,
+        "start": 12,
+        "end": 27,
         "ctxt": 0
       },
       "operator": "==",
       "left": {
         "type": "CallExpression",
         "span": {
-          "start": 11,
-          "end": 21,
+          "start": 12,
+          "end": 22,
           "ctxt": 0
         },
         "callee": {
           "type": "Identifier",
           "span": {
-            "start": 11,
-            "end": 16,
+            "start": 12,
+            "end": 17,
             "ctxt": 0
           },
           "value": "async",
@@ -65,23 +65,23 @@
         "typeArguments": {
           "type": "TsTypeParameterInstantiation",
           "span": {
-            "start": 16,
-            "end": 19,
+            "start": 17,
+            "end": 20,
             "ctxt": 0
           },
           "params": [
             {
               "type": "TsTypeReference",
               "span": {
-                "start": 17,
-                "end": 18,
+                "start": 18,
+                "end": 19,
                 "ctxt": 0
               },
               "typeName": {
                 "type": "Identifier",
                 "span": {
-                  "start": 17,
-                  "end": 18,
+                  "start": 18,
+                  "end": 19,
                   "ctxt": 0
                 },
                 "value": "T",
@@ -96,8 +96,8 @@
       "right": {
         "type": "NumericLiteral",
         "span": {
-          "start": 25,
-          "end": 26,
+          "start": 26,
+          "end": 27,
           "ctxt": 0
         },
         "value": 0.0

--- a/ecmascript/parser/tests/typescript/arrow-function/generic-tsx/input.ts.json
+++ b/ecmascript/parser/tests/typescript/arrow-function/generic-tsx/input.ts.json
@@ -1,46 +1,46 @@
 {
   "type": "Module",
   "span": {
-    "start": 61,
-    "end": 79,
+    "start": 62,
+    "end": 80,
     "ctxt": 0
   },
   "body": [
     {
       "type": "ArrowFunctionExpression",
       "span": {
-        "start": 64,
-        "end": 78,
+        "start": 65,
+        "end": 79,
         "ctxt": 0
       },
       "params": [
         {
           "type": "Identifier",
           "span": {
-            "start": 65,
-            "end": 66,
+            "start": 66,
+            "end": 67,
             "ctxt": 0
           },
           "value": "a",
           "typeAnnotation": {
             "type": "TsTypeAnnotation",
             "span": {
-              "start": 66,
-              "end": 69,
+              "start": 67,
+              "end": 70,
               "ctxt": 0
             },
             "typeAnnotation": {
               "type": "TsTypeReference",
               "span": {
-                "start": 68,
-                "end": 69,
+                "start": 69,
+                "end": 70,
                 "ctxt": 0
               },
               "typeName": {
                 "type": "Identifier",
                 "span": {
-                  "start": 68,
-                  "end": 69,
+                  "start": 69,
+                  "end": 70,
                   "ctxt": 0
                 },
                 "value": "T",
@@ -56,8 +56,8 @@
       "body": {
         "type": "Identifier",
         "span": {
-          "start": 77,
-          "end": 78,
+          "start": 78,
+          "end": 79,
           "ctxt": 0
         },
         "value": "a",
@@ -69,23 +69,23 @@
       "typeParameters": {
         "type": "TsTypeParameterDeclaration",
         "span": {
-          "start": 61,
-          "end": 64,
+          "start": 62,
+          "end": 65,
           "ctxt": 0
         },
         "parameters": [
           {
             "type": "TsTypeParameter",
             "span": {
-              "start": 62,
-              "end": 63,
+              "start": 63,
+              "end": 64,
               "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
-                "start": 62,
-                "end": 63,
+                "start": 63,
+                "end": 64,
                 "ctxt": 0
               },
               "value": "T",
@@ -100,22 +100,22 @@
       "returnType": {
         "type": "TsTypeAnnotation",
         "span": {
-          "start": 70,
-          "end": 73,
+          "start": 71,
+          "end": 74,
           "ctxt": 0
         },
         "typeAnnotation": {
           "type": "TsTypeReference",
           "span": {
-            "start": 72,
-            "end": 73,
+            "start": 73,
+            "end": 74,
             "ctxt": 0
           },
           "typeName": {
             "type": "Identifier",
             "span": {
-              "start": 72,
-              "end": 73,
+              "start": 73,
+              "end": 74,
               "ctxt": 0
             },
             "value": "T",

--- a/ecmascript/parser/tests/typescript/cast/as/input.ts.json
+++ b/ecmascript/parser/tests/typescript/cast/as/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 106,
+    "end": 109,
     "ctxt": 0
   },
   "body": [
@@ -48,23 +48,23 @@
     {
       "type": "TsAsExpression",
       "span": {
-        "start": 8,
-        "end": 13,
+        "start": 9,
+        "end": 14,
         "ctxt": 0
       },
       "expression": {
         "type": "BinaryExpression",
         "span": {
-          "start": 8,
-          "end": 13,
+          "start": 9,
+          "end": 14,
           "ctxt": 0
         },
         "operator": "<",
         "left": {
           "type": "Identifier",
           "span": {
-            "start": 8,
-            "end": 9,
+            "start": 9,
+            "end": 10,
             "ctxt": 0
           },
           "value": "x",
@@ -74,8 +74,8 @@
         "right": {
           "type": "Identifier",
           "span": {
-            "start": 12,
-            "end": 13,
+            "start": 13,
+            "end": 14,
             "ctxt": 0
           },
           "value": "y",
@@ -86,8 +86,8 @@
       "typeAnnotation": {
         "type": "TsKeywordType",
         "span": {
-          "start": 17,
-          "end": 24,
+          "start": 18,
+          "end": 25,
           "ctxt": 0
         },
         "kind": "boolean"
@@ -96,16 +96,16 @@
     {
       "type": "BinaryExpression",
       "span": {
-        "start": 49,
-        "end": 56,
+        "start": 51,
+        "end": 58,
         "ctxt": 0
       },
       "operator": "===",
       "left": {
         "type": "Identifier",
         "span": {
-          "start": 49,
-          "end": 50,
+          "start": 51,
+          "end": 52,
           "ctxt": 0
         },
         "value": "x",
@@ -115,15 +115,15 @@
       "right": {
         "type": "TsAsExpression",
         "span": {
-          "start": 55,
-          "end": 56,
+          "start": 57,
+          "end": 58,
           "ctxt": 0
         },
         "expression": {
           "type": "NumericLiteral",
           "span": {
-            "start": 55,
-            "end": 56,
+            "start": 57,
+            "end": 58,
             "ctxt": 0
           },
           "value": 1.0
@@ -131,8 +131,8 @@
         "typeAnnotation": {
           "type": "TsKeywordType",
           "span": {
-            "start": 60,
-            "end": 66,
+            "start": 62,
+            "end": 68,
             "ctxt": 0
           },
           "kind": "number"
@@ -142,22 +142,22 @@
     {
       "type": "TsAsExpression",
       "span": {
-        "start": 92,
-        "end": 100,
+        "start": 95,
+        "end": 103,
         "ctxt": 0
       },
       "expression": {
         "type": "TsAsExpression",
         "span": {
-          "start": 92,
-          "end": 93,
+          "start": 95,
+          "end": 96,
           "ctxt": 0
         },
         "expression": {
           "type": "Identifier",
           "span": {
-            "start": 92,
-            "end": 93,
+            "start": 95,
+            "end": 96,
             "ctxt": 0
           },
           "value": "x",
@@ -167,8 +167,8 @@
         "typeAnnotation": {
           "type": "TsKeywordType",
           "span": {
-            "start": 97,
-            "end": 100,
+            "start": 100,
+            "end": 103,
             "ctxt": 0
           },
           "kind": "any"
@@ -177,15 +177,15 @@
       "typeAnnotation": {
         "type": "TsTypeReference",
         "span": {
-          "start": 104,
-          "end": 105,
+          "start": 107,
+          "end": 108,
           "ctxt": 0
         },
         "typeName": {
           "type": "Identifier",
           "span": {
-            "start": 104,
-            "end": 105,
+            "start": 107,
+            "end": 108,
             "ctxt": 0
           },
           "value": "T",

--- a/ecmascript/parser/tests/typescript/cast/need-parentheses/input.ts.json
+++ b/ecmascript/parser/tests/typescript/cast/need-parentheses/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 28,
+    "end": 30,
     "ctxt": 0
   },
   "body": [
@@ -76,29 +76,29 @@
     {
       "type": "MemberExpression",
       "span": {
-        "start": 11,
-        "end": 21,
+        "start": 12,
+        "end": 22,
         "ctxt": 0
       },
       "object": {
         "type": "ParenthesisExpression",
         "span": {
-          "start": 11,
-          "end": 19,
+          "start": 12,
+          "end": 20,
           "ctxt": 0
         },
         "expression": {
           "type": "TsAsExpression",
           "span": {
-            "start": 12,
-            "end": 13,
+            "start": 13,
+            "end": 14,
             "ctxt": 0
           },
           "expression": {
             "type": "Identifier",
             "span": {
-              "start": 12,
-              "end": 13,
+              "start": 13,
+              "end": 14,
               "ctxt": 0
             },
             "value": "x",
@@ -108,15 +108,15 @@
           "typeAnnotation": {
             "type": "TsTypeReference",
             "span": {
-              "start": 17,
-              "end": 18,
+              "start": 18,
+              "end": 19,
               "ctxt": 0
             },
             "typeName": {
               "type": "Identifier",
               "span": {
-                "start": 17,
-                "end": 18,
+                "start": 18,
+                "end": 19,
                 "ctxt": 0
               },
               "value": "T",
@@ -130,8 +130,8 @@
       "property": {
         "type": "Identifier",
         "span": {
-          "start": 20,
-          "end": 21,
+          "start": 21,
+          "end": 22,
           "ctxt": 0
         },
         "value": "y",
@@ -143,22 +143,22 @@
     {
       "type": "MemberExpression",
       "span": {
-        "start": 23,
-        "end": 27,
+        "start": 25,
+        "end": 29,
         "ctxt": 0
       },
       "object": {
         "type": "TsNonNullExpression",
         "span": {
-          "start": 23,
-          "end": 25,
+          "start": 25,
+          "end": 27,
           "ctxt": 0
         },
         "expression": {
           "type": "Identifier",
           "span": {
-            "start": 23,
-            "end": 24,
+            "start": 25,
+            "end": 26,
             "ctxt": 0
           },
           "value": "x",
@@ -169,8 +169,8 @@
       "property": {
         "type": "Identifier",
         "span": {
-          "start": 26,
-          "end": 27,
+          "start": 28,
+          "end": 29,
           "ctxt": 0
         },
         "value": "y",

--- a/ecmascript/parser/tests/typescript/cast/null-assertion-false-positive/input.ts.json
+++ b/ecmascript/parser/tests/typescript/cast/null-assertion-false-positive/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 4,
+    "end": 5,
     "ctxt": 0
   },
   "body": [
@@ -20,16 +20,16 @@
     {
       "type": "UnaryExpression",
       "span": {
-        "start": 2,
-        "end": 4,
+        "start": 3,
+        "end": 5,
         "ctxt": 0
       },
       "operator": "!",
       "argument": {
         "type": "Identifier",
         "span": {
-          "start": 3,
-          "end": 4,
+          "start": 4,
+          "end": 5,
           "ctxt": 0
         },
         "value": "b",

--- a/ecmascript/parser/tests/typescript/class/abstract-false-positive/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/abstract-false-positive/input.ts.json
@@ -1,23 +1,23 @@
 {
   "type": "Module",
   "span": {
-    "start": 63,
-    "end": 87,
+    "start": 64,
+    "end": 88,
     "ctxt": 0
   },
   "body": [
     {
       "type": "ExportDefaultExpression",
       "span": {
-        "start": 63,
-        "end": 87,
+        "start": 64,
+        "end": 88,
         "ctxt": 0
       },
       "expression": {
         "type": "Identifier",
         "span": {
-          "start": 78,
-          "end": 86,
+          "start": 79,
+          "end": 87,
           "ctxt": 0
         },
         "value": "abstract",

--- a/ecmascript/parser/tests/typescript/class/abstract/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/abstract/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 199,
+    "end": 204,
     "ctxt": 0
   },
   "body": [
@@ -38,8 +38,8 @@
       "identifier": {
         "type": "Identifier",
         "span": {
-          "start": 43,
-          "end": 44,
+          "start": 44,
+          "end": 45,
           "ctxt": 0
         },
         "value": "C",
@@ -48,8 +48,8 @@
       },
       "declare": true,
       "span": {
-        "start": 37,
-        "end": 47,
+        "start": 38,
+        "end": 48,
         "ctxt": 0
       },
       "decorators": [],
@@ -63,8 +63,8 @@
     {
       "type": "ExportDeclaration",
       "span": {
-        "start": 48,
-        "end": 74,
+        "start": 50,
+        "end": 76,
         "ctxt": 0
       },
       "declaration": {
@@ -72,8 +72,8 @@
         "identifier": {
           "type": "Identifier",
           "span": {
-            "start": 70,
-            "end": 71,
+            "start": 72,
+            "end": 73,
             "ctxt": 0
           },
           "value": "C",
@@ -82,8 +82,8 @@
         },
         "declare": false,
         "span": {
-          "start": 64,
-          "end": 74,
+          "start": 66,
+          "end": 76,
           "ctxt": 0
         },
         "decorators": [],
@@ -98,16 +98,16 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 154,
-        "end": 163,
+        "start": 158,
+        "end": 167,
         "ctxt": 0
       },
       "decl": {
         "type": "ClassExpression",
         "identifier": null,
         "span": {
-          "start": 154,
-          "end": 163,
+          "start": 158,
+          "end": 167,
           "ctxt": 0
         },
         "decorators": [],
@@ -122,8 +122,8 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 188,
-        "end": 199,
+        "start": 193,
+        "end": 204,
         "ctxt": 0
       },
       "decl": {
@@ -131,8 +131,8 @@
         "identifier": {
           "type": "Identifier",
           "span": {
-            "start": 194,
-            "end": 195,
+            "start": 199,
+            "end": 200,
             "ctxt": 0
           },
           "value": "C",
@@ -140,8 +140,8 @@
           "optional": false
         },
         "span": {
-          "start": 188,
-          "end": 199,
+          "start": 193,
+          "end": 204,
           "ctxt": 0
         },
         "decorators": [],

--- a/ecmascript/parser/tests/typescript/class/constructor-with-modifier-names/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/constructor-with-modifier-names/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 91,
+    "end": 94,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 91,
+        "end": 94,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "Constructor",
           "span": {
-            "start": 14,
-            "end": 43,
+            "start": 15,
+            "end": 44,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 14,
-              "end": 25,
+              "start": 15,
+              "end": 26,
               "ctxt": 0
             },
             "value": "constructor",
@@ -49,8 +49,8 @@
             {
               "type": "Identifier",
               "span": {
-                "start": 26,
-                "end": 29,
+                "start": 27,
+                "end": 30,
                 "ctxt": 0
               },
               "value": "set",
@@ -60,8 +60,8 @@
             {
               "type": "Identifier",
               "span": {
-                "start": 31,
-                "end": 39,
+                "start": 32,
+                "end": 40,
                 "ctxt": 0
               },
               "value": "readonly",
@@ -72,8 +72,8 @@
           "body": {
             "type": "BlockStatement",
             "span": {
-              "start": 41,
-              "end": 43,
+              "start": 42,
+              "end": 44,
               "ctxt": 0
             },
             "stmts": []
@@ -84,15 +84,15 @@
         {
           "type": "Constructor",
           "span": {
-            "start": 46,
-            "end": 89,
+            "start": 48,
+            "end": 91,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 46,
-              "end": 57,
+              "start": 48,
+              "end": 59,
               "ctxt": 0
             },
             "value": "constructor",
@@ -103,23 +103,23 @@
             {
               "type": "Identifier",
               "span": {
-                "start": 58,
-                "end": 61,
+                "start": 60,
+                "end": 63,
                 "ctxt": 0
               },
               "value": "set",
               "typeAnnotation": {
                 "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 61,
-                  "end": 66,
+                  "start": 63,
+                  "end": 68,
                   "ctxt": 0
                 },
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 63,
-                    "end": 66,
+                    "start": 65,
+                    "end": 68,
                     "ctxt": 0
                   },
                   "kind": "any"
@@ -130,23 +130,23 @@
             {
               "type": "Identifier",
               "span": {
-                "start": 68,
-                "end": 76,
+                "start": 70,
+                "end": 78,
                 "ctxt": 0
               },
               "value": "readonly",
               "typeAnnotation": {
                 "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 76,
-                  "end": 85,
+                  "start": 78,
+                  "end": 87,
                   "ctxt": 0
                 },
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 78,
-                    "end": 85,
+                    "start": 80,
+                    "end": 87,
                     "ctxt": 0
                   },
                   "kind": "boolean"
@@ -158,8 +158,8 @@
           "body": {
             "type": "BlockStatement",
             "span": {
-              "start": 87,
-              "end": 89,
+              "start": 89,
+              "end": 91,
               "ctxt": 0
             },
             "stmts": []

--- a/ecmascript/parser/tests/typescript/class/constructor/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/constructor/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 124,
+    "end": 128,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 124,
+        "end": 128,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "Constructor",
           "span": {
-            "start": 14,
-            "end": 48,
+            "start": 15,
+            "end": 49,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 14,
-              "end": 25,
+              "start": 15,
+              "end": 26,
               "ctxt": 0
             },
             "value": "constructor",
@@ -49,23 +49,23 @@
             {
               "type": "Identifier",
               "span": {
-                "start": 26,
-                "end": 27,
+                "start": 27,
+                "end": 28,
                 "ctxt": 0
               },
               "value": "x",
               "typeAnnotation": {
                 "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 27,
-                  "end": 35,
+                  "start": 28,
+                  "end": 36,
                   "ctxt": 0
                 },
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 29,
-                    "end": 35,
+                    "start": 30,
+                    "end": 36,
                     "ctxt": 0
                   },
                   "kind": "number"
@@ -76,23 +76,23 @@
             {
               "type": "Identifier",
               "span": {
-                "start": 37,
-                "end": 38,
+                "start": 38,
+                "end": 39,
                 "ctxt": 0
               },
               "value": "y",
               "typeAnnotation": {
                 "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 38,
-                  "end": 46,
+                  "start": 39,
+                  "end": 47,
                   "ctxt": 0
                 },
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 40,
-                    "end": 46,
+                    "start": 41,
+                    "end": 47,
                     "ctxt": 0
                   },
                   "kind": "number"
@@ -108,15 +108,15 @@
         {
           "type": "Constructor",
           "span": {
-            "start": 53,
-            "end": 87,
+            "start": 55,
+            "end": 89,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 53,
-              "end": 64,
+              "start": 55,
+              "end": 66,
               "ctxt": 0
             },
             "value": "constructor",
@@ -127,23 +127,23 @@
             {
               "type": "Identifier",
               "span": {
-                "start": 65,
-                "end": 66,
+                "start": 67,
+                "end": 68,
                 "ctxt": 0
               },
               "value": "x",
               "typeAnnotation": {
                 "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 66,
-                  "end": 74,
+                  "start": 68,
+                  "end": 76,
                   "ctxt": 0
                 },
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 68,
-                    "end": 74,
+                    "start": 70,
+                    "end": 76,
                     "ctxt": 0
                   },
                   "kind": "string"
@@ -154,23 +154,23 @@
             {
               "type": "Identifier",
               "span": {
-                "start": 76,
-                "end": 77,
+                "start": 78,
+                "end": 79,
                 "ctxt": 0
               },
               "value": "y",
               "typeAnnotation": {
                 "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 77,
-                  "end": 85,
+                  "start": 79,
+                  "end": 87,
                   "ctxt": 0
                 },
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 79,
-                    "end": 85,
+                    "start": 81,
+                    "end": 87,
                     "ctxt": 0
                   },
                   "kind": "string"
@@ -186,15 +186,15 @@
         {
           "type": "Constructor",
           "span": {
-            "start": 92,
-            "end": 122,
+            "start": 95,
+            "end": 125,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 92,
-              "end": 103,
+              "start": 95,
+              "end": 106,
               "ctxt": 0
             },
             "value": "constructor",
@@ -205,23 +205,23 @@
             {
               "type": "Identifier",
               "span": {
-                "start": 104,
-                "end": 105,
+                "start": 107,
+                "end": 108,
                 "ctxt": 0
               },
               "value": "x",
               "typeAnnotation": {
                 "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 105,
-                  "end": 110,
+                  "start": 108,
+                  "end": 113,
                   "ctxt": 0
                 },
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 107,
-                    "end": 110,
+                    "start": 110,
+                    "end": 113,
                     "ctxt": 0
                   },
                   "kind": "any"
@@ -232,23 +232,23 @@
             {
               "type": "Identifier",
               "span": {
-                "start": 112,
-                "end": 113,
+                "start": 115,
+                "end": 116,
                 "ctxt": 0
               },
               "value": "y",
               "typeAnnotation": {
                 "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 113,
-                  "end": 118,
+                  "start": 116,
+                  "end": 121,
                   "ctxt": 0
                 },
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 115,
-                    "end": 118,
+                    "start": 118,
+                    "end": 121,
                     "ctxt": 0
                   },
                   "kind": "any"
@@ -260,8 +260,8 @@
           "body": {
             "type": "BlockStatement",
             "span": {
-              "start": 120,
-              "end": 122,
+              "start": 123,
+              "end": 125,
               "ctxt": 0
             },
             "stmts": []

--- a/ecmascript/parser/tests/typescript/class/declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/declare/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 87,
+    "end": 93,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": true,
       "span": {
         "start": 8,
-        "end": 87,
+        "end": 93,
         "ctxt": 0
       },
       "decorators": [],
@@ -33,23 +33,23 @@
             {
               "type": "Identifier",
               "span": {
-                "start": 23,
-                "end": 24,
+                "start": 24,
+                "end": 25,
                 "ctxt": 0
               },
               "value": "x",
               "typeAnnotation": {
                 "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 26,
-                  "end": 32,
+                  "start": 27,
+                  "end": 33,
                   "ctxt": 0
                 },
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 26,
-                    "end": 32,
+                    "start": 27,
+                    "end": 33,
                     "ctxt": 0
                   },
                   "kind": "string"
@@ -61,15 +61,15 @@
           "typeAnnotation": {
             "type": "TsTypeAnnotation",
             "span": {
-              "start": 33,
-              "end": 38,
+              "start": 34,
+              "end": 39,
               "ctxt": 0
             },
             "typeAnnotation": {
               "type": "TsKeywordType",
               "span": {
-                "start": 35,
-                "end": 38,
+                "start": 36,
+                "end": 39,
                 "ctxt": 0
               },
               "kind": "any"
@@ -77,23 +77,23 @@
           },
           "readonly": false,
           "span": {
-            "start": 22,
-            "end": 39,
+            "start": 23,
+            "end": 40,
             "ctxt": 0
           }
         },
         {
           "type": "ClassProperty",
           "span": {
-            "start": 44,
-            "end": 46,
+            "start": 46,
+            "end": 48,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 44,
-              "end": 45,
+              "start": 46,
+              "end": 47,
               "ctxt": 0
             },
             "value": "x",
@@ -114,15 +114,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 51,
-            "end": 61,
+            "start": 54,
+            "end": 64,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 51,
-              "end": 52,
+              "start": 54,
+              "end": 55,
               "ctxt": 0
             },
             "value": "x",
@@ -133,15 +133,15 @@
           "typeAnnotation": {
             "type": "TsTypeAnnotation",
             "span": {
-              "start": 52,
-              "end": 60,
+              "start": 55,
+              "end": 63,
               "ctxt": 0
             },
             "typeAnnotation": {
               "type": "TsKeywordType",
               "span": {
-                "start": 54,
-                "end": 60,
+                "start": 57,
+                "end": 63,
                 "ctxt": 0
               },
               "kind": "number"
@@ -159,15 +159,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 66,
-            "end": 70,
+            "start": 70,
+            "end": 74,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 66,
-              "end": 67,
+              "start": 70,
+              "end": 71,
               "ctxt": 0
             },
             "value": "f",
@@ -178,8 +178,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 66,
-              "end": 70,
+              "start": 70,
+              "end": 74,
               "ctxt": 0
             },
             "body": null,
@@ -197,15 +197,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 75,
-            "end": 85,
+            "start": 80,
+            "end": 90,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 75,
-              "end": 76,
+              "start": 80,
+              "end": 81,
               "ctxt": 0
             },
             "value": "f",
@@ -216,8 +216,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 75,
-              "end": 85,
+              "start": 80,
+              "end": 90,
               "ctxt": 0
             },
             "body": null,
@@ -227,15 +227,15 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 78,
-                "end": 84,
+                "start": 83,
+                "end": 89,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 80,
-                  "end": 84,
+                  "start": 85,
+                  "end": 89,
                   "ctxt": 0
                 },
                 "kind": "void"

--- a/ecmascript/parser/tests/typescript/class/expression-extends-implements/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/expression-extends-implements/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 91,
+    "end": 92,
     "ctxt": 0
   },
   "body": [
@@ -146,8 +146,8 @@
     {
       "type": "ParenthesisExpression",
       "span": {
-        "start": 45,
-        "end": 90,
+        "start": 46,
+        "end": 91,
         "ctxt": 0
       },
       "expression": {
@@ -155,8 +155,8 @@
         "identifier": {
           "type": "Identifier",
           "span": {
-            "start": 52,
-            "end": 53,
+            "start": 53,
+            "end": 54,
             "ctxt": 0
           },
           "value": "C",
@@ -164,8 +164,8 @@
           "optional": false
         },
         "span": {
-          "start": 46,
-          "end": 89,
+          "start": 47,
+          "end": 90,
           "ctxt": 0
         },
         "decorators": [],
@@ -173,15 +173,15 @@
         "superClass": {
           "type": "CallExpression",
           "span": {
-            "start": 62,
-            "end": 65,
+            "start": 63,
+            "end": 66,
             "ctxt": 0
           },
           "callee": {
             "type": "Identifier",
             "span": {
-              "start": 62,
-              "end": 63,
+              "start": 63,
+              "end": 64,
               "ctxt": 0
             },
             "value": "f",
@@ -196,23 +196,23 @@
         "superTypeParams": {
           "type": "TsTypeParameterInstantiation",
           "span": {
-            "start": 65,
-            "end": 68,
+            "start": 66,
+            "end": 69,
             "ctxt": 0
           },
           "params": [
             {
               "type": "TsTypeReference",
               "span": {
-                "start": 66,
-                "end": 67,
+                "start": 67,
+                "end": 68,
                 "ctxt": 0
               },
               "typeName": {
                 "type": "Identifier",
                 "span": {
-                  "start": 66,
-                  "end": 67,
+                  "start": 67,
+                  "end": 68,
                   "ctxt": 0
                 },
                 "value": "T",
@@ -227,8 +227,8 @@
           {
             "type": "TsExpressionWithTypeArguments",
             "span": {
-              "start": 80,
-              "end": 86,
+              "start": 81,
+              "end": 87,
               "ctxt": 0
             },
             "expression": {
@@ -236,8 +236,8 @@
               "left": {
                 "type": "Identifier",
                 "span": {
-                  "start": 80,
-                  "end": 81,
+                  "start": 81,
+                  "end": 82,
                   "ctxt": 0
                 },
                 "value": "X",
@@ -247,8 +247,8 @@
               "right": {
                 "type": "Identifier",
                 "span": {
-                  "start": 82,
-                  "end": 83,
+                  "start": 83,
+                  "end": 84,
                   "ctxt": 0
                 },
                 "value": "Y",
@@ -259,23 +259,23 @@
             "typeParams": {
               "type": "TsTypeParameterInstantiation",
               "span": {
-                "start": 83,
-                "end": 86,
+                "start": 84,
+                "end": 87,
                 "ctxt": 0
               },
               "params": [
                 {
                   "type": "TsTypeReference",
                   "span": {
-                    "start": 84,
-                    "end": 85,
+                    "start": 85,
+                    "end": 86,
                     "ctxt": 0
                   },
                   "typeName": {
                     "type": "Identifier",
                     "span": {
-                      "start": 84,
-                      "end": 85,
+                      "start": 85,
+                      "end": 86,
                       "ctxt": 0
                     },
                     "value": "T",

--- a/ecmascript/parser/tests/typescript/class/expression-extends/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/expression-extends/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 55,
+    "end": 56,
     "ctxt": 0
   },
   "body": [
@@ -82,8 +82,8 @@
     {
       "type": "ParenthesisExpression",
       "span": {
-        "start": 27,
-        "end": 54,
+        "start": 28,
+        "end": 55,
         "ctxt": 0
       },
       "expression": {
@@ -91,8 +91,8 @@
         "identifier": {
           "type": "Identifier",
           "span": {
-            "start": 34,
-            "end": 35,
+            "start": 35,
+            "end": 36,
             "ctxt": 0
           },
           "value": "C",
@@ -100,8 +100,8 @@
           "optional": false
         },
         "span": {
-          "start": 28,
-          "end": 53,
+          "start": 29,
+          "end": 54,
           "ctxt": 0
         },
         "decorators": [],
@@ -109,15 +109,15 @@
         "superClass": {
           "type": "CallExpression",
           "span": {
-            "start": 44,
-            "end": 47,
+            "start": 45,
+            "end": 48,
             "ctxt": 0
           },
           "callee": {
             "type": "Identifier",
             "span": {
-              "start": 44,
-              "end": 45,
+              "start": 45,
+              "end": 46,
               "ctxt": 0
             },
             "value": "f",
@@ -132,23 +132,23 @@
         "superTypeParams": {
           "type": "TsTypeParameterInstantiation",
           "span": {
-            "start": 47,
-            "end": 50,
+            "start": 48,
+            "end": 51,
             "ctxt": 0
           },
           "params": [
             {
               "type": "TsTypeReference",
               "span": {
-                "start": 48,
-                "end": 49,
+                "start": 49,
+                "end": 50,
                 "ctxt": 0
               },
               "typeName": {
                 "type": "Identifier",
                 "span": {
-                  "start": 48,
-                  "end": 49,
+                  "start": 49,
+                  "end": 50,
                   "ctxt": 0
                 },
                 "value": "T",

--- a/ecmascript/parser/tests/typescript/class/expression-generic/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/expression-generic/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 31,
+    "end": 32,
     "ctxt": 0
   },
   "body": [
@@ -63,8 +63,8 @@
     {
       "type": "ParenthesisExpression",
       "span": {
-        "start": 15,
-        "end": 30,
+        "start": 16,
+        "end": 31,
         "ctxt": 0
       },
       "expression": {
@@ -72,8 +72,8 @@
         "identifier": {
           "type": "Identifier",
           "span": {
-            "start": 22,
-            "end": 23,
+            "start": 23,
+            "end": 24,
             "ctxt": 0
           },
           "value": "C",
@@ -81,8 +81,8 @@
           "optional": false
         },
         "span": {
-          "start": 16,
-          "end": 29,
+          "start": 17,
+          "end": 30,
           "ctxt": 0
         },
         "decorators": [],
@@ -92,23 +92,23 @@
         "typeParams": {
           "type": "TsTypeParameterDeclaration",
           "span": {
-            "start": 23,
-            "end": 26,
+            "start": 24,
+            "end": 27,
             "ctxt": 0
           },
           "parameters": [
             {
               "type": "TsTypeParameter",
               "span": {
-                "start": 24,
-                "end": 25,
+                "start": 25,
+                "end": 26,
                 "ctxt": 0
               },
               "name": {
                 "type": "Identifier",
                 "span": {
-                  "start": 24,
-                  "end": 25,
+                  "start": 25,
+                  "end": 26,
                   "ctxt": 0
                 },
                 "value": "T",

--- a/ecmascript/parser/tests/typescript/class/expression-implements/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/expression-implements/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 61,
+    "end": 62,
     "ctxt": 0
   },
   "body": [
@@ -97,8 +97,8 @@
     {
       "type": "ParenthesisExpression",
       "span": {
-        "start": 30,
-        "end": 60,
+        "start": 31,
+        "end": 61,
         "ctxt": 0
       },
       "expression": {
@@ -106,8 +106,8 @@
         "identifier": {
           "type": "Identifier",
           "span": {
-            "start": 37,
-            "end": 38,
+            "start": 38,
+            "end": 39,
             "ctxt": 0
           },
           "value": "C",
@@ -115,8 +115,8 @@
           "optional": false
         },
         "span": {
-          "start": 31,
-          "end": 59,
+          "start": 32,
+          "end": 60,
           "ctxt": 0
         },
         "decorators": [],
@@ -129,8 +129,8 @@
           {
             "type": "TsExpressionWithTypeArguments",
             "span": {
-              "start": 50,
-              "end": 56,
+              "start": 51,
+              "end": 57,
               "ctxt": 0
             },
             "expression": {
@@ -138,8 +138,8 @@
               "left": {
                 "type": "Identifier",
                 "span": {
-                  "start": 50,
-                  "end": 51,
+                  "start": 51,
+                  "end": 52,
                   "ctxt": 0
                 },
                 "value": "X",
@@ -149,8 +149,8 @@
               "right": {
                 "type": "Identifier",
                 "span": {
-                  "start": 52,
-                  "end": 53,
+                  "start": 53,
+                  "end": 54,
                   "ctxt": 0
                 },
                 "value": "Y",
@@ -161,23 +161,23 @@
             "typeParams": {
               "type": "TsTypeParameterInstantiation",
               "span": {
-                "start": 53,
-                "end": 56,
+                "start": 54,
+                "end": 57,
                 "ctxt": 0
               },
               "params": [
                 {
                   "type": "TsTypeReference",
                   "span": {
-                    "start": 54,
-                    "end": 55,
+                    "start": 55,
+                    "end": 56,
                     "ctxt": 0
                   },
                   "typeName": {
                     "type": "Identifier",
                     "span": {
-                      "start": 54,
-                      "end": 55,
+                      "start": 55,
+                      "end": 56,
                       "ctxt": 0
                     },
                     "value": "T",

--- a/ecmascript/parser/tests/typescript/class/get-generic/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/get-generic/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 39,
+    "end": 41,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": true,
       "span": {
         "start": 8,
-        "end": 39,
+        "end": 41,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 22,
-            "end": 37,
+            "start": 23,
+            "end": 38,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 22,
-              "end": 25,
+              "start": 23,
+              "end": 26,
               "ctxt": 0
             },
             "value": "get",
@@ -49,8 +49,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 22,
-              "end": 37,
+              "start": 23,
+              "end": 38,
               "ctxt": 0
             },
             "body": null,
@@ -59,23 +59,23 @@
             "typeParameters": {
               "type": "TsTypeParameterDeclaration",
               "span": {
-                "start": 25,
-                "end": 28,
+                "start": 26,
+                "end": 29,
                 "ctxt": 0
               },
               "parameters": [
                 {
                   "type": "TsTypeParameter",
                   "span": {
-                    "start": 26,
-                    "end": 27,
+                    "start": 27,
+                    "end": 28,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 26,
-                      "end": 27,
+                      "start": 27,
+                      "end": 28,
                       "ctxt": 0
                     },
                     "value": "T",
@@ -90,15 +90,15 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 30,
-                "end": 36,
+                "start": 31,
+                "end": 37,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 32,
-                  "end": 36,
+                  "start": 33,
+                  "end": 37,
                   "ctxt": 0
                 },
                 "kind": "void"

--- a/ecmascript/parser/tests/typescript/class/index-signature/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/index-signature/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 64,
+    "end": 67,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 64,
+        "end": 67,
         "ctxt": 0
       },
       "decorators": [],
@@ -33,23 +33,23 @@
             {
               "type": "Identifier",
               "span": {
-                "start": 15,
-                "end": 16,
+                "start": 16,
+                "end": 17,
                 "ctxt": 0
               },
               "value": "x",
               "typeAnnotation": {
                 "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 18,
-                  "end": 24,
+                  "start": 19,
+                  "end": 25,
                   "ctxt": 0
                 },
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 18,
-                    "end": 24,
+                    "start": 19,
+                    "end": 25,
                     "ctxt": 0
                   },
                   "kind": "string"
@@ -61,15 +61,15 @@
           "typeAnnotation": {
             "type": "TsTypeAnnotation",
             "span": {
-              "start": 25,
-              "end": 30,
+              "start": 26,
+              "end": 31,
               "ctxt": 0
             },
             "typeAnnotation": {
               "type": "TsKeywordType",
               "span": {
-                "start": 27,
-                "end": 30,
+                "start": 28,
+                "end": 31,
                 "ctxt": 0
               },
               "kind": "any"
@@ -77,8 +77,8 @@
           },
           "readonly": false,
           "span": {
-            "start": 14,
-            "end": 31,
+            "start": 15,
+            "end": 32,
             "ctxt": 0
           }
         },
@@ -88,23 +88,23 @@
             {
               "type": "Identifier",
               "span": {
-                "start": 46,
-                "end": 47,
+                "start": 48,
+                "end": 49,
                 "ctxt": 0
               },
               "value": "x",
               "typeAnnotation": {
                 "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 49,
-                  "end": 55,
+                  "start": 51,
+                  "end": 57,
                   "ctxt": 0
                 },
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 49,
-                    "end": 55,
+                    "start": 51,
+                    "end": 57,
                     "ctxt": 0
                   },
                   "kind": "string"
@@ -116,15 +116,15 @@
           "typeAnnotation": {
             "type": "TsTypeAnnotation",
             "span": {
-              "start": 56,
-              "end": 61,
+              "start": 58,
+              "end": 63,
               "ctxt": 0
             },
             "typeAnnotation": {
               "type": "TsKeywordType",
               "span": {
-                "start": 58,
-                "end": 61,
+                "start": 60,
+                "end": 63,
                 "ctxt": 0
               },
               "kind": "any"
@@ -132,8 +132,8 @@
           },
           "readonly": true,
           "span": {
-            "start": 36,
-            "end": 62,
+            "start": 38,
+            "end": 64,
             "ctxt": 0
           }
         }

--- a/ecmascript/parser/tests/typescript/class/members-with-modifier-names/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/members-with-modifier-names/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 98,
+    "end": 103,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 98,
+        "end": 103,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 14,
-            "end": 29,
+            "start": 15,
+            "end": 30,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 14,
-              "end": 20,
+              "start": 15,
+              "end": 21,
               "ctxt": 0
             },
             "value": "public",
@@ -49,8 +49,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 14,
-              "end": 29,
+              "start": 15,
+              "end": 30,
               "ctxt": 0
             },
             "body": null,
@@ -60,15 +60,15 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 22,
-                "end": 28,
+                "start": 23,
+                "end": 29,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 24,
-                  "end": 28,
+                  "start": 25,
+                  "end": 29,
                   "ctxt": 0
                 },
                 "kind": "void"
@@ -84,15 +84,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 34,
-            "end": 56,
+            "start": 36,
+            "end": 58,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 41,
-              "end": 47,
+              "start": 43,
+              "end": 49,
               "ctxt": 0
             },
             "value": "static",
@@ -103,8 +103,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 34,
-              "end": 56,
+              "start": 36,
+              "end": 58,
               "ctxt": 0
             },
             "body": null,
@@ -114,15 +114,15 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 49,
-                "end": 55,
+                "start": 51,
+                "end": 57,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 51,
-                  "end": 55,
+                  "start": 53,
+                  "end": 57,
                   "ctxt": 0
                 },
                 "kind": "void"
@@ -138,15 +138,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 61,
-            "end": 74,
+            "start": 64,
+            "end": 77,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 61,
-              "end": 69,
+              "start": 64,
+              "end": 72,
               "ctxt": 0
             },
             "value": "readonly",
@@ -156,8 +156,8 @@
           "value": {
             "type": "NumericLiteral",
             "span": {
-              "start": 72,
-              "end": 73,
+              "start": 75,
+              "end": 76,
               "ctxt": 0
             },
             "value": 0.0
@@ -175,15 +175,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 79,
-            "end": 96,
+            "start": 83,
+            "end": 100,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 79,
-              "end": 84,
+              "start": 83,
+              "end": 88,
               "ctxt": 0
             },
             "value": "async",
@@ -194,8 +194,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 79,
-              "end": 96,
+              "start": 83,
+              "end": 100,
               "ctxt": 0
             },
             "body": null,
@@ -204,23 +204,23 @@
             "typeParameters": {
               "type": "TsTypeParameterDeclaration",
               "span": {
-                "start": 84,
-                "end": 87,
+                "start": 88,
+                "end": 91,
                 "ctxt": 0
               },
               "parameters": [
                 {
                   "type": "TsTypeParameter",
                   "span": {
-                    "start": 85,
-                    "end": 86,
+                    "start": 89,
+                    "end": 90,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 85,
-                      "end": 86,
+                      "start": 89,
+                      "end": 90,
                       "ctxt": 0
                     },
                     "value": "T",
@@ -235,15 +235,15 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 89,
-                "end": 95,
+                "start": 93,
+                "end": 99,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 91,
-                  "end": 95,
+                  "start": 95,
+                  "end": 99,
                   "ctxt": 0
                 },
                 "kind": "void"

--- a/ecmascript/parser/tests/typescript/class/members-with-reserved-names/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/members-with-reserved-names/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 38,
+    "end": 40,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 38,
+        "end": 40,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 21,
-            "end": 36,
+            "start": 22,
+            "end": 37,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 21,
-              "end": 27,
+              "start": 22,
+              "end": 28,
               "ctxt": 0
             },
             "value": "delete",
@@ -49,8 +49,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 21,
-              "end": 36,
+              "start": 22,
+              "end": 37,
               "ctxt": 0
             },
             "body": null,
@@ -60,15 +60,15 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 29,
-                "end": 35,
+                "start": 30,
+                "end": 36,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 31,
-                  "end": 35,
+                  "start": 32,
+                  "end": 36,
                   "ctxt": 0
                 },
                 "kind": "void"

--- a/ecmascript/parser/tests/typescript/class/method-computed/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/method-computed/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 74,
+    "end": 77,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 74,
+        "end": 77,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,29 +30,29 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 14,
-            "end": 40,
+            "start": 15,
+            "end": 41,
             "ctxt": 0
           },
           "key": {
             "type": "Computed",
             "span": {
-              "start": 14,
-              "end": 31,
+              "start": 15,
+              "end": 32,
               "ctxt": 0
             },
             "expression": {
               "type": "MemberExpression",
               "span": {
-                "start": 15,
-                "end": 30,
+                "start": 16,
+                "end": 31,
                 "ctxt": 0
               },
               "object": {
                 "type": "Identifier",
                 "span": {
-                  "start": 15,
-                  "end": 21,
+                  "start": 16,
+                  "end": 22,
                   "ctxt": 0
                 },
                 "value": "Symbol",
@@ -62,8 +62,8 @@
               "property": {
                 "type": "Identifier",
                 "span": {
-                  "start": 22,
-                  "end": 30,
+                  "start": 23,
+                  "end": 31,
                   "ctxt": 0
                 },
                 "value": "iterator",
@@ -77,8 +77,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 14,
-              "end": 40,
+              "start": 15,
+              "end": 41,
               "ctxt": 0
             },
             "body": null,
@@ -88,15 +88,15 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 33,
-                "end": 39,
+                "start": 34,
+                "end": 40,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 35,
-                  "end": 39,
+                  "start": 36,
+                  "end": 40,
                   "ctxt": 0
                 },
                 "kind": "void"
@@ -112,29 +112,29 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 45,
-            "end": 72,
+            "start": 47,
+            "end": 74,
             "ctxt": 0
           },
           "key": {
             "type": "Computed",
             "span": {
-              "start": 45,
-              "end": 62,
+              "start": 47,
+              "end": 64,
               "ctxt": 0
             },
             "expression": {
               "type": "MemberExpression",
               "span": {
-                "start": 46,
-                "end": 61,
+                "start": 48,
+                "end": 63,
                 "ctxt": 0
               },
               "object": {
                 "type": "Identifier",
                 "span": {
-                  "start": 46,
-                  "end": 52,
+                  "start": 48,
+                  "end": 54,
                   "ctxt": 0
                 },
                 "value": "Symbol",
@@ -144,8 +144,8 @@
               "property": {
                 "type": "Identifier",
                 "span": {
-                  "start": 53,
-                  "end": 61,
+                  "start": 55,
+                  "end": 63,
                   "ctxt": 0
                 },
                 "value": "iterator",
@@ -159,8 +159,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 45,
-              "end": 72,
+              "start": 47,
+              "end": 74,
               "ctxt": 0
             },
             "body": null,
@@ -170,15 +170,15 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 65,
-                "end": 71,
+                "start": 67,
+                "end": 73,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 67,
-                  "end": 71,
+                  "start": 69,
+                  "end": 73,
                   "ctxt": 0
                 },
                 "kind": "void"

--- a/ecmascript/parser/tests/typescript/class/method-generic/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/method-generic/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 83,
+    "end": 86,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 83,
+        "end": 86,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 14,
-            "end": 48,
+            "start": 15,
+            "end": 49,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 14,
-              "end": 15,
+              "start": 15,
+              "end": 16,
               "ctxt": 0
             },
             "value": "f",
@@ -50,30 +50,30 @@
               {
                 "type": "Identifier",
                 "span": {
-                  "start": 19,
-                  "end": 20,
+                  "start": 20,
+                  "end": 21,
                   "ctxt": 0
                 },
                 "value": "a",
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 20,
-                    "end": 23,
+                    "start": 21,
+                    "end": 24,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsTypeReference",
                     "span": {
-                      "start": 22,
-                      "end": 23,
+                      "start": 23,
+                      "end": 24,
                       "ctxt": 0
                     },
                     "typeName": {
                       "type": "Identifier",
                       "span": {
-                        "start": 22,
-                        "end": 23,
+                        "start": 23,
+                        "end": 24,
                         "ctxt": 0
                       },
                       "value": "T",
@@ -88,30 +88,30 @@
               {
                 "type": "Identifier",
                 "span": {
-                  "start": 25,
-                  "end": 26,
+                  "start": 26,
+                  "end": 27,
                   "ctxt": 0
                 },
                 "value": "b",
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 27,
-                    "end": 30,
+                    "start": 28,
+                    "end": 31,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsTypeReference",
                     "span": {
-                      "start": 29,
-                      "end": 30,
+                      "start": 30,
+                      "end": 31,
                       "ctxt": 0
                     },
                     "typeName": {
                       "type": "Identifier",
                       "span": {
-                        "start": 29,
-                        "end": 30,
+                        "start": 30,
+                        "end": 31,
                         "ctxt": 0
                       },
                       "value": "T",
@@ -126,15 +126,15 @@
               {
                 "type": "RestElement",
                 "rest": {
-                  "start": 32,
-                  "end": 35,
+                  "start": 33,
+                  "end": 36,
                   "ctxt": 0
                 },
                 "argument": {
                   "type": "Identifier",
                   "span": {
-                    "start": 35,
-                    "end": 36,
+                    "start": 36,
+                    "end": 37,
                     "ctxt": 0
                   },
                   "value": "c",
@@ -144,29 +144,29 @@
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 36,
-                    "end": 41,
+                    "start": 37,
+                    "end": 42,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsArrayType",
                     "span": {
-                      "start": 38,
-                      "end": 41,
+                      "start": 39,
+                      "end": 42,
                       "ctxt": 0
                     },
                     "elemType": {
                       "type": "TsTypeReference",
                       "span": {
-                        "start": 38,
-                        "end": 39,
+                        "start": 39,
+                        "end": 40,
                         "ctxt": 0
                       },
                       "typeName": {
                         "type": "Identifier",
                         "span": {
-                          "start": 38,
-                          "end": 39,
+                          "start": 39,
+                          "end": 40,
                           "ctxt": 0
                         },
                         "value": "T",
@@ -181,15 +181,15 @@
             ],
             "decorators": [],
             "span": {
-              "start": 14,
-              "end": 48,
+              "start": 15,
+              "end": 49,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 46,
-                "end": 48,
+                "start": 47,
+                "end": 49,
                 "ctxt": 0
               },
               "stmts": []
@@ -199,23 +199,23 @@
             "typeParameters": {
               "type": "TsTypeParameterDeclaration",
               "span": {
-                "start": 15,
-                "end": 18,
+                "start": 16,
+                "end": 19,
                 "ctxt": 0
               },
               "parameters": [
                 {
                   "type": "TsTypeParameter",
                   "span": {
-                    "start": 16,
-                    "end": 17,
+                    "start": 17,
+                    "end": 18,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 16,
-                      "end": 17,
+                      "start": 17,
+                      "end": 18,
                       "ctxt": 0
                     },
                     "value": "T",
@@ -230,22 +230,22 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 42,
-                "end": 45,
+                "start": 43,
+                "end": 46,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsTypeReference",
                 "span": {
-                  "start": 44,
-                  "end": 45,
+                  "start": 45,
+                  "end": 46,
                   "ctxt": 0
                 },
                 "typeName": {
                   "type": "Identifier",
                   "span": {
-                    "start": 44,
-                    "end": 45,
+                    "start": 45,
+                    "end": 46,
                     "ctxt": 0
                   },
                   "value": "T",
@@ -265,29 +265,29 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 53,
-            "end": 81,
+            "start": 55,
+            "end": 83,
             "ctxt": 0
           },
           "key": {
             "type": "Computed",
             "span": {
-              "start": 53,
-              "end": 70,
+              "start": 55,
+              "end": 72,
               "ctxt": 0
             },
             "expression": {
               "type": "MemberExpression",
               "span": {
-                "start": 54,
-                "end": 69,
+                "start": 56,
+                "end": 71,
                 "ctxt": 0
               },
               "object": {
                 "type": "Identifier",
                 "span": {
-                  "start": 54,
-                  "end": 60,
+                  "start": 56,
+                  "end": 62,
                   "ctxt": 0
                 },
                 "value": "Symbol",
@@ -297,8 +297,8 @@
               "property": {
                 "type": "Identifier",
                 "span": {
-                  "start": 61,
-                  "end": 69,
+                  "start": 63,
+                  "end": 71,
                   "ctxt": 0
                 },
                 "value": "iterator",
@@ -312,15 +312,15 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 53,
-              "end": 81,
+              "start": 55,
+              "end": 83,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 79,
-                "end": 81,
+                "start": 81,
+                "end": 83,
                 "ctxt": 0
               },
               "stmts": []
@@ -330,23 +330,23 @@
             "typeParameters": {
               "type": "TsTypeParameterDeclaration",
               "span": {
-                "start": 70,
-                "end": 73,
+                "start": 72,
+                "end": 75,
                 "ctxt": 0
               },
               "parameters": [
                 {
                   "type": "TsTypeParameter",
                   "span": {
-                    "start": 71,
-                    "end": 72,
+                    "start": 73,
+                    "end": 74,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 71,
-                      "end": 72,
+                      "start": 73,
+                      "end": 74,
                       "ctxt": 0
                     },
                     "value": "T",
@@ -361,22 +361,22 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 75,
-                "end": 78,
+                "start": 77,
+                "end": 80,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsTypeReference",
                 "span": {
-                  "start": 77,
-                  "end": 78,
+                  "start": 79,
+                  "end": 80,
                   "ctxt": 0
                 },
                 "typeName": {
                   "type": "Identifier",
                   "span": {
-                    "start": 77,
-                    "end": 78,
+                    "start": 79,
+                    "end": 80,
                     "ctxt": 0
                   },
                   "value": "T",

--- a/ecmascript/parser/tests/typescript/class/method-no-body/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/method-no-body/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 35,
+    "end": 38,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 35,
+        "end": 38,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 14,
-            "end": 18,
+            "start": 15,
+            "end": 19,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 14,
-              "end": 15,
+              "start": 15,
+              "end": 16,
               "ctxt": 0
             },
             "value": "f",
@@ -49,8 +49,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 14,
-              "end": 18,
+              "start": 15,
+              "end": 19,
               "ctxt": 0
             },
             "body": null,
@@ -68,15 +68,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 23,
-            "end": 33,
+            "start": 25,
+            "end": 35,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 23,
-              "end": 24,
+              "start": 25,
+              "end": 26,
               "ctxt": 0
             },
             "value": "f",
@@ -87,8 +87,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 23,
-              "end": 33,
+              "start": 25,
+              "end": 35,
               "ctxt": 0
             },
             "body": null,
@@ -98,15 +98,15 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 26,
-                "end": 32,
+                "start": 28,
+                "end": 34,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 28,
-                  "end": 32,
+                  "start": 30,
+                  "end": 34,
                   "ctxt": 0
                 },
                 "kind": "void"

--- a/ecmascript/parser/tests/typescript/class/method-optional/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/method-optional/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 29,
+    "end": 31,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 29,
+        "end": 31,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 14,
-            "end": 27,
+            "start": 15,
+            "end": 28,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 14,
-              "end": 15,
+              "start": 15,
+              "end": 16,
               "ctxt": 0
             },
             "value": "m",
@@ -49,15 +49,15 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 14,
-              "end": 27,
+              "start": 15,
+              "end": 28,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 25,
-                "end": 27,
+                "start": 26,
+                "end": 28,
                 "ctxt": 0
               },
               "stmts": []
@@ -68,15 +68,15 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 18,
-                "end": 24,
+                "start": 19,
+                "end": 25,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 20,
-                  "end": 24,
+                  "start": 21,
+                  "end": 25,
                   "ctxt": 0
                 },
                 "kind": "void"

--- a/ecmascript/parser/tests/typescript/class/method-return-type/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/method-return-type/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 28,
+    "end": 30,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 28,
+        "end": 30,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 14,
-            "end": 26,
+            "start": 15,
+            "end": 27,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 14,
-              "end": 15,
+              "start": 15,
+              "end": 16,
               "ctxt": 0
             },
             "value": "f",
@@ -49,15 +49,15 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 14,
-              "end": 26,
+              "start": 15,
+              "end": 27,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 24,
-                "end": 26,
+                "start": 25,
+                "end": 27,
                 "ctxt": 0
               },
               "stmts": []
@@ -68,15 +68,15 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 17,
-                "end": 23,
+                "start": 18,
+                "end": 24,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 19,
-                  "end": 23,
+                  "start": 20,
+                  "end": 24,
                   "ctxt": 0
                 },
                 "kind": "void"

--- a/ecmascript/parser/tests/typescript/class/method-with-newline-with-body/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/method-with-newline-with-body/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 31,
+    "end": 36,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 31,
+        "end": 36,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 14,
-            "end": 29,
+            "start": 16,
+            "end": 33,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 14,
-              "end": 15,
+              "start": 16,
+              "end": 17,
               "ctxt": 0
             },
             "value": "m",
@@ -49,15 +49,15 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 14,
-              "end": 29,
+              "start": 16,
+              "end": 33,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 22,
-                "end": 29,
+                "start": 25,
+                "end": 33,
                 "ctxt": 0
               },
               "stmts": []

--- a/ecmascript/parser/tests/typescript/class/method-with-newline-without-body/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/method-with-newline-without-body/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 27,
+    "end": 31,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 27,
+        "end": 31,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 14,
-            "end": 17,
+            "start": 16,
+            "end": 19,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 14,
-              "end": 15,
+              "start": 16,
+              "end": 17,
               "ctxt": 0
             },
             "value": "m",
@@ -49,8 +49,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 14,
-              "end": 17,
+              "start": 16,
+              "end": 19,
               "ctxt": 0
             },
             "body": null,
@@ -68,15 +68,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 22,
-            "end": 25,
+            "start": 25,
+            "end": 28,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 22,
-              "end": 23,
+              "start": 25,
+              "end": 26,
               "ctxt": 0
             },
             "value": "n",
@@ -87,8 +87,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 22,
-              "end": 25,
+              "start": 25,
+              "end": 28,
               "ctxt": 0
             },
             "body": null,

--- a/ecmascript/parser/tests/typescript/class/modifiers-accessors/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-accessors/input.ts.json
@@ -1,8 +1,8 @@
 {
   "type": "Module",
   "span": {
-    "start": 40,
-    "end": 295,
+    "start": 41,
+    "end": 305,
     "ctxt": 0
   },
   "body": [
@@ -11,8 +11,8 @@
       "identifier": {
         "type": "Identifier",
         "span": {
-          "start": 55,
-          "end": 56,
+          "start": 56,
+          "end": 57,
           "ctxt": 0
         },
         "value": "C",
@@ -21,8 +21,8 @@
       },
       "declare": false,
       "span": {
-        "start": 49,
-        "end": 295,
+        "start": 50,
+        "end": 305,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 63,
-            "end": 80,
+            "start": 65,
+            "end": 82,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 76,
-              "end": 77,
+              "start": 78,
+              "end": 79,
               "ctxt": 0
             },
             "value": "a",
@@ -49,8 +49,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 63,
-              "end": 80,
+              "start": 65,
+              "end": 82,
               "ctxt": 0
             },
             "body": null,
@@ -68,15 +68,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 85,
-            "end": 113,
+            "start": 88,
+            "end": 116,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 96,
-              "end": 97,
+              "start": 99,
+              "end": 100,
               "ctxt": 0
             },
             "value": "s",
@@ -87,30 +87,30 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 85,
-              "end": 113,
+              "start": 88,
+              "end": 116,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 100,
-                "end": 113,
+                "start": 103,
+                "end": 116,
                 "ctxt": 0
               },
               "stmts": [
                 {
                   "type": "ReturnStatement",
                   "span": {
-                    "start": 102,
-                    "end": 111,
+                    "start": 105,
+                    "end": 114,
                     "ctxt": 0
                   },
                   "argument": {
                     "type": "NumericLiteral",
                     "span": {
-                      "start": 109,
-                      "end": 110,
+                      "start": 112,
+                      "end": 113,
                       "ctxt": 0
                     },
                     "value": 0.0
@@ -132,15 +132,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 125,
-            "end": 144,
+            "start": 129,
+            "end": 148,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 138,
-              "end": 141,
+              "start": 142,
+              "end": 145,
               "ctxt": 0
             },
             "value": "pua",
@@ -151,8 +151,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 125,
-              "end": 144,
+              "start": 129,
+              "end": 148,
               "ctxt": 0
             },
             "body": null,
@@ -170,15 +170,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 156,
-            "end": 186,
+            "start": 161,
+            "end": 191,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 167,
-              "end": 170,
+              "start": 172,
+              "end": 175,
               "ctxt": 0
             },
             "value": "pus",
@@ -189,30 +189,30 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 156,
-              "end": 186,
+              "start": 161,
+              "end": 191,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 173,
-                "end": 186,
+                "start": 178,
+                "end": 191,
                 "ctxt": 0
               },
               "stmts": [
                 {
                   "type": "ReturnStatement",
                   "span": {
-                    "start": 175,
-                    "end": 184,
+                    "start": 180,
+                    "end": 189,
                     "ctxt": 0
                   },
                   "argument": {
                     "type": "NumericLiteral",
                     "span": {
-                      "start": 182,
-                      "end": 183,
+                      "start": 187,
+                      "end": 188,
                       "ctxt": 0
                     },
                     "value": 0.0
@@ -234,15 +234,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 199,
-            "end": 221,
+            "start": 206,
+            "end": 228,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 203,
-              "end": 205,
+              "start": 210,
+              "end": 212,
               "ctxt": 0
             },
             "value": "pu",
@@ -253,30 +253,30 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 199,
-              "end": 221,
+              "start": 206,
+              "end": 228,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 208,
-                "end": 221,
+                "start": 215,
+                "end": 228,
                 "ctxt": 0
               },
               "stmts": [
                 {
                   "type": "ReturnStatement",
                   "span": {
-                    "start": 210,
-                    "end": 219,
+                    "start": 217,
+                    "end": 226,
                     "ctxt": 0
                   },
                   "argument": {
                     "type": "NumericLiteral",
                     "span": {
-                      "start": 217,
-                      "end": 218,
+                      "start": 224,
+                      "end": 225,
                       "ctxt": 0
                     },
                     "value": 0.0
@@ -298,15 +298,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 236,
-            "end": 258,
+            "start": 244,
+            "end": 266,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 240,
-              "end": 242,
+              "start": 248,
+              "end": 250,
               "ctxt": 0
             },
             "value": "po",
@@ -317,30 +317,30 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 236,
-              "end": 258,
+              "start": 244,
+              "end": 266,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 245,
-                "end": 258,
+                "start": 253,
+                "end": 266,
                 "ctxt": 0
               },
               "stmts": [
                 {
                   "type": "ReturnStatement",
                   "span": {
-                    "start": 247,
-                    "end": 256,
+                    "start": 255,
+                    "end": 264,
                     "ctxt": 0
                   },
                   "argument": {
                     "type": "NumericLiteral",
                     "span": {
-                      "start": 254,
-                      "end": 255,
+                      "start": 262,
+                      "end": 263,
                       "ctxt": 0
                     },
                     "value": 0.0
@@ -362,15 +362,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 271,
-            "end": 293,
+            "start": 280,
+            "end": 302,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 275,
-              "end": 277,
+              "start": 284,
+              "end": 286,
               "ctxt": 0
             },
             "value": "pi",
@@ -381,30 +381,30 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 271,
-              "end": 293,
+              "start": 280,
+              "end": 302,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 280,
-                "end": 293,
+                "start": 289,
+                "end": 302,
                 "ctxt": 0
               },
               "stmts": [
                 {
                   "type": "ReturnStatement",
                   "span": {
-                    "start": 282,
-                    "end": 291,
+                    "start": 291,
+                    "end": 300,
                     "ctxt": 0
                   },
                   "argument": {
                     "type": "NumericLiteral",
                     "span": {
-                      "start": 289,
-                      "end": 290,
+                      "start": 298,
+                      "end": 299,
                       "ctxt": 0
                     },
                     "value": 0.0

--- a/ecmascript/parser/tests/typescript/class/modifiers-methods-async/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-methods-async/input.ts.json
@@ -1,8 +1,8 @@
 {
   "type": "Module",
   "span": {
-    "start": 42,
-    "end": 256,
+    "start": 43,
+    "end": 266,
     "ctxt": 0
   },
   "body": [
@@ -11,8 +11,8 @@
       "identifier": {
         "type": "Identifier",
         "span": {
-          "start": 57,
-          "end": 58,
+          "start": 58,
+          "end": 59,
           "ctxt": 0
         },
         "value": "C",
@@ -21,8 +21,8 @@
       },
       "declare": false,
       "span": {
-        "start": 51,
-        "end": 256,
+        "start": 52,
+        "end": 266,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 65,
-            "end": 84,
+            "start": 67,
+            "end": 86,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 80,
-              "end": 81,
+              "start": 82,
+              "end": 83,
               "ctxt": 0
             },
             "value": "a",
@@ -49,8 +49,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 65,
-              "end": 84,
+              "start": 67,
+              "end": 86,
               "ctxt": 0
             },
             "body": null,
@@ -68,15 +68,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 89,
-            "end": 108,
+            "start": 92,
+            "end": 111,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 102,
-              "end": 103,
+              "start": 105,
+              "end": 106,
               "ctxt": 0
             },
             "value": "s",
@@ -87,15 +87,15 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 89,
-              "end": 108,
+              "start": 92,
+              "end": 111,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 106,
-                "end": 108,
+                "start": 109,
+                "end": 111,
                 "ctxt": 0
               },
               "stmts": []
@@ -114,15 +114,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 120,
-            "end": 141,
+            "start": 124,
+            "end": 145,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 135,
-              "end": 138,
+              "start": 139,
+              "end": 142,
               "ctxt": 0
             },
             "value": "pua",
@@ -133,8 +133,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 120,
-              "end": 141,
+              "start": 124,
+              "end": 145,
               "ctxt": 0
             },
             "body": null,
@@ -152,15 +152,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 153,
-            "end": 174,
+            "start": 158,
+            "end": 179,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 166,
-              "end": 169,
+              "start": 171,
+              "end": 174,
               "ctxt": 0
             },
             "value": "pus",
@@ -171,15 +171,15 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 153,
-              "end": 174,
+              "start": 158,
+              "end": 179,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 172,
-                "end": 174,
+                "start": 177,
+                "end": 179,
                 "ctxt": 0
               },
               "stmts": []
@@ -198,15 +198,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 187,
-            "end": 200,
+            "start": 194,
+            "end": 207,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 193,
-              "end": 195,
+              "start": 200,
+              "end": 202,
               "ctxt": 0
             },
             "value": "pu",
@@ -217,15 +217,15 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 187,
-              "end": 200,
+              "start": 194,
+              "end": 207,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 198,
-                "end": 200,
+                "start": 205,
+                "end": 207,
                 "ctxt": 0
               },
               "stmts": []
@@ -244,15 +244,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 215,
-            "end": 228,
+            "start": 223,
+            "end": 236,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 221,
-              "end": 223,
+              "start": 229,
+              "end": 231,
               "ctxt": 0
             },
             "value": "po",
@@ -263,15 +263,15 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 215,
-              "end": 228,
+              "start": 223,
+              "end": 236,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 226,
-                "end": 228,
+                "start": 234,
+                "end": 236,
                 "ctxt": 0
               },
               "stmts": []
@@ -290,15 +290,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 241,
-            "end": 254,
+            "start": 250,
+            "end": 263,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 247,
-              "end": 249,
+              "start": 256,
+              "end": 258,
               "ctxt": 0
             },
             "value": "pi",
@@ -309,15 +309,15 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 241,
-              "end": 254,
+              "start": 250,
+              "end": 263,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 252,
-                "end": 254,
+                "start": 261,
+                "end": 263,
                 "ctxt": 0
               },
               "stmts": []

--- a/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 396,
+    "end": 416,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 9,
-        "end": 396,
+        "end": 416,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 23,
-            "end": 34,
+            "start": 24,
+            "end": 35,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 32,
-              "end": 33,
+              "start": 33,
+              "end": 34,
               "ctxt": 0
             },
             "value": "r",
@@ -59,15 +59,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 39,
-            "end": 60,
+            "start": 41,
+            "end": 62,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 48,
-              "end": 50,
+              "start": 50,
+              "end": 52,
               "ctxt": 0
             },
             "value": "r2",
@@ -78,15 +78,15 @@
           "typeAnnotation": {
             "type": "TsTypeAnnotation",
             "span": {
-              "start": 51,
-              "end": 59,
+              "start": 53,
+              "end": 61,
               "ctxt": 0
             },
             "typeAnnotation": {
               "type": "TsKeywordType",
               "span": {
-                "start": 53,
-                "end": 59,
+                "start": 55,
+                "end": 61,
                 "ctxt": 0
               },
               "kind": "number"
@@ -104,15 +104,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 65,
-            "end": 76,
+            "start": 68,
+            "end": 79,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 74,
-              "end": 75,
+              "start": 77,
+              "end": 78,
               "ctxt": 0
             },
             "value": "a",
@@ -133,15 +133,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 81,
-            "end": 90,
+            "start": 85,
+            "end": 94,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 88,
-              "end": 89,
+              "start": 92,
+              "end": 93,
               "ctxt": 0
             },
             "value": "s",
@@ -162,15 +162,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 103,
-            "end": 106,
+            "start": 109,
+            "end": 112,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 103,
-              "end": 105,
+              "start": 109,
+              "end": 111,
               "ctxt": 0
             },
             "value": "pu",
@@ -191,15 +191,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 121,
-            "end": 124,
+            "start": 128,
+            "end": 131,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 121,
-              "end": 123,
+              "start": 128,
+              "end": 130,
               "ctxt": 0
             },
             "value": "po",
@@ -220,15 +220,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 137,
-            "end": 140,
+            "start": 145,
+            "end": 148,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 137,
-              "end": 139,
+              "start": 145,
+              "end": 147,
               "ctxt": 0
             },
             "value": "pi",
@@ -249,15 +249,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 146,
-            "end": 167,
+            "start": 156,
+            "end": 177,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 164,
-              "end": 166,
+              "start": 174,
+              "end": 176,
               "ctxt": 0
             },
             "value": "ra",
@@ -278,15 +278,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 172,
-            "end": 193,
+            "start": 183,
+            "end": 204,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 190,
-              "end": 192,
+              "start": 201,
+              "end": 203,
               "ctxt": 0
             },
             "value": "ar",
@@ -307,15 +307,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 198,
-            "end": 217,
+            "start": 210,
+            "end": 229,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 214,
-              "end": 216,
+              "start": 226,
+              "end": 228,
               "ctxt": 0
             },
             "value": "sr",
@@ -336,15 +336,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 230,
-            "end": 243,
+            "start": 244,
+            "end": 257,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 239,
-              "end": 242,
+              "start": 253,
+              "end": 256,
               "ctxt": 0
             },
             "value": "pur",
@@ -365,15 +365,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 255,
-            "end": 268,
+            "start": 270,
+            "end": 283,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 264,
-              "end": 267,
+              "start": 279,
+              "end": 282,
               "ctxt": 0
             },
             "value": "pua",
@@ -394,15 +394,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 280,
-            "end": 291,
+            "start": 296,
+            "end": 307,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 287,
-              "end": 290,
+              "start": 303,
+              "end": 306,
               "ctxt": 0
             },
             "value": "pus",
@@ -423,15 +423,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 303,
-            "end": 326,
+            "start": 320,
+            "end": 343,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 321,
-              "end": 325,
+              "start": 338,
+              "end": 342,
               "ctxt": 0
             },
             "value": "pura",
@@ -452,15 +452,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 338,
-            "end": 361,
+            "start": 356,
+            "end": 379,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 356,
-              "end": 360,
+              "start": 374,
+              "end": 378,
               "ctxt": 0
             },
             "value": "puar",
@@ -481,15 +481,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 373,
-            "end": 394,
+            "start": 392,
+            "end": 413,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 389,
-              "end": 393,
+              "start": 408,
+              "end": 412,
               "ctxt": 0
             },
             "value": "pusr",

--- a/ecmascript/parser/tests/typescript/class/parameter-properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/parameter-properties/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 257,
+    "end": 267,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 257,
+        "end": 267,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "Constructor",
           "span": {
-            "start": 14,
-            "end": 255,
+            "start": 15,
+            "end": 264,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 14,
-              "end": 25,
+              "start": 15,
+              "end": 26,
               "ctxt": 0
             },
             "value": "constructor",
@@ -49,8 +49,8 @@
             {
               "type": "TsParameterProperty",
               "span": {
-                "start": 35,
-                "end": 43,
+                "start": 37,
+                "end": 45,
                 "ctxt": 0
               },
               "decorators": [],
@@ -59,8 +59,8 @@
               "param": {
                 "type": "Identifier",
                 "span": {
-                  "start": 44,
-                  "end": 45,
+                  "start": 46,
+                  "end": 47,
                   "ctxt": 0
                 },
                 "value": "r",
@@ -71,8 +71,8 @@
             {
               "type": "TsParameterProperty",
               "span": {
-                "start": 55,
-                "end": 61,
+                "start": 58,
+                "end": 64,
                 "ctxt": 0
               },
               "decorators": [],
@@ -81,23 +81,23 @@
               "param": {
                 "type": "Identifier",
                 "span": {
-                  "start": 62,
-                  "end": 64,
+                  "start": 65,
+                  "end": 67,
                   "ctxt": 0
                 },
                 "value": "pu",
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 64,
-                    "end": 72,
+                    "start": 67,
+                    "end": 75,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 66,
-                      "end": 72,
+                      "start": 69,
+                      "end": 75,
                       "ctxt": 0
                     },
                     "kind": "number"
@@ -109,8 +109,8 @@
             {
               "type": "TsParameterProperty",
               "span": {
-                "start": 82,
-                "end": 91,
+                "start": 86,
+                "end": 95,
                 "ctxt": 0
               },
               "decorators": [],
@@ -119,8 +119,8 @@
               "param": {
                 "type": "Identifier",
                 "span": {
-                  "start": 92,
-                  "end": 94,
+                  "start": 96,
+                  "end": 98,
                   "ctxt": 0
                 },
                 "value": "po",
@@ -131,8 +131,8 @@
             {
               "type": "TsParameterProperty",
               "span": {
-                "start": 105,
-                "end": 112,
+                "start": 110,
+                "end": 117,
                 "ctxt": 0
               },
               "decorators": [],
@@ -141,23 +141,23 @@
               "param": {
                 "type": "Identifier",
                 "span": {
-                  "start": 113,
-                  "end": 115,
+                  "start": 118,
+                  "end": 120,
                   "ctxt": 0
                 },
                 "value": "pi",
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 116,
-                    "end": 124,
+                    "start": 121,
+                    "end": 129,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 118,
-                      "end": 124,
+                      "start": 123,
+                      "end": 129,
                       "ctxt": 0
                     },
                     "kind": "number"
@@ -169,8 +169,8 @@
             {
               "type": "TsParameterProperty",
               "span": {
-                "start": 134,
-                "end": 149,
+                "start": 140,
+                "end": 155,
                 "ctxt": 0
               },
               "decorators": [],
@@ -179,8 +179,8 @@
               "param": {
                 "type": "Identifier",
                 "span": {
-                  "start": 150,
-                  "end": 153,
+                  "start": 156,
+                  "end": 159,
                   "ctxt": 0
                 },
                 "value": "pur",
@@ -191,8 +191,8 @@
             {
               "type": "TsParameterProperty",
               "span": {
-                "start": 206,
-                "end": 214,
+                "start": 214,
+                "end": 222,
                 "ctxt": 0
               },
               "decorators": [],
@@ -201,15 +201,15 @@
               "param": {
                 "type": "AssignmentPattern",
                 "span": {
-                  "start": 215,
-                  "end": 220,
+                  "start": 223,
+                  "end": 228,
                   "ctxt": 0
                 },
                 "left": {
                   "type": "Identifier",
                   "span": {
-                    "start": 215,
-                    "end": 216,
+                    "start": 223,
+                    "end": 224,
                     "ctxt": 0
                   },
                   "value": "x",
@@ -219,8 +219,8 @@
                 "right": {
                   "type": "NumericLiteral",
                   "span": {
-                    "start": 219,
-                    "end": 220,
+                    "start": 227,
+                    "end": 228,
                     "ctxt": 0
                   },
                   "value": 0.0
@@ -231,8 +231,8 @@
             {
               "type": "TsParameterProperty",
               "span": {
-                "start": 230,
-                "end": 236,
+                "start": 239,
+                "end": 245,
                 "ctxt": 0
               },
               "decorators": [],
@@ -241,30 +241,30 @@
               "param": {
                 "type": "AssignmentPattern",
                 "span": {
-                  "start": 237,
-                  "end": 251,
+                  "start": 246,
+                  "end": 260,
                   "ctxt": 0
                 },
                 "left": {
                   "type": "Identifier",
                   "span": {
-                    "start": 237,
-                    "end": 238,
+                    "start": 246,
+                    "end": 247,
                     "ctxt": 0
                   },
                   "value": "y",
                   "typeAnnotation": {
                     "type": "TsTypeAnnotation",
                     "span": {
-                      "start": 239,
-                      "end": 247,
+                      "start": 248,
+                      "end": 256,
                       "ctxt": 0
                     },
                     "typeAnnotation": {
                       "type": "TsKeywordType",
                       "span": {
-                        "start": 241,
-                        "end": 247,
+                        "start": 250,
+                        "end": 256,
                         "ctxt": 0
                       },
                       "kind": "number"
@@ -275,8 +275,8 @@
                 "right": {
                   "type": "NumericLiteral",
                   "span": {
-                    "start": 250,
-                    "end": 251,
+                    "start": 259,
+                    "end": 260,
                     "ctxt": 0
                   },
                   "value": 0.0
@@ -288,8 +288,8 @@
           "body": {
             "type": "BlockStatement",
             "span": {
-              "start": 253,
-              "end": 255,
+              "start": 262,
+              "end": 264,
               "ctxt": 0
             },
             "stmts": []

--- a/ecmascript/parser/tests/typescript/class/properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/properties/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 84,
+    "end": 91,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 84,
+        "end": 91,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 14,
-            "end": 16,
+            "start": 15,
+            "end": 17,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 14,
-              "end": 15,
+              "start": 15,
+              "end": 16,
               "ctxt": 0
             },
             "value": "x",
@@ -59,15 +59,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 21,
-            "end": 24,
+            "start": 23,
+            "end": 26,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 21,
-              "end": 22,
+              "start": 23,
+              "end": 24,
               "ctxt": 0
             },
             "value": "x",
@@ -88,15 +88,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 29,
-            "end": 39,
+            "start": 32,
+            "end": 42,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 29,
-              "end": 30,
+              "start": 32,
+              "end": 33,
               "ctxt": 0
             },
             "value": "x",
@@ -107,15 +107,15 @@
           "typeAnnotation": {
             "type": "TsTypeAnnotation",
             "span": {
-              "start": 30,
-              "end": 38,
+              "start": 33,
+              "end": 41,
               "ctxt": 0
             },
             "typeAnnotation": {
               "type": "TsKeywordType",
               "span": {
-                "start": 32,
-                "end": 38,
+                "start": 35,
+                "end": 41,
                 "ctxt": 0
               },
               "kind": "number"
@@ -133,15 +133,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 44,
-            "end": 58,
+            "start": 48,
+            "end": 62,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 44,
-              "end": 45,
+              "start": 48,
+              "end": 49,
               "ctxt": 0
             },
             "value": "x",
@@ -151,8 +151,8 @@
           "value": {
             "type": "NumericLiteral",
             "span": {
-              "start": 56,
-              "end": 57,
+              "start": 60,
+              "end": 61,
               "ctxt": 0
             },
             "value": 1.0
@@ -160,15 +160,15 @@
           "typeAnnotation": {
             "type": "TsTypeAnnotation",
             "span": {
-              "start": 45,
-              "end": 53,
+              "start": 49,
+              "end": 57,
               "ctxt": 0
             },
             "typeAnnotation": {
               "type": "TsKeywordType",
               "span": {
-                "start": 47,
-                "end": 53,
+                "start": 51,
+                "end": 57,
                 "ctxt": 0
               },
               "kind": "number"
@@ -186,15 +186,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 63,
-            "end": 66,
+            "start": 68,
+            "end": 71,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 63,
-              "end": 64,
+              "start": 68,
+              "end": 69,
               "ctxt": 0
             },
             "value": "x",
@@ -215,15 +215,15 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 71,
-            "end": 82,
+            "start": 77,
+            "end": 88,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 71,
-              "end": 72,
+              "start": 77,
+              "end": 78,
               "ctxt": 0
             },
             "value": "x",
@@ -234,15 +234,15 @@
           "typeAnnotation": {
             "type": "TsTypeAnnotation",
             "span": {
-              "start": 73,
-              "end": 81,
+              "start": 79,
+              "end": 87,
               "ctxt": 0
             },
             "typeAnnotation": {
               "type": "TsKeywordType",
               "span": {
-                "start": 75,
-                "end": 81,
+                "start": 81,
+                "end": 87,
                 "ctxt": 0
               },
               "kind": "number"

--- a/ecmascript/parser/tests/typescript/class/property-computed/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/property-computed/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 74,
+    "end": 77,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 74,
+        "end": 77,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,22 +30,22 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 14,
-            "end": 40,
+            "start": 15,
+            "end": 41,
             "ctxt": 0
           },
           "key": {
             "type": "MemberExpression",
             "span": {
-              "start": 15,
-              "end": 30,
+              "start": 16,
+              "end": 31,
               "ctxt": 0
             },
             "object": {
               "type": "Identifier",
               "span": {
-                "start": 15,
-                "end": 21,
+                "start": 16,
+                "end": 22,
                 "ctxt": 0
               },
               "value": "Symbol",
@@ -55,8 +55,8 @@
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 22,
-                "end": 30,
+                "start": 23,
+                "end": 31,
                 "ctxt": 0
               },
               "value": "iterator",
@@ -69,15 +69,15 @@
           "typeAnnotation": {
             "type": "TsTypeAnnotation",
             "span": {
-              "start": 31,
-              "end": 39,
+              "start": 32,
+              "end": 40,
               "ctxt": 0
             },
             "typeAnnotation": {
               "type": "TsKeywordType",
               "span": {
-                "start": 33,
-                "end": 39,
+                "start": 34,
+                "end": 40,
                 "ctxt": 0
               },
               "kind": "number"
@@ -95,22 +95,22 @@
         {
           "type": "ClassProperty",
           "span": {
-            "start": 45,
-            "end": 72,
+            "start": 47,
+            "end": 74,
             "ctxt": 0
           },
           "key": {
             "type": "MemberExpression",
             "span": {
-              "start": 46,
-              "end": 61,
+              "start": 48,
+              "end": 63,
               "ctxt": 0
             },
             "object": {
               "type": "Identifier",
               "span": {
-                "start": 46,
-                "end": 52,
+                "start": 48,
+                "end": 54,
                 "ctxt": 0
               },
               "value": "Symbol",
@@ -120,8 +120,8 @@
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 53,
-                "end": 61,
+                "start": 55,
+                "end": 63,
                 "ctxt": 0
               },
               "value": "iterator",
@@ -134,15 +134,15 @@
           "typeAnnotation": {
             "type": "TsTypeAnnotation",
             "span": {
-              "start": 63,
-              "end": 71,
+              "start": 65,
+              "end": 73,
               "ctxt": 0
             },
             "typeAnnotation": {
               "type": "TsKeywordType",
               "span": {
-                "start": 65,
-                "end": 71,
+                "start": 67,
+                "end": 73,
                 "ctxt": 0
               },
               "kind": "number"

--- a/ecmascript/parser/tests/typescript/class/static/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/static/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 100,
+    "end": 105,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 100,
+        "end": 105,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,15 +30,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 14,
-            "end": 25,
+            "start": 15,
+            "end": 26,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 21,
-              "end": 22,
+              "start": 22,
+              "end": 23,
               "ctxt": 0
             },
             "value": "f",
@@ -49,8 +49,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 14,
-              "end": 25,
+              "start": 15,
+              "end": 26,
               "ctxt": 0
             },
             "body": null,
@@ -68,15 +68,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 37,
-            "end": 48,
+            "start": 39,
+            "end": 50,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 44,
-              "end": 45,
+              "start": 46,
+              "end": 47,
               "ctxt": 0
             },
             "value": "f",
@@ -87,8 +87,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 37,
-              "end": 48,
+              "start": 39,
+              "end": 50,
               "ctxt": 0
             },
             "body": null,
@@ -106,15 +106,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 63,
-            "end": 74,
+            "start": 66,
+            "end": 77,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 70,
-              "end": 71,
+              "start": 73,
+              "end": 74,
               "ctxt": 0
             },
             "value": "f",
@@ -125,8 +125,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 63,
-              "end": 74,
+              "start": 66,
+              "end": 77,
               "ctxt": 0
             },
             "body": null,
@@ -144,15 +144,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 87,
-            "end": 98,
+            "start": 91,
+            "end": 102,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 94,
-              "end": 95,
+              "start": 98,
+              "end": 99,
               "ctxt": 0
             },
             "value": "f",
@@ -163,8 +163,8 @@
             "params": [],
             "decorators": [],
             "span": {
-              "start": 87,
-              "end": 98,
+              "start": 91,
+              "end": 102,
               "ctxt": 0
             },
             "body": null,

--- a/ecmascript/parser/tests/typescript/custom/const-enum/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/const-enum/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 38,
+    "end": 42,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsEnumDeclaration",
       "span": {
         "start": 0,
-        "end": 38,
+        "end": 42,
         "ctxt": 0
       },
       "declare": false,
@@ -30,15 +30,15 @@
         {
           "type": "TsEnumMember",
           "span": {
-            "start": 21,
-            "end": 22,
+            "start": 22,
+            "end": 23,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 21,
-              "end": 22,
+              "start": 22,
+              "end": 23,
               "ctxt": 0
             },
             "value": "A",
@@ -50,15 +50,15 @@
         {
           "type": "TsEnumMember",
           "span": {
-            "start": 28,
-            "end": 29,
+            "start": 30,
+            "end": 31,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 28,
-              "end": 29,
+              "start": 30,
+              "end": 31,
               "ctxt": 0
             },
             "value": "B",
@@ -70,15 +70,15 @@
         {
           "type": "TsEnumMember",
           "span": {
-            "start": 35,
-            "end": 36,
+            "start": 38,
+            "end": 39,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 35,
-              "end": 36,
+              "start": 38,
+              "end": 39,
               "ctxt": 0
             },
             "value": "C",

--- a/ecmascript/parser/tests/typescript/custom/default-followed-by-type/arrow/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/default-followed-by-type/arrow/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 97,
+    "end": 99,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "VariableDeclaration",
       "span": {
         "start": 0,
-        "end": 97,
+        "end": 99,
         "ctxt": 0
       },
       "kind": "var",
@@ -20,7 +20,7 @@
           "type": "VariableDeclarator",
           "span": {
             "start": 4,
-            "end": 96,
+            "end": 98,
             "ctxt": 0
           },
           "id": {
@@ -38,7 +38,7 @@
             "type": "ArrowFunctionExpression",
             "span": {
               "start": 8,
-              "end": 96,
+              "end": 98,
               "ctxt": 0
             },
             "params": [
@@ -120,30 +120,30 @@
               "type": "BlockStatement",
               "span": {
                 "start": 56,
-                "end": 96,
+                "end": 98,
                 "ctxt": 0
               },
               "stmts": [
                 {
                   "type": "ReturnStatement",
                   "span": {
-                    "start": 62,
-                    "end": 94,
+                    "start": 63,
+                    "end": 95,
                     "ctxt": 0
                   },
                   "argument": {
                     "type": "TemplateLiteral",
                     "span": {
-                      "start": 69,
-                      "end": 93,
+                      "start": 70,
+                      "end": 94,
                       "ctxt": 0
                     },
                     "expressions": [
                       {
                         "type": "Identifier",
                         "span": {
-                          "start": 72,
-                          "end": 80,
+                          "start": 73,
+                          "end": 81,
                           "ctxt": 0
                         },
                         "value": "greeting",
@@ -153,8 +153,8 @@
                       {
                         "type": "Identifier",
                         "span": {
-                          "start": 84,
-                          "end": 90,
+                          "start": 85,
+                          "end": 91,
                           "ctxt": 0
                         },
                         "value": "target",
@@ -166,16 +166,16 @@
                       {
                         "type": "TemplateElement",
                         "span": {
-                          "start": 70,
-                          "end": 70,
+                          "start": 71,
+                          "end": 71,
                           "ctxt": 0
                         },
                         "tail": false,
                         "cooked": {
                           "type": "StringLiteral",
                           "span": {
-                            "start": 70,
-                            "end": 70,
+                            "start": 71,
+                            "end": 71,
                             "ctxt": 0
                           },
                           "value": "",
@@ -184,8 +184,8 @@
                         "raw": {
                           "type": "StringLiteral",
                           "span": {
-                            "start": 70,
-                            "end": 70,
+                            "start": 71,
+                            "end": 71,
                             "ctxt": 0
                           },
                           "value": "",
@@ -195,16 +195,16 @@
                       {
                         "type": "TemplateElement",
                         "span": {
-                          "start": 81,
-                          "end": 82,
+                          "start": 82,
+                          "end": 83,
                           "ctxt": 0
                         },
                         "tail": false,
                         "cooked": {
                           "type": "StringLiteral",
                           "span": {
-                            "start": 81,
-                            "end": 82,
+                            "start": 82,
+                            "end": 83,
                             "ctxt": 0
                           },
                           "value": " ",
@@ -213,8 +213,8 @@
                         "raw": {
                           "type": "StringLiteral",
                           "span": {
-                            "start": 81,
-                            "end": 82,
+                            "start": 82,
+                            "end": 83,
                             "ctxt": 0
                           },
                           "value": " ",
@@ -224,16 +224,16 @@
                       {
                         "type": "TemplateElement",
                         "span": {
-                          "start": 91,
-                          "end": 92,
+                          "start": 92,
+                          "end": 93,
                           "ctxt": 0
                         },
                         "tail": true,
                         "cooked": {
                           "type": "StringLiteral",
                           "span": {
-                            "start": 91,
-                            "end": 92,
+                            "start": 92,
+                            "end": 93,
                             "ctxt": 0
                           },
                           "value": "!",
@@ -242,8 +242,8 @@
                         "raw": {
                           "type": "StringLiteral",
                           "span": {
-                            "start": 91,
-                            "end": 92,
+                            "start": 92,
+                            "end": 93,
                             "ctxt": 0
                           },
                           "value": "!",

--- a/ecmascript/parser/tests/typescript/custom/default-followed-by-type/function/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/default-followed-by-type/function/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 99,
+    "end": 101,
     "ctxt": 0
   },
   "body": [
@@ -98,37 +98,37 @@
       "decorators": [],
       "span": {
         "start": 0,
-        "end": 98,
+        "end": 100,
         "ctxt": 0
       },
       "body": {
         "type": "BlockStatement",
         "span": {
           "start": 58,
-          "end": 98,
+          "end": 100,
           "ctxt": 0
         },
         "stmts": [
           {
             "type": "ReturnStatement",
             "span": {
-              "start": 64,
-              "end": 96,
+              "start": 65,
+              "end": 97,
               "ctxt": 0
             },
             "argument": {
               "type": "TemplateLiteral",
               "span": {
-                "start": 71,
-                "end": 95,
+                "start": 72,
+                "end": 96,
                 "ctxt": 0
               },
               "expressions": [
                 {
                   "type": "Identifier",
                   "span": {
-                    "start": 74,
-                    "end": 82,
+                    "start": 75,
+                    "end": 83,
                     "ctxt": 0
                   },
                   "value": "greeting",
@@ -138,8 +138,8 @@
                 {
                   "type": "Identifier",
                   "span": {
-                    "start": 86,
-                    "end": 92,
+                    "start": 87,
+                    "end": 93,
                     "ctxt": 0
                   },
                   "value": "target",
@@ -151,16 +151,16 @@
                 {
                   "type": "TemplateElement",
                   "span": {
-                    "start": 72,
-                    "end": 72,
+                    "start": 73,
+                    "end": 73,
                     "ctxt": 0
                   },
                   "tail": false,
                   "cooked": {
                     "type": "StringLiteral",
                     "span": {
-                      "start": 72,
-                      "end": 72,
+                      "start": 73,
+                      "end": 73,
                       "ctxt": 0
                     },
                     "value": "",
@@ -169,8 +169,8 @@
                   "raw": {
                     "type": "StringLiteral",
                     "span": {
-                      "start": 72,
-                      "end": 72,
+                      "start": 73,
+                      "end": 73,
                       "ctxt": 0
                     },
                     "value": "",
@@ -180,16 +180,16 @@
                 {
                   "type": "TemplateElement",
                   "span": {
-                    "start": 83,
-                    "end": 84,
+                    "start": 84,
+                    "end": 85,
                     "ctxt": 0
                   },
                   "tail": false,
                   "cooked": {
                     "type": "StringLiteral",
                     "span": {
-                      "start": 83,
-                      "end": 84,
+                      "start": 84,
+                      "end": 85,
                       "ctxt": 0
                     },
                     "value": " ",
@@ -198,8 +198,8 @@
                   "raw": {
                     "type": "StringLiteral",
                     "span": {
-                      "start": 83,
-                      "end": 84,
+                      "start": 84,
+                      "end": 85,
                       "ctxt": 0
                     },
                     "value": " ",
@@ -209,16 +209,16 @@
                 {
                   "type": "TemplateElement",
                   "span": {
-                    "start": 93,
-                    "end": 94,
+                    "start": 94,
+                    "end": 95,
                     "ctxt": 0
                   },
                   "tail": true,
                   "cooked": {
                     "type": "StringLiteral",
                     "span": {
-                      "start": 93,
-                      "end": 94,
+                      "start": 94,
+                      "end": 95,
                       "ctxt": 0
                     },
                     "value": "!",
@@ -227,8 +227,8 @@
                   "raw": {
                     "type": "StringLiteral",
                     "span": {
-                      "start": 93,
-                      "end": 94,
+                      "start": 94,
+                      "end": 95,
                       "ctxt": 0
                     },
                     "value": "!",
@@ -248,8 +248,8 @@
     {
       "type": "EmptyStatement",
       "span": {
-        "start": 98,
-        "end": 99,
+        "start": 100,
+        "end": 101,
         "ctxt": 0
       }
     }

--- a/ecmascript/parser/tests/typescript/custom/issue-196-02/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-196-02/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 59,
+    "end": 60,
     "ctxt": 0
   },
   "body": [
@@ -124,23 +124,23 @@
     {
       "type": "ExportNamedDeclaration",
       "span": {
-        "start": 43,
-        "end": 59,
+        "start": 44,
+        "end": 60,
         "ctxt": 0
       },
       "specifiers": [
         {
           "type": "ExportSpecifier",
           "span": {
-            "start": 52,
-            "end": 56,
+            "start": 53,
+            "end": 57,
             "ctxt": 0
           },
           "orig": {
             "type": "Identifier",
             "span": {
-              "start": 52,
-              "end": 56,
+              "start": 53,
+              "end": 57,
               "ctxt": 0
             },
             "value": "Link",

--- a/ecmascript/parser/tests/typescript/custom/issue-236/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-236/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 171,
+    "end": 174,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "ExportDeclaration",
       "span": {
         "start": 0,
-        "end": 171,
+        "end": 174,
         "ctxt": 0
       },
       "declaration": {
@@ -163,45 +163,45 @@
         "decorators": [],
         "span": {
           "start": 7,
-          "end": 171,
+          "end": 174,
           "ctxt": 0
         },
         "body": {
           "type": "BlockStatement",
           "span": {
             "start": 116,
-            "end": 171,
+            "end": 174,
             "ctxt": 0
           },
           "stmts": [
             {
               "type": "AssignmentExpression",
               "span": {
-                "start": 122,
-                "end": 142,
+                "start": 123,
+                "end": 143,
                 "ctxt": 0
               },
               "operator": "=",
               "left": {
                 "type": "MemberExpression",
                 "span": {
-                  "start": 122,
-                  "end": 133,
+                  "start": 123,
+                  "end": 134,
                   "ctxt": 0
                 },
                 "object": {
                   "type": "ThisExpression",
                   "span": {
-                    "start": 122,
-                    "end": 126,
+                    "start": 123,
+                    "end": 127,
                     "ctxt": 0
                   }
                 },
                 "property": {
                   "type": "Identifier",
                   "span": {
-                    "start": 127,
-                    "end": 133,
+                    "start": 128,
+                    "end": 134,
                     "ctxt": 0
                   },
                   "value": "$scope",
@@ -213,8 +213,8 @@
               "right": {
                 "type": "Identifier",
                 "span": {
-                  "start": 136,
-                  "end": 142,
+                  "start": 137,
+                  "end": 143,
                   "ctxt": 0
                 },
                 "value": "$scope",
@@ -225,31 +225,31 @@
             {
               "type": "AssignmentExpression",
               "span": {
-                "start": 148,
-                "end": 168,
+                "start": 150,
+                "end": 170,
                 "ctxt": 0
               },
               "operator": "=",
               "left": {
                 "type": "MemberExpression",
                 "span": {
-                  "start": 148,
-                  "end": 159,
+                  "start": 150,
+                  "end": 161,
                   "ctxt": 0
                 },
                 "object": {
                   "type": "ThisExpression",
                   "span": {
-                    "start": 148,
-                    "end": 152,
+                    "start": 150,
+                    "end": 154,
                     "ctxt": 0
                   }
                 },
                 "property": {
                   "type": "Identifier",
                   "span": {
-                    "start": 153,
-                    "end": 159,
+                    "start": 155,
+                    "end": 161,
                     "ctxt": 0
                   },
                   "value": "$attrs",
@@ -261,8 +261,8 @@
               "right": {
                 "type": "Identifier",
                 "span": {
-                  "start": 162,
-                  "end": 168,
+                  "start": 164,
+                  "end": 170,
                   "ctxt": 0
                 },
                 "value": "$attrs",

--- a/ecmascript/parser/tests/typescript/custom/issue-370/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-370/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 39,
+    "end": 43,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "VariableDeclaration",
       "span": {
         "start": 0,
-        "end": 39,
+        "end": 43,
         "ctxt": 0
       },
       "kind": "const",
@@ -20,7 +20,7 @@
           "type": "VariableDeclarator",
           "span": {
             "start": 6,
-            "end": 38,
+            "end": 42,
             "ctxt": 0
           },
           "id": {
@@ -65,15 +65,15 @@
             "type": "ArrowFunctionExpression",
             "span": {
               "start": 13,
-              "end": 38,
+              "end": 42,
               "ctxt": 0
             },
             "params": [
               {
                 "type": "Identifier",
                 "span": {
-                  "start": 19,
-                  "end": 20,
+                  "start": 20,
+                  "end": 21,
                   "ctxt": 0
                 },
                 "value": "a",
@@ -83,8 +83,8 @@
               {
                 "type": "Identifier",
                 "span": {
-                  "start": 26,
-                  "end": 27,
+                  "start": 28,
+                  "end": 29,
                   "ctxt": 0
                 },
                 "value": "b",
@@ -95,8 +95,8 @@
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 35,
-                "end": 38,
+                "start": 38,
+                "end": 42,
                 "ctxt": 0
               },
               "stmts": []

--- a/ecmascript/parser/tests/typescript/custom/issue-374/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-374/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 92,
+    "end": 93,
     "ctxt": 0
   },
   "body": [
@@ -67,8 +67,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 41,
-        "end": 92,
+        "start": 42,
+        "end": 93,
         "ctxt": 0
       },
       "kind": "let",
@@ -77,30 +77,30 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 45,
-            "end": 91,
+            "start": 46,
+            "end": 92,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 45,
-              "end": 54,
+              "start": 46,
+              "end": 55,
               "ctxt": 0
             },
             "value": "strLength",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 54,
-                "end": 62,
+                "start": 55,
+                "end": 63,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 56,
-                  "end": 62,
+                  "start": 57,
+                  "end": 63,
                   "ctxt": 0
                 },
                 "kind": "number"
@@ -111,29 +111,29 @@
           "init": {
             "type": "MemberExpression",
             "span": {
-              "start": 65,
-              "end": 91,
+              "start": 66,
+              "end": 92,
               "ctxt": 0
             },
             "object": {
               "type": "ParenthesisExpression",
               "span": {
-                "start": 65,
-                "end": 84,
+                "start": 66,
+                "end": 85,
                 "ctxt": 0
               },
               "expression": {
                 "type": "TsTypeAssertion",
                 "span": {
-                  "start": 66,
-                  "end": 83,
+                  "start": 67,
+                  "end": 84,
                   "ctxt": 0
                 },
                 "expression": {
                   "type": "Identifier",
                   "span": {
-                    "start": 74,
-                    "end": 83,
+                    "start": 75,
+                    "end": 84,
                     "ctxt": 0
                   },
                   "value": "someValue",
@@ -143,8 +143,8 @@
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 67,
-                    "end": 73,
+                    "start": 68,
+                    "end": 74,
                     "ctxt": 0
                   },
                   "kind": "string"
@@ -154,8 +154,8 @@
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 85,
-                "end": 91,
+                "start": 86,
+                "end": 92,
                 "ctxt": 0
               },
               "value": "length",

--- a/ecmascript/parser/tests/typescript/custom/issue-461/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-461/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 38,
+    "end": 40,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "ForInStatement",
       "span": {
         "start": 0,
-        "end": 38,
+        "end": 40,
         "ctxt": 0
       },
       "left": {
@@ -73,37 +73,37 @@
         "type": "BlockStatement",
         "span": {
           "start": 20,
-          "end": 38,
+          "end": 40,
           "ctxt": 0
         },
         "stmts": [
           {
             "type": "CallExpression",
             "span": {
-              "start": 24,
-              "end": 35,
+              "start": 25,
+              "end": 36,
               "ctxt": 0
             },
             "callee": {
               "type": "ParenthesisExpression",
               "span": {
-                "start": 24,
-                "end": 32,
+                "start": 25,
+                "end": 33,
                 "ctxt": 0
               },
               "expression": {
                 "type": "ArrowFunctionExpression",
                 "span": {
-                  "start": 25,
-                  "end": 32,
+                  "start": 26,
+                  "end": 33,
                   "ctxt": 0
                 },
                 "params": [
                   {
                     "type": "Identifier",
                     "span": {
-                      "start": 25,
-                      "end": 26,
+                      "start": 26,
+                      "end": 27,
                       "ctxt": 0
                     },
                     "value": "x",
@@ -114,8 +114,8 @@
                 "body": {
                   "type": "NumericLiteral",
                   "span": {
-                    "start": 30,
-                    "end": 31,
+                    "start": 31,
+                    "end": 32,
                     "ctxt": 0
                   },
                   "value": 0.0
@@ -132,8 +132,8 @@
                 "expression": {
                   "type": "Identifier",
                   "span": {
-                    "start": 33,
-                    "end": 34,
+                    "start": 34,
+                    "end": 35,
                     "ctxt": 0
                   },
                   "value": "x",

--- a/ecmascript/parser/tests/typescript/custom/tsx-unary-paren/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/custom/tsx-unary-paren/input.tsx.json
@@ -1,23 +1,23 @@
 {
   "type": "Module",
   "span": {
-    "start": 1,
-    "end": 183,
+    "start": 2,
+    "end": 194,
     "ctxt": 0
   },
   "body": [
     {
       "type": "ParenthesisExpression",
       "span": {
-        "start": 1,
-        "end": 182,
+        "start": 2,
+        "end": 193,
         "ctxt": 0
       },
       "expression": {
         "type": "JSXElement",
         "span": {
-          "start": 7,
-          "end": 180,
+          "start": 9,
+          "end": 190,
           "ctxt": 0
         },
         "opening": {
@@ -25,8 +25,8 @@
           "name": {
             "type": "Identifier",
             "span": {
-              "start": 8,
-              "end": 11,
+              "start": 10,
+              "end": 13,
               "ctxt": 0
             },
             "value": "div",
@@ -34,8 +34,8 @@
             "optional": false
           },
           "span": {
-            "start": 8,
-            "end": 12,
+            "start": 10,
+            "end": 14,
             "ctxt": 0
           },
           "attributes": [],
@@ -46,27 +46,27 @@
           {
             "type": "JSXText",
             "span": {
-              "start": 12,
-              "end": 21,
+              "start": 14,
+              "end": 24,
               "ctxt": 0
             },
-            "value": "\n\n        ",
-            "raw": "\n\n        "
+            "value": "\n\r\n        ",
+            "raw": "\n\r\n        "
           },
           {
             "type": "JSXExpressionContainer",
             "expression": {
               "type": "ConditionalExpression",
               "span": {
-                "start": 35,
-                "end": 158,
+                "start": 39,
+                "end": 165,
                 "ctxt": 0
               },
               "test": {
                 "type": "Identifier",
                 "span": {
-                  "start": 35,
-                  "end": 44,
+                  "start": 39,
+                  "end": 48,
                   "ctxt": 0
                 },
                 "value": "isLoading",
@@ -76,15 +76,15 @@
               "consequent": {
                 "type": "ParenthesisExpression",
                 "span": {
-                  "start": 63,
-                  "end": 82,
+                  "start": 68,
+                  "end": 87,
                   "ctxt": 0
                 },
                 "expression": {
                   "type": "JSXElement",
                   "span": {
-                    "start": 64,
-                    "end": 81,
+                    "start": 69,
+                    "end": 86,
                     "ctxt": 0
                   },
                   "opening": {
@@ -92,8 +92,8 @@
                     "name": {
                       "type": "Identifier",
                       "span": {
-                        "start": 65,
-                        "end": 67,
+                        "start": 70,
+                        "end": 72,
                         "ctxt": 0
                       },
                       "value": "h2",
@@ -101,8 +101,8 @@
                       "optional": false
                     },
                     "span": {
-                      "start": 65,
-                      "end": 68,
+                      "start": 70,
+                      "end": 73,
                       "ctxt": 0
                     },
                     "attributes": [],
@@ -113,8 +113,8 @@
                     {
                       "type": "JSXText",
                       "span": {
-                        "start": 68,
-                        "end": 76,
+                        "start": 73,
+                        "end": 81,
                         "ctxt": 0
                       },
                       "value": "loading ",
@@ -124,15 +124,15 @@
                   "closing": {
                     "type": "JSXClosingElement",
                     "span": {
-                      "start": 78,
-                      "end": 81,
+                      "start": 83,
+                      "end": 86,
                       "ctxt": 0
                     },
                     "name": {
                       "type": "Identifier",
                       "span": {
-                        "start": 78,
-                        "end": 80,
+                        "start": 83,
+                        "end": 85,
                         "ctxt": 0
                       },
                       "value": "h2",
@@ -145,15 +145,15 @@
               "alternate": {
                 "type": "ParenthesisExpression",
                 "span": {
-                  "start": 117,
-                  "end": 158,
+                  "start": 124,
+                  "end": 165,
                   "ctxt": 0
                 },
                 "expression": {
                   "type": "JSXElement",
                   "span": {
-                    "start": 118,
-                    "end": 157,
+                    "start": 125,
+                    "end": 164,
                     "ctxt": 0
                   },
                   "opening": {
@@ -161,8 +161,8 @@
                     "name": {
                       "type": "Identifier",
                       "span": {
-                        "start": 119,
-                        "end": 121,
+                        "start": 126,
+                        "end": 128,
                         "ctxt": 0
                       },
                       "value": "h3",
@@ -170,8 +170,8 @@
                       "optional": false
                     },
                     "span": {
-                      "start": 119,
-                      "end": 122,
+                      "start": 126,
+                      "end": 129,
                       "ctxt": 0
                     },
                     "attributes": [],
@@ -182,8 +182,8 @@
                     {
                       "type": "JSXText",
                       "span": {
-                        "start": 122,
-                        "end": 152,
+                        "start": 129,
+                        "end": 159,
                         "ctxt": 0
                       },
                       "value": "naaaaaaaaaaaaffffffffffffffff ",
@@ -193,15 +193,15 @@
                   "closing": {
                     "type": "JSXClosingElement",
                     "span": {
-                      "start": 154,
-                      "end": 157,
+                      "start": 161,
+                      "end": 164,
                       "ctxt": 0
                     },
                     "name": {
                       "type": "Identifier",
                       "span": {
-                        "start": 154,
-                        "end": 156,
+                        "start": 161,
+                        "end": 163,
                         "ctxt": 0
                       },
                       "value": "h3",
@@ -216,26 +216,26 @@
           {
             "type": "JSXText",
             "span": {
-              "start": 169,
-              "end": 174,
+              "start": 178,
+              "end": 184,
               "ctxt": 0
             },
-            "value": "\n\n    ",
-            "raw": "\n\n    "
+            "value": "\n\r\n    ",
+            "raw": "\n\r\n    "
           }
         ],
         "closing": {
           "type": "JSXClosingElement",
           "span": {
-            "start": 176,
-            "end": 180,
+            "start": 186,
+            "end": 190,
             "ctxt": 0
           },
           "name": {
             "type": "Identifier",
             "span": {
-              "start": 176,
-              "end": 179,
+              "start": 186,
+              "end": 189,
               "ctxt": 0
             },
             "value": "div",

--- a/ecmascript/parser/tests/typescript/custom/tsx-unary/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/custom/tsx-unary/input.tsx.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 252,
+    "end": 266,
     "ctxt": 0
   },
   "body": [
@@ -50,8 +50,8 @@
       "identifier": {
         "type": "Identifier",
         "span": {
-          "start": 37,
-          "end": 40,
+          "start": 39,
+          "end": 42,
           "ctxt": 0
         },
         "value": "App",
@@ -62,23 +62,23 @@
       "params": [],
       "decorators": [],
       "span": {
-        "start": 28,
-        "end": 231,
+        "start": 30,
+        "end": 243,
         "ctxt": 0
       },
       "body": {
         "type": "BlockStatement",
         "span": {
-          "start": 43,
-          "end": 231,
+          "start": 45,
+          "end": 243,
           "ctxt": 0
         },
         "stmts": [
           {
             "type": "VariableDeclaration",
             "span": {
-              "start": 47,
-              "end": 70,
+              "start": 50,
+              "end": 73,
               "ctxt": 0
             },
             "kind": "const",
@@ -87,15 +87,15 @@
               {
                 "type": "VariableDeclarator",
                 "span": {
-                  "start": 53,
-                  "end": 69,
+                  "start": 56,
+                  "end": 72,
                   "ctxt": 0
                 },
                 "id": {
                   "type": "Identifier",
                   "span": {
-                    "start": 53,
-                    "end": 62,
+                    "start": 56,
+                    "end": 65,
                     "ctxt": 0
                   },
                   "value": "isLoading",
@@ -105,8 +105,8 @@
                 "init": {
                   "type": "BooleanLiteral",
                   "span": {
-                    "start": 65,
-                    "end": 69,
+                    "start": 68,
+                    "end": 72,
                     "ctxt": 0
                   },
                   "value": true
@@ -118,22 +118,22 @@
           {
             "type": "ReturnStatement",
             "span": {
-              "start": 73,
-              "end": 229,
+              "start": 77,
+              "end": 240,
               "ctxt": 0
             },
             "argument": {
               "type": "ParenthesisExpression",
               "span": {
-                "start": 80,
-                "end": 228,
+                "start": 84,
+                "end": 239,
                 "ctxt": 0
               },
               "expression": {
                 "type": "JSXElement",
                 "span": {
-                  "start": 86,
-                  "end": 224,
+                  "start": 91,
+                  "end": 234,
                   "ctxt": 0
                 },
                 "opening": {
@@ -141,8 +141,8 @@
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 87,
-                      "end": 90,
+                      "start": 92,
+                      "end": 95,
                       "ctxt": 0
                     },
                     "value": "div",
@@ -150,8 +150,8 @@
                     "optional": false
                   },
                   "span": {
-                    "start": 87,
-                    "end": 91,
+                    "start": 92,
+                    "end": 96,
                     "ctxt": 0
                   },
                   "attributes": [],
@@ -162,18 +162,18 @@
                   {
                     "type": "JSXText",
                     "span": {
-                      "start": 91,
-                      "end": 98,
+                      "start": 96,
+                      "end": 104,
                       "ctxt": 0
                     },
-                    "value": "\n\n      ",
-                    "raw": "\n\n      "
+                    "value": "\n\r\n      ",
+                    "raw": "\n\r\n      "
                   },
                   {
                     "type": "JSXElement",
                     "span": {
-                      "start": 98,
-                      "end": 113,
+                      "start": 104,
+                      "end": 119,
                       "ctxt": 0
                     },
                     "opening": {
@@ -181,8 +181,8 @@
                       "name": {
                         "type": "Identifier",
                         "span": {
-                          "start": 99,
-                          "end": 101,
+                          "start": 105,
+                          "end": 107,
                           "ctxt": 0
                         },
                         "value": "h1",
@@ -190,8 +190,8 @@
                         "optional": false
                       },
                       "span": {
-                        "start": 99,
-                        "end": 102,
+                        "start": 105,
+                        "end": 108,
                         "ctxt": 0
                       },
                       "attributes": [],
@@ -202,8 +202,8 @@
                       {
                         "type": "JSXText",
                         "span": {
-                          "start": 102,
-                          "end": 108,
+                          "start": 108,
+                          "end": 114,
                           "ctxt": 0
                         },
                         "value": "works ",
@@ -213,15 +213,15 @@
                     "closing": {
                       "type": "JSXClosingElement",
                       "span": {
-                        "start": 110,
-                        "end": 113,
+                        "start": 116,
+                        "end": 119,
                         "ctxt": 0
                       },
                       "name": {
                         "type": "Identifier",
                         "span": {
-                          "start": 110,
-                          "end": 112,
+                          "start": 116,
+                          "end": 118,
                           "ctxt": 0
                         },
                         "value": "h1",
@@ -233,27 +233,27 @@
                   {
                     "type": "JSXText",
                     "span": {
-                      "start": 113,
-                      "end": 120,
+                      "start": 119,
+                      "end": 127,
                       "ctxt": 0
                     },
-                    "value": "\n\n      ",
-                    "raw": "\n\n      "
+                    "value": "\n\r\n      ",
+                    "raw": "\n\r\n      "
                   },
                   {
                     "type": "JSXExpressionContainer",
                     "expression": {
                       "type": "ConditionalExpression",
                       "span": {
-                        "start": 130,
-                        "end": 205,
+                        "start": 138,
+                        "end": 213,
                         "ctxt": 0
                       },
                       "test": {
                         "type": "Identifier",
                         "span": {
-                          "start": 130,
-                          "end": 139,
+                          "start": 138,
+                          "end": 147,
                           "ctxt": 0
                         },
                         "value": "isLoading",
@@ -263,8 +263,8 @@
                       "consequent": {
                         "type": "JSXElement",
                         "span": {
-                          "start": 142,
-                          "end": 161,
+                          "start": 150,
+                          "end": 169,
                           "ctxt": 0
                         },
                         "opening": {
@@ -272,8 +272,8 @@
                           "name": {
                             "type": "Identifier",
                             "span": {
-                              "start": 143,
-                              "end": 146,
+                              "start": 151,
+                              "end": 154,
                               "ctxt": 0
                             },
                             "value": "div",
@@ -281,8 +281,8 @@
                             "optional": false
                           },
                           "span": {
-                            "start": 143,
-                            "end": 147,
+                            "start": 151,
+                            "end": 155,
                             "ctxt": 0
                           },
                           "attributes": [],
@@ -293,8 +293,8 @@
                           {
                             "type": "JSXText",
                             "span": {
-                              "start": 147,
-                              "end": 155,
+                              "start": 155,
+                              "end": 163,
                               "ctxt": 0
                             },
                             "value": "loading ",
@@ -304,15 +304,15 @@
                         "closing": {
                           "type": "JSXClosingElement",
                           "span": {
-                            "start": 157,
-                            "end": 161,
+                            "start": 165,
+                            "end": 169,
                             "ctxt": 0
                           },
                           "name": {
                             "type": "Identifier",
                             "span": {
-                              "start": 157,
-                              "end": 160,
+                              "start": 165,
+                              "end": 168,
                               "ctxt": 0
                             },
                             "value": "div",
@@ -324,8 +324,8 @@
                       "alternate": {
                         "type": "JSXElement",
                         "span": {
-                          "start": 164,
-                          "end": 205,
+                          "start": 172,
+                          "end": 213,
                           "ctxt": 0
                         },
                         "opening": {
@@ -333,8 +333,8 @@
                           "name": {
                             "type": "Identifier",
                             "span": {
-                              "start": 165,
-                              "end": 168,
+                              "start": 173,
+                              "end": 176,
                               "ctxt": 0
                             },
                             "value": "div",
@@ -342,8 +342,8 @@
                             "optional": false
                           },
                           "span": {
-                            "start": 165,
-                            "end": 169,
+                            "start": 173,
+                            "end": 177,
                             "ctxt": 0
                           },
                           "attributes": [],
@@ -354,8 +354,8 @@
                           {
                             "type": "JSXText",
                             "span": {
-                              "start": 169,
-                              "end": 199,
+                              "start": 177,
+                              "end": 207,
                               "ctxt": 0
                             },
                             "value": "naaaaaaaaaaaaffffffffffffffff ",
@@ -365,15 +365,15 @@
                         "closing": {
                           "type": "JSXClosingElement",
                           "span": {
-                            "start": 201,
-                            "end": 205,
+                            "start": 209,
+                            "end": 213,
                             "ctxt": 0
                           },
                           "name": {
                             "type": "Identifier",
                             "span": {
-                              "start": 201,
-                              "end": 204,
+                              "start": 209,
+                              "end": 212,
                               "ctxt": 0
                             },
                             "value": "div",
@@ -387,26 +387,26 @@
                   {
                     "type": "JSXText",
                     "span": {
-                      "start": 213,
-                      "end": 218,
+                      "start": 222,
+                      "end": 228,
                       "ctxt": 0
                     },
-                    "value": "\n\n    ",
-                    "raw": "\n\n    "
+                    "value": "\n\r\n    ",
+                    "raw": "\n\r\n    "
                   }
                 ],
                 "closing": {
                   "type": "JSXClosingElement",
                   "span": {
-                    "start": 220,
-                    "end": 224,
+                    "start": 230,
+                    "end": 234,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 220,
-                      "end": 223,
+                      "start": 230,
+                      "end": 233,
                       "ctxt": 0
                     },
                     "value": "div",
@@ -427,15 +427,15 @@
     {
       "type": "ExportDefaultExpression",
       "span": {
-        "start": 233,
-        "end": 252,
+        "start": 247,
+        "end": 266,
         "ctxt": 0
       },
       "expression": {
         "type": "Identifier",
         "span": {
-          "start": 248,
-          "end": 251,
+          "start": 262,
+          "end": 265,
           "ctxt": 0
         },
         "value": "App",

--- a/ecmascript/parser/tests/typescript/declare/var/input.ts.json
+++ b/ecmascript/parser/tests/typescript/declare/var/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 34,
+    "end": 35,
     "ctxt": 0
   },
   "body": [
@@ -42,8 +42,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 23,
-        "end": 34,
+        "start": 24,
+        "end": 35,
         "ctxt": 0
       },
       "kind": "var",
@@ -52,30 +52,30 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 27,
-            "end": 33,
+            "start": 28,
+            "end": 34,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 27,
-              "end": 28,
+              "start": 28,
+              "end": 29,
               "ctxt": 0
             },
             "value": "x",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 28,
-                "end": 33,
+                "start": 29,
+                "end": 34,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 30,
-                  "end": 33,
+                  "start": 31,
+                  "end": 34,
                   "ctxt": 0
                 },
                 "kind": "any"

--- a/ecmascript/parser/tests/typescript/decorators/type-arguments/input.ts.json
+++ b/ecmascript/parser/tests/typescript/decorators/type-arguments/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 34,
+    "end": 35,
     "ctxt": 0
   },
   "body": [
@@ -11,8 +11,8 @@
       "identifier": {
         "type": "Identifier",
         "span": {
-          "start": 27,
-          "end": 31,
+          "start": 28,
+          "end": 32,
           "ctxt": 0
         },
         "value": "Test",
@@ -21,8 +21,8 @@
       },
       "declare": false,
       "span": {
-        "start": 21,
-        "end": 34,
+        "start": 22,
+        "end": 35,
         "ctxt": 0
       },
       "decorators": [

--- a/ecmascript/parser/tests/typescript/enum/members-reserved-words/input.ts.json
+++ b/ecmascript/parser/tests/typescript/enum/members-reserved-words/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 33,
+    "end": 36,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsEnumDeclaration",
       "span": {
         "start": 0,
-        "end": 33,
+        "end": 36,
         "ctxt": 0
       },
       "declare": false,
@@ -30,15 +30,15 @@
         {
           "type": "TsEnumMember",
           "span": {
-            "start": 13,
-            "end": 18,
+            "start": 14,
+            "end": 19,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 13,
-              "end": 18,
+              "start": 14,
+              "end": 19,
               "ctxt": 0
             },
             "value": "const",
@@ -50,15 +50,15 @@
         {
           "type": "TsEnumMember",
           "span": {
-            "start": 24,
-            "end": 31,
+            "start": 26,
+            "end": 33,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 24,
-              "end": 31,
+              "start": 26,
+              "end": 33,
               "ctxt": 0
             },
             "value": "default",

--- a/ecmascript/parser/tests/typescript/enum/members-strings/input.ts.json
+++ b/ecmascript/parser/tests/typescript/enum/members-strings/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 35,
+    "end": 38,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsEnumDeclaration",
       "span": {
         "start": 0,
-        "end": 35,
+        "end": 38,
         "ctxt": 0
       },
       "declare": false,
@@ -30,15 +30,15 @@
         {
           "type": "TsEnumMember",
           "span": {
-            "start": 13,
-            "end": 18,
+            "start": 14,
+            "end": 19,
             "ctxt": 0
           },
           "id": {
             "type": "StringLiteral",
             "span": {
-              "start": 13,
-              "end": 18,
+              "start": 14,
+              "end": 19,
               "ctxt": 0
             },
             "value": "foo",
@@ -49,15 +49,15 @@
         {
           "type": "TsEnumMember",
           "span": {
-            "start": 24,
-            "end": 33,
+            "start": 26,
+            "end": 35,
             "ctxt": 0
           },
           "id": {
             "type": "StringLiteral",
             "span": {
-              "start": 24,
-              "end": 29,
+              "start": 26,
+              "end": 31,
               "ctxt": 0
             },
             "value": "bar",
@@ -66,8 +66,8 @@
           "init": {
             "type": "NumericLiteral",
             "span": {
-              "start": 32,
-              "end": 33,
+              "start": 34,
+              "end": 35,
               "ctxt": 0
             },
             "value": 1.0

--- a/ecmascript/parser/tests/typescript/enum/members-trailing-comma-with-initializer/input.ts.json
+++ b/ecmascript/parser/tests/typescript/enum/members-trailing-comma-with-initializer/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 21,
+    "end": 23,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsEnumDeclaration",
       "span": {
         "start": 0,
-        "end": 21,
+        "end": 23,
         "ctxt": 0
       },
       "declare": false,
@@ -30,15 +30,15 @@
         {
           "type": "TsEnumMember",
           "span": {
-            "start": 13,
-            "end": 18,
+            "start": 14,
+            "end": 19,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 13,
-              "end": 14,
+              "start": 14,
+              "end": 15,
               "ctxt": 0
             },
             "value": "A",
@@ -48,8 +48,8 @@
           "init": {
             "type": "NumericLiteral",
             "span": {
-              "start": 17,
-              "end": 18,
+              "start": 18,
+              "end": 19,
               "ctxt": 0
             },
             "value": 0.0

--- a/ecmascript/parser/tests/typescript/enum/members-trailing-comma/input.ts.json
+++ b/ecmascript/parser/tests/typescript/enum/members-trailing-comma/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 17,
+    "end": 19,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsEnumDeclaration",
       "span": {
         "start": 0,
-        "end": 17,
+        "end": 19,
         "ctxt": 0
       },
       "declare": false,
@@ -30,15 +30,15 @@
         {
           "type": "TsEnumMember",
           "span": {
-            "start": 13,
-            "end": 14,
+            "start": 14,
+            "end": 15,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 13,
-              "end": 14,
+              "start": 14,
+              "end": 15,
               "ctxt": 0
             },
             "value": "A",

--- a/ecmascript/parser/tests/typescript/enum/members/input.ts.json
+++ b/ecmascript/parser/tests/typescript/enum/members/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 27,
+    "end": 30,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsEnumDeclaration",
       "span": {
         "start": 0,
-        "end": 27,
+        "end": 30,
         "ctxt": 0
       },
       "declare": false,
@@ -30,15 +30,15 @@
         {
           "type": "TsEnumMember",
           "span": {
-            "start": 13,
-            "end": 14,
+            "start": 14,
+            "end": 15,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 13,
-              "end": 14,
+              "start": 14,
+              "end": 15,
               "ctxt": 0
             },
             "value": "A",
@@ -50,15 +50,15 @@
         {
           "type": "TsEnumMember",
           "span": {
-            "start": 20,
-            "end": 25,
+            "start": 22,
+            "end": 27,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 20,
-              "end": 21,
+              "start": 22,
+              "end": 23,
               "ctxt": 0
             },
             "value": "B",
@@ -68,8 +68,8 @@
           "init": {
             "type": "NumericLiteral",
             "span": {
-              "start": 24,
-              "end": 25,
+              "start": 26,
+              "end": 27,
               "ctxt": 0
             },
             "value": 0.0

--- a/ecmascript/parser/tests/typescript/es2019/from-entries/input.ts.json
+++ b/ecmascript/parser/tests/typescript/es2019/from-entries/input.ts.json
@@ -1,23 +1,23 @@
 {
   "type": "Module",
   "span": {
-    "start": 1,
-    "end": 188,
+    "start": 2,
+    "end": 192,
     "ctxt": 0
   },
   "body": [
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 11,
-        "end": 188,
+        "start": 12,
+        "end": 192,
         "ctxt": 0
       },
       "id": {
         "type": "Identifier",
         "span": {
-          "start": 11,
-          "end": 28,
+          "start": 12,
+          "end": 29,
           "ctxt": 0
         },
         "value": "ObjectConstructor",
@@ -30,24 +30,24 @@
       "body": {
         "type": "TsInterfaceBody",
         "span": {
-          "start": 29,
-          "end": 188,
+          "start": 30,
+          "end": 192,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsMethodSignature",
             "span": {
-              "start": 35,
-              "end": 129,
+              "start": 37,
+              "end": 131,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 35,
-                "end": 46,
+                "start": 37,
+                "end": 48,
                 "ctxt": 0
               },
               "value": "fromEntries",
@@ -60,30 +60,30 @@
               {
                 "type": "Identifier",
                 "span": {
-                  "start": 56,
-                  "end": 63,
+                  "start": 58,
+                  "end": 65,
                   "ctxt": 0
                 },
                 "value": "entries",
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 63,
-                    "end": 100,
+                    "start": 65,
+                    "end": 102,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsTypeReference",
                     "span": {
-                      "start": 65,
-                      "end": 100,
+                      "start": 67,
+                      "end": 102,
                       "ctxt": 0
                     },
                     "typeName": {
                       "type": "Identifier",
                       "span": {
-                        "start": 65,
-                        "end": 73,
+                        "start": 67,
+                        "end": 75,
                         "ctxt": 0
                       },
                       "value": "Iterable",
@@ -93,39 +93,39 @@
                     "typeParams": {
                       "type": "TsTypeParameterInstantiation",
                       "span": {
-                        "start": 73,
-                        "end": 100,
+                        "start": 75,
+                        "end": 102,
                         "ctxt": 0
                       },
                       "params": [
                         {
                           "type": "TsTypeOperator",
                           "span": {
-                            "start": 74,
-                            "end": 99,
+                            "start": 76,
+                            "end": 101,
                             "ctxt": 0
                           },
                           "op": "readonly",
                           "typeAnnotation": {
                             "type": "TsTupleType",
                             "span": {
-                              "start": 83,
-                              "end": 99,
+                              "start": 85,
+                              "end": 101,
                               "ctxt": 0
                             },
                             "elemTypes": [
                               {
                                 "type": "TsTypeReference",
                                 "span": {
-                                  "start": 84,
-                                  "end": 95,
+                                  "start": 86,
+                                  "end": 97,
                                   "ctxt": 0
                                 },
                                 "typeName": {
                                   "type": "Identifier",
                                   "span": {
-                                    "start": 84,
-                                    "end": 95,
+                                    "start": 86,
+                                    "end": 97,
                                     "ctxt": 0
                                   },
                                   "value": "PropertyKey",
@@ -137,15 +137,15 @@
                               {
                                 "type": "TsTypeReference",
                                 "span": {
-                                  "start": 97,
-                                  "end": 98,
+                                  "start": 99,
+                                  "end": 100,
                                   "ctxt": 0
                                 },
                                 "typeName": {
                                   "type": "Identifier",
                                   "span": {
-                                    "start": 97,
-                                    "end": 98,
+                                    "start": 99,
+                                    "end": 100,
                                     "ctxt": 0
                                   },
                                   "value": "T",
@@ -167,30 +167,30 @@
             "typeAnn": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 101,
-                "end": 128,
+                "start": 103,
+                "end": 130,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsMappedType",
                 "span": {
-                  "start": 103,
-                  "end": 128,
+                  "start": 105,
+                  "end": 130,
                   "ctxt": 0
                 },
                 "readonly": null,
                 "typeParam": {
                   "type": "TsTypeParameter",
                   "span": {
-                    "start": 106,
-                    "end": 122,
+                    "start": 108,
+                    "end": 124,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 106,
-                      "end": 107,
+                      "start": 108,
+                      "end": 109,
                       "ctxt": 0
                     },
                     "value": "k",
@@ -200,15 +200,15 @@
                   "constraint": {
                     "type": "TsTypeReference",
                     "span": {
-                      "start": 111,
-                      "end": 122,
+                      "start": 113,
+                      "end": 124,
                       "ctxt": 0
                     },
                     "typeName": {
                       "type": "Identifier",
                       "span": {
-                        "start": 111,
-                        "end": 122,
+                        "start": 113,
+                        "end": 124,
                         "ctxt": 0
                       },
                       "value": "PropertyKey",
@@ -223,15 +223,15 @@
                 "typeAnnotation": {
                   "type": "TsTypeReference",
                   "span": {
-                    "start": 125,
-                    "end": 126,
+                    "start": 127,
+                    "end": 128,
                     "ctxt": 0
                   },
                   "typeName": {
                     "type": "Identifier",
                     "span": {
-                      "start": 125,
-                      "end": 126,
+                      "start": 127,
+                      "end": 128,
                       "ctxt": 0
                     },
                     "value": "T",
@@ -245,23 +245,23 @@
             "typeParams": {
               "type": "TsTypeParameterDeclaration",
               "span": {
-                "start": 46,
-                "end": 55,
+                "start": 48,
+                "end": 57,
                 "ctxt": 0
               },
               "parameters": [
                 {
                   "type": "TsTypeParameter",
                   "span": {
-                    "start": 47,
-                    "end": 54,
+                    "start": 49,
+                    "end": 56,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 47,
-                      "end": 48,
+                      "start": 49,
+                      "end": 50,
                       "ctxt": 0
                     },
                     "value": "T",
@@ -272,8 +272,8 @@
                   "default": {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 51,
-                      "end": 54,
+                      "start": 53,
+                      "end": 56,
                       "ctxt": 0
                     },
                     "kind": "any"
@@ -285,16 +285,16 @@
           {
             "type": "TsMethodSignature",
             "span": {
-              "start": 134,
-              "end": 186,
+              "start": 137,
+              "end": 189,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 134,
-                "end": 145,
+                "start": 137,
+                "end": 148,
                 "ctxt": 0
               },
               "value": "fromEntries",
@@ -307,30 +307,30 @@
               {
                 "type": "Identifier",
                 "span": {
-                  "start": 146,
-                  "end": 153,
+                  "start": 149,
+                  "end": 156,
                   "ctxt": 0
                 },
                 "value": "entries",
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 153,
-                    "end": 179,
+                    "start": 156,
+                    "end": 182,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsTypeReference",
                     "span": {
-                      "start": 155,
-                      "end": 179,
+                      "start": 158,
+                      "end": 182,
                       "ctxt": 0
                     },
                     "typeName": {
                       "type": "Identifier",
                       "span": {
-                        "start": 155,
-                        "end": 163,
+                        "start": 158,
+                        "end": 166,
                         "ctxt": 0
                       },
                       "value": "Iterable",
@@ -340,31 +340,31 @@
                     "typeParams": {
                       "type": "TsTypeParameterInstantiation",
                       "span": {
-                        "start": 163,
-                        "end": 179,
+                        "start": 166,
+                        "end": 182,
                         "ctxt": 0
                       },
                       "params": [
                         {
                           "type": "TsTypeOperator",
                           "span": {
-                            "start": 164,
-                            "end": 178,
+                            "start": 167,
+                            "end": 181,
                             "ctxt": 0
                           },
                           "op": "readonly",
                           "typeAnnotation": {
                             "type": "TsArrayType",
                             "span": {
-                              "start": 173,
-                              "end": 178,
+                              "start": 176,
+                              "end": 181,
                               "ctxt": 0
                             },
                             "elemType": {
                               "type": "TsKeywordType",
                               "span": {
-                                "start": 173,
-                                "end": 176,
+                                "start": 176,
+                                "end": 179,
                                 "ctxt": 0
                               },
                               "kind": "any"
@@ -381,15 +381,15 @@
             "typeAnn": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 180,
-                "end": 185,
+                "start": 183,
+                "end": 188,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 182,
-                  "end": 185,
+                  "start": 185,
+                  "end": 188,
                   "ctxt": 0
                 },
                 "kind": "any"

--- a/ecmascript/parser/tests/typescript/export/declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/export/declare/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 211,
+    "end": 217,
     "ctxt": 0
   },
   "body": [
@@ -66,8 +66,8 @@
     {
       "type": "ExportDeclaration",
       "span": {
-        "start": 32,
-        "end": 66,
+        "start": 33,
+        "end": 67,
         "ctxt": 0
       },
       "declaration": {
@@ -75,8 +75,8 @@
         "identifier": {
           "type": "Identifier",
           "span": {
-            "start": 56,
-            "end": 57,
+            "start": 57,
+            "end": 58,
             "ctxt": 0
           },
           "value": "f",
@@ -87,8 +87,8 @@
         "params": [],
         "decorators": [],
         "span": {
-          "start": 47,
-          "end": 66,
+          "start": 48,
+          "end": 67,
           "ctxt": 0
         },
         "body": null,
@@ -98,15 +98,15 @@
         "returnType": {
           "type": "TsTypeAnnotation",
           "span": {
-            "start": 59,
-            "end": 65,
+            "start": 60,
+            "end": 66,
             "ctxt": 0
           },
           "typeAnnotation": {
             "type": "TsKeywordType",
             "span": {
-              "start": 61,
-              "end": 65,
+              "start": 62,
+              "end": 66,
               "ctxt": 0
             },
             "kind": "void"
@@ -117,8 +117,8 @@
     {
       "type": "ExportDeclaration",
       "span": {
-        "start": 67,
-        "end": 92,
+        "start": 69,
+        "end": 94,
         "ctxt": 0
       },
       "declaration": {
@@ -126,8 +126,8 @@
         "identifier": {
           "type": "Identifier",
           "span": {
-            "start": 88,
-            "end": 89,
+            "start": 90,
+            "end": 91,
             "ctxt": 0
           },
           "value": "C",
@@ -136,8 +136,8 @@
         },
         "declare": false,
         "span": {
-          "start": 82,
-          "end": 92,
+          "start": 84,
+          "end": 94,
           "ctxt": 0
         },
         "decorators": [],
@@ -152,22 +152,22 @@
     {
       "type": "ExportDeclaration",
       "span": {
-        "start": 93,
-        "end": 122,
+        "start": 96,
+        "end": 125,
         "ctxt": 0
       },
       "declaration": {
         "type": "TsInterfaceDeclaration",
         "span": {
-          "start": 118,
-          "end": 122,
+          "start": 121,
+          "end": 125,
           "ctxt": 0
         },
         "id": {
           "type": "Identifier",
           "span": {
-            "start": 118,
-            "end": 119,
+            "start": 121,
+            "end": 122,
             "ctxt": 0
           },
           "value": "I",
@@ -180,8 +180,8 @@
         "body": {
           "type": "TsInterfaceBody",
           "span": {
-            "start": 120,
-            "end": 122,
+            "start": 123,
+            "end": 125,
             "ctxt": 0
           },
           "body": []
@@ -191,23 +191,23 @@
     {
       "type": "ExportDeclaration",
       "span": {
-        "start": 123,
-        "end": 154,
+        "start": 127,
+        "end": 158,
         "ctxt": 0
       },
       "declaration": {
         "type": "TsTypeAliasDeclaration",
         "span": {
-          "start": 123,
-          "end": 154,
+          "start": 127,
+          "end": 158,
           "ctxt": 0
         },
         "declare": true,
         "id": {
           "type": "Identifier",
           "span": {
-            "start": 143,
-            "end": 144,
+            "start": 147,
+            "end": 148,
             "ctxt": 0
           },
           "value": "T",
@@ -218,8 +218,8 @@
         "typeAnnotation": {
           "type": "TsKeywordType",
           "span": {
-            "start": 147,
-            "end": 153,
+            "start": 151,
+            "end": 157,
             "ctxt": 0
           },
           "kind": "number"
@@ -229,15 +229,15 @@
     {
       "type": "ExportDeclaration",
       "span": {
-        "start": 155,
-        "end": 181,
+        "start": 160,
+        "end": 186,
         "ctxt": 0
       },
       "declaration": {
         "type": "TsModuleDeclaration",
         "span": {
-          "start": 155,
-          "end": 181,
+          "start": 160,
+          "end": 186,
           "ctxt": 0
         },
         "declare": true,
@@ -245,8 +245,8 @@
         "id": {
           "type": "Identifier",
           "span": {
-            "start": 177,
-            "end": 178,
+            "start": 182,
+            "end": 183,
             "ctxt": 0
           },
           "value": "M",
@@ -256,8 +256,8 @@
         "body": {
           "type": "TsModuleBlock",
           "span": {
-            "start": 179,
-            "end": 181,
+            "start": 184,
+            "end": 186,
             "ctxt": 0
           },
           "body": []
@@ -267,15 +267,15 @@
     {
       "type": "ExportDeclaration",
       "span": {
-        "start": 182,
-        "end": 211,
+        "start": 188,
+        "end": 217,
         "ctxt": 0
       },
       "declaration": {
         "type": "TsModuleDeclaration",
         "span": {
-          "start": 182,
-          "end": 211,
+          "start": 188,
+          "end": 217,
           "ctxt": 0
         },
         "declare": true,
@@ -283,8 +283,8 @@
         "id": {
           "type": "Identifier",
           "span": {
-            "start": 207,
-            "end": 208,
+            "start": 213,
+            "end": 214,
             "ctxt": 0
           },
           "value": "N",
@@ -294,8 +294,8 @@
         "body": {
           "type": "TsModuleBlock",
           "span": {
-            "start": 209,
-            "end": 211,
+            "start": 215,
+            "end": 217,
             "ctxt": 0
           },
           "body": []

--- a/ecmascript/parser/tests/typescript/export/nested-same-name/input.ts.json
+++ b/ecmascript/parser/tests/typescript/export/nested-same-name/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 66,
+    "end": 69,
     "ctxt": 0
   },
   "body": [
@@ -58,15 +58,15 @@
     {
       "type": "ExportDeclaration",
       "span": {
-        "start": 20,
-        "end": 66,
+        "start": 21,
+        "end": 69,
         "ctxt": 0
       },
       "declaration": {
         "type": "TsModuleDeclaration",
         "span": {
-          "start": 27,
-          "end": 66,
+          "start": 28,
+          "end": 69,
           "ctxt": 0
         },
         "declare": false,
@@ -74,8 +74,8 @@
         "id": {
           "type": "Identifier",
           "span": {
-            "start": 37,
-            "end": 38,
+            "start": 38,
+            "end": 39,
             "ctxt": 0
           },
           "value": "N",
@@ -85,23 +85,23 @@
         "body": {
           "type": "TsModuleBlock",
           "span": {
-            "start": 39,
-            "end": 66,
+            "start": 40,
+            "end": 69,
             "ctxt": 0
           },
           "body": [
             {
               "type": "ExportDeclaration",
               "span": {
-                "start": 45,
-                "end": 64,
+                "start": 47,
+                "end": 66,
                 "ctxt": 0
               },
               "declaration": {
                 "type": "VariableDeclaration",
                 "span": {
-                  "start": 52,
-                  "end": 64,
+                  "start": 54,
+                  "end": 66,
                   "ctxt": 0
                 },
                 "kind": "const",
@@ -110,15 +110,15 @@
                   {
                     "type": "VariableDeclarator",
                     "span": {
-                      "start": 58,
-                      "end": 63,
+                      "start": 60,
+                      "end": 65,
                       "ctxt": 0
                     },
                     "id": {
                       "type": "Identifier",
                       "span": {
-                        "start": 58,
-                        "end": 59,
+                        "start": 60,
+                        "end": 61,
                         "ctxt": 0
                       },
                       "value": "x",
@@ -128,8 +128,8 @@
                     "init": {
                       "type": "NumericLiteral",
                       "span": {
-                        "start": 62,
-                        "end": 63,
+                        "start": 64,
+                        "end": 65,
                         "ctxt": 0
                       },
                       "value": 1.0

--- a/ecmascript/parser/tests/typescript/function/declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/declare/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 55,
+    "end": 56,
     "ctxt": 0
   },
   "body": [
@@ -54,8 +54,8 @@
       "identifier": {
         "type": "Identifier",
         "span": {
-          "start": 45,
-          "end": 46,
+          "start": 46,
+          "end": 47,
           "ctxt": 0
         },
         "value": "f",
@@ -66,8 +66,8 @@
       "params": [],
       "decorators": [],
       "span": {
-        "start": 36,
-        "end": 55,
+        "start": 37,
+        "end": 56,
         "ctxt": 0
       },
       "body": null,
@@ -76,23 +76,23 @@
       "typeParameters": {
         "type": "TsTypeParameterDeclaration",
         "span": {
-          "start": 46,
-          "end": 49,
+          "start": 47,
+          "end": 50,
           "ctxt": 0
         },
         "parameters": [
           {
             "type": "TsTypeParameter",
             "span": {
-              "start": 47,
-              "end": 48,
+              "start": 48,
+              "end": 49,
               "ctxt": 0
             },
             "name": {
               "type": "Identifier",
               "span": {
-                "start": 47,
-                "end": 48,
+                "start": 48,
+                "end": 49,
                 "ctxt": 0
               },
               "value": "T",
@@ -107,22 +107,22 @@
       "returnType": {
         "type": "TsTypeAnnotation",
         "span": {
-          "start": 51,
-          "end": 54,
+          "start": 52,
+          "end": 55,
           "ctxt": 0
         },
         "typeAnnotation": {
           "type": "TsTypeReference",
           "span": {
-            "start": 53,
-            "end": 54,
+            "start": 54,
+            "end": 55,
             "ctxt": 0
           },
           "typeName": {
             "type": "Identifier",
             "span": {
-              "start": 53,
-              "end": 54,
+              "start": 54,
+              "end": 55,
               "ctxt": 0
             },
             "value": "T",

--- a/ecmascript/parser/tests/typescript/function/overloads/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/overloads/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 75,
+    "end": 76,
     "ctxt": 0
   },
   "body": [
@@ -88,8 +88,8 @@
     {
       "type": "ExportDeclaration",
       "span": {
-        "start": 38,
-        "end": 75,
+        "start": 39,
+        "end": 76,
         "ctxt": 0
       },
       "declaration": {
@@ -97,8 +97,8 @@
         "identifier": {
           "type": "Identifier",
           "span": {
-            "start": 54,
-            "end": 55,
+            "start": 55,
+            "end": 56,
             "ctxt": 0
           },
           "value": "f",
@@ -110,23 +110,23 @@
           {
             "type": "Identifier",
             "span": {
-              "start": 56,
-              "end": 57,
+              "start": 57,
+              "end": 58,
               "ctxt": 0
             },
             "value": "x",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 57,
-                "end": 65,
+                "start": 58,
+                "end": 66,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 59,
-                  "end": 65,
+                  "start": 60,
+                  "end": 66,
                   "ctxt": 0
                 },
                 "kind": "string"
@@ -137,8 +137,8 @@
         ],
         "decorators": [],
         "span": {
-          "start": 45,
-          "end": 75,
+          "start": 46,
+          "end": 76,
           "ctxt": 0
         },
         "body": null,
@@ -148,15 +148,15 @@
         "returnType": {
           "type": "TsTypeAnnotation",
           "span": {
-            "start": 66,
-            "end": 74,
+            "start": 67,
+            "end": 75,
             "ctxt": 0
           },
           "typeAnnotation": {
             "type": "TsKeywordType",
             "span": {
-              "start": 68,
-              "end": 74,
+              "start": 69,
+              "end": 75,
               "ctxt": 0
             },
             "kind": "string"

--- a/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 71,
+    "end": 72,
     "ctxt": 0
   },
   "body": [
@@ -115,8 +115,8 @@
     {
       "type": "ParenthesisExpression",
       "span": {
-        "start": 36,
-        "end": 71,
+        "start": 37,
+        "end": 72,
         "ctxt": 0
       },
       "expression": {
@@ -126,23 +126,23 @@
           {
             "type": "Identifier",
             "span": {
-              "start": 46,
-              "end": 47,
+              "start": 47,
+              "end": 48,
               "ctxt": 0
             },
             "value": "x",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 47,
-                "end": 52,
+                "start": 48,
+                "end": 53,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 49,
-                  "end": 52,
+                  "start": 50,
+                  "end": 53,
                   "ctxt": 0
                 },
                 "kind": "any"
@@ -153,15 +153,15 @@
         ],
         "decorators": [],
         "span": {
-          "start": 37,
-          "end": 70,
+          "start": 38,
+          "end": 71,
           "ctxt": 0
         },
         "body": {
           "type": "BlockStatement",
           "span": {
-            "start": 68,
-            "end": 70,
+            "start": 69,
+            "end": 71,
             "ctxt": 0
           },
           "stmts": []
@@ -172,22 +172,22 @@
         "returnType": {
           "type": "TsTypeAnnotation",
           "span": {
-            "start": 53,
-            "end": 67,
+            "start": 54,
+            "end": 68,
             "ctxt": 0
           },
           "typeAnnotation": {
             "type": "TsTypePredicate",
             "span": {
-              "start": 53,
-              "end": 67,
+              "start": 54,
+              "end": 68,
               "ctxt": 0
             },
             "paramName": {
               "type": "Identifier",
               "span": {
-                "start": 55,
-                "end": 56,
+                "start": 56,
+                "end": 57,
                 "ctxt": 0
               },
               "value": "x",
@@ -197,15 +197,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 60,
-                "end": 67,
+                "start": 61,
+                "end": 68,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 60,
-                  "end": 67,
+                  "start": 61,
+                  "end": 68,
                   "ctxt": 0
                 },
                 "kind": "boolean"

--- a/ecmascript/parser/tests/typescript/import/not-top-level/input.ts.json
+++ b/ecmascript/parser/tests/typescript/import/not-top-level/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 50,
+    "end": 52,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsModuleDeclaration",
       "span": {
         "start": 0,
-        "end": 50,
+        "end": 52,
         "ctxt": 0
       },
       "declare": true,
@@ -29,30 +29,30 @@
         "type": "TsModuleBlock",
         "span": {
           "start": 19,
-          "end": 50,
+          "end": 52,
           "ctxt": 0
         },
         "body": [
           {
             "type": "ImportDeclaration",
             "span": {
-              "start": 25,
-              "end": 48,
+              "start": 26,
+              "end": 49,
               "ctxt": 0
             },
             "specifiers": [
               {
                 "type": "ImportNamespaceSpecifier",
                 "span": {
-                  "start": 32,
-                  "end": 38,
+                  "start": 33,
+                  "end": 39,
                   "ctxt": 0
                 },
                 "local": {
                   "type": "Identifier",
                   "span": {
-                    "start": 37,
-                    "end": 38,
+                    "start": 38,
+                    "end": 39,
                     "ctxt": 0
                   },
                   "value": "a",
@@ -64,8 +64,8 @@
             "source": {
               "type": "StringLiteral",
               "span": {
-                "start": 44,
-                "end": 48,
+                "start": 45,
+                "end": 49,
                 "ctxt": 0
               },
               "value": "a",

--- a/ecmascript/parser/tests/typescript/interface/call-signature/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/call-signature/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 38,
+    "end": 40,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsInterfaceDeclaration",
       "span": {
         "start": 10,
-        "end": 38,
+        "end": 40,
         "ctxt": 0
       },
       "id": {
@@ -31,38 +31,38 @@
         "type": "TsInterfaceBody",
         "span": {
           "start": 12,
-          "end": 38,
+          "end": 40,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsCallSignatureDeclaration",
             "span": {
-              "start": 18,
-              "end": 36,
+              "start": 19,
+              "end": 37,
               "ctxt": 0
             },
             "params": [
               {
                 "type": "Identifier",
                 "span": {
-                  "start": 19,
-                  "end": 20,
+                  "start": 20,
+                  "end": 21,
                   "ctxt": 0
                 },
                 "value": "x",
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 20,
-                    "end": 28,
+                    "start": 21,
+                    "end": 29,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 22,
-                      "end": 28,
+                      "start": 23,
+                      "end": 29,
                       "ctxt": 0
                     },
                     "kind": "number"
@@ -74,15 +74,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 29,
-                "end": 35,
+                "start": 30,
+                "end": 36,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 31,
-                  "end": 35,
+                  "start": 32,
+                  "end": 36,
                   "ctxt": 0
                 },
                 "kind": "void"

--- a/ecmascript/parser/tests/typescript/interface/construct-signature/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/construct-signature/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 42,
+    "end": 44,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsInterfaceDeclaration",
       "span": {
         "start": 10,
-        "end": 42,
+        "end": 44,
         "ctxt": 0
       },
       "id": {
@@ -31,38 +31,38 @@
         "type": "TsInterfaceBody",
         "span": {
           "start": 12,
-          "end": 42,
+          "end": 44,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsConstructSignatureDeclaration",
             "span": {
-              "start": 18,
-              "end": 40,
+              "start": 19,
+              "end": 41,
               "ctxt": 0
             },
             "params": [
               {
                 "type": "Identifier",
                 "span": {
-                  "start": 23,
-                  "end": 24,
+                  "start": 24,
+                  "end": 25,
                   "ctxt": 0
                 },
                 "value": "x",
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 24,
-                    "end": 32,
+                    "start": 25,
+                    "end": 33,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 26,
-                      "end": 32,
+                      "start": 27,
+                      "end": 33,
                       "ctxt": 0
                     },
                     "kind": "number"
@@ -74,15 +74,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 33,
-                "end": 39,
+                "start": 34,
+                "end": 40,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 35,
-                  "end": 39,
+                  "start": 36,
+                  "end": 40,
                   "ctxt": 0
                 },
                 "kind": "void"

--- a/ecmascript/parser/tests/typescript/interface/export/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/export/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 51,
+    "end": 52,
     "ctxt": 0
   },
   "body": [
@@ -48,22 +48,22 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 22,
-        "end": 51,
+        "start": 23,
+        "end": 52,
         "ctxt": 0
       },
       "decl": {
         "type": "TsInterfaceDeclaration",
         "span": {
-          "start": 47,
-          "end": 51,
+          "start": 48,
+          "end": 52,
           "ctxt": 0
         },
         "id": {
           "type": "Identifier",
           "span": {
-            "start": 47,
-            "end": 48,
+            "start": 48,
+            "end": 49,
             "ctxt": 0
           },
           "value": "A",
@@ -76,8 +76,8 @@
         "body": {
           "type": "TsInterfaceBody",
           "span": {
-            "start": 49,
-            "end": 51,
+            "start": 50,
+            "end": 52,
             "ctxt": 0
           },
           "body": []

--- a/ecmascript/parser/tests/typescript/interface/index-signature/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/index-signature/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 40,
+    "end": 42,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsInterfaceDeclaration",
       "span": {
         "start": 10,
-        "end": 40,
+        "end": 42,
         "ctxt": 0
       },
       "id": {
@@ -31,7 +31,7 @@
         "type": "TsInterfaceBody",
         "span": {
           "start": 12,
-          "end": 40,
+          "end": 42,
           "ctxt": 0
         },
         "body": [
@@ -41,23 +41,23 @@
               {
                 "type": "Identifier",
                 "span": {
-                  "start": 19,
-                  "end": 20,
+                  "start": 20,
+                  "end": 21,
                   "ctxt": 0
                 },
                 "value": "s",
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 22,
-                    "end": 28,
+                    "start": 23,
+                    "end": 29,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 22,
-                      "end": 28,
+                      "start": 23,
+                      "end": 29,
                       "ctxt": 0
                     },
                     "kind": "string"
@@ -69,15 +69,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 29,
-                "end": 37,
+                "start": 30,
+                "end": 38,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 31,
-                  "end": 37,
+                  "start": 32,
+                  "end": 38,
                   "ctxt": 0
                 },
                 "kind": "number"
@@ -85,8 +85,8 @@
             },
             "readonly": false,
             "span": {
-              "start": 18,
-              "end": 38,
+              "start": 19,
+              "end": 39,
               "ctxt": 0
             }
           }

--- a/ecmascript/parser/tests/typescript/interface/method-computed/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/method-computed/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 80,
+    "end": 83,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsInterfaceDeclaration",
       "span": {
         "start": 10,
-        "end": 80,
+        "end": 83,
         "ctxt": 0
       },
       "id": {
@@ -31,30 +31,30 @@
         "type": "TsInterfaceBody",
         "span": {
           "start": 12,
-          "end": 80,
+          "end": 83,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsMethodSignature",
             "span": {
-              "start": 18,
-              "end": 44,
+              "start": 19,
+              "end": 45,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "MemberExpression",
               "span": {
-                "start": 19,
-                "end": 34,
+                "start": 20,
+                "end": 35,
                 "ctxt": 0
               },
               "object": {
                 "type": "Identifier",
                 "span": {
-                  "start": 19,
-                  "end": 25,
+                  "start": 20,
+                  "end": 26,
                   "ctxt": 0
                 },
                 "value": "Symbol",
@@ -64,8 +64,8 @@
               "property": {
                 "type": "Identifier",
                 "span": {
-                  "start": 26,
-                  "end": 34,
+                  "start": 27,
+                  "end": 35,
                   "ctxt": 0
                 },
                 "value": "iterator",
@@ -80,15 +80,15 @@
             "typeAnn": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 37,
-                "end": 43,
+                "start": 38,
+                "end": 44,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 39,
-                  "end": 43,
+                  "start": 40,
+                  "end": 44,
                   "ctxt": 0
                 },
                 "kind": "void"
@@ -99,23 +99,23 @@
           {
             "type": "TsMethodSignature",
             "span": {
-              "start": 49,
-              "end": 78,
+              "start": 51,
+              "end": 80,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "MemberExpression",
               "span": {
-                "start": 50,
-                "end": 65,
+                "start": 52,
+                "end": 67,
                 "ctxt": 0
               },
               "object": {
                 "type": "Identifier",
                 "span": {
-                  "start": 50,
-                  "end": 56,
+                  "start": 52,
+                  "end": 58,
                   "ctxt": 0
                 },
                 "value": "Symbol",
@@ -125,8 +125,8 @@
               "property": {
                 "type": "Identifier",
                 "span": {
-                  "start": 57,
-                  "end": 65,
+                  "start": 59,
+                  "end": 67,
                   "ctxt": 0
                 },
                 "value": "iterator",
@@ -141,15 +141,15 @@
             "typeAnn": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 69,
-                "end": 77,
+                "start": 71,
+                "end": 79,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 71,
-                  "end": 77,
+                  "start": 73,
+                  "end": 79,
                   "ctxt": 0
                 },
                 "kind": "number"

--- a/ecmascript/parser/tests/typescript/interface/method-generic/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/method-generic/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 61,
+    "end": 63,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsInterfaceDeclaration",
       "span": {
         "start": 10,
-        "end": 61,
+        "end": 63,
         "ctxt": 0
       },
       "id": {
@@ -31,23 +31,23 @@
         "type": "TsInterfaceBody",
         "span": {
           "start": 12,
-          "end": 61,
+          "end": 63,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsMethodSignature",
             "span": {
-              "start": 18,
-              "end": 59,
+              "start": 19,
+              "end": 60,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 18,
-                "end": 19,
+                "start": 19,
+                "end": 20,
                 "ctxt": 0
               },
               "value": "m",
@@ -60,22 +60,22 @@
             "typeAnn": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 55,
-                "end": 58,
+                "start": 56,
+                "end": 59,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsTypeReference",
                 "span": {
-                  "start": 57,
-                  "end": 58,
+                  "start": 58,
+                  "end": 59,
                   "ctxt": 0
                 },
                 "typeName": {
                   "type": "Identifier",
                   "span": {
-                    "start": 57,
-                    "end": 58,
+                    "start": 58,
+                    "end": 59,
                     "ctxt": 0
                   },
                   "value": "T",
@@ -88,23 +88,23 @@
             "typeParams": {
               "type": "TsTypeParameterDeclaration",
               "span": {
-                "start": 19,
-                "end": 53,
+                "start": 20,
+                "end": 54,
                 "ctxt": 0
               },
               "parameters": [
                 {
                   "type": "TsTypeParameter",
                   "span": {
-                    "start": 20,
-                    "end": 52,
+                    "start": 21,
+                    "end": 53,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 20,
-                      "end": 21,
+                      "start": 21,
+                      "end": 22,
                       "ctxt": 0
                     },
                     "value": "T",
@@ -114,8 +114,8 @@
                   "constraint": {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 30,
-                      "end": 36,
+                      "start": 31,
+                      "end": 37,
                       "ctxt": 0
                     },
                     "kind": "object"
@@ -123,24 +123,24 @@
                   "default": {
                     "type": "TsTypeLiteral",
                     "span": {
-                      "start": 39,
-                      "end": 52,
+                      "start": 40,
+                      "end": 53,
                       "ctxt": 0
                     },
                     "members": [
                       {
                         "type": "TsPropertySignature",
                         "span": {
-                          "start": 41,
-                          "end": 50,
+                          "start": 42,
+                          "end": 51,
                           "ctxt": 0
                         },
                         "readonly": false,
                         "key": {
                           "type": "Identifier",
                           "span": {
-                            "start": 41,
-                            "end": 42,
+                            "start": 42,
+                            "end": 43,
                             "ctxt": 0
                           },
                           "value": "x",
@@ -154,15 +154,15 @@
                         "typeAnnotation": {
                           "type": "TsTypeAnnotation",
                           "span": {
-                            "start": 42,
-                            "end": 50,
+                            "start": 43,
+                            "end": 51,
                             "ctxt": 0
                           },
                           "typeAnnotation": {
                             "type": "TsKeywordType",
                             "span": {
-                              "start": 44,
-                              "end": 50,
+                              "start": 45,
+                              "end": 51,
                               "ctxt": 0
                             },
                             "kind": "number"

--- a/ecmascript/parser/tests/typescript/interface/method-optional/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/method-optional/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 31,
+    "end": 33,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsInterfaceDeclaration",
       "span": {
         "start": 10,
-        "end": 31,
+        "end": 33,
         "ctxt": 0
       },
       "id": {
@@ -31,23 +31,23 @@
         "type": "TsInterfaceBody",
         "span": {
           "start": 12,
-          "end": 31,
+          "end": 33,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsMethodSignature",
             "span": {
-              "start": 18,
-              "end": 29,
+              "start": 19,
+              "end": 30,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 18,
-                "end": 19,
+                "start": 19,
+                "end": 20,
                 "ctxt": 0
               },
               "value": "m",
@@ -60,15 +60,15 @@
             "typeAnn": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 22,
-                "end": 28,
+                "start": 23,
+                "end": 29,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 24,
-                  "end": 28,
+                  "start": 25,
+                  "end": 29,
                   "ctxt": 0
                 },
                 "kind": "void"

--- a/ecmascript/parser/tests/typescript/interface/method-plain/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/method-plain/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 65,
+    "end": 68,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsInterfaceDeclaration",
       "span": {
         "start": 10,
-        "end": 65,
+        "end": 68,
         "ctxt": 0
       },
       "id": {
@@ -31,23 +31,23 @@
         "type": "TsInterfaceBody",
         "span": {
           "start": 12,
-          "end": 65,
+          "end": 68,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsMethodSignature",
             "span": {
-              "start": 18,
-              "end": 22,
+              "start": 19,
+              "end": 23,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 18,
-                "end": 19,
+                "start": 19,
+                "end": 20,
                 "ctxt": 0
               },
               "value": "m",
@@ -63,16 +63,16 @@
           {
             "type": "TsMethodSignature",
             "span": {
-              "start": 27,
-              "end": 63,
+              "start": 29,
+              "end": 65,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 27,
-                "end": 28,
+                "start": 29,
+                "end": 30,
                 "ctxt": 0
               },
               "value": "m",
@@ -85,23 +85,23 @@
               {
                 "type": "Identifier",
                 "span": {
-                  "start": 29,
-                  "end": 30,
+                  "start": 31,
+                  "end": 32,
                   "ctxt": 0
                 },
                 "value": "x",
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 31,
-                    "end": 39,
+                    "start": 33,
+                    "end": 41,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 33,
-                      "end": 39,
+                      "start": 35,
+                      "end": 41,
                       "ctxt": 0
                     },
                     "kind": "number"
@@ -112,15 +112,15 @@
               {
                 "type": "RestElement",
                 "rest": {
-                  "start": 41,
-                  "end": 44,
+                  "start": 43,
+                  "end": 46,
                   "ctxt": 0
                 },
                 "argument": {
                   "type": "Identifier",
                   "span": {
-                    "start": 44,
-                    "end": 45,
+                    "start": 46,
+                    "end": 47,
                     "ctxt": 0
                   },
                   "value": "y",
@@ -130,22 +130,22 @@
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 45,
-                    "end": 55,
+                    "start": 47,
+                    "end": 57,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsArrayType",
                     "span": {
-                      "start": 47,
-                      "end": 55,
+                      "start": 49,
+                      "end": 57,
                       "ctxt": 0
                     },
                     "elemType": {
                       "type": "TsKeywordType",
                       "span": {
-                        "start": 47,
-                        "end": 53,
+                        "start": 49,
+                        "end": 55,
                         "ctxt": 0
                       },
                       "kind": "number"
@@ -157,15 +157,15 @@
             "typeAnn": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 56,
-                "end": 62,
+                "start": 58,
+                "end": 64,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 58,
-                  "end": 62,
+                  "start": 60,
+                  "end": 64,
                   "ctxt": 0
                 },
                 "kind": "void"

--- a/ecmascript/parser/tests/typescript/interface/modifiers/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/modifiers/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 39,
+    "end": 41,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsInterfaceDeclaration",
       "span": {
         "start": 10,
-        "end": 39,
+        "end": 41,
         "ctxt": 0
       },
       "id": {
@@ -31,23 +31,23 @@
         "type": "TsInterfaceBody",
         "span": {
           "start": 12,
-          "end": 39,
+          "end": 41,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 18,
-              "end": 37,
+              "start": 19,
+              "end": 38,
               "ctxt": 0
             },
             "readonly": true,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 27,
-                "end": 28,
+                "start": 28,
+                "end": 29,
                 "ctxt": 0
               },
               "value": "x",
@@ -61,15 +61,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 28,
-                "end": 36,
+                "start": 29,
+                "end": 37,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 30,
-                  "end": 36,
+                  "start": 31,
+                  "end": 37,
                   "ctxt": 0
                 },
                 "kind": "number"

--- a/ecmascript/parser/tests/typescript/interface/properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/properties/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 53,
+    "end": 57,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsInterfaceDeclaration",
       "span": {
         "start": 10,
-        "end": 53,
+        "end": 57,
         "ctxt": 0
       },
       "id": {
@@ -31,23 +31,23 @@
         "type": "TsInterfaceBody",
         "span": {
           "start": 12,
-          "end": 53,
+          "end": 57,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 18,
-              "end": 20,
+              "start": 19,
+              "end": 21,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 18,
-                "end": 19,
+                "start": 19,
+                "end": 20,
                 "ctxt": 0
               },
               "value": "x",
@@ -64,16 +64,16 @@
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 25,
-              "end": 35,
+              "start": 27,
+              "end": 37,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 25,
-                "end": 26,
+                "start": 27,
+                "end": 28,
                 "ctxt": 0
               },
               "value": "y",
@@ -87,15 +87,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 26,
-                "end": 34,
+                "start": 28,
+                "end": 36,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 28,
-                  "end": 34,
+                  "start": 30,
+                  "end": 36,
                   "ctxt": 0
                 },
                 "kind": "number"
@@ -106,16 +106,16 @@
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 40,
-              "end": 51,
+              "start": 43,
+              "end": 54,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 40,
-                "end": 41,
+                "start": 43,
+                "end": 44,
                 "ctxt": 0
               },
               "value": "z",
@@ -129,15 +129,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 42,
-                "end": 50,
+                "start": 45,
+                "end": 53,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 44,
-                  "end": 50,
+                  "start": 47,
+                  "end": 53,
                   "ctxt": 0
                 },
                 "kind": "number"

--- a/ecmascript/parser/tests/typescript/interface/property-computed/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/property-computed/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 78,
+    "end": 81,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsInterfaceDeclaration",
       "span": {
         "start": 10,
-        "end": 78,
+        "end": 81,
         "ctxt": 0
       },
       "id": {
@@ -31,30 +31,30 @@
         "type": "TsInterfaceBody",
         "span": {
           "start": 12,
-          "end": 78,
+          "end": 81,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 18,
-              "end": 44,
+              "start": 19,
+              "end": 45,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "MemberExpression",
               "span": {
-                "start": 19,
-                "end": 34,
+                "start": 20,
+                "end": 35,
                 "ctxt": 0
               },
               "object": {
                 "type": "Identifier",
                 "span": {
-                  "start": 19,
-                  "end": 25,
+                  "start": 20,
+                  "end": 26,
                   "ctxt": 0
                 },
                 "value": "Symbol",
@@ -64,8 +64,8 @@
               "property": {
                 "type": "Identifier",
                 "span": {
-                  "start": 26,
-                  "end": 34,
+                  "start": 27,
+                  "end": 35,
                   "ctxt": 0
                 },
                 "value": "iterator",
@@ -81,15 +81,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 35,
-                "end": 43,
+                "start": 36,
+                "end": 44,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 37,
-                  "end": 43,
+                  "start": 38,
+                  "end": 44,
                   "ctxt": 0
                 },
                 "kind": "number"
@@ -100,23 +100,23 @@
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 49,
-              "end": 76,
+              "start": 51,
+              "end": 78,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "MemberExpression",
               "span": {
-                "start": 50,
-                "end": 65,
+                "start": 52,
+                "end": 67,
                 "ctxt": 0
               },
               "object": {
                 "type": "Identifier",
                 "span": {
-                  "start": 50,
-                  "end": 56,
+                  "start": 52,
+                  "end": 58,
                   "ctxt": 0
                 },
                 "value": "Symbol",
@@ -126,8 +126,8 @@
               "property": {
                 "type": "Identifier",
                 "span": {
-                  "start": 57,
-                  "end": 65,
+                  "start": 59,
+                  "end": 67,
                   "ctxt": 0
                 },
                 "value": "iterator",
@@ -143,15 +143,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 67,
-                "end": 75,
+                "start": 69,
+                "end": 77,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 69,
-                  "end": 75,
+                  "start": 71,
+                  "end": 77,
                   "ctxt": 0
                 },
                 "kind": "number"

--- a/ecmascript/parser/tests/typescript/interface/property-named-public/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/property-named-public/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 32,
+    "end": 34,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsInterfaceDeclaration",
       "span": {
         "start": 10,
-        "end": 32,
+        "end": 34,
         "ctxt": 0
       },
       "id": {
@@ -31,23 +31,23 @@
         "type": "TsInterfaceBody",
         "span": {
           "start": 12,
-          "end": 32,
+          "end": 34,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 15,
-              "end": 30,
+              "start": 16,
+              "end": 31,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 15,
-                "end": 21,
+                "start": 16,
+                "end": 22,
                 "ctxt": 0
               },
               "value": "public",
@@ -61,15 +61,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 21,
-                "end": 29,
+                "start": 22,
+                "end": 30,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 23,
-                  "end": 29,
+                  "start": 24,
+                  "end": 30,
                   "ctxt": 0
                 },
                 "kind": "number"

--- a/ecmascript/parser/tests/typescript/interface/reserved-method-name/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/reserved-method-name/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 34,
+    "end": 36,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsInterfaceDeclaration",
       "span": {
         "start": 10,
-        "end": 34,
+        "end": 36,
         "ctxt": 0
       },
       "id": {
@@ -31,23 +31,23 @@
         "type": "TsInterfaceBody",
         "span": {
           "start": 12,
-          "end": 34,
+          "end": 36,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsMethodSignature",
             "span": {
-              "start": 18,
-              "end": 32,
+              "start": 19,
+              "end": 33,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 18,
-                "end": 23,
+                "start": 19,
+                "end": 24,
                 "ctxt": 0
               },
               "value": "catch",
@@ -60,15 +60,15 @@
             "typeAnn": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 25,
-                "end": 31,
+                "start": 26,
+                "end": 32,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 27,
-                  "end": 31,
+                  "start": 28,
+                  "end": 32,
                   "ctxt": 0
                 },
                 "kind": "void"

--- a/ecmascript/parser/tests/typescript/interface/separators/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/separators/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 130,
+    "end": 135,
     "ctxt": 0
   },
   "body": [
@@ -125,15 +125,15 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 51,
-        "end": 80,
+        "start": 52,
+        "end": 81,
         "ctxt": 0
       },
       "id": {
         "type": "Identifier",
         "span": {
-          "start": 51,
-          "end": 55,
+          "start": 52,
+          "end": 56,
           "ctxt": 0
         },
         "value": "Semi",
@@ -146,24 +146,24 @@
       "body": {
         "type": "TsInterfaceBody",
         "span": {
-          "start": 56,
-          "end": 80,
+          "start": 57,
+          "end": 81,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 58,
-              "end": 68,
+              "start": 59,
+              "end": 69,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 58,
-                "end": 59,
+                "start": 59,
+                "end": 60,
                 "ctxt": 0
               },
               "value": "x",
@@ -177,15 +177,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 59,
-                "end": 67,
+                "start": 60,
+                "end": 68,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 61,
-                  "end": 67,
+                  "start": 62,
+                  "end": 68,
                   "ctxt": 0
                 },
                 "kind": "number"
@@ -196,16 +196,16 @@
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 69,
-              "end": 78,
+              "start": 70,
+              "end": 79,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 69,
-                "end": 70,
+                "start": 70,
+                "end": 71,
                 "ctxt": 0
               },
               "value": "y",
@@ -219,15 +219,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 70,
-                "end": 78,
+                "start": 71,
+                "end": 79,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 72,
-                  "end": 78,
+                  "start": 73,
+                  "end": 79,
                   "ctxt": 0
                 },
                 "kind": "number"
@@ -241,15 +241,15 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 91,
-        "end": 130,
+        "start": 93,
+        "end": 135,
         "ctxt": 0
       },
       "id": {
         "type": "Identifier",
         "span": {
-          "start": 91,
-          "end": 98,
+          "start": 93,
+          "end": 100,
           "ctxt": 0
         },
         "value": "Newline",
@@ -262,24 +262,24 @@
       "body": {
         "type": "TsInterfaceBody",
         "span": {
-          "start": 99,
-          "end": 130,
+          "start": 101,
+          "end": 135,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 105,
-              "end": 114,
+              "start": 108,
+              "end": 117,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 105,
-                "end": 106,
+                "start": 108,
+                "end": 109,
                 "ctxt": 0
               },
               "value": "x",
@@ -293,15 +293,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 106,
-                "end": 114,
+                "start": 109,
+                "end": 117,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 108,
-                  "end": 114,
+                  "start": 111,
+                  "end": 117,
                   "ctxt": 0
                 },
                 "kind": "number"
@@ -312,16 +312,16 @@
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 119,
-              "end": 128,
+              "start": 123,
+              "end": 132,
               "ctxt": 0
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 119,
-                "end": 120,
+                "start": 123,
+                "end": 124,
                 "ctxt": 0
               },
               "value": "y",
@@ -335,15 +335,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 120,
-                "end": 128,
+                "start": 124,
+                "end": 132,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 122,
-                  "end": 128,
+                  "start": 126,
+                  "end": 132,
                   "ctxt": 0
                 },
                 "kind": "number"

--- a/ecmascript/parser/tests/typescript/module-namespace/body-declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/module-namespace/body-declare/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 44,
+    "end": 46,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsModuleDeclaration",
       "span": {
         "start": 0,
-        "end": 44,
+        "end": 46,
         "ctxt": 0
       },
       "declare": true,
@@ -30,15 +30,15 @@
         "type": "TsModuleBlock",
         "span": {
           "start": 20,
-          "end": 44,
+          "end": 46,
           "ctxt": 0
         },
         "body": [
           {
             "type": "VariableDeclaration",
             "span": {
-              "start": 26,
-              "end": 42,
+              "start": 27,
+              "end": 43,
               "ctxt": 0
             },
             "kind": "const",
@@ -47,30 +47,30 @@
               {
                 "type": "VariableDeclarator",
                 "span": {
-                  "start": 32,
-                  "end": 41,
+                  "start": 33,
+                  "end": 42,
                   "ctxt": 0
                 },
                 "id": {
                   "type": "Identifier",
                   "span": {
-                    "start": 32,
-                    "end": 33,
+                    "start": 33,
+                    "end": 34,
                     "ctxt": 0
                   },
                   "value": "x",
                   "typeAnnotation": {
                     "type": "TsTypeAnnotation",
                     "span": {
-                      "start": 33,
-                      "end": 41,
+                      "start": 34,
+                      "end": 42,
                       "ctxt": 0
                     },
                     "typeAnnotation": {
                       "type": "TsKeywordType",
                       "span": {
-                        "start": 35,
-                        "end": 41,
+                        "start": 36,
+                        "end": 42,
                         "ctxt": 0
                       },
                       "kind": "number"

--- a/ecmascript/parser/tests/typescript/module-namespace/body-nested-declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/module-namespace/body-nested-declare/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 72,
+    "end": 76,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsModuleDeclaration",
       "span": {
         "start": 0,
-        "end": 72,
+        "end": 76,
         "ctxt": 0
       },
       "declare": true,
@@ -30,15 +30,15 @@
         "type": "TsModuleBlock",
         "span": {
           "start": 20,
-          "end": 72,
+          "end": 76,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsModuleDeclaration",
             "span": {
-              "start": 26,
-              "end": 70,
+              "start": 27,
+              "end": 73,
               "ctxt": 0
             },
             "declare": true,
@@ -46,8 +46,8 @@
             "id": {
               "type": "Identifier",
               "span": {
-                "start": 36,
-                "end": 37,
+                "start": 37,
+                "end": 38,
                 "ctxt": 0
               },
               "value": "B",
@@ -57,16 +57,16 @@
             "body": {
               "type": "TsModuleBlock",
               "span": {
-                "start": 38,
-                "end": 70,
+                "start": 39,
+                "end": 73,
                 "ctxt": 0
               },
               "body": [
                 {
                   "type": "VariableDeclaration",
                   "span": {
-                    "start": 48,
-                    "end": 64,
+                    "start": 50,
+                    "end": 66,
                     "ctxt": 0
                   },
                   "kind": "const",
@@ -75,30 +75,30 @@
                     {
                       "type": "VariableDeclarator",
                       "span": {
-                        "start": 54,
-                        "end": 63,
+                        "start": 56,
+                        "end": 65,
                         "ctxt": 0
                       },
                       "id": {
                         "type": "Identifier",
                         "span": {
-                          "start": 54,
-                          "end": 55,
+                          "start": 56,
+                          "end": 57,
                           "ctxt": 0
                         },
                         "value": "x",
                         "typeAnnotation": {
                           "type": "TsTypeAnnotation",
                           "span": {
-                            "start": 55,
-                            "end": 63,
+                            "start": 57,
+                            "end": 65,
                             "ctxt": 0
                           },
                           "typeAnnotation": {
                             "type": "TsKeywordType",
                             "span": {
-                              "start": 57,
-                              "end": 63,
+                              "start": 59,
+                              "end": 65,
                               "ctxt": 0
                             },
                             "kind": "number"

--- a/ecmascript/parser/tests/typescript/module-namespace/body-nested/input.ts.json
+++ b/ecmascript/parser/tests/typescript/module-namespace/body-nested/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 39,
+    "end": 42,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsModuleDeclaration",
       "span": {
         "start": 0,
-        "end": 39,
+        "end": 42,
         "ctxt": 0
       },
       "declare": false,
@@ -30,15 +30,15 @@
         "type": "TsModuleBlock",
         "span": {
           "start": 12,
-          "end": 39,
+          "end": 42,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsModuleDeclaration",
             "span": {
-              "start": 18,
-              "end": 37,
+              "start": 19,
+              "end": 39,
               "ctxt": 0
             },
             "declare": false,
@@ -46,8 +46,8 @@
             "id": {
               "type": "Identifier",
               "span": {
-                "start": 28,
-                "end": 29,
+                "start": 29,
+                "end": 30,
                 "ctxt": 0
               },
               "value": "B",
@@ -57,8 +57,8 @@
             "body": {
               "type": "TsModuleBlock",
               "span": {
-                "start": 30,
-                "end": 37,
+                "start": 31,
+                "end": 39,
                 "ctxt": 0
               },
               "body": []

--- a/ecmascript/parser/tests/typescript/module-namespace/body/input.ts.json
+++ b/ecmascript/parser/tests/typescript/module-namespace/body/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 32,
+    "end": 34,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsModuleDeclaration",
       "span": {
         "start": 0,
-        "end": 32,
+        "end": 34,
         "ctxt": 0
       },
       "declare": false,
@@ -30,15 +30,15 @@
         "type": "TsModuleBlock",
         "span": {
           "start": 12,
-          "end": 32,
+          "end": 34,
           "ctxt": 0
         },
         "body": [
           {
             "type": "VariableDeclaration",
             "span": {
-              "start": 18,
-              "end": 30,
+              "start": 19,
+              "end": 31,
               "ctxt": 0
             },
             "kind": "const",
@@ -47,15 +47,15 @@
               {
                 "type": "VariableDeclarator",
                 "span": {
-                  "start": 24,
-                  "end": 29,
+                  "start": 25,
+                  "end": 30,
                   "ctxt": 0
                 },
                 "id": {
                   "type": "Identifier",
                   "span": {
-                    "start": 24,
-                    "end": 25,
+                    "start": 25,
+                    "end": 26,
                     "ctxt": 0
                   },
                   "value": "x",
@@ -65,8 +65,8 @@
                 "init": {
                   "type": "NumericLiteral",
                   "span": {
-                    "start": 28,
-                    "end": 29,
+                    "start": 29,
+                    "end": 30,
                     "ctxt": 0
                   },
                   "value": 0.0

--- a/ecmascript/parser/tests/typescript/module-namespace/global-in-module/input.ts.json
+++ b/ecmascript/parser/tests/typescript/module-namespace/global-in-module/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 64,
+    "end": 68,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsModuleDeclaration",
       "span": {
         "start": 0,
-        "end": 64,
+        "end": 68,
         "ctxt": 0
       },
       "declare": true,
@@ -29,15 +29,15 @@
         "type": "TsModuleBlock",
         "span": {
           "start": 19,
-          "end": 64,
+          "end": 68,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsModuleDeclaration",
             "span": {
-              "start": 25,
-              "end": 62,
+              "start": 26,
+              "end": 65,
               "ctxt": 0
             },
             "declare": true,
@@ -45,8 +45,8 @@
             "id": {
               "type": "Identifier",
               "span": {
-                "start": 25,
-                "end": 31,
+                "start": 26,
+                "end": 32,
                 "ctxt": 0
               },
               "value": "global",
@@ -56,16 +56,16 @@
             "body": {
               "type": "TsModuleBlock",
               "span": {
-                "start": 32,
-                "end": 62,
+                "start": 33,
+                "end": 65,
                 "ctxt": 0
               },
               "body": [
                 {
                   "type": "VariableDeclaration",
                   "span": {
-                    "start": 42,
-                    "end": 56,
+                    "start": 44,
+                    "end": 58,
                     "ctxt": 0
                   },
                   "kind": "var",
@@ -74,30 +74,30 @@
                     {
                       "type": "VariableDeclarator",
                       "span": {
-                        "start": 46,
-                        "end": 55,
+                        "start": 48,
+                        "end": 57,
                         "ctxt": 0
                       },
                       "id": {
                         "type": "Identifier",
                         "span": {
-                          "start": 46,
-                          "end": 47,
+                          "start": 48,
+                          "end": 49,
                           "ctxt": 0
                         },
                         "value": "x",
                         "typeAnnotation": {
                           "type": "TsTypeAnnotation",
                           "span": {
-                            "start": 47,
-                            "end": 55,
+                            "start": 49,
+                            "end": 57,
                             "ctxt": 0
                           },
                           "typeAnnotation": {
                             "type": "TsKeywordType",
                             "span": {
-                              "start": 49,
-                              "end": 55,
+                              "start": 51,
+                              "end": 57,
                               "ctxt": 0
                             },
                             "kind": "number"

--- a/ecmascript/parser/tests/typescript/module-namespace/head-declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/module-namespace/head-declare/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 84,
+    "end": 87,
     "ctxt": 0
   },
   "body": [
@@ -60,8 +60,8 @@
     {
       "type": "TsModuleDeclaration",
       "span": {
-        "start": 25,
-        "end": 44,
+        "start": 26,
+        "end": 45,
         "ctxt": 0
       },
       "declare": true,
@@ -69,8 +69,8 @@
       "id": {
         "type": "Identifier",
         "span": {
-          "start": 40,
-          "end": 41,
+          "start": 41,
+          "end": 42,
           "ctxt": 0
         },
         "value": "M",
@@ -80,8 +80,8 @@
       "body": {
         "type": "TsModuleBlock",
         "span": {
-          "start": 42,
-          "end": 44,
+          "start": 43,
+          "end": 45,
           "ctxt": 0
         },
         "body": []
@@ -90,8 +90,8 @@
     {
       "type": "TsModuleDeclaration",
       "span": {
-        "start": 45,
-        "end": 66,
+        "start": 47,
+        "end": 68,
         "ctxt": 0
       },
       "declare": true,
@@ -99,8 +99,8 @@
       "id": {
         "type": "StringLiteral",
         "span": {
-          "start": 60,
-          "end": 63,
+          "start": 62,
+          "end": 65,
           "ctxt": 0
         },
         "value": "m",
@@ -109,8 +109,8 @@
       "body": {
         "type": "TsModuleBlock",
         "span": {
-          "start": 64,
-          "end": 66,
+          "start": 66,
+          "end": 68,
           "ctxt": 0
         },
         "body": []
@@ -119,8 +119,8 @@
     {
       "type": "TsModuleDeclaration",
       "span": {
-        "start": 67,
-        "end": 84,
+        "start": 70,
+        "end": 87,
         "ctxt": 0
       },
       "declare": true,
@@ -128,8 +128,8 @@
       "id": {
         "type": "Identifier",
         "span": {
-          "start": 75,
-          "end": 81,
+          "start": 78,
+          "end": 84,
           "ctxt": 0
         },
         "value": "global",
@@ -139,8 +139,8 @@
       "body": {
         "type": "TsModuleBlock",
         "span": {
-          "start": 82,
-          "end": 84,
+          "start": 85,
+          "end": 87,
           "ctxt": 0
         },
         "body": []

--- a/ecmascript/parser/tests/typescript/module-namespace/head-export/input.ts.json
+++ b/ecmascript/parser/tests/typescript/module-namespace/head-export/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 42,
+    "end": 43,
     "ctxt": 0
   },
   "body": [
@@ -68,15 +68,15 @@
     {
       "type": "ExportDeclaration",
       "span": {
-        "start": 24,
-        "end": 42,
+        "start": 25,
+        "end": 43,
         "ctxt": 0
       },
       "declaration": {
         "type": "TsModuleDeclaration",
         "span": {
-          "start": 31,
-          "end": 42,
+          "start": 32,
+          "end": 43,
           "ctxt": 0
         },
         "declare": false,
@@ -84,8 +84,8 @@
         "id": {
           "type": "Identifier",
           "span": {
-            "start": 38,
-            "end": 39,
+            "start": 39,
+            "end": 40,
             "ctxt": 0
           },
           "value": "X",
@@ -95,8 +95,8 @@
         "body": {
           "type": "TsModuleBlock",
           "span": {
-            "start": 40,
-            "end": 42,
+            "start": 41,
+            "end": 43,
             "ctxt": 0
           },
           "body": []

--- a/ecmascript/parser/tests/typescript/module-namespace/head/input.ts.json
+++ b/ecmascript/parser/tests/typescript/module-namespace/head/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 59,
+    "end": 62,
     "ctxt": 0
   },
   "body": [
@@ -39,8 +39,8 @@
     {
       "type": "TsModuleDeclaration",
       "span": {
-        "start": 15,
-        "end": 33,
+        "start": 16,
+        "end": 34,
         "ctxt": 0
       },
       "declare": false,
@@ -48,8 +48,8 @@
       "id": {
         "type": "Identifier",
         "span": {
-          "start": 25,
-          "end": 26,
+          "start": 26,
+          "end": 27,
           "ctxt": 0
         },
         "value": "M",
@@ -59,8 +59,8 @@
       "body": {
         "type": "TsNamespaceDeclaration",
         "span": {
-          "start": 27,
-          "end": 33,
+          "start": 28,
+          "end": 34,
           "ctxt": 0
         },
         "declare": false,
@@ -68,8 +68,8 @@
         "id": {
           "type": "Identifier",
           "span": {
-            "start": 27,
-            "end": 28,
+            "start": 28,
+            "end": 29,
             "ctxt": 0
           },
           "value": "N",
@@ -79,8 +79,8 @@
         "body": {
           "type": "TsNamespaceDeclaration",
           "span": {
-            "start": 29,
-            "end": 33,
+            "start": 30,
+            "end": 34,
             "ctxt": 0
           },
           "declare": false,
@@ -88,8 +88,8 @@
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 29,
-              "end": 30,
+              "start": 30,
+              "end": 31,
               "ctxt": 0
             },
             "value": "O",
@@ -99,8 +99,8 @@
           "body": {
             "type": "TsModuleBlock",
             "span": {
-              "start": 31,
-              "end": 33,
+              "start": 32,
+              "end": 34,
               "ctxt": 0
             },
             "body": []
@@ -111,8 +111,8 @@
     {
       "type": "TsModuleDeclaration",
       "span": {
-        "start": 34,
-        "end": 45,
+        "start": 36,
+        "end": 47,
         "ctxt": 0
       },
       "declare": false,
@@ -120,8 +120,8 @@
       "id": {
         "type": "Identifier",
         "span": {
-          "start": 41,
-          "end": 42,
+          "start": 43,
+          "end": 44,
           "ctxt": 0
         },
         "value": "M",
@@ -131,8 +131,8 @@
       "body": {
         "type": "TsModuleBlock",
         "span": {
-          "start": 43,
-          "end": 45,
+          "start": 45,
+          "end": 47,
           "ctxt": 0
         },
         "body": []
@@ -141,8 +141,8 @@
     {
       "type": "TsModuleDeclaration",
       "span": {
-        "start": 46,
-        "end": 59,
+        "start": 49,
+        "end": 62,
         "ctxt": 0
       },
       "declare": false,
@@ -150,8 +150,8 @@
       "id": {
         "type": "StringLiteral",
         "span": {
-          "start": 53,
-          "end": 56,
+          "start": 56,
+          "end": 59,
           "ctxt": 0
         },
         "value": "m",
@@ -160,8 +160,8 @@
       "body": {
         "type": "TsModuleBlock",
         "span": {
-          "start": 57,
-          "end": 59,
+          "start": 60,
+          "end": 62,
           "ctxt": 0
         },
         "body": []

--- a/ecmascript/parser/tests/typescript/regression/is-default-export/input.ts.json
+++ b/ecmascript/parser/tests/typescript/regression/is-default-export/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 62,
+    "end": 64,
     "ctxt": 0
   },
   "body": [
@@ -47,15 +47,15 @@
     {
       "type": "ExportDeclaration",
       "span": {
-        "start": 24,
-        "end": 40,
+        "start": 25,
+        "end": 41,
         "ctxt": 0
       },
       "declaration": {
         "type": "TsEnumDeclaration",
         "span": {
-          "start": 31,
-          "end": 40,
+          "start": 32,
+          "end": 41,
           "ctxt": 0
         },
         "declare": false,
@@ -63,8 +63,8 @@
         "id": {
           "type": "Identifier",
           "span": {
-            "start": 36,
-            "end": 37,
+            "start": 37,
+            "end": 38,
             "ctxt": 0
           },
           "value": "E",
@@ -77,22 +77,22 @@
     {
       "type": "ExportDeclaration",
       "span": {
-        "start": 41,
-        "end": 62,
+        "start": 43,
+        "end": 64,
         "ctxt": 0
       },
       "declaration": {
         "type": "TsInterfaceDeclaration",
         "span": {
-          "start": 58,
-          "end": 62,
+          "start": 60,
+          "end": 64,
           "ctxt": 0
         },
         "id": {
           "type": "Identifier",
           "span": {
-            "start": 58,
-            "end": 59,
+            "start": 60,
+            "end": 61,
             "ctxt": 0
           },
           "value": "I",
@@ -105,8 +105,8 @@
         "body": {
           "type": "TsInterfaceBody",
           "span": {
-            "start": 60,
-            "end": 62,
+            "start": 62,
+            "end": 64,
             "ctxt": 0
           },
           "body": []

--- a/ecmascript/parser/tests/typescript/regression/tsx-issue-7742/input.ts.json
+++ b/ecmascript/parser/tests/typescript/regression/tsx-issue-7742/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 40,
+    "end": 42,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "TsInterfaceDeclaration",
       "span": {
         "start": 10,
-        "end": 40,
+        "end": 42,
         "ctxt": 0
       },
       "id": {
@@ -61,45 +61,45 @@
         "type": "TsInterfaceBody",
         "span": {
           "start": 17,
-          "end": 40,
+          "end": 42,
           "ctxt": 0
         },
         "body": [
           {
             "type": "TsCallSignatureDeclaration",
             "span": {
-              "start": 23,
-              "end": 38,
+              "start": 24,
+              "end": 39,
               "ctxt": 0
             },
             "params": [
               {
                 "type": "Identifier",
                 "span": {
-                  "start": 27,
-                  "end": 30,
+                  "start": 28,
+                  "end": 31,
                   "ctxt": 0
                 },
                 "value": "bar",
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 30,
-                    "end": 33,
+                    "start": 31,
+                    "end": 34,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsTypeReference",
                     "span": {
-                      "start": 32,
-                      "end": 33,
+                      "start": 33,
+                      "end": 34,
                       "ctxt": 0
                     },
                     "typeName": {
                       "type": "Identifier",
                       "span": {
-                        "start": 32,
-                        "end": 33,
+                        "start": 33,
+                        "end": 34,
                         "ctxt": 0
                       },
                       "value": "G",
@@ -115,22 +115,22 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 34,
-                "end": 37,
+                "start": 35,
+                "end": 38,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsTypeReference",
                 "span": {
-                  "start": 36,
-                  "end": 37,
+                  "start": 37,
+                  "end": 38,
                   "ctxt": 0
                 },
                 "typeName": {
                   "type": "Identifier",
                   "span": {
-                    "start": 36,
-                    "end": 37,
+                    "start": 37,
+                    "end": 38,
                     "ctxt": 0
                   },
                   "value": "T",
@@ -143,23 +143,23 @@
             "typeParams": {
               "type": "TsTypeParameterDeclaration",
               "span": {
-                "start": 23,
-                "end": 26,
+                "start": 24,
+                "end": 27,
                 "ctxt": 0
               },
               "parameters": [
                 {
                   "type": "TsTypeParameter",
                   "span": {
-                    "start": 24,
-                    "end": 25,
+                    "start": 25,
+                    "end": 26,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 24,
-                      "end": 25,
+                      "start": 25,
+                      "end": 26,
                       "ctxt": 0
                     },
                     "value": "T",

--- a/ecmascript/parser/tests/typescript/tsx/brace-is-block/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsx/brace-is-block/input.ts.json
@@ -1,8 +1,8 @@
 {
   "type": "Module",
   "span": {
-    "start": 99,
-    "end": 127,
+    "start": 100,
+    "end": 129,
     "ctxt": 0
   },
   "body": [
@@ -11,8 +11,8 @@
       "identifier": {
         "type": "Identifier",
         "span": {
-          "start": 105,
-          "end": 106,
+          "start": 106,
+          "end": 107,
           "ctxt": 0
         },
         "value": "C",
@@ -21,8 +21,8 @@
       },
       "declare": false,
       "span": {
-        "start": 99,
-        "end": 122,
+        "start": 100,
+        "end": 123,
         "ctxt": 0
       },
       "decorators": [],
@@ -30,8 +30,8 @@
       "superClass": {
         "type": "Identifier",
         "span": {
-          "start": 115,
-          "end": 116,
+          "start": 116,
+          "end": 117,
           "ctxt": 0
         },
         "value": "D",
@@ -43,23 +43,23 @@
       "superTypeParams": {
         "type": "TsTypeParameterInstantiation",
         "span": {
-          "start": 116,
-          "end": 119,
+          "start": 117,
+          "end": 120,
           "ctxt": 0
         },
         "params": [
           {
             "type": "TsTypeReference",
             "span": {
-              "start": 117,
-              "end": 118,
+              "start": 118,
+              "end": 119,
               "ctxt": 0
             },
             "typeName": {
               "type": "Identifier",
               "span": {
-                "start": 117,
-                "end": 118,
+                "start": 118,
+                "end": 119,
                 "ctxt": 0
               },
               "value": "T",
@@ -75,8 +75,8 @@
     {
       "type": "JSXElement",
       "span": {
-        "start": 123,
-        "end": 127,
+        "start": 125,
+        "end": 129,
         "ctxt": 0
       },
       "opening": {
@@ -84,8 +84,8 @@
         "name": {
           "type": "Identifier",
           "span": {
-            "start": 124,
-            "end": 125,
+            "start": 126,
+            "end": 127,
             "ctxt": 0
           },
           "value": "C",
@@ -93,8 +93,8 @@
           "optional": false
         },
         "span": {
-          "start": 124,
-          "end": 127,
+          "start": 126,
+          "end": 129,
           "ctxt": 0
         },
         "attributes": [],

--- a/ecmascript/parser/tests/typescript/tsx/type-arguments/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsx/type-arguments/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 34,
+    "end": 36,
     "ctxt": 0
   },
   "body": [
@@ -59,15 +59,15 @@
     {
       "type": "NewExpression",
       "span": {
-        "start": 8,
-        "end": 18,
+        "start": 9,
+        "end": 19,
         "ctxt": 0
       },
       "callee": {
         "type": "Identifier",
         "span": {
-          "start": 12,
-          "end": 13,
+          "start": 13,
+          "end": 14,
           "ctxt": 0
         },
         "value": "C",
@@ -78,23 +78,23 @@
       "typeArguments": {
         "type": "TsTypeParameterInstantiation",
         "span": {
-          "start": 13,
-          "end": 16,
+          "start": 14,
+          "end": 17,
           "ctxt": 0
         },
         "params": [
           {
             "type": "TsTypeReference",
             "span": {
-              "start": 14,
-              "end": 15,
+              "start": 15,
+              "end": 16,
               "ctxt": 0
             },
             "typeName": {
               "type": "Identifier",
               "span": {
-                "start": 14,
-                "end": 15,
+                "start": 15,
+                "end": 16,
                 "ctxt": 0
               },
               "value": "T",
@@ -109,16 +109,16 @@
     {
       "type": "TsTypeAliasDeclaration",
       "span": {
-        "start": 20,
-        "end": 34,
+        "start": 22,
+        "end": 36,
         "ctxt": 0
       },
       "declare": false,
       "id": {
         "type": "Identifier",
         "span": {
-          "start": 25,
-          "end": 26,
+          "start": 27,
+          "end": 28,
           "ctxt": 0
         },
         "value": "A",
@@ -129,15 +129,15 @@
       "typeAnnotation": {
         "type": "TsTypeReference",
         "span": {
-          "start": 29,
-          "end": 33,
+          "start": 31,
+          "end": 35,
           "ctxt": 0
         },
         "typeName": {
           "type": "Identifier",
           "span": {
-            "start": 29,
-            "end": 30,
+            "start": 31,
+            "end": 32,
             "ctxt": 0
           },
           "value": "T",
@@ -147,23 +147,23 @@
         "typeParams": {
           "type": "TsTypeParameterInstantiation",
           "span": {
-            "start": 30,
-            "end": 33,
+            "start": 32,
+            "end": 35,
             "ctxt": 0
           },
           "params": [
             {
               "type": "TsTypeReference",
               "span": {
-                "start": 31,
-                "end": 32,
+                "start": 33,
+                "end": 34,
                 "ctxt": 0
               },
               "typeName": {
                 "type": "Identifier",
                 "span": {
-                  "start": 31,
-                  "end": 32,
+                  "start": 33,
+                  "end": 34,
                   "ctxt": 0
                 },
                 "value": "T",

--- a/ecmascript/parser/tests/typescript/type-arguments/call/input.ts.json
+++ b/ecmascript/parser/tests/typescript/type-arguments/call/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 18,
+    "end": 19,
     "ctxt": 0
   },
   "body": [
@@ -59,15 +59,15 @@
     {
       "type": "CallExpression",
       "span": {
-        "start": 8,
-        "end": 17,
+        "start": 9,
+        "end": 18,
         "ctxt": 0
       },
       "callee": {
         "type": "Identifier",
         "span": {
-          "start": 8,
-          "end": 9,
+          "start": 9,
+          "end": 10,
           "ctxt": 0
         },
         "value": "f",
@@ -78,23 +78,23 @@
       "typeArguments": {
         "type": "TsTypeParameterInstantiation",
         "span": {
-          "start": 9,
-          "end": 15,
+          "start": 10,
+          "end": 16,
           "ctxt": 0
         },
         "params": [
           {
             "type": "TsTypeReference",
             "span": {
-              "start": 10,
-              "end": 11,
+              "start": 11,
+              "end": 12,
               "ctxt": 0
             },
             "typeName": {
               "type": "Identifier",
               "span": {
-                "start": 10,
-                "end": 11,
+                "start": 11,
+                "end": 12,
                 "ctxt": 0
               },
               "value": "T",
@@ -106,15 +106,15 @@
           {
             "type": "TsTypeReference",
             "span": {
-              "start": 13,
-              "end": 14,
+              "start": 14,
+              "end": 15,
               "ctxt": 0
             },
             "typeName": {
               "type": "Identifier",
               "span": {
-                "start": 13,
-                "end": 14,
+                "start": 14,
+                "end": 15,
                 "ctxt": 0
               },
               "value": "U",

--- a/ecmascript/parser/tests/typescript/type-arguments/new/input.ts.json
+++ b/ecmascript/parser/tests/typescript/type-arguments/new/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 26,
+    "end": 27,
     "ctxt": 0
   },
   "body": [
@@ -59,15 +59,15 @@
     {
       "type": "NewExpression",
       "span": {
-        "start": 12,
-        "end": 25,
+        "start": 13,
+        "end": 26,
         "ctxt": 0
       },
       "callee": {
         "type": "Identifier",
         "span": {
-          "start": 16,
-          "end": 17,
+          "start": 17,
+          "end": 18,
           "ctxt": 0
         },
         "value": "C",
@@ -78,23 +78,23 @@
       "typeArguments": {
         "type": "TsTypeParameterInstantiation",
         "span": {
-          "start": 17,
-          "end": 23,
+          "start": 18,
+          "end": 24,
           "ctxt": 0
         },
         "params": [
           {
             "type": "TsTypeReference",
             "span": {
-              "start": 18,
-              "end": 19,
+              "start": 19,
+              "end": 20,
               "ctxt": 0
             },
             "typeName": {
               "type": "Identifier",
               "span": {
-                "start": 18,
-                "end": 19,
+                "start": 19,
+                "end": 20,
                 "ctxt": 0
               },
               "value": "T",
@@ -106,15 +106,15 @@
           {
             "type": "TsTypeReference",
             "span": {
-              "start": 21,
-              "end": 22,
+              "start": 22,
+              "end": 23,
               "ctxt": 0
             },
             "typeName": {
               "type": "Identifier",
               "span": {
-                "start": 21,
-                "end": 22,
+                "start": 22,
+                "end": 23,
                 "ctxt": 0
               },
               "value": "U",

--- a/ecmascript/parser/tests/typescript/type-arguments/tagged-template-no-asi/input.ts.json
+++ b/ecmascript/parser/tests/typescript/type-arguments/tagged-template-no-asi/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 11,
+    "end": 12,
     "ctxt": 0
   },
   "body": [
@@ -10,14 +10,14 @@
       "type": "NewExpression",
       "span": {
         "start": 0,
-        "end": 11,
+        "end": 12,
         "ctxt": 0
       },
       "callee": {
         "type": "TaggedTemplateExpression",
         "span": {
-          "start": 9,
-          "end": 11,
+          "start": 10,
+          "end": 12,
           "ctxt": 0
         },
         "tag": {
@@ -36,16 +36,16 @@
           {
             "type": "TemplateElement",
             "span": {
-              "start": 10,
-              "end": 10,
+              "start": 11,
+              "end": 11,
               "ctxt": 0
             },
             "tail": true,
             "cooked": {
               "type": "StringLiteral",
               "span": {
-                "start": 10,
-                "end": 10,
+                "start": 11,
+                "end": 11,
                 "ctxt": 0
               },
               "value": "",
@@ -54,8 +54,8 @@
             "raw": {
               "type": "StringLiteral",
               "span": {
-                "start": 10,
-                "end": 10,
+                "start": 11,
+                "end": 11,
                 "ctxt": 0
               },
               "value": "",

--- a/ecmascript/parser/tests/typescript/type-arguments/tsx/input.ts.json
+++ b/ecmascript/parser/tests/typescript/type-arguments/tsx/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 30,
+    "end": 31,
     "ctxt": 0
   },
   "body": [
@@ -77,8 +77,8 @@
     {
       "type": "JSXElement",
       "span": {
-        "start": 17,
-        "end": 29,
+        "start": 18,
+        "end": 30,
         "ctxt": 0
       },
       "opening": {
@@ -86,8 +86,8 @@
         "name": {
           "type": "Identifier",
           "span": {
-            "start": 18,
-            "end": 19,
+            "start": 19,
+            "end": 20,
             "ctxt": 0
           },
           "value": "C",
@@ -95,8 +95,8 @@
           "optional": false
         },
         "span": {
-          "start": 18,
-          "end": 29,
+          "start": 19,
+          "end": 30,
           "ctxt": 0
         },
         "attributes": [],
@@ -104,16 +104,16 @@
         "typeArguments": {
           "type": "TsTypeParameterInstantiation",
           "span": {
-            "start": 19,
-            "end": 27,
+            "start": 20,
+            "end": 28,
             "ctxt": 0
           },
           "params": [
             {
               "type": "TsKeywordType",
               "span": {
-                "start": 20,
-                "end": 26,
+                "start": 21,
+                "end": 27,
                 "ctxt": 0
               },
               "kind": "number"

--- a/ecmascript/parser/tests/typescript/types/keywords/input.ts.json
+++ b/ecmascript/parser/tests/typescript/types/keywords/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 184,
+    "end": 195,
     "ctxt": 0
   },
   "body": [
@@ -58,8 +58,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 12,
-        "end": 28,
+        "start": 13,
+        "end": 29,
         "ctxt": 0
       },
       "kind": "let",
@@ -68,30 +68,30 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 16,
-            "end": 27,
+            "start": 17,
+            "end": 28,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 16,
-              "end": 18,
+              "start": 17,
+              "end": 19,
               "ctxt": 0
             },
             "value": "un",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 18,
-                "end": 27,
+                "start": 19,
+                "end": 28,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 20,
-                  "end": 27,
+                  "start": 21,
+                  "end": 28,
                   "ctxt": 0
                 },
                 "kind": "unknown"
@@ -107,8 +107,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 29,
-        "end": 44,
+        "start": 31,
+        "end": 46,
         "ctxt": 0
       },
       "kind": "let",
@@ -117,30 +117,30 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 33,
-            "end": 43,
+            "start": 35,
+            "end": 45,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 33,
-              "end": 34,
+              "start": 35,
+              "end": 36,
               "ctxt": 0
             },
             "value": "b",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 34,
-                "end": 43,
+                "start": 36,
+                "end": 45,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 36,
-                  "end": 43,
+                  "start": 38,
+                  "end": 45,
                   "ctxt": 0
                 },
                 "kind": "boolean"
@@ -156,8 +156,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 45,
-        "end": 59,
+        "start": 48,
+        "end": 62,
         "ctxt": 0
       },
       "kind": "let",
@@ -166,30 +166,30 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 49,
-            "end": 58,
+            "start": 52,
+            "end": 61,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 49,
-              "end": 51,
+              "start": 52,
+              "end": 54,
               "ctxt": 0
             },
             "value": "ne",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 51,
-                "end": 58,
+                "start": 54,
+                "end": 61,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 53,
-                  "end": 58,
+                  "start": 56,
+                  "end": 61,
                   "ctxt": 0
                 },
                 "kind": "never"
@@ -205,8 +205,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 60,
-        "end": 74,
+        "start": 64,
+        "end": 78,
         "ctxt": 0
       },
       "kind": "let",
@@ -215,30 +215,30 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 64,
-            "end": 73,
+            "start": 68,
+            "end": 77,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 64,
-              "end": 67,
+              "start": 68,
+              "end": 71,
               "ctxt": 0
             },
             "value": "nul",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 67,
-                "end": 73,
+                "start": 71,
+                "end": 77,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 69,
-                  "end": 73,
+                  "start": 73,
+                  "end": 77,
                   "ctxt": 0
                 },
                 "kind": "null"
@@ -254,8 +254,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 75,
-        "end": 91,
+        "start": 80,
+        "end": 96,
         "ctxt": 0
       },
       "kind": "let",
@@ -264,30 +264,30 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 79,
-            "end": 90,
+            "start": 84,
+            "end": 95,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 79,
-              "end": 82,
+              "start": 84,
+              "end": 87,
               "ctxt": 0
             },
             "value": "num",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 82,
-                "end": 90,
+                "start": 87,
+                "end": 95,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 84,
-                  "end": 90,
+                  "start": 89,
+                  "end": 95,
                   "ctxt": 0
                 },
                 "kind": "number"
@@ -303,8 +303,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 92,
-        "end": 106,
+        "start": 98,
+        "end": 112,
         "ctxt": 0
       },
       "kind": "let",
@@ -313,30 +313,30 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 96,
-            "end": 105,
+            "start": 102,
+            "end": 111,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 96,
-              "end": 97,
+              "start": 102,
+              "end": 103,
               "ctxt": 0
             },
             "value": "o",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 97,
-                "end": 105,
+                "start": 103,
+                "end": 111,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 99,
-                  "end": 105,
+                  "start": 105,
+                  "end": 111,
                   "ctxt": 0
                 },
                 "kind": "object"
@@ -352,8 +352,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 107,
-        "end": 122,
+        "start": 114,
+        "end": 129,
         "ctxt": 0
       },
       "kind": "let",
@@ -362,30 +362,30 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 111,
-            "end": 121,
+            "start": 118,
+            "end": 128,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 111,
-              "end": 113,
+              "start": 118,
+              "end": 120,
               "ctxt": 0
             },
             "value": "st",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 113,
-                "end": 121,
+                "start": 120,
+                "end": 128,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 115,
-                  "end": 121,
+                  "start": 122,
+                  "end": 128,
                   "ctxt": 0
                 },
                 "kind": "string"
@@ -401,8 +401,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 123,
-        "end": 138,
+        "start": 131,
+        "end": 146,
         "ctxt": 0
       },
       "kind": "let",
@@ -411,30 +411,30 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 127,
-            "end": 137,
+            "start": 135,
+            "end": 145,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 127,
-              "end": 129,
+              "start": 135,
+              "end": 137,
               "ctxt": 0
             },
             "value": "sy",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 129,
-                "end": 137,
+                "start": 137,
+                "end": 145,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 131,
-                  "end": 137,
+                  "start": 139,
+                  "end": 145,
                   "ctxt": 0
                 },
                 "kind": "symbol"
@@ -450,8 +450,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 139,
-        "end": 156,
+        "start": 148,
+        "end": 165,
         "ctxt": 0
       },
       "kind": "let",
@@ -460,30 +460,30 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 143,
-            "end": 155,
+            "start": 152,
+            "end": 164,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 143,
-              "end": 144,
+              "start": 152,
+              "end": 153,
               "ctxt": 0
             },
             "value": "u",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 144,
-                "end": 155,
+                "start": 153,
+                "end": 164,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 146,
-                  "end": 155,
+                  "start": 155,
+                  "end": 164,
                   "ctxt": 0
                 },
                 "kind": "undefined"
@@ -499,8 +499,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 157,
-        "end": 169,
+        "start": 167,
+        "end": 179,
         "ctxt": 0
       },
       "kind": "let",
@@ -509,30 +509,30 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 161,
-            "end": 168,
+            "start": 171,
+            "end": 178,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 161,
-              "end": 162,
+              "start": 171,
+              "end": 172,
               "ctxt": 0
             },
             "value": "v",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 162,
-                "end": 168,
+                "start": 172,
+                "end": 178,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 164,
-                  "end": 168,
+                  "start": 174,
+                  "end": 178,
                   "ctxt": 0
                 },
                 "kind": "void"
@@ -548,8 +548,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 170,
-        "end": 184,
+        "start": 181,
+        "end": 195,
         "ctxt": 0
       },
       "kind": "let",
@@ -558,30 +558,30 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 174,
-            "end": 183,
+            "start": 185,
+            "end": 194,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 174,
-              "end": 175,
+              "start": 185,
+              "end": 186,
               "ctxt": 0
             },
             "value": "n",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 175,
-                "end": 183,
+                "start": 186,
+                "end": 194,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 177,
-                  "end": 183,
+                  "start": 188,
+                  "end": 194,
                   "ctxt": 0
                 },
                 "kind": "bigint"

--- a/ecmascript/parser/tests/typescript/types/literal-boolean/input.ts.json
+++ b/ecmascript/parser/tests/typescript/types/literal-boolean/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 26,
+    "end": 27,
     "ctxt": 0
   },
   "body": [
@@ -66,8 +66,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 13,
-        "end": 26,
+        "start": 14,
+        "end": 27,
         "ctxt": 0
       },
       "kind": "let",
@@ -76,37 +76,37 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 17,
-            "end": 25,
+            "start": 18,
+            "end": 26,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 17,
-              "end": 18,
+              "start": 18,
+              "end": 19,
               "ctxt": 0
             },
             "value": "x",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 18,
-                "end": 25,
+                "start": 19,
+                "end": 26,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsLiteralType",
                 "span": {
-                  "start": 20,
-                  "end": 25,
+                  "start": 21,
+                  "end": 26,
                   "ctxt": 0
                 },
                 "literal": {
                   "type": "BooleanLiteral",
                   "span": {
-                    "start": 20,
-                    "end": 25,
+                    "start": 21,
+                    "end": 26,
                     "ctxt": 0
                   },
                   "value": false

--- a/ecmascript/parser/tests/typescript/types/mapped/input.ts.json
+++ b/ecmascript/parser/tests/typescript/types/mapped/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 180,
+    "end": 183,
     "ctxt": 0
   },
   "body": [
@@ -97,8 +97,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 37,
-        "end": 83,
+        "start": 38,
+        "end": 84,
         "ctxt": 0
       },
       "kind": "let",
@@ -107,45 +107,45 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 41,
-            "end": 82,
+            "start": 42,
+            "end": 83,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 41,
-              "end": 44,
+              "start": 42,
+              "end": 45,
               "ctxt": 0
             },
             "value": "map",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 44,
-                "end": 82,
+                "start": 45,
+                "end": 83,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsMappedType",
                 "span": {
-                  "start": 46,
-                  "end": 82,
+                  "start": 47,
+                  "end": 83,
                   "ctxt": 0
                 },
                 "readonly": true,
                 "typeParam": {
                   "type": "TsTypeParameter",
                   "span": {
-                    "start": 58,
-                    "end": 69,
+                    "start": 59,
+                    "end": 70,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 58,
-                      "end": 59,
+                      "start": 59,
+                      "end": 60,
                       "ctxt": 0
                     },
                     "value": "P",
@@ -155,8 +155,8 @@
                   "constraint": {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 63,
-                      "end": 69,
+                      "start": 64,
+                      "end": 70,
                       "ctxt": 0
                     },
                     "kind": "string"
@@ -167,8 +167,8 @@
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 73,
-                    "end": 79,
+                    "start": 74,
+                    "end": 80,
                     "ctxt": 0
                   },
                   "kind": "number"
@@ -185,8 +185,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 84,
-        "end": 132,
+        "start": 86,
+        "end": 134,
         "ctxt": 0
       },
       "kind": "let",
@@ -195,45 +195,45 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 88,
-            "end": 131,
+            "start": 90,
+            "end": 133,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 88,
-              "end": 91,
+              "start": 90,
+              "end": 93,
               "ctxt": 0
             },
             "value": "map",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 91,
-                "end": 131,
+                "start": 93,
+                "end": 133,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsMappedType",
                 "span": {
-                  "start": 93,
-                  "end": 131,
+                  "start": 95,
+                  "end": 133,
                   "ctxt": 0
                 },
                 "readonly": "+",
                 "typeParam": {
                   "type": "TsTypeParameter",
                   "span": {
-                    "start": 106,
-                    "end": 117,
+                    "start": 108,
+                    "end": 119,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 106,
-                      "end": 107,
+                      "start": 108,
+                      "end": 109,
                       "ctxt": 0
                     },
                     "value": "P",
@@ -243,8 +243,8 @@
                   "constraint": {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 111,
-                      "end": 117,
+                      "start": 113,
+                      "end": 119,
                       "ctxt": 0
                     },
                     "kind": "string"
@@ -255,8 +255,8 @@
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 122,
-                    "end": 128,
+                    "start": 124,
+                    "end": 130,
                     "ctxt": 0
                   },
                   "kind": "number"
@@ -273,8 +273,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 133,
-        "end": 180,
+        "start": 136,
+        "end": 183,
         "ctxt": 0
       },
       "kind": "let",
@@ -283,45 +283,45 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 137,
-            "end": 179,
+            "start": 140,
+            "end": 182,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 137,
-              "end": 140,
+              "start": 140,
+              "end": 143,
               "ctxt": 0
             },
             "value": "map",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 140,
-                "end": 179,
+                "start": 143,
+                "end": 182,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsMappedType",
                 "span": {
-                  "start": 142,
-                  "end": 179,
+                  "start": 145,
+                  "end": 182,
                   "ctxt": 0
                 },
                 "readonly": "-",
                 "typeParam": {
                   "type": "TsTypeParameter",
                   "span": {
-                    "start": 155,
-                    "end": 166,
+                    "start": 158,
+                    "end": 169,
                     "ctxt": 0
                   },
                   "name": {
                     "type": "Identifier",
                     "span": {
-                      "start": 155,
-                      "end": 156,
+                      "start": 158,
+                      "end": 159,
                       "ctxt": 0
                     },
                     "value": "P",
@@ -331,8 +331,8 @@
                   "constraint": {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 160,
-                      "end": 166,
+                      "start": 163,
+                      "end": 169,
                       "ctxt": 0
                     },
                     "kind": "string"
@@ -343,8 +343,8 @@
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 171,
-                    "end": 177,
+                    "start": 174,
+                    "end": 180,
                     "ctxt": 0
                   },
                   "kind": "number"

--- a/ecmascript/parser/tests/typescript/types/object-shorthand/input.ts.json
+++ b/ecmascript/parser/tests/typescript/types/object-shorthand/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 87,
+    "end": 91,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "VariableDeclaration",
       "span": {
         "start": 0,
-        "end": 87,
+        "end": 91,
         "ctxt": 0
       },
       "kind": "const",
@@ -20,7 +20,7 @@
           "type": "VariableDeclarator",
           "span": {
             "start": 6,
-            "end": 86,
+            "end": 90,
             "ctxt": 0
           },
           "id": {
@@ -38,7 +38,7 @@
             "type": "ObjectExpression",
             "span": {
               "start": 14,
-              "end": 86,
+              "end": 90,
               "ctxt": 0
             },
             "properties": [
@@ -47,8 +47,8 @@
                 "key": {
                   "type": "Identifier",
                   "span": {
-                    "start": 18,
-                    "end": 21,
+                    "start": 19,
+                    "end": 22,
                     "ctxt": 0
                   },
                   "value": "put",
@@ -59,30 +59,30 @@
                   {
                     "type": "Identifier",
                     "span": {
-                      "start": 48,
-                      "end": 53,
+                      "start": 49,
+                      "end": 54,
                       "ctxt": 0
                     },
                     "value": "value",
                     "typeAnnotation": {
                       "type": "TsTypeAnnotation",
                       "span": {
-                        "start": 53,
-                        "end": 56,
+                        "start": 54,
+                        "end": 57,
                         "ctxt": 0
                       },
                       "typeAnnotation": {
                         "type": "TsTypeReference",
                         "span": {
-                          "start": 55,
-                          "end": 56,
+                          "start": 56,
+                          "end": 57,
                           "ctxt": 0
                         },
                         "typeName": {
                           "type": "Identifier",
                           "span": {
-                            "start": 55,
-                            "end": 56,
+                            "start": 56,
+                            "end": 57,
                             "ctxt": 0
                           },
                           "value": "T",
@@ -97,15 +97,15 @@
                 ],
                 "decorators": [],
                 "span": {
-                  "start": 18,
-                  "end": 84,
+                  "start": 19,
+                  "end": 87,
                   "ctxt": 0
                 },
                 "body": {
                   "type": "BlockStatement",
                   "span": {
-                    "start": 58,
-                    "end": 84,
+                    "start": 59,
+                    "end": 87,
                     "ctxt": 0
                   },
                   "stmts": []
@@ -115,23 +115,23 @@
                 "typeParameters": {
                   "type": "TsTypeParameterDeclaration",
                   "span": {
-                    "start": 21,
-                    "end": 47,
+                    "start": 22,
+                    "end": 48,
                     "ctxt": 0
                   },
                   "parameters": [
                     {
                       "type": "TsTypeParameter",
                       "span": {
-                        "start": 22,
-                        "end": 46,
+                        "start": 23,
+                        "end": 47,
                         "ctxt": 0
                       },
                       "name": {
                         "type": "Identifier",
                         "span": {
-                          "start": 22,
-                          "end": 23,
+                          "start": 23,
+                          "end": 24,
                           "ctxt": 0
                         },
                         "value": "T",
@@ -141,24 +141,24 @@
                       "constraint": {
                         "type": "TsTypeLiteral",
                         "span": {
-                          "start": 32,
-                          "end": 46,
+                          "start": 33,
+                          "end": 47,
                           "ctxt": 0
                         },
                         "members": [
                           {
                             "type": "TsPropertySignature",
                             "span": {
-                              "start": 34,
-                              "end": 44,
+                              "start": 35,
+                              "end": 45,
                               "ctxt": 0
                             },
                             "readonly": false,
                             "key": {
                               "type": "Identifier",
                               "span": {
-                                "start": 34,
-                                "end": 36,
+                                "start": 35,
+                                "end": 37,
                                 "ctxt": 0
                               },
                               "value": "id",
@@ -172,15 +172,15 @@
                             "typeAnnotation": {
                               "type": "TsTypeAnnotation",
                               "span": {
-                                "start": 36,
-                                "end": 44,
+                                "start": 37,
+                                "end": 45,
                                 "ctxt": 0
                               },
                               "typeAnnotation": {
                                 "type": "TsKeywordType",
                                 "span": {
-                                  "start": 38,
-                                  "end": 44,
+                                  "start": 39,
+                                  "end": 45,
                                   "ctxt": 0
                                 },
                                 "kind": "string"

--- a/ecmascript/parser/tests/typescript/types/type-operator/input.ts.json
+++ b/ecmascript/parser/tests/typescript/types/type-operator/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 37,
+    "end": 38,
     "ctxt": 0
   },
   "body": [
@@ -78,8 +78,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 16,
-        "end": 37,
+        "start": 17,
+        "end": 38,
         "ctxt": 0
       },
       "kind": "let",
@@ -88,38 +88,38 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 20,
-            "end": 36,
+            "start": 21,
+            "end": 37,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 20,
-              "end": 21,
+              "start": 21,
+              "end": 22,
               "ctxt": 0
             },
             "value": "y",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 21,
-                "end": 36,
+                "start": 22,
+                "end": 37,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsTypeOperator",
                 "span": {
-                  "start": 23,
-                  "end": 36,
+                  "start": 24,
+                  "end": 37,
                   "ctxt": 0
                 },
                 "op": "unique",
                 "typeAnnotation": {
                   "type": "TsKeywordType",
                   "span": {
-                    "start": 30,
-                    "end": 36,
+                    "start": 31,
+                    "end": 37,
                     "ctxt": 0
                   },
                   "kind": "symbol"

--- a/ecmascript/parser/tests/typescript/types/union-intersection/input.ts.json
+++ b/ecmascript/parser/tests/typescript/types/union-intersection/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 160,
+    "end": 163,
     "ctxt": 0
   },
   "body": [
@@ -86,8 +86,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 38,
-        "end": 72,
+        "start": 39,
+        "end": 73,
         "ctxt": 0
       },
       "kind": "let",
@@ -96,38 +96,38 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 42,
-            "end": 71,
+            "start": 43,
+            "end": 72,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 42,
-              "end": 54,
+              "start": 43,
+              "end": 55,
               "ctxt": 0
             },
             "value": "intersection",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 54,
-                "end": 71,
+                "start": 55,
+                "end": 72,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsIntersectionType",
                 "span": {
-                  "start": 56,
-                  "end": 71,
+                  "start": 57,
+                  "end": 72,
                   "ctxt": 0
                 },
                 "types": [
                   {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 56,
-                      "end": 62,
+                      "start": 57,
+                      "end": 63,
                       "ctxt": 0
                     },
                     "kind": "number"
@@ -135,8 +135,8 @@
                   {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 65,
-                      "end": 71,
+                      "start": 66,
+                      "end": 72,
                       "ctxt": 0
                     },
                     "kind": "string"
@@ -154,8 +154,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 73,
-        "end": 116,
+        "start": 75,
+        "end": 118,
         "ctxt": 0
       },
       "kind": "let",
@@ -164,38 +164,38 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 77,
-            "end": 115,
+            "start": 79,
+            "end": 117,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 77,
-              "end": 88,
+              "start": 79,
+              "end": 90,
               "ctxt": 0
             },
             "value": "precedence1",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 88,
-                "end": 115,
+                "start": 90,
+                "end": 117,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsUnionType",
                 "span": {
-                  "start": 90,
-                  "end": 115,
+                  "start": 92,
+                  "end": 117,
                   "ctxt": 0
                 },
                 "types": [
                   {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 90,
-                      "end": 96,
+                      "start": 92,
+                      "end": 98,
                       "ctxt": 0
                     },
                     "kind": "number"
@@ -203,16 +203,16 @@
                   {
                     "type": "TsIntersectionType",
                     "span": {
-                      "start": 99,
-                      "end": 115,
+                      "start": 101,
+                      "end": 117,
                       "ctxt": 0
                     },
                     "types": [
                       {
                         "type": "TsKeywordType",
                         "span": {
-                          "start": 99,
-                          "end": 105,
+                          "start": 101,
+                          "end": 107,
                           "ctxt": 0
                         },
                         "kind": "string"
@@ -220,8 +220,8 @@
                       {
                         "type": "TsKeywordType",
                         "span": {
-                          "start": 108,
-                          "end": 115,
+                          "start": 110,
+                          "end": 117,
                           "ctxt": 0
                         },
                         "kind": "boolean"
@@ -241,8 +241,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 117,
-        "end": 160,
+        "start": 120,
+        "end": 163,
         "ctxt": 0
       },
       "kind": "let",
@@ -251,46 +251,46 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 121,
-            "end": 159,
+            "start": 124,
+            "end": 162,
             "ctxt": 0
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 121,
-              "end": 132,
+              "start": 124,
+              "end": 135,
               "ctxt": 0
             },
             "value": "precedence2",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 132,
-                "end": 159,
+                "start": 135,
+                "end": 162,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsUnionType",
                 "span": {
-                  "start": 134,
-                  "end": 159,
+                  "start": 137,
+                  "end": 162,
                   "ctxt": 0
                 },
                 "types": [
                   {
                     "type": "TsIntersectionType",
                     "span": {
-                      "start": 134,
-                      "end": 149,
+                      "start": 137,
+                      "end": 152,
                       "ctxt": 0
                     },
                     "types": [
                       {
                         "type": "TsKeywordType",
                         "span": {
-                          "start": 134,
-                          "end": 140,
+                          "start": 137,
+                          "end": 143,
                           "ctxt": 0
                         },
                         "kind": "number"
@@ -298,8 +298,8 @@
                       {
                         "type": "TsKeywordType",
                         "span": {
-                          "start": 143,
-                          "end": 149,
+                          "start": 146,
+                          "end": 152,
                           "ctxt": 0
                         },
                         "kind": "string"
@@ -309,8 +309,8 @@
                   {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 152,
-                      "end": 159,
+                      "start": 155,
+                      "end": 162,
                       "ctxt": 0
                     },
                     "kind": "boolean"

--- a/ecmascript/transforms/benches/base.rs
+++ b/ecmascript/transforms/benches/base.rs
@@ -6,7 +6,7 @@ extern crate test;
 
 use ast::*;
 use swc_common::{FileName, Fold, FoldWith, Visit, VisitWith, DUMMY_SP};
-use swc_ecma_parser::{Parser, Session, SourceFileInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, Parser, Session, SourceFileInput, Syntax};
 use swc_ecma_transforms::util::ExprFactory;
 use test::Bencher;
 
@@ -85,13 +85,14 @@ module.exports = {
 fn module_clone(b: &mut Bencher) {
     let _ = ::testing::run_test(false, |cm, handler| {
         let fm = cm.new_source_file(FileName::Anon, SOURCE.into());
-
-        let mut parser = Parser::new(
+        let lexer = Lexer::new(
             Session { handler: &handler },
             Syntax::default(),
+            Default::default(),
             SourceFileInput::from(&*fm),
             None,
         );
+        let mut parser = Parser::new_from(Session { handler: &handler }, lexer);
         let module = parser
             .parse_module()
             .map_err(|mut e| {
@@ -111,13 +112,14 @@ fn fold_empty(b: &mut Bencher) {
     struct Noop;
     let _ = ::testing::run_test(false, |cm, handler| {
         let fm = cm.new_source_file(FileName::Anon, SOURCE.into());
-
-        let mut parser = Parser::new(
+        let lexer = Lexer::new(
             Session { handler: &handler },
             Syntax::default(),
+            Default::default(),
             SourceFileInput::from(&*fm),
             None,
         );
+        let mut parser = Parser::new_from(Session { handler: &handler }, lexer);
         let module = parser
             .parse_module()
             .map_err(|mut e| {
@@ -149,12 +151,14 @@ fn fold_noop_impl_all(b: &mut Bencher) {
     let _ = ::testing::run_test(false, |cm, handler| {
         let fm = cm.new_source_file(FileName::Anon, SOURCE.into());
 
-        let mut parser = Parser::new(
+        let lexer = Lexer::new(
             Session { handler: &handler },
             Syntax::default(),
+            Default::default(),
             SourceFileInput::from(&*fm),
             None,
         );
+        let mut parser = Parser::new_from(Session { handler: &handler }, lexer);
         let module = parser
             .parse_module()
             .map_err(|mut e| {
@@ -185,13 +189,14 @@ fn fold_noop_impl_vec(b: &mut Bencher) {
 
     let _ = ::testing::run_test(false, |cm, handler| {
         let fm = cm.new_source_file(FileName::Anon, SOURCE.into());
-
-        let mut parser = Parser::new(
+        let lexer = Lexer::new(
             Session { handler: &handler },
             Syntax::default(),
+            Default::default(),
             SourceFileInput::from(&*fm),
             None,
         );
+        let mut parser = Parser::new_from(Session { handler: &handler }, lexer);
         let module = parser
             .parse_module()
             .map_err(|mut e| {
@@ -266,13 +271,14 @@ fn visit_empty(b: &mut Bencher) {
 
     let _ = ::testing::run_test(false, |cm, handler| {
         let fm = cm.new_source_file(FileName::Anon, SOURCE.into());
-
-        let mut parser = Parser::new(
+        let lexer = Lexer::new(
             Session { handler: &handler },
             Syntax::default(),
+            Default::default(),
             SourceFileInput::from(&*fm),
             None,
         );
+        let mut parser = Parser::new_from(Session { handler: &handler }, lexer);
         let _module = parser
             .parse_module()
             .map_err(|mut e| {
@@ -317,13 +323,14 @@ fn visit_contains_this(b: &mut Bencher) {
 
     let _ = ::testing::run_test(false, |cm, handler| {
         let fm = cm.new_source_file(FileName::Anon, SOURCE.into());
-
-        let mut parser = Parser::new(
+        let lexer = Lexer::new(
             Session { handler: &handler },
             Syntax::default(),
+            Default::default(),
             SourceFileInput::from(&*fm),
             None,
         );
+        let mut parser = Parser::new_from(Session { handler: &handler }, lexer);
         let module = parser
             .parse_module()
             .map_err(|mut e| {

--- a/ecmascript/transforms/benches/compat.rs
+++ b/ecmascript/transforms/benches/compat.rs
@@ -8,7 +8,7 @@ static GLOBAL: System = System;
 
 use std::alloc::System;
 use swc_common::{chain, FileName, FoldWith};
-use swc_ecma_parser::{Parser, Session, SourceFileInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, Parser, Session, SourceFileInput};
 use swc_ecma_transforms::{compat, helpers};
 use test::Bencher;
 
@@ -90,13 +90,14 @@ macro_rules! tr {
 
         let _ = ::testing::run_test(false, |cm, handler| {
             let fm = cm.new_source_file(FileName::Anon, SOURCE.into());
-
-            let mut parser = Parser::new(
+            let lexer = Lexer::new(
                 Session { handler: &handler },
-                Syntax::default(),
+                Default::default(),
+                Default::default(),
                 SourceFileInput::from(&*fm),
                 None,
             );
+            let mut parser = Parser::new_from(Session { handler: &handler }, lexer);
             let module = parser
                 .parse_module()
                 .map_err(|mut e| {

--- a/ecmascript/transforms/src/const_modules.rs
+++ b/ecmascript/transforms/src/const_modules.rs
@@ -12,7 +12,7 @@ use lazy_static::lazy_static;
 use std::sync::Arc;
 use swc_atoms::JsWord;
 use swc_common::{util::move_map::MoveMap, FileName, Fold, FoldWith};
-use swc_ecma_parser::{lexer::Lexer, Parser, SourceFileInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, Parser, SourceFileInput};
 
 pub fn const_modules(globals: HashMap<JsWord, HashMap<JsWord, String>>) -> impl Pass {
     ConstModules {

--- a/ecmascript/transforms/src/const_modules.rs
+++ b/ecmascript/transforms/src/const_modules.rs
@@ -12,7 +12,7 @@ use lazy_static::lazy_static;
 use std::sync::Arc;
 use swc_atoms::JsWord;
 use swc_common::{util::move_map::MoveMap, FileName, Fold, FoldWith};
-use swc_ecma_parser::{Parser, SourceFileInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, Parser, SourceFileInput, Syntax};
 
 pub fn const_modules(globals: HashMap<JsWord, HashMap<JsWord, String>>) -> impl Pass {
     ConstModules {
@@ -45,23 +45,25 @@ fn parse_option(name: &str, src: String) -> Arc<Expr> {
         return expr.clone();
     }
 
-    let expr = Parser::new(
+    let lexer = Lexer::new(
         *SESSION,
-        Syntax::default(),
+        Default::default(),
+        Default::default(),
         SourceFileInput::from(&*fm),
         None,
-    )
-    .parse_expr()
-    .map_err(|mut e| {
-        e.emit();
-    })
-    .map(drop_span)
-    .unwrap_or_else(|()| {
-        panic!(
-            "faield to parse jsx option {}: '{}' is not an expression",
-            name, fm.src,
-        )
-    });
+    );
+    let expr = Parser::new_from(*SESSION, lexer)
+        .parse_expr()
+        .map_err(|mut e| {
+            e.emit();
+        })
+        .map(drop_span)
+        .unwrap_or_else(|()| {
+            panic!(
+                "faield to parse jsx option {}: '{}' is not an expression",
+                name, fm.src,
+            )
+        });
 
     let expr = Arc::new(*expr);
 

--- a/ecmascript/transforms/src/modules/umd/config.rs
+++ b/ecmascript/transforms/src/modules/umd/config.rs
@@ -9,7 +9,7 @@ use swc_common::{
     errors::{ColorConfig, Handler},
     FileName, SourceMap,
 };
-use swc_ecma_parser::{Parser, Session, SourceFileInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, Parser, Session, SourceFileInput, Syntax};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
@@ -37,17 +37,19 @@ impl Config {
                         let fm = cm
                             .new_source_file(FileName::Custom(format!("<umd-config-{}.js>", s)), s);
 
-                        Parser::new(
+                        let lexer = Lexer::new(
                             session,
                             Syntax::default(),
+                            Default::default(),
                             SourceFileInput::from(&*fm),
                             None,
-                        )
-                        .parse_expr()
-                        .map_err(|mut e| {
-                            e.emit();
-                        })
-                        .unwrap()
+                        );
+                        Parser::new_from(session, lexer)
+                            .parse_expr()
+                            .map_err(|mut e| {
+                                e.emit();
+                            })
+                            .unwrap()
                     };
                     (k, parse(v))
                 })

--- a/macros/ast_node/benches/serde.rs
+++ b/macros/ast_node/benches/serde.rs
@@ -1,6 +1,8 @@
 #![feature(box_syntax)]
 #![feature(test)]
 
+extern crate test;
+
 use ast_node::ast_node;
 use serde::{Deserialize, Serialize};
 use std::hint::black_box;

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -17,19 +17,21 @@ where
             .load_file(Path::new(file_name))
             .unwrap_or_else(|e| panic!("failed to load {}: {}", file_name, e));
 
-        let res = f(&mut Parser::new(
+        let lexer = Lexer::new(
             Session { handler: &handler },
             if file_name.ends_with(".ts") {
                 Syntax::Typescript(Default::default())
             } else {
                 Syntax::default()
             },
+            Default::default(),
             (&*fm).into(),
             None,
-        ))
-        .map_err(|mut e| {
-            e.emit();
-        });
+        );
+        let res =
+            f(&mut Parser::new_from(Session { handler: &handler }, lexer)).map_err(|mut e| {
+                e.emit();
+            });
 
         if handler.has_errors() {
             return Err(());


### PR DESCRIPTION
This pr makes parser respect `jsc.target`.
Closes #468. 