### PR TITLE
Fix assignment pattern start when there is a type annotation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ once_cell = "1"
 hashbrown = "0.6"
 regex = "1"
 either = "1"
-dashmap = "=3.4.0"
+dashmap = "=3.5.1"
 sourcemap = "5"
 
 [dev-dependencies]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -28,7 +28,7 @@ parking_lot = "0.7.1"
 hashbrown = "0.6"
 termcolor = "1.0"
 serde = { version = "1", features = ["derive"] }
-dashmap = "=3.4.0"
+dashmap = "=3.5.1"
 fxhash = "0.2.1"
 
 [dev-dependencies]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_common"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/parser/src/parser/expr.rs
+++ b/ecmascript/parser/src/parser/expr.rs
@@ -1279,7 +1279,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 if eat!('=') {
                     let right = self.parse_assignment_expr()?;
                     pat = Pat::Assign(AssignPat {
-                        span: span!(start),
+                        span: span!(pat_start),
                         left: Box::new(pat),
                         right,
                         type_ann: None,

--- a/ecmascript/parser/tests/typescript/arrow-function/default-parameter-values/input.ts.json
+++ b/ecmascript/parser/tests/typescript/arrow-function/default-parameter-values/input.ts.json
@@ -24,7 +24,7 @@
           {
             "type": "AssignmentPattern",
             "span": {
-              "start": 2,
+              "start": 1,
               "end": 14,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/custom/default-followed-by-type/arrow/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/default-followed-by-type/arrow/input.ts.json
@@ -45,7 +45,7 @@
               {
                 "type": "AssignmentPattern",
                 "span": {
-                  "start": 17,
+                  "start": 9,
                   "end": 35,
                   "ctxt": 0
                 },

--- a/ecmascript/preset_env/Cargo.toml
+++ b/ecmascript/preset_env/Cargo.toml
@@ -21,7 +21,7 @@ once_cell = "1.2.0"
 hashbrown = "0.6"
 st-map = "0.1.2"
 fxhash = "0.2.1"
-dashmap = "=3.4.0"
+dashmap = "=3.5.1"
 
 [dev-dependencies]
 swc_ecma_codegen = { path = "../codegen" }

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_transforms"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -14,7 +14,7 @@ swc_common = { version = "0.5.0", path ="../../common" }
 swc_ecma_ast = { version = "0.17.0", path ="../ast" }
 swc_ecma_utils = { version = "0.3.0", path ="../utils" }
 swc_ecma_parser = { version = "0.19", path ="../parser", features = ["verify"] }
-dashmap = "=3.4.0"
+dashmap = "=3.5.1"
 either = "1.5"
 fxhash = "0.2"
 indexmap = "1"


### PR DESCRIPTION
The assignment pattern start didn't include the left expression start sometimes.

Also, upgraded dashmap because there is apparently a way to into_iter().collect() now, so I will be able to eliminate my comment cloning 🕺. Let me know if you'd like a separate PR for this though.