### PR TITLE
Fix bigint literals

### DIFF
--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_codegen"
-version = "0.22.1"
+version = "0.22.2"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/codegen/src/text_writer/basic_impl.rs
+++ b/ecmascript/codegen/src/text_writer/basic_impl.rs
@@ -213,13 +213,7 @@ fn compute_line_starts(s: &str) -> Vec<usize> {
                 break;
             }
 
-            _ => {
-                // if c > MAX_ASCII_CHAR && is_line_break(c) {
-                //     res.push(line_start);
-                //     line_start = pos;
-                // }
-                unimplemented!("compute_line_starts(char = {:?})", c)
-            }
+            _ => {}
         }
     }
 

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -24,7 +24,7 @@ fn compile(src: &str, options: Options) -> String {
                         Ok(v.code.into())
                     }
                 }
-                Err(err) => panic!("Error: {}", err),
+                Err(err) => Err(()),
             }
         })
         .unwrap()

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -60,6 +60,7 @@ const someValue = 'test' ?? 'default value';",
                 jsc: JscConfig {
                     syntax: Some(Syntax::Es(EsConfig {
                         nullish_coalescing: true,
+                        optional_chaining: true,
                         ..Default::default()
                     })),
                     ..Default::default()

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,0 +1,42 @@
+use swc::{config::Options, Compiler};
+use swc_common::FileName;
+use testing::Tester;
+
+fn compile(src: &str, options: Options) -> String {
+    Tester::new()
+        .print_errors(|cm, handler| {
+            let c = Compiler::new(cm.clone(), handler);
+
+            let fm = cm.new_source_file(FileName::Real("input.js".into()), src.into());
+            let s = c.process_js_file(
+                fm,
+                &Options {
+                    is_module: true,
+                    ..options
+                },
+            );
+
+            match s {
+                Ok(v) => {
+                    if c.handler.has_errors() {
+                        Err(())
+                    } else {
+                        Ok(v.code.into())
+                    }
+                }
+                Err(err) => panic!("Error: {}", err),
+            }
+        })
+        .unwrap()
+}
+
+#[test]
+fn issue_834_1() {
+    compile(
+        "var foo =  2n + 7n;",
+        Options {
+            swcrc: false,
+            ..Default::default()
+        },
+    );
+}

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -40,3 +40,20 @@ fn issue_834_1() {
         },
     );
 }
+
+#[test]
+fn issue_834_2() {
+    compile(
+        "var ano = { some: {
+	ne:  {
+
+	}
+}};
+var foo = ano.some.ne?.sdf?.snop;
+const someValue = 'test' ?? 'default value';",
+        Options {
+            swcrc: false,
+            ..Default::default()
+        },
+    );
+}

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -28,7 +28,7 @@ fn compile(src: &str, options: Options) -> String {
                         Ok(v.code.into())
                     }
                 }
-                Err(err) => Err(()),
+                Err(..) => Err(()),
             }
         })
         .unwrap()

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,4 +1,8 @@
-use swc::{config::Options, Compiler};
+use swc::{
+    config::{Config, JscConfig, Options},
+    ecmascript::parser::{EsConfig, Syntax},
+    Compiler,
+};
 use swc_common::FileName;
 use testing::Tester;
 
@@ -52,6 +56,16 @@ fn issue_834_2() {
 var foo = ano.some.ne?.sdf?.snop;
 const someValue = 'test' ?? 'default value';",
         Options {
+            config: Some(Config {
+                jsc: JscConfig {
+                    syntax: Some(Syntax::Es(EsConfig {
+                        nullish_coalescing: true,
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
             swcrc: false,
             ..Default::default()
         },


### PR DESCRIPTION
Closes #834.
Numeric separators are tracked at #836