### PR TITLE
typescript_strip: Handle types used only in casts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,9 @@ package-lock.json
 .idea/
 
 wasm/
+
+# Reduce package size
+**/tests/
+**/benches/
+**/target/
+*.svg

--- a/ecmascript/transforms/src/typescript.rs
+++ b/ecmascript/transforms/src/typescript.rs
@@ -711,11 +711,20 @@ type_to_none!(TsType, TsTypeAnn, TsTypeParamDecl, TsTypeParamInstantiation);
 impl Fold<Expr> for Strip {
     fn fold(&mut self, expr: Expr) -> Expr {
         let expr = match expr {
-            Expr::TsAs(TsAsExpr { expr, .. }) => validate!(*expr),
+            Expr::TsAs(TsAsExpr { expr, type_ann, .. }) => {
+                type_ann.visit_with(self);
+                validate!(*expr)
+            }
             Expr::TsNonNull(TsNonNullExpr { expr, .. }) => validate!(*expr),
-            Expr::TsTypeAssertion(TsTypeAssertion { expr, .. }) => validate!(*expr),
+            Expr::TsTypeAssertion(TsTypeAssertion { expr, type_ann, .. }) => {
+                type_ann.visit_with(self);
+                validate!(*expr)
+            }
             Expr::TsConstAssertion(TsConstAssertion { expr, .. }) => validate!(*expr),
-            Expr::TsTypeCast(TsTypeCastExpr { expr, .. }) => validate!(*expr),
+            Expr::TsTypeCast(TsTypeCastExpr { expr, type_ann, .. }) => {
+                type_ann.visit_with(self);
+                validate!(*expr)
+            }
             _ => validate!(expr),
         };
 

--- a/ecmascript/transforms/tests/typescript_strip.rs
+++ b/ecmascript/transforms/tests/typescript_strip.rs
@@ -519,3 +519,25 @@ to!(
     }
     "
 );
+
+to!(
+    issue_793_1,
+    "import { IPerson } from '../types/types'
+     export function createPerson(person) {
+        const a = {} as IPerson
+      }",
+    "export function createPerson(person) {
+        const a = {};
+      }"
+);
+
+to!(
+    issue_793_2,
+    "import { IPerson } from '../types/types'
+     export function createPerson(person) {
+        const a = <IPerson>{};
+      }",
+    "export function createPerson(person) {
+        const a = {};
+      }"
+);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/core",
-  "version": "1.1.47",
+  "version": "1.1.48",
   "description": "Super-fast alternative for babel",
   "main": "./index.js",
   "author": "강동윤 <kdy1997.dev@gmail.com>",


### PR DESCRIPTION
Fixes #793 