### PR TITLE
[Merged by Bors] - Remove dependency renaming to enable WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ edition = "2018"
 name = "swc"
 
 [dependencies]
-atoms = { package = "swc_atoms", path ="./atoms" }
-common = { package = "swc_common", path ="./common" }
-ecmascript = { package = "swc_ecmascript", path ="./ecmascript" }
+swc_atoms = { path ="./atoms" }
+swc_common = { path ="./common" }
+swc_ecmascript = { path ="./ecmascript" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 failure = "0.1"

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -10,11 +10,11 @@ publish = false
 edition = "2018"
 
 [dependencies]
-ast = { package = "swc_ecma_ast", path ="./ast" }
-codegen = { package = "swc_ecma_codegen", path ="./codegen" }
-parser = { package = "swc_ecma_parser", path ="./parser", features = ["verify"] }
-preset_env = { package = "swc_ecma_preset_env", path ="preset_env" }
-utils = { package = "swc_ecma_utils", path ="./utils" }
-transforms = { package = "swc_ecma_transforms", path ="./transforms" }
+swc_ecma_ast = { path ="./ast" }
+swc_ecma_codegen = { path ="./codegen" }
+swc_ecma_parser = { path ="./parser", features = ["verify"] }
+swc_ecma_preset_env = { path ="preset_env" }
+swc_ecma_utils = { path ="./utils" }
+swc_ecma_transforms = { path ="./transforms" }
 
 [dev-dependencies]

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -19,7 +19,7 @@ verify = ["fold"]
 swc_atoms = { version = "0.2", path ="../../atoms" }
 swc_common = { version = "0.5.0", path ="../../common" }
 swc_ecma_ast = { version = "0.16.0", path ="../ast" }
-swc_ecma_parser_macros = { package = "swc_ecma_parser_macros", version = "0.4", path ="./macros" }
+swc_ecma_parser_macros = { version = "0.4", path ="./macros" }
 enum_kind = { version = "0.2", path ="../../macros/enum_kind" }
 unicode-xid = "0.2"
 log = { version = "0.4", features = ["release_max_level_debug"] }

--- a/ecmascript/src/lib.rs
+++ b/ecmascript/src/lib.rs
@@ -1,5 +1,5 @@
-pub use ast;
-pub use codegen;
-pub use parser;
-pub use preset_env;
-pub use transforms;
+pub use swc_ecma_ast as ast;
+pub use swc_ecma_codegen as codegen;
+pub use swc_ecma_parser as parser;
+pub use swc_ecma_preset_env as preset_env;
+pub use swc_ecma_transforms as transforms;

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 [dependencies]
 swc_atoms = { version = "0.2.0", path ="../../atoms" }
 swc_common = { version = "0.5.0", path ="../../common" }
-ast = { package = "swc_ecma_ast", version = "0.16.0", path ="../ast" }
-utils = { package = "swc_ecma_utils", version = "0.3.0", path ="../utils" }
+swc_ecma_ast = { version = "0.16.0", path ="../ast" }
+swc_ecma_utils = { version = "0.3.0", path ="../utils" }
 swc_ecma_parser = { version = "0.18", path ="../parser", features = ["verify"] }
 dashmap = "3.2.2"
 either = "1.5"

--- a/ecmascript/transforms/benches/base.rs
+++ b/ecmascript/transforms/benches/base.rs
@@ -4,7 +4,7 @@
 
 extern crate test;
 
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{FileName, Fold, FoldWith, Visit, VisitWith, DUMMY_SP};
 use swc_ecma_parser::{lexer::Lexer, Parser, Session, SourceFileInput, Syntax};
 use swc_ecma_transforms::util::ExprFactory;

--- a/ecmascript/transforms/benches/base.rs
+++ b/ecmascript/transforms/benches/base.rs
@@ -4,8 +4,8 @@
 
 extern crate test;
 
-use swc_ecma_ast::*;
 use swc_common::{FileName, Fold, FoldWith, Visit, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser, Session, SourceFileInput, Syntax};
 use swc_ecma_transforms::util::ExprFactory;
 use test::Bencher;

--- a/ecmascript/transforms/src/compat/es2015.rs
+++ b/ecmascript/transforms/src/compat/es2015.rs
@@ -7,9 +7,9 @@ pub use self::{
     template_literal::TemplateLiteral, typeof_symbol::TypeOfSymbol,
 };
 use crate::pass::Pass;
-use swc_ecma_ast::Expr;
 use serde::Deserialize;
 use swc_common::chain;
+use swc_ecma_ast::Expr;
 
 mod arrow;
 mod block_scoped_fn;

--- a/ecmascript/transforms/src/compat/es2015.rs
+++ b/ecmascript/transforms/src/compat/es2015.rs
@@ -7,7 +7,7 @@ pub use self::{
     template_literal::TemplateLiteral, typeof_symbol::TypeOfSymbol,
 };
 use crate::pass::Pass;
-use ast::Expr;
+use swc_ecma_ast::Expr;
 use serde::Deserialize;
 use swc_common::chain;
 

--- a/ecmascript/transforms/src/compat/es2015/arrow.rs
+++ b/ecmascript/transforms/src/compat/es2015/arrow.rs
@@ -2,9 +2,9 @@ use crate::{
     pass::Pass,
     util::{contains_this_expr, ExprFactory},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Spanned, Visit, VisitWith, DUMMY_SP};
-use utils::quote_ident;
+use swc_ecma_utils::quote_ident;
 
 /// Compile ES2015 arrow functions to ES5
 ///

--- a/ecmascript/transforms/src/compat/es2015/arrow.rs
+++ b/ecmascript/transforms/src/compat/es2015/arrow.rs
@@ -2,8 +2,8 @@ use crate::{
     pass::Pass,
     util::{contains_this_expr, ExprFactory},
 };
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Spanned, Visit, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 use swc_ecma_utils::quote_ident;
 
 /// Compile ES2015 arrow functions to ES5

--- a/ecmascript/transforms/src/compat/es2015/block_scoped_fn.rs
+++ b/ecmascript/transforms/src/compat/es2015/block_scoped_fn.rs
@@ -1,6 +1,6 @@
 use crate::util::UsageFinder;
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Spanned, DUMMY_SP};
+use swc_ecma_ast::*;
 
 #[derive(Clone, Copy)]
 pub struct BlockScopedFns;

--- a/ecmascript/transforms/src/compat/es2015/block_scoped_fn.rs
+++ b/ecmascript/transforms/src/compat/es2015/block_scoped_fn.rs
@@ -1,5 +1,5 @@
 use crate::util::UsageFinder;
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Spanned, DUMMY_SP};
 
 #[derive(Clone, Copy)]

--- a/ecmascript/transforms/src/compat/es2015/block_scoping.rs
+++ b/ecmascript/transforms/src/compat/es2015/block_scoping.rs
@@ -1,9 +1,11 @@
 use crate::{pass::Pass, util::undefined};
-use swc_ecma_ast::*;
 use smallvec::SmallVec;
 use std::mem::replace;
 use swc_common::{util::map::Map, Fold, FoldWith, Spanned, Visit, VisitWith, DUMMY_SP};
-use swc_ecma_utils::{find_ids, ident::IdentLike, prepend, var::VarCollector, ExprFactory, Id, StmtLike};
+use swc_ecma_ast::*;
+use swc_ecma_utils::{
+    find_ids, ident::IdentLike, prepend, var::VarCollector, ExprFactory, Id, StmtLike,
+};
 
 ///
 ///

--- a/ecmascript/transforms/src/compat/es2015/block_scoping.rs
+++ b/ecmascript/transforms/src/compat/es2015/block_scoping.rs
@@ -1,9 +1,9 @@
 use crate::{pass::Pass, util::undefined};
-use ast::*;
+use swc_ecma_ast::*;
 use smallvec::SmallVec;
 use std::mem::replace;
 use swc_common::{util::map::Map, Fold, FoldWith, Spanned, Visit, VisitWith, DUMMY_SP};
-use utils::{find_ids, ident::IdentLike, prepend, var::VarCollector, ExprFactory, Id, StmtLike};
+use swc_ecma_utils::{find_ids, ident::IdentLike, prepend, var::VarCollector, ExprFactory, Id, StmtLike};
 
 ///
 ///

--- a/ecmascript/transforms/src/compat/es2015/classes.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes.rs
@@ -11,10 +11,10 @@ use crate::util::{
     alias_if_required, default_constructor, prepend, prop_name_to_expr, ExprFactory, IsDirective,
     ModuleItemLike, StmtLike,
 };
-use swc_ecma_ast::*;
 use fxhash::FxBuildHasher;
 use std::iter;
 use swc_common::{Fold, FoldWith, Mark, Spanned, Visit, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 #[macro_use]
 mod macros;

--- a/ecmascript/transforms/src/compat/es2015/classes.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes.rs
@@ -11,7 +11,7 @@ use crate::util::{
     alias_if_required, default_constructor, prepend, prop_name_to_expr, ExprFactory, IsDirective,
     ModuleItemLike, StmtLike,
 };
-use ast::*;
+use swc_ecma_ast::*;
 use fxhash::FxBuildHasher;
 use std::iter;
 use swc_common::{Fold, FoldWith, Mark, Spanned, Visit, VisitWith, DUMMY_SP};

--- a/ecmascript/transforms/src/compat/es2015/classes/constructor.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes/constructor.rs
@@ -1,9 +1,9 @@
 use super::get_prototype_of;
 use crate::util::ExprFactory;
-use swc_ecma_ast::*;
 use std::iter;
 use swc_atoms::JsWord;
 use swc_common::{Fold, FoldWith, Mark, Visit, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 use swc_ecma_utils::quote_ident;
 
 pub(super) struct SuperCallFinder {
@@ -469,7 +469,7 @@ pub(super) fn replace_this_in_constructor(mark: Mark, c: Constructor) -> (Constr
 /// # In
 ///
 /// ```js
-///
+/// 
 /// class Example {
 ///   constructor() {
 ///     var Example;

--- a/ecmascript/transforms/src/compat/es2015/classes/constructor.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes/constructor.rs
@@ -1,10 +1,10 @@
 use super::get_prototype_of;
 use crate::util::ExprFactory;
-use ast::*;
+use swc_ecma_ast::*;
 use std::iter;
 use swc_atoms::JsWord;
 use swc_common::{Fold, FoldWith, Mark, Visit, VisitWith, DUMMY_SP};
-use utils::quote_ident;
+use swc_ecma_utils::quote_ident;
 
 pub(super) struct SuperCallFinder {
     mode: Option<SuperFoldingMode>,
@@ -469,7 +469,7 @@ pub(super) fn replace_this_in_constructor(mark: Mark, c: Constructor) -> (Constr
 /// # In
 ///
 /// ```js
-/// 
+///
 /// class Example {
 ///   constructor() {
 ///     var Example;

--- a/ecmascript/transforms/src/compat/es2015/classes/prop_name.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes/prop_name.rs
@@ -1,7 +1,7 @@
-use swc_ecma_ast::*;
 use ordered_float::OrderedFloat;
 use swc_atoms::JsWord;
 use swc_common::{Span, Spanned};
+use swc_ecma_ast::*;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum HashKey {

--- a/ecmascript/transforms/src/compat/es2015/classes/prop_name.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes/prop_name.rs
@@ -1,4 +1,4 @@
-use ast::*;
+use swc_ecma_ast::*;
 use ordered_float::OrderedFloat;
 use swc_atoms::JsWord;
 use swc_common::{Span, Spanned};

--- a/ecmascript/transforms/src/compat/es2015/classes/super_field.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes/super_field.rs
@@ -1,10 +1,10 @@
 use super::get_prototype_of;
 use crate::util::{alias_ident_for, is_rest_arguments, ExprFactory};
-use ast::*;
+use swc_ecma_ast::*;
 use std::iter;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, Mark, Span, Spanned, DUMMY_SP};
-use utils::quote_ident;
+use swc_ecma_utils::quote_ident;
 
 /// Process function body.
 ///

--- a/ecmascript/transforms/src/compat/es2015/classes/super_field.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes/super_field.rs
@@ -1,9 +1,9 @@
 use super::get_prototype_of;
 use crate::util::{alias_ident_for, is_rest_arguments, ExprFactory};
-use swc_ecma_ast::*;
 use std::iter;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, Mark, Span, Spanned, DUMMY_SP};
+use swc_ecma_ast::*;
 use swc_ecma_utils::quote_ident;
 
 /// Process function body.

--- a/ecmascript/transforms/src/compat/es2015/computed_props.rs
+++ b/ecmascript/transforms/src/compat/es2015/computed_props.rs
@@ -2,7 +2,7 @@ use crate::{
     pass::Pass,
     util::{ExprFactory, StmtLike},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Mark, Spanned, Visit, VisitWith, DUMMY_SP};
 
 /// `@babel/plugin-transform-computed-properties`

--- a/ecmascript/transforms/src/compat/es2015/computed_props.rs
+++ b/ecmascript/transforms/src/compat/es2015/computed_props.rs
@@ -2,8 +2,8 @@ use crate::{
     pass::Pass,
     util::{ExprFactory, StmtLike},
 };
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Mark, Spanned, Visit, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 /// `@babel/plugin-transform-computed-properties`
 ///

--- a/ecmascript/transforms/src/compat/es2015/destructuring.rs
+++ b/ecmascript/transforms/src/compat/es2015/destructuring.rs
@@ -5,10 +5,10 @@ use crate::{
         ExprFactory, StmtLike,
     },
 };
-use swc_ecma_ast::*;
 use serde::Deserialize;
 use std::iter;
 use swc_common::{Fold, FoldWith, Spanned, SyntaxContext, Visit, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 /// `@babel/plugin-transform-destructuring`
 ///

--- a/ecmascript/transforms/src/compat/es2015/destructuring.rs
+++ b/ecmascript/transforms/src/compat/es2015/destructuring.rs
@@ -5,7 +5,7 @@ use crate::{
         ExprFactory, StmtLike,
     },
 };
-use ast::*;
+use swc_ecma_ast::*;
 use serde::Deserialize;
 use std::iter;
 use swc_common::{Fold, FoldWith, Spanned, SyntaxContext, Visit, VisitWith, DUMMY_SP};

--- a/ecmascript/transforms/src/compat/es2015/duplicate_keys.rs
+++ b/ecmascript/transforms/src/compat/es2015/duplicate_keys.rs
@@ -1,5 +1,5 @@
 use crate::pass::Pass;
-use ast::*;
+use swc_ecma_ast::*;
 use hashbrown::HashSet;
 use swc_atoms::JsWord;
 use swc_common::{Fold, FoldWith, Spanned};

--- a/ecmascript/transforms/src/compat/es2015/duplicate_keys.rs
+++ b/ecmascript/transforms/src/compat/es2015/duplicate_keys.rs
@@ -1,8 +1,8 @@
 use crate::pass::Pass;
-use swc_ecma_ast::*;
 use hashbrown::HashSet;
 use swc_atoms::JsWord;
 use swc_common::{Fold, FoldWith, Spanned};
+use swc_ecma_ast::*;
 
 pub fn duplicate_keys() -> impl Pass {
     DuplicateKeys

--- a/ecmascript/transforms/src/compat/es2015/for_of.rs
+++ b/ecmascript/transforms/src/compat/es2015/for_of.rs
@@ -2,7 +2,7 @@ use crate::{
     pass::Pass,
     util::{alias_if_required, prepend, ExprFactory, StmtLike},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use serde::Deserialize;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, Mark, Spanned, Visit, VisitWith, DUMMY_SP};
@@ -424,7 +424,7 @@ impl Fold<Stmt> for Actual {
 }
 
 /// ```js
-/// 
+///
 ///   try {
 ///     if (!_iteratorNormalCompletion && _iterator.return != null) {
 ///       _iterator.return();

--- a/ecmascript/transforms/src/compat/es2015/for_of.rs
+++ b/ecmascript/transforms/src/compat/es2015/for_of.rs
@@ -2,10 +2,10 @@ use crate::{
     pass::Pass,
     util::{alias_if_required, prepend, ExprFactory, StmtLike},
 };
-use swc_ecma_ast::*;
 use serde::Deserialize;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, Mark, Spanned, Visit, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 /// `@babel/plugin-transform-for-of`
 ///
@@ -424,7 +424,7 @@ impl Fold<Stmt> for Actual {
 }
 
 /// ```js
-///
+/// 
 ///   try {
 ///     if (!_iteratorNormalCompletion && _iterator.return != null) {
 ///       _iterator.return();

--- a/ecmascript/transforms/src/compat/es2015/function_name.rs
+++ b/ecmascript/transforms/src/compat/es2015/function_name.rs
@@ -1,5 +1,5 @@
 use crate::{pass::Pass, util::UsageFinder};
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
 
 /// `@babel/plugin-transform-function-name`

--- a/ecmascript/transforms/src/compat/es2015/function_name.rs
+++ b/ecmascript/transforms/src/compat/es2015/function_name.rs
@@ -1,6 +1,6 @@
 use crate::{pass::Pass, util::UsageFinder};
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
+use swc_ecma_ast::*;
 
 /// `@babel/plugin-transform-function-name`
 ///

--- a/ecmascript/transforms/src/compat/es2015/instanceof.rs
+++ b/ecmascript/transforms/src/compat/es2015/instanceof.rs
@@ -1,6 +1,6 @@
 use crate::util::ExprFactory;
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Visit, VisitWith};
+use swc_ecma_ast::*;
 
 /// `@babel/plugin-transform-instanceof`
 ///

--- a/ecmascript/transforms/src/compat/es2015/instanceof.rs
+++ b/ecmascript/transforms/src/compat/es2015/instanceof.rs
@@ -1,5 +1,5 @@
 use crate::util::ExprFactory;
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Visit, VisitWith};
 
 /// `@babel/plugin-transform-instanceof`

--- a/ecmascript/transforms/src/compat/es2015/parameters.rs
+++ b/ecmascript/transforms/src/compat/es2015/parameters.rs
@@ -1,7 +1,7 @@
 use crate::util::{prepend_stmts, ExprFactory};
 use arrayvec::ArrayVec;
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Mark, Spanned, DUMMY_SP};
+use swc_ecma_ast::*;
 
 pub fn parameters() -> Params {
     Params

--- a/ecmascript/transforms/src/compat/es2015/parameters.rs
+++ b/ecmascript/transforms/src/compat/es2015/parameters.rs
@@ -1,6 +1,6 @@
 use crate::util::{prepend_stmts, ExprFactory};
 use arrayvec::ArrayVec;
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Mark, Spanned, DUMMY_SP};
 
 pub fn parameters() -> Params {

--- a/ecmascript/transforms/src/compat/es2015/regenerator/case.rs
+++ b/ecmascript/transforms/src/compat/es2015/regenerator/case.rs
@@ -3,7 +3,7 @@ use crate::{
     compat::es2015::regenerator::leap::{CatchEntry, FinallyEntry, TryEntry},
     util::{ident::IdentLike, undefined, ExprFactory},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use smallvec::SmallVec;
 use std::mem::replace;
 use swc_atoms::JsWord;

--- a/ecmascript/transforms/src/compat/es2015/regenerator/case.rs
+++ b/ecmascript/transforms/src/compat/es2015/regenerator/case.rs
@@ -3,7 +3,6 @@ use crate::{
     compat::es2015::regenerator::leap::{CatchEntry, FinallyEntry, TryEntry},
     util::{ident::IdentLike, undefined, ExprFactory},
 };
-use swc_ecma_ast::*;
 use smallvec::SmallVec;
 use std::mem::replace;
 use swc_atoms::JsWord;
@@ -11,6 +10,7 @@ use swc_common::{
     util::{map::Map, move_map::MoveMap},
     BytePos, Fold, FoldWith, Span, Spanned, SyntaxContext, Visit, VisitWith, DUMMY_SP,
 };
+use swc_ecma_ast::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) struct Loc {

--- a/ecmascript/transforms/src/compat/es2015/regenerator/hoist.rs
+++ b/ecmascript/transforms/src/compat/es2015/regenerator/hoist.rs
@@ -1,5 +1,5 @@
 use crate::util::find_ids;
-use ast::*;
+use swc_ecma_ast::*;
 use smallvec::SmallVec;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, DUMMY_SP};

--- a/ecmascript/transforms/src/compat/es2015/regenerator/hoist.rs
+++ b/ecmascript/transforms/src/compat/es2015/regenerator/hoist.rs
@@ -1,8 +1,8 @@
 use crate::util::find_ids;
-use swc_ecma_ast::*;
 use smallvec::SmallVec;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 pub(super) type Vars = SmallVec<[Ident; 32]>;
 

--- a/ecmascript/transforms/src/compat/es2015/regenerator/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/regenerator/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     pass::Pass,
     util::{contains_this_expr, prepend, ExprFactory, StmtLike},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use std::mem::replace;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, Spanned, Visit, VisitWith, DUMMY_SP};

--- a/ecmascript/transforms/src/compat/es2015/regenerator/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/regenerator/mod.rs
@@ -3,10 +3,10 @@ use crate::{
     pass::Pass,
     util::{contains_this_expr, prepend, ExprFactory, StmtLike},
 };
-use swc_ecma_ast::*;
 use std::mem::replace;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, Spanned, Visit, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 mod case;
 mod hoist;

--- a/ecmascript/transforms/src/compat/es2015/shorthand_property.rs
+++ b/ecmascript/transforms/src/compat/es2015/shorthand_property.rs
@@ -1,4 +1,4 @@
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
 
 /// Compile ES2015 shorthand properties to ES5

--- a/ecmascript/transforms/src/compat/es2015/shorthand_property.rs
+++ b/ecmascript/transforms/src/compat/es2015/shorthand_property.rs
@@ -1,5 +1,5 @@
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
+use swc_ecma_ast::*;
 
 /// Compile ES2015 shorthand properties to ES5
 ///

--- a/ecmascript/transforms/src/compat/es2015/spread.rs
+++ b/ecmascript/transforms/src/compat/es2015/spread.rs
@@ -2,11 +2,11 @@ use crate::{
     pass::Pass,
     util::{alias_ident_for, is_literal, prepend, undefined, ExprFactory, StmtLike},
 };
-use swc_ecma_ast::*;
 use serde::Deserialize;
 use std::mem;
 use swc_atoms::js_word;
 use swc_common::{util::move_map::MoveMap, Fold, FoldWith, Span, Spanned, DUMMY_SP};
+use swc_ecma_ast::*;
 
 pub fn spread(c: Config) -> impl Pass {
     Spread { c }

--- a/ecmascript/transforms/src/compat/es2015/spread.rs
+++ b/ecmascript/transforms/src/compat/es2015/spread.rs
@@ -2,7 +2,7 @@ use crate::{
     pass::Pass,
     util::{alias_ident_for, is_literal, prepend, undefined, ExprFactory, StmtLike},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use serde::Deserialize;
 use std::mem;
 use swc_atoms::js_word;

--- a/ecmascript/transforms/src/compat/es2015/sticky_regex.rs
+++ b/ecmascript/transforms/src/compat/es2015/sticky_regex.rs
@@ -1,5 +1,5 @@
 use crate::util::ExprFactory;
-use ast::*;
+use swc_ecma_ast::*;
 use swc_atoms::JsWord;
 use swc_common::{Fold, FoldWith, DUMMY_SP};
 

--- a/ecmascript/transforms/src/compat/es2015/sticky_regex.rs
+++ b/ecmascript/transforms/src/compat/es2015/sticky_regex.rs
@@ -1,7 +1,7 @@
 use crate::util::ExprFactory;
-use swc_ecma_ast::*;
 use swc_atoms::JsWord;
 use swc_common::{Fold, FoldWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 /// Compile ES2015 sticky regex to an ES5 RegExp constructor
 ///

--- a/ecmascript/transforms/src/compat/es2015/template_literal.rs
+++ b/ecmascript/transforms/src/compat/es2015/template_literal.rs
@@ -1,8 +1,8 @@
 use crate::util::{is_literal, prepend_stmts, ExprFactory, StmtLike};
-use swc_ecma_ast::*;
 use std::{iter, mem};
 use swc_atoms::js_word;
 use swc_common::{BytePos, Fold, FoldWith, Spanned, DUMMY_SP};
+use swc_ecma_ast::*;
 
 #[derive(Default, Clone)]
 pub struct TemplateLiteral {

--- a/ecmascript/transforms/src/compat/es2015/template_literal.rs
+++ b/ecmascript/transforms/src/compat/es2015/template_literal.rs
@@ -1,5 +1,5 @@
 use crate::util::{is_literal, prepend_stmts, ExprFactory, StmtLike};
-use ast::*;
+use swc_ecma_ast::*;
 use std::{iter, mem};
 use swc_atoms::js_word;
 use swc_common::{BytePos, Fold, FoldWith, Spanned, DUMMY_SP};

--- a/ecmascript/transforms/src/compat/es2015/typeof_symbol.rs
+++ b/ecmascript/transforms/src/compat/es2015/typeof_symbol.rs
@@ -1,5 +1,5 @@
 use crate::util::ExprFactory;
-use ast::*;
+use swc_ecma_ast::*;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, Visit, VisitWith};
 

--- a/ecmascript/transforms/src/compat/es2015/typeof_symbol.rs
+++ b/ecmascript/transforms/src/compat/es2015/typeof_symbol.rs
@@ -1,7 +1,7 @@
 use crate::util::ExprFactory;
-use swc_ecma_ast::*;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, Visit, VisitWith};
+use swc_ecma_ast::*;
 
 /// `@babel/plugin-transform-typeof-symbol`
 ///

--- a/ecmascript/transforms/src/compat/es2016/exponentation.rs
+++ b/ecmascript/transforms/src/compat/es2016/exponentation.rs
@@ -2,8 +2,8 @@ use crate::{
     pass::Pass,
     util::{ExprFactory, StmtLike},
 };
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Span, Spanned, Visit, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 /// `@babel/plugin-transform-exponentiation-operator`
 ///

--- a/ecmascript/transforms/src/compat/es2016/exponentation.rs
+++ b/ecmascript/transforms/src/compat/es2016/exponentation.rs
@@ -2,7 +2,7 @@ use crate::{
     pass::Pass,
     util::{ExprFactory, StmtLike},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Span, Spanned, Visit, VisitWith, DUMMY_SP};
 
 /// `@babel/plugin-transform-exponentiation-operator`

--- a/ecmascript/transforms/src/compat/es2017/async_to_generator.rs
+++ b/ecmascript/transforms/src/compat/es2017/async_to_generator.rs
@@ -3,7 +3,7 @@ use crate::{
     pass::Pass,
     util::{contains_ident_ref, contains_this_expr, ExprFactory, StmtLike},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use std::iter;
 use swc_common::{Fold, FoldWith, Mark, Spanned, Visit, VisitWith, DUMMY_SP};
 

--- a/ecmascript/transforms/src/compat/es2017/async_to_generator.rs
+++ b/ecmascript/transforms/src/compat/es2017/async_to_generator.rs
@@ -3,9 +3,9 @@ use crate::{
     pass::Pass,
     util::{contains_ident_ref, contains_this_expr, ExprFactory, StmtLike},
 };
-use swc_ecma_ast::*;
 use std::iter;
 use swc_common::{Fold, FoldWith, Mark, Spanned, Visit, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 /// `@babel/plugin-transform-async-to-generator`
 ///

--- a/ecmascript/transforms/src/compat/es2018/object_rest_spread.rs
+++ b/ecmascript/transforms/src/compat/es2018/object_rest_spread.rs
@@ -4,7 +4,7 @@ use crate::{
         alias_ident_for, alias_if_required, is_literal, var::VarCollector, ExprFactory, StmtLike,
     },
 };
-use ast::*;
+use swc_ecma_ast::*;
 use std::{iter, mem};
 use swc_common::{
     chain, util::move_map::MoveMap, Fold, FoldWith, Mark, Spanned, Visit, VisitWith, DUMMY_SP,

--- a/ecmascript/transforms/src/compat/es2018/object_rest_spread.rs
+++ b/ecmascript/transforms/src/compat/es2018/object_rest_spread.rs
@@ -4,11 +4,11 @@ use crate::{
         alias_ident_for, alias_if_required, is_literal, var::VarCollector, ExprFactory, StmtLike,
     },
 };
-use swc_ecma_ast::*;
 use std::{iter, mem};
 use swc_common::{
     chain, util::move_map::MoveMap, Fold, FoldWith, Mark, Spanned, Visit, VisitWith, DUMMY_SP,
 };
+use swc_ecma_ast::*;
 
 /// `@babel/plugin-proposal-object-rest-spread`
 pub fn object_rest_spread() -> impl Pass {

--- a/ecmascript/transforms/src/compat/es2018/optional_catch_binding.rs
+++ b/ecmascript/transforms/src/compat/es2018/optional_catch_binding.rs
@@ -1,5 +1,5 @@
 use crate::pass::Pass;
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::Fold;
 
 struct OptionalCatchBinding;

--- a/ecmascript/transforms/src/compat/es2018/optional_catch_binding.rs
+++ b/ecmascript/transforms/src/compat/es2018/optional_catch_binding.rs
@@ -1,6 +1,6 @@
 use crate::pass::Pass;
-use swc_ecma_ast::*;
 use swc_common::Fold;
+use swc_ecma_ast::*;
 
 struct OptionalCatchBinding;
 

--- a/ecmascript/transforms/src/compat/es3.rs
+++ b/ecmascript/transforms/src/compat/es3.rs
@@ -2,7 +2,7 @@ pub use self::{
     member_expr_lits::MemberExprLit, prop_lits::PropertyLiteral, reserved_word::ReservedWord,
 };
 use crate::pass::Pass;
-use ast::Expr;
+use swc_ecma_ast::Expr;
 
 mod member_expr_lits;
 mod prop_lits;

--- a/ecmascript/transforms/src/compat/es3/member_expr_lits.rs
+++ b/ecmascript/transforms/src/compat/es3/member_expr_lits.rs
@@ -1,6 +1,6 @@
 use crate::util::is_valid_ident;
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
+use swc_ecma_ast::*;
 
 /// babel: `transform-member-expression-literals`
 ///

--- a/ecmascript/transforms/src/compat/es3/member_expr_lits.rs
+++ b/ecmascript/transforms/src/compat/es3/member_expr_lits.rs
@@ -1,5 +1,5 @@
 use crate::util::is_valid_ident;
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
 
 /// babel: `transform-member-expression-literals`

--- a/ecmascript/transforms/src/compat/es3/prop_lits.rs
+++ b/ecmascript/transforms/src/compat/es3/prop_lits.rs
@@ -1,5 +1,5 @@
 use crate::util::is_valid_ident;
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
 
 /// babel: `transform-property-literals`

--- a/ecmascript/transforms/src/compat/es3/prop_lits.rs
+++ b/ecmascript/transforms/src/compat/es3/prop_lits.rs
@@ -1,6 +1,6 @@
 use crate::util::is_valid_ident;
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
+use swc_ecma_ast::*;
 
 /// babel: `transform-property-literals`
 ///

--- a/ecmascript/transforms/src/compat/es3/reserved_word.rs
+++ b/ecmascript/transforms/src/compat/es3/reserved_word.rs
@@ -1,5 +1,5 @@
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
+use swc_ecma_ast::*;
 
 /// babel: `@babel/plugin-transform-reserved-words`
 ///

--- a/ecmascript/transforms/src/compat/es3/reserved_word.rs
+++ b/ecmascript/transforms/src/compat/es3/reserved_word.rs
@@ -1,4 +1,4 @@
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
 
 /// babel: `@babel/plugin-transform-reserved-words`

--- a/ecmascript/transforms/src/const_modules.rs
+++ b/ecmascript/transforms/src/const_modules.rs
@@ -5,7 +5,7 @@ use crate::{
         options::{CM, SESSION},
     },
 };
-use ast::*;
+use swc_ecma_ast::*;
 use dashmap::DashMap;
 use hashbrown::HashMap;
 use once_cell::sync::Lazy;

--- a/ecmascript/transforms/src/const_modules.rs
+++ b/ecmascript/transforms/src/const_modules.rs
@@ -5,13 +5,13 @@ use crate::{
         options::{CM, SESSION},
     },
 };
-use swc_ecma_ast::*;
 use dashmap::DashMap;
 use hashbrown::HashMap;
 use once_cell::sync::Lazy;
 use std::sync::Arc;
 use swc_atoms::JsWord;
 use swc_common::{util::move_map::MoveMap, FileName, Fold, FoldWith};
+use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser, SourceFileInput};
 
 pub fn const_modules(globals: HashMap<JsWord, HashMap<JsWord, String>>) -> impl Pass {

--- a/ecmascript/transforms/src/debug/validator.rs
+++ b/ecmascript/transforms/src/debug/validator.rs
@@ -1,4 +1,4 @@
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Spanned};
 
 /// This transform validates span on debug mode and does nothing on release

--- a/ecmascript/transforms/src/debug/validator.rs
+++ b/ecmascript/transforms/src/debug/validator.rs
@@ -1,5 +1,5 @@
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, Spanned};
+use swc_ecma_ast::*;
 
 /// This transform validates span on debug mode and does nothing on release
 /// mode.

--- a/ecmascript/transforms/src/fixer.rs
+++ b/ecmascript/transforms/src/fixer.rs
@@ -2,7 +2,7 @@ use crate::{
     pass::Pass,
     util::{ExprFactory, COMMENTS},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use fxhash::FxHashMap;
 use swc_common::{
     util::{map::Map, move_map::MoveMap},

--- a/ecmascript/transforms/src/fixer.rs
+++ b/ecmascript/transforms/src/fixer.rs
@@ -2,12 +2,12 @@ use crate::{
     pass::Pass,
     util::{ExprFactory, COMMENTS},
 };
-use swc_ecma_ast::*;
 use fxhash::FxHashMap;
 use swc_common::{
     util::{map::Map, move_map::MoveMap},
     Fold, FoldWith, Span, Spanned,
 };
+use swc_ecma_ast::*;
 
 pub fn fixer() -> impl Pass {
     Fixer {

--- a/ecmascript/transforms/src/helpers.rs
+++ b/ecmascript/transforms/src/helpers.rs
@@ -1,10 +1,10 @@
-use ast::*;
+use swc_ecma_ast::*;
 use once_cell::sync::Lazy;
 use scoped_tls::scoped_thread_local;
 use std::sync::atomic::{AtomicBool, Ordering};
 use swc_common::{FileName, Fold, FoldWith, Mark, Span, DUMMY_SP};
 use swc_ecma_parser::{lexer::Lexer, Parser, SourceFileInput};
-use utils::{
+use swc_ecma_utils::{
     options::{CM, SESSION},
     prepend_stmts, quote_ident, quote_str, DropSpan,
 };

--- a/ecmascript/transforms/src/helpers.rs
+++ b/ecmascript/transforms/src/helpers.rs
@@ -1,8 +1,8 @@
-use swc_ecma_ast::*;
 use once_cell::sync::Lazy;
 use scoped_tls::scoped_thread_local;
 use std::sync::atomic::{AtomicBool, Ordering};
 use swc_common::{FileName, Fold, FoldWith, Mark, Span, DUMMY_SP};
+use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser, SourceFileInput};
 use swc_ecma_utils::{
     options::{CM, SESSION},

--- a/ecmascript/transforms/src/hygiene.rs
+++ b/ecmascript/transforms/src/hygiene.rs
@@ -4,12 +4,12 @@ use crate::{
     pass::Pass,
     scope::{IdentType, ScopeKind},
 };
-use swc_ecma_ast::*;
 use hashbrown::HashMap;
 use smallvec::{smallvec, SmallVec};
 use std::cell::RefCell;
 use swc_atoms::JsWord;
 use swc_common::{chain, Fold, FoldWith, Span, SyntaxContext};
+use swc_ecma_ast::*;
 
 mod ops;
 #[cfg(test)]

--- a/ecmascript/transforms/src/hygiene.rs
+++ b/ecmascript/transforms/src/hygiene.rs
@@ -4,7 +4,7 @@ use crate::{
     pass::Pass,
     scope::{IdentType, ScopeKind},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use hashbrown::HashMap;
 use smallvec::{smallvec, SmallVec};
 use std::cell::RefCell;

--- a/ecmascript/transforms/src/hygiene/ops.rs
+++ b/ecmascript/transforms/src/hygiene/ops.rs
@@ -1,4 +1,4 @@
-use ast::*;
+use swc_ecma_ast::*;
 use swc_atoms::JsWord;
 use swc_common::{util::move_map::MoveMap, Fold, FoldWith, Spanned, SyntaxContext, DUMMY_SP};
 

--- a/ecmascript/transforms/src/hygiene/ops.rs
+++ b/ecmascript/transforms/src/hygiene/ops.rs
@@ -1,6 +1,6 @@
-use swc_ecma_ast::*;
 use swc_atoms::JsWord;
 use swc_common::{util::move_map::MoveMap, Fold, FoldWith, Spanned, SyntaxContext, DUMMY_SP};
+use swc_ecma_ast::*;
 
 #[derive(Debug)]
 pub(super) enum ScopeOp {

--- a/ecmascript/transforms/src/lib.rs
+++ b/ecmascript/transforms/src/lib.rs
@@ -9,7 +9,7 @@
 #![recursion_limit = "1024"]
 
 #[macro_use]
-extern crate utils;
+extern crate swc_ecma_utils;
 
 pub use self::{const_modules::const_modules, fixer::fixer, hygiene::hygiene, resolver::resolver};
 
@@ -37,5 +37,5 @@ mod resolver;
 pub mod scope;
 pub mod typescript;
 pub mod util {
-    pub use utils::*;
+    pub use swc_ecma_utils::*;
 }

--- a/ecmascript/transforms/src/modules/amd.rs
+++ b/ecmascript/transforms/src/modules/amd.rs
@@ -6,7 +6,7 @@ use crate::{
     pass::Pass,
     util::{prepend_stmts, var::VarCollector, DestructuringFinder, ExprFactory},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use fxhash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use std::iter;

--- a/ecmascript/transforms/src/modules/amd.rs
+++ b/ecmascript/transforms/src/modules/amd.rs
@@ -6,12 +6,12 @@ use crate::{
     pass::Pass,
     util::{prepend_stmts, var::VarCollector, DestructuringFinder, ExprFactory},
 };
-use swc_ecma_ast::*;
 use fxhash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use std::iter;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, Mark, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 pub fn amd(config: Config) -> impl Pass {
     Amd {

--- a/ecmascript/transforms/src/modules/common_js.rs
+++ b/ecmascript/transforms/src/modules/common_js.rs
@@ -7,10 +7,10 @@ use crate::{
     pass::Pass,
     util::{var::VarCollector, DestructuringFinder, ExprFactory},
 };
-use swc_ecma_ast::*;
 use fxhash::FxHashSet;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 pub fn common_js(config: Config) -> impl Pass {
     CommonJs {

--- a/ecmascript/transforms/src/modules/common_js.rs
+++ b/ecmascript/transforms/src/modules/common_js.rs
@@ -7,7 +7,7 @@ use crate::{
     pass::Pass,
     util::{var::VarCollector, DestructuringFinder, ExprFactory},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use fxhash::FxHashSet;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, VisitWith, DUMMY_SP};

--- a/ecmascript/transforms/src/modules/import_analysis.rs
+++ b/ecmascript/transforms/src/modules/import_analysis.rs
@@ -1,8 +1,8 @@
 use super::util::Scope;
 use crate::pass::Pass;
-use swc_ecma_ast::*;
 use swc_atoms::js_word;
 use swc_common::{Fold, Visit, VisitWith};
+use swc_ecma_ast::*;
 
 pub fn import_analyzer() -> impl Pass {
     ImportAnalyzer {

--- a/ecmascript/transforms/src/modules/import_analysis.rs
+++ b/ecmascript/transforms/src/modules/import_analysis.rs
@@ -1,6 +1,6 @@
 use super::util::Scope;
 use crate::pass::Pass;
-use ast::*;
+use swc_ecma_ast::*;
 use swc_atoms::js_word;
 use swc_common::{Fold, Visit, VisitWith};
 

--- a/ecmascript/transforms/src/modules/umd.rs
+++ b/ecmascript/transforms/src/modules/umd.rs
@@ -8,7 +8,7 @@ use crate::{
     pass::Pass,
     util::{prepend_stmts, var::VarCollector, DestructuringFinder, ExprFactory},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use fxhash::FxHashSet;
 use std::sync::Arc;
 use swc_atoms::js_word;

--- a/ecmascript/transforms/src/modules/umd.rs
+++ b/ecmascript/transforms/src/modules/umd.rs
@@ -8,11 +8,11 @@ use crate::{
     pass::Pass,
     util::{prepend_stmts, var::VarCollector, DestructuringFinder, ExprFactory},
 };
-use swc_ecma_ast::*;
 use fxhash::FxHashSet;
 use std::sync::Arc;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, Mark, SourceMap, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 mod config;
 

--- a/ecmascript/transforms/src/modules/umd/config.rs
+++ b/ecmascript/transforms/src/modules/umd/config.rs
@@ -1,5 +1,5 @@
 use super::super::util;
-use ast::Expr;
+use swc_ecma_ast::Expr;
 use hashbrown::HashMap;
 use inflector::Inflector;
 use serde::{Deserialize, Serialize};

--- a/ecmascript/transforms/src/modules/umd/config.rs
+++ b/ecmascript/transforms/src/modules/umd/config.rs
@@ -1,5 +1,4 @@
 use super::super::util;
-use swc_ecma_ast::Expr;
 use hashbrown::HashMap;
 use inflector::Inflector;
 use serde::{Deserialize, Serialize};
@@ -9,6 +8,7 @@ use swc_common::{
     errors::{ColorConfig, Handler},
     FileName, SourceMap,
 };
+use swc_ecma_ast::Expr;
 use swc_ecma_parser::{lexer::Lexer, Parser, Session, SourceFileInput, Syntax};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/ecmascript/transforms/src/modules/util.rs
+++ b/ecmascript/transforms/src/modules/util.rs
@@ -1,5 +1,4 @@
 use crate::util::{undefined, DestructuringFinder, ExprFactory};
-use swc_ecma_ast::*;
 use fxhash::FxHashSet;
 use hashbrown::{hash_map::Entry, HashMap, HashSet};
 use indexmap::IndexMap;
@@ -8,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::iter;
 use swc_atoms::{js_word, JsWord};
 use swc_common::{FoldWith, Mark, Span, SyntaxContext, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 pub(super) trait ModulePass {
     fn config(&self) -> &Config;
@@ -678,7 +678,7 @@ pub(super) fn define_property(args: Vec<ExprOrSpread>) -> Expr {
 /// Creates
 ///
 ///```js
-///
+/// 
 ///  Object.defineProperty(exports, '__esModule', {
 ///       value: true
 ///  });

--- a/ecmascript/transforms/src/modules/util.rs
+++ b/ecmascript/transforms/src/modules/util.rs
@@ -1,5 +1,5 @@
 use crate::util::{undefined, DestructuringFinder, ExprFactory};
-use ast::*;
+use swc_ecma_ast::*;
 use fxhash::FxHashSet;
 use hashbrown::{hash_map::Entry, HashMap, HashSet};
 use indexmap::IndexMap;
@@ -678,7 +678,7 @@ pub(super) fn define_property(args: Vec<ExprOrSpread>) -> Expr {
 /// Creates
 ///
 ///```js
-/// 
+///
 ///  Object.defineProperty(exports, '__esModule', {
 ///       value: true
 ///  });

--- a/ecmascript/transforms/src/optimization/inline_globals.rs
+++ b/ecmascript/transforms/src/optimization/inline_globals.rs
@@ -1,4 +1,4 @@
-use ast::*;
+use swc_ecma_ast::*;
 use hashbrown::HashMap;
 use swc_atoms::{js_word, JsWord};
 use swc_common::{Fold, FoldWith};

--- a/ecmascript/transforms/src/optimization/inline_globals.rs
+++ b/ecmascript/transforms/src/optimization/inline_globals.rs
@@ -1,7 +1,7 @@
-use swc_ecma_ast::*;
 use hashbrown::HashMap;
 use swc_atoms::{js_word, JsWord};
 use swc_common::{Fold, FoldWith};
+use swc_ecma_ast::*;
 
 #[derive(Clone)]
 pub struct InlineGlobals {

--- a/ecmascript/transforms/src/optimization/json_parse.rs
+++ b/ecmascript/transforms/src/optimization/json_parse.rs
@@ -1,5 +1,5 @@
 use crate::util::{calc_literal_cost, ExprFactory};
-use ast::*;
+use swc_ecma_ast::*;
 use serde_json::Value;
 use std::usize;
 use swc_common::{Fold, FoldWith, Spanned, DUMMY_SP};
@@ -179,14 +179,14 @@ mod tests {
         "const a = {
         method(arg) {
           return arg;
-        }, 
-        b: 1 
+        },
+        b: 1
       };",
         "const a = {
         method(arg) {
           return arg;
-        }, 
-        b: 1 
+        },
+        b: 1
       };"
     );
 

--- a/ecmascript/transforms/src/optimization/json_parse.rs
+++ b/ecmascript/transforms/src/optimization/json_parse.rs
@@ -1,8 +1,8 @@
 use crate::util::{calc_literal_cost, ExprFactory};
-use swc_ecma_ast::*;
 use serde_json::Value;
 use std::usize;
 use swc_common::{Fold, FoldWith, Spanned, DUMMY_SP};
+use swc_ecma_ast::*;
 
 /// Trnasform to optimize performance of literals.
 ///

--- a/ecmascript/transforms/src/optimization/simplify.rs
+++ b/ecmascript/transforms/src/optimization/simplify.rs
@@ -2,8 +2,8 @@
 pub use self::dce::dce;
 use self::expr::SimplifyExpr;
 use crate::pass::Pass;
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
+use swc_ecma_ast::*;
 
 pub mod dce;
 mod expr;

--- a/ecmascript/transforms/src/optimization/simplify.rs
+++ b/ecmascript/transforms/src/optimization/simplify.rs
@@ -2,7 +2,7 @@
 pub use self::dce::dce;
 use self::expr::SimplifyExpr;
 use crate::pass::Pass;
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
 
 pub mod dce;

--- a/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
@@ -2,12 +2,12 @@ use crate::{
     pass::Pass,
     util::{StmtLike, *},
 };
-use swc_ecma_ast::*;
 use std::{cmp::min, iter::once};
 use swc_atoms::js_word;
 use swc_common::{
     fold::VisitWith, util::move_map::MoveMap, Fold, FoldWith, Spanned, Visit, DUMMY_SP,
 };
+use swc_ecma_ast::*;
 
 #[cfg(test)]
 mod tests;

--- a/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     pass::Pass,
     util::{StmtLike, *},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use std::{cmp::min, iter::once};
 use swc_atoms::js_word;
 use swc_common::{

--- a/ecmascript/transforms/src/optimization/simplify/expr.rs
+++ b/ecmascript/transforms/src/optimization/simplify/expr.rs
@@ -1,8 +1,8 @@
 use crate::util::*;
-use swc_ecma_ast::{Ident, Lit, *};
 use std::{iter, iter::once};
 use swc_atoms::{js_word, JsWord};
 use swc_common::{Fold, FoldWith, Span, Spanned};
+use swc_ecma_ast::{Ident, Lit, *};
 
 #[cfg(test)]
 mod tests;

--- a/ecmascript/transforms/src/optimization/simplify/expr.rs
+++ b/ecmascript/transforms/src/optimization/simplify/expr.rs
@@ -1,5 +1,5 @@
 use crate::util::*;
-use ast::{Ident, Lit, *};
+use swc_ecma_ast::{Ident, Lit, *};
 use std::{iter, iter::once};
 use swc_atoms::{js_word, JsWord};
 use swc_common::{Fold, FoldWith, Span, Spanned};

--- a/ecmascript/transforms/src/pass.rs
+++ b/ecmascript/transforms/src/pass.rs
@@ -1,6 +1,6 @@
-use swc_ecma_ast::*;
 use std::marker::PhantomData;
 use swc_common::{Fold, FoldWith};
+use swc_ecma_ast::*;
 
 pub fn noop() -> impl Pass {
     struct Noop;

--- a/ecmascript/transforms/src/pass.rs
+++ b/ecmascript/transforms/src/pass.rs
@@ -1,4 +1,4 @@
-use ast::*;
+use swc_ecma_ast::*;
 use std::marker::PhantomData;
 use swc_common::{Fold, FoldWith};
 

--- a/ecmascript/transforms/src/proposals/class_properties.rs
+++ b/ecmascript/transforms/src/proposals/class_properties.rs
@@ -12,7 +12,7 @@ use crate::{
         undefined, ExprFactory, ModuleItemLike, StmtLike,
     },
 };
-use ast::*;
+use swc_ecma_ast::*;
 use hashbrown::HashSet;
 use swc_atoms::JsWord;
 use swc_common::{Fold, FoldWith, Mark, Spanned, VisitWith, DUMMY_SP};

--- a/ecmascript/transforms/src/proposals/class_properties.rs
+++ b/ecmascript/transforms/src/proposals/class_properties.rs
@@ -12,10 +12,10 @@ use crate::{
         undefined, ExprFactory, ModuleItemLike, StmtLike,
     },
 };
-use swc_ecma_ast::*;
 use hashbrown::HashSet;
 use swc_atoms::JsWord;
 use swc_common::{Fold, FoldWith, Mark, Spanned, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 mod class_name_tdz;
 mod private_field;

--- a/ecmascript/transforms/src/proposals/class_properties/class_name_tdz.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/class_name_tdz.rs
@@ -1,6 +1,6 @@
 use crate::util::ExprFactory;
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 pub(super) struct ClassNameTdzFolder<'a> {
     pub class_name: &'a Ident,

--- a/ecmascript/transforms/src/proposals/class_properties/class_name_tdz.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/class_name_tdz.rs
@@ -1,5 +1,5 @@
 use crate::util::ExprFactory;
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith, DUMMY_SP};
 
 pub(super) struct ClassNameTdzFolder<'a> {

--- a/ecmascript/transforms/src/proposals/class_properties/private_field.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/private_field.rs
@@ -1,5 +1,5 @@
 use crate::util::{alias_ident_for, alias_if_required, prepend, ExprFactory};
-use ast::*;
+use swc_ecma_ast::*;
 use hashbrown::HashSet;
 use std::{iter, mem};
 use swc_atoms::JsWord;

--- a/ecmascript/transforms/src/proposals/class_properties/private_field.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/private_field.rs
@@ -1,9 +1,9 @@
 use crate::util::{alias_ident_for, alias_if_required, prepend, ExprFactory};
-use swc_ecma_ast::*;
 use hashbrown::HashSet;
 use std::{iter, mem};
 use swc_atoms::JsWord;
 use swc_common::{Fold, FoldWith, Mark, Spanned, DUMMY_SP};
+use swc_ecma_ast::*;
 
 pub(super) struct FieldAccessFolder<'a> {
     pub mark: Mark,

--- a/ecmascript/transforms/src/proposals/class_properties/this_in_static.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/this_in_static.rs
@@ -1,4 +1,4 @@
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
 
 pub(super) struct ThisInStaticFolder {

--- a/ecmascript/transforms/src/proposals/class_properties/this_in_static.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/this_in_static.rs
@@ -1,5 +1,5 @@
-use swc_ecma_ast::*;
 use swc_common::{Fold, FoldWith};
+use swc_ecma_ast::*;
 
 pub(super) struct ThisInStaticFolder {
     pub ident: Ident,

--- a/ecmascript/transforms/src/proposals/class_properties/used_name.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/used_name.rs
@@ -1,4 +1,4 @@
-use ast::*;
+use swc_ecma_ast::*;
 use swc_atoms::JsWord;
 use swc_common::{Fold, Mark, Visit, VisitWith};
 

--- a/ecmascript/transforms/src/proposals/class_properties/used_name.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/used_name.rs
@@ -1,6 +1,6 @@
-use swc_ecma_ast::*;
 use swc_atoms::JsWord;
 use swc_common::{Fold, Mark, Visit, VisitWith};
+use swc_ecma_ast::*;
 
 pub(super) struct UsedNameRenamer<'a> {
     pub mark: Mark,

--- a/ecmascript/transforms/src/proposals/decorators.rs
+++ b/ecmascript/transforms/src/proposals/decorators.rs
@@ -6,7 +6,7 @@ use crate::{
         ExprFactory, IdentExt,
     },
 };
-use ast::*;
+use swc_ecma_ast::*;
 use either::Either;
 use serde::Deserialize;
 use std::iter;
@@ -18,7 +18,7 @@ mod usage;
 /// ## Simple class decorator
 ///
 /// ```js
-/// 
+///
 /// @annotation
 /// class MyClass { }
 ///

--- a/ecmascript/transforms/src/proposals/decorators.rs
+++ b/ecmascript/transforms/src/proposals/decorators.rs
@@ -6,11 +6,11 @@ use crate::{
         ExprFactory, IdentExt,
     },
 };
-use swc_ecma_ast::*;
 use either::Either;
 use serde::Deserialize;
 use std::iter;
 use swc_common::{Fold, FoldWith, Spanned, Visit, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 mod legacy;
 mod usage;
@@ -18,7 +18,7 @@ mod usage;
 /// ## Simple class decorator
 ///
 /// ```js
-///
+/// 
 /// @annotation
 /// class MyClass { }
 ///

--- a/ecmascript/transforms/src/proposals/decorators/legacy.rs
+++ b/ecmascript/transforms/src/proposals/decorators/legacy.rs
@@ -3,7 +3,7 @@ use crate::util::{
     alias_if_required, default_constructor, prepend, prop_name_to_expr_value, undefined,
     ExprFactory, ModuleItemLike, StmtLike,
 };
-use ast::*;
+use swc_ecma_ast::*;
 use smallvec::SmallVec;
 use std::mem::replace;
 use swc_common::{util::move_map::MoveMap, Fold, FoldWith, VisitWith, DUMMY_SP};

--- a/ecmascript/transforms/src/proposals/decorators/legacy.rs
+++ b/ecmascript/transforms/src/proposals/decorators/legacy.rs
@@ -3,10 +3,10 @@ use crate::util::{
     alias_if_required, default_constructor, prepend, prop_name_to_expr_value, undefined,
     ExprFactory, ModuleItemLike, StmtLike,
 };
-use swc_ecma_ast::*;
 use smallvec::SmallVec;
 use std::mem::replace;
 use swc_common::{util::move_map::MoveMap, Fold, FoldWith, VisitWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 #[derive(Debug, Default)]
 pub(super) struct Legacy {

--- a/ecmascript/transforms/src/proposals/decorators/usage.rs
+++ b/ecmascript/transforms/src/proposals/decorators/usage.rs
@@ -1,5 +1,5 @@
-use swc_ecma_ast::Decorator;
 use swc_common::{Visit, VisitWith};
+use swc_ecma_ast::Decorator;
 
 pub(super) fn has_decorator<T: VisitWith<DecoratorFinder>>(node: &T) -> bool {
     let mut v = DecoratorFinder { found: false };

--- a/ecmascript/transforms/src/proposals/decorators/usage.rs
+++ b/ecmascript/transforms/src/proposals/decorators/usage.rs
@@ -1,4 +1,4 @@
-use ast::Decorator;
+use swc_ecma_ast::Decorator;
 use swc_common::{Visit, VisitWith};
 
 pub(super) fn has_decorator<T: VisitWith<DecoratorFinder>>(node: &T) -> bool {

--- a/ecmascript/transforms/src/proposals/export.rs
+++ b/ecmascript/transforms/src/proposals/export.rs
@@ -1,6 +1,6 @@
 use crate::{pass::Pass, util::IdentExt};
-use swc_ecma_ast::*;
 use swc_common::{Fold, DUMMY_SP};
+use swc_ecma_ast::*;
 
 /// `@babel/plugin-proposal-export-default-from` and
 /// `@babel/plugin-proposal-export-namespace-from`

--- a/ecmascript/transforms/src/proposals/export.rs
+++ b/ecmascript/transforms/src/proposals/export.rs
@@ -1,5 +1,5 @@
 use crate::{pass::Pass, util::IdentExt};
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, DUMMY_SP};
 
 /// `@babel/plugin-proposal-export-default-from` and

--- a/ecmascript/transforms/src/proposals/nullish_coalescing/mod.rs
+++ b/ecmascript/transforms/src/proposals/nullish_coalescing/mod.rs
@@ -2,9 +2,9 @@ use crate::{
     pass::Pass,
     util::{alias_if_required, undefined, StmtLike},
 };
-use swc_ecma_ast::*;
 use std::mem::replace;
 use swc_common::{Fold, FoldWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 #[cfg(test)]
 mod tests;

--- a/ecmascript/transforms/src/proposals/nullish_coalescing/mod.rs
+++ b/ecmascript/transforms/src/proposals/nullish_coalescing/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     pass::Pass,
     util::{alias_if_required, undefined, StmtLike},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use std::mem::replace;
 use swc_common::{Fold, FoldWith, DUMMY_SP};
 

--- a/ecmascript/transforms/src/proposals/opt_chaining.rs
+++ b/ecmascript/transforms/src/proposals/opt_chaining.rs
@@ -2,9 +2,9 @@ use crate::{
     pass::Pass,
     util::{prepend, undefined, ExprFactory, StmtLike},
 };
-use swc_ecma_ast::*;
 use std::{fmt::Debug, iter::once, mem};
 use swc_common::{Fold, FoldWith, Spanned, DUMMY_SP};
+use swc_ecma_ast::*;
 
 pub fn optional_chaining() -> impl Pass {
     OptChaining::default()

--- a/ecmascript/transforms/src/proposals/opt_chaining.rs
+++ b/ecmascript/transforms/src/proposals/opt_chaining.rs
@@ -2,7 +2,7 @@ use crate::{
     pass::Pass,
     util::{prepend, undefined, ExprFactory, StmtLike},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use std::{fmt::Debug, iter::once, mem};
 use swc_common::{Fold, FoldWith, Spanned, DUMMY_SP};
 

--- a/ecmascript/transforms/src/react/display_name.rs
+++ b/ecmascript/transforms/src/react/display_name.rs
@@ -1,7 +1,7 @@
 use crate::pass::Pass;
-use swc_ecma_ast::*;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 #[cfg(test)]
 mod tests;

--- a/ecmascript/transforms/src/react/display_name.rs
+++ b/ecmascript/transforms/src/react/display_name.rs
@@ -1,5 +1,5 @@
 use crate::pass::Pass;
-use ast::*;
+use swc_ecma_ast::*;
 use swc_atoms::js_word;
 use swc_common::{Fold, FoldWith, DUMMY_SP};
 

--- a/ecmascript/transforms/src/react/jsx.rs
+++ b/ecmascript/transforms/src/react/jsx.rs
@@ -6,7 +6,6 @@ use crate::{
         ExprFactory, HANDLER,
     },
 };
-use swc_ecma_ast::*;
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -14,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::{iter, mem, sync::Arc};
 use swc_atoms::{js_word, JsWord};
 use swc_common::{iter::IdentifyLast, FileName, Fold, FoldWith, Spanned, DUMMY_SP};
+use swc_ecma_ast::*;
 use swc_ecma_parser::{Parser, SourceFileInput, Syntax};
 
 #[cfg(test)]

--- a/ecmascript/transforms/src/react/jsx.rs
+++ b/ecmascript/transforms/src/react/jsx.rs
@@ -6,7 +6,7 @@ use crate::{
         ExprFactory, HANDLER,
     },
 };
-use ast::*;
+use swc_ecma_ast::*;
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use regex::Regex;

--- a/ecmascript/transforms/src/react/jsx_self.rs
+++ b/ecmascript/transforms/src/react/jsx_self.rs
@@ -1,6 +1,6 @@
 use crate::pass::Pass;
-use swc_ecma_ast::*;
 use swc_common::{Fold, DUMMY_SP};
+use swc_ecma_ast::*;
 
 #[cfg(test)]
 mod tests;

--- a/ecmascript/transforms/src/react/jsx_self.rs
+++ b/ecmascript/transforms/src/react/jsx_self.rs
@@ -1,5 +1,5 @@
 use crate::pass::Pass;
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{Fold, DUMMY_SP};
 
 #[cfg(test)]

--- a/ecmascript/transforms/src/react/jsx_src.rs
+++ b/ecmascript/transforms/src/react/jsx_src.rs
@@ -1,7 +1,7 @@
 use crate::pass::Pass;
-use swc_ecma_ast::*;
 use std::sync::Arc;
 use swc_common::{FileName, Fold, SourceMap, DUMMY_SP};
+use swc_ecma_ast::*;
 
 #[cfg(test)]
 mod tests;

--- a/ecmascript/transforms/src/react/jsx_src.rs
+++ b/ecmascript/transforms/src/react/jsx_src.rs
@@ -1,5 +1,5 @@
 use crate::pass::Pass;
-use ast::*;
+use swc_ecma_ast::*;
 use std::sync::Arc;
 use swc_common::{FileName, Fold, SourceMap, DUMMY_SP};
 

--- a/ecmascript/transforms/src/resolver.rs
+++ b/ecmascript/transforms/src/resolver.rs
@@ -2,11 +2,11 @@ use crate::{
     pass::Pass,
     scope::{IdentType, ScopeKind},
 };
-use swc_ecma_ast::*;
 use hashbrown::HashSet;
 use std::cell::RefCell;
 use swc_atoms::JsWord;
 use swc_common::{Fold, FoldWith, Mark, SyntaxContext};
+use swc_ecma_ast::*;
 
 #[cfg(test)]
 mod tests;

--- a/ecmascript/transforms/src/resolver.rs
+++ b/ecmascript/transforms/src/resolver.rs
@@ -2,7 +2,7 @@ use crate::{
     pass::Pass,
     scope::{IdentType, ScopeKind},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use hashbrown::HashSet;
 use std::cell::RefCell;
 use swc_atoms::JsWord;

--- a/ecmascript/transforms/src/tests.rs
+++ b/ecmascript/transforms/src/tests.rs
@@ -2,7 +2,6 @@ use crate::{
     helpers::{InjectHelpers, HELPERS},
     pass::Pass,
 };
-use swc_ecma_ast::*;
 use sourcemap::SourceMapBuilder;
 use std::{
     fmt,
@@ -13,6 +12,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 use swc_common::{comments::Comments, errors::Handler, FileName, Fold, FoldWith, SourceMap};
+use swc_ecma_ast::*;
 use swc_ecma_codegen::Emitter;
 use swc_ecma_parser::{lexer::Lexer, Parser, Session, SourceFileInput, Syntax};
 use tempfile::tempdir_in;

--- a/ecmascript/transforms/src/tests.rs
+++ b/ecmascript/transforms/src/tests.rs
@@ -2,7 +2,7 @@ use crate::{
     helpers::{InjectHelpers, HELPERS},
     pass::Pass,
 };
-use ast::*;
+use swc_ecma_ast::*;
 use sourcemap::SourceMapBuilder;
 use std::{
     fmt,

--- a/ecmascript/transforms/src/typescript.rs
+++ b/ecmascript/transforms/src/typescript.rs
@@ -2,12 +2,12 @@ use crate::{
     pass::Pass,
     util::{prepend_stmts, var::VarCollector, ExprFactory},
 };
-use swc_ecma_ast::*;
 use hashbrown::HashMap;
 use swc_atoms::{js_word, JsWord};
 use swc_common::{
     util::move_map::MoveMap, Fold, FoldWith, Spanned, SyntaxContext, Visit, VisitWith, DUMMY_SP,
 };
+use swc_ecma_ast::*;
 
 /// Strips type annotations out.
 pub fn strip() -> impl Pass {

--- a/ecmascript/transforms/src/typescript.rs
+++ b/ecmascript/transforms/src/typescript.rs
@@ -2,7 +2,7 @@ use crate::{
     pass::Pass,
     util::{prepend_stmts, var::VarCollector, ExprFactory},
 };
-use ast::*;
+use swc_ecma_ast::*;
 use hashbrown::HashMap;
 use swc_atoms::{js_word, JsWord};
 use swc_common::{

--- a/ecmascript/transforms/tests/common/mod.rs
+++ b/ecmascript/transforms/tests/common/mod.rs
@@ -1,7 +1,6 @@
 #![allow(unused_macros)]
 #![allow(dead_code)]
 
-use swc_ecma_ast::*;
 use sourcemap::SourceMapBuilder;
 use std::{
     fmt,
@@ -12,6 +11,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 use swc_common::{comments::Comments, errors::Handler, FileName, Fold, FoldWith, SourceMap};
+use swc_ecma_ast::*;
 use swc_ecma_codegen::Emitter;
 use swc_ecma_parser::{lexer::Lexer, Parser, Session, SourceFileInput, Syntax};
 use swc_ecma_transforms::{

--- a/ecmascript/transforms/tests/common/mod.rs
+++ b/ecmascript/transforms/tests/common/mod.rs
@@ -1,7 +1,7 @@
 #![allow(unused_macros)]
 #![allow(dead_code)]
 
-use ast::*;
+use swc_ecma_ast::*;
 use sourcemap::SourceMapBuilder;
 use std::{
     fmt,

--- a/ecmascript/transforms/tests/es2017_async_to_generator.rs
+++ b/ecmascript/transforms/tests/es2017_async_to_generator.rs
@@ -3,7 +3,7 @@
 #![feature(box_patterns)]
 #![feature(specialization)]
 
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{chain, fold::FoldWith, Fold, Spanned};
 use swc_ecma_parser::Syntax;
 use swc_ecma_transforms::{
@@ -103,7 +103,7 @@ let TestClass = {
             return _ref.apply(this, arguments);
           };
         })().bind(this));
-      } 
+      }
 };
 "#
 );
@@ -325,7 +325,7 @@ var foo = function() {
   function bar() {
     return _bar.apply(this, arguments);
   }
-  
+
   return bar;
 }();
 "#
@@ -1694,7 +1694,7 @@ test!(
   function poll() {
     return _poll.apply(this, arguments);
   }
-  
+
   return poll;
 })()();
 
@@ -1832,7 +1832,7 @@ function _foo() {
       });
       return _bar.apply(this, arguments);
     }
-    
+
     function bar() {
       return _bar.apply(this, arguments);
     }

--- a/ecmascript/transforms/tests/es2017_async_to_generator.rs
+++ b/ecmascript/transforms/tests/es2017_async_to_generator.rs
@@ -3,8 +3,8 @@
 #![feature(box_patterns)]
 #![feature(specialization)]
 
-use swc_ecma_ast::*;
 use swc_common::{chain, fold::FoldWith, Fold, Spanned};
+use swc_ecma_ast::*;
 use swc_ecma_parser::Syntax;
 use swc_ecma_transforms::{
     compat::{

--- a/ecmascript/transforms/tests/es2018_object_rest_spread.rs
+++ b/ecmascript/transforms/tests/es2018_object_rest_spread.rs
@@ -3,7 +3,7 @@
 #![feature(box_patterns)]
 #![feature(specialization)]
 
-use ast::Module;
+use swc_ecma_ast::Module;
 use swc_common::{chain, Fold};
 use swc_ecma_parser::Syntax;
 use swc_ecma_transforms::{
@@ -982,7 +982,7 @@ _ref2;
 
 if (_ref3 = {}, _Symbol$for3 = Symbol.for("foo"), ({
   [_Symbol$for3]: foo
-} = _ref3), rest = _objectWithoutProperties(_ref3, 
+} = _ref3), rest = _objectWithoutProperties(_ref3,
     [_Symbol$for3].map(_toPropertyKey)), _ref3) {}
 "#
 );
@@ -1126,7 +1126,7 @@ let {
 "#,
     r#"
 let _ref = {
-     a: [1, 2, 3, 4], d: 'oyez' 
+     a: [1, 2, 3, 4], d: 'oyez'
 }, { a: [b, ...arrayRest] , c =function(...functionRest) {
 }  } = _ref, objectRest = _objectWithoutProperties(_ref, ['a', 'c']);
 "#
@@ -1212,7 +1212,7 @@ const objSpread = { ...obj };
 
 const obj2 = { NOSET: 123, NOWRITE: 456 };
 // this line would throw `TypeError: Cannot assign to read only property 'NOWRITE'`
-// if transformed as Object.assign (or equivalent) because 
+// if transformed as Object.assign (or equivalent) because
 // those use *assignment* for creating properties
 // (spread defines them)
 const obj2Spread = { ...obj2 };

--- a/ecmascript/transforms/tests/es2018_object_rest_spread.rs
+++ b/ecmascript/transforms/tests/es2018_object_rest_spread.rs
@@ -3,8 +3,8 @@
 #![feature(box_patterns)]
 #![feature(specialization)]
 
-use swc_ecma_ast::Module;
 use swc_common::{chain, Fold};
+use swc_ecma_ast::Module;
 use swc_ecma_parser::Syntax;
 use swc_ecma_transforms::{
     compat::{

--- a/ecmascript/transforms/tests/fixer_test262.rs
+++ b/ecmascript/transforms/tests/fixer_test262.rs
@@ -5,7 +5,6 @@
 
 extern crate test;
 
-use swc_ecma_ast::*;
 use std::{
     env,
     fs::{read_dir, File},
@@ -14,6 +13,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 use swc_common::{Fold, FoldWith};
+use swc_ecma_ast::*;
 use swc_ecma_codegen::{self, Emitter};
 use swc_ecma_parser::{lexer::Lexer, Parser, Session, SourceFileInput, Syntax};
 use swc_ecma_transforms::fixer;

--- a/ecmascript/transforms/tests/fixer_test262.rs
+++ b/ecmascript/transforms/tests/fixer_test262.rs
@@ -5,7 +5,7 @@
 
 extern crate test;
 
-use ast::*;
+use swc_ecma_ast::*;
 use std::{
     env,
     fs::{read_dir, File},

--- a/ecmascript/transforms/tests/modules_amd.rs
+++ b/ecmascript/transforms/tests/modules_amd.rs
@@ -3,7 +3,7 @@
 #![feature(box_patterns)]
 #![feature(specialization)]
 
-use ast::Module;
+use swc_ecma_ast::Module;
 use swc_common::{chain, Fold};
 use swc_ecma_parser::Syntax;
 use swc_ecma_transforms::{
@@ -155,7 +155,7 @@ test!(
     custom_named_define,
     r#"
 import {foo} from 'src';
-export {foo};  
+export {foo};
   "#,
     r#"define('moduleId', ['exports', 'src'], function(_exports, _src) {
     'use strict';
@@ -751,7 +751,7 @@ bar2;
 
 "#,
     r#"
-define(["exports", "foo", "foo-bar", "./directory/foo-bar"], 
+define(["exports", "foo", "foo-bar", "./directory/foo-bar"],
 function (_exports, foo2, _fooBar, _fooBar1) {
   "use strict";
 

--- a/ecmascript/transforms/tests/modules_amd.rs
+++ b/ecmascript/transforms/tests/modules_amd.rs
@@ -3,8 +3,8 @@
 #![feature(box_patterns)]
 #![feature(specialization)]
 
-use swc_ecma_ast::Module;
 use swc_common::{chain, Fold};
+use swc_ecma_ast::Module;
 use swc_ecma_parser::Syntax;
 use swc_ecma_transforms::{
     modules::{

--- a/ecmascript/transforms/tests/modules_common_js.rs
+++ b/ecmascript/transforms/tests/modules_common_js.rs
@@ -3,8 +3,8 @@
 #![feature(box_patterns)]
 #![feature(specialization)]
 
-use swc_ecma_ast::*;
 use swc_common::{chain, Fold};
+use swc_ecma_ast::*;
 use swc_ecma_transforms::{
     compat, fixer,
     helpers::InjectHelpers,

--- a/ecmascript/transforms/tests/modules_common_js.rs
+++ b/ecmascript/transforms/tests/modules_common_js.rs
@@ -3,7 +3,7 @@
 #![feature(box_patterns)]
 #![feature(specialization)]
 
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::{chain, Fold};
 use swc_ecma_transforms::{
     compat, fixer,
@@ -244,7 +244,7 @@ foo = 3;
     r#"
 "use strict";
 Object.defineProperty(exports, '__esModule', {
-     value: true 
+     value: true
 });
 
 exports.foo = void 0;
@@ -2486,7 +2486,7 @@ test!(
     interop_module_shadow,
     r#"
 export function module() {
-  
+
 }
 
 "#,

--- a/ecmascript/transforms/tests/proposal_export.rs
+++ b/ecmascript/transforms/tests/proposal_export.rs
@@ -3,7 +3,7 @@
 #![feature(box_patterns)]
 #![feature(specialization)]
 
-use ast::*;
+use swc_ecma_ast::*;
 use swc_common::Fold;
 use swc_ecma_parser::{EsConfig, Syntax};
 use swc_ecma_transforms::proposals::export;

--- a/ecmascript/transforms/tests/proposal_export.rs
+++ b/ecmascript/transforms/tests/proposal_export.rs
@@ -3,8 +3,8 @@
 #![feature(box_patterns)]
 #![feature(specialization)]
 
-use swc_ecma_ast::*;
 use swc_common::Fold;
+use swc_ecma_ast::*;
 use swc_ecma_parser::{EsConfig, Syntax};
 use swc_ecma_transforms::proposals::export;
 

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ast = { package = "swc_ecma_ast", version = "0.16.0", path ="../ast" }
+swc_ecma_ast = { version = "0.16.0", path ="../ast" }
 swc_atoms = { version = "0.2.0", path ="../../atoms" }
 swc_common = { version = "0.5.0", path ="../../common" }
 swc_ecma_parser = { version = "0.18", path ="../parser", features = ["verify"] }

--- a/ecmascript/utils/src/constructor.rs
+++ b/ecmascript/utils/src/constructor.rs
@@ -1,7 +1,7 @@
 use crate::{prepend_stmts, ExprFactory};
-use swc_ecma_ast::*;
 use std::iter;
 use swc_common::{Fold, FoldWith, DUMMY_SP};
+use swc_ecma_ast::*;
 
 #[allow(clippy::vec_box)]
 pub fn inject_after_super(mut c: Constructor, exprs: Vec<Box<Expr>>) -> Constructor {

--- a/ecmascript/utils/src/constructor.rs
+++ b/ecmascript/utils/src/constructor.rs
@@ -1,5 +1,5 @@
 use crate::{prepend_stmts, ExprFactory};
-use ast::*;
+use swc_ecma_ast::*;
 use std::iter;
 use swc_common::{Fold, FoldWith, DUMMY_SP};
 

--- a/ecmascript/utils/src/factory.rs
+++ b/ecmascript/utils/src/factory.rs
@@ -1,4 +1,4 @@
-use ast::*;
+use swc_ecma_ast::*;
 use std::iter;
 use swc_atoms::js_word;
 use swc_common::{Span, Spanned, DUMMY_SP};

--- a/ecmascript/utils/src/factory.rs
+++ b/ecmascript/utils/src/factory.rs
@@ -1,7 +1,7 @@
-use swc_ecma_ast::*;
 use std::iter;
 use swc_atoms::js_word;
 use swc_common::{Span, Spanned, DUMMY_SP};
+use swc_ecma_ast::*;
 
 /// Extension methods for [Expr].
 pub trait ExprFactory: Into<Expr> {

--- a/ecmascript/utils/src/ident.rs
+++ b/ecmascript/utils/src/ident.rs
@@ -1,4 +1,4 @@
-use ast::Ident;
+use swc_ecma_ast::Ident;
 use swc_atoms::JsWord;
 use swc_common::{Span, SyntaxContext};
 

--- a/ecmascript/utils/src/ident.rs
+++ b/ecmascript/utils/src/ident.rs
@@ -1,6 +1,6 @@
-use swc_ecma_ast::Ident;
 use swc_atoms::JsWord;
 use swc_common::{Span, SyntaxContext};
+use swc_ecma_ast::Ident;
 
 pub trait IdentLike: Sized {
     fn from_ident(i: &Ident) -> Self;

--- a/ecmascript/utils/src/lib.rs
+++ b/ecmascript/utils/src/lib.rs
@@ -16,7 +16,7 @@ pub use self::{
     Purity::{MayBeImpure, Pure},
 };
 use crate::ident::IdentLike;
-use ast::*;
+use swc_ecma_ast::*;
 use scoped_tls::scoped_thread_local;
 use std::{
     borrow::Cow,

--- a/ecmascript/utils/src/lib.rs
+++ b/ecmascript/utils/src/lib.rs
@@ -16,7 +16,6 @@ pub use self::{
     Purity::{MayBeImpure, Pure},
 };
 use crate::ident::IdentLike;
-use swc_ecma_ast::*;
 use scoped_tls::scoped_thread_local;
 use std::{
     borrow::Cow,
@@ -29,6 +28,7 @@ use swc_common::{
     comments::Comments, errors::Handler, Fold, FoldWith, Mark, Span, Spanned, Visit, VisitWith,
     DUMMY_SP,
 };
+use swc_ecma_ast::*;
 use unicode_xid::UnicodeXID;
 
 #[macro_use]

--- a/ecmascript/utils/src/macros.rs
+++ b/ecmascript/utils/src/macros.rs
@@ -8,7 +8,7 @@ macro_rules! private_ident {
         use swc_common::Mark;
         let mark = Mark::fresh(Mark::root());
         let span = $span.apply_mark(mark);
-        ::ast::Ident::new($s.into(), span)
+        ::swc_ecma_ast::Ident::new($s.into(), span)
     }};
 }
 
@@ -18,7 +18,7 @@ macro_rules! quote_ident {
         quote_ident!(::swc_common::DUMMY_SP, $s)
     };
     ($span:expr, $s:expr) => {{
-        ::ast::Ident::new($s.into(), $span)
+        ::swc_ecma_ast::Ident::new($s.into(), $span)
     }};
 }
 
@@ -28,7 +28,7 @@ macro_rules! quote_str {
         quote_str!(::swc_common::DUMMY_SP, $s)
     };
     ($span:expr, $s:expr) => {{
-        ::ast::Str {
+        ::swc_ecma_ast::Str {
             span: $span,
             value: $s.into(),
             has_escape: false,
@@ -39,7 +39,7 @@ macro_rules! quote_str {
 #[macro_export]
 macro_rules! quote_expr {
     ($span:expr, null) => {{
-        use ast::*;
+        use swc_ecma_ast::*;
         Expr::Lit(Lit::Null(Null { span: $span }))
     }};
 
@@ -59,7 +59,7 @@ macro_rules! quote_expr {
 #[macro_export]
 macro_rules! member_expr {
     ($span:expr, $first:ident) => {{
-        use ast::Expr;
+        use swc_ecma_ast::Expr;
         box Expr::Ident(quote_ident!($span, stringify!($first)))
     }};
 
@@ -81,7 +81,7 @@ macro_rules! member_expr {
     }};
 
     (@EXT, $span:expr, $obj:expr,  $first:ident) => {{
-        use ast::*;
+        use swc_ecma_ast::*;
         let prop = member_expr!($span, $first);
 
         box Expr::Member(MemberExpr{
@@ -95,7 +95,7 @@ macro_rules! member_expr {
 
 #[cfg(test)]
 mod tests {
-    use ast::*;
+    use swc_ecma_ast::*;
     use swc_common::DUMMY_SP as span;
     #[test]
     fn quote_member_expr() {

--- a/ecmascript/utils/src/macros.rs
+++ b/ecmascript/utils/src/macros.rs
@@ -95,8 +95,8 @@ macro_rules! member_expr {
 
 #[cfg(test)]
 mod tests {
-    use swc_ecma_ast::*;
     use swc_common::DUMMY_SP as span;
+    use swc_ecma_ast::*;
     #[test]
     fn quote_member_expr() {
         let expr: Box<Expr> = member_expr!(span, Function.prototype.bind);

--- a/ecmascript/utils/src/var.rs
+++ b/ecmascript/utils/src/var.rs
@@ -1,4 +1,4 @@
-use ast::*;
+use swc_ecma_ast::*;
 use swc_atoms::JsWord;
 use swc_common::{SyntaxContext, Visit, VisitWith};
 

--- a/ecmascript/utils/src/var.rs
+++ b/ecmascript/utils/src/var.rs
@@ -1,6 +1,6 @@
-use swc_ecma_ast::*;
 use swc_atoms::JsWord;
 use swc_common::{SyntaxContext, Visit, VisitWith};
+use swc_ecma_ast::*;
 
 pub struct VarCollector<'a> {
     pub to: &'a mut Vec<(JsWord, SyntaxContext)>,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,7 @@
 use crate::config::{GlobalPassOption, JscTarget, ModuleConfig};
-use atoms::JsWord;
-use common::{chain, errors::Handler, fold::and_then::AndThen, SourceMap};
-use ecmascript::{
+use swc_atoms::JsWord;
+use swc_common::{chain, errors::Handler, fold::and_then::AndThen, SourceMap};
+use swc_ecmascript::{
     parser::Syntax,
     preset_env,
     transforms::{

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,7 @@
 use crate::config::{GlobalPassOption, JscTarget, ModuleConfig};
+use either::Either;
+use hashbrown::hash_map::HashMap;
+use std::sync::Arc;
 use swc_atoms::JsWord;
 use swc_common::{chain, errors::Handler, fold::and_then::AndThen, SourceMap};
 use swc_ecmascript::{
@@ -10,9 +13,6 @@ use swc_ecmascript::{
         typescript,
     },
 };
-use either::Either;
-use hashbrown::hash_map::HashMap;
-use std::sync::Arc;
 
 /// Builder is used to create a high performance `Compiler`.
 pub struct PassBuilder<'a, 'b, P: Pass> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,10 @@
 use crate::{builder::PassBuilder, error::Error};
-use atoms::JsWord;
-pub use common::chain;
-use common::{errors::Handler, FileName, SourceMap};
+use swc_atoms::JsWord;
+pub use swc_common::chain;
+use swc_common::{errors::Handler, FileName, SourceMap};
 use dashmap::DashMap;
-pub use ecmascript::parser::JscTarget;
-use ecmascript::{
+pub use swc_ecmascript::parser::JscTarget;
+use swc_ecmascript::{
     ast::{Expr, ExprStmt, ModuleItem, Stmt},
     parser::{lexer::Lexer, Parser, Session as ParseSess, SourceFileInput, Syntax},
     preset_env,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,18 @@
 use crate::{builder::PassBuilder, error::Error};
+use dashmap::DashMap;
+use hashbrown::{HashMap, HashSet};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::{
+    env,
+    path::{Path, PathBuf},
+    sync::Arc,
+    usize,
+};
 use swc_atoms::JsWord;
 pub use swc_common::chain;
 use swc_common::{errors::Handler, FileName, SourceMap};
-use dashmap::DashMap;
 pub use swc_ecmascript::parser::JscTarget;
 use swc_ecmascript::{
     ast::{Expr, ExprStmt, ModuleItem, Stmt},
@@ -15,16 +25,6 @@ use swc_ecmascript::{
         proposals::{class_properties, decorators, export, nullish_coalescing, optional_chaining},
         react, resolver, typescript,
     },
-};
-use hashbrown::{HashMap, HashSet};
-use once_cell::sync::Lazy;
-use regex::Regex;
-use serde::{Deserialize, Serialize};
-use std::{
-    env,
-    path::{Path, PathBuf},
-    sync::Arc,
-    usize,
 };
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![feature(box_syntax, box_patterns)]
 
-pub use atoms;
-pub use common;
-pub use ecmascript;
+pub use swc_atoms as atoms;
+pub use swc_common as common;
+pub use swc_ecmascript as ecmascript;
 pub use sourcemap;
 
 mod builder;
@@ -14,11 +14,11 @@ use crate::{
     config::{BuiltConfig, ConfigFile, JscTarget, Merge, Options, Rc, RootMode},
     error::Error,
 };
-use common::{
+use swc_common::{
     comments::Comments, errors::Handler, FileName, FoldWith, Globals, SourceFile, SourceMap,
     GLOBALS,
 };
-use ecmascript::{
+use swc_ecmascript::{
     ast::Program,
     codegen::{self, Emitter},
     parser::{lexer::Lexer, Parser, Session as ParseSess, Syntax},
@@ -28,7 +28,7 @@ use ecmascript::{
         util::COMMENTS,
     },
 };
-pub use ecmascript::{
+pub use swc_ecmascript::{
     parser::SourceFileInput,
     transforms::{chain_at, pass::Pass},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,14 +14,11 @@ use crate::{
     config::{BuiltConfig, ConfigFile, JscTarget, Merge, Options, Rc, RootMode},
     error::Error,
 };
-use serde::Serialize;
-use sourcemap::SourceMapBuilder;
-use std::{fs::File, path::Path, sync::Arc};
-use swc_common::{
+use common::{
     comments::Comments, errors::Handler, FileName, FoldWith, Globals, SourceFile, SourceMap,
     GLOBALS,
 };
-use swc_ecmascript::{
+use ecmascript::{
     ast::Program,
     codegen::{self, Emitter},
     parser::{lexer::Lexer, Parser, Session as ParseSess, Syntax},
@@ -31,10 +28,13 @@ use swc_ecmascript::{
         util::COMMENTS,
     },
 };
-pub use swc_ecmascript::{
+pub use ecmascript::{
     parser::SourceFileInput,
     transforms::{chain_at, pass::Pass},
 };
+use serde::Serialize;
+use sourcemap::SourceMapBuilder;
+use std::{fs::File, path::Path, sync::Arc};
 
 pub struct Compiler {
     /// swc uses rustc's span interning.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #![feature(box_syntax, box_patterns)]
 
+pub use sourcemap;
 pub use swc_atoms as atoms;
 pub use swc_common as common;
 pub use swc_ecmascript as ecmascript;
-pub use sourcemap;
 
 mod builder;
 pub mod config;
@@ -14,6 +14,9 @@ use crate::{
     config::{BuiltConfig, ConfigFile, JscTarget, Merge, Options, Rc, RootMode},
     error::Error,
 };
+use serde::Serialize;
+use sourcemap::SourceMapBuilder;
+use std::{fs::File, path::Path, sync::Arc};
 use swc_common::{
     comments::Comments, errors::Handler, FileName, FoldWith, Globals, SourceFile, SourceMap,
     GLOBALS,
@@ -32,9 +35,6 @@ pub use swc_ecmascript::{
     parser::SourceFileInput,
     transforms::{chain_at, pass::Pass},
 };
-use serde::Serialize;
-use sourcemap::SourceMapBuilder;
-use std::{fs::File, path::Path, sync::Arc};
 
 pub struct Compiler {
     /// swc uses rustc's span interning.


### PR DESCRIPTION
This PR supercedes https://github.com/swc-project/swc/pull/621 and tries to remove dependency renaming to enable WASM, as discussed in https://github.com/swc-project/swc/issues/106