### PR TITLE
Smaller runtime

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install node dependencies
         run: |
           npm config set prefix ~/npm
-          npm i browserslist @babel/runtime
+          npm i browserslist regenerator-runtime
           npm i -g jest
 
       # Ensure that all components all compilable.

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - source ~/.nvm/nvm.sh
   - nvm install 8.15.0
   - nvm use 8.15.0
-  - npm install browserslist @babel/runtime
+  - npm install browserslist regenerator
   - npm install -g jest
   - RUST_BACKTRACE=0 cargo test --no-run --color always --all --all-features
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ addons:
   apt:
     packages:
       - libssl-dev
+      - pkg-config
+      - cmake
+      - zlib1g-dev
 
 language: rust
 rust:

--- a/ecmascript/transforms/package.json
+++ b/ecmascript/transforms/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@babel/runtime": "^7.7.7",
+    "regenerator-runtime": "^7.7.7",
     "jest": "^23.6.0"
   }
 }

--- a/ecmascript/transforms/src/compat/es2015/regenerator/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/regenerator/mod.rs
@@ -37,7 +37,7 @@ fn rt(rt: Ident) -> Stmt {
             init: Some(box Expr::Call(CallExpr {
                 span: DUMMY_SP,
                 callee: quote_ident!("require").as_callee(),
-                args: vec![quote_str!("@babel/runtime/regenerator").as_arg()],
+                args: vec![quote_str!("regenerator-runtime").as_arg()],
                 type_args: Default::default(),
             })),
             definite: false,
@@ -45,7 +45,7 @@ fn rt(rt: Ident) -> Stmt {
     }))
 }
 
-/// Injects `var _regeneratorRuntime = require('@babel/runtime/regenerator');`
+/// Injects `var _regeneratorRuntime = require('regenerator-runtime');`
 impl Fold<Module> for Regenerator {
     fn fold(&mut self, m: Module) -> Module {
         let mut m: Module = m.fold_children(self);
@@ -56,7 +56,7 @@ impl Fold<Module> for Regenerator {
     }
 }
 
-/// Injects `var _regeneratorRuntime = require('@babel/runtime/regenerator');`
+/// Injects `var _regeneratorRuntime = require('regenerator-runtime');`
 impl Fold<Script> for Regenerator {
     fn fold(&mut self, s: Script) -> Script {
         let mut s: Script = s.fold_children(self);

--- a/ecmascript/transforms/tests/es2015_regenerator.rs
+++ b/ecmascript/transforms/tests/es2015_regenerator.rs
@@ -37,7 +37,7 @@ var o = {
 
 "#,
     r#"
-var regeneratorRuntime = require('@babel/runtime/regenerator');
+var regeneratorRuntime = require('regenerator-runtime');
 
 var o = {
   foo() {
@@ -85,7 +85,7 @@ expect(test.iter().next().value).toBe(test);
 //    |_| tr(Default::default()),
 //    regression_t7041,
 //    r#"
-//var _regeneratorRuntime = require("@babel/runtime/regenerator");
+//var _regeneratorRuntime = require("regenerator-runtime");
 //
 //Object.keys({});
 //
@@ -93,7 +93,7 @@ expect(test.iter().next().value).toBe(test);
 //
 //"#,
 //    r#"
-//var _regeneratorRuntime = require("@babel/runtime/regenerator");
+//var _regeneratorRuntime = require("regenerator-runtime");
 //
 //var _marked = _regeneratorRuntime.mark(fn);
 //
@@ -132,7 +132,7 @@ Object.defineProperty(exports, '__esModule', {
     value: true
 });
 exports.default = void 0;
-var regeneratorRuntime = require('@babel/runtime/regenerator');
+var regeneratorRuntime = require('regenerator-runtime');
 var _default = function _callee() {
     var x;
     return regeneratorRuntime.wrap(function _callee$(_ctx) {
@@ -160,7 +160,7 @@ test!(
     "function* foo(a,b,c){}
 ",
     r#"
-var regeneratorRuntime = require('@babel/runtime/regenerator');
+var regeneratorRuntime = require('regenerator-runtime');
 var _marked = regeneratorRuntime.mark(foo);
 
 function foo(a, b, c) {


### PR DESCRIPTION
Replaced `@babel/runtime/regenerator` to `regenerator-runtime`