### PR TITLE
Optimize parser

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.21.10"
+version = "0.21.11"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/parser/src/lexer/util.rs
+++ b/ecmascript/parser/src/lexer/util.rs
@@ -275,7 +275,7 @@ pub trait CharExt: Copy {
             None => return false,
         };
         // TODO: Use Unicode ID instead of XID.
-        c == '$' || c == '_' || UnicodeXID::is_xid_start(c)
+        c == '$' || c == '_' || c.is_ascii_alphabetic() || UnicodeXID::is_xid_start(c)
     }
 
     /// Test whether a given character is part of an identifier.
@@ -285,7 +285,11 @@ pub trait CharExt: Copy {
             None => return false,
         };
         // TODO: Use Unicode ID instead of XID.
-        c == '$' || c == '\u{200c}' || c == '\u{200d}' || UnicodeXID::is_xid_continue(c)
+        c == '$'
+            || c == '\u{200c}'
+            || c == '\u{200d}'
+            || c.is_ascii_alphanumeric()
+            || UnicodeXID::is_xid_continue(c)
     }
 
     /// See https://tc39.github.io/ecma262/#sec-line-terminators


### PR DESCRIPTION

# Original

test lexer::tests::lex_colors_js               ... bench:      36,332 ns/iter (+/- 1,870) = 31 MB/s
test lexer::tests::lex_colors_ts               ... bench:      36,459 ns/iter (+/- 2,503) = 31 MB/s
test lexer::tests::lex_dec_lit                 ... bench:      44,803 ns/iter (+/- 1,797) = 12 MB/s
test lexer::tests::lex_escaped_char            ... bench:       8,756 ns/iter (+/- 647) = 26 MB/s
test lexer::tests::lex_ident                   ... bench:      45,219 ns/iter (+/- 10,016) = 12 MB/s
test lexer::tests::lex_large_number            ... bench:      14,559 ns/iter (+/- 947) = 15 MB/s
test lexer::tests::lex_legact_octal_lit        ... bench:      72,158 ns/iter (+/- 5,640) = 8 MB/s
test lexer::tests::lex_long_ident              ... bench:      11,553 ns/iter (+/- 2,754) = 41 MB/s
test lexer::tests::lex_regex                   ... bench:      12,166 ns/iter (+/- 1,231) = 12 MB/s
test lexer::tests::lex_semicolons              ... bench:     207,768 ns/iter (+/- 9,532) = 8 MB/s
test parser::expr::tests::bench_member_expr_es ... bench:       4,668 ns/iter (+/- 115) = 2 MB/s
test parser::expr::tests::bench_member_expr_ts ... bench:       5,022 ns/iter (+/- 1,354) = 2 MB/s
test parser::expr::tests::bench_new_expr_es    ... bench:       2,177 ns/iter (+/- 33) = 4 MB/s
test parser::expr::tests::bench_new_expr_ts    ... bench:       2,490 ns/iter (+/- 1,011) = 3 MB/s

test result: ok. 0 passed; 0 failed; 132 ignored; 14 measured; 0 filtered out

     Running /Users/kdy1/projects/swc/target/release/deps/lexer-ce35f2c5d5962045

running 8 tests
test angular       ... bench:  14,994,283 ns/iter (+/- 507,160) = 47 MB/s
test backbone      ... bench:   1,994,936 ns/iter (+/- 109,703) = 30 MB/s
test colors        ... bench:      31,434 ns/iter (+/- 2,086) = 36 MB/s
test jquery        ... bench:  10,841,840 ns/iter (+/- 302,267) = 24 MB/s
test jquery_mobile ... bench:  17,493,828 ns/iter (+/- 740,477) = 25 MB/s
test mootools      ... bench:   8,561,363 ns/iter (+/- 378,194) = 18 MB/s
test underscore    ... bench:   1,636,191 ns/iter (+/- 75,884) = 26 MB/s
test yui           ... bench:   8,455,809 ns/iter (+/- 391,988) = 40 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 8 measured; 0 filtered out

     Running /Users/kdy1/projects/swc/target/release/deps/parser-12368b761b81548a

running 17 tests
test angular          ... bench:  33,204,090 ns/iter (+/- 793,185) = 21 MB/s
test angular_ts       ... bench:  34,701,708 ns/iter (+/- 959,578) = 20 MB/s
test backbone         ... bench:   4,671,903 ns/iter (+/- 693,398) = 12 MB/s
test backbone_ts      ... bench:   4,951,267 ns/iter (+/- 1,725,604) = 12 MB/s
test colors           ... bench:      62,131 ns/iter (+/- 5,478) = 18 MB/s
test colors_ts        ... bench:      63,443 ns/iter (+/- 3,117) = 18 MB/s
test jquery           ... bench:  36,205,453 ns/iter (+/- 44,254,581) = 7 MB/s
test jquery_mobile    ... bench:  43,941,369 ns/iter (+/- 7,885,233) = 10 MB/s
test jquery_mobile_ts ... bench:  44,376,296 ns/iter (+/- 1,251,740) = 10 MB/s
test jquery_ts        ... bench:  27,899,646 ns/iter (+/- 818,202) = 9 MB/s
test large            ... bench:     820,341 ns/iter (+/- 159,690) = 6 MB/s
test mootools         ... bench:  21,626,823 ns/iter (+/- 4,217,202) = 7 MB/s
test mootools_ts      ... bench:  22,460,968 ns/iter (+/- 623,912) = 7 MB/s
test underscore       ... bench:   3,878,629 ns/iter (+/- 375,080) = 11 MB/s
test underscore_ts    ... bench:   4,111,796 ns/iter (+/- 362,116) = 10 MB/s
test yui              ... bench:  19,945,436 ns/iter (+/- 1,096,234) = 16 MB/s
test yui_ts           ... bench:  20,911,793 ns/iter (+/- 662,875) = 16 MB/s


# After


test lexer::tests::lex_colors_js               ... bench:      32,632 ns/iter (+/- 2,619) = 35 MB/s
test lexer::tests::lex_colors_ts               ... bench:      32,728 ns/iter (+/- 4,485) = 35 MB/s
test lexer::tests::lex_dec_lit                 ... bench:      45,292 ns/iter (+/- 1,649) = 11 MB/s
test lexer::tests::lex_escaped_char            ... bench:       8,640 ns/iter (+/- 2,096) = 26 MB/s
test lexer::tests::lex_ident                   ... bench:      37,688 ns/iter (+/- 4,862) = 15 MB/s
test lexer::tests::lex_large_number            ... bench:      14,458 ns/iter (+/- 3,187) = 15 MB/s
test lexer::tests::lex_legact_octal_lit        ... bench:      71,754 ns/iter (+/- 10,527) = 8 MB/s
test lexer::tests::lex_long_ident              ... bench:       5,926 ns/iter (+/- 886) = 80 MB/s
test lexer::tests::lex_regex                   ... bench:      11,489 ns/iter (+/- 1,398) = 13 MB/s
test lexer::tests::lex_semicolons              ... bench:     206,298 ns/iter (+/- 14,921) = 9 MB/s
test parser::expr::tests::bench_member_expr_es ... bench:       4,631 ns/iter (+/- 711) = 2 MB/s
test parser::expr::tests::bench_member_expr_ts ... bench:       5,011 ns/iter (+/- 625) = 2 MB/s
test parser::expr::tests::bench_new_expr_es    ... bench:       2,188 ns/iter (+/- 218) = 4 MB/s
test parser::expr::tests::bench_new_expr_ts    ... bench:       2,529 ns/iter (+/- 264) = 3 MB/s

test result: ok. 0 passed; 0 failed; 132 ignored; 14 measured; 0 filtered out

     Running /Users/kdy1/projects/swc/target/release/deps/lexer-ce35f2c5d5962045

running 8 tests
test angular       ... bench:  13,315,295 ns/iter (+/- 312,680) = 53 MB/s
test backbone      ... bench:   1,736,406 ns/iter (+/- 86,967) = 34 MB/s
test colors        ... bench:      28,772 ns/iter (+/- 2,350) = 40 MB/s
test jquery        ... bench:   9,470,308 ns/iter (+/- 224,796) = 28 MB/s
test jquery_mobile ... bench:  15,352,350 ns/iter (+/- 377,140) = 29 MB/s
test mootools      ... bench:   7,390,424 ns/iter (+/- 156,080) = 21 MB/s
test underscore    ... bench:   1,433,430 ns/iter (+/- 58,225) = 30 MB/s
test yui           ... bench:   7,971,797 ns/iter (+/- 1,709,227) = 42 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 8 measured; 0 filtered out

     Running /Users/kdy1/projects/swc/target/release/deps/parser-12368b761b81548a

running 17 tests
test angular          ... bench:  31,593,833 ns/iter (+/- 1,912,996) = 22 MB/s
test angular_ts       ... bench:  33,024,393 ns/iter (+/- 861,372) = 21 MB/s
test backbone         ... bench:   4,448,323 ns/iter (+/- 210,247) = 13 MB/s
test backbone_ts      ... bench:   4,659,465 ns/iter (+/- 264,936) = 12 MB/s
test colors           ... bench:      59,279 ns/iter (+/- 14,675) = 19 MB/s
test colors_ts        ... bench:      61,611 ns/iter (+/- 3,381) = 18 MB/s
test jquery           ... bench:  25,485,023 ns/iter (+/- 668,015) = 10 MB/s
test jquery_mobile    ... bench:  40,769,076 ns/iter (+/- 1,960,233) = 11 MB/s
test jquery_mobile_ts ... bench:  42,063,412 ns/iter (+/- 1,225,278) = 10 MB/s
test jquery_ts        ... bench:  26,461,936 ns/iter (+/- 737,270) = 10 MB/s
test large            ... bench:     777,305 ns/iter (+/- 65,038) = 6 MB/s
test mootools         ... bench:  20,374,171 ns/iter (+/- 582,282) = 7 MB/s
test mootools_ts      ... bench:  21,149,114 ns/iter (+/- 471,449) = 7 MB/s
test underscore       ... bench:   3,732,939 ns/iter (+/- 202,299) = 11 MB/s
test underscore_ts    ... bench:   3,949,101 ns/iter (+/- 210,457) = 11 MB/s
test yui              ... bench:  19,242,730 ns/iter (+/- 508,865) = 17 MB/s
test yui_ts           ... bench:  20,240,100 ns/iter (+/- 450,025) = 16 MB/s




Thanks to Riccardo Dambrosio, lexer and parser become 10% faster.