### PR TITLE
Directly map the box contents without unsafe

### DIFF
--- a/common/src/util/map.rs
+++ b/common/src/util/map.rs
@@ -1,5 +1,3 @@
-use std::{mem, ptr};
-
 /// Copied from `syntax::ptr::P`
 pub trait Map<T> {
     /// Transform the inner value, consuming `self` and producing a new `P<T>`.
@@ -13,19 +11,7 @@ impl<T> Map<T> for Box<T> {
     where
         F: FnOnce(T) -> T,
     {
-        let p: *mut T = &mut *self;
-
-        // Leak self in case of panic.
-        // FIXME(eddyb) Use some sort of "free guard" that
-        // only deallocates, without dropping the pointee,
-        // in case the call the `f` below ends in a panic.
-        mem::forget(self);
-
-        unsafe {
-            ptr::write(p, f(ptr::read(p)));
-
-            // Recreate self from the raw pointer.
-            Box::from_raw(p)
-        }
+        *self = f(*self);
+        self
     }
 }


### PR DESCRIPTION
We can directly map box's contents without using unsafe with no difference in generated assembly.