### PR TITLE
Support "export namespace from" in TypeScript

### DIFF
--- a/ecmascript/parser/src/lib.rs
+++ b/ecmascript/parser/src/lib.rs
@@ -255,7 +255,8 @@ impl Syntax {
             Syntax::Es(EsConfig {
                 export_namespace_from: true,
                 ..
-            }) => true,
+            })
+            | Syntax::Typescript(..) => true,
             _ => false,
         }
     }

--- a/ecmascript/parser/tests/typescript/export/namespace-from/input.ts
+++ b/ecmascript/parser/tests/typescript/export/namespace-from/input.ts
@@ -1,0 +1,1 @@
+export * as ns from "package";

--- a/ecmascript/parser/tests/typescript/export/namespace-from/input.ts.json
+++ b/ecmascript/parser/tests/typescript/export/namespace-from/input.ts.json
@@ -1,0 +1,50 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 0,
+    "end": 30,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ExportNamedDeclaration",
+      "span": {
+        "start": 0,
+        "end": 29,
+        "ctxt": 0
+      },
+      "specifiers": [
+        {
+          "type": "ExportNamespaceSpecifer",
+          "span": {
+            "start": 0,
+            "end": 14,
+            "ctxt": 0
+          },
+          "name": {
+            "type": "Identifier",
+            "span": {
+              "start": 12,
+              "end": 14,
+              "ctxt": 0
+            },
+            "value": "ns",
+            "typeAnnotation": null,
+            "optional": false
+          }
+        }
+      ],
+      "source": {
+        "type": "StringLiteral",
+        "span": {
+          "start": 20,
+          "end": 29,
+          "ctxt": 0
+        },
+        "value": "package",
+        "hasEscape": false
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
Another TS 3.8 feature: https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-rc/#export-star-as-namespace-syntax

It's nice that these have already been implemented :)