### PR TITLE
[Merged by Bors] - hygiene / block scoping improvement

### DIFF
--- a/ecmascript/transforms/src/compat/es2015/block_scoping.rs
+++ b/ecmascript/transforms/src/compat/es2015/block_scoping.rs
@@ -49,6 +49,13 @@ impl BlockScoping {
 
         node
     }
+
+    fn in_loop_body(&self) -> bool {
+        self.scope.iter().any(|scope| match scope {
+            ScopeKind::ForLetLoop(..) | ScopeKind::Loop => true,
+            _ => false,
+        })
+    }
 }
 
 impl Fold<DoWhileStmt> for BlockScoping {
@@ -203,7 +210,7 @@ impl Fold<VarDeclarator> for BlockScoping {
     fn fold(&mut self, var: VarDeclarator) -> VarDeclarator {
         let var = var.fold_children(self);
 
-        let init = if self.in_loop_body && var.init.is_none() {
+        let init = if self.in_loop_body() && var.init.is_none() {
             Some(undefined(var.span()))
         } else {
             var.init

--- a/ecmascript/transforms/src/compat/es2015/block_scoping.rs
+++ b/ecmascript/transforms/src/compat/es2015/block_scoping.rs
@@ -2,8 +2,8 @@ use crate::{pass::Pass, util::undefined};
 use ast::*;
 use smallvec::SmallVec;
 use std::mem::replace;
-use swc_common::{Fold, FoldWith, Spanned, VisitWith, DUMMY_SP};
-use utils::{prepend, var::VarCollector, Id};
+use swc_common::{util::map::Map, Fold, FoldWith, Spanned, VisitWith, DUMMY_SP};
+use utils::{ident::IdentLike, prepend, var::VarCollector, ExprFactory, Id, StmtLike};
 
 ///
 ///
@@ -27,7 +27,11 @@ type ScopeStack = SmallVec<[ScopeKind; 8]>;
 #[derive(Debug, PartialEq, Eq)]
 enum ScopeKind {
     Loop,
-    ForLetLoop(Vec<Id>),
+    ForLetLoop {
+        all: Vec<Id>,
+        /// Produced by identifier reference and consumed by for-of/in loop.
+        used: Vec<Id>,
+    },
     Fn,
 }
 
@@ -38,21 +42,111 @@ struct BlockScoping {
 }
 
 impl BlockScoping {
+    /// This methods remove [ScopeKind::Loop] and [ScopeKind::Fn], but not
+    /// [ScopeKind::ForLetLoop]
     fn fold_with_scope<T>(&mut self, kind: ScopeKind, node: T) -> T
     where
         T: FoldWith<Self>,
     {
+        let remove = match kind {
+            ScopeKind::ForLetLoop { .. } => false,
+            _ => true,
+        };
         self.scope.push(kind);
         let node = node.fold_with(self);
-        self.scope.pop();
+
+        if remove {
+            self.scope.pop();
+        }
 
         node
     }
 
+    fn mark_as_used(&mut self, i: Id) {
+        for (idx, scope) in self.scope.iter_mut().rev().enumerate() {
+            match scope {
+                ScopeKind::ForLetLoop { all, used } => {
+                    //
+                    if all.contains(&i) {
+                        if idx == 0 {
+                            return;
+                        }
+
+                        used.push(i);
+                        return;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
     fn in_loop_body(&self) -> bool {
         self.scope.iter().any(|scope| match scope {
-            ScopeKind::ForLetLoop(..) | ScopeKind::Loop => true,
+            ScopeKind::ForLetLoop { .. } | ScopeKind::Loop => true,
             _ => false,
+        })
+    }
+
+    fn handle_vars(&mut self, body: Box<Stmt>) -> Box<Stmt> {
+        body.map(|body| {
+            //
+            if let Some(ScopeKind::ForLetLoop { used, .. }) = self.scope.pop() {
+                if used.is_empty() {
+                    return body;
+                }
+
+                let var_name = private_ident!("_loop");
+
+                self.vars.push(VarDeclarator {
+                    span: DUMMY_SP,
+                    name: Pat::Ident(var_name.clone()),
+                    init: Some(
+                        box FnExpr {
+                            ident: None,
+                            function: Function {
+                                span: DUMMY_SP,
+                                params: used
+                                    .iter()
+                                    .map(|i| {
+                                        Pat::Ident(Ident::new(i.0.clone(), DUMMY_SP.with_ctxt(i.1)))
+                                    })
+                                    .collect(),
+                                decorators: Default::default(),
+                                body: Some(match body {
+                                    Stmt::Block(bs) => bs,
+                                    _ => BlockStmt {
+                                        span: DUMMY_SP,
+                                        stmts: vec![body],
+                                    },
+                                }),
+                                is_generator: false,
+                                is_async: false,
+                                type_params: None,
+                                return_type: None,
+                            },
+                        }
+                        .into(),
+                    ),
+                    definite: false,
+                });
+
+                return CallExpr {
+                    span: DUMMY_SP,
+                    callee: var_name.as_callee(),
+                    args: used
+                        .into_iter()
+                        .map(|i| ExprOrSpread {
+                            spread: None,
+                            expr: box Expr::Ident(Ident::new(i.0, DUMMY_SP.with_ctxt(i.1))),
+                        })
+                        .collect(),
+                    type_args: None,
+                }
+                .into_stmt();
+            }
+
+            body
         })
     }
 }
@@ -80,10 +174,21 @@ impl Fold<WhileStmt> for BlockScoping {
 impl Fold<ForStmt> for BlockScoping {
     fn fold(&mut self, node: ForStmt) -> ForStmt {
         let init = node.init.fold_with(self);
+        let vars = find_vars(&init);
+
         let test = node.test.fold_with(self);
         let update = node.update.fold_with(self);
 
-        let body = self.fold_with_scope(ScopeKind::Loop, node.body);
+        let kind = if vars.is_empty() {
+            ScopeKind::Loop
+        } else {
+            ScopeKind::ForLetLoop {
+                all: vars,
+                used: vec![],
+            }
+        };
+        let body = self.fold_with_scope(kind, node.body);
+        let body = self.handle_vars(body);
 
         ForStmt {
             init,
@@ -105,9 +210,13 @@ impl Fold<ForOfStmt> for BlockScoping {
         let kind = if vars.is_empty() {
             ScopeKind::Loop
         } else {
-            ScopeKind::ForLetLoop(vars)
+            ScopeKind::ForLetLoop {
+                all: vars,
+                used: vec![],
+            }
         };
         let body = self.fold_with_scope(kind, node.body);
+        let body = self.handle_vars(body);
 
         ForOfStmt {
             left,
@@ -128,9 +237,13 @@ impl Fold<ForInStmt> for BlockScoping {
         let kind = if vars.is_empty() {
             ScopeKind::Loop
         } else {
-            ScopeKind::ForLetLoop(vars)
+            ScopeKind::ForLetLoop {
+                all: vars,
+                used: vec![],
+            }
         };
         let body = self.fold_with_scope(kind, node.body);
+        let body = self.handle_vars(body);
 
         ForInStmt {
             left,
@@ -219,39 +332,35 @@ impl Fold<VarDeclarator> for BlockScoping {
     }
 }
 
-impl Fold<Module> for BlockScoping {
-    fn fold(&mut self, node: Module) -> Module {
-        let mut module: Module = node.fold_children(self);
+impl Fold<Ident> for BlockScoping {
+    fn fold(&mut self, node: Ident) -> Ident {
+        let id = node.to_id();
+        self.mark_as_used(id);
 
-        prepend(
-            &mut module.body,
-            ModuleItem::Stmt(Stmt::Decl(Decl::Var(VarDecl {
-                span: DUMMY_SP,
-                kind: VarDeclKind::Var,
-                declare: false,
-                decls: replace(&mut self.vars, Default::default()),
-            }))),
-        );
-
-        validate!(module)
+        node
     }
 }
 
-impl Fold<Script> for BlockScoping {
-    fn fold(&mut self, node: Script) -> Script {
-        let mut script: Script = node.fold_children(self);
+impl<T> Fold<Vec<T>> for BlockScoping
+where
+    T: StmtLike,
+    Vec<T>: FoldWith<Self>,
+{
+    fn fold(&mut self, stmts: Vec<T>) -> Vec<T> {
+        let mut stmts = stmts.fold_children(self);
 
-        prepend(
-            &mut script.body,
-            Stmt::Decl(Decl::Var(VarDecl {
-                span: DUMMY_SP,
-                kind: VarDeclKind::Var,
-                declare: false,
-                decls: replace(&mut self.vars, Default::default()),
-            })),
-        );
-
-        validate!(script)
+        if !self.vars.is_empty() {
+            prepend(
+                &mut stmts,
+                T::from_stmt(Stmt::Decl(Decl::Var(VarDecl {
+                    span: DUMMY_SP,
+                    kind: VarDeclKind::Var,
+                    declare: false,
+                    decls: replace(&mut self.vars, Default::default()),
+                }))),
+            );
+        }
+        stmts
     }
 }
 
@@ -304,5 +413,60 @@ mod tests {
 
             baz(key, qux, fog);
         }"
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| block_scoping(),
+        for_let_loop,
+        "let functions = [];
+for (let i = 0; i < 10; i++) {
+	functions.push(function() {
+		console.log(i);
+	});
+}
+functions[0]();
+functions[7]();",
+        "
+var _loop = function(i) {
+    functions.push(function() {
+        console.log(i);
+    });
+};
+var functions = [];
+for(var i = 0; i < 10; i++)_loop(i);
+functions[0]();
+functions[7]();
+"
+    );
+
+    test_exec!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| block_scoping(),
+        for_let_loop_exec,
+        "let functions = [];
+for (let i = 0; i < 10; i++) {
+	functions.push(function() {
+		return i;
+	});
+}
+expect(functions[0]()).toBe(0);
+expect(functions[7]()).toBe(7);
+"
+    );
+
+    test_exec!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| block_scoping(),
+        for_let_of_exec,
+        "let functions = [];
+for (let i of [1, 3, 5, 7, 9]) {
+	functions.push(function() {
+		return i;
+	});
+}
+expect(functions[0]()).toBe(1);
+expect(functions[1]()).toBe(3);
+"
     );
 }

--- a/ecmascript/transforms/src/compat/es2015/block_scoping.rs
+++ b/ecmascript/transforms/src/compat/es2015/block_scoping.rs
@@ -3,7 +3,7 @@ use ast::*;
 use smallvec::SmallVec;
 use std::mem::replace;
 use swc_common::{Fold, FoldWith, Spanned, VisitWith, DUMMY_SP};
-use utils::{prepend, var::VarCollector, Id, IdentFinder, UsageFinder};
+use utils::{prepend, var::VarCollector, Id};
 
 ///
 ///
@@ -44,8 +44,7 @@ impl BlockScoping {
     {
         self.scope.push(kind);
         let node = node.fold_with(self);
-        let last = self.scope.pop();
-        debug_assert_eq!(Some(kind), last);
+        self.scope.pop();
 
         node
     }
@@ -99,7 +98,7 @@ impl Fold<ForStmt> for BlockScoping {
 impl Fold<ForOfStmt> for BlockScoping {
     fn fold(&mut self, node: ForOfStmt) -> ForOfStmt {
         let left = node.left.fold_with(self);
-        let vars = find_vars(&node.left);
+        let vars = find_vars(&left);
 
         let right = node.right.fold_with(self);
 
@@ -122,7 +121,7 @@ impl Fold<ForOfStmt> for BlockScoping {
 impl Fold<ForInStmt> for BlockScoping {
     fn fold(&mut self, node: ForInStmt) -> ForInStmt {
         let left = node.left.fold_with(self);
-        let vars = find_vars(&node.left);
+        let vars = find_vars(&left);
 
         let right = node.right.fold_with(self);
 

--- a/ecmascript/transforms/src/compat/es2015/classes.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes.rs
@@ -19,7 +19,7 @@ use swc_common::{Fold, FoldWith, Mark, Spanned, Visit, VisitWith, DUMMY_SP};
 #[macro_use]
 mod macros;
 mod constructor;
-mod native;
+pub(crate) mod native;
 mod prop_name;
 mod super_field;
 

--- a/ecmascript/transforms/src/compat/es2015/classes/native.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes/native.rs
@@ -16,7 +16,7 @@ macro_rules! native {
     };
 }
 
-pub(super) fn is_native(sym: &JsWord) -> bool {
+pub(crate) fn is_native(sym: &JsWord) -> bool {
     native!(
         sym,
         "Array",

--- a/ecmascript/transforms/src/hygiene.rs
+++ b/ecmascript/transforms/src/hygiene.rs
@@ -266,7 +266,7 @@ impl<'a> Fold<FnDecl> for Hygiene<'a> {
 impl<'a> Fold<Ident> for Hygiene<'a> {
     /// Invoked for `IdetifierRefrence` / `BindingIdentifier`
     fn fold(&mut self, i: Ident) -> Ident {
-        if i.sym == js_word!("arguments") {
+        if i.sym == js_word!("arguments") || i.sym == js_word!("undefined") {
             return i;
         }
 

--- a/ecmascript/transforms/src/hygiene.rs
+++ b/ecmascript/transforms/src/hygiene.rs
@@ -1,5 +1,6 @@
 use self::ops::{Operator, ScopeOp};
 use crate::{
+    compat::es2015::classes::native::is_native,
     pass::Pass,
     scope::{IdentType, ScopeKind},
 };
@@ -265,20 +266,18 @@ impl<'a> Fold<FnDecl> for Hygiene<'a> {
 impl<'a> Fold<Ident> for Hygiene<'a> {
     /// Invoked for `IdetifierRefrence` / `BindingIdentifier`
     fn fold(&mut self, i: Ident) -> Ident {
-        // Special cases
-        if i.sym == js_word!("arguments")
-            || i.sym == js_word!("undefined")
-            || i.sym == js_word!("NaN")
-            || i.sym == js_word!("Object")
-            || i.sym == js_word!("Array")
-            || i.sym == js_word!("Number")
-        {
+        if i.sym == js_word!("arguments") {
             return i;
         }
 
         match self.ident_type {
             IdentType::Binding => self.add_declared_ref(i.clone()),
             IdentType::Ref => {
+                // Special cases
+                if is_native(&i.sym) {
+                    return i;
+                }
+
                 self.add_used_ref(i.clone());
             }
             IdentType::Label => {
@@ -375,6 +374,10 @@ impl<'a> Scope<'a> {
                     return false;
                 }
             }
+        }
+
+        if is_native(&sym) {
+            return false;
         }
 
         if let Some(ctxts) = self.declared_symbols.borrow().get(&sym) {

--- a/ecmascript/transforms/src/hygiene.rs
+++ b/ecmascript/transforms/src/hygiene.rs
@@ -269,6 +269,9 @@ impl<'a> Fold<Ident> for Hygiene<'a> {
         if i.sym == js_word!("arguments")
             || i.sym == js_word!("undefined")
             || i.sym == js_word!("NaN")
+            || i.sym == js_word!("Object")
+            || i.sym == js_word!("Array")
+            || i.sym == js_word!("Number")
         {
             return i;
         }

--- a/ecmascript/transforms/src/resolver/tests.rs
+++ b/ecmascript/transforms/src/resolver/tests.rs
@@ -29,6 +29,12 @@ macro_rules! to {
     };
 }
 
+macro_rules! identical_no_block {
+    ($name:ident, $src:literal) => {
+        test!(syntax(), |_| resolver(), $name, $src, $src);
+    };
+}
+
 #[test]
 fn test_mark_for() {
     ::testing::run_test(false, |_, _| {
@@ -311,7 +317,9 @@ test!(
 
 // TODO: try {} catch (a) { let a } should report error
 
-to!(
+test!(
+    Default::default(),
+    |_| resolver(),
     babel_issue_973,
     r#"let arr = [];
 for(let i = 0; i < 10; i++) {
@@ -621,7 +629,7 @@ identical!(
 }"
 );
 
-identical!(
+identical_no_block!(
     issue_292_1,
     "var __assign = function () {
   __assign = Object.assign || function __assign(t) {
@@ -638,7 +646,7 @@ identical!(
 };"
 );
 
-identical!(
+identical_no_block!(
     issue_292_2,
     "__assign = Object.assign || function __assign(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -1023,4 +1031,16 @@ var instance = new SomeClass({
     }
 });
 instance.call();"
+);
+
+test!(
+    syntax(),
+    |_| tr(),
+    global_object,
+    "function foo(Object) {
+        Object.defineProperty()
+    }",
+    "function foo(Object1) {
+    Object1.defineProperty();
+}"
 );

--- a/ecmascript/transforms/src/resolver/tests.rs
+++ b/ecmascript/transforms/src/resolver/tests.rs
@@ -328,9 +328,9 @@ for(let i = 0; i < 10; i++) {
   }
 }
 "#,
-    r#"var arr = [];
-for(var i = 0; i < 10; i++){
-    for(var i1 = 0; i1 < 10; i1++){
+    r#"let arr = [];
+for(let i = 0; i < 10; i++){
+    for(let i1 = 0; i1 < 10; i1++){
         arr.push(()=>i1);
     }
 }"#

--- a/ecmascript/transforms/tests/es2015_classes.rs
+++ b/ecmascript/transforms/tests/es2015_classes.rs
@@ -96,9 +96,9 @@ test!(
     class List extends Array {}
 "#,
     r#"
-let List = function(Array) {
+let List = function(Array1) {
     'use strict';
-    _inherits(List, Array);
+    _inherits(List, Array1);
     function List() {
         _classCallCheck(this, List);
         return _possibleConstructorReturn(this, _getPrototypeOf(List).apply(this, arguments));
@@ -506,9 +506,9 @@ this.HTMLElement = function() {
     constructor = this.constructor;
 };
 var constructor;
-let CustomElement = function(HTMLElement) {
+let CustomElement = function(HTMLElement1) {
     'use strict';
-    _inherits(CustomElement, HTMLElement);
+    _inherits(CustomElement, HTMLElement1);
     function CustomElement() {
         _classCallCheck(this, CustomElement);
         return _possibleConstructorReturn(this, _getPrototypeOf(CustomElement).apply(this, arguments));

--- a/ecmascript/transforms/tests/modules_common_js.rs
+++ b/ecmascript/transforms/tests/modules_common_js.rs
@@ -4049,3 +4049,30 @@ const foo = function() {
 }();
 exports.foo = foo;"
 );
+
+test!(
+    syntax(),
+    |_| tr(Config {
+        strict: false,
+        strict_mode: true,
+        no_interop: true,
+        ..Default::default()
+    }),
+    issue_605,
+    "export * from 'c';",
+    "'use strict';
+Object.defineProperty(exports, '__esModule', {
+    value: true
+});
+var _c = require('c');
+Object.keys(_c).forEach(function(key) {
+    if (key === 'default' || key === '__esModule') return;
+    Object.defineProperty(exports, key, {
+        enumerable: true,
+        get: function() {
+            return _c[key];
+        }
+    });
+});
+"
+);

--- a/tests/projects.rs
+++ b/tests/projects.rs
@@ -336,3 +336,11 @@ fn issue_602() {
 
     assert!(!f.contains("undefined1"));
 }
+
+#[test]
+fn issue_604_1() {
+    let f = file("tests/projects/issue-604-1/input.js").unwrap();
+    println!("{}", f);
+
+    assert!(f.contains("_loop(i)"));
+}

--- a/tests/projects.rs
+++ b/tests/projects.rs
@@ -344,3 +344,11 @@ fn issue_604_1() {
 
     assert!(f.contains("_loop(i)"));
 }
+
+#[test]
+fn issue_605() {
+    let f = file("tests/projects/issue-605/input.js").unwrap();
+    println!("{}", f);
+
+    assert!(f.contains("Object.keys(_c)"));
+}

--- a/tests/projects/issue-604-1/input.js
+++ b/tests/projects/issue-604-1/input.js
@@ -1,0 +1,8 @@
+let functions = [];
+for (let i = 0; i < 10; i++) {
+    functions.push(function() {
+        console.log(i);
+    });
+}
+functions[0]();
+functions[7]();

--- a/tests/projects/issue-605/.swcrc
+++ b/tests/projects/issue-605/.swcrc
@@ -1,0 +1,16 @@
+{
+  "jsc": {
+    "target": "es2015",
+    "parser": {
+      "syntax": "ecmascript",
+      "jsx": true,
+      "dynamicImport": true,
+      "classProperty": true,
+      "exportNamespaceFrom": true,
+      "exportDefaultFrom": true
+    }
+  },
+  "module": {
+    "type": "commonjs"
+  }
+}

--- a/tests/projects/issue-605/input.js
+++ b/tests/projects/issue-605/input.js
@@ -1,0 +1,1 @@
+export * from 'c';


### PR DESCRIPTION
`hygiene` pass had a bug related to globally defined variables like `Object` or `undefined`. This pr make hygiene to utilize use-bind conflict to resolve global objects correctly.
Closes #605.

block_scoping pass had a bug with closure in for statement with let or const. This pr fixes it by extracting a loop body as a variable.
Closes #604.