### PR TITLE
Fix span of await token in for/forin/forof stmts

### DIFF
--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -875,8 +875,9 @@ impl<'a, I: Tokens> Parser<'a, I> {
         let start = cur_pos!();
 
         assert_and_bump!("for");
+        let await_start = cur_pos!();
         let await_token = if eat!("await") {
-            Some(span!(start))
+            Some(span!(await_start))
         } else {
             None
         };


### PR DESCRIPTION
As title.

I didn't see any tests this affects, which I was kind of surprised by. I'm probably missing something?