### PR TITLE
Fix type-only import declaration with empty named imports being parsed as having a default import specifier

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.24.2"
+version = "0.24.3"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/parser/tests/typescript/custom/type-only/import/default/input.ts
+++ b/ecmascript/parser/tests/typescript/custom/type-only/import/default/input.ts
@@ -1,1 +1,2 @@
 import type Foo from 'foo';
+import type from './a';

--- a/ecmascript/parser/tests/typescript/custom/type-only/import/default/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/type-only/import/default/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 52,
+    "end": 51,
     "ctxt": 0
   },
   "body": [
@@ -49,23 +49,23 @@
     {
       "type": "ImportDeclaration",
       "span": {
-        "start": 29,
-        "end": 52,
+        "start": 28,
+        "end": 51,
         "ctxt": 0
       },
       "specifiers": [
         {
           "type": "ImportDefaultSpecifier",
           "span": {
-            "start": 36,
-            "end": 40,
+            "start": 35,
+            "end": 39,
             "ctxt": 0
           },
           "local": {
             "type": "Identifier",
             "span": {
-              "start": 36,
-              "end": 40,
+              "start": 35,
+              "end": 39,
               "ctxt": 0
             },
             "value": "type",
@@ -77,8 +77,8 @@
       "source": {
         "type": "StringLiteral",
         "span": {
-          "start": 46,
-          "end": 51,
+          "start": 45,
+          "end": 50,
           "ctxt": 0
         },
         "value": "./a",

--- a/ecmascript/parser/tests/typescript/custom/type-only/import/default/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/type-only/import/default/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 27,
+    "end": 52,
     "ctxt": 0
   },
   "body": [
@@ -45,6 +45,46 @@
         "hasEscape": false
       },
       "typeOnly": true
+    },
+    {
+      "type": "ImportDeclaration",
+      "span": {
+        "start": 29,
+        "end": 52,
+        "ctxt": 0
+      },
+      "specifiers": [
+        {
+          "type": "ImportDefaultSpecifier",
+          "span": {
+            "start": 36,
+            "end": 40,
+            "ctxt": 0
+          },
+          "local": {
+            "type": "Identifier",
+            "span": {
+              "start": 36,
+              "end": 40,
+              "ctxt": 0
+            },
+            "value": "type",
+            "typeAnnotation": null,
+            "optional": false
+          }
+        }
+      ],
+      "source": {
+        "type": "StringLiteral",
+        "span": {
+          "start": 46,
+          "end": 51,
+          "ctxt": 0
+        },
+        "value": "./a",
+        "hasEscape": false
+      },
+      "typeOnly": false
     }
   ],
   "interpreter": null

--- a/ecmascript/parser/tests/typescript/custom/type-only/import/specific/input.ts
+++ b/ecmascript/parser/tests/typescript/custom/type-only/import/specific/input.ts
@@ -1,1 +1,2 @@
 import type { Foo } from 'foo';
+import type {} from 'foo';

--- a/ecmascript/parser/tests/typescript/custom/type-only/import/specific/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/type-only/import/specific/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 31,
+    "end": 59,
     "ctxt": 0
   },
   "body": [
@@ -40,6 +40,26 @@
         "span": {
           "start": 25,
           "end": 30,
+          "ctxt": 0
+        },
+        "value": "foo",
+        "hasEscape": false
+      },
+      "typeOnly": true
+    },
+    {
+      "type": "ImportDeclaration",
+      "span": {
+        "start": 33,
+        "end": 59,
+        "ctxt": 0
+      },
+      "specifiers": [],
+      "source": {
+        "type": "StringLiteral",
+        "span": {
+          "start": 53,
+          "end": 58,
           "ctxt": 0
         },
         "value": "foo",

--- a/ecmascript/parser/tests/typescript/custom/type-only/import/specific/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/type-only/import/specific/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 59,
+    "end": 58,
     "ctxt": 0
   },
   "body": [
@@ -50,16 +50,16 @@
     {
       "type": "ImportDeclaration",
       "span": {
-        "start": 33,
-        "end": 59,
+        "start": 32,
+        "end": 58,
         "ctxt": 0
       },
       "specifiers": [],
       "source": {
         "type": "StringLiteral",
         "span": {
-          "start": 53,
-          "end": 58,
+          "start": 52,
+          "end": 57,
           "ctxt": 0
         },
         "value": "foo",


### PR DESCRIPTION
As title.

Sorry, I missed this until now.