### PR TITLE
Proposal: Comments.take_all?

### DIFF
--- a/common/src/comments.rs
+++ b/common/src/comments.rs
@@ -3,6 +3,7 @@ use crate::{
     syntax_pos::{BytePos, Span},
 };
 use chashmap::{CHashMap, ReadGuard};
+use std::collections::HashMap;
 
 type CommentMap = CHashMap<BytePos, Vec<Comment>>;
 
@@ -69,6 +70,19 @@ impl Comments {
                 None => Some(cmt),
             });
         }
+    }
+
+    /// Takes all the comments as (leading, trailing).
+    pub fn take_all(
+        self,
+    ) -> (
+        HashMap<BytePos, Vec<Comment>>,
+        HashMap<BytePos, Vec<Comment>>,
+    ) {
+        (
+            self.leading.into_iter().collect(),
+            self.trailing.into_iter().collect(),
+        )
     }
 }
 


### PR DESCRIPTION
Sorry, usually for enhancements I would open an issue first for discussion, but this is a very small change.

I would like the ability to be able to get all the comments stored in the `Comments` struct. This will allow me to work with comments in a way that works well for my situation (allow me to get all comments before and after nodes regardless of definition of trailing comments in swc and ensure I don't miss handling anything).

I believe the current way to do this would would be to iterate all the tokens then call `take_leading_comments` and `take_trailing_comments` on the `lo` and `hi` of each one, but it would be nice to just have a single `take_all` method. I also think this single method allows for a more efficient drainage of the concurrent hash maps to avoid acquiring a lock so many times.

Thoughts?