### PR TITLE
Implement codegen of `export foo as Foo from foo;`

### DIFF
--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_codegen"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/codegen/tests/references/218ca74570bf06b5.module.js
+++ b/ecmascript/codegen/tests/references/218ca74570bf06b5.module.js
@@ -1,1 +1,1 @@
-export { a as default, b } from'foo';
+export { a as default, b } from 'foo';

--- a/ecmascript/codegen/tests/references/27ed2f0fdb7f53f6.module.js
+++ b/ecmascript/codegen/tests/references/27ed2f0fdb7f53f6.module.js
@@ -1,1 +1,1 @@
-export { a, b } from'foo';
+export { a, b } from 'foo';

--- a/ecmascript/codegen/tests/references/2b393e093a0e2fb3.module.js
+++ b/ecmascript/codegen/tests/references/2b393e093a0e2fb3.module.js
@@ -1,1 +1,1 @@
-export { a as default } from'foo';
+export { a as default } from 'foo';

--- a/ecmascript/codegen/tests/references/43bbb253d4035175.module.js
+++ b/ecmascript/codegen/tests/references/43bbb253d4035175.module.js
@@ -1,1 +1,1 @@
-export { a as b } from'foo';
+export { a as b } from 'foo';

--- a/ecmascript/codegen/tests/references/551af1dc1686e912.module.js
+++ b/ecmascript/codegen/tests/references/551af1dc1686e912.module.js
@@ -1,1 +1,1 @@
-export { a } from'foo';
+export { a } from 'foo';

--- a/ecmascript/codegen/tests/references/717def9f9459b4e1.module.js
+++ b/ecmascript/codegen/tests/references/717def9f9459b4e1.module.js
@@ -1,1 +1,1 @@
-export { } from'a';
+export { } from 'a';

--- a/ecmascript/codegen/tests/references/8543b43f3c48c975.module.js
+++ b/ecmascript/codegen/tests/references/8543b43f3c48c975.module.js
@@ -1,1 +1,1 @@
-export { default } from'a';
+export { default } from 'a';

--- a/ecmascript/codegen/tests/references/abcfae2381708c43.module.js
+++ b/ecmascript/codegen/tests/references/abcfae2381708c43.module.js
@@ -1,1 +1,1 @@
-export { default } from'foo';
+export { default } from 'foo';


### PR DESCRIPTION
I'm a complete newbie in Rust so please take a close look to these changes and let me know if the code is not written in an idiomatic way 😀