### PR TITLE
Remove comma separators in benchmark presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ The lower bound of the speedup compared to babel is **18**. The benchmarks were 
 | ------------------ | :------------------------------------: |
 | swc (es3)          |  761 ops/sec ±0.23% (89 runs sampled)  |
 | swc (es2015)       |  800 ops/sec ±1.02% (87 runs sampled)  |
-| swc (es2016)       | 2,123 ops/sec ±0.84% (88 runs sampled) |
-| swc (es2017)       | 2,131 ops/sec ±1.13% (90 runs sampled) |
-| swc (es2018)       | 2,981 ops/sec ±0.25% (90 runs sampled) |
+| swc (es2016)       | 2123 ops/sec ±0.84% (88 runs sampled) |
+| swc (es2017)       | 2131 ops/sec ±1.13% (90 runs sampled) |
+| swc (es2018)       | 2981 ops/sec ±0.25% (90 runs sampled) |
 | swc-optimize (es3) |  712 ops/sec ±0.21% (86 runs sampled)  |
 | babel              | 41.75 ops/sec ±8.07% (56 runs sampled) |
 


### PR DESCRIPTION
By first looking at this table I was confused of how could you advertise 2.1-2.9 ops/sec performance, only time later I figured out that the comma is in fact the separator for thousands.
I'd suggest not putting comma here in order to prevent confusion especially for people from countries where commas are used as floating point separators.