### PR TITLE
Fix spelling for Expr::JsxMebmer

### DIFF
--- a/ecmascript/ast/src/expr.rs
+++ b/ecmascript/ast/src/expr.rs
@@ -112,7 +112,7 @@ pub enum Expr {
     Paren(ParenExpr),
 
     #[tag("JSXMemberExpression")]
-    JSXMebmer(JSXMemberExpr),
+    JSXMember(JSXMemberExpr),
 
     #[tag("JSXNamespacedName")]
     JSXNamespacedName(JSXNamespacedName),

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -476,7 +476,7 @@ impl<'a> Emitter<'a> {
             Expr::Yield(ref n) => emit!(n),
             Expr::PrivateName(ref n) => emit!(n),
 
-            Expr::JSXMebmer(ref n) => emit!(n),
+            Expr::JSXMember(ref n) => emit!(n),
             Expr::JSXNamespacedName(ref n) => emit!(n),
             Expr::JSXEmpty(ref n) => emit!(n),
             Expr::JSXElement(ref n) => emit!(n),

--- a/ecmascript/codegen/src/util.rs
+++ b/ecmascript/codegen/src/util.rs
@@ -199,7 +199,7 @@ impl StartsWithAlphaNum for Expr {
             // start with `<`
             Expr::JSXFragment(..) | Expr::JSXElement(..) => false,
             Expr::JSXNamespacedName(..) => true,
-            Expr::JSXMebmer(..) => true,
+            Expr::JSXMember(..) => true,
 
             Expr::TsTypeAssertion(..) => false,
             Expr::TsNonNull(TsNonNullExpr { ref expr, .. })

--- a/ecmascript/parser/src/parser/util.rs
+++ b/ecmascript/parser/src/parser/util.rs
@@ -236,7 +236,7 @@ pub(super) trait ExprExt {
             Expr::PrivateName(..) => false,
 
             // jsx
-            Expr::JSXMebmer(..)
+            Expr::JSXMember(..)
             | Expr::JSXNamespacedName(..)
             | Expr::JSXEmpty(..)
             | Expr::JSXElement(..)

--- a/ecmascript/transforms/src/compat/es2015/destructuring.rs
+++ b/ecmascript/transforms/src/compat/es2015/destructuring.rs
@@ -1038,7 +1038,7 @@ fn can_be_null(e: &Expr) -> bool {
         // TODO(kdy1): I'm not sure about this.
         Expr::Unary(..) | Expr::Update(..) | Expr::Bin(..) => true,
 
-        Expr::JSXMebmer(..)
+        Expr::JSXMember(..)
         | Expr::JSXNamespacedName(..)
         | Expr::JSXEmpty(..)
         | Expr::JSXElement(..)

--- a/ecmascript/transforms/src/util.rs
+++ b/ecmascript/transforms/src/util.rs
@@ -907,7 +907,7 @@ pub trait ExprExt {
                 PropOrSpread::Spread(SpreadElement { expr, .. }) => expr.may_have_side_effects(),
             }),
 
-            Expr::JSXMebmer(..)
+            Expr::JSXMember(..)
             | Expr::JSXNamespacedName(..)
             | Expr::JSXEmpty(..)
             | Expr::JSXElement(..)
@@ -1633,7 +1633,7 @@ where
             Expr::Tpl { .. } => unimplemented!("add_effects for template literal"),
             Expr::Class(ClassExpr { .. }) => unimplemented!("add_effects for class expression"),
 
-            Expr::JSXMebmer(..)
+            Expr::JSXMember(..)
             | Expr::JSXNamespacedName(..)
             | Expr::JSXEmpty(..)
             | Expr::JSXElement(..)


### PR DESCRIPTION
This enum member was misspelled.