### PR TITLE
Fix parser

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.21.6"
+version = "0.21.7"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/parser/src/lexer/state.rs
+++ b/ecmascript/parser/src/lexer/state.rs
@@ -116,6 +116,9 @@ impl<I: Input> Tokens for Lexer<'_, I> {
         self.target
     }
 
+    /// no-op, as `Lexer` does not use `Rc<RefCelll<T>>`.
+    fn revert(&mut self) {}
+
     fn set_expr_allowed(&mut self, allow: bool) {
         self.set_expr_allowed(allow)
     }

--- a/ecmascript/parser/src/parser/input.rs
+++ b/ecmascript/parser/src/parser/input.rs
@@ -14,6 +14,10 @@ pub trait Tokens: Clone + Iterator<Item = TokenAndSpan> {
     fn syntax(&self) -> Syntax;
     fn target(&self) -> JscTarget;
 
+    /// Revert to lastest clone. THis method exists to removed captured token
+    /// while backtracking.
+    fn revert(&mut self);
+
     fn set_expr_allowed(&mut self, allow: bool);
     fn token_context(&self) -> &lexer::TokenContexts;
     fn token_context_mut(&mut self) -> &mut lexer::TokenContexts;
@@ -65,6 +69,9 @@ impl Tokens for TokensInput {
         self.target
     }
 
+    /// no-op, as `TokensInput` does not use `Rc<RefCelll<T>>`.
+    fn revert(&mut self) {}
+
     fn set_expr_allowed(&mut self, _: bool) {}
 
     fn token_context(&self) -> &TokenContexts {
@@ -81,16 +88,28 @@ impl Tokens for TokensInput {
 }
 
 /// Note: Lexer need access to parser's context to lex correctly.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Capturing<I: Tokens> {
     inner: I,
+    last_clone_idx: usize,
     captured: Rc<RefCell<Vec<TokenAndSpan>>>,
+}
+
+impl<I: Tokens> Clone for Capturing<I> {
+    fn clone(&self) -> Self {
+        Capturing {
+            last_clone_idx: self.captured.borrow().len(),
+            inner: self.inner.clone(),
+            captured: self.captured.clone(),
+        }
+    }
 }
 
 impl<I: Tokens> Capturing<I> {
     pub fn new(input: I) -> Self {
         Capturing {
             inner: input,
+            last_clone_idx: 0,
             captured: Default::default(),
         }
     }
@@ -125,6 +144,12 @@ impl<I: Tokens> Tokens for Capturing<I> {
     }
     fn target(&self) -> JscTarget {
         self.inner.target()
+    }
+
+    fn revert(&mut self) {
+        self.inner.revert();
+        let len = self.last_clone_idx;
+        self.captured.borrow_mut().drain(len..);
     }
 
     fn set_expr_allowed(&mut self, allow: bool) {
@@ -169,6 +194,10 @@ impl<I: Tokens> Buffer<I> {
             prev_span: DUMMY_SP.data(),
             next: None,
         }
+    }
+
+    pub fn revert(&mut self) {
+        self.iter.revert()
     }
 
     pub fn store(&mut self, token: Token) {

--- a/ecmascript/parser/src/parser/input.rs
+++ b/ecmascript/parser/src/parser/input.rs
@@ -149,7 +149,7 @@ impl<I: Tokens> Tokens for Capturing<I> {
     fn revert(&mut self) {
         self.inner.revert();
         let len = self.last_clone_idx;
-        self.captured.borrow_mut().drain(len..);
+        self.captured.borrow_mut().truncate(len);
     }
 
     fn set_expr_allowed(&mut self, allow: bool) {

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -2427,6 +2427,7 @@ mod tests {
                 assert_eq!(tokens.len(), 9, "Tokens: {:#?}", tokens);
                 Ok(())
             },
-        );
+        )
+        .unwrap();
     }
 }

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -477,10 +477,14 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 Ok(res)
             }
             Err(mut err) => {
+                self.input.revert();
                 err.cancel();
                 Ok(false)
             }
-            _ => Ok(false),
+            _ => {
+                self.input.revert();
+                Ok(false)
+            }
         }
     }
 
@@ -501,8 +505,12 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 self.emit_err = true;
                 Some(res)
             }
-            Ok(None) => None,
+            Ok(None) => {
+                self.input.revert();
+                None
+            }
             Err(mut err) => {
+                self.input.revert();
                 err.cancel();
                 None
             }

--- a/ecmascript/parser/src/token.rs
+++ b/ecmascript/parser/src/token.rs
@@ -375,7 +375,7 @@ impl Debug for Word {
 #[kind(function(before_expr = "bool", starts_expr = "bool"))]
 pub enum Keyword {
     /// Spec says this might be identifier.
-    #[kind(before_expr)]
+    #[kind(before_expr, starts_expr)]
     Await,
 
     Break,

--- a/ecmascript/parser/tests/jsx/basic/custom/issue-720/input.js
+++ b/ecmascript/parser/tests/jsx/basic/custom/issue-720/input.js
@@ -1,0 +1,3 @@
+async function* main() {
+    yield await 0;
+}

--- a/ecmascript/parser/tests/jsx/basic/custom/issue-720/input.js.json
+++ b/ecmascript/parser/tests/jsx/basic/custom/issue-720/input.js.json
@@ -1,0 +1,81 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 0,
+    "end": 45,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 16,
+          "end": 20,
+          "ctxt": 0
+        },
+        "value": "main",
+        "typeAnnotation": null,
+        "optional": false
+      },
+      "declare": false,
+      "params": [],
+      "decorators": [],
+      "span": {
+        "start": 0,
+        "end": 45,
+        "ctxt": 0
+      },
+      "body": {
+        "type": "BlockStatement",
+        "span": {
+          "start": 23,
+          "end": 45,
+          "ctxt": 0
+        },
+        "stmts": [
+          {
+            "type": "ExpressionStatement",
+            "span": {
+              "start": 29,
+              "end": 43,
+              "ctxt": 0
+            },
+            "expression": {
+              "type": "YieldExpression",
+              "span": {
+                "start": 29,
+                "end": 42,
+                "ctxt": 0
+              },
+              "argument": {
+                "type": "AwaitExpression",
+                "span": {
+                  "start": 35,
+                  "end": 42,
+                  "ctxt": 0
+                },
+                "argument": {
+                  "type": "NumericLiteral",
+                  "span": {
+                    "start": 41,
+                    "end": 42,
+                    "ctxt": 0
+                  },
+                  "value": 0.0
+                }
+              },
+              "delegate": false
+            }
+          }
+        ]
+      },
+      "generator": true,
+      "async": true,
+      "typeParameters": null,
+      "returnType": null
+    }
+  ],
+  "interpreter": null
+}

--- a/ecmascript/parser/tests/typescript/custom/issue-720/input.ts
+++ b/ecmascript/parser/tests/typescript/custom/issue-720/input.ts
@@ -1,0 +1,3 @@
+async function* main() {
+    yield await 0;
+}

--- a/ecmascript/parser/tests/typescript/custom/issue-720/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-720/input.ts.json
@@ -1,0 +1,81 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 0,
+    "end": 45,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 16,
+          "end": 20,
+          "ctxt": 0
+        },
+        "value": "main",
+        "typeAnnotation": null,
+        "optional": false
+      },
+      "declare": false,
+      "params": [],
+      "decorators": [],
+      "span": {
+        "start": 0,
+        "end": 45,
+        "ctxt": 0
+      },
+      "body": {
+        "type": "BlockStatement",
+        "span": {
+          "start": 23,
+          "end": 45,
+          "ctxt": 0
+        },
+        "stmts": [
+          {
+            "type": "ExpressionStatement",
+            "span": {
+              "start": 29,
+              "end": 43,
+              "ctxt": 0
+            },
+            "expression": {
+              "type": "YieldExpression",
+              "span": {
+                "start": 29,
+                "end": 42,
+                "ctxt": 0
+              },
+              "argument": {
+                "type": "AwaitExpression",
+                "span": {
+                  "start": 35,
+                  "end": 42,
+                  "ctxt": 0
+                },
+                "argument": {
+                  "type": "NumericLiteral",
+                  "span": {
+                    "start": 41,
+                    "end": 42,
+                    "ctxt": 0
+                  },
+                  "value": 0.0
+                }
+              },
+              "delegate": false
+            }
+          }
+        ]
+      },
+      "generator": true,
+      "async": true,
+      "typeParameters": null,
+      "returnType": null
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
 - Allow await in an yield expression (fixes #720)
 - Prevent duplicate tokens while capturing (fixes #726) 