### PR TITLE
Support for parsing parameter decorators

### DIFF
--- a/ecmascript/ast/src/class.rs
+++ b/ecmascript/ast/src/class.rs
@@ -1,6 +1,6 @@
 use crate::{
     expr::Expr,
-    function::{Function, PatOrTsParamProp},
+    function::{Function, ParamOrTsParamProp},
     ident::PrivateName,
     prop::PropName,
     stmt::BlockStmt,
@@ -151,7 +151,7 @@ pub struct Constructor {
 
     pub key: PropName,
 
-    pub params: Vec<PatOrTsParamProp>,
+    pub params: Vec<ParamOrTsParamProp>,
 
     #[serde(default)]
     pub body: Option<BlockStmt>,

--- a/ecmascript/ast/src/function.rs
+++ b/ecmascript/ast/src/function.rs
@@ -10,7 +10,7 @@ use swc_common::{ast_node, Span};
 #[ast_node]
 #[derive(Eq, Hash)]
 pub struct Function {
-    pub params: Vec<Pat>,
+    pub params: Vec<Param>,
 
     #[serde(default)]
     pub decorators: Vec<Decorator>,
@@ -33,6 +33,14 @@ pub struct Function {
 
     #[serde(default)]
     pub return_type: Option<TsTypeAnn>,
+}
+
+#[ast_node]
+#[derive(Eq, Hash)]
+pub struct Param {
+    pub span: Span,
+    pub decorators: Vec<Decorator>,
+    pub pat: Pat,
 }
 
 #[ast_node]

--- a/ecmascript/ast/src/function.rs
+++ b/ecmascript/ast/src/function.rs
@@ -35,7 +35,7 @@ pub struct Function {
     pub return_type: Option<TsTypeAnn>,
 }
 
-#[ast_node]
+#[ast_node("Parameter")]
 #[derive(Eq, Hash)]
 pub struct Param {
     pub span: Span,
@@ -45,9 +45,9 @@ pub struct Param {
 
 #[ast_node]
 #[derive(Eq, Hash)]
-pub enum PatOrTsParamProp {
+pub enum ParamOrTsParamProp {
     #[tag("TsParameterProperty")]
     TsParamProp(TsParamProp),
-    #[tag("*")]
-    Pat(Pat),
+    #[tag("Parameter")]
+    Param(Param),
 }

--- a/ecmascript/ast/src/lib.rs
+++ b/ecmascript/ast/src/lib.rs
@@ -18,7 +18,7 @@ pub use self::{
         ObjectLit, OptChainExpr, ParenExpr, PatOrExpr, PropOrSpread, SeqExpr, SpreadElement, Super,
         TaggedTpl, ThisExpr, Tpl, TplElement, UnaryExpr, UpdateExpr, YieldExpr,
     },
-    function::{Function, Param, PatOrTsParamProp},
+    function::{Function, Param, ParamOrTsParamProp},
     ident::{Ident, IdentExt, PrivateName},
     jsx::{
         JSXAttr, JSXAttrName, JSXAttrOrSpread, JSXAttrValue, JSXClosingElement, JSXClosingFragment,

--- a/ecmascript/ast/src/lib.rs
+++ b/ecmascript/ast/src/lib.rs
@@ -18,7 +18,7 @@ pub use self::{
         ObjectLit, OptChainExpr, ParenExpr, PatOrExpr, PropOrSpread, SeqExpr, SpreadElement, Super,
         TaggedTpl, ThisExpr, Tpl, TplElement, UnaryExpr, UpdateExpr, YieldExpr,
     },
-    function::{Function, PatOrTsParamProp},
+    function::{Function, Param, PatOrTsParamProp},
     ident::{Ident, IdentExt, PrivateName},
     jsx::{
         JSXAttr, JSXAttrName, JSXAttrOrSpread, JSXAttrValue, JSXClosingElement, JSXClosingFragment,

--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -486,8 +486,11 @@ impl<'a, I: Tokens> Parser<'a, I> {
                         // TODO: Search deeply for assignment pattern using a Visitor
 
                         let span = match *p {
-                            PatOrTsParamProp::Pat(Pat::Assign(ref p)) => Some(p.span()),
-                            PatOrTsParamProp::TsParamProp(TsParamProp {
+                            ParamOrTsParamProp::Param(ref param) => match param.pat {
+                                Pat::Assign(ref p) => Some(p.span()),
+                                _ => None,
+                            },
+                            ParamOrTsParamProp::TsParamProp(TsParamProp {
                                 param: TsParamPropParam::Assign(ref p),
                                 ..
                             }) => Some(p.span()),

--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -634,8 +634,8 @@ impl<'a, I: Tokens> Parser<'a, I> {
                             }
 
                             if !params.is_empty() {
-                                if let Pat::Rest(..) = params[0] {
-                                    p.emit_err(params[0].span(), SyntaxError::RestPatInSetter);
+                                if let Pat::Rest(..) = params[0].pat {
+                                    p.emit_err(params[0].pat.span(), SyntaxError::RestPatInSetter);
                                 }
                             }
 
@@ -833,7 +833,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         is_generator: bool,
     ) -> PResult<'a, Function>
     where
-        F: FnOnce(&mut Self) -> PResult<'a, Vec<Pat>>,
+        F: FnOnce(&mut Self) -> PResult<'a, Vec<Param>>,
     {
         let ctx = Context {
             in_async: is_async,
@@ -871,10 +871,10 @@ impl<'a, I: Tokens> Parser<'a, I> {
 
             if p.syntax().typescript() && body.is_none() {
                 // Declare functions cannot have assignment pattern in parameters
-                for pat in &params {
+                for param in &params {
                     // TODO: Search deeply for assignment pattern using a Visitor
 
-                    let span = match *pat {
+                    let span = match &param.pat {
                         Pat::Assign(ref p) => Some(p.span()),
                         _ => None,
                     };
@@ -952,7 +952,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         }: MakeMethodArgs,
     ) -> PResult<'a, ClassMember>
     where
-        F: FnOnce(&mut Self) -> PResult<'a, Vec<Pat>>,
+        F: FnOnce(&mut Self) -> PResult<'a, Vec<Param>>,
     {
         let is_static = static_token.is_some();
         let ctx = Context {

--- a/ecmascript/parser/src/parser/object.rs
+++ b/ecmascript/parser/src/parser/object.rs
@@ -294,7 +294,7 @@ impl<'a, I: Tokens> ParseObject<'a, Box<Expr>> for Parser<'a, I> {
                                 }
 
                                 if !params.is_empty() {
-                                    if let Pat::Rest(..) = params[0] {
+                                    if let Pat::Rest(..) = params[0].pat {
                                         p.emit_err(params[0].span(), SyntaxError::RestPatInSetter);
                                     }
                                 }
@@ -326,9 +326,9 @@ impl<'a, I: Tokens> ParseObject<'a, Box<Expr>> for Parser<'a, I> {
                                     span: span!(start),
                                     key,
                                     body,
-                                    param: params.into_iter().next().unwrap_or_else(|| {
-                                        Pat::Invalid(Invalid { span: key_span })
-                                    }),
+                                    param: params.into_iter().map(|p| p.pat).next().unwrap_or_else(
+                                        || Pat::Invalid(Invalid { span: key_span }),
+                                    ),
                                 })))
                             },
                         ),

--- a/ecmascript/parser/src/parser/pat.rs
+++ b/ecmascript/parser/src/parser/pat.rs
@@ -141,7 +141,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
     /// spec: 'FormalParameter'
     ///
     /// babel: `parseAssignableListItem`
-    pub(super) fn parse_formal_param(&mut self) -> PResult<'a, Pat> {
+    pub(super) fn parse_formal_param_pat(&mut self) -> PResult<'a, Pat> {
         let start = cur_pos!();
 
         let has_modifier = self.eat_any_ts_modifier()?;
@@ -292,9 +292,9 @@ impl<'a, I: Tokens> Parser<'a, I> {
             (None, false)
         };
         if accessibility == None && !readonly {
-            self.parse_formal_param().map(PatOrTsParamProp::from)
+            self.parse_formal_param_pat().map(PatOrTsParamProp::from)
         } else {
-            let param = match self.parse_formal_param()? {
+            let param = match self.parse_formal_param_pat()? {
                 Pat::Ident(i) => TsParamPropParam::Ident(i),
                 Pat::Assign(a) => TsParamPropParam::Assign(a),
                 node => syntax_error!(node.span(), SyntaxError::TsInvalidParamPropPat),
@@ -309,7 +309,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
         }
     }
 
-    pub(super) fn parse_formal_params(&mut self) -> PResult<'a, Vec<Pat>> {
+    pub(super) fn parse_formal_params(&mut self) -> PResult<'a, Vec<Param>> {
         let mut first = true;
         let mut params = vec![];
         let mut dot3_token = Span::default();
@@ -332,14 +332,17 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 }
             }
 
-            let start = cur_pos!();
+            let param_start = cur_pos!();
 
             if !dot3_token.is_dummy() {
                 self.emit_err(dot3_token, SyntaxError::TS1014);
             }
 
-            if eat!("...") {
-                dot3_token = span!(start);
+            let decorators = self.parse_decorators(false)?;
+            let pat_start = cur_pos!();
+
+            let pat = if eat!("...") {
+                dot3_token = span!(pat_start);
 
                 let mut pat = self.parse_binding_pat_or_ident()?;
 
@@ -347,7 +350,7 @@ impl<'a, I: Tokens> Parser<'a, I> {
                     let right = self.parse_assignment_expr()?;
                     self.emit_err(pat.span(), SyntaxError::TS1048);
                     pat = AssignPat {
-                        span: span!(start),
+                        span: span!(pat_start),
                         left: Box::new(pat),
                         right,
                         type_ann: None,
@@ -364,31 +367,33 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 };
 
                 let pat = Pat::Rest(RestPat {
-                    span: span!(start),
+                    span: span!(pat_start),
                     dot3_token,
                     arg: Box::new(pat),
                     type_ann,
                 });
-                params.push(pat);
 
                 if self.syntax().typescript() && eat!('?') {
                     self.emit_err(make_span(self.input.prev_span()), SyntaxError::TS1047);
                     //
                 }
 
-                // continue instead of break to recover from
-                //
-                //      function foo(...A, B) { }
-                continue;
-            }
+                pat
+            } else {
+                self.parse_formal_param_pat()?
+            };
 
-            params.push(self.parse_formal_param()?);
+            params.push(Param {
+                span: span!(param_start),
+                decorators,
+                pat,
+            });
         }
 
         Ok(params)
     }
 
-    pub(super) fn parse_unique_formal_params(&mut self) -> PResult<'a, Vec<Pat>> {
+    pub(super) fn parse_unique_formal_params(&mut self) -> PResult<'a, Vec<Param>> {
         // FIXME: This is wrong
         self.parse_formal_params()
     }

--- a/ecmascript/parser/src/parser/pat.rs
+++ b/ecmascript/parser/src/parser/pat.rs
@@ -284,7 +284,11 @@ impl<'a, I: Tokens> Parser<'a, I> {
         Ok(params)
     }
 
-    fn parse_constructor_param(&mut self, param_start: BytePos, decorators: Vec<Decorator>) -> PResult<'a, ParamOrTsParamProp> {
+    fn parse_constructor_param(
+        &mut self,
+        param_start: BytePos,
+        decorators: Vec<Decorator>,
+    ) -> PResult<'a, ParamOrTsParamProp> {
         let (accessibility, readonly) = if self.input.syntax().typescript() {
             let accessibility = self.parse_access_modifier()?;
             (

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -1561,11 +1561,11 @@ impl<'a, I: Tokens> Parser<'a, I> {
     fn parse_ts_binding_list_for_signature(&mut self) -> PResult<'a, Vec<TsFnParam>> {
         debug_assert!(self.input.syntax().typescript());
 
-        let pats = self.parse_formal_params()?;
+        let params = self.parse_formal_params()?;
         let mut list = vec![];
 
-        for pat in pats {
-            let item = match pat {
+        for param in params {
+            let item = match param.pat {
                 Pat::Ident(pat) => TsFnParam::Ident(pat),
                 Pat::Object(pat) => TsFnParam::Object(pat),
                 Pat::Rest(pat) => TsFnParam::Rest(pat),
@@ -2138,7 +2138,11 @@ impl<'a, I: Tokens> Parser<'a, I> {
                 let type_params = p.parse_ts_type_params()?;
                 // Don't use overloaded parseFunctionParams which would look for "<" again.
                 expect!('(');
-                let params = p.parse_formal_params()?;
+                let params = p
+                    .parse_formal_params()?
+                    .into_iter()
+                    .map(|p| p.pat)
+                    .collect();
                 expect!(')');
                 let return_type = p.try_parse_ts_type_or_type_predicate_ann()?;
                 expect!("=>");

--- a/ecmascript/parser/tests/typescript/class/constructor-with-modifier-names/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/constructor-with-modifier-names/input.ts.json
@@ -47,26 +47,44 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "Parameter",
               "span": {
                 "start": 26,
                 "end": 29,
                 "ctxt": 0
               },
-              "value": "set",
-              "typeAnnotation": null,
-              "optional": false
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
+                "span": {
+                  "start": 26,
+                  "end": 29,
+                  "ctxt": 0
+                },
+                "value": "set",
+                "typeAnnotation": null,
+                "optional": false
+              }
             },
             {
-              "type": "Identifier",
+              "type": "Parameter",
               "span": {
                 "start": 31,
                 "end": 39,
                 "ctxt": 0
               },
-              "value": "readonly",
-              "typeAnnotation": null,
-              "optional": false
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
+                "span": {
+                  "start": 31,
+                  "end": 39,
+                  "ctxt": 0
+                },
+                "value": "readonly",
+                "typeAnnotation": null,
+                "optional": false
+              }
             }
           ],
           "body": {
@@ -101,58 +119,76 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "Parameter",
               "span": {
                 "start": 58,
                 "end": 66,
                 "ctxt": 0
               },
-              "value": "set",
-              "typeAnnotation": {
-                "type": "TsTypeAnnotation",
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
                 "span": {
-                  "start": 61,
+                  "start": 58,
                   "end": 66,
                   "ctxt": 0
                 },
+                "value": "set",
                 "typeAnnotation": {
-                  "type": "TsKeywordType",
+                  "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 63,
+                    "start": 61,
                     "end": 66,
                     "ctxt": 0
                   },
-                  "kind": "any"
-                }
-              },
-              "optional": false
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 63,
+                      "end": 66,
+                      "ctxt": 0
+                    },
+                    "kind": "any"
+                  }
+                },
+                "optional": false
+              }
             },
             {
-              "type": "Identifier",
+              "type": "Parameter",
               "span": {
                 "start": 68,
                 "end": 85,
                 "ctxt": 0
               },
-              "value": "readonly",
-              "typeAnnotation": {
-                "type": "TsTypeAnnotation",
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
                 "span": {
-                  "start": 76,
+                  "start": 68,
                   "end": 85,
                   "ctxt": 0
                 },
+                "value": "readonly",
                 "typeAnnotation": {
-                  "type": "TsKeywordType",
+                  "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 78,
+                    "start": 76,
                     "end": 85,
                     "ctxt": 0
                   },
-                  "kind": "boolean"
-                }
-              },
-              "optional": false
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 78,
+                      "end": 85,
+                      "ctxt": 0
+                    },
+                    "kind": "boolean"
+                  }
+                },
+                "optional": false
+              }
             }
           ],
           "body": {

--- a/ecmascript/parser/tests/typescript/class/constructor/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/constructor/input.ts.json
@@ -47,58 +47,76 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "Parameter",
               "span": {
                 "start": 26,
                 "end": 35,
                 "ctxt": 0
               },
-              "value": "x",
-              "typeAnnotation": {
-                "type": "TsTypeAnnotation",
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
                 "span": {
-                  "start": 27,
+                  "start": 26,
                   "end": 35,
                   "ctxt": 0
                 },
+                "value": "x",
                 "typeAnnotation": {
-                  "type": "TsKeywordType",
+                  "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 29,
+                    "start": 27,
                     "end": 35,
                     "ctxt": 0
                   },
-                  "kind": "number"
-                }
-              },
-              "optional": false
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 29,
+                      "end": 35,
+                      "ctxt": 0
+                    },
+                    "kind": "number"
+                  }
+                },
+                "optional": false
+              }
             },
             {
-              "type": "Identifier",
+              "type": "Parameter",
               "span": {
                 "start": 37,
                 "end": 46,
                 "ctxt": 0
               },
-              "value": "y",
-              "typeAnnotation": {
-                "type": "TsTypeAnnotation",
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
                 "span": {
-                  "start": 38,
+                  "start": 37,
                   "end": 46,
                   "ctxt": 0
                 },
+                "value": "y",
                 "typeAnnotation": {
-                  "type": "TsKeywordType",
+                  "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 40,
+                    "start": 38,
                     "end": 46,
                     "ctxt": 0
                   },
-                  "kind": "number"
-                }
-              },
-              "optional": false
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 40,
+                      "end": 46,
+                      "ctxt": 0
+                    },
+                    "kind": "number"
+                  }
+                },
+                "optional": false
+              }
             }
           ],
           "body": null,
@@ -125,58 +143,76 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "Parameter",
               "span": {
                 "start": 65,
                 "end": 74,
                 "ctxt": 0
               },
-              "value": "x",
-              "typeAnnotation": {
-                "type": "TsTypeAnnotation",
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
                 "span": {
-                  "start": 66,
+                  "start": 65,
                   "end": 74,
                   "ctxt": 0
                 },
+                "value": "x",
                 "typeAnnotation": {
-                  "type": "TsKeywordType",
+                  "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 68,
+                    "start": 66,
                     "end": 74,
                     "ctxt": 0
                   },
-                  "kind": "string"
-                }
-              },
-              "optional": false
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 68,
+                      "end": 74,
+                      "ctxt": 0
+                    },
+                    "kind": "string"
+                  }
+                },
+                "optional": false
+              }
             },
             {
-              "type": "Identifier",
+              "type": "Parameter",
               "span": {
                 "start": 76,
                 "end": 85,
                 "ctxt": 0
               },
-              "value": "y",
-              "typeAnnotation": {
-                "type": "TsTypeAnnotation",
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
                 "span": {
-                  "start": 77,
+                  "start": 76,
                   "end": 85,
                   "ctxt": 0
                 },
+                "value": "y",
                 "typeAnnotation": {
-                  "type": "TsKeywordType",
+                  "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 79,
+                    "start": 77,
                     "end": 85,
                     "ctxt": 0
                   },
-                  "kind": "string"
-                }
-              },
-              "optional": false
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 79,
+                      "end": 85,
+                      "ctxt": 0
+                    },
+                    "kind": "string"
+                  }
+                },
+                "optional": false
+              }
             }
           ],
           "body": null,
@@ -203,58 +239,76 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "Parameter",
               "span": {
                 "start": 104,
                 "end": 110,
                 "ctxt": 0
               },
-              "value": "x",
-              "typeAnnotation": {
-                "type": "TsTypeAnnotation",
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
                 "span": {
-                  "start": 105,
+                  "start": 104,
                   "end": 110,
                   "ctxt": 0
                 },
+                "value": "x",
                 "typeAnnotation": {
-                  "type": "TsKeywordType",
+                  "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 107,
+                    "start": 105,
                     "end": 110,
                     "ctxt": 0
                   },
-                  "kind": "any"
-                }
-              },
-              "optional": false
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 107,
+                      "end": 110,
+                      "ctxt": 0
+                    },
+                    "kind": "any"
+                  }
+                },
+                "optional": false
+              }
             },
             {
-              "type": "Identifier",
+              "type": "Parameter",
               "span": {
                 "start": 112,
                 "end": 118,
                 "ctxt": 0
               },
-              "value": "y",
-              "typeAnnotation": {
-                "type": "TsTypeAnnotation",
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
                 "span": {
-                  "start": 113,
+                  "start": 112,
                   "end": 118,
                   "ctxt": 0
                 },
+                "value": "y",
                 "typeAnnotation": {
-                  "type": "TsKeywordType",
+                  "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 115,
+                    "start": 113,
                     "end": 118,
                     "ctxt": 0
                   },
-                  "kind": "any"
-                }
-              },
-              "optional": false
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 115,
+                      "end": 118,
+                      "ctxt": 0
+                    },
+                    "kind": "any"
+                  }
+                },
+                "optional": false
+              }
             }
           ],
           "body": {

--- a/ecmascript/parser/tests/typescript/class/method-generic/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/method-generic/input.ts.json
@@ -48,6 +48,7 @@
           "function": {
             "params": [
               {
+                "type": "Parameter",
                 "span": {
                   "start": 19,
                   "end": 23,
@@ -94,6 +95,7 @@
                 }
               },
               {
+                "type": "Parameter",
                 "span": {
                   "start": 25,
                   "end": 30,
@@ -140,6 +142,7 @@
                 }
               },
               {
+                "type": "Parameter",
                 "span": {
                   "start": 32,
                   "end": 41,

--- a/ecmascript/parser/tests/typescript/class/method-generic/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/method-generic/input.ts.json
@@ -48,130 +48,39 @@
           "function": {
             "params": [
               {
-                "type": "Identifier",
                 "span": {
                   "start": 19,
                   "end": 23,
                   "ctxt": 0
                 },
-                "value": "a",
-                "typeAnnotation": {
-                  "type": "TsTypeAnnotation",
+                "decorators": [],
+                "pat": {
+                  "type": "Identifier",
                   "span": {
-                    "start": 20,
+                    "start": 19,
                     "end": 23,
                     "ctxt": 0
                   },
+                  "value": "a",
                   "typeAnnotation": {
-                    "type": "TsTypeReference",
+                    "type": "TsTypeAnnotation",
                     "span": {
-                      "start": 22,
+                      "start": 20,
                       "end": 23,
                       "ctxt": 0
                     },
-                    "typeName": {
-                      "type": "Identifier",
+                    "typeAnnotation": {
+                      "type": "TsTypeReference",
                       "span": {
                         "start": 22,
                         "end": 23,
                         "ctxt": 0
                       },
-                      "value": "T",
-                      "typeAnnotation": null,
-                      "optional": false
-                    },
-                    "typeParams": null
-                  }
-                },
-                "optional": false
-              },
-              {
-                "type": "Identifier",
-                "span": {
-                  "start": 25,
-                  "end": 30,
-                  "ctxt": 0
-                },
-                "value": "b",
-                "typeAnnotation": {
-                  "type": "TsTypeAnnotation",
-                  "span": {
-                    "start": 27,
-                    "end": 30,
-                    "ctxt": 0
-                  },
-                  "typeAnnotation": {
-                    "type": "TsTypeReference",
-                    "span": {
-                      "start": 29,
-                      "end": 30,
-                      "ctxt": 0
-                    },
-                    "typeName": {
-                      "type": "Identifier",
-                      "span": {
-                        "start": 29,
-                        "end": 30,
-                        "ctxt": 0
-                      },
-                      "value": "T",
-                      "typeAnnotation": null,
-                      "optional": false
-                    },
-                    "typeParams": null
-                  }
-                },
-                "optional": true
-              },
-              {
-                "type": "RestElement",
-                "span": {
-                  "start": 32,
-                  "end": 41,
-                  "ctxt": 0
-                },
-                "rest": {
-                  "start": 32,
-                  "end": 35,
-                  "ctxt": 0
-                },
-                "argument": {
-                  "type": "Identifier",
-                  "span": {
-                    "start": 35,
-                    "end": 36,
-                    "ctxt": 0
-                  },
-                  "value": "c",
-                  "typeAnnotation": null,
-                  "optional": false
-                },
-                "typeAnnotation": {
-                  "type": "TsTypeAnnotation",
-                  "span": {
-                    "start": 36,
-                    "end": 41,
-                    "ctxt": 0
-                  },
-                  "typeAnnotation": {
-                    "type": "TsArrayType",
-                    "span": {
-                      "start": 38,
-                      "end": 41,
-                      "ctxt": 0
-                    },
-                    "elemType": {
-                      "type": "TsTypeReference",
-                      "span": {
-                        "start": 38,
-                        "end": 39,
-                        "ctxt": 0
-                      },
                       "typeName": {
                         "type": "Identifier",
                         "span": {
-                          "start": 38,
-                          "end": 39,
+                          "start": 22,
+                          "end": 23,
                           "ctxt": 0
                         },
                         "value": "T",
@@ -179,6 +88,121 @@
                         "optional": false
                       },
                       "typeParams": null
+                    }
+                  },
+                  "optional": false
+                }
+              },
+              {
+                "span": {
+                  "start": 25,
+                  "end": 30,
+                  "ctxt": 0
+                },
+                "decorators": [],
+                "pat": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 25,
+                    "end": 30,
+                    "ctxt": 0
+                  },
+                  "value": "b",
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 27,
+                      "end": 30,
+                      "ctxt": 0
+                    },
+                    "typeAnnotation": {
+                      "type": "TsTypeReference",
+                      "span": {
+                        "start": 29,
+                        "end": 30,
+                        "ctxt": 0
+                      },
+                      "typeName": {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 29,
+                          "end": 30,
+                          "ctxt": 0
+                        },
+                        "value": "T",
+                        "typeAnnotation": null,
+                        "optional": false
+                      },
+                      "typeParams": null
+                    }
+                  },
+                  "optional": true
+                }
+              },
+              {
+                "span": {
+                  "start": 32,
+                  "end": 41,
+                  "ctxt": 0
+                },
+                "decorators": [],
+                "pat": {
+                  "type": "RestElement",
+                  "span": {
+                    "start": 32,
+                    "end": 41,
+                    "ctxt": 0
+                  },
+                  "rest": {
+                    "start": 32,
+                    "end": 35,
+                    "ctxt": 0
+                  },
+                  "argument": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 35,
+                      "end": 36,
+                      "ctxt": 0
+                    },
+                    "value": "c",
+                    "typeAnnotation": null,
+                    "optional": false
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 36,
+                      "end": 41,
+                      "ctxt": 0
+                    },
+                    "typeAnnotation": {
+                      "type": "TsArrayType",
+                      "span": {
+                        "start": 38,
+                        "end": 41,
+                        "ctxt": 0
+                      },
+                      "elemType": {
+                        "type": "TsTypeReference",
+                        "span": {
+                          "start": 38,
+                          "end": 39,
+                          "ctxt": 0
+                        },
+                        "typeName": {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 38,
+                            "end": 39,
+                            "ctxt": 0
+                          },
+                          "value": "T",
+                          "typeAnnotation": null,
+                          "optional": false
+                        },
+                        "typeParams": null
+                      }
                     }
                   }
                 }

--- a/ecmascript/parser/tests/typescript/custom/arrow/complex/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/arrow/complex/input.ts.json
@@ -29,115 +29,139 @@
         "declare": false,
         "params": [
           {
-            "type": "Identifier",
             "span": {
               "start": 49,
               "end": 99,
               "ctxt": 0
             },
-            "value": "tsConfigSourceFile",
-            "typeAnnotation": {
-              "type": "TsTypeAnnotation",
+            "decorators": [],
+            "pat": {
+              "type": "Identifier",
               "span": {
-                "start": 67,
+                "start": 49,
                 "end": 99,
                 "ctxt": 0
               },
+              "value": "tsConfigSourceFile",
               "typeAnnotation": {
-                "type": "TsUnionType",
+                "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 69,
+                  "start": 67,
                   "end": 99,
                   "ctxt": 0
                 },
-                "types": [
-                  {
-                    "type": "TsTypeReference",
-                    "span": {
-                      "start": 69,
-                      "end": 87,
-                      "ctxt": 0
-                    },
-                    "typeName": {
-                      "type": "Identifier",
+                "typeAnnotation": {
+                  "type": "TsUnionType",
+                  "span": {
+                    "start": 69,
+                    "end": 99,
+                    "ctxt": 0
+                  },
+                  "types": [
+                    {
+                      "type": "TsTypeReference",
                       "span": {
                         "start": 69,
                         "end": 87,
                         "ctxt": 0
                       },
-                      "value": "TsConfigSourceFile",
-                      "typeAnnotation": null,
-                      "optional": false
+                      "typeName": {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 69,
+                          "end": 87,
+                          "ctxt": 0
+                        },
+                        "value": "TsConfigSourceFile",
+                        "typeAnnotation": null,
+                        "optional": false
+                      },
+                      "typeParams": null
                     },
-                    "typeParams": null
-                  },
-                  {
-                    "type": "TsKeywordType",
-                    "span": {
-                      "start": 90,
-                      "end": 99,
-                      "ctxt": 0
-                    },
-                    "kind": "undefined"
-                  }
-                ]
-              }
-            },
-            "optional": false
+                    {
+                      "type": "TsKeywordType",
+                      "span": {
+                        "start": 90,
+                        "end": 99,
+                        "ctxt": 0
+                      },
+                      "kind": "undefined"
+                    }
+                  ]
+                }
+              },
+              "optional": false
+            }
           },
           {
-            "type": "Identifier",
             "span": {
               "start": 101,
               "end": 116,
               "ctxt": 0
             },
-            "value": "propKey",
-            "typeAnnotation": {
-              "type": "TsTypeAnnotation",
+            "decorators": [],
+            "pat": {
+              "type": "Identifier",
               "span": {
-                "start": 108,
+                "start": 101,
                 "end": 116,
                 "ctxt": 0
               },
+              "value": "propKey",
               "typeAnnotation": {
-                "type": "TsKeywordType",
+                "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 110,
+                  "start": 108,
                   "end": 116,
                   "ctxt": 0
                 },
-                "kind": "string"
-              }
-            },
-            "optional": false
+                "typeAnnotation": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 110,
+                    "end": 116,
+                    "ctxt": 0
+                  },
+                  "kind": "string"
+                }
+              },
+              "optional": false
+            }
           },
           {
-            "type": "Identifier",
             "span": {
               "start": 118,
               "end": 138,
               "ctxt": 0
             },
-            "value": "elementValue",
-            "typeAnnotation": {
-              "type": "TsTypeAnnotation",
+            "decorators": [],
+            "pat": {
+              "type": "Identifier",
               "span": {
-                "start": 130,
+                "start": 118,
                 "end": 138,
                 "ctxt": 0
               },
+              "value": "elementValue",
               "typeAnnotation": {
-                "type": "TsKeywordType",
+                "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 132,
+                  "start": 130,
                   "end": 138,
                   "ctxt": 0
                 },
-                "kind": "string"
-              }
-            },
-            "optional": false
+                "typeAnnotation": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 132,
+                    "end": 138,
+                    "ctxt": 0
+                  },
+                  "kind": "string"
+                }
+              },
+              "optional": false
+            }
           }
         ],
         "decorators": [],

--- a/ecmascript/parser/tests/typescript/custom/arrow/complex/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/arrow/complex/input.ts.json
@@ -29,6 +29,7 @@
         "declare": false,
         "params": [
           {
+            "type": "Parameter",
             "span": {
               "start": 49,
               "end": 99,
@@ -94,6 +95,7 @@
             }
           },
           {
+            "type": "Parameter",
             "span": {
               "start": 101,
               "end": 116,
@@ -129,6 +131,7 @@
             }
           },
           {
+            "type": "Parameter",
             "span": {
               "start": 118,
               "end": 138,

--- a/ecmascript/parser/tests/typescript/custom/default-followed-by-type/function/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/default-followed-by-type/function/input.ts.json
@@ -22,6 +22,7 @@
       "declare": false,
       "params": [
         {
+          "type": "Parameter",
           "span": {
             "start": 14,
             "end": 40,
@@ -76,6 +77,7 @@
           }
         },
         {
+          "type": "Parameter",
           "span": {
             "start": 42,
             "end": 56,

--- a/ecmascript/parser/tests/typescript/custom/default-followed-by-type/function/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/default-followed-by-type/function/input.ts.json
@@ -22,77 +22,93 @@
       "declare": false,
       "params": [
         {
-          "type": "AssignmentPattern",
           "span": {
             "start": 14,
             "end": 40,
             "ctxt": 0
           },
-          "left": {
-            "type": "Identifier",
+          "decorators": [],
+          "pat": {
+            "type": "AssignmentPattern",
             "span": {
               "start": 14,
-              "end": 30,
+              "end": 40,
               "ctxt": 0
             },
-            "value": "greeting",
+            "left": {
+              "type": "Identifier",
+              "span": {
+                "start": 14,
+                "end": 30,
+                "ctxt": 0
+              },
+              "value": "greeting",
+              "typeAnnotation": {
+                "type": "TsTypeAnnotation",
+                "span": {
+                  "start": 22,
+                  "end": 30,
+                  "ctxt": 0
+                },
+                "typeAnnotation": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 24,
+                    "end": 30,
+                    "ctxt": 0
+                  },
+                  "kind": "string"
+                }
+              },
+              "optional": false
+            },
+            "right": {
+              "type": "StringLiteral",
+              "span": {
+                "start": 33,
+                "end": 40,
+                "ctxt": 0
+              },
+              "value": "Hello",
+              "hasEscape": false
+            },
+            "typeAnnotation": null
+          }
+        },
+        {
+          "span": {
+            "start": 42,
+            "end": 56,
+            "ctxt": 0
+          },
+          "decorators": [],
+          "pat": {
+            "type": "Identifier",
+            "span": {
+              "start": 42,
+              "end": 56,
+              "ctxt": 0
+            },
+            "value": "target",
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 22,
-                "end": 30,
+                "start": 48,
+                "end": 56,
                 "ctxt": 0
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 24,
-                  "end": 30,
+                  "start": 50,
+                  "end": 56,
                   "ctxt": 0
                 },
                 "kind": "string"
               }
             },
             "optional": false
-          },
-          "right": {
-            "type": "StringLiteral",
-            "span": {
-              "start": 33,
-              "end": 40,
-              "ctxt": 0
-            },
-            "value": "Hello",
-            "hasEscape": false
-          },
-          "typeAnnotation": null
-        },
-        {
-          "type": "Identifier",
-          "span": {
-            "start": 42,
-            "end": 56,
-            "ctxt": 0
-          },
-          "value": "target",
-          "typeAnnotation": {
-            "type": "TsTypeAnnotation",
-            "span": {
-              "start": 48,
-              "end": 56,
-              "ctxt": 0
-            },
-            "typeAnnotation": {
-              "type": "TsKeywordType",
-              "span": {
-                "start": 50,
-                "end": 56,
-                "ctxt": 0
-              },
-              "kind": "string"
-            }
-          },
-          "optional": false
+          }
         }
       ],
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/custom/issue-236/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-236/input.ts.json
@@ -29,135 +29,159 @@
         "declare": false,
         "params": [
           {
-            "type": "Identifier",
             "span": {
               "start": 52,
               "end": 61,
               "ctxt": 0
             },
-            "value": "this",
-            "typeAnnotation": {
-              "type": "TsTypeAnnotation",
+            "decorators": [],
+            "pat": {
+              "type": "Identifier",
               "span": {
-                "start": 56,
+                "start": 52,
                 "end": 61,
                 "ctxt": 0
               },
+              "value": "this",
               "typeAnnotation": {
-                "type": "TsKeywordType",
+                "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 58,
+                  "start": 56,
                   "end": 61,
                   "ctxt": 0
                 },
-                "kind": "any"
-              }
-            },
-            "optional": false
+                "typeAnnotation": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 58,
+                    "end": 61,
+                    "ctxt": 0
+                  },
+                  "kind": "any"
+                }
+              },
+              "optional": false
+            }
           },
           {
-            "type": "Identifier",
             "span": {
               "start": 63,
               "end": 85,
               "ctxt": 0
             },
-            "value": "$scope",
-            "typeAnnotation": {
-              "type": "TsTypeAnnotation",
+            "decorators": [],
+            "pat": {
+              "type": "Identifier",
               "span": {
-                "start": 69,
+                "start": 63,
                 "end": 85,
                 "ctxt": 0
               },
+              "value": "$scope",
               "typeAnnotation": {
-                "type": "TsTypeReference",
+                "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 71,
+                  "start": 69,
                   "end": 85,
                   "ctxt": 0
                 },
-                "typeName": {
-                  "type": "TsQualifiedName",
-                  "left": {
-                    "type": "Identifier",
-                    "span": {
-                      "start": 71,
-                      "end": 78,
-                      "ctxt": 0
-                    },
-                    "value": "angular",
-                    "typeAnnotation": null,
-                    "optional": false
+                "typeAnnotation": {
+                  "type": "TsTypeReference",
+                  "span": {
+                    "start": 71,
+                    "end": 85,
+                    "ctxt": 0
                   },
-                  "right": {
-                    "type": "Identifier",
-                    "span": {
-                      "start": 79,
-                      "end": 85,
-                      "ctxt": 0
+                  "typeName": {
+                    "type": "TsQualifiedName",
+                    "left": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 71,
+                        "end": 78,
+                        "ctxt": 0
+                      },
+                      "value": "angular",
+                      "typeAnnotation": null,
+                      "optional": false
                     },
-                    "value": "IScope",
-                    "typeAnnotation": null,
-                    "optional": false
-                  }
-                },
-                "typeParams": null
-              }
-            },
-            "optional": false
+                    "right": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 79,
+                        "end": 85,
+                        "ctxt": 0
+                      },
+                      "value": "IScope",
+                      "typeAnnotation": null,
+                      "optional": false
+                    }
+                  },
+                  "typeParams": null
+                }
+              },
+              "optional": false
+            }
           },
           {
-            "type": "Identifier",
             "span": {
               "start": 87,
               "end": 114,
               "ctxt": 0
             },
-            "value": "$attrs",
-            "typeAnnotation": {
-              "type": "TsTypeAnnotation",
+            "decorators": [],
+            "pat": {
+              "type": "Identifier",
               "span": {
-                "start": 93,
+                "start": 87,
                 "end": 114,
                 "ctxt": 0
               },
+              "value": "$attrs",
               "typeAnnotation": {
-                "type": "TsTypeReference",
+                "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 95,
+                  "start": 93,
                   "end": 114,
                   "ctxt": 0
                 },
-                "typeName": {
-                  "type": "TsQualifiedName",
-                  "left": {
-                    "type": "Identifier",
-                    "span": {
-                      "start": 95,
-                      "end": 102,
-                      "ctxt": 0
-                    },
-                    "value": "angular",
-                    "typeAnnotation": null,
-                    "optional": false
+                "typeAnnotation": {
+                  "type": "TsTypeReference",
+                  "span": {
+                    "start": 95,
+                    "end": 114,
+                    "ctxt": 0
                   },
-                  "right": {
-                    "type": "Identifier",
-                    "span": {
-                      "start": 103,
-                      "end": 114,
-                      "ctxt": 0
+                  "typeName": {
+                    "type": "TsQualifiedName",
+                    "left": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 95,
+                        "end": 102,
+                        "ctxt": 0
+                      },
+                      "value": "angular",
+                      "typeAnnotation": null,
+                      "optional": false
                     },
-                    "value": "IAttributes",
-                    "typeAnnotation": null,
-                    "optional": false
-                  }
-                },
-                "typeParams": null
-              }
-            },
-            "optional": false
+                    "right": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 103,
+                        "end": 114,
+                        "ctxt": 0
+                      },
+                      "value": "IAttributes",
+                      "typeAnnotation": null,
+                      "optional": false
+                    }
+                  },
+                  "typeParams": null
+                }
+              },
+              "optional": false
+            }
           }
         ],
         "decorators": [],

--- a/ecmascript/parser/tests/typescript/custom/issue-236/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-236/input.ts.json
@@ -29,6 +29,7 @@
         "declare": false,
         "params": [
           {
+            "type": "Parameter",
             "span": {
               "start": 52,
               "end": 61,
@@ -64,6 +65,7 @@
             }
           },
           {
+            "type": "Parameter",
             "span": {
               "start": 63,
               "end": 85,
@@ -124,6 +126,7 @@
             }
           },
           {
+            "type": "Parameter",
             "span": {
               "start": 87,
               "end": 114,

--- a/ecmascript/parser/tests/typescript/custom/issue-496/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-496/input.ts.json
@@ -99,31 +99,40 @@
             },
             "params": [
               {
-                "type": "Identifier",
+                "type": "Parameter",
                 "span": {
                   "start": 62,
                   "end": 74,
                   "ctxt": 0
                 },
-                "value": "variant",
-                "typeAnnotation": {
-                  "type": "TsTypeAnnotation",
+                "decorators": [],
+                "pat": {
+                  "type": "Identifier",
                   "span": {
-                    "start": 69,
+                    "start": 62,
                     "end": 74,
                     "ctxt": 0
                   },
+                  "value": "variant",
                   "typeAnnotation": {
-                    "type": "TsKeywordType",
+                    "type": "TsTypeAnnotation",
                     "span": {
-                      "start": 71,
+                      "start": 69,
                       "end": 74,
                       "ctxt": 0
                     },
-                    "kind": "any"
-                  }
-                },
-                "optional": false
+                    "typeAnnotation": {
+                      "type": "TsKeywordType",
+                      "span": {
+                        "start": 71,
+                        "end": 74,
+                        "ctxt": 0
+                      },
+                      "kind": "any"
+                    }
+                  },
+                  "optional": false
+                }
               }
             ],
             "body": {

--- a/ecmascript/parser/tests/typescript/custom/issue-709-2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-709-2/input.ts.json
@@ -54,48 +54,57 @@
             },
             "params": [
               {
-                "type": "ArrayPattern",
+                "type": "Parameter",
                 "span": {
                   "start": 49,
                   "end": 65,
                   "ctxt": 0
                 },
-                "elements": [
-                  {
-                    "type": "Identifier",
-                    "span": {
-                      "start": 51,
-                      "end": 52,
-                      "ctxt": 0
-                    },
-                    "value": "t",
-                    "typeAnnotation": null,
-                    "optional": false
-                  }
-                ],
-                "optional": true,
-                "typeAnnotation": {
-                  "type": "TsTypeAnnotation",
+                "decorators": [],
+                "pat": {
+                  "type": "ArrayPattern",
                   "span": {
-                    "start": 55,
+                    "start": 49,
                     "end": 65,
                     "ctxt": 0
                   },
+                  "elements": [
+                    {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 51,
+                        "end": 52,
+                        "ctxt": 0
+                      },
+                      "value": "t",
+                      "typeAnnotation": null,
+                      "optional": false
+                    }
+                  ],
+                  "optional": true,
                   "typeAnnotation": {
-                    "type": "TsArrayType",
+                    "type": "TsTypeAnnotation",
                     "span": {
-                      "start": 57,
+                      "start": 55,
                       "end": 65,
                       "ctxt": 0
                     },
-                    "elemType": {
-                      "type": "TsKeywordType",
+                    "typeAnnotation": {
+                      "type": "TsArrayType",
                       "span": {
                         "start": 57,
-                        "end": 63,
+                        "end": 65,
                         "ctxt": 0
                       },
-                      "kind": "string"
+                      "elemType": {
+                        "type": "TsKeywordType",
+                        "span": {
+                          "start": 57,
+                          "end": 63,
+                          "ctxt": 0
+                        },
+                        "kind": "string"
+                      }
                     }
                   }
                 }

--- a/ecmascript/parser/tests/typescript/custom/issue-709-3/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-709-3/input.ts.json
@@ -54,93 +54,102 @@
             },
             "params": [
               {
-                "type": "ObjectPattern",
+                "type": "Parameter",
                 "span": {
                   "start": 49,
                   "end": 68,
                   "ctxt": 0
                 },
-                "properties": [
-                  {
-                    "type": "AssignmentPatternProperty",
-                    "span": {
-                      "start": 51,
-                      "end": 52,
-                      "ctxt": 0
-                    },
-                    "key": {
-                      "type": "Identifier",
+                "decorators": [],
+                "pat": {
+                  "type": "ObjectPattern",
+                  "span": {
+                    "start": 49,
+                    "end": 68,
+                    "ctxt": 0
+                  },
+                  "properties": [
+                    {
+                      "type": "AssignmentPatternProperty",
                       "span": {
                         "start": 51,
                         "end": 52,
                         "ctxt": 0
                       },
-                      "value": "t",
-                      "typeAnnotation": null,
-                      "optional": false
-                    },
-                    "value": null
-                  }
-                ],
-                "optional": true,
-                "typeAnnotation": {
-                  "type": "TsTypeAnnotation",
-                  "span": {
-                    "start": 55,
-                    "end": 68,
-                    "ctxt": 0
-                  },
+                      "key": {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 51,
+                          "end": 52,
+                          "ctxt": 0
+                        },
+                        "value": "t",
+                        "typeAnnotation": null,
+                        "optional": false
+                      },
+                      "value": null
+                    }
+                  ],
+                  "optional": true,
                   "typeAnnotation": {
-                    "type": "TsTypeLiteral",
+                    "type": "TsTypeAnnotation",
                     "span": {
-                      "start": 57,
+                      "start": 55,
                       "end": 68,
                       "ctxt": 0
                     },
-                    "members": [
-                      {
-                        "type": "TsPropertySignature",
-                        "span": {
-                          "start": 59,
-                          "end": 66,
-                          "ctxt": 0
-                        },
-                        "readonly": false,
-                        "key": {
-                          "type": "Identifier",
+                    "typeAnnotation": {
+                      "type": "TsTypeLiteral",
+                      "span": {
+                        "start": 57,
+                        "end": 68,
+                        "ctxt": 0
+                      },
+                      "members": [
+                        {
+                          "type": "TsPropertySignature",
                           "span": {
                             "start": 59,
-                            "end": 60,
-                            "ctxt": 0
-                          },
-                          "value": "t",
-                          "typeAnnotation": null,
-                          "optional": false
-                        },
-                        "computed": false,
-                        "optional": true,
-                        "init": null,
-                        "params": [],
-                        "typeAnnotation": {
-                          "type": "TsTypeAnnotation",
-                          "span": {
-                            "start": 61,
                             "end": 66,
                             "ctxt": 0
                           },
-                          "typeAnnotation": {
-                            "type": "TsKeywordType",
+                          "readonly": false,
+                          "key": {
+                            "type": "Identifier",
                             "span": {
-                              "start": 63,
+                              "start": 59,
+                              "end": 60,
+                              "ctxt": 0
+                            },
+                            "value": "t",
+                            "typeAnnotation": null,
+                            "optional": false
+                          },
+                          "computed": false,
+                          "optional": true,
+                          "init": null,
+                          "params": [],
+                          "typeAnnotation": {
+                            "type": "TsTypeAnnotation",
+                            "span": {
+                              "start": 61,
                               "end": 66,
                               "ctxt": 0
                             },
-                            "kind": "any"
-                          }
-                        },
-                        "typeParams": null
-                      }
-                    ]
+                            "typeAnnotation": {
+                              "type": "TsKeywordType",
+                              "span": {
+                                "start": 63,
+                                "end": 66,
+                                "ctxt": 0
+                              },
+                              "kind": "any"
+                            }
+                          },
+                          "typeParams": null
+                        }
+                      ]
+                    }
                   }
                 }
               }

--- a/ecmascript/parser/tests/typescript/custom/issue-709/input.d.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-709/input.d.ts.json
@@ -82,274 +82,283 @@
                   },
                   "params": [
                     {
-                      "type": "ObjectPattern",
+                      "type": "Parameter",
                       "span": {
                         "start": 77,
                         "end": 349,
                         "ctxt": 0
                       },
-                      "properties": [
-                        {
-                          "type": "AssignmentPatternProperty",
-                          "span": {
-                            "start": 103,
-                            "end": 110,
-                            "ctxt": 0
-                          },
-                          "key": {
-                            "type": "Identifier",
+                      "decorators": [],
+                      "pat": {
+                        "type": "ObjectPattern",
+                        "span": {
+                          "start": 77,
+                          "end": 349,
+                          "ctxt": 0
+                        },
+                        "properties": [
+                          {
+                            "type": "AssignmentPatternProperty",
                             "span": {
                               "start": 103,
                               "end": 110,
                               "ctxt": 0
                             },
-                            "value": "bubbles",
-                            "typeAnnotation": null,
-                            "optional": false
+                            "key": {
+                              "type": "Identifier",
+                              "span": {
+                                "start": 103,
+                                "end": 110,
+                                "ctxt": 0
+                              },
+                              "value": "bubbles",
+                              "typeAnnotation": null,
+                              "optional": false
+                            },
+                            "value": null
                           },
-                          "value": null
-                        },
-                        {
-                          "type": "AssignmentPatternProperty",
-                          "span": {
-                            "start": 136,
-                            "end": 146,
-                            "ctxt": 0
-                          },
-                          "key": {
-                            "type": "Identifier",
+                          {
+                            "type": "AssignmentPatternProperty",
                             "span": {
                               "start": 136,
                               "end": 146,
                               "ctxt": 0
                             },
-                            "value": "cancelable",
-                            "typeAnnotation": null,
-                            "optional": false
+                            "key": {
+                              "type": "Identifier",
+                              "span": {
+                                "start": 136,
+                                "end": 146,
+                                "ctxt": 0
+                              },
+                              "value": "cancelable",
+                              "typeAnnotation": null,
+                              "optional": false
+                            },
+                            "value": null
                           },
-                          "value": null
-                        },
-                        {
-                          "type": "AssignmentPatternProperty",
-                          "span": {
-                            "start": 172,
-                            "end": 180,
-                            "ctxt": 0
-                          },
-                          "key": {
-                            "type": "Identifier",
+                          {
+                            "type": "AssignmentPatternProperty",
                             "span": {
                               "start": 172,
                               "end": 180,
                               "ctxt": 0
                             },
-                            "value": "composed",
-                            "typeAnnotation": null,
-                            "optional": false
-                          },
-                          "value": null
-                        }
-                      ],
-                      "optional": true,
-                      "typeAnnotation": {
-                        "type": "TsTypeAnnotation",
-                        "span": {
-                          "start": 203,
-                          "end": 349,
-                          "ctxt": 0
-                        },
+                            "key": {
+                              "type": "Identifier",
+                              "span": {
+                                "start": 172,
+                                "end": 180,
+                                "ctxt": 0
+                              },
+                              "value": "composed",
+                              "typeAnnotation": null,
+                              "optional": false
+                            },
+                            "value": null
+                          }
+                        ],
+                        "optional": true,
                         "typeAnnotation": {
-                          "type": "TsTypeLiteral",
+                          "type": "TsTypeAnnotation",
                           "span": {
-                            "start": 205,
+                            "start": 203,
                             "end": 349,
                             "ctxt": 0
                           },
-                          "members": [
-                            {
-                              "type": "TsPropertySignature",
-                              "span": {
-                                "start": 219,
-                                "end": 249,
-                                "ctxt": 0
-                              },
-                              "readonly": false,
-                              "key": {
-                                "type": "Identifier",
+                          "typeAnnotation": {
+                            "type": "TsTypeLiteral",
+                            "span": {
+                              "start": 205,
+                              "end": 349,
+                              "ctxt": 0
+                            },
+                            "members": [
+                              {
+                                "type": "TsPropertySignature",
                                 "span": {
                                   "start": 219,
-                                  "end": 226,
+                                  "end": 249,
                                   "ctxt": 0
                                 },
-                                "value": "bubbles",
-                                "typeAnnotation": null,
-                                "optional": false
-                              },
-                              "computed": false,
-                              "optional": true,
-                              "init": null,
-                              "params": [],
-                              "typeAnnotation": {
-                                "type": "TsTypeAnnotation",
-                                "span": {
-                                  "start": 227,
-                                  "end": 248,
-                                  "ctxt": 0
-                                },
-                                "typeAnnotation": {
-                                  "type": "TsUnionType",
+                                "readonly": false,
+                                "key": {
+                                  "type": "Identifier",
                                   "span": {
-                                    "start": 229,
+                                    "start": 219,
+                                    "end": 226,
+                                    "ctxt": 0
+                                  },
+                                  "value": "bubbles",
+                                  "typeAnnotation": null,
+                                  "optional": false
+                                },
+                                "computed": false,
+                                "optional": true,
+                                "init": null,
+                                "params": [],
+                                "typeAnnotation": {
+                                  "type": "TsTypeAnnotation",
+                                  "span": {
+                                    "start": 227,
                                     "end": 248,
                                     "ctxt": 0
                                   },
-                                  "types": [
-                                    {
-                                      "type": "TsKeywordType",
-                                      "span": {
-                                        "start": 229,
-                                        "end": 236,
-                                        "ctxt": 0
-                                      },
-                                      "kind": "boolean"
+                                  "typeAnnotation": {
+                                    "type": "TsUnionType",
+                                    "span": {
+                                      "start": 229,
+                                      "end": 248,
+                                      "ctxt": 0
                                     },
-                                    {
-                                      "type": "TsKeywordType",
-                                      "span": {
-                                        "start": 239,
-                                        "end": 248,
-                                        "ctxt": 0
+                                    "types": [
+                                      {
+                                        "type": "TsKeywordType",
+                                        "span": {
+                                          "start": 229,
+                                          "end": 236,
+                                          "ctxt": 0
+                                        },
+                                        "kind": "boolean"
                                       },
-                                      "kind": "undefined"
-                                    }
-                                  ]
-                                }
+                                      {
+                                        "type": "TsKeywordType",
+                                        "span": {
+                                          "start": 239,
+                                          "end": 248,
+                                          "ctxt": 0
+                                        },
+                                        "kind": "undefined"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "typeParams": null
                               },
-                              "typeParams": null
-                            },
-                            {
-                              "type": "TsPropertySignature",
-                              "span": {
-                                "start": 262,
-                                "end": 295,
-                                "ctxt": 0
-                              },
-                              "readonly": false,
-                              "key": {
-                                "type": "Identifier",
+                              {
+                                "type": "TsPropertySignature",
                                 "span": {
                                   "start": 262,
-                                  "end": 272,
+                                  "end": 295,
                                   "ctxt": 0
                                 },
-                                "value": "cancelable",
-                                "typeAnnotation": null,
-                                "optional": false
-                              },
-                              "computed": false,
-                              "optional": true,
-                              "init": null,
-                              "params": [],
-                              "typeAnnotation": {
-                                "type": "TsTypeAnnotation",
-                                "span": {
-                                  "start": 273,
-                                  "end": 294,
-                                  "ctxt": 0
-                                },
-                                "typeAnnotation": {
-                                  "type": "TsUnionType",
+                                "readonly": false,
+                                "key": {
+                                  "type": "Identifier",
                                   "span": {
-                                    "start": 275,
+                                    "start": 262,
+                                    "end": 272,
+                                    "ctxt": 0
+                                  },
+                                  "value": "cancelable",
+                                  "typeAnnotation": null,
+                                  "optional": false
+                                },
+                                "computed": false,
+                                "optional": true,
+                                "init": null,
+                                "params": [],
+                                "typeAnnotation": {
+                                  "type": "TsTypeAnnotation",
+                                  "span": {
+                                    "start": 273,
                                     "end": 294,
                                     "ctxt": 0
                                   },
-                                  "types": [
-                                    {
-                                      "type": "TsKeywordType",
-                                      "span": {
-                                        "start": 275,
-                                        "end": 282,
-                                        "ctxt": 0
-                                      },
-                                      "kind": "boolean"
+                                  "typeAnnotation": {
+                                    "type": "TsUnionType",
+                                    "span": {
+                                      "start": 275,
+                                      "end": 294,
+                                      "ctxt": 0
                                     },
-                                    {
-                                      "type": "TsKeywordType",
-                                      "span": {
-                                        "start": 285,
-                                        "end": 294,
-                                        "ctxt": 0
+                                    "types": [
+                                      {
+                                        "type": "TsKeywordType",
+                                        "span": {
+                                          "start": 275,
+                                          "end": 282,
+                                          "ctxt": 0
+                                        },
+                                        "kind": "boolean"
                                       },
-                                      "kind": "undefined"
-                                    }
-                                  ]
-                                }
+                                      {
+                                        "type": "TsKeywordType",
+                                        "span": {
+                                          "start": 285,
+                                          "end": 294,
+                                          "ctxt": 0
+                                        },
+                                        "kind": "undefined"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "typeParams": null
                               },
-                              "typeParams": null
-                            },
-                            {
-                              "type": "TsPropertySignature",
-                              "span": {
-                                "start": 308,
-                                "end": 339,
-                                "ctxt": 0
-                              },
-                              "readonly": false,
-                              "key": {
-                                "type": "Identifier",
+                              {
+                                "type": "TsPropertySignature",
                                 "span": {
                                   "start": 308,
-                                  "end": 316,
+                                  "end": 339,
                                   "ctxt": 0
                                 },
-                                "value": "composed",
-                                "typeAnnotation": null,
-                                "optional": false
-                              },
-                              "computed": false,
-                              "optional": true,
-                              "init": null,
-                              "params": [],
-                              "typeAnnotation": {
-                                "type": "TsTypeAnnotation",
-                                "span": {
-                                  "start": 317,
-                                  "end": 338,
-                                  "ctxt": 0
-                                },
-                                "typeAnnotation": {
-                                  "type": "TsUnionType",
+                                "readonly": false,
+                                "key": {
+                                  "type": "Identifier",
                                   "span": {
-                                    "start": 319,
+                                    "start": 308,
+                                    "end": 316,
+                                    "ctxt": 0
+                                  },
+                                  "value": "composed",
+                                  "typeAnnotation": null,
+                                  "optional": false
+                                },
+                                "computed": false,
+                                "optional": true,
+                                "init": null,
+                                "params": [],
+                                "typeAnnotation": {
+                                  "type": "TsTypeAnnotation",
+                                  "span": {
+                                    "start": 317,
                                     "end": 338,
                                     "ctxt": 0
                                   },
-                                  "types": [
-                                    {
-                                      "type": "TsKeywordType",
-                                      "span": {
-                                        "start": 319,
-                                        "end": 326,
-                                        "ctxt": 0
-                                      },
-                                      "kind": "boolean"
+                                  "typeAnnotation": {
+                                    "type": "TsUnionType",
+                                    "span": {
+                                      "start": 319,
+                                      "end": 338,
+                                      "ctxt": 0
                                     },
-                                    {
-                                      "type": "TsKeywordType",
-                                      "span": {
-                                        "start": 329,
-                                        "end": 338,
-                                        "ctxt": 0
+                                    "types": [
+                                      {
+                                        "type": "TsKeywordType",
+                                        "span": {
+                                          "start": 319,
+                                          "end": 326,
+                                          "ctxt": 0
+                                        },
+                                        "kind": "boolean"
                                       },
-                                      "kind": "undefined"
-                                    }
-                                  ]
-                                }
-                              },
-                              "typeParams": null
-                            }
-                          ]
+                                      {
+                                        "type": "TsKeywordType",
+                                        "span": {
+                                          "start": 329,
+                                          "end": 338,
+                                          "ctxt": 0
+                                        },
+                                        "kind": "undefined"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "typeParams": null
+                              }
+                            ]
+                          }
                         }
                       }
                     }

--- a/ecmascript/parser/tests/typescript/custom/issue-717/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-717/input.ts.json
@@ -22,31 +22,39 @@
       "declare": false,
       "params": [
         {
-          "type": "Identifier",
           "span": {
             "start": 23,
             "end": 37,
             "ctxt": 0
           },
-          "value": "async",
-          "typeAnnotation": {
-            "type": "TsTypeAnnotation",
+          "decorators": [],
+          "pat": {
+            "type": "Identifier",
             "span": {
-              "start": 28,
+              "start": 23,
               "end": 37,
               "ctxt": 0
             },
+            "value": "async",
             "typeAnnotation": {
-              "type": "TsKeywordType",
+              "type": "TsTypeAnnotation",
               "span": {
-                "start": 30,
+                "start": 28,
                 "end": 37,
                 "ctxt": 0
               },
-              "kind": "boolean"
-            }
-          },
-          "optional": false
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 30,
+                  "end": 37,
+                  "ctxt": 0
+                },
+                "kind": "boolean"
+              }
+            },
+            "optional": false
+          }
         }
       ],
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/custom/issue-717/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-717/input.ts.json
@@ -22,6 +22,7 @@
       "declare": false,
       "params": [
         {
+          "type": "Parameter",
           "span": {
             "start": 23,
             "end": 37,

--- a/ecmascript/parser/tests/typescript/decorators/parameter/input.ts
+++ b/ecmascript/parser/tests/typescript/decorators/parameter/input.ts
@@ -1,0 +1,7 @@
+class Test {
+    constructor(@p1 t1, @p2 private t2) {
+    }
+
+    method(@p1 t1, @p1 @p2 ...t2) {
+    }
+}

--- a/ecmascript/parser/tests/typescript/decorators/parameter/input.ts
+++ b/ecmascript/parser/tests/typescript/decorators/parameter/input.ts
@@ -1,5 +1,5 @@
 class Test {
-    constructor(@p1 t1, @p2 private t2) {
+    constructor(@p1 t1, @p2 private t2, @p3 ...t3) {
     }
 
     method(@p1 t1, @p1 @p2 ...t2) {

--- a/ecmascript/parser/tests/typescript/decorators/parameter/input.ts.json
+++ b/ecmascript/parser/tests/typescript/decorators/parameter/input.ts.json
@@ -1,0 +1,282 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 0,
+    "end": 105,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ClassDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 6,
+          "end": 10,
+          "ctxt": 0
+        },
+        "value": "Test",
+        "typeAnnotation": null,
+        "optional": false
+      },
+      "declare": false,
+      "span": {
+        "start": 0,
+        "end": 105,
+        "ctxt": 0
+      },
+      "decorators": [],
+      "body": [
+        {
+          "type": "Constructor",
+          "span": {
+            "start": 17,
+            "end": 60,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 17,
+              "end": 28,
+              "ctxt": 0
+            },
+            "value": "constructor",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "params": [
+            {
+              "type": "Identifier",
+              "span": {
+                "start": 33,
+                "end": 35,
+                "ctxt": 0
+              },
+              "value": "t1",
+              "typeAnnotation": null,
+              "optional": false
+            },
+            {
+              "type": "TsParameterProperty",
+              "span": {
+                "start": 37,
+                "end": 51,
+                "ctxt": 0
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "span": {
+                    "start": 37,
+                    "end": 40,
+                    "ctxt": 0
+                  },
+                  "expression": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 38,
+                      "end": 40,
+                      "ctxt": 0
+                    },
+                    "value": "p2",
+                    "typeAnnotation": null,
+                    "optional": false
+                  }
+                }
+              ],
+              "accessibility": "private",
+              "readonly": false,
+              "param": {
+                "type": "Identifier",
+                "span": {
+                  "start": 49,
+                  "end": 51,
+                  "ctxt": 0
+                },
+                "value": "t2",
+                "typeAnnotation": null,
+                "optional": false
+              }
+            }
+          ],
+          "body": {
+            "type": "BlockStatement",
+            "span": {
+              "start": 53,
+              "end": 60,
+              "ctxt": 0
+            },
+            "stmts": []
+          },
+          "accessibility": null,
+          "isOptional": false
+        },
+        {
+          "type": "ClassMethod",
+          "span": {
+            "start": 66,
+            "end": 103,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 66,
+              "end": 72,
+              "ctxt": 0
+            },
+            "value": "method",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "function": {
+            "params": [
+              {
+                "span": {
+                  "start": 73,
+                  "end": 79,
+                  "ctxt": 0
+                },
+                "decorators": [
+                  {
+                    "type": "Decorator",
+                    "span": {
+                      "start": 73,
+                      "end": 76,
+                      "ctxt": 0
+                    },
+                    "expression": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 74,
+                        "end": 76,
+                        "ctxt": 0
+                      },
+                      "value": "p1",
+                      "typeAnnotation": null,
+                      "optional": false
+                    }
+                  }
+                ],
+                "pat": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 77,
+                    "end": 79,
+                    "ctxt": 0
+                  },
+                  "value": "t1",
+                  "typeAnnotation": null,
+                  "optional": false
+                }
+              },
+              {
+                "span": {
+                  "start": 81,
+                  "end": 94,
+                  "ctxt": 0
+                },
+                "decorators": [
+                  {
+                    "type": "Decorator",
+                    "span": {
+                      "start": 81,
+                      "end": 84,
+                      "ctxt": 0
+                    },
+                    "expression": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 82,
+                        "end": 84,
+                        "ctxt": 0
+                      },
+                      "value": "p1",
+                      "typeAnnotation": null,
+                      "optional": false
+                    }
+                  },
+                  {
+                    "type": "Decorator",
+                    "span": {
+                      "start": 85,
+                      "end": 88,
+                      "ctxt": 0
+                    },
+                    "expression": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 86,
+                        "end": 88,
+                        "ctxt": 0
+                      },
+                      "value": "p2",
+                      "typeAnnotation": null,
+                      "optional": false
+                    }
+                  }
+                ],
+                "pat": {
+                  "type": "RestElement",
+                  "span": {
+                    "start": 89,
+                    "end": 94,
+                    "ctxt": 0
+                  },
+                  "rest": {
+                    "start": 89,
+                    "end": 92,
+                    "ctxt": 0
+                  },
+                  "argument": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 92,
+                      "end": 94,
+                      "ctxt": 0
+                    },
+                    "value": "t2",
+                    "typeAnnotation": null,
+                    "optional": false
+                  },
+                  "typeAnnotation": null
+                }
+              }
+            ],
+            "decorators": [],
+            "span": {
+              "start": 66,
+              "end": 103,
+              "ctxt": 0
+            },
+            "body": {
+              "type": "BlockStatement",
+              "span": {
+                "start": 96,
+                "end": 103,
+                "ctxt": 0
+              },
+              "stmts": []
+            },
+            "generator": false,
+            "async": false,
+            "typeParameters": null,
+            "returnType": null
+          },
+          "kind": "method",
+          "isStatic": false,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false
+        }
+      ],
+      "superClass": null,
+      "isAbstract": false,
+      "typeParams": null,
+      "superTypeParams": null,
+      "implements": []
+    }
+  ],
+  "interpreter": null
+}

--- a/ecmascript/parser/tests/typescript/decorators/parameter/input.ts.json
+++ b/ecmascript/parser/tests/typescript/decorators/parameter/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 105,
+    "end": 116,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 105,
+        "end": 116,
         "ctxt": 0
       },
       "decorators": [],
@@ -31,7 +31,7 @@
           "type": "Constructor",
           "span": {
             "start": 17,
-            "end": 60,
+            "end": 71,
             "ctxt": 0
           },
           "key": {
@@ -47,15 +47,44 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "Parameter",
               "span": {
-                "start": 33,
+                "start": 29,
                 "end": 35,
                 "ctxt": 0
               },
-              "value": "t1",
-              "typeAnnotation": null,
-              "optional": false
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "span": {
+                    "start": 29,
+                    "end": 32,
+                    "ctxt": 0
+                  },
+                  "expression": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 30,
+                      "end": 32,
+                      "ctxt": 0
+                    },
+                    "value": "p1",
+                    "typeAnnotation": null,
+                    "optional": false
+                  }
+                }
+              ],
+              "pat": {
+                "type": "Identifier",
+                "span": {
+                  "start": 33,
+                  "end": 35,
+                  "ctxt": 0
+                },
+                "value": "t1",
+                "typeAnnotation": null,
+                "optional": false
+              }
             },
             {
               "type": "TsParameterProperty",
@@ -98,13 +127,67 @@
                 "typeAnnotation": null,
                 "optional": false
               }
+            },
+            {
+              "type": "Parameter",
+              "span": {
+                "start": 53,
+                "end": 62,
+                "ctxt": 0
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "span": {
+                    "start": 53,
+                    "end": 56,
+                    "ctxt": 0
+                  },
+                  "expression": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 54,
+                      "end": 56,
+                      "ctxt": 0
+                    },
+                    "value": "p3",
+                    "typeAnnotation": null,
+                    "optional": false
+                  }
+                }
+              ],
+              "pat": {
+                "type": "RestElement",
+                "span": {
+                  "start": 57,
+                  "end": 62,
+                  "ctxt": 0
+                },
+                "rest": {
+                  "start": 57,
+                  "end": 60,
+                  "ctxt": 0
+                },
+                "argument": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 60,
+                    "end": 62,
+                    "ctxt": 0
+                  },
+                  "value": "t3",
+                  "typeAnnotation": null,
+                  "optional": false
+                },
+                "typeAnnotation": null
+              }
             }
           ],
           "body": {
             "type": "BlockStatement",
             "span": {
-              "start": 53,
-              "end": 60,
+              "start": 64,
+              "end": 71,
               "ctxt": 0
             },
             "stmts": []
@@ -115,15 +198,15 @@
         {
           "type": "ClassMethod",
           "span": {
-            "start": 66,
-            "end": 103,
+            "start": 77,
+            "end": 114,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 66,
-              "end": 72,
+              "start": 77,
+              "end": 83,
               "ctxt": 0
             },
             "value": "method",
@@ -133,24 +216,25 @@
           "function": {
             "params": [
               {
+                "type": "Parameter",
                 "span": {
-                  "start": 73,
-                  "end": 79,
+                  "start": 84,
+                  "end": 90,
                   "ctxt": 0
                 },
                 "decorators": [
                   {
                     "type": "Decorator",
                     "span": {
-                      "start": 73,
-                      "end": 76,
+                      "start": 84,
+                      "end": 87,
                       "ctxt": 0
                     },
                     "expression": {
                       "type": "Identifier",
                       "span": {
-                        "start": 74,
-                        "end": 76,
+                        "start": 85,
+                        "end": 87,
                         "ctxt": 0
                       },
                       "value": "p1",
@@ -162,8 +246,8 @@
                 "pat": {
                   "type": "Identifier",
                   "span": {
-                    "start": 77,
-                    "end": 79,
+                    "start": 88,
+                    "end": 90,
                     "ctxt": 0
                   },
                   "value": "t1",
@@ -172,24 +256,25 @@
                 }
               },
               {
+                "type": "Parameter",
                 "span": {
-                  "start": 81,
-                  "end": 94,
+                  "start": 92,
+                  "end": 105,
                   "ctxt": 0
                 },
                 "decorators": [
                   {
                     "type": "Decorator",
                     "span": {
-                      "start": 81,
-                      "end": 84,
+                      "start": 92,
+                      "end": 95,
                       "ctxt": 0
                     },
                     "expression": {
                       "type": "Identifier",
                       "span": {
-                        "start": 82,
-                        "end": 84,
+                        "start": 93,
+                        "end": 95,
                         "ctxt": 0
                       },
                       "value": "p1",
@@ -200,15 +285,15 @@
                   {
                     "type": "Decorator",
                     "span": {
-                      "start": 85,
-                      "end": 88,
+                      "start": 96,
+                      "end": 99,
                       "ctxt": 0
                     },
                     "expression": {
                       "type": "Identifier",
                       "span": {
-                        "start": 86,
-                        "end": 88,
+                        "start": 97,
+                        "end": 99,
                         "ctxt": 0
                       },
                       "value": "p2",
@@ -220,20 +305,20 @@
                 "pat": {
                   "type": "RestElement",
                   "span": {
-                    "start": 89,
-                    "end": 94,
+                    "start": 100,
+                    "end": 105,
                     "ctxt": 0
                   },
                   "rest": {
-                    "start": 89,
-                    "end": 92,
+                    "start": 100,
+                    "end": 103,
                     "ctxt": 0
                   },
                   "argument": {
                     "type": "Identifier",
                     "span": {
-                      "start": 92,
-                      "end": 94,
+                      "start": 103,
+                      "end": 105,
                       "ctxt": 0
                     },
                     "value": "t2",
@@ -246,15 +331,15 @@
             ],
             "decorators": [],
             "span": {
-              "start": 66,
-              "end": 103,
+              "start": 77,
+              "end": 114,
               "ctxt": 0
             },
             "body": {
               "type": "BlockStatement",
               "span": {
-                "start": 96,
-                "end": 103,
+                "start": 107,
+                "end": 114,
                 "ctxt": 0
               },
               "stmts": []

--- a/ecmascript/parser/tests/typescript/function/annotated/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/annotated/input.ts.json
@@ -22,6 +22,7 @@
       "declare": false,
       "params": [
         {
+          "type": "Parameter",
           "span": {
             "start": 14,
             "end": 19,

--- a/ecmascript/parser/tests/typescript/function/annotated/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/annotated/input.ts.json
@@ -22,42 +22,50 @@
       "declare": false,
       "params": [
         {
-          "type": "Identifier",
           "span": {
             "start": 14,
             "end": 19,
             "ctxt": 0
           },
-          "value": "x",
-          "typeAnnotation": {
-            "type": "TsTypeAnnotation",
+          "decorators": [],
+          "pat": {
+            "type": "Identifier",
             "span": {
-              "start": 16,
+              "start": 14,
               "end": 19,
               "ctxt": 0
             },
+            "value": "x",
             "typeAnnotation": {
-              "type": "TsTypeReference",
+              "type": "TsTypeAnnotation",
               "span": {
-                "start": 18,
+                "start": 16,
                 "end": 19,
                 "ctxt": 0
               },
-              "typeName": {
-                "type": "Identifier",
+              "typeAnnotation": {
+                "type": "TsTypeReference",
                 "span": {
                   "start": 18,
                   "end": 19,
                   "ctxt": 0
                 },
-                "value": "T",
-                "typeAnnotation": null,
-                "optional": false
-              },
-              "typeParams": null
-            }
-          },
-          "optional": true
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 18,
+                    "end": 19,
+                    "ctxt": 0
+                  },
+                  "value": "T",
+                  "typeAnnotation": null,
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            },
+            "optional": true
+          }
         }
       ],
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/function/anonymous/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/anonymous/input.ts.json
@@ -39,42 +39,50 @@
             "identifier": null,
             "params": [
               {
-                "type": "Identifier",
                 "span": {
                   "start": 22,
                   "end": 27,
                   "ctxt": 0
                 },
-                "value": "x",
-                "typeAnnotation": {
-                  "type": "TsTypeAnnotation",
+                "decorators": [],
+                "pat": {
+                  "type": "Identifier",
                   "span": {
-                    "start": 24,
+                    "start": 22,
                     "end": 27,
                     "ctxt": 0
                   },
+                  "value": "x",
                   "typeAnnotation": {
-                    "type": "TsTypeReference",
+                    "type": "TsTypeAnnotation",
                     "span": {
-                      "start": 26,
+                      "start": 24,
                       "end": 27,
                       "ctxt": 0
                     },
-                    "typeName": {
-                      "type": "Identifier",
+                    "typeAnnotation": {
+                      "type": "TsTypeReference",
                       "span": {
                         "start": 26,
                         "end": 27,
                         "ctxt": 0
                       },
-                      "value": "T",
-                      "typeAnnotation": null,
-                      "optional": false
-                    },
-                    "typeParams": null
-                  }
-                },
-                "optional": true
+                      "typeName": {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 26,
+                          "end": 27,
+                          "ctxt": 0
+                        },
+                        "value": "T",
+                        "typeAnnotation": null,
+                        "optional": false
+                      },
+                      "typeParams": null
+                    }
+                  },
+                  "optional": true
+                }
               }
             ],
             "decorators": [],

--- a/ecmascript/parser/tests/typescript/function/anonymous/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/anonymous/input.ts.json
@@ -39,6 +39,7 @@
             "identifier": null,
             "params": [
               {
+                "type": "Parameter",
                 "span": {
                   "start": 22,
                   "end": 27,

--- a/ecmascript/parser/tests/typescript/function/export-default/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/export-default/input.ts.json
@@ -18,31 +18,39 @@
         "identifier": null,
         "params": [
           {
-            "type": "Identifier",
             "span": {
               "start": 24,
               "end": 34,
               "ctxt": 0
             },
-            "value": "x",
-            "typeAnnotation": {
-              "type": "TsTypeAnnotation",
+            "decorators": [],
+            "pat": {
+              "type": "Identifier",
               "span": {
-                "start": 26,
+                "start": 24,
                 "end": 34,
                 "ctxt": 0
               },
+              "value": "x",
               "typeAnnotation": {
-                "type": "TsKeywordType",
+                "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 28,
+                  "start": 26,
                   "end": 34,
                   "ctxt": 0
                 },
-                "kind": "number"
-              }
-            },
-            "optional": true
+                "typeAnnotation": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 28,
+                    "end": 34,
+                    "ctxt": 0
+                  },
+                  "kind": "number"
+                }
+              },
+              "optional": true
+            }
           }
         ],
         "decorators": [],

--- a/ecmascript/parser/tests/typescript/function/export-default/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/export-default/input.ts.json
@@ -18,6 +18,7 @@
         "identifier": null,
         "params": [
           {
+            "type": "Parameter",
             "span": {
               "start": 24,
               "end": 34,

--- a/ecmascript/parser/tests/typescript/function/overloads/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/overloads/input.ts.json
@@ -29,6 +29,7 @@
         "declare": false,
         "params": [
           {
+            "type": "Parameter",
             "span": {
               "start": 18,
               "end": 27,
@@ -116,6 +117,7 @@
         "declare": false,
         "params": [
           {
+            "type": "Parameter",
             "span": {
               "start": 56,
               "end": 65,

--- a/ecmascript/parser/tests/typescript/function/overloads/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/overloads/input.ts.json
@@ -29,31 +29,39 @@
         "declare": false,
         "params": [
           {
-            "type": "Identifier",
             "span": {
               "start": 18,
               "end": 27,
               "ctxt": 0
             },
-            "value": "x",
-            "typeAnnotation": {
-              "type": "TsTypeAnnotation",
+            "decorators": [],
+            "pat": {
+              "type": "Identifier",
               "span": {
-                "start": 19,
+                "start": 18,
                 "end": 27,
                 "ctxt": 0
               },
+              "value": "x",
               "typeAnnotation": {
-                "type": "TsKeywordType",
+                "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 21,
+                  "start": 19,
                   "end": 27,
                   "ctxt": 0
                 },
-                "kind": "number"
-              }
-            },
-            "optional": false
+                "typeAnnotation": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 21,
+                    "end": 27,
+                    "ctxt": 0
+                  },
+                  "kind": "number"
+                }
+              },
+              "optional": false
+            }
           }
         ],
         "decorators": [],
@@ -108,31 +116,39 @@
         "declare": false,
         "params": [
           {
-            "type": "Identifier",
             "span": {
               "start": 56,
               "end": 65,
               "ctxt": 0
             },
-            "value": "x",
-            "typeAnnotation": {
-              "type": "TsTypeAnnotation",
+            "decorators": [],
+            "pat": {
+              "type": "Identifier",
               "span": {
-                "start": 57,
+                "start": 56,
                 "end": 65,
                 "ctxt": 0
               },
+              "value": "x",
               "typeAnnotation": {
-                "type": "TsKeywordType",
+                "type": "TsTypeAnnotation",
                 "span": {
-                  "start": 59,
+                  "start": 57,
                   "end": 65,
                   "ctxt": 0
                 },
-                "kind": "string"
-              }
-            },
-            "optional": false
+                "typeAnnotation": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 59,
+                    "end": 65,
+                    "ctxt": 0
+                  },
+                  "kind": "string"
+                }
+              },
+              "optional": false
+            }
           }
         ],
         "decorators": [],

--- a/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
@@ -22,6 +22,7 @@
       "declare": false,
       "params": [
         {
+          "type": "Parameter",
           "span": {
             "start": 11,
             "end": 17,
@@ -140,6 +141,7 @@
           "identifier": null,
           "params": [
             {
+              "type": "Parameter",
               "span": {
                 "start": 46,
                 "end": 52,
@@ -257,6 +259,7 @@
       "declare": false,
       "params": [
         {
+          "type": "Parameter",
           "span": {
             "start": 83,
             "end": 89,
@@ -372,6 +375,7 @@
       "declare": false,
       "params": [
         {
+          "type": "Parameter",
           "span": {
             "start": 127,
             "end": 133,

--- a/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/predicate-types/input.ts.json
@@ -22,31 +22,39 @@
       "declare": false,
       "params": [
         {
-          "type": "Identifier",
           "span": {
             "start": 11,
             "end": 17,
             "ctxt": 0
           },
-          "value": "x",
-          "typeAnnotation": {
-            "type": "TsTypeAnnotation",
+          "decorators": [],
+          "pat": {
+            "type": "Identifier",
             "span": {
-              "start": 12,
+              "start": 11,
               "end": 17,
               "ctxt": 0
             },
+            "value": "x",
             "typeAnnotation": {
-              "type": "TsKeywordType",
+              "type": "TsTypeAnnotation",
               "span": {
-                "start": 14,
+                "start": 12,
                 "end": 17,
                 "ctxt": 0
               },
-              "kind": "any"
-            }
-          },
-          "optional": false
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 14,
+                  "end": 17,
+                  "ctxt": 0
+                },
+                "kind": "any"
+              }
+            },
+            "optional": false
+          }
         }
       ],
       "decorators": [],
@@ -132,31 +140,39 @@
           "identifier": null,
           "params": [
             {
-              "type": "Identifier",
               "span": {
                 "start": 46,
                 "end": 52,
                 "ctxt": 0
               },
-              "value": "x",
-              "typeAnnotation": {
-                "type": "TsTypeAnnotation",
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
                 "span": {
-                  "start": 47,
+                  "start": 46,
                   "end": 52,
                   "ctxt": 0
                 },
+                "value": "x",
                 "typeAnnotation": {
-                  "type": "TsKeywordType",
+                  "type": "TsTypeAnnotation",
                   "span": {
-                    "start": 49,
+                    "start": 47,
                     "end": 52,
                     "ctxt": 0
                   },
-                  "kind": "any"
-                }
-              },
-              "optional": false
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 49,
+                      "end": 52,
+                      "ctxt": 0
+                    },
+                    "kind": "any"
+                  }
+                },
+                "optional": false
+              }
             }
           ],
           "decorators": [],
@@ -241,31 +257,39 @@
       "declare": false,
       "params": [
         {
-          "type": "Identifier",
           "span": {
             "start": 83,
             "end": 89,
             "ctxt": 0
           },
-          "value": "x",
-          "typeAnnotation": {
-            "type": "TsTypeAnnotation",
+          "decorators": [],
+          "pat": {
+            "type": "Identifier",
             "span": {
-              "start": 84,
+              "start": 83,
               "end": 89,
               "ctxt": 0
             },
+            "value": "x",
             "typeAnnotation": {
-              "type": "TsKeywordType",
+              "type": "TsTypeAnnotation",
               "span": {
-                "start": 86,
+                "start": 84,
                 "end": 89,
                 "ctxt": 0
               },
-              "kind": "any"
-            }
-          },
-          "optional": false
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 86,
+                  "end": 89,
+                  "ctxt": 0
+                },
+                "kind": "any"
+              }
+            },
+            "optional": false
+          }
         }
       ],
       "decorators": [],
@@ -348,31 +372,39 @@
       "declare": false,
       "params": [
         {
-          "type": "Identifier",
           "span": {
             "start": 127,
             "end": 133,
             "ctxt": 0
           },
-          "value": "x",
-          "typeAnnotation": {
-            "type": "TsTypeAnnotation",
+          "decorators": [],
+          "pat": {
+            "type": "Identifier",
             "span": {
-              "start": 128,
+              "start": 127,
               "end": 133,
               "ctxt": 0
             },
+            "value": "x",
             "typeAnnotation": {
-              "type": "TsKeywordType",
+              "type": "TsTypeAnnotation",
               "span": {
-                "start": 130,
+                "start": 128,
                 "end": 133,
                 "ctxt": 0
               },
-              "kind": "any"
-            }
-          },
-          "optional": false
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 130,
+                  "end": 133,
+                  "ctxt": 0
+                },
+                "kind": "any"
+              }
+            },
+            "optional": false
+          }
         }
       ],
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/types/object-shorthand/input.ts.json
+++ b/ecmascript/parser/tests/typescript/types/object-shorthand/input.ts.json
@@ -57,42 +57,50 @@
                 },
                 "params": [
                   {
-                    "type": "Identifier",
                     "span": {
                       "start": 48,
                       "end": 56,
                       "ctxt": 0
                     },
-                    "value": "value",
-                    "typeAnnotation": {
-                      "type": "TsTypeAnnotation",
+                    "decorators": [],
+                    "pat": {
+                      "type": "Identifier",
                       "span": {
-                        "start": 53,
+                        "start": 48,
                         "end": 56,
                         "ctxt": 0
                       },
+                      "value": "value",
                       "typeAnnotation": {
-                        "type": "TsTypeReference",
+                        "type": "TsTypeAnnotation",
                         "span": {
-                          "start": 55,
+                          "start": 53,
                           "end": 56,
                           "ctxt": 0
                         },
-                        "typeName": {
-                          "type": "Identifier",
+                        "typeAnnotation": {
+                          "type": "TsTypeReference",
                           "span": {
                             "start": 55,
                             "end": 56,
                             "ctxt": 0
                           },
-                          "value": "T",
-                          "typeAnnotation": null,
-                          "optional": false
-                        },
-                        "typeParams": null
-                      }
-                    },
-                    "optional": false
+                          "typeName": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 55,
+                              "end": 56,
+                              "ctxt": 0
+                            },
+                            "value": "T",
+                            "typeAnnotation": null,
+                            "optional": false
+                          },
+                          "typeParams": null
+                        }
+                      },
+                      "optional": false
+                    }
                   }
                 ],
                 "decorators": [],

--- a/ecmascript/parser/tests/typescript/types/object-shorthand/input.ts.json
+++ b/ecmascript/parser/tests/typescript/types/object-shorthand/input.ts.json
@@ -57,6 +57,7 @@
                 },
                 "params": [
                   {
+                    "type": "Parameter",
                     "span": {
                       "start": 48,
                       "end": 56,

--- a/ecmascript/parser/tests/typescript/types/tuple-rest-after-optional/input.ts.json
+++ b/ecmascript/parser/tests/typescript/types/tuple-rest-after-optional/input.ts.json
@@ -22,95 +22,103 @@
       "declare": false,
       "params": [
         {
-          "type": "RestElement",
           "span": {
             "start": 13,
             "end": 52,
             "ctxt": 0
           },
-          "rest": {
-            "start": 13,
-            "end": 16,
-            "ctxt": 0
-          },
-          "argument": {
-            "type": "Identifier",
+          "decorators": [],
+          "pat": {
+            "type": "RestElement",
             "span": {
-              "start": 16,
-              "end": 20,
-              "ctxt": 0
-            },
-            "value": "args",
-            "typeAnnotation": null,
-            "optional": false
-          },
-          "typeAnnotation": {
-            "type": "TsTypeAnnotation",
-            "span": {
-              "start": 20,
+              "start": 13,
               "end": 52,
               "ctxt": 0
             },
-            "typeAnnotation": {
-              "type": "TsTupleType",
+            "rest": {
+              "start": 13,
+              "end": 16,
+              "ctxt": 0
+            },
+            "argument": {
+              "type": "Identifier",
               "span": {
-                "start": 22,
+                "start": 16,
+                "end": 20,
+                "ctxt": 0
+              },
+              "value": "args",
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 20,
                 "end": 52,
                 "ctxt": 0
               },
-              "elemTypes": [
-                {
-                  "type": "TsKeywordType",
-                  "span": {
-                    "start": 23,
-                    "end": 29,
-                    "ctxt": 0
-                  },
-                  "kind": "number"
+              "typeAnnotation": {
+                "type": "TsTupleType",
+                "span": {
+                  "start": 22,
+                  "end": 52,
+                  "ctxt": 0
                 },
-                {
-                  "type": "TsOptionalType",
-                  "span": {
-                    "start": 31,
-                    "end": 38,
-                    "ctxt": 0
-                  },
-                  "typeAnnotation": {
+                "elemTypes": [
+                  {
                     "type": "TsKeywordType",
                     "span": {
-                      "start": 31,
-                      "end": 37,
+                      "start": 23,
+                      "end": 29,
                       "ctxt": 0
                     },
-                    "kind": "string"
-                  }
-                },
-                {
-                  "type": "TsRestType",
-                  "span": {
-                    "start": 40,
-                    "end": 51,
-                    "ctxt": 0
+                    "kind": "number"
                   },
-                  "typeAnnotation": {
-                    "type": "TsArrayType",
+                  {
+                    "type": "TsOptionalType",
                     "span": {
-                      "start": 43,
+                      "start": 31,
+                      "end": 38,
+                      "ctxt": 0
+                    },
+                    "typeAnnotation": {
+                      "type": "TsKeywordType",
+                      "span": {
+                        "start": 31,
+                        "end": 37,
+                        "ctxt": 0
+                      },
+                      "kind": "string"
+                    }
+                  },
+                  {
+                    "type": "TsRestType",
+                    "span": {
+                      "start": 40,
                       "end": 51,
                       "ctxt": 0
                     },
-                    "elemType": {
-                      "type": "TsKeywordType",
+                    "typeAnnotation": {
+                      "type": "TsArrayType",
                       "span": {
                         "start": 43,
-                        "end": 49,
+                        "end": 51,
                         "ctxt": 0
                       },
-                      "kind": "number"
+                      "elemType": {
+                        "type": "TsKeywordType",
+                        "span": {
+                          "start": 43,
+                          "end": 49,
+                          "ctxt": 0
+                        },
+                        "kind": "number"
+                      }
                     }
                   }
-                }
-              ]
+                ]
+              }
             }
           }
         }

--- a/ecmascript/parser/tests/typescript/types/tuple-rest-after-optional/input.ts.json
+++ b/ecmascript/parser/tests/typescript/types/tuple-rest-after-optional/input.ts.json
@@ -22,6 +22,7 @@
       "declare": false,
       "params": [
         {
+          "type": "Parameter",
           "span": {
             "start": 13,
             "end": 52,


### PR DESCRIPTION
I took a quick stab at an initial implementation in hopes that we could start working from here. Would really like to get this in swc.

Note: This is a parsing only commit. I have not looked at transformations at all.

Do you have any suggestion for the AST?

**TypeScript**

![image](https://user-images.githubusercontent.com/1609021/81484691-b2cd7800-9215-11ea-828e-2a7f044ce53a.png)

**ESTree**

![image](https://user-images.githubusercontent.com/1609021/81484715-ead4bb00-9215-11ea-9165-7389a768399e.png)

For #750
