### PR TITLE
Fix span of MethodProp

### DIFF
--- a/ecmascript/ast/Cargo.toml
+++ b/ecmascript/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_ast"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/ast/src/prop.rs
+++ b/ecmascript/ast/src/prop.rs
@@ -75,11 +75,10 @@ pub struct SetterProp {
 #[ast_node("MethodProperty")]
 #[derive(Eq, Hash)]
 pub struct MethodProp {
-    #[span(lo)]
     pub key: PropName,
 
     #[serde(flatten)]
-    #[span(hi)]
+    #[span]
     pub function: Function,
 }
 


### PR DESCRIPTION
Needs to include stuff like the `async` modifier.

There is actually a test for this ("method-async-generator"), but the output was already correct, which I don't understand. I'm probably missing something or perhaps the CI will shed some light.