### PR TITLE
Preserve commits starting with "!" when minifying (#690)

### DIFF
--- a/common/src/comments.rs
+++ b/common/src/comments.rs
@@ -73,6 +73,14 @@ impl Comments {
         }
     }
 
+    pub fn retain_leading(&self, f: impl FnMut(&BytePos, &mut Vec<Comment>) -> bool) {
+        self.leading.retain(f);
+    }
+
+    pub fn retain_trailing(&self, f: impl FnMut(&BytePos, &mut Vec<Comment>) -> bool) {
+        self.trailing.retain(f);
+    }
+
     /// Takes all the comments as (leading, trailing).
     pub fn take_all(self) -> (CommentMap, CommentMap) {
         (self.leading, self.trailing)


### PR DESCRIPTION
Hi! I'm a first-time contributor to this project, so I decided to try to tackle one of the easy issues currently open; specifically, #690.

Comments are now always lexed by `Compiler::process_js`, but when the `minify` configuration option is set, all comments except the ones starting with "!" are discarded.