### PR TITLE
Fix swc_ecma_visit

### DIFF
--- a/ecmascript/visit/Cargo.toml
+++ b/ecmascript/visit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_visit"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/visit/src/lib.rs
+++ b/ecmascript/visit/src/lib.rs
@@ -11,6 +11,26 @@ pub trait Node: Any {}
 impl<T: ?Sized> Node for T where T: Any {}
 
 define!({
+    pub struct Class {
+        pub span: Span,
+        pub decorators: Vec<Decorator>,
+        pub body: Vec<ClassMember>,
+        pub super_class: Option<Box<Expr>>,
+        pub is_abstract: bool,
+        pub type_params: Option<TsTypeParamDecl>,
+        pub super_type_params: Option<TsTypeParamInstantiation>,
+        pub implements: Vec<TsExprWithTypeArgs>,
+    }
+
+    pub enum ClassMember {
+        Constructor(Constructor),
+        Method(ClassMethod),
+        PrivateMethod(PrivateMethod),
+        ClassProp(ClassProp),
+        PrivateProp(PrivateProp),
+        TsIndexSignature(TsIndexSignature),
+    }
+
     pub struct ClassProp {
         pub span: Span,
         pub key: Box<Expr>,


### PR DESCRIPTION
Closes #808.

I verified that `{}` (the sign of no-op fold/visit) exists only on the `Span` and primitive types.