### PR TITLE
[Merged by Bors] - Import type should have type arguments rather than type params

### DIFF
--- a/ecmascript/ast/src/typescript.rs
+++ b/ecmascript/ast/src/typescript.rs
@@ -434,8 +434,8 @@ pub struct TsImportType {
     #[serde(rename = "argument")]
     pub arg: Str,
     pub qualifier: Option<TsEntityName>,
-    #[serde(rename = "typeParameters")]
-    pub type_params: Option<TsTypeParamInstantiation>,
+    #[serde(rename = "typeArguments")]
+    pub type_args: Option<TsTypeParamInstantiation>,
 }
 
 #[ast_node("TsTypeLiteral")]

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -315,7 +315,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
             None
         };
 
-        let type_params = if is!('<') {
+        let type_args = if is!('<') {
             self.parse_ts_type_args().map(Some)?
         } else {
             None
@@ -325,7 +325,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
             span: span!(start),
             arg,
             qualifier,
-            type_params,
+            type_args,
         })
     }
 

--- a/ecmascript/parser/tests/typescript/custom/import-type/typeof/as/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/import-type/typeof/as/input.ts.json
@@ -101,7 +101,7 @@
                   "hasEscape": false
                 },
                 "qualifier": null,
-                "typeParameters": null
+                "typeArguments": null
               }
             }
           },

--- a/ecmascript/parser/tests/typescript/custom/import-type/typeof/simple/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/import-type/typeof/simple/input.ts.json
@@ -63,7 +63,7 @@
                     "hasEscape": false
                   },
                   "qualifier": null,
-                  "typeParameters": null
+                  "typeArguments": null
                 }
               }
             },


### PR DESCRIPTION
Just found another occurrence of this. Similar to #548. 

![image](https://user-images.githubusercontent.com/1609021/71735836-716b2d00-2e1d-11ea-8878-50d28da9fa5e.png)

I'm currently going through all the types right now so you might want to hold off on merging this or doing a breaking change release until I finish that.