### PR TITLE
[Merged by Bors] - Fix class and interface spans

### DIFF
--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -45,31 +45,36 @@ impl<'a, I: Tokens> Parser<'a, I> {
         self.parse_fn(None, decorators)
     }
 
-    pub(super) fn parse_class_decl(&mut self, decorators: Vec<Decorator>) -> PResult<'a, Decl> {
-        self.parse_class(decorators)
+    pub(super) fn parse_class_decl(
+        &mut self,
+        start: BytePos,
+        decorators: Vec<Decorator>,
+    ) -> PResult<'a, Decl> {
+        self.parse_class(start, decorators)
     }
 
     pub(super) fn parse_class_expr(
         &mut self,
+        start: BytePos,
         decorators: Vec<Decorator>,
     ) -> PResult<'a, Box<Expr>> {
-        self.parse_class(decorators)
+        self.parse_class(start, decorators)
     }
 
     pub(super) fn parse_default_class(
         &mut self,
+        start: BytePos,
         decorators: Vec<Decorator>,
     ) -> PResult<'a, ExportDefaultDecl> {
-        self.parse_class(decorators)
+        self.parse_class(start, decorators)
     }
 
-    fn parse_class<T>(&mut self, decorators: Vec<Decorator>) -> PResult<'a, T>
+    fn parse_class<T>(&mut self, start: BytePos, decorators: Vec<Decorator>) -> PResult<'a, T>
     where
         T: OutputType,
         Self: MaybeOptionalIdentParser<'a, T::Ident>,
     {
         self.strict_mode().parse_with(|p| {
-            let start = cur_pos!();
             expect!("class");
 
             let ident = p.parse_maybe_opt_binding_ident()?;

--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -48,9 +48,10 @@ impl<'a, I: Tokens> Parser<'a, I> {
     pub(super) fn parse_class_decl(
         &mut self,
         start: BytePos,
+        class_start: BytePos,
         decorators: Vec<Decorator>,
     ) -> PResult<'a, Decl> {
-        self.parse_class(start, decorators)
+        self.parse_class(start, class_start, decorators)
     }
 
     pub(super) fn parse_class_expr(
@@ -58,18 +59,24 @@ impl<'a, I: Tokens> Parser<'a, I> {
         start: BytePos,
         decorators: Vec<Decorator>,
     ) -> PResult<'a, Box<Expr>> {
-        self.parse_class(start, decorators)
+        self.parse_class(start, start, decorators)
     }
 
     pub(super) fn parse_default_class(
         &mut self,
         start: BytePos,
+        class_start: BytePos,
         decorators: Vec<Decorator>,
     ) -> PResult<'a, ExportDefaultDecl> {
-        self.parse_class(start, decorators)
+        self.parse_class(start, class_start, decorators)
     }
 
-    fn parse_class<T>(&mut self, start: BytePos, decorators: Vec<Decorator>) -> PResult<'a, T>
+    fn parse_class<T>(
+        &mut self,
+        start: BytePos,
+        class_start: BytePos,
+        decorators: Vec<Decorator>,
+    ) -> PResult<'a, T>
     where
         T: OutputType,
         Self: MaybeOptionalIdentParser<'a, T::Ident>,
@@ -161,7 +168,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 span!(start),
                 ident,
                 Class {
-                    span: Span::new(start, end, Default::default()),
+                    span: Span::new(class_start, end, Default::default()),
                     decorators,
                     is_abstract: false,
                     type_params,

--- a/ecmascript/parser/src/parser/expr.rs
+++ b/ecmascript/parser/src/parser/expr.rs
@@ -253,7 +253,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         if is!("function") {
             return self.parse_fn_expr();
         } else if is!("class") {
-            return self.parse_class_expr(decorators);
+            return self.parse_class_expr(start, decorators);
         }
 
         // Literals

--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -164,7 +164,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
             if !include_decl {
                 unexpected!()
             }
-            return self.parse_class_decl(decorators).map(Stmt::from);
+            return self.parse_class_decl(start, decorators).map(Stmt::from);
         }
 
         if is!("if") {
@@ -313,7 +313,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                         if eat!("interface") {
                             self.emit_err(i.span, SyntaxError::TS2427);
                             return self
-                                .parse_ts_interface_decl()
+                                .parse_ts_interface_decl(start)
                                 .map(Decl::from)
                                 .map(Stmt::from);
                         }

--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -164,7 +164,9 @@ impl<'a, I: Tokens> Parser<'a, I> {
             if !include_decl {
                 unexpected!()
             }
-            return self.parse_class_decl(start, decorators).map(Stmt::from);
+            return self
+                .parse_class_decl(start, start, decorators)
+                .map(Stmt::from);
         }
 
         if is!("if") {

--- a/ecmascript/parser/src/parser/stmt/module_item.rs
+++ b/ecmascript/parser/src/parser/stmt/module_item.rs
@@ -157,13 +157,14 @@ impl<'a, I: Tokens> Parser<'a, I> {
         let start = cur_pos!();
         assert_and_bump!("export");
         let _ = cur!(true);
+        let after_export_start = cur_pos!();
 
         // "export declare" is equivalent to just "export".
         let declare = self.input.syntax().typescript() && eat!("declare");
 
         if declare {
             // TODO: Remove
-            if let Some(decl) = self.try_parse_ts_declare(start, decorators.clone())? {
+            if let Some(decl) = self.try_parse_ts_declare(after_export_start, decorators.clone())? {
                 return Ok(ModuleDecl::ExportDecl(ExportDecl {
                     span: span!(start),
                     decl,

--- a/ecmascript/parser/src/parser/stmt/module_item.rs
+++ b/ecmascript/parser/src/parser/stmt/module_item.rs
@@ -250,11 +250,11 @@ impl<'a, I: Tokens> Parser<'a, I> {
         if export_ns.is_none() && eat!("default") {
             if self.input.syntax().typescript() {
                 if is!("abstract") && peeked_is!("class") {
-                    let start = cur_pos!();
+                    let class_start = cur_pos!();
                     assert_and_bump!("abstract");
                     let _ = cur!(true);
 
-                    let mut class = self.parse_default_class(start, decorators)?;
+                    let mut class = self.parse_default_class(start, class_start, decorators)?;
                     match class {
                         ExportDefaultDecl {
                             decl: DefaultDecl::Class(ClassExpr { ref mut class, .. }),
@@ -280,7 +280,8 @@ impl<'a, I: Tokens> Parser<'a, I> {
             }
 
             if is!("class") {
-                let decl = self.parse_default_class(start, decorators)?;
+                let class_start = cur_pos!();
+                let decl = self.parse_default_class(start, class_start, decorators)?;
                 return Ok(ModuleDecl::ExportDefaultDecl(decl));
             } else if is!("async")
                 && peeked_is!("function")
@@ -306,7 +307,8 @@ impl<'a, I: Tokens> Parser<'a, I> {
         }
 
         let decl = if is!("class") {
-            self.parse_class_decl(start, decorators)?
+            let class_start = cur_pos!();
+            self.parse_class_decl(start, class_start, decorators)?
         } else if is!("async")
             && peeked_is!("function")
             && !self.input.has_linebreak_between_cur_and_peeked()

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -1926,7 +1926,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
 
             if is!("class") {
                 return p
-                    .parse_class_decl(start, decorators)
+                    .parse_class_decl(start, start, decorators)
                     .map(|decl| match decl {
                         Decl::Class(c) => Decl::Class(ClassDecl { declare: true, ..c }),
                         _ => decl,
@@ -2008,7 +2008,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                     if next {
                         bump!();
                     }
-                    let mut decl = self.parse_class_decl(start, decorators)?;
+                    let mut decl = self.parse_class_decl(start, start, decorators)?;
                     match decl {
                         Decl::Class(ClassDecl {
                             class:

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -859,10 +859,11 @@ impl<'a, I: Tokens> Parser<'a, I> {
         })
     }
     /// `tsParseInterfaceDeclaration`
-    pub(super) fn parse_ts_interface_decl(&mut self) -> PResult<'a, TsInterfaceDecl> {
+    pub(super) fn parse_ts_interface_decl(
+        &mut self,
+        start: BytePos,
+    ) -> PResult<'a, TsInterfaceDecl> {
         debug_assert!(self.input.syntax().typescript());
-
-        let start = cur_pos!();
 
         let id = self.parse_ident_name()?;
         match id.sym {
@@ -1925,7 +1926,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
 
             if is!("class") {
                 return p
-                    .parse_class_decl(decorators)
+                    .parse_class_decl(start, decorators)
                     .map(|decl| match decl {
                         Decl::Class(c) => Decl::Class(ClassDecl { declare: true, ..c }),
                         _ => decl,
@@ -2007,7 +2008,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                     if next {
                         bump!();
                     }
-                    let mut decl = self.parse_class_decl(decorators)?;
+                    let mut decl = self.parse_class_decl(start, decorators)?;
                     match decl {
                         Decl::Class(ClassDecl {
                             class:
@@ -2041,7 +2042,10 @@ impl<'a, I: Tokens> Parser<'a, I> {
                         bump!();
                     }
 
-                    return self.parse_ts_interface_decl().map(From::from).map(Some);
+                    return self
+                        .parse_ts_interface_decl(start)
+                        .map(From::from)
+                        .map(Some);
                 }
             }
 

--- a/ecmascript/parser/tests/typescript/class/abstract/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/abstract/input.ts.json
@@ -48,10 +48,8 @@
       },
       "declare": true,
       "span": {
-        "start": 37,
+        "start": 20,
         "end": 47,
-        "start": 21,
-        "end": 48,
         "ctxt": 0
       },
       "decorators": [],
@@ -84,10 +82,8 @@
         },
         "declare": false,
         "span": {
-          "start": 64,
+          "start": 55,
           "end": 74,
-          "start": 57,
-          "end": 76,
           "ctxt": 0
         },
         "decorators": [],
@@ -102,20 +98,16 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 154,
+        "start": 130,
         "end": 163,
-        "start": 134,
-        "end": 167,
         "ctxt": 0
       },
       "decl": {
         "type": "ClassExpression",
         "identifier": null,
         "span": {
-          "start": 154,
+          "start": 145,
           "end": 163,
-          "start": 149,
-          "end": 167,
           "ctxt": 0
         },
         "decorators": [],
@@ -130,10 +122,8 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 188,
+        "start": 164,
         "end": 199,
-        "start": 169,
-        "end": 204,
         "ctxt": 0
       },
       "decl": {
@@ -150,10 +140,8 @@
           "optional": false
         },
         "span": {
-          "start": 188,
+          "start": 179,
           "end": 199,
-          "start": 184,
-          "end": 204,
           "ctxt": 0
         },
         "decorators": [],

--- a/ecmascript/parser/tests/typescript/class/abstract/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/abstract/input.ts.json
@@ -104,6 +104,8 @@
       "span": {
         "start": 154,
         "end": 163,
+        "start": 134,
+        "end": 167,
         "ctxt": 0
       },
       "decl": {
@@ -130,6 +132,8 @@
       "span": {
         "start": 188,
         "end": 199,
+        "start": 169,
+        "end": 204,
         "ctxt": 0
       },
       "decl": {

--- a/ecmascript/parser/tests/typescript/class/abstract/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/abstract/input.ts.json
@@ -21,7 +21,7 @@
       },
       "declare": false,
       "span": {
-        "start": 9,
+        "start": 0,
         "end": 19,
         "ctxt": 0
       },
@@ -50,6 +50,8 @@
       "span": {
         "start": 37,
         "end": 47,
+        "start": 21,
+        "end": 48,
         "ctxt": 0
       },
       "decorators": [],
@@ -84,6 +86,8 @@
         "span": {
           "start": 64,
           "end": 74,
+          "start": 57,
+          "end": 76,
           "ctxt": 0
         },
         "decorators": [],
@@ -108,6 +112,8 @@
         "span": {
           "start": 154,
           "end": 163,
+          "start": 149,
+          "end": 167,
           "ctxt": 0
         },
         "decorators": [],
@@ -142,6 +148,8 @@
         "span": {
           "start": 188,
           "end": 199,
+          "start": 184,
+          "end": 204,
           "ctxt": 0
         },
         "decorators": [],

--- a/ecmascript/parser/tests/typescript/class/declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/declare/input.ts.json
@@ -23,6 +23,8 @@
       "span": {
         "start": 8,
         "end": 87,
+        "start": 0,
+        "end": 93,
         "ctxt": 0
       },
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/class/declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/declare/input.ts.json
@@ -21,10 +21,8 @@
       },
       "declare": true,
       "span": {
-        "start": 8,
-        "end": 87,
         "start": 0,
-        "end": 93,
+        "end": 87,
         "ctxt": 0
       },
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/class/get-generic/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/get-generic/input.ts.json
@@ -23,6 +23,8 @@
       "span": {
         "start": 8,
         "end": 39,
+        "start": 0,
+        "end": 41,
         "ctxt": 0
       },
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/class/get-generic/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/get-generic/input.ts.json
@@ -21,10 +21,8 @@
       },
       "declare": true,
       "span": {
-        "start": 8,
-        "end": 39,
         "start": 0,
-        "end": 41,
+        "end": 39,
         "ctxt": 0
       },
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/class/modifiers-accessors/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-accessors/input.ts.json
@@ -21,10 +21,8 @@
       },
       "declare": false,
       "span": {
-        "start": 49,
+        "start": 40,
         "end": 295,
-        "start": 41,
-        "end": 305,
         "ctxt": 0
       },
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/class/modifiers-accessors/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-accessors/input.ts.json
@@ -23,6 +23,8 @@
       "span": {
         "start": 49,
         "end": 295,
+        "start": 41,
+        "end": 305,
         "ctxt": 0
       },
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/class/modifiers-methods-async/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-methods-async/input.ts.json
@@ -21,10 +21,8 @@
       },
       "declare": false,
       "span": {
-        "start": 51,
+        "start": 42,
         "end": 256,
-        "start": 43,
-        "end": 266,
         "ctxt": 0
       },
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/class/modifiers-methods-async/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-methods-async/input.ts.json
@@ -23,6 +23,8 @@
       "span": {
         "start": 51,
         "end": 256,
+        "start": 43,
+        "end": 266,
         "ctxt": 0
       },
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
@@ -23,6 +23,8 @@
       "span": {
         "start": 9,
         "end": 396,
+        "start": 0,
+        "end": 416,
         "ctxt": 0
       },
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
@@ -21,10 +21,8 @@
       },
       "declare": false,
       "span": {
-        "start": 9,
-        "end": 396,
         "start": 0,
-        "end": 416,
+        "end": 396,
         "ctxt": 0
       },
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/custom/issue-496/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-496/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 157,
+    "end": 167,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "ExportDeclaration",
       "span": {
         "start": 0,
-        "end": 157,
+        "end": 167,
         "ctxt": 0
       },
       "declaration": {
@@ -29,7 +29,7 @@
         "declare": false,
         "span": {
           "start": 7,
-          "end": 157,
+          "end": 167,
           "ctxt": 0
         },
         "decorators": [],
@@ -37,15 +37,15 @@
           {
             "type": "ClassProperty",
             "span": {
-              "start": 33,
-              "end": 46,
+              "start": 34,
+              "end": 47,
               "ctxt": 0
             },
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 33,
-                "end": 40,
+                "start": 34,
+                "end": 41,
                 "ctxt": 0
               },
               "value": "variant",
@@ -56,15 +56,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 40,
-                "end": 45,
+                "start": 41,
+                "end": 46,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 42,
-                  "end": 45,
+                  "start": 43,
+                  "end": 46,
                   "ctxt": 0
                 },
                 "kind": "any"
@@ -82,15 +82,15 @@
           {
             "type": "Constructor",
             "span": {
-              "start": 50,
-              "end": 109,
+              "start": 53,
+              "end": 114,
               "ctxt": 0
             },
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 50,
-                "end": 61,
+                "start": 53,
+                "end": 64,
                 "ctxt": 0
               },
               "value": "constructor",
@@ -101,23 +101,23 @@
               {
                 "type": "Identifier",
                 "span": {
-                  "start": 62,
-                  "end": 74,
+                  "start": 65,
+                  "end": 77,
                   "ctxt": 0
                 },
                 "value": "variant",
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 69,
-                    "end": 74,
+                    "start": 72,
+                    "end": 77,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 71,
-                      "end": 74,
+                      "start": 74,
+                      "end": 77,
                       "ctxt": 0
                     },
                     "kind": "any"
@@ -129,46 +129,46 @@
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 76,
-                "end": 109,
+                "start": 79,
+                "end": 114,
                 "ctxt": 0
               },
               "stmts": [
                 {
                   "type": "ExpressionStatement",
                   "span": {
-                    "start": 82,
-                    "end": 105,
+                    "start": 86,
+                    "end": 109,
                     "ctxt": 0
                   },
                   "expression": {
                     "type": "AssignmentExpression",
                     "span": {
-                      "start": 82,
-                      "end": 104,
+                      "start": 86,
+                      "end": 108,
                       "ctxt": 0
                     },
                     "operator": "=",
                     "left": {
                       "type": "MemberExpression",
                       "span": {
-                        "start": 82,
-                        "end": 94,
+                        "start": 86,
+                        "end": 98,
                         "ctxt": 0
                       },
                       "object": {
                         "type": "ThisExpression",
                         "span": {
-                          "start": 82,
-                          "end": 86,
+                          "start": 86,
+                          "end": 90,
                           "ctxt": 0
                         }
                       },
                       "property": {
                         "type": "Identifier",
                         "span": {
-                          "start": 87,
-                          "end": 94,
+                          "start": 91,
+                          "end": 98,
                           "ctxt": 0
                         },
                         "value": "variant",
@@ -180,8 +180,8 @@
                     "right": {
                       "type": "Identifier",
                       "span": {
-                        "start": 97,
-                        "end": 104,
+                        "start": 101,
+                        "end": 108,
                         "ctxt": 0
                       },
                       "value": "variant",
@@ -198,15 +198,15 @@
           {
             "type": "ClassMethod",
             "span": {
-              "start": 113,
-              "end": 155,
+              "start": 120,
+              "end": 164,
               "ctxt": 0
             },
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 117,
-                "end": 119,
+                "start": 124,
+                "end": 126,
                 "ctxt": 0
               },
               "value": "id",
@@ -217,52 +217,52 @@
               "params": [],
               "decorators": [],
               "span": {
-                "start": 113,
-                "end": 155,
+                "start": 120,
+                "end": 164,
                 "ctxt": 0
               },
               "body": {
                 "type": "BlockStatement",
                 "span": {
-                  "start": 122,
-                  "end": 155,
+                  "start": 129,
+                  "end": 164,
                   "ctxt": 0
                 },
                 "stmts": [
                   {
                     "type": "ReturnStatement",
                     "span": {
-                      "start": 128,
-                      "end": 151,
+                      "start": 136,
+                      "end": 159,
                       "ctxt": 0
                     },
                     "argument": {
                       "type": "MemberExpression",
                       "span": {
-                        "start": 135,
-                        "end": 150,
+                        "start": 143,
+                        "end": 158,
                         "ctxt": 0
                       },
                       "object": {
                         "type": "MemberExpression",
                         "span": {
-                          "start": 135,
-                          "end": 147,
+                          "start": 143,
+                          "end": 155,
                           "ctxt": 0
                         },
                         "object": {
                           "type": "ThisExpression",
                           "span": {
-                            "start": 135,
-                            "end": 139,
+                            "start": 143,
+                            "end": 147,
                             "ctxt": 0
                           }
                         },
                         "property": {
                           "type": "Identifier",
                           "span": {
-                            "start": 140,
-                            "end": 147,
+                            "start": 148,
+                            "end": 155,
                             "ctxt": 0
                           },
                           "value": "variant",
@@ -274,8 +274,8 @@
                       "property": {
                         "type": "Identifier",
                         "span": {
-                          "start": 148,
-                          "end": 150,
+                          "start": 156,
+                          "end": 158,
                           "ctxt": 0
                         },
                         "value": "id",

--- a/ecmascript/parser/tests/typescript/custom/issue-496/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-496/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 167,
+    "end": 157,
     "ctxt": 0
   },
   "body": [
@@ -10,7 +10,7 @@
       "type": "ExportDeclaration",
       "span": {
         "start": 0,
-        "end": 167,
+        "end": 157,
         "ctxt": 0
       },
       "declaration": {
@@ -29,7 +29,7 @@
         "declare": false,
         "span": {
           "start": 7,
-          "end": 167,
+          "end": 157,
           "ctxt": 0
         },
         "decorators": [],
@@ -37,15 +37,15 @@
           {
             "type": "ClassProperty",
             "span": {
-              "start": 34,
-              "end": 47,
+              "start": 33,
+              "end": 46,
               "ctxt": 0
             },
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 34,
-                "end": 41,
+                "start": 33,
+                "end": 40,
                 "ctxt": 0
               },
               "value": "variant",
@@ -56,15 +56,15 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 41,
-                "end": 46,
+                "start": 40,
+                "end": 45,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 43,
-                  "end": 46,
+                  "start": 42,
+                  "end": 45,
                   "ctxt": 0
                 },
                 "kind": "any"
@@ -82,15 +82,15 @@
           {
             "type": "Constructor",
             "span": {
-              "start": 53,
-              "end": 114,
+              "start": 50,
+              "end": 109,
               "ctxt": 0
             },
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 53,
-                "end": 64,
+                "start": 50,
+                "end": 61,
                 "ctxt": 0
               },
               "value": "constructor",
@@ -101,23 +101,23 @@
               {
                 "type": "Identifier",
                 "span": {
-                  "start": 65,
-                  "end": 77,
+                  "start": 62,
+                  "end": 74,
                   "ctxt": 0
                 },
                 "value": "variant",
                 "typeAnnotation": {
                   "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 72,
-                    "end": 77,
+                    "start": 69,
+                    "end": 74,
                     "ctxt": 0
                   },
                   "typeAnnotation": {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 74,
-                      "end": 77,
+                      "start": 71,
+                      "end": 74,
                       "ctxt": 0
                     },
                     "kind": "any"
@@ -129,46 +129,46 @@
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 79,
-                "end": 114,
+                "start": 76,
+                "end": 109,
                 "ctxt": 0
               },
               "stmts": [
                 {
                   "type": "ExpressionStatement",
                   "span": {
-                    "start": 86,
-                    "end": 109,
+                    "start": 82,
+                    "end": 105,
                     "ctxt": 0
                   },
                   "expression": {
                     "type": "AssignmentExpression",
                     "span": {
-                      "start": 86,
-                      "end": 108,
+                      "start": 82,
+                      "end": 104,
                       "ctxt": 0
                     },
                     "operator": "=",
                     "left": {
                       "type": "MemberExpression",
                       "span": {
-                        "start": 86,
-                        "end": 98,
+                        "start": 82,
+                        "end": 94,
                         "ctxt": 0
                       },
                       "object": {
                         "type": "ThisExpression",
                         "span": {
-                          "start": 86,
-                          "end": 90,
+                          "start": 82,
+                          "end": 86,
                           "ctxt": 0
                         }
                       },
                       "property": {
                         "type": "Identifier",
                         "span": {
-                          "start": 91,
-                          "end": 98,
+                          "start": 87,
+                          "end": 94,
                           "ctxt": 0
                         },
                         "value": "variant",
@@ -180,8 +180,8 @@
                     "right": {
                       "type": "Identifier",
                       "span": {
-                        "start": 101,
-                        "end": 108,
+                        "start": 97,
+                        "end": 104,
                         "ctxt": 0
                       },
                       "value": "variant",
@@ -198,15 +198,15 @@
           {
             "type": "ClassMethod",
             "span": {
-              "start": 120,
-              "end": 164,
+              "start": 113,
+              "end": 155,
               "ctxt": 0
             },
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 124,
-                "end": 126,
+                "start": 117,
+                "end": 119,
                 "ctxt": 0
               },
               "value": "id",
@@ -217,52 +217,52 @@
               "params": [],
               "decorators": [],
               "span": {
-                "start": 120,
-                "end": 164,
+                "start": 113,
+                "end": 155,
                 "ctxt": 0
               },
               "body": {
                 "type": "BlockStatement",
                 "span": {
-                  "start": 129,
-                  "end": 164,
+                  "start": 122,
+                  "end": 155,
                   "ctxt": 0
                 },
                 "stmts": [
                   {
                     "type": "ReturnStatement",
                     "span": {
-                      "start": 136,
-                      "end": 159,
+                      "start": 128,
+                      "end": 151,
                       "ctxt": 0
                     },
                     "argument": {
                       "type": "MemberExpression",
                       "span": {
-                        "start": 143,
-                        "end": 158,
+                        "start": 135,
+                        "end": 150,
                         "ctxt": 0
                       },
                       "object": {
                         "type": "MemberExpression",
                         "span": {
-                          "start": 143,
-                          "end": 155,
+                          "start": 135,
+                          "end": 147,
                           "ctxt": 0
                         },
                         "object": {
                           "type": "ThisExpression",
                           "span": {
-                            "start": 143,
-                            "end": 147,
+                            "start": 135,
+                            "end": 139,
                             "ctxt": 0
                           }
                         },
                         "property": {
                           "type": "Identifier",
                           "span": {
-                            "start": 148,
-                            "end": 155,
+                            "start": 140,
+                            "end": 147,
                             "ctxt": 0
                           },
                           "value": "variant",
@@ -274,8 +274,8 @@
                       "property": {
                         "type": "Identifier",
                         "span": {
-                          "start": 156,
-                          "end": 158,
+                          "start": 148,
+                          "end": 150,
                           "ctxt": 0
                         },
                         "value": "id",

--- a/ecmascript/parser/tests/typescript/declare/interface/input.ts.json
+++ b/ecmascript/parser/tests/typescript/declare/interface/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 18,
+        "start": 0,
         "end": 22,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/enum/export-declare-const/input.ts.json
+++ b/ecmascript/parser/tests/typescript/enum/export-declare-const/input.ts.json
@@ -16,7 +16,7 @@
       "declaration": {
         "type": "TsEnumDeclaration",
         "span": {
-          "start": 0,
+          "start": 7,
           "end": 30,
           "ctxt": 0
         },

--- a/ecmascript/parser/tests/typescript/es2019/from-entries/input.ts.json
+++ b/ecmascript/parser/tests/typescript/es2019/from-entries/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 11,
+        "start": 1,
         "end": 188,
-        "start": 2,
-        "end": 192,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/es2019/from-entries/input.ts.json
+++ b/ecmascript/parser/tests/typescript/es2019/from-entries/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 11,
         "end": 188,
+        "start": 2,
+        "end": 192,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/export-default-interface/index.ts.json
+++ b/ecmascript/parser/tests/typescript/export-default-interface/index.ts.json
@@ -16,7 +16,7 @@
       "decl": {
         "type": "TsInterfaceDeclaration",
         "span": {
-          "start": 25,
+          "start": 15,
           "end": 31,
           "ctxt": 0
         },

--- a/ecmascript/parser/tests/typescript/export/declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/export/declare/input.ts.json
@@ -138,6 +138,8 @@
         "span": {
           "start": 82,
           "end": 92,
+          "start": 69,
+          "end": 94,
           "ctxt": 0
         },
         "decorators": [],
@@ -161,6 +163,8 @@
         "span": {
           "start": 118,
           "end": 122,
+          "start": 96,
+          "end": 125,
           "ctxt": 0
         },
         "id": {

--- a/ecmascript/parser/tests/typescript/export/declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/export/declare/input.ts.json
@@ -136,10 +136,8 @@
         },
         "declare": true,
         "span": {
-          "start": 82,
+          "start": 74,
           "end": 92,
-          "start": 69,
-          "end": 94,
           "ctxt": 0
         },
         "decorators": [],
@@ -161,10 +159,8 @@
       "declaration": {
         "type": "TsInterfaceDeclaration",
         "span": {
-          "start": 118,
+          "start": 100,
           "end": 122,
-          "start": 96,
-          "end": 125,
           "ctxt": 0
         },
         "id": {
@@ -202,7 +198,7 @@
       "declaration": {
         "type": "TsTypeAliasDeclaration",
         "span": {
-          "start": 123,
+          "start": 130,
           "end": 154,
           "ctxt": 0
         },
@@ -240,7 +236,7 @@
       "declaration": {
         "type": "TsModuleDeclaration",
         "span": {
-          "start": 155,
+          "start": 162,
           "end": 181,
           "ctxt": 0
         },
@@ -278,7 +274,7 @@
       "declaration": {
         "type": "TsModuleDeclaration",
         "span": {
-          "start": 182,
+          "start": 189,
           "end": 211,
           "ctxt": 0
         },

--- a/ecmascript/parser/tests/typescript/interface/call-signature/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/call-signature/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
-        "end": 38,
         "start": 0,
-        "end": 40,
+        "end": 38,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/call-signature/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/call-signature/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 10,
         "end": 38,
+        "start": 0,
+        "end": 40,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/construct-signature/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/construct-signature/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 10,
         "end": 42,
+        "start": 0,
+        "end": 44,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/construct-signature/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/construct-signature/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
-        "end": 42,
         "start": 0,
-        "end": 44,
+        "end": 42,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/export/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/export/input.ts.json
@@ -55,10 +55,8 @@
       "decl": {
         "type": "TsInterfaceDeclaration",
         "span": {
-          "start": 47,
+          "start": 37,
           "end": 51,
-          "start": 38,
-          "end": 52,
           "ctxt": 0
         },
         "id": {

--- a/ecmascript/parser/tests/typescript/interface/export/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/export/input.ts.json
@@ -16,7 +16,7 @@
       "declaration": {
         "type": "TsInterfaceDeclaration",
         "span": {
-          "start": 17,
+          "start": 7,
           "end": 21,
           "ctxt": 0
         },
@@ -57,6 +57,8 @@
         "span": {
           "start": 47,
           "end": 51,
+          "start": 38,
+          "end": 52,
           "ctxt": 0
         },
         "id": {

--- a/ecmascript/parser/tests/typescript/interface/extends/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/extends/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
+        "start": 0,
         "end": 29,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/interface/generic/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/generic/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
+        "start": 0,
         "end": 48,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/interface/index-signature/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/index-signature/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
-        "end": 40,
         "start": 0,
-        "end": 42,
+        "end": 40,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/index-signature/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/index-signature/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 10,
         "end": 40,
+        "start": 0,
+        "end": 42,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/method-computed/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/method-computed/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 10,
         "end": 80,
+        "start": 0,
+        "end": 83,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/method-computed/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/method-computed/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
-        "end": 80,
         "start": 0,
-        "end": 83,
+        "end": 80,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/method-generic/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/method-generic/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
-        "end": 61,
         "start": 0,
-        "end": 63,
+        "end": 61,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/method-generic/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/method-generic/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 10,
         "end": 61,
+        "start": 0,
+        "end": 63,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/method-optional/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/method-optional/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
-        "end": 31,
         "start": 0,
-        "end": 33,
+        "end": 31,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/method-optional/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/method-optional/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 10,
         "end": 31,
+        "start": 0,
+        "end": 33,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/method-plain/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/method-plain/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 10,
         "end": 65,
+        "start": 0,
+        "end": 68,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/method-plain/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/method-plain/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
-        "end": 65,
         "start": 0,
-        "end": 68,
+        "end": 65,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/modifiers/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/modifiers/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 10,
         "end": 39,
+        "start": 0,
+        "end": 41,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/modifiers/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/modifiers/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
-        "end": 39,
         "start": 0,
-        "end": 41,
+        "end": 39,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/properties/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 10,
         "end": 53,
+        "start": 0,
+        "end": 57,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/properties/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
-        "end": 53,
         "start": 0,
-        "end": 57,
+        "end": 53,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/property-computed/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/property-computed/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
-        "end": 78,
         "start": 0,
-        "end": 81,
+        "end": 78,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/property-computed/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/property-computed/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 10,
         "end": 78,
+        "start": 0,
+        "end": 81,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/property-named-public/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/property-named-public/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
-        "end": 32,
         "start": 0,
-        "end": 34,
+        "end": 32,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/property-named-public/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/property-named-public/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 10,
         "end": 32,
+        "start": 0,
+        "end": 34,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/reserved-method-name/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/reserved-method-name/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
-        "end": 34,
         "start": 0,
-        "end": 36,
+        "end": 34,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/reserved-method-name/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/reserved-method-name/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 10,
         "end": 34,
+        "start": 0,
+        "end": 36,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/separators/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/separators/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
+        "start": 0,
         "end": 40,
         "ctxt": 0
       },
@@ -127,6 +127,8 @@
       "span": {
         "start": 51,
         "end": 80,
+        "start": 42,
+        "end": 81,
         "ctxt": 0
       },
       "id": {
@@ -243,6 +245,8 @@
       "span": {
         "start": 91,
         "end": 130,
+        "start": 83,
+        "end": 135,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/interface/separators/input.ts.json
+++ b/ecmascript/parser/tests/typescript/interface/separators/input.ts.json
@@ -125,10 +125,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 51,
+        "start": 41,
         "end": 80,
-        "start": 42,
-        "end": 81,
         "ctxt": 0
       },
       "id": {
@@ -243,10 +241,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 91,
+        "start": 81,
         "end": 130,
-        "start": 83,
-        "end": 135,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/regression/is-default-export/input.ts.json
+++ b/ecmascript/parser/tests/typescript/regression/is-default-export/input.ts.json
@@ -84,10 +84,8 @@
       "declaration": {
         "type": "TsInterfaceDeclaration",
         "span": {
-          "start": 58,
+          "start": 48,
           "end": 62,
-          "start": 50,
-          "end": 64,
           "ctxt": 0
         },
         "id": {

--- a/ecmascript/parser/tests/typescript/regression/is-default-export/input.ts.json
+++ b/ecmascript/parser/tests/typescript/regression/is-default-export/input.ts.json
@@ -86,6 +86,8 @@
         "span": {
           "start": 58,
           "end": 62,
+          "start": 50,
+          "end": 64,
           "ctxt": 0
         },
         "id": {

--- a/ecmascript/parser/tests/typescript/regression/tsx-issue-7742/input.ts.json
+++ b/ecmascript/parser/tests/typescript/regression/tsx-issue-7742/input.ts.json
@@ -9,10 +9,8 @@
     {
       "type": "TsInterfaceDeclaration",
       "span": {
-        "start": 10,
-        "end": 40,
         "start": 0,
-        "end": 42,
+        "end": 40,
         "ctxt": 0
       },
       "id": {

--- a/ecmascript/parser/tests/typescript/regression/tsx-issue-7742/input.ts.json
+++ b/ecmascript/parser/tests/typescript/regression/tsx-issue-7742/input.ts.json
@@ -11,6 +11,8 @@
       "span": {
         "start": 10,
         "end": 40,
+        "start": 0,
+        "end": 42,
         "ctxt": 0
       },
       "id": {


### PR DESCRIPTION
The interface span for something like `interface Test {}` was `Test {}`. Also, for stuff like `export default abstract class Test{}` it was `class Test{}` instead of `abstract class Test {}`.