### PR TITLE
[Merged by Bors] - hygiene: fix handling of special identifiers

### DIFF
--- a/ecmascript/transforms/src/hygiene.rs
+++ b/ecmascript/transforms/src/hygiene.rs
@@ -265,8 +265,11 @@ impl<'a> Fold<FnDecl> for Hygiene<'a> {
 impl<'a> Fold<Ident> for Hygiene<'a> {
     /// Invoked for `IdetifierRefrence` / `BindingIdentifier`
     fn fold(&mut self, i: Ident) -> Ident {
-        // Special case
-        if i.sym == js_word!("arguments") {
+        // Special cases
+        if i.sym == js_word!("arguments")
+            || i.sym == js_word!("undefined")
+            || i.sym == js_word!("NaN")
+        {
             return i;
         }
 

--- a/tests/projects.rs
+++ b/tests/projects.rs
@@ -328,3 +328,11 @@ test(123/*post:9*/
 );"
     )
 }
+
+#[test]
+fn issue_602() {
+    let f = file("tests/projects/issue-602/input.js").unwrap();
+    println!("{}", f);
+
+    assert!(!f.contains("undefined1"));
+}

--- a/tests/projects/issue-602/input.js
+++ b/tests/projects/issue-602/input.js
@@ -1,0 +1,3 @@
+undefined;
+for (let a of b) {
+}


### PR DESCRIPTION
The identifiers are `arguments`, `undefined`, `NaN`.

Closes #602. 