### PR TITLE
Comment and TokenAndSpan - Implement Spanned

### DIFF
--- a/common/src/comments.rs
+++ b/common/src/comments.rs
@@ -1,5 +1,7 @@
-use crate::pos::Spanned;
-use crate::syntax_pos::{BytePos, Span};
+use crate::{
+    pos::Spanned,
+    syntax_pos::{BytePos, Span},
+};
 use chashmap::{CHashMap, ReadGuard};
 
 type CommentMap = CHashMap<BytePos, Vec<Comment>>;

--- a/common/src/comments.rs
+++ b/common/src/comments.rs
@@ -1,3 +1,4 @@
+use crate::pos::Spanned;
 use crate::syntax_pos::{BytePos, Span};
 use chashmap::{CHashMap, ReadGuard};
 
@@ -66,6 +67,12 @@ pub struct Comment {
     pub kind: CommentKind,
     pub span: Span,
     pub text: String,
+}
+
+impl Spanned for Comment {
+    fn span(&self) -> Span {
+        self.span
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/ecmascript/parser/src/token.rs
+++ b/ecmascript/parser/src/token.rs
@@ -13,6 +13,7 @@ use swc_atoms::{js_word, JsWord};
 #[cfg(feature = "fold")]
 use swc_common::Fold;
 use swc_common::Span;
+use swc_common::Spanned;
 pub(crate) use swc_ecma_ast::AssignOp as AssignOpToken;
 use swc_ecma_ast::BinaryOp;
 
@@ -214,7 +215,7 @@ impl BinOpToken {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Spanned)]
 pub struct TokenAndSpan {
     pub token: Token,
     /// Had a line break before this token?

--- a/ecmascript/parser/src/token.rs
+++ b/ecmascript/parser/src/token.rs
@@ -12,8 +12,7 @@ use std::{
 use swc_atoms::{js_word, JsWord};
 #[cfg(feature = "fold")]
 use swc_common::Fold;
-use swc_common::Span;
-use swc_common::Spanned;
+use swc_common::{Span, Spanned};
 pub(crate) use swc_ecma_ast::AssignOp as AssignOpToken;
 use swc_ecma_ast::BinaryOp;
 


### PR DESCRIPTION
As title. These structures both have a `span` property, but didn't implement the `Spanned` trait.