### PR TITLE
Fix version of regenerator-runtime

### DIFF
--- a/ecmascript/transforms/package.json
+++ b/ecmascript/transforms/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "regenerator-runtime": "^7.7.7",
+    "regenerator-runtime": "^0.11.0",
     "jest": "^23.6.0"
   }
 }


### PR DESCRIPTION
7.7.7 is version of @babel/runtime, not regenerator-runtime. Looks like the intended version was "0.11.0" as you can see in the yarn.lock:

    regenerator-runtime@^0.11.0:
      version "0.11.1"
      resolved "https://registry.yarnpkg.com/regenerator-runtime/-/re...
      integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT9...

###### Reference:
- https://github.com/swc-project/swc/commit/05be89c19