### PR TITLE
[Merged by Bors] - Fix parsing of declare

### DIFF
--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -653,7 +653,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
 
         Ok(VarDecl {
             span: span!(start),
-            declare: self.ctx().in_declare,
+            declare: false,
             kind,
             decls,
         })

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -1992,7 +1992,8 @@ impl<'a, I: Tokens> Parser<'a, I> {
             if is!("global") {
                 return p
                     .parse_ts_ambient_external_module_decl(start)
-                    .map(From::from)
+                    .map(Decl::from)
+                    .map(make_decl_declare)
                     .map(Some);
             } else if is!(IdentName) {
                 let value = match *cur!(true)? {
@@ -2001,9 +2002,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 };
                 return p
                     .parse_ts_decl(start, decorators, value, /* next */ true)
-                    .map(|v| {
-                        // Mark as declare
-                    });
+                    .map(|v| v.map(make_decl_declare));
             }
 
             Ok(None)
@@ -2308,4 +2307,19 @@ enum ParsingContext {
 enum SignatureParsingMode {
     TSCallSignatureDeclaration,
     TSConstructSignatureDeclaration,
+}
+
+/// Mark as declare
+fn make_decl_declare(mut decl: Decl) -> Decl {
+    match decl {
+        Decl::Class(ref mut c) => c.decalre = true,
+        Decl::Fn(ref mut f) => f.declare = true,
+        Decl::Var(ref mut v) => v.declare = true,
+        Decl::TsInterface(ref mut i) => i.declare = true,
+        Decl::TsTypeAlias(ref mut a) => a.declare = true,
+        Decl::TsEnum(ref mut e) => e.declare = true,
+        Decl::TsModule(ref mut m) => m.declare = true,
+    }
+
+    decl
 }

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -653,8 +653,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
 
         Ok(TsEnumDecl {
             span: span!(start),
-            // TODO(kdy1): Is this correct?
-            declare: self.ctx().in_declare,
+            declare: false,
             is_const,
             id,
             members,
@@ -706,7 +705,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
 
         Ok(TsModuleDecl {
             span: span!(start),
-            declare: self.ctx().in_declare,
+            declare: false,
             id: TsModuleName::Ident(id),
             body: Some(body),
             global: false,
@@ -737,7 +736,10 @@ impl<'a, I: Tokens> Parser<'a, I> {
         };
 
         let body = if is!('{') {
-            Some(self.parse_ts_module_block().map(TsNamespaceBody::from)?)
+            Some(
+                self.parse_ts_module_block()
+                    .map(|body| TsNamespaceBody::from)?,
+            )
         } else {
             expect!(';');
             None
@@ -745,7 +747,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
 
         Ok(TsModuleDecl {
             span: span!(start),
-            declare: self.ctx().in_declare,
+            declare: false,
             id,
             global,
             body,
@@ -928,7 +930,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         };
         Ok(TsInterfaceDecl {
             span: span!(start),
-            declare: self.ctx().in_declare,
+            declare: false,
             id,
             type_params,
             extends,
@@ -945,7 +947,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         let type_ann = self.expect_then_parse_ts_type(&tok!('='))?;
         expect!(';');
         Ok(TsTypeAliasDecl {
-            declare: self.ctx().in_declare,
+            declare: false,
             span: span!(start),
             id,
             type_params,
@@ -968,7 +970,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         expect!(';');
         Ok(TsImportEqualsDecl {
             span: span!(start),
-            declare: self.ctx().in_declare,
+            declare: false,
             id,
             is_export,
             module_ref,
@@ -1906,7 +1908,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                         TsModuleDecl {
                             span: span!(start),
                             global,
-                            declare: self.ctx().in_declare,
+                            declare: false,
                             id,
                             body,
                         }
@@ -1997,7 +1999,11 @@ impl<'a, I: Tokens> Parser<'a, I> {
                     Token::Word(ref w) => w.clone().into(),
                     _ => unreachable!(),
                 };
-                return p.parse_ts_decl(start, decorators, value, /* next */ true);
+                return p
+                    .parse_ts_decl(start, decorators, value, /* next */ true)
+                    .map(|v| {
+                        // Mark as declare
+                    });
             }
 
             Ok(None)

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -736,10 +736,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         };
 
         let body = if is!('{') {
-            Some(
-                self.parse_ts_module_block()
-                    .map(|body| TsNamespaceBody::from)?,
-            )
+            Some(self.parse_ts_module_block().map(TsNamespaceBody::from)?)
         } else {
             expect!(';');
             None

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -2309,7 +2309,7 @@ enum SignatureParsingMode {
 /// Mark as declare
 fn make_decl_declare(mut decl: Decl) -> Decl {
     match decl {
-        Decl::Class(ref mut c) => c.decalre = true,
+        Decl::Class(ref mut c) => c.declare = true,
         Decl::Fn(ref mut f) => f.declare = true,
         Decl::Var(ref mut v) => v.declare = true,
         Decl::TsInterface(ref mut i) => i.declare = true,

--- a/ecmascript/parser/tests/typescript/custom/issue-623/input.ts
+++ b/ecmascript/parser/tests/typescript/custom/issue-623/input.ts
@@ -1,0 +1,4 @@
+declare module "@dsherret/package" {
+    namespace packageName {
+    }
+}

--- a/ecmascript/parser/tests/typescript/custom/issue-623/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-623/input.ts.json
@@ -1,0 +1,71 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 0,
+    "end": 72,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "TsModuleDeclaration",
+      "span": {
+        "start": 0,
+        "end": 72,
+        "ctxt": 0
+      },
+      "declare": true,
+      "global": false,
+      "id": {
+        "type": "StringLiteral",
+        "span": {
+          "start": 15,
+          "end": 34,
+          "ctxt": 0
+        },
+        "value": "@dsherret/package",
+        "hasEscape": false
+      },
+      "body": {
+        "type": "TsModuleBlock",
+        "span": {
+          "start": 35,
+          "end": 72,
+          "ctxt": 0
+        },
+        "body": [
+          {
+            "type": "TsModuleDeclaration",
+            "span": {
+              "start": 41,
+              "end": 70,
+              "ctxt": 0
+            },
+            "declare": false,
+            "global": false,
+            "id": {
+              "type": "Identifier",
+              "span": {
+                "start": 51,
+                "end": 62,
+                "ctxt": 0
+              },
+              "value": "packageName",
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "body": {
+              "type": "TsModuleBlock",
+              "span": {
+                "start": 63,
+                "end": 70,
+                "ctxt": 0
+              },
+              "body": []
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/ecmascript/parser/tests/typescript/module-namespace/body-declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/module-namespace/body-declare/input.ts.json
@@ -42,7 +42,7 @@
               "ctxt": 0
             },
             "kind": "const",
-            "declare": true,
+            "declare": false,
             "declarations": [
               {
                 "type": "VariableDeclarator",

--- a/ecmascript/parser/tests/typescript/module-namespace/body-nested-declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/module-namespace/body-nested-declare/input.ts.json
@@ -41,7 +41,7 @@
               "end": 70,
               "ctxt": 0
             },
-            "declare": true,
+            "declare": false,
             "global": false,
             "id": {
               "type": "Identifier",
@@ -70,7 +70,7 @@
                     "ctxt": 0
                   },
                   "kind": "const",
-                  "declare": true,
+                  "declare": false,
                   "declarations": [
                     {
                       "type": "VariableDeclarator",

--- a/ecmascript/parser/tests/typescript/module-namespace/global-in-module/input.ts.json
+++ b/ecmascript/parser/tests/typescript/module-namespace/global-in-module/input.ts.json
@@ -40,7 +40,7 @@
               "end": 62,
               "ctxt": 0
             },
-            "declare": true,
+            "declare": false,
             "global": true,
             "id": {
               "type": "Identifier",
@@ -69,7 +69,7 @@
                     "ctxt": 0
                   },
                   "kind": "var",
-                  "declare": true,
+                  "declare": false,
                   "declarations": [
                     {
                       "type": "VariableDeclarator",

--- a/ecmascript/parser/tests/typescript/module-namespace/head-declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/module-namespace/head-declare/input.ts.json
@@ -33,7 +33,7 @@
           "end": 24,
           "ctxt": 0
         },
-        "declare": true,
+        "declare": false,
         "global": false,
         "id": {
           "type": "Identifier",


### PR DESCRIPTION
Previously all children in declare context were marked as `declare`. It's wrong, and I fixed to set declare: true only on the exact node