### PR TITLE
Reduce binary size

### DIFF
--- a/ecmascript/transforms/src/compat/es2015/arrow.rs
+++ b/ecmascript/transforms/src/compat/es2015/arrow.rs
@@ -60,6 +60,8 @@ pub fn arrow() -> impl Pass {
 
 struct Arrow;
 
+noop_fold_type!(Arrow);
+
 impl Fold<Expr> for Arrow {
     fn fold(&mut self, e: Expr) -> Expr {
         // fast path

--- a/ecmascript/transforms/src/compat/es2015/block_scoped_fn.rs
+++ b/ecmascript/transforms/src/compat/es2015/block_scoped_fn.rs
@@ -5,6 +5,8 @@ use swc_ecma_ast::*;
 #[derive(Clone, Copy)]
 pub struct BlockScopedFns;
 
+noop_fold_type!(BlockScopedFns);
+
 impl Fold<Vec<Stmt>> for BlockScopedFns {
     fn fold(&mut self, items: Vec<Stmt>) -> Vec<Stmt> {
         let mut stmts = Vec::with_capacity(items.len());

--- a/ecmascript/transforms/src/compat/es2015/block_scoping.rs
+++ b/ecmascript/transforms/src/compat/es2015/block_scoping.rs
@@ -45,6 +45,8 @@ struct BlockScoping {
     vars: Vec<VarDeclarator>,
 }
 
+noop_fold_type!(BlockScoping);
+
 impl BlockScoping {
     /// This methods remove [ScopeKind::Loop] and [ScopeKind::Fn], but not
     /// [ScopeKind::ForLetLoop]

--- a/ecmascript/transforms/src/compat/es2015/classes.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes.rs
@@ -61,6 +61,8 @@ pub struct Classes {
     in_strict: bool,
 }
 
+noop_fold_type!(Classes);
+
 struct Data {
     key_prop: Box<Prop>,
     method: Option<Box<Expr>>,

--- a/ecmascript/transforms/src/compat/es2015/classes/constructor.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes/constructor.rs
@@ -12,6 +12,8 @@ pub(super) struct SuperCallFinder {
     in_complex: bool,
 }
 
+noop_visit_type!(SuperCallFinder);
+
 impl SuperCallFinder {
     ///
     /// - `None`: if no `super()` is found or super() is last call

--- a/ecmascript/transforms/src/compat/es2015/classes/super_field.rs
+++ b/ecmascript/transforms/src/compat/es2015/classes/super_field.rs
@@ -39,6 +39,8 @@ pub(crate) struct SuperFieldAccessFolder<'a> {
     pub this_alias_mark: Option<Mark>,
 }
 
+noop_fold_type!(SuperFieldAccessFolder<'_>);
+
 struct SuperCalleeFolder<'a> {
     vars: &'a mut Vec<VarDeclarator>,
     class_name: &'a Ident,
@@ -55,6 +57,8 @@ struct SuperCalleeFolder<'a> {
     /// `Some(mark)` if `var this2 = this`is required.
     this_alias_mark: Option<Mark>,
 }
+
+noop_fold_type!(SuperCalleeFolder<'_>);
 
 macro_rules! mark_nested {
     ($T:tt) => {

--- a/ecmascript/transforms/src/compat/es2015/computed_props.rs
+++ b/ecmascript/transforms/src/compat/es2015/computed_props.rs
@@ -42,6 +42,8 @@ pub fn computed_properties() -> impl Pass {
 
 struct ComputedProps;
 
+noop_fold_type!(ComputedProps);
+
 #[derive(Default)]
 struct ObjectLitFolder {
     vars: Vec<VarDeclarator>,

--- a/ecmascript/transforms/src/compat/es2015/destructuring.rs
+++ b/ecmascript/transforms/src/compat/es2015/destructuring.rs
@@ -39,6 +39,8 @@ struct Destructuring {
     c: Config,
 }
 
+noop_fold_type!(Destructuring);
+
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 pub struct Config {
     #[serde(default)]

--- a/ecmascript/transforms/src/compat/es2015/duplicate_keys.rs
+++ b/ecmascript/transforms/src/compat/es2015/duplicate_keys.rs
@@ -10,6 +10,8 @@ pub fn duplicate_keys() -> impl Pass {
 
 struct DuplicateKeys;
 
+noop_fold_type!(DuplicateKeys);
+
 impl Fold<Expr> for DuplicateKeys {
     fn fold(&mut self, expr: Expr) -> Expr {
         let expr = expr.fold_children(self);
@@ -34,6 +36,8 @@ struct PropFolder {
     getter_props: HashSet<JsWord>,
     setter_props: HashSet<JsWord>,
 }
+
+noop_fold_type!(PropFolder);
 
 impl Fold<Expr> for PropFolder {
     fn fold(&mut self, node: Expr) -> Expr {

--- a/ecmascript/transforms/src/compat/es2015/for_of.rs
+++ b/ecmascript/transforms/src/compat/es2015/for_of.rs
@@ -55,6 +55,8 @@ struct ForOf {
     c: Config,
 }
 
+noop_fold_type!(ForOf);
+
 /// Real folder.
 struct Actual {
     c: Config,

--- a/ecmascript/transforms/src/compat/es2015/function_name.rs
+++ b/ecmascript/transforms/src/compat/es2015/function_name.rs
@@ -26,9 +26,13 @@ pub fn function_name() -> impl Pass {
 #[derive(Clone, Copy)]
 struct FnName;
 
+noop_fold_type!(FnName);
+
 struct Renamer {
     name: Option<Ident>,
 }
+
+noop_fold_type!(Renamer);
 
 /// This function makes a new private identifier if required.
 fn prepare(i: Ident, force: bool) -> Ident {

--- a/ecmascript/transforms/src/compat/es2015/instanceof.rs
+++ b/ecmascript/transforms/src/compat/es2015/instanceof.rs
@@ -30,6 +30,8 @@ use swc_ecma_ast::*;
 #[derive(Clone)]
 pub struct InstanceOf;
 
+noop_fold_type!(InstanceOf);
+
 impl Fold<Expr> for InstanceOf {
     fn fold(&mut self, expr: Expr) -> Expr {
         fn should_work(node: &Expr) -> bool {

--- a/ecmascript/transforms/src/compat/es2015/parameters.rs
+++ b/ecmascript/transforms/src/compat/es2015/parameters.rs
@@ -11,6 +11,8 @@ pub fn parameters() -> Params {
 pub struct Params;
 // prevent_recurse!(Params, Pat);
 
+noop_fold_type!(Params);
+
 impl Params {
     fn fold_fn_like(&mut self, ps: Vec<Pat>, body: BlockStmt) -> (Vec<Pat>, BlockStmt) {
         let body = validate!(body);

--- a/ecmascript/transforms/src/compat/es2015/regenerator/hoist.rs
+++ b/ecmascript/transforms/src/compat/es2015/regenerator/hoist.rs
@@ -25,6 +25,8 @@ pub(super) struct Hoister {
     pub arguments: Option<Ident>,
 }
 
+noop_fold_type!(Hoister);
+
 impl Hoister {
     fn var_decl_to_expr(&mut self, var: VarDecl) -> Expr {
         let var = var.fold_children(self);

--- a/ecmascript/transforms/src/compat/es2015/regenerator/mod.rs
+++ b/ecmascript/transforms/src/compat/es2015/regenerator/mod.rs
@@ -26,6 +26,8 @@ struct Regenerator {
     top_level_vars: Vec<VarDeclarator>,
 }
 
+noop_fold_type!(Regenerator);
+
 fn rt(rt: Ident) -> Stmt {
     Stmt::Decl(Decl::Var(VarDecl {
         span: DUMMY_SP,

--- a/ecmascript/transforms/src/compat/es2015/shorthand_property.rs
+++ b/ecmascript/transforms/src/compat/es2015/shorthand_property.rs
@@ -38,6 +38,8 @@ use swc_ecma_ast::*;
 #[derive(Default, Clone, Copy)]
 pub struct Shorthand;
 
+noop_fold_type!(Shorthand);
+
 impl Fold<Prop> for Shorthand {
     fn fold(&mut self, prop: Prop) -> Prop {
         let prop = prop.fold_children(self);

--- a/ecmascript/transforms/src/compat/es2015/spread.rs
+++ b/ecmascript/transforms/src/compat/es2015/spread.rs
@@ -24,11 +24,15 @@ struct Spread {
     c: Config,
 }
 
+noop_fold_type!(Spread);
+
 #[derive(Default)]
 struct ActualFolder {
     c: Config,
     vars: Vec<VarDeclarator>,
 }
+
+noop_fold_type!(ActualFolder);
 
 impl<T> Fold<Vec<T>> for Spread
 where

--- a/ecmascript/transforms/src/compat/es2015/sticky_regex.rs
+++ b/ecmascript/transforms/src/compat/es2015/sticky_regex.rs
@@ -20,6 +20,8 @@ use swc_ecma_ast::*;
 #[derive(Clone, Copy)]
 pub struct StickyRegex;
 
+noop_fold_type!(StickyRegex);
+
 impl Fold<Expr> for StickyRegex {
     fn fold(&mut self, e: Expr) -> Expr {
         let e = e.fold_children(self);

--- a/ecmascript/transforms/src/compat/es2015/template_literal.rs
+++ b/ecmascript/transforms/src/compat/es2015/template_literal.rs
@@ -9,6 +9,8 @@ pub struct TemplateLiteral {
     added: Vec<Stmt>,
 }
 
+noop_fold_type!(TemplateLiteral);
+
 impl Fold<Module> for TemplateLiteral {
     fn fold(&mut self, m: Module) -> Module {
         let mut body = m.body.fold_children(self);

--- a/ecmascript/transforms/src/compat/es2015/typeof_symbol.rs
+++ b/ecmascript/transforms/src/compat/es2015/typeof_symbol.rs
@@ -23,6 +23,8 @@ use swc_ecma_ast::*;
 #[derive(Clone)]
 pub struct TypeOfSymbol;
 
+noop_fold_type!(TypeOfSymbol);
+
 impl Fold<Expr> for TypeOfSymbol {
     fn fold(&mut self, expr: Expr) -> Expr {
         // fast path

--- a/ecmascript/transforms/src/compat/es2016/exponentation.rs
+++ b/ecmascript/transforms/src/compat/es2016/exponentation.rs
@@ -30,10 +30,14 @@ pub fn exponentation() -> impl Pass {
 #[derive(Clone, Copy)]
 struct Exponentation;
 
+noop_fold_type!(Exponentation);
+
 #[derive(Default)]
 struct AssignFolder {
     vars: Vec<VarDeclarator>,
 }
+
+noop_fold_type!(AssignFolder);
 
 impl Fold<Expr> for AssignFolder {
     fn fold(&mut self, e: Expr) -> Expr {

--- a/ecmascript/transforms/src/compat/es2017/async_to_generator.rs
+++ b/ecmascript/transforms/src/compat/es2017/async_to_generator.rs
@@ -33,9 +33,14 @@ pub fn async_to_generator() -> impl Pass {
 
 #[derive(Default, Clone)]
 struct AsyncToGenerator;
+
+noop_fold_type!(AsyncToGenerator);
+
 struct Actual {
     extra_stmts: Vec<Stmt>,
 }
+
+noop_fold_type!(Actual);
 
 impl<T> Fold<Vec<T>> for AsyncToGenerator
 where

--- a/ecmascript/transforms/src/compat/es2018/object_rest_spread.rs
+++ b/ecmascript/transforms/src/compat/es2018/object_rest_spread.rs
@@ -17,6 +17,8 @@ pub fn object_rest_spread() -> impl Pass {
 
 struct ObjectRest;
 
+noop_fold_type!(ObjectRest);
+
 #[allow(clippy::vec_box)]
 struct RestFolder {
     /// Injected before the original statement.
@@ -26,6 +28,8 @@ struct RestFolder {
     /// Assignment expressions.
     exprs: Vec<Box<Expr>>,
 }
+
+noop_fold_type!(RestFolder);
 
 macro_rules! impl_for_for_stmt {
     ($T:tt) => {
@@ -1011,6 +1015,8 @@ fn simplify_pat(pat: Pat) -> Pat {
 }
 
 struct ObjectSpread;
+
+noop_fold_type!(ObjectSpread);
 
 impl Fold<Expr> for ObjectSpread {
     fn fold(&mut self, expr: Expr) -> Expr {

--- a/ecmascript/transforms/src/compat/es2018/optional_catch_binding.rs
+++ b/ecmascript/transforms/src/compat/es2018/optional_catch_binding.rs
@@ -4,6 +4,8 @@ use swc_ecma_ast::*;
 
 struct OptionalCatchBinding;
 
+noop_fold_type!(OptionalCatchBinding);
+
 pub fn optional_catch_binding() -> impl Pass {
     OptionalCatchBinding
 }

--- a/ecmascript/transforms/src/compat/es3/member_expr_lits.rs
+++ b/ecmascript/transforms/src/compat/es3/member_expr_lits.rs
@@ -22,6 +22,8 @@ use swc_ecma_ast::*;
 #[derive(Default, Clone, Copy)]
 pub struct MemberExprLit;
 
+noop_fold_type!(MemberExprLit);
+
 impl Fold<Module> for MemberExprLit {
     fn fold(&mut self, node: Module) -> Module {
         validate!(node.fold_children(self))

--- a/ecmascript/transforms/src/compat/es3/prop_lits.rs
+++ b/ecmascript/transforms/src/compat/es3/prop_lits.rs
@@ -32,6 +32,8 @@ use swc_ecma_ast::*;
 #[derive(Default, Clone, Copy)]
 pub struct PropertyLiteral;
 
+noop_fold_type!(PropertyLiteral);
+
 impl Fold<Module> for PropertyLiteral {
     fn fold(&mut self, node: Module) -> Module {
         validate!(node.fold_children(self))

--- a/ecmascript/transforms/src/compat/es3/reserved_word.rs
+++ b/ecmascript/transforms/src/compat/es3/reserved_word.rs
@@ -23,6 +23,8 @@ pub struct ReservedWord {
     pub preserve_import: bool,
 }
 
+noop_fold_type!(ReservedWord);
+
 impl Fold<Ident> for ReservedWord {
     fn fold(&mut self, i: Ident) -> Ident {
         fold_ident(self.preserve_import, i)

--- a/ecmascript/transforms/src/const_modules.rs
+++ b/ecmascript/transforms/src/const_modules.rs
@@ -75,6 +75,8 @@ struct ConstModules {
     scope: Scope,
 }
 
+noop_fold_type!(ConstModules);
+
 #[derive(Default)]
 struct Scope {
     imported: HashMap<JsWord, Arc<Expr>>,

--- a/ecmascript/transforms/src/fixer.rs
+++ b/ecmascript/transforms/src/fixer.rs
@@ -26,6 +26,8 @@ struct Fixer {
     span_map: FxHashMap<Span, Span>,
 }
 
+noop_fold_type!(Fixer);
+
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Context {

--- a/ecmascript/transforms/src/helpers.rs
+++ b/ecmascript/transforms/src/helpers.rs
@@ -224,6 +224,9 @@ define_helpers!(Helpers {
 
 #[derive(Clone)]
 pub struct InjectHelpers;
+
+noop_fold_type!(InjectHelpers);
+
 impl InjectHelpers {
     fn mk_helpers(&self) -> Vec<ModuleItem> {
         let (mark, external) = HELPERS.with(|helper| (helper.mark(), helper.external()));
@@ -257,6 +260,9 @@ impl Fold<Module> for InjectHelpers {
 }
 
 struct Marker(Mark);
+
+noop_fold_type!(Marker);
+
 impl Fold<Span> for Marker {
     fn fold(&mut self, sp: Span) -> Span {
         sp.apply_mark(self.0)

--- a/ecmascript/transforms/src/hygiene.rs
+++ b/ecmascript/transforms/src/hygiene.rs
@@ -22,6 +22,8 @@ struct Hygiene<'a> {
     ident_type: IdentType,
 }
 
+noop_fold_type!(Hygiene<'_>);
+
 type Contexts = SmallVec<[SyntaxContext; 32]>;
 
 impl<'a> Hygiene<'a> {

--- a/ecmascript/transforms/src/hygiene/ops.rs
+++ b/ecmascript/transforms/src/hygiene/ops.rs
@@ -12,6 +12,8 @@ pub(super) enum ScopeOp {
 
 pub(super) struct Operator<'a>(pub &'a [ScopeOp]);
 
+noop_fold_type!(Operator<'_>);
+
 impl<'a> Fold<Vec<ModuleItem>> for Operator<'a> {
     fn fold(&mut self, items: Vec<ModuleItem>) -> Vec<ModuleItem> {
         let mut stmts = Vec::with_capacity(items.len());

--- a/ecmascript/transforms/src/macros.rs
+++ b/ecmascript/transforms/src/macros.rs
@@ -212,10 +212,10 @@ macro_rules! validate {
 }
 
 macro_rules! noop_fold_type {
-    ($F:ty, $N:ty) => {
-        impl Fold<$N> for $F {
+    ($F:ty, $N:tt) => {
+        impl Fold<swc_ecma_ast::$N> for $F {
             #[inline]
-            fn fold(&mut self, node: $N) -> $N {
+            fn fold(&mut self, node: swc_ecma_ast::$N) -> swc_ecma_ast::$N {
                 node
             }
         }
@@ -288,10 +288,10 @@ macro_rules! noop_fold_type {
 }
 
 macro_rules! noop_visit_type {
-    ($F:ty, $N:ty) => {
-        impl Visit<$N> for $F {
+    ($F:ty, $N:tt) => {
+        impl Visit<swc_ecma_ast::$N> for $F {
             #[inline]
-            fn visit(&mut self, _: &$N) {}
+            fn visit(&mut self, _: &swc_ecma_ast::$N) {}
         }
     };
     ($F:ty) => {

--- a/ecmascript/transforms/src/macros.rs
+++ b/ecmascript/transforms/src/macros.rs
@@ -210,3 +210,153 @@ macro_rules! validate {
         }
     }};
 }
+
+macro_rules! noop_fold_type {
+    ($F:ty, $N:ty) => {
+        impl Fold<$N> for $F {
+            #[inline]
+            fn fold(&mut self, node: $N) -> $N {
+                node
+            }
+        }
+    };
+    ($F:ty) => {
+        noop_fold_type!($F, Accessibility);
+        noop_fold_type!($F, TruePlusMinus);
+        noop_fold_type!($F, TsArrayType);
+        noop_fold_type!($F, TsCallSignatureDecl);
+        noop_fold_type!($F, TsConditionalType);
+        noop_fold_type!($F, TsConstructSignatureDecl);
+        noop_fold_type!($F, TsConstructorType);
+        noop_fold_type!($F, TsEntityName);
+        noop_fold_type!($F, TsEnumDecl);
+        noop_fold_type!($F, TsEnumMember);
+        noop_fold_type!($F, TsEnumMemberId);
+        noop_fold_type!($F, TsExternalModuleRef);
+        noop_fold_type!($F, TsFnOrConstructorType);
+        noop_fold_type!($F, TsFnParam);
+        noop_fold_type!($F, TsFnType);
+        noop_fold_type!($F, TsImportEqualsDecl);
+        noop_fold_type!($F, TsImportType);
+        noop_fold_type!($F, TsIndexSignature);
+        noop_fold_type!($F, TsIndexedAccessType);
+        noop_fold_type!($F, TsInferType);
+        noop_fold_type!($F, TsInterfaceBody);
+        noop_fold_type!($F, TsInterfaceDecl);
+        noop_fold_type!($F, TsIntersectionType);
+        noop_fold_type!($F, TsKeywordType);
+        noop_fold_type!($F, TsKeywordTypeKind);
+        noop_fold_type!($F, TsMappedType);
+        noop_fold_type!($F, TsMethodSignature);
+        noop_fold_type!($F, TsModuleBlock);
+        noop_fold_type!($F, TsModuleDecl);
+        noop_fold_type!($F, TsModuleName);
+        noop_fold_type!($F, TsModuleRef);
+        noop_fold_type!($F, TsNamespaceBody);
+        noop_fold_type!($F, TsNamespaceDecl);
+        noop_fold_type!($F, TsNamespaceExportDecl);
+        noop_fold_type!($F, TsOptionalType);
+        noop_fold_type!($F, TsParamProp);
+        noop_fold_type!($F, TsParamPropParam);
+        noop_fold_type!($F, TsParenthesizedType);
+        noop_fold_type!($F, TsPropertySignature);
+        noop_fold_type!($F, TsQualifiedName);
+        noop_fold_type!($F, TsRestType);
+        noop_fold_type!($F, TsSignatureDecl);
+        noop_fold_type!($F, TsThisType);
+        noop_fold_type!($F, TsThisTypeOrIdent);
+        noop_fold_type!($F, TsTupleType);
+        noop_fold_type!($F, TsType);
+        noop_fold_type!($F, TsTypeAliasDecl);
+        noop_fold_type!($F, TsTypeAnn);
+        noop_fold_type!($F, TsTypeAssertion);
+        noop_fold_type!($F, TsTypeCastExpr);
+        noop_fold_type!($F, TsTypeElement);
+        noop_fold_type!($F, TsTypeLit);
+        noop_fold_type!($F, TsTypeOperator);
+        noop_fold_type!($F, TsTypeOperatorOp);
+        noop_fold_type!($F, TsTypeParam);
+        noop_fold_type!($F, TsTypeParamDecl);
+        noop_fold_type!($F, TsTypeParamInstantiation);
+        noop_fold_type!($F, TsTypePredicate);
+        noop_fold_type!($F, TsTypeQuery);
+        noop_fold_type!($F, TsTypeQueryExpr);
+        noop_fold_type!($F, TsTypeRef);
+        noop_fold_type!($F, TsUnionOrIntersectionType);
+        noop_fold_type!($F, TsUnionType);
+    };
+}
+
+macro_rules! noop_visit_type {
+    ($F:ty, $N:ty) => {
+        impl Visit<$N> for $F {
+            #[inline]
+            fn visit(&mut self, _: &$N) {}
+        }
+    };
+    ($F:ty) => {
+        noop_visit_type!($F, Accessibility);
+        noop_visit_type!($F, TruePlusMinus);
+        noop_visit_type!($F, TsArrayType);
+        noop_visit_type!($F, TsCallSignatureDecl);
+        noop_visit_type!($F, TsConditionalType);
+        noop_visit_type!($F, TsConstructSignatureDecl);
+        noop_visit_type!($F, TsConstructorType);
+        noop_visit_type!($F, TsEntityName);
+        noop_visit_type!($F, TsEnumDecl);
+        noop_visit_type!($F, TsEnumMember);
+        noop_visit_type!($F, TsEnumMemberId);
+        noop_visit_type!($F, TsExternalModuleRef);
+        noop_visit_type!($F, TsFnOrConstructorType);
+        noop_visit_type!($F, TsFnParam);
+        noop_visit_type!($F, TsFnType);
+        noop_visit_type!($F, TsImportEqualsDecl);
+        noop_visit_type!($F, TsImportType);
+        noop_visit_type!($F, TsIndexSignature);
+        noop_visit_type!($F, TsIndexedAccessType);
+        noop_visit_type!($F, TsInferType);
+        noop_visit_type!($F, TsInterfaceBody);
+        noop_visit_type!($F, TsInterfaceDecl);
+        noop_visit_type!($F, TsIntersectionType);
+        noop_visit_type!($F, TsKeywordType);
+        noop_visit_type!($F, TsKeywordTypeKind);
+        noop_visit_type!($F, TsMappedType);
+        noop_visit_type!($F, TsMethodSignature);
+        noop_visit_type!($F, TsModuleBlock);
+        noop_visit_type!($F, TsModuleDecl);
+        noop_visit_type!($F, TsModuleName);
+        noop_visit_type!($F, TsModuleRef);
+        noop_visit_type!($F, TsNamespaceBody);
+        noop_visit_type!($F, TsNamespaceDecl);
+        noop_visit_type!($F, TsNamespaceExportDecl);
+        noop_visit_type!($F, TsOptionalType);
+        noop_visit_type!($F, TsParamProp);
+        noop_visit_type!($F, TsParamPropParam);
+        noop_visit_type!($F, TsParenthesizedType);
+        noop_visit_type!($F, TsPropertySignature);
+        noop_visit_type!($F, TsQualifiedName);
+        noop_visit_type!($F, TsRestType);
+        noop_visit_type!($F, TsSignatureDecl);
+        noop_visit_type!($F, TsThisType);
+        noop_visit_type!($F, TsThisTypeOrIdent);
+        noop_visit_type!($F, TsTupleType);
+        noop_visit_type!($F, TsType);
+        noop_visit_type!($F, TsTypeAliasDecl);
+        noop_visit_type!($F, TsTypeAnn);
+        noop_visit_type!($F, TsTypeAssertion);
+        noop_visit_type!($F, TsTypeCastExpr);
+        noop_visit_type!($F, TsTypeElement);
+        noop_visit_type!($F, TsTypeLit);
+        noop_visit_type!($F, TsTypeOperator);
+        noop_visit_type!($F, TsTypeOperatorOp);
+        noop_visit_type!($F, TsTypeParam);
+        noop_visit_type!($F, TsTypeParamDecl);
+        noop_visit_type!($F, TsTypeParamInstantiation);
+        noop_visit_type!($F, TsTypePredicate);
+        noop_visit_type!($F, TsTypeQuery);
+        noop_visit_type!($F, TsTypeQueryExpr);
+        noop_visit_type!($F, TsTypeRef);
+        noop_visit_type!($F, TsUnionOrIntersectionType);
+        noop_visit_type!($F, TsUnionType);
+    };
+}

--- a/ecmascript/transforms/src/modules/amd.rs
+++ b/ecmascript/transforms/src/modules/amd.rs
@@ -29,6 +29,8 @@ struct Amd {
     exports: Exports,
 }
 
+noop_fold_type!(Amd);
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Config {

--- a/ecmascript/transforms/src/modules/common_js.rs
+++ b/ecmascript/transforms/src/modules/common_js.rs
@@ -26,6 +26,8 @@ struct CommonJs {
     in_top_level: bool,
 }
 
+noop_fold_type!(CommonJs);
+
 impl Fold<Vec<ModuleItem>> for CommonJs {
     fn fold(&mut self, items: Vec<ModuleItem>) -> Vec<ModuleItem> {
         let mut emitted_esmodule = false;

--- a/ecmascript/transforms/src/modules/import_analysis.rs
+++ b/ecmascript/transforms/src/modules/import_analysis.rs
@@ -15,6 +15,9 @@ struct ImportAnalyzer {
     scope: Scope,
 }
 
+noop_fold_type!(ImportAnalyzer);
+noop_visit_type!(ImportAnalyzer);
+
 impl Fold<Module> for ImportAnalyzer {
     fn fold(&mut self, module: Module) -> Module {
         module.visit_with(self);

--- a/ecmascript/transforms/src/modules/umd.rs
+++ b/ecmascript/transforms/src/modules/umd.rs
@@ -35,6 +35,8 @@ struct Umd {
     exports: Exports,
 }
 
+noop_fold_type!(Umd);
+
 impl Fold<Module> for Umd {
     fn fold(&mut self, module: Module) -> Module {
         self.in_top_level = true;

--- a/ecmascript/transforms/src/optimization/inline_globals.rs
+++ b/ecmascript/transforms/src/optimization/inline_globals.rs
@@ -9,6 +9,8 @@ pub struct InlineGlobals {
     pub globals: HashMap<JsWord, Expr>,
 }
 
+noop_fold_type!(InlineGlobals);
+
 impl Fold<Expr> for InlineGlobals {
     fn fold(&mut self, expr: Expr) -> Expr {
         let expr = match expr {

--- a/ecmascript/transforms/src/optimization/json_parse.rs
+++ b/ecmascript/transforms/src/optimization/json_parse.rs
@@ -31,6 +31,8 @@ pub struct JsonParse {
     pub min_cost: usize,
 }
 
+noop_fold_type!(JsonParse);
+
 impl Default for JsonParse {
     fn default() -> Self {
         JsonParse { min_cost: 1024 }

--- a/ecmascript/transforms/src/optimization/simplify/branch/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/branch/mod.rs
@@ -44,6 +44,8 @@ struct Remover {
     normal_block: bool,
 }
 
+noop_fold_type!(Remover);
+
 impl<T: StmtLike> Fold<Vec<T>> for Remover
 where
     Self: Fold<T>,

--- a/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
@@ -73,6 +73,8 @@ struct UsedMarkRemover {
     used_mark: Mark,
 }
 
+noop_fold_type!(UsedMarkRemover);
+
 impl CompilerPass for UsedMarkRemover {
     fn name() -> Cow<'static, str> {
         Cow::Borrowed("dce-cleanup")
@@ -111,6 +113,8 @@ struct Dce<'a> {
 
     dropped: bool,
 }
+
+noop_fold_type!(Dce<'_>);
 
 impl CompilerPass for Dce<'_> {
     fn name() -> Cow<'static, str> {

--- a/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
@@ -114,8 +114,6 @@ struct Dce<'a> {
     dropped: bool,
 }
 
-noop_fold_type!(Dce<'_>);
-
 impl CompilerPass for Dce<'_> {
     fn name() -> Cow<'static, str> {
         Cow::Borrowed("dce")

--- a/ecmascript/transforms/src/optimization/simplify/dce/side_effect.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/side_effect.rs
@@ -34,6 +34,8 @@ impl SideEffectVisitor<'_> {
     }
 }
 
+noop_visit_type!(SideEffectVisitor<'_>);
+
 pub(super) struct SideEffectVisitor<'a> {
     included: &'a mut FxHashSet<Id>,
     exports: Option<&'a [Id]>,

--- a/ecmascript/transforms/src/optimization/simplify/expr/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/expr/mod.rs
@@ -22,6 +22,8 @@ struct SimplifyExpr {
     changed: bool,
 }
 
+noop_fold_type!(SimplifyExpr);
+
 impl CompilerPass for SimplifyExpr {
     fn name() -> Cow<'static, str> {
         Cow::Borrowed("simplify-expr")

--- a/ecmascript/transforms/src/optimization/simplify/inlining/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/inlining/mod.rs
@@ -71,6 +71,8 @@ struct Inlining<'a> {
     pat_mode: PatFoldingMode,
 }
 
+noop_fold_type!(Inlining<'_>);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PatFoldingMode {
     Assign,

--- a/ecmascript/transforms/src/proposals/class_properties/class_name_tdz.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/class_name_tdz.rs
@@ -6,7 +6,7 @@ pub(super) struct ClassNameTdzFolder<'a> {
     pub class_name: &'a Ident,
 }
 
-noop_fold_type!(ClassNameTdzFilter<'_>);
+noop_fold_type!(ClassNameTdzFolder<'_>);
 
 impl<'a> Fold<Expr> for ClassNameTdzFolder<'a> {
     fn fold(&mut self, expr: Expr) -> Expr {

--- a/ecmascript/transforms/src/proposals/class_properties/class_name_tdz.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/class_name_tdz.rs
@@ -6,6 +6,8 @@ pub(super) struct ClassNameTdzFolder<'a> {
     pub class_name: &'a Ident,
 }
 
+noop_fold_type!(ClassNameTdzFilter<'_>);
+
 impl<'a> Fold<Expr> for ClassNameTdzFolder<'a> {
     fn fold(&mut self, expr: Expr) -> Expr {
         match expr {

--- a/ecmascript/transforms/src/proposals/class_properties/private_field.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/private_field.rs
@@ -13,6 +13,8 @@ pub(super) struct FieldAccessFolder<'a> {
     pub in_assign_pat: bool,
 }
 
+noop_fold_type!(FieldAccessFolder<'_>);
+
 impl<'a> Fold<Expr> for FieldAccessFolder<'a> {
     fn fold(&mut self, e: Expr) -> Expr {
         match e {

--- a/ecmascript/transforms/src/proposals/class_properties/this_in_static.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/this_in_static.rs
@@ -5,6 +5,8 @@ pub(super) struct ThisInStaticFolder {
     pub ident: Ident,
 }
 
+noop_fold_type!(ThisInStaticFolder);
+
 impl Fold<Expr> for ThisInStaticFolder {
     fn fold(&mut self, e: Expr) -> Expr {
         let e = e.fold_children(self);

--- a/ecmascript/transforms/src/proposals/class_properties/used_name.rs
+++ b/ecmascript/transforms/src/proposals/class_properties/used_name.rs
@@ -7,6 +7,8 @@ pub(super) struct UsedNameRenamer<'a> {
     pub used_names: &'a [JsWord],
 }
 
+noop_fold_type!(UsedNameRenamer<'_>);
+
 impl<'a> Fold<Ident> for UsedNameRenamer<'a> {
     fn fold(&mut self, ident: Ident) -> Ident {
         if self.used_names.contains(&ident.sym) {
@@ -22,6 +24,8 @@ impl<'a> Fold<Ident> for UsedNameRenamer<'a> {
 pub(super) struct UsedNameCollector<'a> {
     pub used_names: &'a mut Vec<JsWord>,
 }
+
+noop_visit_type!(UsedNameCollector<'_>);
 
 impl<'a> Visit<Expr> for UsedNameCollector<'a> {
     fn visit(&mut self, expr: &Expr) {

--- a/ecmascript/transforms/src/proposals/decorators.rs
+++ b/ecmascript/transforms/src/proposals/decorators.rs
@@ -75,6 +75,8 @@ struct Decorators {
     is_in_strict: bool,
 }
 
+noop_fold_type!(Decorators);
+
 impl Fold<Vec<ModuleItem>> for Decorators {
     fn fold(&mut self, items: Vec<ModuleItem>) -> Vec<ModuleItem> {
         if !self::usage::has_decorator(&items) {

--- a/ecmascript/transforms/src/proposals/decorators/legacy.rs
+++ b/ecmascript/transforms/src/proposals/decorators/legacy.rs
@@ -15,6 +15,8 @@ pub(super) struct Legacy {
     exports: Vec<ExportSpecifier>,
 }
 
+noop_fold_type!(Legacy);
+
 impl Fold<Module> for Legacy {
     fn fold(&mut self, m: Module) -> Module {
         let mut m = m.fold_children(self);

--- a/ecmascript/transforms/src/proposals/decorators/usage.rs
+++ b/ecmascript/transforms/src/proposals/decorators/usage.rs
@@ -12,6 +12,8 @@ pub(super) struct DecoratorFinder {
     found: bool,
 }
 
+noop_visit_type!(DecoratorFinder);
+
 impl Visit<Decorator> for DecoratorFinder {
     fn visit(&mut self, _: &Decorator) {
         self.found = true;

--- a/ecmascript/transforms/src/proposals/export.rs
+++ b/ecmascript/transforms/src/proposals/export.rs
@@ -11,6 +11,8 @@ pub fn export() -> impl Pass {
 #[derive(Clone)]
 struct ExportDefaultFrom;
 
+noop_fold_type!(ExportDefaultFrom);
+
 impl Fold<Vec<ModuleItem>> for ExportDefaultFrom {
     fn fold(&mut self, items: Vec<ModuleItem>) -> Vec<ModuleItem> {
         // Imports

--- a/ecmascript/transforms/src/proposals/opt_chaining.rs
+++ b/ecmascript/transforms/src/proposals/opt_chaining.rs
@@ -15,6 +15,8 @@ struct OptChaining {
     vars: Vec<VarDeclarator>,
 }
 
+noop_fold_type!(OptChaining);
+
 impl<T> Fold<Vec<T>> for OptChaining
 where
     T: Debug + StmtLike + FoldWith<Self>,

--- a/ecmascript/transforms/src/react/display_name.rs
+++ b/ecmascript/transforms/src/react/display_name.rs
@@ -15,6 +15,8 @@ pub fn display_name() -> impl Pass {
 
 struct DisplayName;
 
+noop_fold_type!(DisplayName);
+
 impl Fold<VarDeclarator> for DisplayName {
     fn fold(&mut self, decl: VarDeclarator) -> VarDeclarator {
         match decl.name {

--- a/ecmascript/transforms/src/react/jsx.rs
+++ b/ecmascript/transforms/src/react/jsx.rs
@@ -114,6 +114,8 @@ struct Jsx {
     throw_if_namespace: bool,
 }
 
+noop_fold_type!(Jsx);
+
 impl Jsx {
     fn jsx_frag_to_expr(&mut self, el: JSXFragment) -> Expr {
         let span = el.span();

--- a/ecmascript/transforms/src/react/jsx_self.rs
+++ b/ecmascript/transforms/src/react/jsx_self.rs
@@ -15,6 +15,8 @@ struct JsxSelf {
     dev: bool,
 }
 
+noop_fold_type!(JsxSelf);
+
 impl Fold<JSXOpeningElement> for JsxSelf {
     fn fold(&mut self, mut n: JSXOpeningElement) -> JSXOpeningElement {
         if !self.dev {

--- a/ecmascript/transforms/src/react/jsx_src.rs
+++ b/ecmascript/transforms/src/react/jsx_src.rs
@@ -16,6 +16,8 @@ struct JsxSrc {
     dev: bool,
 }
 
+noop_fold_type!(JsxSrc);
+
 impl Fold<JSXOpeningElement> for JsxSrc {
     fn fold(&mut self, mut e: JSXOpeningElement) -> JSXOpeningElement {
         if !self.dev || e.span == DUMMY_SP {

--- a/ecmascript/transforms/src/resolver.rs
+++ b/ecmascript/transforms/src/resolver.rs
@@ -64,6 +64,8 @@ struct Resolver<'a> {
     ident_type: IdentType,
 }
 
+noop_fold_type!(Resolver<'_>);
+
 impl<'a> Resolver<'a> {
     fn new(mark: Mark, current: Scope<'a>, cur_defining: Option<(JsWord, Mark)>) -> Self {
         Resolver {


### PR DESCRIPTION
This pr add two helper macros to prevent folding type unnecessarily.
This reduces the binary size by 3MB on linux.