### PR TITLE
hygiene:  handle use-use conflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - source ~/.nvm/nvm.sh
   - nvm install 8.15.0
   - nvm use 8.15.0
-  - npm install
+  - npm install browserslist @babel/runtime
   - npm install -g jest
   - RUST_BACKTRACE=0 cargo test --no-run --color always --all --all-features
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - source ~/.nvm/nvm.sh
   - nvm install 8.15.0
   - nvm use 8.15.0
-  - npm install browserslist @babel/runtime
+  - npm install
   - npm install -g jest
   - RUST_BACKTRACE=0 cargo test --no-run --color always --all --all-features
 

--- a/ecmascript/preset_env/package.json
+++ b/ecmascript/preset_env/package.json
@@ -2,5 +2,7 @@
   "devDependencies": {
     "browserslist": "=4.7.3"
   },
-  "browserslist": ["defaults"]
+  "browserslist": [
+    "defaults"
+  ]
 }

--- a/ecmascript/preset_env/src/query.js
+++ b/ecmascript/preset_env/src/query.js
@@ -7,7 +7,8 @@ target = target.filter(v => !v.startsWith('esmodules') && !!v);
 
 // console.log('Target: ', target);
 
-const browsers = browserslist(target && target.length ? target : undefined, {
+let browsers = browserslist(target && target.length ? target : undefined, {
     mobileToDesktop: true,
 });
+browsers = browsers.filter((v) => !v.includes("TP"))
 console.log(JSON.stringify(browsers));

--- a/ecmascript/preset_env/src/query.js
+++ b/ecmascript/preset_env/src/query.js
@@ -1,14 +1,20 @@
-const browserslist = require('browserslist')
-let target = JSON.parse(process.argv[1]);
+"use strict";
 
+var browserslist = require('browserslist');
+
+var target = JSON.parse(process.argv[1]);
 target = target.browsers ? target.browsers : target;
-target = Array.isArray(target) ? target : (typeof target === 'string' ? [target] : Object.keys(target).map((k) => `${k} ${target[k]}`));
-target = target.filter(v => !v.startsWith('esmodules') && !!v);
-
-// console.log('Target: ', target);
-
-let browsers = browserslist(target && target.length ? target : undefined, {
-    mobileToDesktop: true,
+target = Array.isArray(target) ? target : typeof target === 'string' ? [target] : Object.keys(target).map(function (k) {
+    return k + " " + target[k];
 });
-browsers = browsers.filter((v) => !v.includes("TP"))
+target = target.filter(function (v) {
+    return !v.startsWith('esmodules') && !!v;
+}); // console.log('Target: ', target);
+
+var browsers = browserslist(target && target.length ? target : undefined, {
+    mobileToDesktop: true
+});
+browsers = browsers.filter(function (v) {
+    return !v.includes("TP");
+});
 console.log(JSON.stringify(browsers));

--- a/ecmascript/preset_env/src/query.src.js
+++ b/ecmascript/preset_env/src/query.src.js
@@ -1,0 +1,14 @@
+const browserslist = require('browserslist')
+let target = JSON.parse(process.argv[1]);
+
+target = target.browsers ? target.browsers : target;
+target = Array.isArray(target) ? target : (typeof target === 'string' ? [target] : Object.keys(target).map((k) => `${k} ${target[k]}`));
+target = target.filter(v => !v.startsWith('esmodules') && !!v);
+
+// console.log('Target: ', target);
+
+let browsers = browserslist(target && target.length ? target : undefined, {
+    mobileToDesktop: true,
+});
+browsers = browsers.filter((v) => !v.includes("TP"))
+console.log(JSON.stringify(browsers));

--- a/ecmascript/transforms/src/hygiene.rs
+++ b/ecmascript/transforms/src/hygiene.rs
@@ -265,6 +265,11 @@ impl<'a> Fold<FnDecl> for Hygiene<'a> {
 impl<'a> Fold<Ident> for Hygiene<'a> {
     /// Invoked for `IdetifierRefrence` / `BindingIdentifier`
     fn fold(&mut self, i: Ident) -> Ident {
+        // Special case
+        if i.sym == js_word!("arguments") {
+            return i;
+        }
+
         match self.ident_type {
             IdentType::Binding => self.add_declared_ref(i.clone()),
             IdentType::Ref => {

--- a/ecmascript/transforms/src/hygiene.rs
+++ b/ecmascript/transforms/src/hygiene.rs
@@ -55,12 +55,20 @@ impl<'a> Hygiene<'a> {
     fn add_used_ref(&mut self, ident: Ident) {
         let ctxt = ident.span.ctxt();
 
+        self.current
+            .declared_symbols
+            .borrow_mut()
+            .entry(ident.sym.clone())
+            .or_insert_with(Vec::new)
+            .push(ctxt);
+
         // We rename declaration instead of usage
         let conflicts = self.current.conflicts(ident.sym.clone(), ctxt);
 
         if cfg!(debug_assertions) && LOG && !conflicts.is_empty() {
             eprintln!("Renaming from usage");
         }
+
         for cx in conflicts {
             self.rename(ident.sym.clone(), cx)
         }

--- a/ecmascript/transforms/src/hygiene.rs
+++ b/ecmascript/transforms/src/hygiene.rs
@@ -119,7 +119,7 @@ impl<'a> Hygiene<'a> {
             ctxt
         );
         old.retain(|c| *c != ctxt);
-        debug_assert!(old.is_empty() || old.len() == 1);
+        //        debug_assert!(old.is_empty() || old.len() == 1);
 
         let new = declared_symbols.entry(renamed.clone()).or_default();
         new.push(ctxt);

--- a/ecmascript/transforms/src/hygiene/ops.rs
+++ b/ecmascript/transforms/src/hygiene/ops.rs
@@ -45,6 +45,7 @@ impl<'a> Fold<Vec<ModuleItem>> for Operator<'a> {
                             declare,
                         }),
                 })) => {
+                    let class = class.fold_with(self);
                     let orig_ident = ident.clone();
                     match self.rename_ident(ident) {
                         Ok(ident) => {
@@ -76,6 +77,7 @@ impl<'a> Fold<Vec<ModuleItem>> for Operator<'a> {
                             declare,
                         }),
                 })) => {
+                    let function = function.fold_with(self);
                     let orig_ident = ident.clone();
                     match self.rename_ident(ident) {
                         Ok(ident) => {

--- a/ecmascript/transforms/src/hygiene/tests.rs
+++ b/ecmascript/transforms/src/hygiene/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::tests::HygieneVisualizer;
 use std::collections::HashMap;
 use swc_common::{hygiene::*, Fold, DUMMY_SP};
 use swc_ecma_parser::Syntax;
@@ -70,6 +71,14 @@ where
 {
     crate::tests::Tester::run(|tester| {
         let module = op(tester)?;
+
+        match ::std::env::var("PRINT_HYGIENE") {
+            Ok(ref s) if s == "1" => {
+                let hygiene_src = tester.print(&module.clone().fold_with(&mut HygieneVisualizer));
+                println!("----- Hygiene -----\n{}", hygiene_src);
+            }
+            _ => {}
+        }
 
         let module = module.fold_with(&mut hygiene());
 
@@ -1162,5 +1171,95 @@ fn exported_class_1() {
         "var Foo = {};
         class Foo1 {}
         export { Foo1 as Foo };",
+    );
+}
+
+#[test]
+fn issue_598() {
+    test_module(
+        |tester| {
+            let mark1 = Mark::fresh(Mark::root());
+            let mark2 = Mark::fresh(Mark::root());
+
+            Ok(tester
+                .parse_module(
+                    "actual1.js",
+                    "export function foo() {
+    console.log(i18n(_templateObject()));
+    console.log(i18n(_templateObject()));
+}",
+                )?
+                .fold_with(&mut OnceMarker::new(&[(
+                    "_templateObject",
+                    &[mark1, mark2],
+                )])))
+        },
+        "export function foo() {
+    console.log(i18n(_templateObject1()));
+    console.log(i18n(_templateObject()));
+}",
+    );
+}
+
+#[test]
+fn issue_598_2() {
+    test_module(
+        |tester| {
+            let mark1 = Mark::fresh(Mark::root());
+            let mark2 = Mark::fresh(Mark::root());
+            let mark3 = Mark::fresh(Mark::root());
+
+            Ok(tester
+                .parse_module(
+                    "actual1.js",
+                    "export function foo() {
+    console.log(i18n(_templateObject()));
+    console.log(i18n(_templateObject()));
+    console.log(i18n(_templateObject()));
+}",
+                )?
+                .fold_with(&mut OnceMarker::new(&[(
+                    "_templateObject",
+                    &[mark1, mark2, mark3],
+                )])))
+        },
+        "export function foo() {
+    console.log(i18n(_templateObject1()));
+    console.log(i18n(_templateObject2()));
+    console.log(i18n(_templateObject()));
+}",
+    );
+}
+
+#[test]
+fn issue_598_3() {
+    test_module(
+        |tester| {
+            let mark1 = Mark::fresh(Mark::root());
+            let mark2 = Mark::fresh(Mark::root());
+            let mark3 = Mark::fresh(Mark::root());
+            let mark4 = Mark::fresh(Mark::root());
+
+            Ok(tester
+                .parse_module(
+                    "actual1.js",
+                    "export function foo() {
+    console.log(i18n(_templateObject()));
+    console.log(i18n(_templateObject()));
+    console.log(i18n(_templateObject()));
+    console.log(i18n(_templateObject()));
+}",
+                )?
+                .fold_with(&mut OnceMarker::new(&[(
+                    "_templateObject",
+                    &[mark1, mark2, mark3, mark4],
+                )])))
+        },
+        "export function foo() {
+    console.log(i18n(_templateObject1()));
+    console.log(i18n(_templateObject2()));
+    console.log(i18n(_templateObject3()));
+    console.log(i18n(_templateObject()));
+}",
     );
 }

--- a/ecmascript/transforms/src/resolver.rs
+++ b/ecmascript/transforms/src/resolver.rs
@@ -491,3 +491,22 @@ impl Fold<Function> for Hoister<'_, '_> {
         node
     }
 }
+
+impl Fold<Constructor> for Resolver<'_> {
+    fn fold(&mut self, c: Constructor) -> Constructor {
+        let old = self.ident_type;
+        self.ident_type = IdentType::Binding;
+        let params = c.params.fold_with(self);
+        self.ident_type = old;
+
+        let body = c.body.fold_with(self);
+        let key = c.key.fold_with(self);
+
+        Constructor {
+            params,
+            body,
+            key,
+            ..c
+        }
+    }
+}

--- a/ecmascript/transforms/src/tests.rs
+++ b/ecmascript/transforms/src/tests.rs
@@ -408,7 +408,7 @@ impl Fold<PatOrExpr> for Normalizer {
     }
 }
 
-struct HygieneVisualizer;
+pub(crate) struct HygieneVisualizer;
 impl Fold<Ident> for HygieneVisualizer {
     fn fold(&mut self, ident: Ident) -> Ident {
         Ident {

--- a/ecmascript/transforms/tests/proposal_class_properties.rs
+++ b/ecmascript/transforms/tests/proposal_class_properties.rs
@@ -3490,7 +3490,7 @@ var _myAsyncMethod1 = new WeakMap();
 
 class MyClass3{
     constructor(){
-        _myAsyncMethod2.set(this, {
+        _myAsyncMethod.set(this, {
             writable: true,
             value: (function() {
                 var _ref = _asyncToGenerator((function*() {
@@ -3503,7 +3503,7 @@ class MyClass3{
         });
     }
 }
-var _myAsyncMethod2 = new WeakMap();
+var _myAsyncMethod = new WeakMap();
 export { MyClass3 as default }
 
 "#
@@ -4059,8 +4059,8 @@ new SuperClass(); // ensure ComputedKey Method is still transformed
 
 class ComputedMethod extends Obj {
   constructor() {
-    var _temp;
-    var tmp = (_temp = super(), _defineProperty(this, "field", 1), _temp);
+    var _temp1;
+    var tmp = (_temp1 = super(), _defineProperty(this, "field", 1), _temp1);
     class B extends Obj {
       [tmp]() {}
 
@@ -4082,9 +4082,9 @@ new ComputedMethod(); // ensure ComputedKey Field is still transformed
 
 class ComputedField extends Obj {
   constructor() {
-    var _temp;
+    var _temp2;
 
-    var _ref = (_temp = super(), _defineProperty(this, "field", 1), _temp);
+    var _ref = (_temp2 = super(), _defineProperty(this, "field", 1), _temp2);
 
     class B extends Obj {
       constructor() {
@@ -4651,8 +4651,8 @@ export class Foo extends Bar {
 "#,
     r#"
 export class Foo extends Bar {
-  constructor(...args) {
-    super(...args);
+  constructor(...args1) {
+    super(...args1);
     _defineProperty(this, "test", args);
   }
 


### PR DESCRIPTION
Kind indicates the type of identifier. Note that as we don't care about emitting a clean code, the renamed output may not match it of bind-bind conflict or bind-use conflict.

Closes #598 