### PR TITLE
Fixed wasm compilation errors.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,10 @@ pub struct ParseOptions {
     pub target: JscTarget,
 }
 
+fn default_as_true() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Options {
@@ -54,6 +58,10 @@ pub struct Options {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[serde(skip_deserializing, default)]
+    pub disable_hygiene: bool,
+
+    #[cfg(target_arch = "wasm32")]
+    #[serde(default="default_as_true")]
     pub disable_hygiene: bool,
 
     #[serde(skip_deserializing, default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,7 +61,7 @@ pub struct Options {
     pub disable_hygiene: bool,
 
     #[cfg(target_arch = "wasm32")]
-    #[serde(default="default_as_true")]
+    #[serde(default = "default_as_true")]
     pub disable_hygiene: bool,
 
     #[serde(skip_deserializing, default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,7 @@ pub struct Options {
     #[serde(skip_deserializing, default)]
     pub global_mark: Option<Mark>,
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[serde(default = "default_cwd")]
     pub cwd: PathBuf,
 


### PR DESCRIPTION
Cwd references default_cwd which is excluded in the wasm32 build.

Disable_hygiene must be defined for the code to compile.