### PR TITLE
Support parsing declare properties

### DIFF
--- a/ecmascript/ast/Cargo.toml
+++ b/ecmascript/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_ast"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/ast/src/class.rs
+++ b/ecmascript/ast/src/class.rs
@@ -103,6 +103,9 @@ macro_rules! property {
             pub readonly: bool,
 
             #[serde(default)]
+            pub declare: bool,
+
+            #[serde(default)]
             pub definite: bool,
         }
     };

--- a/ecmascript/ast/src/class.rs
+++ b/ecmascript/ast/src/class.rs
@@ -63,56 +63,90 @@ pub enum ClassMember {
     Empty(EmptyStmt),
 }
 
-macro_rules! property {
-    ($name:ident, $ty:literal, $KEY:ty) => {
-        #[ast_node($ty)]
-        #[derive(Eq, Hash)]
-        pub struct $name {
-            #[serde(default)]
-            pub span: Span,
+#[ast_node("ClassProperty")]
+#[derive(Eq, Hash)]
+pub struct ClassProp {
+    #[serde(default)]
+    pub span: Span,
 
-            pub key: $KEY,
+    pub key: Box<Expr>,
 
-            #[serde(default)]
-            pub value: Option<Box<Expr>>,
+    #[serde(default)]
+    pub value: Option<Box<Expr>>,
 
-            #[serde(default, rename = "typeAnnotation")]
-            pub type_ann: Option<TsTypeAnn>,
+    #[serde(default, rename = "typeAnnotation")]
+    pub type_ann: Option<TsTypeAnn>,
 
-            #[serde(default)]
-            pub is_static: bool,
+    #[serde(default)]
+    pub is_static: bool,
 
-            #[serde(default)]
-            pub decorators: Vec<Decorator>,
+    #[serde(default)]
+    pub decorators: Vec<Decorator>,
 
-            #[serde(default)]
-            pub computed: bool,
+    #[serde(default)]
+    pub computed: bool,
 
-            /// Typescript extension.
-            #[serde(default)]
-            pub accessibility: Option<Accessibility>,
+    /// Typescript extension.
+    #[serde(default)]
+    pub accessibility: Option<Accessibility>,
 
-            /// Typescript extension.
-            #[serde(default)]
-            pub is_abstract: bool,
+    /// Typescript extension.
+    #[serde(default)]
+    pub is_abstract: bool,
 
-            #[serde(default)]
-            pub is_optional: bool,
+    #[serde(default)]
+    pub is_optional: bool,
 
-            #[serde(default)]
-            pub readonly: bool,
+    #[serde(default)]
+    pub readonly: bool,
 
-            #[serde(default)]
-            pub declare: bool,
+    #[serde(default)]
+    pub declare: bool,
 
-            #[serde(default)]
-            pub definite: bool,
-        }
-    };
+    #[serde(default)]
+    pub definite: bool,
 }
 
-property!(ClassProp, "ClassProperty", Box<Expr>);
-property!(PrivateProp, "PrivateProperty", PrivateName);
+#[ast_node("PrivateProperty")]
+#[derive(Eq, Hash)]
+pub struct PrivateProp {
+    #[serde(default)]
+    pub span: Span,
+
+    pub key: PrivateName,
+
+    #[serde(default)]
+    pub value: Option<Box<Expr>>,
+
+    #[serde(default, rename = "typeAnnotation")]
+    pub type_ann: Option<TsTypeAnn>,
+
+    #[serde(default)]
+    pub is_static: bool,
+
+    #[serde(default)]
+    pub decorators: Vec<Decorator>,
+
+    #[serde(default)]
+    pub computed: bool,
+
+    /// Typescript extension.
+    #[serde(default)]
+    pub accessibility: Option<Accessibility>,
+
+    /// Typescript extension.
+    #[serde(default)]
+    pub is_abstract: bool,
+
+    #[serde(default)]
+    pub is_optional: bool,
+
+    #[serde(default)]
+    pub readonly: bool,
+
+    #[serde(default)]
+    pub definite: bool,
+}
 
 macro_rules! method {
     ($name:ident, $ty:literal, $KEY:ty) => {

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_codegen"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -13,11 +13,11 @@ include = ["Cargo.toml", "src/**/*.rs"]
 bitflags = "1"
 swc_atoms = { version = "0.2", path ="../../atoms" }
 swc_common = { version = "0.7", path ="../../common" }
-swc_ecma_ast = { version = "0.24.0", path ="../ast" }
+swc_ecma_ast = { version = "0.25.0", path ="../ast" }
 swc_ecma_codegen_macros = { version = "0.5", path ="./macros" }
 sourcemap = "6"
 num-bigint = { version = "0.2", features = ["serde"] }
 
 [dev-dependencies]
-swc_ecma_parser = { version = "0.29", path ="../parser" }
+swc_ecma_parser = { version = "0.30", path ="../parser" }
 testing = { version = "0.7", path ="../../testing" }

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -15,9 +15,9 @@ default = []
 [dependencies]
 swc_atoms = { version = "0.2", path ="../../atoms" }
 swc_common = { version = "0.7.0", path ="../../common" }
-swc_ecma_ast = { version = "0.24.0", path ="../ast" }
+swc_ecma_ast = { version = "0.25.0", path ="../ast" }
 swc_ecma_parser_macros = { version = "0.4.1", path ="./macros" }
-swc_ecma_visit = { version = "0.9.0", path ="../visit" }
+swc_ecma_visit = { version = "0.10.0", path ="../visit" }
 enum_kind = { version = "0.2", path ="../../macros/enum_kind" }
 unicode-xid = "0.2"
 log = "0.4"

--- a/ecmascript/parser/src/error.rs
+++ b/ecmascript/parser/src/error.rs
@@ -126,6 +126,7 @@ pub enum SyntaxError {
 
     AsyncConstructor,
     PropertyNamedConstructor,
+    DeclarePrivateIdentifier,
     ClassProperty,
     ReadOnlyMethod,
     TsBindingPatCannotBeOptional,
@@ -306,6 +307,9 @@ impl Error {
             AsyncConstructor => "Constructor can't be an async function".into(),
             PropertyNamedConstructor => {
                 "Classes may not have a non-static field named 'constructor'".into()
+            }
+            DeclarePrivateIdentifier => {
+                "'declare' modifier cannot be used with a private identifier".into()
             }
             ClassProperty => "Class property requires `jsc.parser.classProperty` to be true".into(),
             ReadOnlyMethod => "A method cannot be readonly".into(),

--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -301,14 +301,14 @@ impl<'a, I: Tokens> Parser<I> {
     fn parse_class_member(&mut self) -> PResult<ClassMember> {
         let start = cur_pos!();
         let decorators = self.parse_decorators(false)?;
-        let is_declare = self.syntax().typescript() && eat!("declare");
+        let declare = self.syntax().typescript() && eat!("declare");
         let accessibility = if self.input.syntax().typescript() {
             self.parse_access_modifier()?
         } else {
             None
         };
 
-        if is_declare && accessibility.is_none() {
+        if declare && accessibility.is_none() {
             // Handle declare(){}
             if self.is_class_method()? {
                 let key = Either::Right(PropName::Ident(Ident::new(
@@ -403,7 +403,7 @@ impl<'a, I: Tokens> Parser<I> {
                     false,
                     is_optional,
                     false,
-                    is_declare,
+                    declare,
                     false,
                 );
             } else {
@@ -411,13 +411,20 @@ impl<'a, I: Tokens> Parser<I> {
             }
         }
 
-        self.parse_class_member_with_is_static(start, accessibility, static_token, decorators)
+        self.parse_class_member_with_is_static(
+            start,
+            declare,
+            accessibility,
+            static_token,
+            decorators,
+        )
     }
 
     #[allow(clippy::cognitive_complexity)]
     fn parse_class_member_with_is_static(
         &mut self,
         start: BytePos,
+        declare: bool,
         accessibility: Option<Accessibility>,
         static_token: Option<Span>,
         decorators: Vec<Decorator>,
@@ -598,7 +605,7 @@ impl<'a, I: Tokens> Parser<I> {
                 is_static,
                 is_optional,
                 readonly,
-                false,
+                declare,
                 is_abstract,
             );
         }

--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -772,7 +772,6 @@ impl<'a, I: Tokens> Parser<I> {
                     is_abstract,
                     is_optional,
                     readonly,
-                    declare,
                     definite,
                     type_ann,
                     computed: false,

--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -734,6 +734,9 @@ impl<'a, I: Tokens> Parser<I> {
         if is_constructor(&key) {
             syntax_error!(key.span(), SyntaxError::PropertyNamedConstructor);
         }
+        if declare && key.is_left() {
+            syntax_error!(key.span(), SyntaxError::DeclarePrivateIdentifier);
+        }
         let definite = self.input.syntax().typescript() && !is_optional && eat!('!');
 
         let type_ann = self.try_parse_ts_type_ann()?;

--- a/ecmascript/parser/tests/typescript-errors/class/declare-private-name/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/class/declare-private-name/input.ts
@@ -1,0 +1,3 @@
+class T {
+    declare #name;
+}

--- a/ecmascript/parser/tests/typescript-errors/class/declare-private-name/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/class/declare-private-name/input.ts.stderr
@@ -1,0 +1,12 @@
+error: 'declare' modifier cannot be used with a private identifier
+ --> $DIR/tests/typescript-errors/class/declare-private-name/input.ts:2:13
+  |
+2 |     declare #name;
+  |             ^^^^^
+
+error: TS1031
+ --> $DIR/tests/typescript-errors/class/declare-private-name/input.ts:2:5
+  |
+2 |     declare #name;
+  |     ^^^^^^^
+

--- a/ecmascript/parser/tests/typescript/class/declare/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/declare/input.ts.json
@@ -109,6 +109,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -154,6 +155,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {

--- a/ecmascript/parser/tests/typescript/class/decorators/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/decorators/input.ts.json
@@ -269,6 +269,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {

--- a/ecmascript/parser/tests/typescript/class/members-with-modifier-names/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/members-with-modifier-names/input.ts.json
@@ -170,6 +170,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {

--- a/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts
+++ b/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts
@@ -18,4 +18,6 @@ abstract class C {
     public readonly abstract pura;
     public abstract readonly puar;
     public static readonly pusr;
+    declare public readonly dpur;
+    declare d;
 }

--- a/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts
+++ b/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts
@@ -19,5 +19,6 @@ abstract class C {
     public abstract readonly puar;
     public static readonly pusr;
     declare public readonly dpur;
+    declare private static readonly dpisr;
     declare d;
 }

--- a/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts
+++ b/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts
@@ -21,4 +21,5 @@ abstract class C {
     declare public readonly dpur;
     declare private static readonly dpisr;
     declare d;
+    declare declare;
 }

--- a/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
@@ -557,14 +557,44 @@
           "type": "ClassProperty",
           "span": {
             "start": 433,
-            "end": 443,
+            "end": 471,
             "ctxt": 0
           },
           "key": {
             "type": "Identifier",
             "span": {
-              "start": 441,
-              "end": 442,
+              "start": 465,
+              "end": 470,
+              "ctxt": 0
+            },
+            "value": "dpisr",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "value": null,
+          "typeAnnotation": null,
+          "isStatic": true,
+          "decorators": [],
+          "computed": false,
+          "accessibility": "private",
+          "isAbstract": false,
+          "isOptional": false,
+          "readonly": true,
+          "declare": true,
+          "definite": false
+        },
+        {
+          "type": "ClassProperty",
+          "span": {
+            "start": 476,
+            "end": 486,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 484,
+              "end": 485,
               "ctxt": 0
             },
             "value": "d",

--- a/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 488,
+    "end": 509,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 488,
+        "end": 509,
         "ctxt": 0
       },
       "decorators": [],
@@ -598,6 +598,36 @@
               "ctxt": 0
             },
             "value": "d",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "value": null,
+          "typeAnnotation": null,
+          "isStatic": false,
+          "decorators": [],
+          "computed": false,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "readonly": false,
+          "declare": true,
+          "definite": false
+        },
+        {
+          "type": "ClassProperty",
+          "span": {
+            "start": 491,
+            "end": 507,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 499,
+              "end": 506,
+              "ctxt": 0
+            },
+            "value": "declare",
             "typeAnnotation": null,
             "optional": false
           },

--- a/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 396,
+    "end": 445,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 396,
+        "end": 445,
         "ctxt": 0
       },
       "decorators": [],
@@ -54,6 +54,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": true,
+          "declare": false,
           "definite": false
         },
         {
@@ -99,6 +100,7 @@
           "isAbstract": false,
           "isOptional": true,
           "readonly": true,
+          "declare": false,
           "definite": false
         },
         {
@@ -128,6 +130,7 @@
           "isAbstract": true,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -157,6 +160,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -186,6 +190,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -215,6 +220,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -244,6 +250,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -273,6 +280,7 @@
           "isAbstract": true,
           "isOptional": false,
           "readonly": true,
+          "declare": false,
           "definite": false
         },
         {
@@ -302,6 +310,7 @@
           "isAbstract": true,
           "isOptional": false,
           "readonly": true,
+          "declare": false,
           "definite": false
         },
         {
@@ -331,6 +340,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": true,
+          "declare": false,
           "definite": false
         },
         {
@@ -360,6 +370,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": true,
+          "declare": false,
           "definite": false
         },
         {
@@ -389,6 +400,7 @@
           "isAbstract": true,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -418,6 +430,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -447,6 +460,7 @@
           "isAbstract": true,
           "isOptional": false,
           "readonly": true,
+          "declare": false,
           "definite": false
         },
         {
@@ -476,6 +490,7 @@
           "isAbstract": true,
           "isOptional": false,
           "readonly": true,
+          "declare": false,
           "definite": false
         },
         {
@@ -505,6 +520,67 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": true,
+          "declare": false,
+          "definite": false
+        },
+        {
+          "type": "ClassProperty",
+          "span": {
+            "start": 399,
+            "end": 428,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 423,
+              "end": 427,
+              "ctxt": 0
+            },
+            "value": "dpur",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "value": null,
+          "typeAnnotation": null,
+          "isStatic": false,
+          "decorators": [],
+          "computed": false,
+          "accessibility": "public",
+          "isAbstract": false,
+          "isOptional": false,
+          "readonly": true,
+          "declare": true,
+          "definite": false
+        },
+        {
+          "type": "ClassProperty",
+          "span": {
+            "start": 433,
+            "end": 443,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 441,
+              "end": 442,
+              "ctxt": 0
+            },
+            "value": "d",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "value": null,
+          "typeAnnotation": null,
+          "isStatic": false,
+          "decorators": [],
+          "computed": false,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "readonly": false,
+          "declare": true,
           "definite": false
         }
       ],

--- a/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifiers-properties/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 445,
+    "end": 488,
     "ctxt": 0
   },
   "body": [
@@ -22,7 +22,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 445,
+        "end": 488,
         "ctxt": 0
       },
       "decorators": [],

--- a/ecmascript/parser/tests/typescript/class/properties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/properties/input.ts.json
@@ -54,6 +54,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -83,6 +84,7 @@
           "isAbstract": false,
           "isOptional": true,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -128,6 +130,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -181,6 +184,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -210,6 +214,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": true
         },
         {
@@ -255,6 +260,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": true
         }
       ],

--- a/ecmascript/parser/tests/typescript/class/property-computed/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/property-computed/input.ts.json
@@ -90,6 +90,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -155,6 +156,7 @@
           "isAbstract": false,
           "isOptional": true,
           "readonly": false,
+          "declare": false,
           "definite": false
         }
       ],

--- a/ecmascript/parser/tests/typescript/class/property-private/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/property-private/input.ts.json
@@ -70,7 +70,6 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
-          "declare": false,
           "definite": false
         },
         {
@@ -124,7 +123,6 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
-          "declare": false,
           "definite": false
         },
         {

--- a/ecmascript/parser/tests/typescript/class/property-private/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/property-private/input.ts.json
@@ -70,6 +70,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {
@@ -123,6 +124,7 @@
           "isAbstract": false,
           "isOptional": false,
           "readonly": false,
+          "declare": false,
           "definite": false
         },
         {

--- a/ecmascript/parser/tests/typescript/custom/issue-496/input.ts.json
+++ b/ecmascript/parser/tests/typescript/custom/issue-496/input.ts.json
@@ -77,6 +77,7 @@
             "isAbstract": false,
             "isOptional": false,
             "readonly": false,
+            "declare": false,
             "definite": false
           },
           {

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_transforms"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -11,10 +11,10 @@ edition = "2018"
 [dependencies]
 swc_atoms = { version = "0.2.0", path ="../../atoms" }
 swc_common = { version = "0.7.0", path ="../../common" }
-swc_ecma_ast = { version = "0.24.0", path ="../ast" }
-swc_ecma_utils = { version = "0.13.0", path ="../utils" }
-swc_ecma_parser = { version = "0.29.0", path ="../parser" }
-swc_ecma_visit = { version = "0.9.0", path ="../visit" }
+swc_ecma_ast = { version = "0.25.0", path ="../ast" }
+swc_ecma_utils = { version = "0.14.0", path ="../utils" }
+swc_ecma_parser = { version = "0.30.0", path ="../parser" }
+swc_ecma_visit = { version = "0.10.0", path ="../visit" }
 dashmap = "=3.5.1"
 either = "1.5"
 fxhash = "0.2"
@@ -34,7 +34,7 @@ log = "0.4.8"
 
 [dev-dependencies]
 testing = { version = "0.7", path ="../../testing" }
-swc_ecma_codegen = { version = "0.27.0", path ="../codegen" }
+swc_ecma_codegen = { version = "0.28.0", path ="../codegen" }
 tempfile = "3"
 pretty_assertions = "0.6"
 sourcemap = "6"

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_utils"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -11,11 +11,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-swc_ecma_ast = { version = "0.24.0", path ="../ast" }
+swc_ecma_ast = { version = "0.25.0", path ="../ast" }
 swc_atoms = { version = "0.2.0", path ="../../atoms" }
 swc_common = { version = "0.7.0", path ="../../common" }
-swc_ecma_parser = { version = "0.29", path ="../parser" }
-swc_ecma_visit = { version = "0.9", path ="../visit" }
+swc_ecma_parser = { version = "0.30", path ="../parser" }
+swc_ecma_visit = { version = "0.10", path ="../visit" }
 anyhow = "1.0.26"
 once_cell = "1"
 scoped-tls = "1"

--- a/ecmascript/visit/Cargo.toml
+++ b/ecmascript/visit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_visit"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -12,6 +12,6 @@ edition = "2018"
 [dependencies]
 swc_atoms = { version = "0.2", path = "../../atoms" }
 swc_common = { version = "0.7", path = "../../common" }
-swc_ecma_ast = { version = "0.24.0", path ="../ast" }
+swc_ecma_ast = { version = "0.25.0", path ="../ast" }
 swc_visit = { version = "0.1", path ="../../visit" }
 num-bigint = { version = "0.2", features = ["serde"] }

--- a/ecmascript/visit/src/lib.rs
+++ b/ecmascript/visit/src/lib.rs
@@ -142,6 +142,7 @@ define!({
         pub is_abstract: bool,
         pub is_optional: bool,
         pub readonly: bool,
+        pub declare: bool,
         pub definite: bool,
     }
     pub struct PrivateProp {
@@ -156,6 +157,7 @@ define!({
         pub is_abstract: bool,
         pub is_optional: bool,
         pub readonly: bool,
+        pub declare: bool,
         pub definite: bool,
     }
     pub struct ClassMethod {

--- a/ecmascript/visit/src/lib.rs
+++ b/ecmascript/visit/src/lib.rs
@@ -157,7 +157,6 @@ define!({
         pub is_abstract: bool,
         pub is_optional: bool,
         pub readonly: bool,
-        pub declare: bool,
         pub definite: bool,
     }
     pub struct ClassMethod {


### PR DESCRIPTION
This is a parsing only implementation for #894.

These properties need to be ignored in the output when transforming.