### PR TITLE
Support numeric separator for TypeScript

### DIFF
--- a/ecmascript/parser/src/lib.rs
+++ b/ecmascript/parser/src/lib.rs
@@ -160,7 +160,7 @@ impl Syntax {
 
     pub fn num_sep(self) -> bool {
         match self {
-            Syntax::Es(EsConfig { num_sep: true, .. }) => true,
+            Syntax::Es(EsConfig { num_sep: true, .. }) | Syntax::Typescript(..) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
Small fix for #521. TypeScript always supports the numeric separator.