### PR TITLE
Fix union and intersection type start

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.21.5"
+version = "0.21.6"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -2233,9 +2233,9 @@ impl<'a, I: Tokens> Parser<'a, I> {
     {
         debug_assert!(self.input.syntax().typescript());
 
+        let start = cur_pos!(); // include the leading operator in the start
         self.input.eat(operator);
 
-        let start = cur_pos!();
         let ty = parse_constituent_type(self)?;
         if self.input.is(&operator) {
             let mut types = vec![ty];

--- a/ecmascript/parser/tests/typescript/types/union-intersection/input.ts
+++ b/ecmascript/parser/tests/typescript/types/union-intersection/input.ts
@@ -2,3 +2,9 @@ let union: number | null | undefined;
 let intersection: number & string;
 let precedence1: number | string & boolean;
 let precedence2: number & string | boolean;
+type LeadingUnion =
+    | string
+    | number;
+type LeadingIntersection =
+    & number
+    & string;

--- a/ecmascript/parser/tests/typescript/types/union-intersection/input.ts.json
+++ b/ecmascript/parser/tests/typescript/types/union-intersection/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 160,
+    "end": 261,
     "ctxt": 0
   },
   "body": [
@@ -324,6 +324,104 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 161,
+        "end": 207,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 166,
+          "end": 178,
+          "ctxt": 0
+        },
+        "value": "LeadingUnion",
+        "typeAnnotation": null,
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsUnionType",
+        "span": {
+          "start": 185,
+          "end": 206,
+          "ctxt": 0
+        },
+        "types": [
+          {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 187,
+              "end": 193,
+              "ctxt": 0
+            },
+            "kind": "string"
+          },
+          {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 200,
+              "end": 206,
+              "ctxt": 0
+            },
+            "kind": "number"
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 208,
+        "end": 261,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 213,
+          "end": 232,
+          "ctxt": 0
+        },
+        "value": "LeadingIntersection",
+        "typeAnnotation": null,
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsIntersectionType",
+        "span": {
+          "start": 239,
+          "end": 260,
+          "ctxt": 0
+        },
+        "types": [
+          {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 241,
+              "end": 247,
+              "ctxt": 0
+            },
+            "kind": "number"
+          },
+          {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 254,
+              "end": 260,
+              "ctxt": 0
+            },
+            "kind": "string"
+          }
+        ]
+      }
     }
   ],
   "interpreter": null


### PR DESCRIPTION
This is an edge case, but the start position should contain the leading operator token.

For reference:

* Babel: https://astexplorer.net/#/gist/f7f586cfcdb8045e17970af9bfdabf81/7e65d776e2fcf5bf3fd0eb0ee7947244211da736
* TS compiler: https://ts-ast-viewer.com/#code/KYDwDg9gTgLgBDAnmYcAqcC8AoOe4BkCwAzjLvkRDABbBQDc2oksCyqAqlhXgD7EyvOAOp1GQA