### PR TITLE
Fix bugs

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.30.0"
+version = "0.30.1"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/parser/src/parser/stmt/module_item.rs
+++ b/ecmascript/parser/src/parser/stmt/module_item.rs
@@ -236,6 +236,8 @@ impl<'a, I: Tokens> Parser<I> {
         let mut export_ns = None;
         let ns_export_specifier_start = cur_pos!();
 
+        let type_only = self.input.syntax().typescript() && eat!("type");
+
         if eat!('*') {
             has_star = true;
             if is!("from") {
@@ -258,8 +260,6 @@ impl<'a, I: Tokens> Parser<I> {
                 }));
             }
         }
-
-        let type_only = self.input.syntax().typescript() && eat!("type");
 
         // Some("default") if default is exported from 'src'
         let mut export_default = None;

--- a/ecmascript/parser/tests/typescript/issue-896/input.ts
+++ b/ecmascript/parser/tests/typescript/issue-896/input.ts
@@ -1,0 +1,1 @@
+export type * from '../typings'

--- a/ecmascript/parser/tests/typescript/issue-896/input.ts
+++ b/ecmascript/parser/tests/typescript/issue-896/input.ts
@@ -1,1 +1,2 @@
+// @ts-ignore
 export type * from '../typings'

--- a/ecmascript/parser/tests/typescript/issue-896/input.ts.json
+++ b/ecmascript/parser/tests/typescript/issue-896/input.ts.json
@@ -1,0 +1,29 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 14,
+    "end": 45,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ExportAllDeclaration",
+      "span": {
+        "start": 14,
+        "end": 45,
+        "ctxt": 0
+      },
+      "source": {
+        "type": "StringLiteral",
+        "span": {
+          "start": 33,
+          "end": 45,
+          "ctxt": 0
+        },
+        "value": "../typings",
+        "hasEscape": false
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_transforms"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/transforms/src/resolver.rs
+++ b/ecmascript/transforms/src/resolver.rs
@@ -474,6 +474,15 @@ impl<'a> Fold for Resolver<'a> {
         }
     }
 
+    fn fold_import_named_specifier(&mut self, s: ImportNamedSpecifier) -> ImportNamedSpecifier {
+        let old = self.ident_type;
+        self.ident_type = IdentType::Ref;
+        let local = s.local.fold_with(self);
+        self.ident_type = old;
+
+        ImportNamedSpecifier { local, ..s }
+    }
+
     fn fold_method_prop(&mut self, m: MethodProp) -> MethodProp {
         let key = m.key.fold_with(self);
 

--- a/ecmascript/transforms/tests/proposal_decorators.rs
+++ b/ecmascript/transforms/tests/proposal_decorators.rs
@@ -3,6 +3,7 @@ use swc_common::chain;
 use swc_ecma_parser::{EsConfig, Syntax, TsConfig};
 use swc_ecma_transforms::{
     compat::{es2015::classes::Classes, es2020::class_properties},
+    optimization::simplify::inlining,
     proposals::{decorators, decorators::Config},
     resolver, typescript,
     typescript::strip,
@@ -4571,4 +4572,23 @@ expect(logs).toEqual([0, 1])
 const c = new ProductController();
 c.findById(100);
 "
+);
+
+test!(
+    ts(),
+    |_| chain!(
+        strip(),
+        inlining::inlining(inlining::Config {}),
+        decorators(Config {
+            legacy: true,
+            ..Default::default()
+        }),
+        class_properties(),
+    ),
+    issue_879_1,
+    "export default class X {
+    @networked
+    prop: string = '';
+}",
+    ""
 );

--- a/ecmascript/transforms/tests/proposal_decorators.rs
+++ b/ecmascript/transforms/tests/proposal_decorators.rs
@@ -4590,5 +4590,24 @@ test!(
     @networked
     prop: string = '';
 }",
-    ""
+    "var _class, _descriptor;
+let X = ((_class = function() {
+    class X {
+        constructor(){
+            _initializerDefineProperty(this, 'prop', _descriptor, this);
+        }
+    }
+    return X;
+}()) || _class, _descriptor = _applyDecoratedDescriptor(_class.prototype, 'prop', [
+    networked
+], {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    initializer: function() {
+        return '';
+    }
+}), _class);
+export { X as default };
+"
 );

--- a/tests/projects.rs
+++ b/tests/projects.rs
@@ -540,7 +540,7 @@ fn issue_879() {
     .unwrap();
     println!("{}", f);
 
-    assert!(f.find("function X"), "swc should compile class");
+    assert!(f.find("function X").is_some(), "swc should compile class");
     assert_eq!(
         f.find("function X"),
         f.rfind("function X"),

--- a/tests/projects.rs
+++ b/tests/projects.rs
@@ -1,10 +1,13 @@
 use rayon::prelude::*;
 use std::{path::Path, sync::Arc};
 use swc::{
-    config::{Config, Options, SourceMapsConfig},
+    config::{Config, JscConfig, ModuleConfig, Options, SourceMapsConfig, TransformConfig},
     Compiler,
 };
-use swc_ecmascript::preset_env;
+use swc_ecmascript::{
+    parser::{Syntax, TsConfig},
+    preset_env,
+};
 use testing::{NormalizedOutput, StdErr, Tester};
 use walkdir::WalkDir;
 
@@ -39,7 +42,7 @@ fn file_with_opt(f: &str, options: Options) -> Result<NormalizedOutput, StdErr> 
                     Ok(v.code.into())
                 }
             }
-            Err(err) => panic!("Error: {}", err),
+            Err(err) => panic!("Error: {:?}", err),
         }
     })
 }
@@ -506,4 +509,41 @@ fn issue_801() {
 #[test]
 fn concurrency() {
     par_project("tests/deno-unit");
+}
+
+#[test]
+fn issue_879() {
+    let f = file_with_opt(
+        "tests/projects/issue-879/input.ts",
+        Options {
+            is_module: true,
+            config: Some(Config {
+                env: Some(Default::default()),
+                module: Some(ModuleConfig::CommonJs(Default::default())),
+                jsc: JscConfig {
+                    syntax: Some(Syntax::Typescript(TsConfig {
+                        tsx: true,
+                        decorators: true,
+                        ..Default::default()
+                    })),
+                    transform: Some(TransformConfig {
+                        legacy_decorator: true,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    println!("{}", f);
+
+    assert!(f.find("function X"), "swc should compile class");
+    assert_eq!(
+        f.find("function X"),
+        f.rfind("function X"),
+        "swc should not emit `function X` twice"
+    );
 }

--- a/tests/projects/issue-879/input.ts
+++ b/tests/projects/issue-879/input.ts
@@ -1,0 +1,4 @@
+export default class X {
+    @networked
+    prop: string = "";
+}


### PR DESCRIPTION
swc_ecma_parser:
 - Accept `export type * from '../typings'` (Closes #896)

swc_ecma_transforms:
 - Ensure that swc does not duplicate classes (Closes #879)