### PR TITLE
Bugfixes

### DIFF
--- a/atoms/Cargo.toml
+++ b/atoms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "swc_atoms"
 build = "build.rs"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/atoms/words.txt
+++ b/atoms/words.txt
@@ -624,6 +624,7 @@ key
 keyof
 length
 let
+meta
 module
 namespace
 never

--- a/ecmascript/ast/Cargo.toml
+++ b/ecmascript/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_ast"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/ast/src/typescript.rs
+++ b/ecmascript/ast/src/typescript.rs
@@ -660,8 +660,8 @@ pub struct TsExprWithTypeArgs {
     pub span: Span,
     #[serde(rename = "expression")]
     pub expr: TsEntityName,
-    #[serde(default)]
-    pub type_params: Option<TsTypeParamInstantiation>,
+    #[serde(default, rename = "typeArguments")]
+    pub type_args: Option<TsTypeParamInstantiation>,
 }
 
 #[ast_node("TsTypeAliasDeclaration")]

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_codegen"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -13,11 +13,11 @@ bitflags = "1"
 hashbrown = "0.6"
 swc_atoms = { version = "0.2", path ="../../atoms" }
 swc_common = { version = "0.4.4", path ="../../common" }
-swc_ecma_ast = { version = "0.13.0", path ="../ast" }
+swc_ecma_ast = { version = "0.14.0", path ="../ast" }
 swc_ecma_codegen_macros = { version = "0.4", path ="./macros" }
 sourcemap = "4.1.1"
 num-bigint = { version = "0.2", features = ["serde"] }
 
 [dev-dependencies]
 testing = { version = "0.4", path ="../../testing" }
-swc_ecma_parser = { version = "0.15", path ="../parser" }
+swc_ecma_parser = { version = "0.16", path ="../parser" }

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -186,6 +186,11 @@ impl<'a> Emitter<'a> {
                     emitted_default = true;
                 }
                 ImportSpecifier::Namespace(ref ns) => {
+                    if emitted_default {
+                        punct!(",");
+                        formatting_space!();
+                    }
+
                     emitted_ns = true;
 
                     assert!(node.specifiers.len() <= 2);

--- a/ecmascript/codegen/src/tests.rs
+++ b/ecmascript/codegen/src/tests.rs
@@ -181,6 +181,14 @@ fn issue_450() {
     );
 }
 
+#[test]
+fn issue_546() {
+    test_from_to(
+        "import availabilities, * as availabilityFunctions from 'reducers/availabilities';",
+        "import availabilities, * as availabilityFunctions from 'reducers/availabilities';",
+    );
+}
+
 #[derive(Debug, Clone)]
 struct Buf(Arc<RwLock<Vec<u8>>>);
 impl Write for Buf {

--- a/ecmascript/codegen/tests/references/0458e0c30e8e6fb0.module.js
+++ b/ecmascript/codegen/tests/references/0458e0c30e8e6fb0.module.js
@@ -1,1 +1,1 @@
-import a* as b from 'foo';
+import a, * as b from 'foo';

--- a/ecmascript/codegen/tests/references/9681f5d844d7acd0.js
+++ b/ecmascript/codegen/tests/references/9681f5d844d7acd0.js
@@ -1,22 +1,16 @@
 (a)=>b
 ; // 1 args
-
 (a, b)=>c
 ; // n args
-
 ()=>b
 ; // 0 args
-
 (a)=>(b)=>c
 ; // func returns func returns func
-
 (a)=>((b)=>c
     )
 ; // So these parens are dropped
-
 ()=>(b, c)=>d
 ; // func returns func returns func
-
 (a)=>{
     return b;
 };

--- a/ecmascript/codegen/tests/references/b4bc5f201c297bca.module.js
+++ b/ecmascript/codegen/tests/references/b4bc5f201c297bca.module.js
@@ -1,1 +1,1 @@
-import a* as b from 'baz';
+import a, * as b from 'baz';

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -18,7 +18,7 @@ verify = ["fold"]
 [dependencies]
 swc_atoms = { version = "0.2", path ="../../atoms" }
 swc_common = { version = "0.4.0", path ="../../common" }
-swc_ecma_ast = { version = "0.13.0", path ="../ast" }
+swc_ecma_ast = { version = "0.14.0", path ="../ast" }
 swc_ecma_parser_macros = { package = "swc_ecma_parser_macros", version = "0.4", path ="./macros" }
 enum_kind = { version = "0.2", path ="../../macros/enum_kind" }
 unicode-xid = "0.2"

--- a/ecmascript/parser/src/lib.rs
+++ b/ecmascript/parser/src/lib.rs
@@ -259,6 +259,17 @@ impl Syntax {
             _ => false,
         }
     }
+
+    pub fn import_meta(self) -> bool {
+        match self {
+            Syntax::Es(EsConfig {
+                import_meta: true, ..
+            })
+            | Syntax::Typescript(..) => true,
+
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
@@ -349,6 +360,10 @@ pub struct EsConfig {
     /// Stage 3.
     #[serde(default)]
     pub nullish_coalescing: bool,
+
+    /// Stage 3.
+    #[serde(default)]
+    pub import_meta: bool,
 }
 
 /// Syntactic context.

--- a/ecmascript/parser/src/macros.rs
+++ b/ecmascript/parser/src/macros.rs
@@ -338,6 +338,9 @@ macro_rules! tok {
     ("undefined") => {
         crate::token::Token::Word(crate::token::Word::Ident(swc_atoms::js_word!("undefined")))
     };
+    ("meta") => {
+        crate::token::Token::Word(crate::token::Word::Ident(swc_atoms::js_word!("meta")))
+    };
 }
 
 macro_rules! token_including_semi {

--- a/ecmascript/parser/src/parser/ident.rs
+++ b/ecmascript/parser/src/parser/ident.rs
@@ -48,7 +48,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         self.parse_ident(!ctx.in_generator, !ctx.in_async)
     }
 
-    /// Use this when spec says "IdentiferName".
+    /// Use this when spec says "IdentifierName".
     /// This allows idents like `catch`.
     pub(super) fn parse_ident_name(&mut self) -> PResult<'a, Ident> {
         let start = cur_pos!();

--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -1084,7 +1084,7 @@ impl<'a, I: Tokens> StmtLikeParser<'a, Stmt> for Parser<'a, I> {
     fn handle_import_export(&mut self, top_level: bool, _: Vec<Decorator>) -> PResult<'a, Stmt> {
         let start = cur_pos!();
         if self.input.syntax().dynamic_import() && is!("import") {
-            let expr = self.parse_primary_expr()?;
+            let expr = self.parse_expr()?;
 
             return Ok(ExprStmt {
                 span: span!(start),
@@ -1092,6 +1092,17 @@ impl<'a, I: Tokens> StmtLikeParser<'a, Stmt> for Parser<'a, I> {
             }
             .into());
         }
+
+        if self.input.syntax().import_meta() && is!("import") && peeked_is!('.') {
+            let expr = self.parse_expr()?;
+
+            return Ok(ExprStmt {
+                span: span!(start),
+                expr,
+            }
+            .into());
+        }
+
         syntax_error!(SyntaxError::ImportExportInScript);
     }
 }

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -846,7 +846,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         // then has grammar errors later if it's not an EntityName.
 
         let expr = self.parse_ts_entity_name(/* allow_reserved_words */ false)?;
-        let type_params = if is!('<') {
+        let type_args = if is!('<') {
             Some(self.parse_ts_type_args()?)
         } else {
             None
@@ -855,7 +855,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         Ok(TsExprWithTypeArgs {
             span: span!(start),
             expr,
-            type_params,
+            type_args,
         })
     }
     /// `tsParseInterfaceDeclaration`

--- a/ecmascript/parser/tests/typescript/class/expression-extends-implements/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/expression-extends-implements/input.ts.json
@@ -116,7 +116,7 @@
                   "optional": false
                 }
               },
-              "typeParams": {
+              "typeArguments": {
                 "type": "TsTypeParameterInstantiation",
                 "span": {
                   "start": 36,
@@ -271,7 +271,7 @@
                   "optional": false
                 }
               },
-              "typeParams": {
+              "typeArguments": {
                 "type": "TsTypeParameterInstantiation",
                 "span": {
                   "start": 84,

--- a/ecmascript/parser/tests/typescript/class/expression-implements/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/expression-implements/input.ts.json
@@ -67,7 +67,7 @@
                   "optional": false
                 }
               },
-              "typeParams": {
+              "typeArguments": {
                 "type": "TsTypeParameterInstantiation",
                 "span": {
                   "start": 21,
@@ -173,7 +173,7 @@
                   "optional": false
                 }
               },
-              "typeParams": {
+              "typeArguments": {
                 "type": "TsTypeParameterInstantiation",
                 "span": {
                   "start": 54,

--- a/ecmascript/parser/tests/typescript/class/extends-implements/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/extends-implements/input.ts.json
@@ -113,7 +113,7 @@
               "optional": false
             }
           },
-          "typeParams": {
+          "typeArguments": {
             "type": "TsTypeParameterInstantiation",
             "span": {
               "start": 37,

--- a/ecmascript/parser/tests/typescript/class/implements/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/implements/input.ts.json
@@ -64,7 +64,7 @@
               "optional": false
             }
           },
-          "typeParams": {
+          "typeArguments": {
             "type": "TsTypeParameterInstantiation",
             "span": {
               "start": 22,

--- a/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
@@ -359,7 +359,7 @@
           "accessibility": "public",
           "isAbstract": false,
           "isOptional": false,
-          "readonly": false,
+          "readonly": true,
           "definite": false
         },
         {

--- a/ecmascript/parser/tests/typescript/custom/dynamic-import-top-level/input.ts
+++ b/ecmascript/parser/tests/typescript/custom/dynamic-import-top-level/input.ts
@@ -1,0 +1,1 @@
+import('foo').from();

--- a/ecmascript/parser/tests/typescript/custom/dynamic-import-top-level/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/dynamic-import-top-level/input.ts.json
@@ -1,0 +1,92 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 0,
+    "end": 21,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 0,
+        "end": 20,
+        "ctxt": 0
+      },
+      "expression": {
+        "type": "CallExpression",
+        "span": {
+          "start": 0,
+          "end": 20,
+          "ctxt": 0
+        },
+        "callee": {
+          "type": "MemberExpression",
+          "span": {
+            "start": 0,
+            "end": 18,
+            "ctxt": 0
+          },
+          "object": {
+            "type": "CallExpression",
+            "span": {
+              "start": 0,
+              "end": 13,
+              "ctxt": 0
+            },
+            "callee": {
+              "type": "Identifier",
+              "span": {
+                "start": 0,
+                "end": 13,
+                "ctxt": 0
+              },
+              "value": "import",
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "arguments": [
+              {
+                "spread": null,
+                "expression": {
+                  "type": "StringLiteral",
+                  "span": {
+                    "start": 7,
+                    "end": 12,
+                    "ctxt": 0
+                  },
+                  "value": "foo",
+                  "hasEscape": false
+                }
+              }
+            ],
+            "typeArguments": null
+          },
+          "property": {
+            "type": "Identifier",
+            "span": {
+              "start": 14,
+              "end": 18,
+              "ctxt": 0
+            },
+            "value": "from",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "computed": false
+        },
+        "arguments": [],
+        "typeArguments": null
+      }
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 20,
+        "end": 21,
+        "ctxt": 0
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/ecmascript/parser/tests/typescript/custom/import-meta-expr-ctx/input.ts
+++ b/ecmascript/parser/tests/typescript/custom/import-meta-expr-ctx/input.ts
@@ -1,0 +1,1 @@
+const test = import.meta.someProp;

--- a/ecmascript/parser/tests/typescript/custom/import-meta-expr-ctx/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/import-meta-expr-ctx/input.ts.json
@@ -1,0 +1,88 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 0,
+    "end": 34,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 0,
+        "end": 34,
+        "ctxt": 0
+      },
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 6,
+            "end": 33,
+            "ctxt": 0
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 6,
+              "end": 10,
+              "ctxt": 0
+            },
+            "value": "test",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "init": {
+            "type": "MemberExpression",
+            "span": {
+              "start": 13,
+              "end": 33,
+              "ctxt": 0
+            },
+            "object": {
+              "type": "MetaProperty",
+              "meta": {
+                "type": "Identifier",
+                "span": {
+                  "start": 13,
+                  "end": 19,
+                  "ctxt": 0
+                },
+                "value": "import",
+                "typeAnnotation": null,
+                "optional": false
+              },
+              "property": {
+                "type": "Identifier",
+                "span": {
+                  "start": 20,
+                  "end": 24,
+                  "ctxt": 0
+                },
+                "value": "meta",
+                "typeAnnotation": null,
+                "optional": false
+              }
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 25,
+                "end": 33,
+                "ctxt": 0
+              },
+              "value": "someProp",
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "computed": false
+          },
+          "definite": false
+        }
+      ]
+    }
+  ],
+  "interpreter": null
+}

--- a/ecmascript/parser/tests/typescript/custom/import-meta-top-ctx/input.ts
+++ b/ecmascript/parser/tests/typescript/custom/import-meta-top-ctx/input.ts
@@ -1,0 +1,1 @@
+import.meta.someProp;

--- a/ecmascript/parser/tests/typescript/custom/import-meta-top-ctx/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/import-meta-top-ctx/input.ts.json
@@ -1,0 +1,72 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 0,
+    "end": 21,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 0,
+        "end": 20,
+        "ctxt": 0
+      },
+      "expression": {
+        "type": "MemberExpression",
+        "span": {
+          "start": 0,
+          "end": 20,
+          "ctxt": 0
+        },
+        "object": {
+          "type": "MetaProperty",
+          "meta": {
+            "type": "Identifier",
+            "span": {
+              "start": 0,
+              "end": 6,
+              "ctxt": 0
+            },
+            "value": "import",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "property": {
+            "type": "Identifier",
+            "span": {
+              "start": 7,
+              "end": 11,
+              "ctxt": 0
+            },
+            "value": "meta",
+            "typeAnnotation": null,
+            "optional": false
+          }
+        },
+        "property": {
+          "type": "Identifier",
+          "span": {
+            "start": 12,
+            "end": 20,
+            "ctxt": 0
+          },
+          "value": "someProp",
+          "typeAnnotation": null,
+          "optional": false
+        },
+        "computed": false
+      }
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 20,
+        "end": 21,
+        "ctxt": 0
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/ecmascript/parser/tests/typescript/interface/extends/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/extends/input.ts.json
@@ -59,7 +59,7 @@
               "optional": false
             }
           },
-          "typeParams": {
+          "typeArguments": {
             "type": "TsTypeParameterInstantiation",
             "span": {
               "start": 23,

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_transforms"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -11,8 +11,8 @@ edition = "2018"
 [dependencies]
 swc_atoms = { version = "0.2.0", path ="../../atoms" }
 swc_common = { version = "0.4.2", path ="../../common" }
-ast = { package = "swc_ecma_ast", version = "0.13.0", path ="../ast" }
-swc_ecma_parser = { version = "0.15", path ="../parser", features = ["verify"] }
+ast = { package = "swc_ecma_ast", version = "0.14.0", path ="../ast" }
+swc_ecma_parser = { version = "0.16", path ="../parser", features = ["verify"] }
 chashmap = "2.2.0"
 either = "1.5"
 fxhash = "0.2"
@@ -31,7 +31,7 @@ smallvec = "1"
 
 [dev-dependencies]
 testing = { version = "0.4", path ="../../testing" }
-swc_ecma_codegen = { version = "0.12.0", path ="../codegen" }
+swc_ecma_codegen = { version = "0.13.0", path ="../codegen" }
 tempfile = "3"
 pretty_assertions = "0.6"
 sourcemap = "4.1.1"


### PR DESCRIPTION
swc_ecma_ast:
 - fix TsExprWithTypeArgs (closes #548)

swc_ecma_codegen:
 - allow using default import with namespace import (closes #546)

swc_ecma_parser:
 - parse import.meta (closes #545)
