### PR TITLE
TypePredicate - Parse the asserts modifier

### DIFF
--- a/atoms/words.txt
+++ b/atoms/words.txt
@@ -577,6 +577,7 @@ any
 apply
 arguments
 as
+asserts
 async
 await
 bigint

--- a/ecmascript/ast/src/typescript.rs
+++ b/ecmascript/ast/src/typescript.rs
@@ -397,6 +397,7 @@ pub struct TsTypeRef {
 #[ast_node("TsTypePredicate")]
 pub struct TsTypePredicate {
     pub span: Span,
+    pub asserts: bool,
     pub param_name: TsThisTypeOrIdent,
     #[serde(rename = "typeAnnotation")]
     pub type_ann: TsTypeAnn,

--- a/ecmascript/parser/src/macros.rs
+++ b/ecmascript/parser/src/macros.rs
@@ -260,6 +260,9 @@ macro_rules! tok {
     // ----------
     // Typescript
     // ----------
+    ("asserts") => {
+        crate::token::Token::Word(crate::token::Word::Ident(swc_atoms::js_word!("asserts")))
+    };
     ("implements") => {
         crate::token::Token::Word(crate::token::Word::Ident(swc_atoms::js_word!("implements")))
     };

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -264,7 +264,9 @@ impl<'a, I: Tokens> Parser<'a, I> {
     ) -> PResult<'a, TsTypePredicate> {
         debug_assert!(self.input.syntax().typescript());
 
+        let _ = cur!(true)?;
         assert_and_bump!("is");
+        let _ = cur!(true)?;
 
         let param_name = TsThisTypeOrIdent::TsThisType(lhs);
         let cur_pos = cur_pos!();
@@ -416,7 +418,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
             let type_pred_asserts = is!("asserts") && peeked_is!(IdentRef);
             if type_pred_asserts {
                 assert_and_bump!("asserts");
-                cur!(false);
+                cur!(false)?;
             }
 
             let type_pred_var = if is!(IdentRef) && peeked_is!("is") {

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -405,7 +405,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         debug_assert!(self.input.syntax().typescript());
 
         self.in_type().parse_with(|p| {
-            let start = cur_pos!();
+            let start = cur_pos!(); // todo: the starts below should not include the return_token
 
             if !p.input.eat(return_token) {
                 let cur = format!("{:?}", cur!(false).ok());
@@ -1628,7 +1628,6 @@ impl<'a, I: Tokens> Parser<'a, I> {
         match *cur!(true)? {
             Token::Word(Word::Ident(..)) | tok!("void") | tok!("null") => {
                 if is!("asserts") && peeked_is!("this") {
-                    let start = cur_pos!();
                     assert_and_bump!("this");
                     assert_and_bump!("is");
                     let this_keyword = self.parse_ts_this_type_node()?;

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -416,6 +416,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
             let type_pred_asserts = is!("asserts") && peeked_is!(IdentRef);
             if type_pred_asserts {
                 assert_and_bump!("asserts");
+                cur!(false);
             }
 
             let type_pred_var = if is!(IdentRef) && peeked_is!("is") {

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -1628,8 +1628,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         match *cur!(true)? {
             Token::Word(Word::Ident(..)) | tok!("void") | tok!("null") => {
                 if is!("asserts") && peeked_is!("this") {
-                    assert_and_bump!("this");
-                    assert_and_bump!("is");
+                    bump!();
                     let this_keyword = self.parse_ts_this_type_node()?;
                     return self
                         .parse_ts_this_type_predicate(start, true, this_keyword)

--- a/ecmascript/parser/tests/typescript/arrow-function/predicate-types/input.ts.json
+++ b/ecmascript/parser/tests/typescript/arrow-function/predicate-types/input.ts.json
@@ -75,6 +75,7 @@
               "end": 21,
               "ctxt": 0
             },
+            "asserts": false,
             "paramName": {
               "type": "Identifier",
               "span": {

--- a/ecmascript/parser/tests/typescript/class/method-return-type/input.ts
+++ b/ecmascript/parser/tests/typescript/class/method-return-type/input.ts
@@ -1,3 +1,5 @@
 class C {
     f(): void {}
+    g(): this is {} { return true; }
+    h(): asserts this is {} { throw ""; }
 }

--- a/ecmascript/parser/tests/typescript/class/method-return-type/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/method-return-type/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 28,
+    "end": 107,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 28,
+        "end": 107,
         "ctxt": 0
       },
       "decorators": [],
@@ -80,6 +80,217 @@
                   "ctxt": 0
                 },
                 "kind": "void"
+              }
+            }
+          },
+          "kind": "method",
+          "isStatic": false,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false
+        },
+        {
+          "type": "ClassMethod",
+          "span": {
+            "start": 31,
+            "end": 63,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 31,
+              "end": 32,
+              "ctxt": 0
+            },
+            "value": "g",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "function": {
+            "params": [],
+            "decorators": [],
+            "span": {
+              "start": 31,
+              "end": 63,
+              "ctxt": 0
+            },
+            "body": {
+              "type": "BlockStatement",
+              "span": {
+                "start": 47,
+                "end": 63,
+                "ctxt": 0
+              },
+              "stmts": [
+                {
+                  "type": "ReturnStatement",
+                  "span": {
+                    "start": 49,
+                    "end": 61,
+                    "ctxt": 0
+                  },
+                  "argument": {
+                    "type": "BooleanLiteral",
+                    "span": {
+                      "start": 56,
+                      "end": 60,
+                      "ctxt": 0
+                    },
+                    "value": true
+                  }
+                }
+              ]
+            },
+            "generator": false,
+            "async": false,
+            "typeParameters": null,
+            "returnType": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 34,
+                "end": 46,
+                "ctxt": 0
+              },
+              "typeAnnotation": {
+                "type": "TsTypePredicate",
+                "span": {
+                  "start": 36,
+                  "end": 46,
+                  "ctxt": 0
+                },
+                "asserts": false,
+                "paramName": {
+                  "type": "TsThisType",
+                  "span": {
+                    "start": 36,
+                    "end": 40,
+                    "ctxt": 0
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 44,
+                    "end": 46,
+                    "ctxt": 0
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeLiteral",
+                    "span": {
+                      "start": 44,
+                      "end": 46,
+                      "ctxt": 0
+                    },
+                    "members": []
+                  }
+                }
+              }
+            }
+          },
+          "kind": "method",
+          "isStatic": false,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false
+        },
+        {
+          "type": "ClassMethod",
+          "span": {
+            "start": 68,
+            "end": 105,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 68,
+              "end": 69,
+              "ctxt": 0
+            },
+            "value": "h",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "function": {
+            "params": [],
+            "decorators": [],
+            "span": {
+              "start": 68,
+              "end": 105,
+              "ctxt": 0
+            },
+            "body": {
+              "type": "BlockStatement",
+              "span": {
+                "start": 92,
+                "end": 105,
+                "ctxt": 0
+              },
+              "stmts": [
+                {
+                  "type": "ThrowStatement",
+                  "span": {
+                    "start": 94,
+                    "end": 103,
+                    "ctxt": 0
+                  },
+                  "argument": {
+                    "type": "StringLiteral",
+                    "span": {
+                      "start": 100,
+                      "end": 102,
+                      "ctxt": 0
+                    },
+                    "value": "",
+                    "hasEscape": false
+                  }
+                }
+              ]
+            },
+            "generator": false,
+            "async": false,
+            "typeParameters": null,
+            "returnType": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 71,
+                "end": 91,
+                "ctxt": 0
+              },
+              "typeAnnotation": {
+                "type": "TsTypePredicate",
+                "span": {
+                  "start": 73,
+                  "end": 91,
+                  "ctxt": 0
+                },
+                "asserts": true,
+                "paramName": {
+                  "type": "TsThisType",
+                  "span": {
+                    "start": 81,
+                    "end": 85,
+                    "ctxt": 0
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 89,
+                    "end": 91,
+                    "ctxt": 0
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeLiteral",
+                    "span": {
+                      "start": 89,
+                      "end": 91,
+                      "ctxt": 0
+                    },
+                    "members": []
+                  }
+                }
               }
             }
           },

--- a/ecmascript/parser/tests/typescript/custom/arrow/complex/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/arrow/complex/input.ts.json
@@ -526,6 +526,7 @@
                                       "end": 396,
                                       "ctxt": 0
                                     },
+                                    "asserts": false,
                                     "paramName": {
                                       "type": "Identifier",
                                       "span": {

--- a/ecmascript/parser/tests/typescript/function/predicate-types/input.ts
+++ b/ecmascript/parser/tests/typescript/function/predicate-types/input.ts
@@ -1,2 +1,3 @@
 function f(x: any): x is boolean {}
 (function(x: any): x is boolean {})
+function f(x: any): asserts x is boolean {}

--- a/ecmascript/parser/tests/typescript/function/predicate-types/input.ts
+++ b/ecmascript/parser/tests/typescript/function/predicate-types/input.ts
@@ -1,3 +1,3 @@
 function f(x: any): x is boolean {}
 (function(x: any): x is boolean {})
-function f(x: any): asserts x is boolean {}
+function g(x: any): asserts x is boolean {}

--- a/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
@@ -81,6 +81,7 @@
             "end": 32,
             "ctxt": 0
           },
+          "asserts": false,
           "paramName": {
             "type": "Identifier",
             "span": {
@@ -190,6 +191,7 @@
                 "end": 67,
                 "ctxt": 0
               },
+              "asserts": false,
               "paramName": {
                 "type": "Identifier",
                 "span": {

--- a/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
@@ -234,7 +234,7 @@
           "end": 82,
           "ctxt": 0
         },
-        "value": "f",
+        "value": "g",
         "typeAnnotation": null,
         "optional": false
       },

--- a/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 71,
+    "end": 115,
     "ctxt": 0
   },
   "body": [
@@ -220,6 +220,113 @@
                   "kind": "boolean"
                 }
               }
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 81,
+          "end": 82,
+          "ctxt": 0
+        },
+        "value": "f",
+        "typeAnnotation": null,
+        "optional": false
+      },
+      "declare": false,
+      "params": [
+        {
+          "type": "Identifier",
+          "span": {
+            "start": 83,
+            "end": 89,
+            "ctxt": 0
+          },
+          "value": "x",
+          "typeAnnotation": {
+            "type": "TsTypeAnnotation",
+            "span": {
+              "start": 84,
+              "end": 89,
+              "ctxt": 0
+            },
+            "typeAnnotation": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 86,
+                "end": 89,
+                "ctxt": 0
+              },
+              "kind": "any"
+            }
+          },
+          "optional": false
+        }
+      ],
+      "decorators": [],
+      "span": {
+        "start": 72,
+        "end": 115,
+        "ctxt": 0
+      },
+      "body": {
+        "type": "BlockStatement",
+        "span": {
+          "start": 113,
+          "end": 115,
+          "ctxt": 0
+        },
+        "stmts": []
+      },
+      "generator": false,
+      "async": false,
+      "typeParameters": null,
+      "returnType": {
+        "type": "TsTypeAnnotation",
+        "span": {
+          "start": 90,
+          "end": 112,
+          "ctxt": 0
+        },
+        "typeAnnotation": {
+          "type": "TsTypePredicate",
+          "span": {
+            "start": 90,
+            "end": 112,
+            "ctxt": 0
+          },
+          "asserts": true,
+          "paramName": {
+            "type": "Identifier",
+            "span": {
+              "start": 100,
+              "end": 101,
+              "ctxt": 0
+            },
+            "value": "x",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "typeAnnotation": {
+            "type": "TsTypeAnnotation",
+            "span": {
+              "start": 105,
+              "end": 112,
+              "ctxt": 0
+            },
+            "typeAnnotation": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 105,
+                "end": 112,
+                "ctxt": 0
+              },
+              "kind": "boolean"
             }
           }
         }


### PR DESCRIPTION
Start of adding support for the asserts modifier:

```ts
function isString(x: unknown): asserts x is string {
    if (typeof x !== "string")
        throw new Error("Not a string.");
}
```

Start of adding the asserts modifier, but this doesn't compile.

More info: https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#assertion-functions