### PR TITLE
Support type predicate "asserts" with no "is"

### DIFF
--- a/ecmascript/ast/src/typescript.rs
+++ b/ecmascript/ast/src/typescript.rs
@@ -400,7 +400,7 @@ pub struct TsTypePredicate {
     pub asserts: bool,
     pub param_name: TsThisTypeOrIdent,
     #[serde(rename = "typeAnnotation")]
-    pub type_ann: TsTypeAnn,
+    pub type_ann: Option<TsTypeAnn>,
 }
 
 #[ast_node]

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -421,7 +421,9 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 cur!(false)?;
             }
 
-            let has_type_pred_is = is!(IdentRef) && peeked_is!("is") && !p.input.has_linebreak_between_cur_and_peeked();
+            let has_type_pred_is = is!(IdentRef)
+                && peeked_is!("is")
+                && !p.input.has_linebreak_between_cur_and_peeked();
             let is_type_predicate = has_type_pred_asserts || has_type_pred_is;
             if !is_type_predicate {
                 return p.parse_ts_type_ann(

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -264,14 +264,16 @@ impl<'a, I: Tokens> Parser<'a, I> {
     ) -> PResult<'a, TsTypePredicate> {
         debug_assert!(self.input.syntax().typescript());
 
-        assert_and_bump!("is");
-
         let param_name = TsThisTypeOrIdent::TsThisType(lhs);
-        let cur_pos = cur_pos!();
-        let type_ann = self.parse_ts_type_ann(
-            // eat_colon
-            false, cur_pos,
-        )?;
+        let type_ann = if eat!("is") {
+            let cur_pos = cur_pos!();
+            Some(self.parse_ts_type_ann(
+                // eat_colon
+                false, cur_pos,
+            )?)
+        } else {
+            None
+        };
 
         Ok(TsTypePredicate {
             span: span!(start),
@@ -413,39 +415,38 @@ impl<'a, I: Tokens> Parser<'a, I> {
             }
 
             let type_pred_start = cur_pos!();
-            let type_pred_asserts = is!("asserts") && peeked_is!(IdentRef);
-            if type_pred_asserts {
+            let has_type_pred_asserts = is!("asserts") && peeked_is!(IdentRef);
+            if has_type_pred_asserts {
                 assert_and_bump!("asserts");
                 cur!(false)?;
             }
 
-            let type_pred_var = if is!(IdentRef) && peeked_is!("is") {
-                p.try_parse_ts(|p| p.parse_ts_type_predicate_prefix())
+            let has_type_pred_is = is!(IdentRef) && peeked_is!("is") && !p.input.has_linebreak_between_cur_and_peeked();
+            let is_type_predicate = has_type_pred_asserts || has_type_pred_is;
+            if !is_type_predicate {
+                return p.parse_ts_type_ann(
+                    // eat_colon
+                    false,
+                    return_token_start,
+                );
+            }
+
+            let type_pred_var = p.parse_ident_name()?;
+            let type_ann = if has_type_pred_is {
+                assert_and_bump!("is");
+                let pos = cur_pos!();
+                Some(p.parse_ts_type_ann(
+                    // eat_colon
+                    false, pos,
+                )?)
             } else {
                 None
             };
 
-            let type_pred_var = match type_pred_var {
-                Some(v) => v.into(),
-                None => {
-                    return p.parse_ts_type_ann(
-                        // eat_colon
-                        false,
-                        return_token_start,
-                    );
-                }
-            };
-
-            let pos = cur_pos!();
-            let type_ann = p.parse_ts_type_ann(
-                // eat_colon
-                false, pos,
-            )?;
-
             let node = Box::new(TsType::TsTypePredicate(TsTypePredicate {
                 span: span!(type_pred_start),
-                asserts: type_pred_asserts,
-                param_name: type_pred_var,
+                asserts: has_type_pred_asserts,
+                param_name: TsThisTypeOrIdent::Ident(type_pred_var),
                 type_ann,
             }));
 
@@ -454,19 +455,6 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 type_ann: node,
             })
         })
-    }
-
-    fn parse_ts_type_predicate_prefix(&mut self) -> PResult<'a, Option<Ident>> {
-        debug_assert!(self.input.syntax().typescript());
-
-        let id = self.parse_ident_name()?;
-
-        if is!("is") && !self.input.had_line_break_before_cur() {
-            assert_and_bump!("is");
-            return Ok(Some(id));
-        }
-
-        Ok(None)
     }
 
     /// `tsTryParse`

--- a/ecmascript/parser/tests/typescript/class/method-return-type/input.ts
+++ b/ecmascript/parser/tests/typescript/class/method-return-type/input.ts
@@ -2,4 +2,5 @@ class C {
     f(): void {}
     g(): this is {} { return true; }
     h(): asserts this is {} { throw ""; }
+    i(): asserts this { throw ""; }
 }

--- a/ecmascript/parser/tests/typescript/class/method-return-type/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/method-return-type/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 107,
+    "end": 143,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 107,
+        "end": 143,
         "ctxt": 0
       },
       "decorators": [],
@@ -291,6 +291,96 @@
                     "members": []
                   }
                 }
+              }
+            }
+          },
+          "kind": "method",
+          "isStatic": false,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false
+        },
+        {
+          "type": "ClassMethod",
+          "span": {
+            "start": 110,
+            "end": 141,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 110,
+              "end": 111,
+              "ctxt": 0
+            },
+            "value": "i",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "function": {
+            "params": [],
+            "decorators": [],
+            "span": {
+              "start": 110,
+              "end": 141,
+              "ctxt": 0
+            },
+            "body": {
+              "type": "BlockStatement",
+              "span": {
+                "start": 128,
+                "end": 141,
+                "ctxt": 0
+              },
+              "stmts": [
+                {
+                  "type": "ThrowStatement",
+                  "span": {
+                    "start": 130,
+                    "end": 139,
+                    "ctxt": 0
+                  },
+                  "argument": {
+                    "type": "StringLiteral",
+                    "span": {
+                      "start": 136,
+                      "end": 138,
+                      "ctxt": 0
+                    },
+                    "value": "",
+                    "hasEscape": false
+                  }
+                }
+              ]
+            },
+            "generator": false,
+            "async": false,
+            "typeParameters": null,
+            "returnType": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 113,
+                "end": 127,
+                "ctxt": 0
+              },
+              "typeAnnotation": {
+                "type": "TsTypePredicate",
+                "span": {
+                  "start": 115,
+                  "end": 127,
+                  "ctxt": 0
+                },
+                "asserts": true,
+                "paramName": {
+                  "type": "TsThisType",
+                  "span": {
+                    "start": 123,
+                    "end": 127,
+                    "ctxt": 0
+                  }
+                },
+                "typeAnnotation": null
               }
             }
           },

--- a/ecmascript/parser/tests/typescript/function/predicate-types/input.ts
+++ b/ecmascript/parser/tests/typescript/function/predicate-types/input.ts
@@ -1,3 +1,4 @@
 function f(x: any): x is boolean {}
 (function(x: any): x is boolean {})
 function g(x: any): asserts x is boolean {}
+function h(x: any): asserts x {}

--- a/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 115,
+    "end": 148,
     "ctxt": 0
   },
   "body": [
@@ -329,6 +329,97 @@
               "kind": "boolean"
             }
           }
+        }
+      }
+    },
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 125,
+          "end": 126,
+          "ctxt": 0
+        },
+        "value": "h",
+        "typeAnnotation": null,
+        "optional": false
+      },
+      "declare": false,
+      "params": [
+        {
+          "type": "Identifier",
+          "span": {
+            "start": 127,
+            "end": 133,
+            "ctxt": 0
+          },
+          "value": "x",
+          "typeAnnotation": {
+            "type": "TsTypeAnnotation",
+            "span": {
+              "start": 128,
+              "end": 133,
+              "ctxt": 0
+            },
+            "typeAnnotation": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 130,
+                "end": 133,
+                "ctxt": 0
+              },
+              "kind": "any"
+            }
+          },
+          "optional": false
+        }
+      ],
+      "decorators": [],
+      "span": {
+        "start": 116,
+        "end": 148,
+        "ctxt": 0
+      },
+      "body": {
+        "type": "BlockStatement",
+        "span": {
+          "start": 146,
+          "end": 148,
+          "ctxt": 0
+        },
+        "stmts": []
+      },
+      "generator": false,
+      "async": false,
+      "typeParameters": null,
+      "returnType": {
+        "type": "TsTypeAnnotation",
+        "span": {
+          "start": 134,
+          "end": 145,
+          "ctxt": 0
+        },
+        "typeAnnotation": {
+          "type": "TsTypePredicate",
+          "span": {
+            "start": 136,
+            "end": 145,
+            "ctxt": 0
+          },
+          "asserts": true,
+          "paramName": {
+            "type": "Identifier",
+            "span": {
+              "start": 144,
+              "end": 145,
+              "ctxt": 0
+            },
+            "value": "x",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "typeAnnotation": null
         }
       }
     }


### PR DESCRIPTION
Supports parsing code that looks like the following:

```ts
class Test {
    test(): asserts this { // apparently valid typescript code...
    }
}

function assert(condition: any, msg?: string): asserts condition {
  if (!condition) {
    throw new Error(msg);
  }
}
```

https://ts-ast-viewer.com/#code/MYGwhgzhAEAqCmEAu0DeAoaXpMUgFAJQBc0kE8ATkjEgBYCWMG20Avuh+gGYCuAdsCQMA9vzJQqBYGIAmDYWNJh+ATwA00ALYQA5gH5SySg366SEitRgz+8xeJbQG3aPgCEt+6P6E0mbHpKEQB3aH54MIBRSmDKfB1zAG4AjjYgA

https://www.typescriptlang.org/play/?ssl=1&ssc=1&pln=10&pc=2#code/MYGwhgzhAEAqCmEAu0DeBYAUNH0mKQAoBKALmkgngCckYkALASxg21wF8svMsAzAK4A7YEiYB7IRSg0iwSQBMmYyeTBCAngBpoAWwgBzAPzlk1JkINlpVWjHlClKqWxxM+0QgEIHTiUOI0LFw8BmpxAHdoIXgogFFqcOpCfSsAbmDoHg4gA