### PR TITLE
Handle input source map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ name = "swc"
 swc_atoms = { path ="./atoms" }
 swc_common = { path ="./common" }
 swc_ecmascript = { path ="./ecmascript" }
+anyhow = "1"
 log = { version = "0.4", features = ["release_max_level_info"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-failure = "0.1"
 path-clean = "0.1"
 once_cell = "1"
 hashbrown = "0.6"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_common"
-version = "0.5.9"
+version = "0.5.10"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/common/src/source_map.rs
+++ b/common/src/source_map.rs
@@ -1002,7 +1002,7 @@ impl SourceMap {
     pub fn build_source_map_from(
         &self,
         mappings: &mut Vec<(BytePos, LineCol)>,
-        orig: Option<sourcemap::SourceMap>,
+        orig: Option<&sourcemap::SourceMap>,
     ) -> sourcemap::SourceMap {
         let mut builder = SourceMapBuilder::new(None);
 

--- a/common/src/source_map.rs
+++ b/common/src/source_map.rs
@@ -1059,7 +1059,7 @@ impl SourceMap {
 
             if let Some(orig) = &orig {
                 if let Some(token) = orig.lookup_token(line, col) {
-                    line = token.get_src_line();
+                    line = token.get_src_line() + 1;
                     col = token.get_src_col();
                 }
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,7 +79,7 @@ pub struct Options {
     pub env_name: String,
 
     #[serde(default)]
-    pub input_source_map: Option<InputSourceMap>,
+    pub input_source_map: InputSourceMap,
 
     #[serde(default)]
     pub source_maps: Option<SourceMapsConfig>,
@@ -238,6 +238,7 @@ impl Options {
                 .source_maps
                 .clone()
                 .unwrap_or(SourceMapsConfig::Bool(false)),
+            input_source_map: self.input_source_map.clone(),
         }
     }
 }
@@ -479,6 +480,7 @@ pub struct BuiltConfig<P: Pass> {
     pub minify: bool,
     pub external_helpers: bool,
     pub source_maps: SourceMapsConfig,
+    pub input_source_map: InputSourceMap,
     pub is_module: bool,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
-use crate::{builder::PassBuilder, error::Error};
+use crate::builder::PassBuilder;
+use anyhow::{bail, Context, Error};
 use dashmap::DashMap;
 use hashbrown::{HashMap, HashSet};
 use once_cell::sync::Lazy;
@@ -356,7 +357,7 @@ impl Rc {
                     if c.matches(filename)? {
                         return Ok(c);
                     } else {
-                        return Err(Error::Unmatched);
+                        bail!("not matched")
                     }
                 }
                 // TODO
@@ -377,7 +378,7 @@ impl Rc {
             None => return Ok(cs.remove(0)),
         }
 
-        Err(Error::Unmatched)
+        bail!("not matched")
     }
 }
 
@@ -428,10 +429,7 @@ impl FileMatcher {
                 }
 
                 if !CACHE.contains_key(&*s) {
-                    let re = Regex::new(&s).map_err(|err| Error::InvalidRegex {
-                        regex: s.into(),
-                        err,
-                    })?;
+                    let re = Regex::new(&s).with_context(|| format!("invalid regex: {}", s))?;
                     CACHE.insert(s.clone(), re);
                 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,43 +1,4 @@
-use failure::Fail;
 use once_cell::sync::Lazy;
-use regex;
-use serde_json;
-use sourcemap;
-use std::{io, string::FromUtf8Error};
-
-#[derive(Debug, Fail)]
-pub enum Error {
-    #[fail(display = "failed to read config file: {}", err)]
-    FailedToReadConfigFile { err: io::Error },
-
-    #[fail(display = "failed to parse config file: {}", err)]
-    FailedToParseConfigFile { err: serde_json::error::Error },
-
-    #[fail(display = "failed to parse module")]
-    FailedToParseModule {},
-
-    #[fail(display = "failed to read module: {}", err)]
-    FailedToReadModule { err: io::Error },
-
-    #[fail(display = "failed to emit module: {}", err)]
-    FailedToEmitModule { err: io::Error },
-
-    #[fail(display = "failed to write sourcemap: {}", err)]
-    FailedToWriteSourceMap { err: sourcemap::Error },
-
-    #[fail(display = "sourcemap is not utf8: {}", err)]
-    SourceMapNotUtf8 { err: FromUtf8Error },
-
-    #[fail(display = "invalid regexp: {}: {}", regex, err)]
-    InvalidRegex { regex: String, err: regex::Error },
-
-    /* #[fail(display = "generated code is not utf8: {}", err)]
-     * GeneratedCodeNotUtf8 { err: FromUtf8Error }, */
-    /// This means `test` field in .swcrc file did not matched the compiling
-    /// file.
-    #[fail(display = "unmatched")]
-    Unmatched,
-}
 
 /// Returns true if `SWC_DEBUG` environment is set to `1` or `true`.
 pub(crate) fn debug() -> bool {

--- a/tests/projects.rs
+++ b/tests/projects.rs
@@ -2,7 +2,6 @@ use rayon::prelude::*;
 use std::path::Path;
 use swc::{
     config::{Options, SourceMapsConfig},
-    error::Error,
     Compiler,
 };
 use testing::{NormalizedOutput, StdErr, Tester};
@@ -65,8 +64,8 @@ fn project(dir: &str) {
                     },
                 ) {
                     Ok(..) => {}
-                    Err(Error::Unmatched) => {}
-                    Err(..) => return Err(()),
+                    Err(ref err) if format!("{:?}", err).contains("not matched") => {}
+                    Err(err) => panic!("Error: {:?}", err),
                 }
             }
 

--- a/tests/source_map.rs
+++ b/tests/source_map.rs
@@ -93,8 +93,6 @@ fn inline(f: &str) -> Result<(), StdErr> {
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
-
-        Ok(())
     })
 }
 #[test]

--- a/tests/srcmap/issue-732-inline/.swcrc
+++ b/tests/srcmap/issue-732-inline/.swcrc
@@ -1,0 +1,3 @@
+{
+    "inputSourceMap": "inline",
+}

--- a/tests/srcmap/issue-732-inline/index.js
+++ b/tests/srcmap/issue-732-inline/index.js
@@ -1,0 +1,26 @@
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Foo = /** @class */ (function () {
+    function Foo() {
+    }
+    return Foo;
+}());
+var Bar = /** @class */ (function (_super) {
+    __extends(Bar, _super);
+    function Bar() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return Bar;
+}(Foo));
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5kZXguanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJpbmRleC50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOzs7Ozs7Ozs7Ozs7O0FBQUE7SUFBQTtJQUVBLENBQUM7SUFBRCxVQUFDO0FBQUQsQ0FBQyxBQUZELElBRUM7QUFFRDtJQUFrQix1QkFBRztJQUFyQjs7SUFFQSxDQUFDO0lBQUQsVUFBQztBQUFELENBQUMsQUFGRCxDQUFrQixHQUFHLEdBRXBCIn0=

--- a/tests/srcmap/issue-732/.swcrc
+++ b/tests/srcmap/issue-732/.swcrc
@@ -1,0 +1,3 @@
+{
+    "inputSourceMap": true,
+}

--- a/tests/srcmap/issue-732/index.js
+++ b/tests/srcmap/issue-732/index.js
@@ -1,0 +1,26 @@
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Foo = /** @class */ (function () {
+    function Foo() {
+    }
+    return Foo;
+}());
+var Bar = /** @class */ (function (_super) {
+    __extends(Bar, _super);
+    function Bar() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return Bar;
+}(Foo));
+//# sourceMappingURL=index.js.map

--- a/tests/srcmap/issue-732/index.js.map
+++ b/tests/srcmap/issue-732/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":";;;;;;;;;;;;;AAAA;IAAA;IAEA,CAAC;IAAD,UAAC;AAAD,CAAC,AAFD,IAEC;AAED;IAAkB,uBAAG;IAArB;;IACA,CAAC;IAAD,UAAC;AAAD,CAAC,AADD,CAAkB,GAAG,GACpB"}


### PR DESCRIPTION
Add support for various input source map. It can be one of true, false, "inline" or content of a input source map.

Closes #733.