### PR TITLE
Fix parsing class properties as readonly

### DIFF
--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -523,7 +523,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 key,
                 is_static,
                 is_optional,
-                false,
+                readonly,
                 is_abstract,
             );
         }

--- a/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
@@ -53,7 +53,7 @@
           "accessibility": null,
           "isAbstract": false,
           "isOptional": false,
-          "readonly": false,
+          "readonly": true,
           "definite": false
         },
         {
@@ -98,7 +98,7 @@
           "accessibility": null,
           "isAbstract": false,
           "isOptional": true,
-          "readonly": false,
+          "readonly": true,
           "definite": false
         },
         {
@@ -272,7 +272,7 @@
           "accessibility": null,
           "isAbstract": true,
           "isOptional": false,
-          "readonly": false,
+          "readonly": true,
           "definite": false
         },
         {
@@ -301,7 +301,7 @@
           "accessibility": null,
           "isAbstract": true,
           "isOptional": false,
-          "readonly": false,
+          "readonly": true,
           "definite": false
         },
         {
@@ -330,7 +330,7 @@
           "accessibility": null,
           "isAbstract": false,
           "isOptional": false,
-          "readonly": false,
+          "readonly": true,
           "definite": false
         },
         {
@@ -446,7 +446,7 @@
           "accessibility": "public",
           "isAbstract": true,
           "isOptional": false,
-          "readonly": false,
+          "readonly": true,
           "definite": false
         },
         {
@@ -475,7 +475,7 @@
           "accessibility": "public",
           "isAbstract": true,
           "isOptional": false,
-          "readonly": false,
+          "readonly": true,
           "definite": false
         },
         {
@@ -504,7 +504,7 @@
           "accessibility": "public",
           "isAbstract": false,
           "isOptional": false,
-          "readonly": false,
+          "readonly": true,
           "definite": false
         }
       ],


### PR DESCRIPTION
The `readonly` property was always false.