### PR TITLE
[Merged by Bors] - Top level await

### DIFF
--- a/ecmascript/parser/src/error.rs
+++ b/ecmascript/parser/src/error.rs
@@ -228,7 +228,9 @@ impl<'a> From<ErrorToDiag<'a>> for DiagnosticBuilder<'a> {
     #[cold]
     fn from(e: ErrorToDiag<'a>) -> Self {
         let msg: Cow<'static, _> = match e.error {
-            TopLevelAwait => "top level await requires es2017 or higher".into(),
+            TopLevelAwait => "top level await requires target to es2017 or higher and \
+                              topLevelAwait:true for ecmascript"
+                .into(),
             LegacyDecimal => "Legacy decimal escape is not permitted in strict mode".into(),
             LegacyOctal => "Legacy octal escape is not permitted in strict mode".into(),
             InvalidIdentChar => "Invalid character in identifier".into(),

--- a/ecmascript/parser/src/error.rs
+++ b/ecmascript/parser/src/error.rs
@@ -46,6 +46,8 @@ pub struct Error {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum SyntaxError {
+    TopLevelAwait,
+
     LegacyDecimal,
     LegacyOctal,
     InvalidIdentChar,
@@ -226,6 +228,7 @@ impl<'a> From<ErrorToDiag<'a>> for DiagnosticBuilder<'a> {
     #[cold]
     fn from(e: ErrorToDiag<'a>) -> Self {
         let msg: Cow<'static, _> = match e.error {
+            TopLevelAwait => "top level await requires es2017 or higher".into(),
             LegacyDecimal => "Legacy decimal escape is not permitted in strict mode".into(),
             LegacyOctal => "Legacy octal escape is not permitted in strict mode".into(),
             InvalidIdentChar => "Invalid character in identifier".into(),

--- a/ecmascript/parser/src/lib.rs
+++ b/ecmascript/parser/src/lib.rs
@@ -281,6 +281,18 @@ impl Syntax {
             _ => false,
         }
     }
+
+    pub fn top_level_await(self) -> bool {
+        match self {
+            Syntax::Es(EsConfig {
+                top_level_await: true,
+                ..
+            })
+            | Syntax::Typescript(..) => true,
+
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
@@ -378,6 +390,10 @@ pub struct EsConfig {
     /// Stage 3.
     #[serde(default)]
     pub import_meta: bool,
+
+    /// Stage 3.
+    #[serde(default)]
+    pub top_level_await: bool,
 }
 
 /// Syntactic context.

--- a/ecmascript/parser/src/parser/expr/ops.rs
+++ b/ecmascript/parser/src/parser/expr/ops.rs
@@ -338,7 +338,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         Ok(expr)
     }
 
-    fn parse_await_expr(&mut self) -> PResult<'a, Box<Expr>> {
+    pub(super) fn parse_await_expr(&mut self) -> PResult<'a, Box<Expr>> {
         let start = cur_pos!();
 
         assert_and_bump!("await");

--- a/ecmascript/parser/src/parser/expr/ops.rs
+++ b/ecmascript/parser/src/parser/expr/ops.rs
@@ -338,7 +338,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         Ok(expr)
     }
 
-    pub(super) fn parse_await_expr(&mut self) -> PResult<'a, Box<Expr>> {
+    pub(crate) fn parse_await_expr(&mut self) -> PResult<'a, Box<Expr>> {
         let start = cur_pos!();
 
         assert_and_bump!("await");

--- a/ecmascript/parser/src/parser/expr/ops.rs
+++ b/ecmascript/parser/src/parser/expr/ops.rs
@@ -342,7 +342,6 @@ impl<'a, I: Tokens> Parser<'a, I> {
         let start = cur_pos!();
 
         assert_and_bump!("await");
-        debug_assert!(self.ctx().in_async);
 
         if is!('*') {
             syntax_error!(SyntaxError::AwaitStar);

--- a/ecmascript/parser/src/parser/mod.rs
+++ b/ecmascript/parser/src/parser/mod.rs
@@ -175,7 +175,7 @@ where
     F: for<'a> FnOnce(&'a mut Parser<'a, Lexer<'a, crate::SourceFileInput<'_>>>) -> Result<Ret, ()>,
 {
     crate::with_test_sess(s, |sess, input| {
-        let lexer = Lexer::new(sess, syntax, Default::default(), input, None);
+        let lexer = Lexer::new(sess, syntax, JscTarget::Es2019, input, None);
         f(&mut Parser::new_from(sess, lexer))
     })
     .unwrap_or_else(|output| panic!("test_parser(): failed to parse \n{}\n{}", s, output))

--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -92,6 +92,18 @@ impl<'a, I: Tokens> Parser<'a, I> {
         top_level: bool,
         decorators: Vec<Decorator>,
     ) -> PResult<'a, Stmt> {
+        let start = cur_pos!();
+        if top_level && is!("await") {
+            if self.target() >= JscTarget::Es2017 {
+                let expr = self.parse_await_expr()?;
+
+                let span = span!(start);
+                return Ok(Stmt::Expr(ExprStmt { span, expr });)
+            }
+
+            self.emit_err(span!(start),SyntaxError::TopLevelAwait);
+        }
+
         if self.input.syntax().typescript() && is!("const") && peeked_is!("enum") {
             assert_and_bump!("const");
             assert_and_bump!("enum");

--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -94,14 +94,16 @@ impl<'a, I: Tokens> Parser<'a, I> {
     ) -> PResult<'a, Stmt> {
         let start = cur_pos!();
         if top_level && is!("await") {
-            if self.target() >= JscTarget::Es2017 && self.syntax().top_level_await() {
-                let expr = self.parse_await_expr()?;
+            let valid = self.target() >= JscTarget::Es2017 && self.syntax().top_level_await();
 
-                let span = span!(start);
-                return Ok(Stmt::Expr(ExprStmt { span, expr }));
+            if !valid {
+                self.emit_err(self.input.cur_span(), SyntaxError::TopLevelAwait);
             }
 
-            self.emit_err(span!(start), SyntaxError::TopLevelAwait);
+            let expr = self.parse_await_expr()?;
+
+            let span = span!(start);
+            return Ok(Stmt::Expr(ExprStmt { span, expr }));
         }
 
         if self.input.syntax().typescript() && is!("const") && peeked_is!("enum") {

--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -94,7 +94,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
     ) -> PResult<'a, Stmt> {
         let start = cur_pos!();
         if top_level && is!("await") {
-            if self.target() >= JscTarget::Es2017 && self.syntax().top_level_awiat() {
+            if self.target() >= JscTarget::Es2017 && self.syntax().top_level_await() {
                 let expr = self.parse_await_expr()?;
 
                 let span = span!(start);

--- a/ecmascript/parser/tests/test262-error-references/fail/1aefe47e20eb91fa.module.js.stderr
+++ b/ecmascript/parser/tests/test262-error-references/fail/1aefe47e20eb91fa.module.js.stderr
@@ -1,4 +1,10 @@
-error: Unexpected token Some(Word(await))
+error: top level await requires target to es2017 or higher and topLevelAwait:true for ecmascript
+ --> $DIR/tests/test262-parser/fail/1aefe47e20eb91fa.module.js:1:1
+  |
+1 | await
+  | ^^^^^
+
+error: Unexpected token None
  --> $DIR/tests/test262-parser/fail/1aefe47e20eb91fa.module.js:1:1
   |
 1 | await

--- a/ecmascript/parser/tests/typescript-errors/custom/top-level-await-jsc-target/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/custom/top-level-await-jsc-target/input.ts
@@ -1,0 +1,1 @@
+await foo

--- a/ecmascript/parser/tests/typescript-errors/custom/top-level-await-jsc-target/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/custom/top-level-await-jsc-target/input.ts.stderr
@@ -1,0 +1,6 @@
+error: top level await requires target to es2017 or higher and topLevelAwait:true for ecmascript
+ --> $DIR/tests/typescript-errors/custom/top-level-await-jsc-target/input.ts:1:1
+  |
+1 | await foo
+  | ^^^^^
+

--- a/ecmascript/parser/tests/typescript/class/decorators/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/decorators/input.ts.json
@@ -21,7 +21,7 @@
       },
       "declare": false,
       "span": {
-        "start": 0,
+        "start": 5,
         "end": 196,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/decorators/type-arguments/input.ts.json
+++ b/ecmascript/parser/tests/typescript/decorators/type-arguments/input.ts.json
@@ -21,7 +21,7 @@
       },
       "declare": false,
       "span": {
-        "start": 0,
+        "start": 21,
         "end": 34,
         "ctxt": 0
       },


### PR DESCRIPTION
Implements a top level await for es2017+, and allow it for typescript and ecmascript (ecmascript requires topLevelAwait: true).

Closes #626.