### PR TITLE
implement { Hash, Eq } for ast nodes

### DIFF
--- a/ecmascript/ast/Cargo.toml
+++ b/ecmascript/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_ast"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/ast/src/class.rs
+++ b/ecmascript/ast/src/class.rs
@@ -15,6 +15,7 @@ use swc_common::Fold;
 use swc_common::{ast_node, Span};
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub struct Class {
     pub span: Span,
 
@@ -42,6 +43,7 @@ pub struct Class {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum ClassMember {
     #[tag("Constructor")]
     Constructor(Constructor),
@@ -62,6 +64,7 @@ pub enum ClassMember {
 macro_rules! property {
     ($name:ident, $ty:literal, $KEY:ty) => {
         #[ast_node($ty)]
+        #[derive(Eq, Hash)]
         pub struct $name {
             #[serde(default)]
             pub span: Span,
@@ -109,6 +112,7 @@ property!(PrivateProp, "PrivateProperty", PrivateName);
 macro_rules! method {
     ($name:ident, $ty:literal, $KEY:ty) => {
         #[ast_node($ty)]
+        #[derive(Eq, Hash)]
         pub struct $name {
             #[serde(default)]
             pub span: Span,
@@ -141,6 +145,7 @@ method!(ClassMethod, "ClassMethod", PropName);
 method!(PrivateMethod, "PrivateMethod", PrivateName);
 
 #[ast_node("Constructor")]
+#[derive(Eq, Hash)]
 pub struct Constructor {
     pub span: Span,
 
@@ -159,6 +164,7 @@ pub struct Constructor {
 }
 
 #[ast_node("Decorator")]
+#[derive(Eq, Hash)]
 pub struct Decorator {
     pub span: Span,
 

--- a/ecmascript/ast/src/decl.rs
+++ b/ecmascript/ast/src/decl.rs
@@ -12,6 +12,7 @@ use swc_common::Fold;
 use swc_common::{ast_node, Span};
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum Decl {
     #[tag("ClassDeclaration")]
     Class(ClassDecl),
@@ -30,6 +31,7 @@ pub enum Decl {
 }
 
 #[ast_node("FunctionDeclaration")]
+#[derive(Eq, Hash)]
 pub struct FnDecl {
     #[serde(rename = "identifier")]
     pub ident: Ident,
@@ -43,6 +45,7 @@ pub struct FnDecl {
 }
 
 #[ast_node("ClassDeclaration")]
+#[derive(Eq, Hash)]
 pub struct ClassDecl {
     #[serde(rename = "identifier")]
     pub ident: Ident,
@@ -56,6 +59,7 @@ pub struct ClassDecl {
 }
 
 #[ast_node("VariableDeclaration")]
+#[derive(Eq, Hash)]
 pub struct VarDecl {
     pub span: Span,
 
@@ -80,6 +84,7 @@ pub enum VarDeclKind {
 }
 
 #[ast_node("VariableDeclarator")]
+#[derive(Eq, Hash)]
 pub struct VarDeclarator {
     pub span: Span,
     #[serde(rename = "id")]

--- a/ecmascript/ast/src/expr.rs
+++ b/ecmascript/ast/src/expr.rs
@@ -21,6 +21,7 @@ use swc_common::Fold;
 use swc_common::{ast_node, Span, Spanned, DUMMY_SP};
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum Expr {
     #[tag("ThisExpression")]
     This(ThisExpr),
@@ -152,13 +153,14 @@ pub enum Expr {
 }
 
 #[ast_node("ThisExpression")]
-#[derive(Copy)]
+#[derive(Eq, Hash, Copy)]
 pub struct ThisExpr {
     pub span: Span,
 }
 
 /// Array literal.
 #[ast_node("ArrayExpression")]
+#[derive(Eq, Hash)]
 pub struct ArrayLit {
     pub span: Span,
 
@@ -168,6 +170,7 @@ pub struct ArrayLit {
 
 /// Object literal.
 #[ast_node("ObjectExpression")]
+#[derive(Eq, Hash)]
 pub struct ObjectLit {
     pub span: Span,
 
@@ -176,6 +179,7 @@ pub struct ObjectLit {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum PropOrSpread {
     /// Spread properties, e.g., `{a: 1, ...obj, b: 2}`.
     #[tag("SpreadElement")]
@@ -186,6 +190,7 @@ pub enum PropOrSpread {
 }
 
 #[ast_node("SpreadElement")]
+#[derive(Eq, Hash)]
 pub struct SpreadElement {
     #[serde(rename = "spread")]
     #[span(lo)]
@@ -197,6 +202,7 @@ pub struct SpreadElement {
 }
 
 #[ast_node("UnaryExpression")]
+#[derive(Eq, Hash)]
 pub struct UnaryExpr {
     pub span: Span,
 
@@ -208,6 +214,7 @@ pub struct UnaryExpr {
 }
 
 #[ast_node("UpdateExpression")]
+#[derive(Eq, Hash)]
 pub struct UpdateExpr {
     pub span: Span,
 
@@ -221,6 +228,7 @@ pub struct UpdateExpr {
 }
 
 #[ast_node("BinaryExpression")]
+#[derive(Eq, Hash)]
 pub struct BinExpr {
     pub span: Span,
 
@@ -234,6 +242,7 @@ pub struct BinExpr {
 
 /// Function expression.
 #[ast_node("FunctionExpression")]
+#[derive(Eq, Hash)]
 pub struct FnExpr {
     #[serde(default, rename = "identifier")]
     pub ident: Option<Ident>,
@@ -245,6 +254,7 @@ pub struct FnExpr {
 
 /// Class expression.
 #[ast_node("ClassExpression")]
+#[derive(Eq, Hash)]
 pub struct ClassExpr {
     #[serde(default, rename = "identifier")]
     pub ident: Option<Ident>,
@@ -255,6 +265,7 @@ pub struct ClassExpr {
 }
 
 #[ast_node("AssignmentExpression")]
+#[derive(Eq, Hash)]
 pub struct AssignExpr {
     pub span: Span,
 
@@ -267,6 +278,7 @@ pub struct AssignExpr {
 }
 
 #[ast_node("MemberExpression")]
+#[derive(Eq, Hash)]
 pub struct MemberExpr {
     pub span: Span,
 
@@ -280,6 +292,7 @@ pub struct MemberExpr {
 }
 
 #[ast_node("ConditionalExpression")]
+#[derive(Eq, Hash)]
 pub struct CondExpr {
     pub span: Span,
 
@@ -293,6 +306,7 @@ pub struct CondExpr {
 }
 
 #[ast_node("CallExpression")]
+#[derive(Eq, Hash)]
 pub struct CallExpr {
     pub span: Span,
 
@@ -307,6 +321,7 @@ pub struct CallExpr {
 }
 
 #[ast_node("NewExpression")]
+#[derive(Eq, Hash)]
 pub struct NewExpr {
     pub span: Span,
 
@@ -321,6 +336,7 @@ pub struct NewExpr {
 }
 
 #[ast_node("SequenceExpression")]
+#[derive(Eq, Hash)]
 pub struct SeqExpr {
     pub span: Span,
 
@@ -329,6 +345,7 @@ pub struct SeqExpr {
 }
 
 #[ast_node("ArrowFunctionExpression")]
+#[derive(Eq, Hash)]
 pub struct ArrowExpr {
     pub span: Span,
 
@@ -350,6 +367,7 @@ pub struct ArrowExpr {
 }
 
 #[ast_node("YieldExpression")]
+#[derive(Eq, Hash)]
 pub struct YieldExpr {
     pub span: Span,
 
@@ -361,6 +379,7 @@ pub struct YieldExpr {
 }
 
 #[ast_node("MetaProperty")]
+#[derive(Eq, Hash)]
 pub struct MetaPropExpr {
     #[span(lo)]
     pub meta: Ident,
@@ -371,6 +390,7 @@ pub struct MetaPropExpr {
 }
 
 #[ast_node("AwaitExpression")]
+#[derive(Eq, Hash)]
 pub struct AwaitExpr {
     pub span: Span,
 
@@ -379,6 +399,7 @@ pub struct AwaitExpr {
 }
 
 #[ast_node("TemplateLiteral")]
+#[derive(Eq, Hash)]
 pub struct Tpl {
     pub span: Span,
 
@@ -389,6 +410,7 @@ pub struct Tpl {
 }
 
 #[ast_node("TaggedTemplateExpression")]
+#[derive(Eq, Hash)]
 pub struct TaggedTpl {
     pub span: Span,
 
@@ -403,6 +425,7 @@ pub struct TaggedTpl {
 }
 
 #[ast_node("TemplateElement")]
+#[derive(Eq, Hash)]
 pub struct TplElement {
     pub span: Span,
     pub tail: bool,
@@ -411,6 +434,7 @@ pub struct TplElement {
 }
 
 #[ast_node("ParenthesisExpression")]
+#[derive(Eq, Hash)]
 pub struct ParenExpr {
     pub span: Span,
 
@@ -420,6 +444,7 @@ pub struct ParenExpr {
 
 #[ast_node]
 #[allow(variant_size_differences)]
+#[derive(Eq, Hash)]
 pub enum ExprOrSuper {
     #[tag("Super")]
     Super(Super),
@@ -429,12 +454,12 @@ pub enum ExprOrSuper {
 }
 
 #[ast_node("Super")]
-#[derive(Copy)]
+#[derive(Eq, Hash, Copy)]
 pub struct Super {
     pub span: Span,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Eq, Hash)]
 #[cfg_attr(feature = "fold", derive(Fold))]
 pub struct ExprOrSpread {
     #[serde(default)]
@@ -455,6 +480,7 @@ impl Spanned for ExprOrSpread {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 #[allow(variant_size_differences)]
 pub enum BlockStmtOrExpr {
     #[tag("BlockStatement")]
@@ -464,6 +490,7 @@ pub enum BlockStmtOrExpr {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum PatOrExpr {
     #[tag("ThisExpression")]
     #[tag("ArrayExpression")]
@@ -545,6 +572,7 @@ impl From<Str> for Expr {
 }
 
 #[ast_node("OptionalChainingExpression")]
+#[derive(Eq, Hash)]
 pub struct OptChainExpr {
     pub span: Span,
     pub expr: Box<Expr>,

--- a/ecmascript/ast/src/function.rs
+++ b/ecmascript/ast/src/function.rs
@@ -8,6 +8,7 @@ use swc_common::{ast_node, Span};
 
 /// Common parts of function and method.
 #[ast_node]
+#[derive(Eq, Hash)]
 pub struct Function {
     pub params: Vec<Pat>,
 
@@ -35,6 +36,7 @@ pub struct Function {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum PatOrTsParamProp {
     #[tag("TsParameterProperty")]
     TsParamProp(TsParamProp),

--- a/ecmascript/ast/src/ident.rs
+++ b/ecmascript/ast/src/ident.rs
@@ -4,6 +4,7 @@ use swc_common::{ast_node, Span};
 
 /// Ident with span.
 #[ast_node("Identifier")]
+#[derive(Eq, Hash)]
 pub struct Ident {
     pub span: Span,
     #[serde(rename = "value")]
@@ -17,6 +18,7 @@ pub struct Ident {
 }
 
 #[ast_node("PrivateName")]
+#[derive(Eq, Hash)]
 pub struct PrivateName {
     pub span: Span,
     pub id: Ident,

--- a/ecmascript/ast/src/jsx.rs
+++ b/ecmascript/ast/src/jsx.rs
@@ -9,6 +9,7 @@ use swc_common::{ast_node, Span};
 
 /// Used for `obj` property of `JSXMemberExpr`.
 #[ast_node]
+#[derive(Eq, Hash)]
 #[allow(variant_size_differences)]
 pub enum JSXObject {
     #[tag("JSXMemberExpression")]
@@ -18,6 +19,7 @@ pub enum JSXObject {
 }
 
 #[ast_node("JSXMemberExpression")]
+#[derive(Eq, Hash)]
 pub struct JSXMemberExpr {
     #[serde(rename = "object")]
     #[span(lo)]
@@ -30,6 +32,7 @@ pub struct JSXMemberExpr {
 
 /// XML-based namespace syntax:
 #[ast_node("JSXNamespacedName")]
+#[derive(Eq, Hash)]
 pub struct JSXNamespacedName {
     #[serde(rename = "namespace")]
     #[span(lo)]
@@ -39,12 +42,13 @@ pub struct JSXNamespacedName {
 }
 
 #[ast_node("JSXEmptyExpression")]
-#[derive(Copy)]
+#[derive(Eq, Hash, Copy)]
 pub struct JSXEmptyExpr {
     pub span: Span,
 }
 
 #[ast_node("JSXExpressionContainer")]
+#[derive(Eq, Hash)]
 pub struct JSXExprContainer {
     pub span: Span,
     #[serde(rename = "expression")]
@@ -52,6 +56,7 @@ pub struct JSXExprContainer {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 #[allow(variant_size_differences)]
 pub enum JSXExpr {
     #[tag("JSXEmptyExpression")]
@@ -61,6 +66,7 @@ pub enum JSXExpr {
 }
 
 #[ast_node("JSXSpreadChild")]
+#[derive(Eq, Hash)]
 pub struct JSXSpreadChild {
     pub span: Span,
     #[serde(rename = "expression")]
@@ -68,6 +74,7 @@ pub struct JSXSpreadChild {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum JSXElementName {
     #[tag("Identifier")]
     Ident(Ident),
@@ -78,6 +85,7 @@ pub enum JSXElementName {
 }
 
 #[ast_node("JSXOpeningElement")]
+#[derive(Eq, Hash)]
 pub struct JSXOpeningElement {
     pub name: JSXElementName,
 
@@ -96,6 +104,7 @@ pub struct JSXOpeningElement {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 #[allow(variant_size_differences)]
 pub enum JSXAttrOrSpread {
     #[tag("JSXAttribute")]
@@ -105,12 +114,14 @@ pub enum JSXAttrOrSpread {
 }
 
 #[ast_node("JSXClosingElement")]
+#[derive(Eq, Hash)]
 pub struct JSXClosingElement {
     pub span: Span,
     pub name: JSXElementName,
 }
 
 #[ast_node("JSXAttribute")]
+#[derive(Eq, Hash)]
 pub struct JSXAttr {
     pub span: Span,
     pub name: JSXAttrName,
@@ -119,6 +130,7 @@ pub struct JSXAttr {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum JSXAttrName {
     #[tag("Identifier")]
     Ident(Ident),
@@ -127,6 +139,7 @@ pub enum JSXAttrName {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum JSXAttrValue {
     #[tag("StringLiteral")]
     #[tag("BooleanLiteral")]
@@ -147,6 +160,7 @@ pub enum JSXAttrValue {
 }
 
 #[ast_node("JSXText")]
+#[derive(Eq, Hash)]
 pub struct JSXText {
     pub span: Span,
     pub value: JsWord,
@@ -154,6 +168,7 @@ pub struct JSXText {
 }
 
 #[ast_node("JSXElement")]
+#[derive(Eq, Hash)]
 pub struct JSXElement {
     pub span: Span,
     pub opening: JSXOpeningElement,
@@ -162,6 +177,7 @@ pub struct JSXElement {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum JSXElementChild {
     #[tag("JSXText")]
     JSXText(JSXText),
@@ -180,6 +196,7 @@ pub enum JSXElementChild {
 }
 
 #[ast_node("JSXFragment")]
+#[derive(Eq, Hash)]
 pub struct JSXFragment {
     pub span: Span,
 
@@ -192,13 +209,13 @@ pub struct JSXFragment {
 }
 
 #[ast_node("JSXOpeningFragment")]
-#[derive(Copy)]
+#[derive(Eq, Hash, Copy)]
 pub struct JSXOpeningFragment {
     pub span: Span,
 }
 
 #[ast_node("JSXClosingFragment")]
-#[derive(Copy)]
+#[derive(Eq, Hash, Copy)]
 pub struct JSXClosingFragment {
     pub span: Span,
 }

--- a/ecmascript/ast/src/lib.rs
+++ b/ecmascript/ast/src/lib.rs
@@ -85,7 +85,7 @@ mod typescript;
 
 /// Represents a invalid node.
 #[ast_node("Invalid")]
-#[derive(Copy)]
+#[derive(Eq, Hash, Copy)]
 pub struct Invalid {
     pub span: Span,
 }

--- a/ecmascript/ast/src/module.rs
+++ b/ecmascript/ast/src/module.rs
@@ -3,6 +3,7 @@ use swc_atoms::JsWord;
 use swc_common::{ast_node, Span};
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum Program {
     #[tag("Module")]
     Module(Module),
@@ -11,6 +12,7 @@ pub enum Program {
 }
 
 #[ast_node("Module")]
+#[derive(Eq, Hash)]
 pub struct Module {
     pub span: Span,
 
@@ -21,6 +23,7 @@ pub struct Module {
 }
 
 #[ast_node("Script")]
+#[derive(Eq, Hash)]
 pub struct Script {
     pub span: Span,
 
@@ -31,6 +34,7 @@ pub struct Script {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum ModuleItem {
     #[tag("ImportDeclaration")]
     #[tag("ExportDeclaration")]

--- a/ecmascript/ast/src/module_decl.rs
+++ b/ecmascript/ast/src/module_decl.rs
@@ -8,6 +8,7 @@ use crate::{
 use swc_common::{ast_node, Span};
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum ModuleDecl {
     #[tag("ImportDeclaration")]
     Import(ImportDecl),
@@ -38,6 +39,7 @@ pub enum ModuleDecl {
 }
 
 #[ast_node("ExportDefaultExpression")]
+#[derive(Eq, Hash)]
 pub struct ExportDefaultExpr {
     pub span: Span,
 
@@ -46,6 +48,7 @@ pub struct ExportDefaultExpr {
 }
 
 #[ast_node("ExportDeclaration")]
+#[derive(Eq, Hash)]
 pub struct ExportDecl {
     pub span: Span,
 
@@ -54,6 +57,7 @@ pub struct ExportDecl {
 }
 
 #[ast_node("ImportDeclaration")]
+#[derive(Eq, Hash)]
 pub struct ImportDecl {
     pub span: Span,
 
@@ -69,6 +73,7 @@ pub struct ImportDecl {
 
 /// `export * from 'mod'`
 #[ast_node("ExportAllDeclaration")]
+#[derive(Eq, Hash)]
 pub struct ExportAll {
     pub span: Span,
 
@@ -79,6 +84,7 @@ pub struct ExportAll {
 /// `export { foo } from 'mod'`
 /// `export { foo as bar } from 'mod'`
 #[ast_node("ExportNamedDeclaration")]
+#[derive(Eq, Hash)]
 pub struct NamedExport {
     pub span: Span,
 
@@ -92,6 +98,7 @@ pub struct NamedExport {
 }
 
 #[ast_node("ExportDefaultDeclaration")]
+#[derive(Eq, Hash)]
 pub struct ExportDefaultDecl {
     pub span: Span,
 
@@ -99,6 +106,7 @@ pub struct ExportDefaultDecl {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum DefaultDecl {
     #[tag("ClassExpression")]
     Class(ClassExpr),
@@ -111,6 +119,7 @@ pub enum DefaultDecl {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum ImportSpecifier {
     #[tag("ImportSpecifier")]
     Specific(ImportSpecific),
@@ -122,6 +131,7 @@ pub enum ImportSpecifier {
 
 /// e.g. `import foo from 'mod.js'`
 #[ast_node("ImportDefaultSpecifier")]
+#[derive(Eq, Hash)]
 pub struct ImportDefault {
     pub span: Span,
 
@@ -129,6 +139,7 @@ pub struct ImportDefault {
 }
 /// e.g. `import * as foo from 'mod.js'`.
 #[ast_node("ImportNamespaceSpecifier")]
+#[derive(Eq, Hash)]
 pub struct ImportStarAs {
     pub span: Span,
 
@@ -138,6 +149,7 @@ pub struct ImportStarAs {
 /// e.g. local = bar, imported = Some(foo) for `import { foo as bar } from
 /// 'mod.js'`
 #[ast_node("ImportSpecifier")]
+#[derive(Eq, Hash)]
 pub struct ImportSpecific {
     pub span: Span,
 
@@ -148,6 +160,7 @@ pub struct ImportSpecific {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum ExportSpecifier {
     #[tag("ExportNamespaceSpecifer")]
     Namespace(NamespaceExportSpecifier),
@@ -160,7 +173,8 @@ pub enum ExportSpecifier {
 }
 
 /// `export * as foo from 'src';`
-#[ast_node("ExportNamespaceSpecifer")]
+#[ast_node("ExportNamespaceSpecifier")]
+#[derive(Eq, Hash)]
 pub struct NamespaceExportSpecifier {
     pub span: Span,
 
@@ -168,12 +182,14 @@ pub struct NamespaceExportSpecifier {
 }
 
 #[ast_node("ExportDefaultSpecifier")]
+#[derive(Eq, Hash)]
 pub struct DefaultExportSpecifier {
     #[span]
     pub exported: Ident,
 }
 
 #[ast_node("ExportSpecifier")]
+#[derive(Eq, Hash)]
 pub struct NamedExportSpecifier {
     pub span: Span,
     /// `foo` in `export { foo as bar }`

--- a/ecmascript/ast/src/module_decl.rs
+++ b/ecmascript/ast/src/module_decl.rs
@@ -162,7 +162,7 @@ pub struct ImportSpecific {
 #[ast_node]
 #[derive(Eq, Hash)]
 pub enum ExportSpecifier {
-    #[tag("ExportNamespaceSpecifer")]
+    #[tag("ExportNamespaceSpecifier")]
     Namespace(NamespaceExportSpecifier),
 
     #[tag("ExportDefaultSpecifier")]

--- a/ecmascript/ast/src/pat.rs
+++ b/ecmascript/ast/src/pat.rs
@@ -2,6 +2,7 @@ use crate::{expr::Expr, ident::Ident, prop::PropName, typescript::TsTypeAnn, Inv
 use swc_common::{ast_node, Span};
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum Pat {
     #[tag("Identifier")]
     Ident(Ident),
@@ -27,6 +28,7 @@ pub enum Pat {
 }
 
 #[ast_node("ArrayPattern")]
+#[derive(Eq, Hash)]
 pub struct ArrayPat {
     pub span: Span,
 
@@ -38,6 +40,7 @@ pub struct ArrayPat {
 }
 
 #[ast_node("ObjectPattern")]
+#[derive(Eq, Hash)]
 pub struct ObjectPat {
     pub span: Span,
 
@@ -49,6 +52,7 @@ pub struct ObjectPat {
 }
 
 #[ast_node("AssignmentPattern")]
+#[derive(Eq, Hash)]
 pub struct AssignPat {
     pub span: Span,
 
@@ -62,6 +66,7 @@ pub struct AssignPat {
 
 /// EsTree `RestElement`
 #[ast_node("RestElement")]
+#[derive(Eq, Hash)]
 pub struct RestPat {
     pub span: Span,
 
@@ -76,6 +81,7 @@ pub struct RestPat {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum ObjectPatProp {
     #[tag("KeyValuePatternProperty")]
     KeyValue(KeyValuePatProp),
@@ -89,6 +95,7 @@ pub enum ObjectPatProp {
 
 /// `{key: value}`
 #[ast_node("KeyValuePatternProperty")]
+#[derive(Eq, Hash)]
 pub struct KeyValuePatProp {
     #[span(lo)]
     pub key: PropName,
@@ -98,6 +105,7 @@ pub struct KeyValuePatProp {
 }
 /// `{key}` or `{key = value}`
 #[ast_node("AssignmentPatternProperty")]
+#[derive(Eq, Hash)]
 pub struct AssignPatProp {
     pub span: Span,
     pub key: Ident,

--- a/ecmascript/ast/src/prop.rs
+++ b/ecmascript/ast/src/prop.rs
@@ -10,6 +10,7 @@ use crate::{
 use swc_common::{ast_node, Span};
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum Prop {
     /// `a` in `{ a, }`
     #[tag("Identifier")]
@@ -34,6 +35,7 @@ pub enum Prop {
 }
 
 #[ast_node("KeyValueProperty")]
+#[derive(Eq, Hash)]
 pub struct KeyValueProp {
     #[span(lo)]
     pub key: PropName,
@@ -43,13 +45,16 @@ pub struct KeyValueProp {
 }
 
 #[ast_node("AssignmentProperty")]
+#[derive(Eq, Hash)]
 pub struct AssignProp {
     #[span(lo)]
     pub key: Ident,
     #[span(hi)]
     pub value: Box<Expr>,
 }
+
 #[ast_node("GetterProperty")]
+#[derive(Eq, Hash)]
 pub struct GetterProp {
     pub span: Span,
     pub key: PropName,
@@ -59,6 +64,7 @@ pub struct GetterProp {
     pub body: Option<BlockStmt>,
 }
 #[ast_node("SetterProperty")]
+#[derive(Eq, Hash)]
 pub struct SetterProp {
     pub span: Span,
     pub key: PropName,
@@ -67,6 +73,7 @@ pub struct SetterProp {
     pub body: Option<BlockStmt>,
 }
 #[ast_node("MethodProperty")]
+#[derive(Eq, Hash)]
 pub struct MethodProp {
     #[span(lo)]
     pub key: PropName,
@@ -77,6 +84,7 @@ pub struct MethodProp {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum PropName {
     #[tag("Identifier")]
     Ident(Ident),
@@ -91,6 +99,7 @@ pub enum PropName {
 }
 
 #[ast_node("Computed")]
+#[derive(Eq, Hash)]
 pub struct ComputedPropName {
     /// Span including `[` and `]`.
     pub span: Span,

--- a/ecmascript/ast/src/stmt.rs
+++ b/ecmascript/ast/src/stmt.rs
@@ -8,6 +8,7 @@ use swc_common::{ast_node, Span};
 
 /// Use when only block statements are allowed.
 #[ast_node("BlockStatement")]
+#[derive(Eq, Hash)]
 pub struct BlockStmt {
     /// Span including the braces.
     pub span: Span,
@@ -16,6 +17,7 @@ pub struct BlockStmt {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum Stmt {
     #[tag("BlockStatement")]
     Block(BlockStmt),
@@ -83,6 +85,7 @@ pub enum Stmt {
 }
 
 #[ast_node("ExpressionStatement")]
+#[derive(Eq, Hash)]
 pub struct ExprStmt {
     pub span: Span,
     #[serde(rename = "expression")]
@@ -90,19 +93,20 @@ pub struct ExprStmt {
 }
 
 #[ast_node("EmptyStatement")]
-#[derive(Copy)]
+#[derive(Eq, Hash, Copy)]
 pub struct EmptyStmt {
     /// Span of semicolon.
     pub span: Span,
 }
 
 #[ast_node("DebuggerStatement")]
-#[derive(Copy)]
+#[derive(Eq, Hash, Copy)]
 pub struct DebuggerStmt {
     pub span: Span,
 }
 
 #[ast_node("WithStatement")]
+#[derive(Eq, Hash)]
 pub struct WithStmt {
     pub span: Span,
     #[serde(rename = "object")]
@@ -111,6 +115,7 @@ pub struct WithStmt {
 }
 
 #[ast_node("ReturnStatement")]
+#[derive(Eq, Hash)]
 pub struct ReturnStmt {
     pub span: Span,
     #[serde(default, rename = "argument")]
@@ -118,6 +123,7 @@ pub struct ReturnStmt {
 }
 
 #[ast_node("LabeledStatement")]
+#[derive(Eq, Hash)]
 pub struct LabeledStmt {
     pub span: Span,
     pub label: Ident,
@@ -125,6 +131,7 @@ pub struct LabeledStmt {
 }
 
 #[ast_node("BreakStatement")]
+#[derive(Eq, Hash)]
 pub struct BreakStmt {
     pub span: Span,
     #[serde(default)]
@@ -132,6 +139,7 @@ pub struct BreakStmt {
 }
 
 #[ast_node("ContinueStatement")]
+#[derive(Eq, Hash)]
 pub struct ContinueStmt {
     pub span: Span,
     #[serde(default)]
@@ -139,6 +147,7 @@ pub struct ContinueStmt {
 }
 
 #[ast_node("IfStatement")]
+#[derive(Eq, Hash)]
 pub struct IfStmt {
     pub span: Span,
     pub test: Box<Expr>,
@@ -151,6 +160,7 @@ pub struct IfStmt {
 }
 
 #[ast_node("SwitchStatement")]
+#[derive(Eq, Hash)]
 pub struct SwitchStmt {
     pub span: Span,
     pub discriminant: Box<Expr>,
@@ -158,6 +168,7 @@ pub struct SwitchStmt {
 }
 
 #[ast_node("ThrowStatement")]
+#[derive(Eq, Hash)]
 pub struct ThrowStmt {
     pub span: Span,
     #[serde(rename = "argument")]
@@ -165,6 +176,7 @@ pub struct ThrowStmt {
 }
 
 #[ast_node("TryStatement")]
+#[derive(Eq, Hash)]
 pub struct TryStmt {
     pub span: Span,
 
@@ -178,6 +190,7 @@ pub struct TryStmt {
 }
 
 #[ast_node("WhileStatement")]
+#[derive(Eq, Hash)]
 pub struct WhileStmt {
     pub span: Span,
     pub test: Box<Expr>,
@@ -185,6 +198,7 @@ pub struct WhileStmt {
 }
 
 #[ast_node("DoWhileStatement")]
+#[derive(Eq, Hash)]
 pub struct DoWhileStmt {
     pub span: Span,
     pub test: Box<Expr>,
@@ -192,6 +206,7 @@ pub struct DoWhileStmt {
 }
 
 #[ast_node("ForStatement")]
+#[derive(Eq, Hash)]
 pub struct ForStmt {
     pub span: Span,
 
@@ -208,6 +223,7 @@ pub struct ForStmt {
 }
 
 #[ast_node("ForInStatement")]
+#[derive(Eq, Hash)]
 pub struct ForInStmt {
     pub span: Span,
     pub left: VarDeclOrPat,
@@ -216,6 +232,7 @@ pub struct ForInStmt {
 }
 
 #[ast_node("ForOfStatement")]
+#[derive(Eq, Hash)]
 pub struct ForOfStmt {
     pub span: Span,
     /// Span of the await token.
@@ -231,6 +248,7 @@ pub struct ForOfStmt {
 }
 
 #[ast_node("SwitchCase")]
+#[derive(Eq, Hash)]
 pub struct SwitchCase {
     pub span: Span,
 
@@ -243,6 +261,7 @@ pub struct SwitchCase {
 }
 
 #[ast_node("CatchClause")]
+#[derive(Eq, Hash)]
 pub struct CatchClause {
     pub span: Span,
     /// es2019
@@ -256,6 +275,7 @@ pub struct CatchClause {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum VarDeclOrPat {
     #[tag("VariableDeclaration")]
     VarDecl(VarDecl),
@@ -265,6 +285,7 @@ pub enum VarDeclOrPat {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 #[allow(variant_size_differences)]
 pub enum VarDeclOrExpr {
     #[tag("VariableDeclaration")]

--- a/ecmascript/ast/src/typescript.rs
+++ b/ecmascript/ast/src/typescript.rs
@@ -19,6 +19,7 @@ use swc_common::Fold;
 use swc_common::{ast_node, Span};
 
 #[ast_node("TsTypeAnnotation")]
+#[derive(Eq, Hash)]
 pub struct TsTypeAnn {
     pub span: Span,
     #[serde(rename = "typeAnnotation")]
@@ -26,6 +27,7 @@ pub struct TsTypeAnn {
 }
 
 #[ast_node("TsTypeParameterDeclaration")]
+#[derive(Eq, Hash)]
 pub struct TsTypeParamDecl {
     pub span: Span,
     #[serde(rename = "parameters")]
@@ -33,6 +35,7 @@ pub struct TsTypeParamDecl {
 }
 
 #[ast_node("TsTypeParameter")]
+#[derive(Eq, Hash)]
 pub struct TsTypeParam {
     pub span: Span,
     pub name: Ident,
@@ -45,12 +48,14 @@ pub struct TsTypeParam {
 }
 
 #[ast_node("TsTypeParameterInstantiation")]
+#[derive(Eq, Hash)]
 pub struct TsTypeParamInstantiation {
     pub span: Span,
     pub params: Vec<Box<TsType>>,
 }
 
 #[ast_node("TsTypeCastExpression")]
+#[derive(Eq, Hash)]
 pub struct TsTypeCastExpr {
     pub span: Span,
     #[serde(rename = "expression")]
@@ -60,6 +65,7 @@ pub struct TsTypeCastExpr {
 }
 
 #[ast_node("TsParameterProperty")]
+#[derive(Eq, Hash)]
 pub struct TsParamProp {
     pub span: Span,
     #[serde(default)]
@@ -72,6 +78,7 @@ pub struct TsParamProp {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum TsParamPropParam {
     #[tag("Identifier")]
     Ident(Ident),
@@ -81,6 +88,7 @@ pub enum TsParamPropParam {
 }
 
 #[ast_node("TsQualifiedName")]
+#[derive(Eq, Hash)]
 pub struct TsQualifiedName {
     #[span(lo)]
     pub left: TsEntityName,
@@ -89,6 +97,7 @@ pub struct TsQualifiedName {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 #[allow(variant_size_differences)]
 pub enum TsEntityName {
     #[tag("TsQualifiedName")]
@@ -99,6 +108,7 @@ pub enum TsEntityName {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum TsSignatureDecl {
     #[tag("TsCallSignatureDeclaration")]
     TsCallSignatureDecl(TsCallSignatureDecl),
@@ -121,6 +131,7 @@ pub enum TsSignatureDecl {
 // ================
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum TsTypeElement {
     #[tag("TsCallSignatureDeclaration")]
     TsCallSignatureDecl(TsCallSignatureDecl),
@@ -139,6 +150,7 @@ pub enum TsTypeElement {
 }
 
 #[ast_node("TsCallSignatureDeclaration")]
+#[derive(Eq, Hash)]
 pub struct TsCallSignatureDecl {
     pub span: Span,
     pub params: Vec<TsFnParam>,
@@ -149,6 +161,7 @@ pub struct TsCallSignatureDecl {
 }
 
 #[ast_node("TsConstructSignatureDeclaration")]
+#[derive(Eq, Hash)]
 pub struct TsConstructSignatureDecl {
     pub span: Span,
     pub params: Vec<TsFnParam>,
@@ -159,6 +172,7 @@ pub struct TsConstructSignatureDecl {
 }
 
 #[ast_node("TsPropertySignature")]
+#[derive(Eq, Hash)]
 pub struct TsPropertySignature {
     pub span: Span,
     pub readonly: bool,
@@ -175,6 +189,7 @@ pub struct TsPropertySignature {
 }
 
 #[ast_node("TsMethodSignature")]
+#[derive(Eq, Hash)]
 pub struct TsMethodSignature {
     pub span: Span,
     pub readonly: bool,
@@ -189,6 +204,7 @@ pub struct TsMethodSignature {
 }
 
 #[ast_node("TsIndexSignature")]
+#[derive(Eq, Hash)]
 pub struct TsIndexSignature {
     pub params: Vec<TsFnParam>,
     #[serde(default, rename = "typeAnnotation")]
@@ -203,6 +219,7 @@ pub struct TsIndexSignature {
 // ================
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum TsType {
     #[tag("TsKeywordType")]
     TsKeywordType(TsKeywordType),
@@ -268,6 +285,7 @@ pub enum TsType {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum TsFnOrConstructorType {
     #[tag("TsFunctionType")]
     TsFnType(TsFnType),
@@ -300,12 +318,13 @@ impl From<TsIntersectionType> for TsType {
 }
 
 #[ast_node("TsKeywordType")]
+#[derive(Eq, Hash)]
 pub struct TsKeywordType {
     pub span: Span,
     pub kind: TsKeywordTypeKind,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "fold", derive(Fold))]
 pub enum TsKeywordTypeKind {
     #[serde(rename = "any")]
@@ -346,11 +365,13 @@ pub enum TsKeywordTypeKind {
 }
 
 #[ast_node("TsThisType")]
+#[derive(Copy, Eq, Hash)]
 pub struct TsThisType {
     pub span: Span,
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum TsFnParam {
     #[tag("Identifier")]
     Ident(Ident),
@@ -366,6 +387,7 @@ pub enum TsFnParam {
 }
 
 #[ast_node("TsFunctionType")]
+#[derive(Eq, Hash)]
 pub struct TsFnType {
     pub span: Span,
     pub params: Vec<TsFnParam>,
@@ -377,6 +399,7 @@ pub struct TsFnType {
 }
 
 #[ast_node("TsConstructorType")]
+#[derive(Eq, Hash)]
 pub struct TsConstructorType {
     pub span: Span,
     pub params: Vec<TsFnParam>,
@@ -387,6 +410,7 @@ pub struct TsConstructorType {
 }
 
 #[ast_node("TsTypeReference")]
+#[derive(Eq, Hash)]
 pub struct TsTypeRef {
     pub span: Span,
     pub type_name: TsEntityName,
@@ -395,6 +419,7 @@ pub struct TsTypeRef {
 }
 
 #[ast_node("TsTypePredicate")]
+#[derive(Eq, Hash)]
 pub struct TsTypePredicate {
     pub span: Span,
     pub asserts: bool,
@@ -404,6 +429,7 @@ pub struct TsTypePredicate {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 #[allow(variant_size_differences)]
 pub enum TsThisTypeOrIdent {
     #[tag("TsThisType")]
@@ -415,12 +441,14 @@ pub enum TsThisTypeOrIdent {
 
 /// `typeof` operator
 #[ast_node("TsTypeQuery")]
+#[derive(Eq, Hash)]
 pub struct TsTypeQuery {
     pub span: Span,
     pub expr_name: TsTypeQueryExpr,
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum TsTypeQueryExpr {
     #[tag("TsQualifiedName")]
     #[tag("Identifier")]
@@ -430,6 +458,7 @@ pub enum TsTypeQueryExpr {
 }
 
 #[ast_node("TsImportType")]
+#[derive(Eq, Hash)]
 pub struct TsImportType {
     pub span: Span,
     #[serde(rename = "argument")]
@@ -440,24 +469,28 @@ pub struct TsImportType {
 }
 
 #[ast_node("TsTypeLiteral")]
+#[derive(Eq, Hash)]
 pub struct TsTypeLit {
     pub span: Span,
     pub members: Vec<TsTypeElement>,
 }
 
 #[ast_node("TsArrayType")]
+#[derive(Eq, Hash)]
 pub struct TsArrayType {
     pub span: Span,
     pub elem_type: Box<TsType>,
 }
 
 #[ast_node("TsTupleType")]
+#[derive(Eq, Hash)]
 pub struct TsTupleType {
     pub span: Span,
     pub elem_types: Vec<Box<TsType>>,
 }
 
 #[ast_node("TsOptionalType")]
+#[derive(Eq, Hash)]
 pub struct TsOptionalType {
     pub span: Span,
     #[serde(rename = "typeAnnotation")]
@@ -465,6 +498,7 @@ pub struct TsOptionalType {
 }
 
 #[ast_node("TsRestType")]
+#[derive(Eq, Hash)]
 pub struct TsRestType {
     pub span: Span,
     #[serde(rename = "typeAnnotation")]
@@ -472,6 +506,7 @@ pub struct TsRestType {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum TsUnionOrIntersectionType {
     #[tag("TsUnionType")]
     TsUnionType(TsUnionType),
@@ -481,18 +516,21 @@ pub enum TsUnionOrIntersectionType {
 }
 
 #[ast_node("TsUnionType")]
+#[derive(Eq, Hash)]
 pub struct TsUnionType {
     pub span: Span,
     pub types: Vec<Box<TsType>>,
 }
 
 #[ast_node("TsIntersectionType")]
+#[derive(Eq, Hash)]
 pub struct TsIntersectionType {
     pub span: Span,
     pub types: Vec<Box<TsType>>,
 }
 
 #[ast_node("TsConditionalType")]
+#[derive(Eq, Hash)]
 pub struct TsConditionalType {
     pub span: Span,
     pub check_type: Box<TsType>,
@@ -502,12 +540,14 @@ pub struct TsConditionalType {
 }
 
 #[ast_node("TsInferType")]
+#[derive(Eq, Hash)]
 pub struct TsInferType {
     pub span: Span,
     pub type_param: TsTypeParam,
 }
 
 #[ast_node("TsParenthesizedType")]
+#[derive(Eq, Hash)]
 pub struct TsParenthesizedType {
     pub span: Span,
     #[serde(rename = "typeAnnotation")]
@@ -515,6 +555,7 @@ pub struct TsParenthesizedType {
 }
 
 #[ast_node("TsTypeOperator")]
+#[derive(Eq, Hash)]
 pub struct TsTypeOperator {
     pub span: Span,
     pub op: TsTypeOperatorOp,
@@ -522,7 +563,7 @@ pub struct TsTypeOperator {
     pub type_ann: Box<TsType>,
 }
 
-#[derive(StringEnum, Clone, Copy, PartialEq, Eq)]
+#[derive(StringEnum, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "fold", derive(Fold))]
 pub enum TsTypeOperatorOp {
     /// `keyof`
@@ -534,6 +575,7 @@ pub enum TsTypeOperatorOp {
 }
 
 #[ast_node("TsIndexedAccessType")]
+#[derive(Eq, Hash)]
 pub struct TsIndexedAccessType {
     pub span: Span,
     pub readonly: bool,
@@ -542,7 +584,7 @@ pub struct TsIndexedAccessType {
     pub index_type: Box<TsType>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "fold", derive(Fold))]
 pub enum TruePlusMinus {
     True,
@@ -605,6 +647,7 @@ impl<'de> Deserialize<'de> for TruePlusMinus {
 }
 
 #[ast_node("TsMappedType")]
+#[derive(Eq, Hash)]
 pub struct TsMappedType {
     pub span: Span,
     #[serde(default)]
@@ -617,6 +660,7 @@ pub struct TsMappedType {
 }
 
 #[ast_node("TsLiteralType")]
+#[derive(Eq, Hash)]
 pub struct TsLitType {
     pub span: Span,
     #[serde(rename = "literal")]
@@ -624,6 +668,7 @@ pub struct TsLitType {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum TsLit {
     #[tag("NumericLiteral")]
     Number(Number),
@@ -640,6 +685,7 @@ pub enum TsLit {
 // // ================
 
 #[ast_node("TsInterfaceDeclaration")]
+#[derive(Eq, Hash)]
 pub struct TsInterfaceDecl {
     pub span: Span,
     pub id: Ident,
@@ -651,12 +697,14 @@ pub struct TsInterfaceDecl {
 }
 
 #[ast_node("TsInterfaceBody")]
+#[derive(Eq, Hash)]
 pub struct TsInterfaceBody {
     pub span: Span,
     pub body: Vec<TsTypeElement>,
 }
 
 #[ast_node("TsExpressionWithTypeArguments")]
+#[derive(Eq, Hash)]
 pub struct TsExprWithTypeArgs {
     pub span: Span,
     #[serde(rename = "expression")]
@@ -666,6 +714,7 @@ pub struct TsExprWithTypeArgs {
 }
 
 #[ast_node("TsTypeAliasDeclaration")]
+#[derive(Eq, Hash)]
 pub struct TsTypeAliasDecl {
     pub span: Span,
     pub declare: bool,
@@ -677,6 +726,7 @@ pub struct TsTypeAliasDecl {
 }
 
 #[ast_node("TsEnumDeclaration")]
+#[derive(Eq, Hash)]
 pub struct TsEnumDecl {
     pub span: Span,
     pub declare: bool,
@@ -686,6 +736,7 @@ pub struct TsEnumDecl {
 }
 
 #[ast_node("TsEnumMember")]
+#[derive(Eq, Hash)]
 pub struct TsEnumMember {
     pub span: Span,
     pub id: TsEnumMemberId,
@@ -696,6 +747,7 @@ pub struct TsEnumMember {
 ///
 /// - Invalid: [Ident] with empty symbol.
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum TsEnumMemberId {
     #[tag("Identifier")]
     Ident(Ident),
@@ -705,6 +757,7 @@ pub enum TsEnumMemberId {
 }
 
 #[ast_node("TsModuleDeclaration")]
+#[derive(Eq, Hash)]
 pub struct TsModuleDecl {
     pub span: Span,
     pub declare: bool,
@@ -718,6 +771,7 @@ pub struct TsModuleDecl {
 /// `namespace A.B { }` is a namespace named `A` with another TsNamespaceDecl as
 /// its body.
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum TsNamespaceBody {
     #[tag("TsModuleBlock")]
     TsModuleBlock(TsModuleBlock),
@@ -727,12 +781,14 @@ pub enum TsNamespaceBody {
 }
 
 #[ast_node("TsModuleBlock")]
+#[derive(Eq, Hash)]
 pub struct TsModuleBlock {
     pub span: Span,
     pub body: Vec<ModuleItem>,
 }
 
 #[ast_node("TsNamespaceDeclaration")]
+#[derive(Eq, Hash)]
 pub struct TsNamespaceDecl {
     pub span: Span,
     pub declare: bool,
@@ -743,6 +799,7 @@ pub struct TsNamespaceDecl {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum TsModuleName {
     #[tag("Identifier")]
     Ident(Ident),
@@ -752,6 +809,7 @@ pub enum TsModuleName {
 }
 
 #[ast_node("TsImportEqualsDeclaration")]
+#[derive(Eq, Hash)]
 pub struct TsImportEqualsDecl {
     pub span: Span,
     pub declare: bool,
@@ -761,6 +819,7 @@ pub struct TsImportEqualsDecl {
 }
 
 #[ast_node]
+#[derive(Eq, Hash)]
 pub enum TsModuleRef {
     #[tag("TsQualifiedName")]
     #[tag("Identifier")]
@@ -771,6 +830,7 @@ pub enum TsModuleRef {
 }
 
 #[ast_node("TsExternalModuleReference")]
+#[derive(Eq, Hash)]
 pub struct TsExternalModuleRef {
     pub span: Span,
     #[serde(rename = "expression")]
@@ -781,6 +841,7 @@ pub struct TsExternalModuleRef {
 /// `export =`. But for @babel/parser, `export default` is an ExportDefaultDecl,
 /// so a TsExportAssignment is always `export =`.
 #[ast_node("TsExportAssignment")]
+#[derive(Eq, Hash)]
 pub struct TsExportAssignment {
     pub span: Span,
     #[serde(rename = "expression")]
@@ -788,6 +849,7 @@ pub struct TsExportAssignment {
 }
 
 #[ast_node("TsNamespaceExportDeclaration")]
+#[derive(Eq, Hash)]
 pub struct TsNamespaceExportDecl {
     pub span: Span,
     pub id: Ident,
@@ -798,6 +860,7 @@ pub struct TsNamespaceExportDecl {
 // // ================
 
 #[ast_node("TsAsExpression")]
+#[derive(Eq, Hash)]
 pub struct TsAsExpr {
     pub span: Span,
     #[serde(rename = "expression")]
@@ -807,6 +870,7 @@ pub struct TsAsExpr {
 }
 
 #[ast_node("TsTypeAssertion")]
+#[derive(Eq, Hash)]
 pub struct TsTypeAssertion {
     pub span: Span,
     #[serde(rename = "expression")]
@@ -816,13 +880,14 @@ pub struct TsTypeAssertion {
 }
 
 #[ast_node("TsNonNullExpression")]
+#[derive(Eq, Hash)]
 pub struct TsNonNullExpr {
     pub span: Span,
     #[serde(rename = "expression")]
     pub expr: Box<Expr>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Eq, Hash)]
 #[cfg_attr(feature = "fold", derive(Fold))]
 pub enum Accessibility {
     #[serde(rename = "public")]
@@ -834,6 +899,7 @@ pub enum Accessibility {
 }
 
 #[ast_node("TsConstAssertion")]
+#[derive(Eq, Hash)]
 pub struct TsConstAssertion {
     pub span: Span,
     pub expr: Box<Expr>,

--- a/ecmascript/parser/tests/typescript/export/namespace-from/input.ts.json
+++ b/ecmascript/parser/tests/typescript/export/namespace-from/input.ts.json
@@ -15,7 +15,7 @@
       },
       "specifiers": [
         {
-          "type": "ExportNamespaceSpecifer",
+          "type": "ExportNamespaceSpecifier",
           "span": {
             "start": 7,
             "end": 14,

--- a/ecmascript/transforms/src/compat/es2015/block_scoping.rs
+++ b/ecmascript/transforms/src/compat/es2015/block_scoping.rs
@@ -510,7 +510,7 @@ struct FunctionFinder {
 noop_visit_type!(FunctionFinder);
 
 impl Visit<Function> for FunctionFinder {
-    fn visit(&mut self, node: &Function) {
+    fn visit(&mut self, _: &Function) {
         self.found = true
     }
 }


### PR DESCRIPTION
As NaN is`IIdent` not `Number`, we can use implement Hash and Eq for ast nodes.