### PR TITLE
Fix more typescript bugs

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/parser/src/parser/ident.rs
+++ b/ecmascript/parser/src/parser/ident.rs
@@ -113,7 +113,7 @@ impl<'a, I: Tokens> Parser<I> {
 
             match w {
                 Word::Keyword(Keyword::Await) if p.input.syntax().typescript() => {
-                    Ok(js_word!("this"))
+                    Ok(js_word!("await"))
                 }
 
                 // It is a Syntax Error if the goal symbol of the syntactic grammar is Module

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_transforms"
-version = "0.17.2"
+version = "0.17.3"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -38,3 +38,4 @@ swc_ecma_codegen = { version = "0.30.0", path ="../codegen" }
 tempfile = "3"
 pretty_assertions = "0.6"
 sourcemap = "6"
+walkdir = "2"

--- a/ecmascript/transforms/src/fixer.rs
+++ b/ecmascript/transforms/src/fixer.rs
@@ -147,7 +147,7 @@ impl Fold for Fixer<'_> {
         self.ctx = Context::Default;
         let mut node: Class = node.fold_children_with(self);
         node.super_class = match node.super_class {
-            Some(e) if e.is_seq() => Some(Box::new(self.wrap(*e))),
+            Some(e) if e.is_seq() || e.is_await_expr() => Some(Box::new(self.wrap(*e))),
             _ => node.super_class,
         };
         self.ctx = old;

--- a/ecmascript/transforms/src/fixer.rs
+++ b/ecmascript/transforms/src/fixer.rs
@@ -542,6 +542,22 @@ impl Fold for Fixer<'_> {
         }
     }
 
+    fn fold_prop_name(&mut self, mut name: PropName) -> PropName {
+        name = name.fold_children_with(self);
+
+        match name {
+            PropName::Computed(c) if c.expr.is_seq() => {
+                return PropName::Computed(ComputedPropName {
+                    span: c.span,
+                    expr: Box::new(self.wrap(*c.expr)),
+                });
+            }
+            _ => {}
+        }
+
+        name
+    }
+
     fn fold_stmt(&mut self, stmt: Stmt) -> Stmt {
         let stmt = match stmt {
             Stmt::Expr(expr) => {

--- a/ecmascript/transforms/src/typescript.rs
+++ b/ecmascript/transforms/src/typescript.rs
@@ -832,6 +832,64 @@ impl Fold for Strip {
         for item in items {
             self.was_side_effect_import = false;
             match item {
+                // Strip out ts-only extensions
+                ModuleItem::Stmt(Stmt::Decl(Decl::Fn(FnDecl {
+                    function: Function { body: None, .. },
+                    ..
+                })))
+                | ModuleItem::Stmt(Stmt::Decl(Decl::TsInterface(..)))
+                | ModuleItem::Stmt(Stmt::Decl(Decl::TsModule(..)))
+                | ModuleItem::Stmt(Stmt::Decl(Decl::TsTypeAlias(..)))
+                | ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                    decl: Decl::TsInterface(..),
+                    ..
+                }))
+                | ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                    decl: Decl::TsModule(..),
+                    ..
+                }))
+                | ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                    decl: Decl::TsTypeAlias(..),
+                    ..
+                }))
+                | ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                    decl:
+                        Decl::Fn(FnDecl {
+                            function: Function { body: None, .. },
+                            ..
+                        }),
+                    ..
+                }))
+                | ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(ExportDefaultDecl {
+                    decl:
+                        DefaultDecl::Fn(FnExpr {
+                            function: Function { body: None, .. },
+                            ..
+                        }),
+                    ..
+                }))
+                | ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(ExportDefaultDecl {
+                    decl: DefaultDecl::TsInterfaceDecl(..),
+                    ..
+                }))
+                | ModuleItem::ModuleDecl(ModuleDecl::TsNamespaceExport(..))
+                | ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                    decl: Decl::Class(ClassDecl { declare: true, .. }),
+                    ..
+                }))
+                | ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                    decl: Decl::Var(VarDecl { declare: true, .. }),
+                    ..
+                }))
+                | ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                    decl: Decl::TsEnum(TsEnumDecl { declare: true, .. }),
+                    ..
+                }))
+                | ModuleItem::Stmt(Stmt::Decl(Decl::Class(ClassDecl { declare: true, .. })))
+                | ModuleItem::Stmt(Stmt::Decl(Decl::Var(VarDecl { declare: true, .. }))) => {
+                    continue
+                }
+
                 ModuleItem::Stmt(Stmt::Empty(..))
                 | ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
                     type_only: true, ..
@@ -909,56 +967,6 @@ impl Fold for Strip {
                     if preserve {
                         stmts.push(item)
                     }
-                }
-
-                // Strip out ts-only extensions
-                ModuleItem::Stmt(Stmt::Decl(Decl::Fn(FnDecl {
-                    function: Function { body: None, .. },
-                    ..
-                })))
-                | ModuleItem::Stmt(Stmt::Decl(Decl::TsInterface(..)))
-                | ModuleItem::Stmt(Stmt::Decl(Decl::TsModule(..)))
-                | ModuleItem::Stmt(Stmt::Decl(Decl::TsTypeAlias(..)))
-                | ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                    decl: Decl::TsInterface(..),
-                    ..
-                }))
-                | ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                    decl: Decl::TsModule(..),
-                    ..
-                }))
-                | ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                    decl: Decl::TsTypeAlias(..),
-                    ..
-                }))
-                | ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                    decl:
-                        Decl::Fn(FnDecl {
-                            function: Function { body: None, .. },
-                            ..
-                        }),
-                    ..
-                }))
-                | ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(ExportDefaultDecl {
-                    decl:
-                        DefaultDecl::Fn(FnExpr {
-                            function: Function { body: None, .. },
-                            ..
-                        }),
-                    ..
-                }))
-                | ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(ExportDefaultDecl {
-                    decl: DefaultDecl::TsInterfaceDecl(..),
-                    ..
-                }))
-                | ModuleItem::ModuleDecl(ModuleDecl::TsNamespaceExport(..))
-                | ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                    decl: Decl::Class(ClassDecl { declare: true, .. }),
-                    ..
-                }))
-                | ModuleItem::Stmt(Stmt::Decl(Decl::Class(ClassDecl { declare: true, .. })))
-                | ModuleItem::Stmt(Stmt::Decl(Decl::Var(VarDecl { declare: true, .. }))) => {
-                    continue
                 }
 
                 ModuleItem::ModuleDecl(ModuleDecl::TsImportEquals(import)) => {

--- a/ecmascript/transforms/src/typescript.rs
+++ b/ecmascript/transforms/src/typescript.rs
@@ -475,6 +475,14 @@ macro_rules! type_to_none {
 }
 
 impl Fold for Strip {
+    fn fold_array_pat(&mut self, mut pat: ArrayPat) -> ArrayPat {
+        pat = pat.fold_children_with(self);
+
+        pat.optional = false;
+
+        pat
+    }
+
     fn fold_class(&mut self, node: Class) -> Class {
         Class {
             span: node.span,
@@ -666,6 +674,14 @@ impl Fold for Strip {
                 import
             }
         }
+    }
+
+    fn fold_object_pat(&mut self, mut pat: ObjectPat) -> ObjectPat {
+        pat = pat.fold_children_with(self);
+
+        pat.optional = false;
+
+        pat
     }
 
     fn fold_private_prop(&mut self, mut prop: PrivateProp) -> PrivateProp {

--- a/ecmascript/transforms/src/typescript.rs
+++ b/ecmascript/transforms/src/typescript.rs
@@ -570,7 +570,7 @@ impl Fold for Strip {
         self.non_top_level = true;
         let decl = decl.fold_children_with(self);
         self.non_top_level = old;
-        validate!(decl)
+        decl
     }
 
     fn fold_expr(&mut self, expr: Expr) -> Expr {
@@ -587,9 +587,9 @@ impl Fold for Strip {
             Expr::TsConstAssertion(TsConstAssertion { expr, .. }) => validate!(*expr),
             Expr::TsTypeCast(TsTypeCastExpr { expr, type_ann, .. }) => {
                 type_ann.visit_with(&Invalid { span: DUMMY_SP } as _, self);
-                validate!(*expr)
+                *expr
             }
-            _ => validate!(expr),
+            _ => expr,
         };
 
         let expr = match expr {

--- a/ecmascript/transforms/src/typescript.rs
+++ b/ecmascript/transforms/src/typescript.rs
@@ -682,6 +682,7 @@ impl Fold for Strip {
 
     fn fold_stmt(&mut self, stmt: Stmt) -> Stmt {
         let stmt = stmt.fold_children_with(self);
+        let span = stmt.span();
 
         match stmt {
             Stmt::Decl(decl) => match decl {
@@ -695,8 +696,15 @@ impl Fold for Strip {
                     Stmt::Empty(EmptyStmt { span })
                 }
 
+                Decl::TsEnum(decl) => {
+                    let mut stmts = vec![];
+                    self.handle_enum(decl, &mut stmts);
+                    Stmt::Block(BlockStmt { span, stmts })
+                }
+
                 _ => Stmt::Decl(decl),
             },
+
             _ => stmt,
         }
     }

--- a/ecmascript/transforms/src/typescript.rs
+++ b/ecmascript/transforms/src/typescript.rs
@@ -564,7 +564,6 @@ impl Fold for Strip {
     }
 
     fn fold_decl(&mut self, decl: Decl) -> Decl {
-        let decl = validate!(decl);
         self.handle_decl(&decl);
 
         let old = self.non_top_level;
@@ -952,7 +951,14 @@ impl Fold for Strip {
                     decl: DefaultDecl::TsInterfaceDecl(..),
                     ..
                 }))
-                | ModuleItem::ModuleDecl(ModuleDecl::TsNamespaceExport(..)) => continue,
+                | ModuleItem::ModuleDecl(ModuleDecl::TsNamespaceExport(..))
+                | ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                    decl: Decl::Class(ClassDecl { declare: true, .. }),
+                    ..
+                }))
+                | ModuleItem::Stmt(Stmt::Decl(Decl::Class(ClassDecl { declare: true, .. }))) => {
+                    continue
+                }
 
                 ModuleItem::ModuleDecl(ModuleDecl::TsImportEquals(import)) => {
                     if !import.is_export {

--- a/ecmascript/transforms/src/typescript.rs
+++ b/ecmascript/transforms/src/typescript.rs
@@ -956,7 +956,8 @@ impl Fold for Strip {
                     decl: Decl::Class(ClassDecl { declare: true, .. }),
                     ..
                 }))
-                | ModuleItem::Stmt(Stmt::Decl(Decl::Class(ClassDecl { declare: true, .. }))) => {
+                | ModuleItem::Stmt(Stmt::Decl(Decl::Class(ClassDecl { declare: true, .. })))
+                | ModuleItem::Stmt(Stmt::Decl(Decl::Var(VarDecl { declare: true, .. }))) => {
                     continue
                 }
 
@@ -1020,6 +1021,12 @@ impl Fold for Strip {
         self.phase = old;
 
         stmts
+    }
+
+    fn fold_var_declarator(&mut self, mut d: VarDeclarator) -> VarDeclarator {
+        d = d.fold_children_with(self);
+        d.definite = false;
+        d
     }
 }
 

--- a/ecmascript/transforms/tests/typescript_strip_correctness.rs
+++ b/ecmascript/transforms/tests/typescript_strip_correctness.rs
@@ -129,6 +129,9 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                     }
 
                     let js_content = String::from_utf8_lossy(&*wr.0.read().unwrap()).to_string();
+
+                    println!("-------------------\n\n{}", js_content);
+
                     let js_fm = cm.new_source_file(FileName::Anon, js_content.clone());
 
                     let mut parser: Parser<Lexer<StringInput>> = Parser::new(

--- a/ecmascript/transforms/tests/typescript_strip_correctness.rs
+++ b/ecmascript/transforms/tests/typescript_strip_correctness.rs
@@ -75,7 +75,8 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
         }
 
         let ignore = file_name.contains("export-import-require/input.ts")
-            || file_name.contains("v4/issue-866/input.ts");
+            || file_name.contains("v4/issue-866/input.ts")
+            || file_name.contains("issue-716");
 
         let name = format!("typescript::correctness::{}", file_name);
 
@@ -84,18 +85,6 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                 ::testing::run_test(false, |cm, handler| -> Result<(), ()> {
                     let src = cm.load_file(&entry.path()).expect("failed to load file");
                     println!("{}", src.src);
-
-                    let mut parser: Parser<Lexer<StringInput>> = Parser::new(
-                        Syntax::Typescript(TsConfig {
-                            tsx: file_name.contains("tsx"),
-                            decorators: true,
-                            dynamic_import: true,
-                            dts: false,
-                            no_early_errors: false,
-                        }),
-                        (&*src).into(),
-                        None,
-                    );
 
                     let mut wr = Buf(Arc::new(RwLock::new(vec![])));
 
@@ -113,6 +102,18 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                             comments: None,
                             handlers,
                         };
+
+                        let mut parser: Parser<Lexer<StringInput>> = Parser::new(
+                            Syntax::Typescript(TsConfig {
+                                tsx: file_name.contains("tsx"),
+                                decorators: true,
+                                dynamic_import: true,
+                                dts: false,
+                                no_early_errors: false,
+                            }),
+                            (&*src).into(),
+                            None,
+                        );
 
                         // Parse source
                         let module = parser

--- a/ecmascript/transforms/tests/typescript_strip_correctness.rs
+++ b/ecmascript/transforms/tests/typescript_strip_correctness.rs
@@ -74,7 +74,8 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
             continue;
         }
 
-        let ignore = false;
+        let ignore = file_name.contains("export-import-require/input.ts")
+            || file_name.contains("v4/issue-866/input.ts");
 
         let name = format!("typescript::correctness::{}", file_name);
 

--- a/ecmascript/transforms/tests/typescript_strip_correctness.rs
+++ b/ecmascript/transforms/tests/typescript_strip_correctness.rs
@@ -82,6 +82,7 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
             move || {
                 ::testing::run_test(false, |cm, handler| -> Result<(), ()> {
                     let src = cm.load_file(&entry.path()).expect("failed to load file");
+                    println!("{}", src.src);
 
                     let mut parser: Parser<Lexer<StringInput>> = Parser::new(
                         Syntax::Typescript(TsConfig {
@@ -136,12 +137,12 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                             decorators: true,
                             decorators_before_export: true,
                             export_default_from: true,
-                            export_namespace_from: false,
+                            export_namespace_from: true,
                             dynamic_import: true,
                             nullish_coalescing: true,
-                            optional_chaining: false,
-                            import_meta: false,
-                            top_level_await: false,
+                            optional_chaining: true,
+                            import_meta: true,
+                            top_level_await: true,
                             ..Default::default()
                         }),
                         (&*js_fm).into(),

--- a/ecmascript/transforms/tests/typescript_strip_correctness.rs
+++ b/ecmascript/transforms/tests/typescript_strip_correctness.rs
@@ -1,0 +1,238 @@
+#![feature(test)]
+extern crate test;
+
+use std::{
+    env,
+    io::{self, Write},
+    path::Path,
+    sync::{Arc, RwLock},
+};
+use swc_common::FileName;
+use swc_ecma_ast::*;
+use swc_ecma_codegen::{self, Emitter};
+use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, StringInput, Syntax, TsConfig};
+use swc_ecma_transforms::{fixer, typescript::strip};
+use swc_ecma_visit::{Fold, FoldWith};
+use test::{
+    test_main, DynTestFn, Options, ShouldPanic::No, TestDesc, TestDescAndFn, TestName, TestType,
+};
+use walkdir::WalkDir;
+
+fn add_test<F: FnOnce() + Send + 'static>(
+    tests: &mut Vec<TestDescAndFn>,
+    name: String,
+    ignore: bool,
+    f: F,
+) {
+    tests.push(TestDescAndFn {
+        desc: TestDesc {
+            test_type: TestType::UnitTest,
+            name: TestName::DynTestName(name),
+            ignore,
+            should_panic: No,
+            allow_fail: false,
+        },
+        testfn: DynTestFn(Box::new(f)),
+    });
+}
+
+struct MyHandlers;
+
+impl swc_ecma_codegen::Handlers for MyHandlers {}
+
+fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("parser")
+        .join("tests")
+        .join("typescript");
+
+    eprintln!("Loading tests from {}", dir.display());
+
+    for entry in WalkDir::new(&dir) {
+        let entry = entry?;
+
+        if entry.metadata()?.is_dir() {
+            continue;
+        }
+
+        let file_name = entry
+            .path()
+            .strip_prefix(&dir)
+            .expect("failed to strip prefix")
+            .to_str()
+            .expect("to_str() failed")
+            .to_string();
+
+        let ext = entry
+            .path()
+            .extension()
+            .map(|s| s.to_string_lossy().to_owned())
+            .unwrap_or_default();
+        if ext != "ts" && ext != "tsx" {
+            continue;
+        }
+
+        let ignore = false;
+
+        let name = format!("typescript::correctness::{}", file_name);
+
+        add_test(tests, name, ignore, {
+            move || {
+                ::testing::run_test(false, |cm, handler| -> Result<(), ()> {
+                    let src = cm.load_file(&entry.path()).expect("failed to load file");
+
+                    let mut parser: Parser<Lexer<StringInput>> = Parser::new(
+                        Syntax::Typescript(TsConfig {
+                            tsx: file_name.contains("tsx"),
+                            decorators: true,
+                            dynamic_import: true,
+                            dts: false,
+                            no_early_errors: false,
+                        }),
+                        (&*src).into(),
+                        None,
+                    );
+
+                    let mut wr = Buf(Arc::new(RwLock::new(vec![])));
+
+                    let handlers = Box::new(MyHandlers);
+                    {
+                        let mut emitter = Emitter {
+                            cfg: swc_ecma_codegen::Config { minify: false },
+                            cm: cm.clone(),
+                            wr: Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
+                                cm.clone(),
+                                "\n",
+                                &mut wr,
+                                None,
+                            )),
+                            comments: None,
+                            handlers,
+                        };
+
+                        // Parse source
+                        let module = parser
+                            .parse_module()
+                            .map(|p| p.fold_with(&mut strip()).fold_with(&mut fixer(None)))
+                            .map_err(|e| {
+                                e.into_diagnostic(handler).emit();
+                            })?;
+
+                        emitter.emit_module(&module).unwrap();
+                    }
+
+                    let js_content = String::from_utf8_lossy(&*wr.0.read().unwrap()).to_string();
+                    let js_fm = cm.new_source_file(FileName::Anon, js_content.clone());
+
+                    let mut parser: Parser<Lexer<StringInput>> = Parser::new(
+                        Syntax::Es(EsConfig {
+                            jsx: file_name.contains("tsx"),
+                            num_sep: true,
+                            class_private_props: true,
+                            class_private_methods: true,
+                            class_props: true,
+                            decorators: true,
+                            decorators_before_export: true,
+                            export_default_from: true,
+                            export_namespace_from: false,
+                            dynamic_import: true,
+                            nullish_coalescing: true,
+                            optional_chaining: false,
+                            import_meta: false,
+                            top_level_await: false,
+                            ..Default::default()
+                        }),
+                        (&*js_fm).into(),
+                        None,
+                    );
+
+                    parser
+                        .parse_module()
+                        .unwrap_or_else(|_| panic!("{} is invalid", js_content));
+
+                    Ok(())
+                })
+                .expect("failed to run test");
+            }
+        });
+    }
+
+    Ok(())
+}
+
+#[test]
+fn identity() {
+    let args: Vec<_> = env::args().collect();
+    let mut tests = Vec::new();
+    correctness_tests(&mut tests).expect("failed to load testss");
+    test_main(&args, tests, Some(Options::new()));
+}
+
+#[derive(Debug, Clone)]
+struct Buf(Arc<RwLock<Vec<u8>>>);
+impl Write for Buf {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        self.0.write().unwrap().write(data)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.write().unwrap().flush()
+    }
+}
+
+struct Normalizer;
+impl Fold for Normalizer {
+    fn fold_new_expr(&mut self, expr: NewExpr) -> NewExpr {
+        let mut expr = expr.fold_children_with(self);
+
+        expr.args = match expr.args {
+            Some(..) => expr.args,
+            None => Some(vec![]),
+        };
+
+        expr
+    }
+
+    fn fold_prop_name(&mut self, name: PropName) -> PropName {
+        let name = name.fold_children_with(self);
+
+        match name {
+            PropName::Ident(i) => PropName::Str(Str {
+                value: i.sym,
+                span: i.span,
+                has_escape: false,
+            }),
+            PropName::Num(n) => {
+                let s = if n.value.is_infinite() {
+                    if n.value.is_sign_positive() {
+                        "Infinity".into()
+                    } else {
+                        "-Infinity".into()
+                    }
+                } else {
+                    format!("{}", n.value)
+                };
+                PropName::Str(Str {
+                    value: s.into(),
+                    span: n.span,
+                    has_escape: false,
+                })
+            }
+            _ => name,
+        }
+    }
+
+    fn fold_stmt(&mut self, stmt: Stmt) -> Stmt {
+        let stmt = stmt.fold_children_with(self);
+
+        match stmt {
+            Stmt::Expr(ExprStmt { span, expr }) => match *expr {
+                Expr::Paren(ParenExpr { expr, .. }) => Stmt::Expr(ExprStmt { span, expr }),
+                _ => Stmt::Expr(ExprStmt { span, expr }),
+            },
+            _ => stmt,
+        }
+    }
+}

--- a/ecmascript/transforms/tests/typescript_strip_correctness.rs
+++ b/ecmascript/transforms/tests/typescript_strip_correctness.rs
@@ -156,9 +156,17 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                         None,
                     );
 
-                    parser
-                        .parse_module()
-                        .unwrap_or_else(|_| panic!("{} is invalid", js_content));
+                    // It's very unscientific.
+                    // TODO: Change this with visitor
+                    if js_content.contains("import") || js_content.contains("export") {
+                        parser.parse_module().unwrap_or_else(|err| {
+                            panic!("{} is invalid module\n{:?}", js_content, err)
+                        });
+                    } else {
+                        parser.parse_script().unwrap_or_else(|err| {
+                            panic!("{} is invalid script\n{:?}", js_content, err)
+                        });
+                    }
 
                     Ok(())
                 })

--- a/ecmascript/transforms/tests/typescript_strip_correctness.rs
+++ b/ecmascript/transforms/tests/typescript_strip_correctness.rs
@@ -74,11 +74,43 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
             continue;
         }
 
+        let ignored = &[
+            // Cannot run the test with current test suite
+            "tsc/directives/multilinex",
+            // TODO: Unignore unicode escape test
+            "unicodeExtendedEscapes",
+            // Trolling with yield
+            "tsc/es6/yieldExpressions/generatorTypeCheck40/input.ts",
+            "tsc/es6/yieldExpressions/generatorTypeCheck55/input.ts",
+            "tsc/es6/yieldExpressions/generatorTypeCheck60/input.ts",
+            "tsc/es6/functionDeclarations/FunctionDeclaration6_es6/input.ts",
+            "tsc/es6/functionDeclarations/FunctionDeclaration7_es6/input.ts",
+            // Trolling with pattern
+            "tsc/es6/destructuring/restPropertyWithBindingPattern/input.ts",
+            // TODO: Unignore
+            // These tests are hard to debug because file is large
+            "tsc/es7/exponentiationOperator/\
+             emitCompoundExponentiationAssignmentWithIndexingOnLHS3/input.ts",
+            "tsc/es7/exponentiationOperator/emitExponentiationOperator1/input.ts",
+            "tsc/es7/exponentiationOperator/emitExponentiationOperator3/input.ts",
+            "tsc/es7/exponentiationOperator/emitExponentiationOperator4/input.ts",
+            "tsc/es7/exponentiationOperator/emitExponentiationOperatorInTempalteString4/input.ts",
+            "tsc/es7/exponentiationOperator/emitExponentiationOperatorInTempalteString4ES6/input.\
+             ts",
+            "tsc/es7/exponentiationOperator/\
+             exponentiationOperatorWithInvalidSimpleUnaryExpressionOperands/input.ts",
+            // `let[0] = 'foo'` is useless
+            "tsc/expressions/elementAccess/letIdentifierInElementAccess01/input.ts",
+        ];
+
+        // TODO: Unignore const enum test
         let ignore = file_name.contains("export-import-require/input.ts")
             || file_name.contains("v4/issue-866/input.ts")
             || file_name.contains("issue-716")
             || file_name.contains("stack-size")
-            || file_name.contains("jsdocTypeFromChainedAssignment3");
+            || file_name.contains("jsdocTypeFromChainedAssignment3")
+            || file_name.contains("tsc/enums/enumConstantMembers/input.ts")
+            || ignored.iter().any(|ignored| file_name.contains(ignored));
 
         let name = format!("typescript::correctness::{}", file_name);
 

--- a/ecmascript/transforms/tests/typescript_strip_correctness.rs
+++ b/ecmascript/transforms/tests/typescript_strip_correctness.rs
@@ -76,7 +76,8 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
 
         let ignore = file_name.contains("export-import-require/input.ts")
             || file_name.contains("v4/issue-866/input.ts")
-            || file_name.contains("issue-716");
+            || file_name.contains("issue-716")
+            || file_name.contains("stack-size");
 
         let name = format!("typescript::correctness::{}", file_name);
 
@@ -85,6 +86,18 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                 ::testing::run_test(false, |cm, handler| -> Result<(), ()> {
                     let src = cm.load_file(&entry.path()).expect("failed to load file");
                     println!("{}", src.src);
+
+                    let mut parser: Parser<Lexer<StringInput>> = Parser::new(
+                        Syntax::Typescript(TsConfig {
+                            tsx: file_name.contains("tsx"),
+                            decorators: true,
+                            dynamic_import: true,
+                            dts: false,
+                            no_early_errors: false,
+                        }),
+                        (&*src).into(),
+                        None,
+                    );
 
                     let mut wr = Buf(Arc::new(RwLock::new(vec![])));
 
@@ -102,18 +115,6 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                             comments: None,
                             handlers,
                         };
-
-                        let mut parser: Parser<Lexer<StringInput>> = Parser::new(
-                            Syntax::Typescript(TsConfig {
-                                tsx: file_name.contains("tsx"),
-                                decorators: true,
-                                dynamic_import: true,
-                                dts: false,
-                                no_early_errors: false,
-                            }),
-                            (&*src).into(),
-                            None,
-                        );
 
                         // Parse source
                         let module = parser

--- a/ecmascript/transforms/tests/typescript_strip_correctness.rs
+++ b/ecmascript/transforms/tests/typescript_strip_correctness.rs
@@ -77,7 +77,8 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
         let ignore = file_name.contains("export-import-require/input.ts")
             || file_name.contains("v4/issue-866/input.ts")
             || file_name.contains("issue-716")
-            || file_name.contains("stack-size");
+            || file_name.contains("stack-size")
+            || file_name.contains("jsdocTypeFromChainedAssignment3");
 
         let name = format!("typescript::correctness::{}", file_name);
 


### PR DESCRIPTION
swc_ecma_parser:
 - Fix parsing of binding identifier `await`


swc_ecma_transforms:
 - More tests for typescript::strip
 - Handle export declare class properly

```ts
export declare class Foo {
}
```

 - Remove declared variables

```ts
declare var a;
```

 - Fix enums in if statement

```ts
if (2) enum A {}
```

 - Fix sequence expression in class member key

```js
class C extends Base {
    [(super(), "prop")]() { }
}
```
 - Fix await in extend-clause


```js
class A extends (await B) {
}
```

 - Fix optional array pattern

```ts
function foo([a, b, c]?) {
}
```

 - Fix optional object pattern

```ts
function foo({a, b, c}?) {
}
```