### PR TITLE
Reduce size

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -51,6 +51,14 @@ jobs:
           npm i browserslist regenerator-runtime sourcemap-validator progress
           npm i -g jest
 
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/
+            **/target/
+          key: ${{ runner.os }}-cargo-test
+
       # Ensure that all components all compilable.
       - name: Run cargo check for all targets
         run: cargo check --color always --all --all-targets

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -19,20 +19,26 @@ env:
 
 jobs:
   check:
-    name: test
+    name: compilation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - name: Checkout submodules
-        shell: bash
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/
+          key: ${{ runner.os }}-cargo-compliation
+
+      - name: Install cargo hack
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-          git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          cargo install cargo-hack --version 0.3.11
 
       - name: Check swc_common
         run: |
-          (cd common && cargo build)
-          (cd common && cargo build --features tty-emitter)
-          (cd common && cargo build --features sourcemap)
+          (cd common && cargo hack check --feature-powerset --no-dev-deps)
+
+      - name: Check swc_ecma_transforms
+        run: |
+          (cd ecmascript/transforms && cargo hack check --feature-powerset --no-dev-deps)

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,14 @@ jobs:
         with:
           node-version: '12'
 
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/
+            **/target/
+          key: ${{ runner.os }}-cargo-test
+
       - name: Prepare
         run: |
           npm config set prefix ~/npm

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,8 +43,7 @@ jobs:
           npm i -g qunit failonlyreporter
 
           # Download three.js
-          # Current hash: b993f5c99341b1b483c6bdf94fdc4fbac61aa0f1
-          git clone --depth 1 https://github.com/mrdoob/three.js.git integration-tests/three-js/repo
+          git clone --depth 1 https://github.com/mrdoob/three.js.git -b r117 integration-tests/three-js/repo
 
           swc --sync integration-tests/three-js/repo/ -d integration-tests/three-js/build/
           # swc integration-tests/three-js/repo/src/ -d integration-tests/three-js/repo/build/

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
           path: |
             ~/.cargo/
             **/target/
-          key: ${{ runner.os }}-cargo-test
+          key: ${{ runner.os }}-cargo-integration
 
       - name: Prepare
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ name = "swc"
 
 [dependencies]
 swc_atoms = { path ="./atoms" }
-swc_common = { path ="./common", features = ["sourcemap"] }
+swc_common = { path ="./common", features = ["sourcemap", "concurrent"] }
 swc_ecma_ast = { path ="./ecmascript/ast" }
 swc_ecma_codegen = { path ="./ecmascript/codegen" }
 swc_ecma_parser = { path ="./ecmascript/parser" }
 swc_ecma_preset_env = { path ="./ecmascript/preset_env" }
-swc_ecma_transforms = { path ="./ecmascript/transforms" }
+swc_ecma_transforms = { path ="./ecmascript/transforms", features = ["const-modules", "jsx"] }
 swc_ecma_visit = { path ="./ecmascript/visit" }
 swc_visit = { path ="./visit" }
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ name = "usage"
 codegen-units = 1
 lto = true
 # debug = true
+opt-level = 'z'
 
 [profile.bench]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ swc_ecma_ast = { path ="./ecmascript/ast" }
 swc_ecma_codegen = { path ="./ecmascript/codegen" }
 swc_ecma_parser = { path ="./ecmascript/parser" }
 swc_ecma_preset_env = { path ="./ecmascript/preset_env" }
-swc_ecma_transforms = { path ="./ecmascript/transforms", features = ["const-modules", "jsx"] }
+swc_ecma_transforms = { path ="./ecmascript/transforms", features = ["const-modules", "react"] }
 swc_ecma_visit = { path ="./ecmascript/visit" }
 swc_visit = { path ="./visit" }
 anyhow = "1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,6 +23,7 @@ unicode-width = "0.1.4"
 cfg-if = "0.1.2"
 log = "0.4"
 atty = { version = "0.2", optional = true }
+owning_ref = "0.4"
 parking_lot = { version = "0.7.1", optional = true }
 termcolor = { version = "1.0", optional = true }
 serde = { version = "1", features = ["derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 
 [features]
 tty-emitter = ["atty", "termcolor"]
+concurrent = ["parking_lot"]
 default = []
-
 
 [dependencies]
 ast_node = { version = "0.7", path = "../macros/ast_node" }
@@ -23,7 +23,7 @@ unicode-width = "0.1.4"
 cfg-if = "0.1.2"
 log = "0.4"
 atty = { version = "0.2", optional = true }
-parking_lot = "0.7.1"
+parking_lot = { version = "0.7.1", optional = true }
 termcolor = { version = "1.0", optional = true }
 serde = { version = "1", features = ["derive"] }
 fxhash = "0.2.1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,6 +17,7 @@ default = []
 ast_node = { version = "0.7", path = "../macros/ast_node" }
 from_variant = { version = "0.1", path = "../macros/from_variant" }
 swc_visit = { version = "0.1", path = "../visit" }
+once_cell = "1"
 either = "1.5"
 scoped-tls = { version = "1" }
 unicode-width = "0.1.4"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_common"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -15,13 +15,13 @@ pub use self::{
     diagnostic_builder::DiagnosticBuilder,
     emitter::{ColorConfig, Emitter},
 };
+#[cfg(feature = "tty-emitter")]
+use crate::sync::Lrc;
 use crate::{
     rustc_data_structures::stable_hasher::StableHasher,
     sync::{Lock, LockCell},
     syntax_pos::{BytePos, FileLinesResult, FileName, Loc, MultiSpan, Span, NO_EXPANSION},
 };
-#[cfg(feature = "tty-emitter")]
-use std::sync::Arc;
 use std::{
     borrow::Cow,
     cell::RefCell,
@@ -101,9 +101,9 @@ pub struct SubstitutionPart {
     pub snippet: String,
 }
 
-pub type SourceMapperDyn = dyn SourceMapper + Send + Sync;
+pub type SourceMapperDyn = dyn SourceMapper;
 
-pub trait SourceMapper {
+pub trait SourceMapper: crate::sync::Send + crate::sync::Sync {
     fn lookup_char_pos(&self, pos: BytePos) -> Loc;
     fn span_to_lines(&self, sp: Span) -> FileLinesResult;
     fn span_to_string(&self, sp: Span) -> String;
@@ -274,7 +274,7 @@ pub struct Handler {
     pub flags: HandlerFlags,
 
     err_count: AtomicUsize,
-    emitter: Lock<Box<dyn Emitter + Send>>,
+    emitter: Lock<Box<dyn Emitter>>,
     continue_after_error: LockCell<bool>,
     delayed_span_bugs: Lock<Vec<Diagnostic>>,
 
@@ -337,7 +337,7 @@ impl Handler {
         color_config: ColorConfig,
         can_emit_warnings: bool,
         treat_err_as_bug: bool,
-        cm: Option<Arc<SourceMapperDyn>>,
+        cm: Option<Lrc<SourceMapperDyn>>,
     ) -> Handler {
         Handler::with_tty_emitter_and_flags(
             color_config,
@@ -353,7 +353,7 @@ impl Handler {
     #[cfg(feature = "tty-emitter")]
     pub fn with_tty_emitter_and_flags(
         color_config: ColorConfig,
-        cm: Option<Arc<SourceMapperDyn>>,
+        cm: Option<Lrc<SourceMapperDyn>>,
         flags: HandlerFlags,
     ) -> Handler {
         let emitter = Box::new(EmitterWriter::stderr(color_config, cm, false, false));
@@ -375,7 +375,7 @@ impl Handler {
         )
     }
 
-    pub fn with_emitter_and_flags(e: Box<dyn Emitter + Send>, flags: HandlerFlags) -> Handler {
+    pub fn with_emitter_and_flags(e: Box<dyn Emitter>, flags: HandlerFlags) -> Handler {
         Handler {
             flags,
             err_count: AtomicUsize::new(0),

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -44,6 +44,6 @@ mod pos;
 mod rustc_data_structures;
 pub mod serializer;
 mod source_map;
-mod sync;
+pub mod sync;
 mod syntax_pos;
 pub mod util;

--- a/common/src/pos.rs
+++ b/common/src/pos.rs
@@ -3,7 +3,7 @@ pub use crate::syntax_pos::{
     SourceFileAndBytePos, SourceFileAndLine, Span, SpanLinesError, SyntaxContext, DUMMY_SP,
     GLOBALS, NO_EXPANSION,
 };
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, rc::Rc, sync::Arc};
 
 ///
 /// # Derive
@@ -47,6 +47,15 @@ where
             Some(ref s) => s.span(),
             None => DUMMY_SP,
         }
+    }
+}
+
+impl<S> Spanned for Rc<S>
+where
+    S: ?Sized + Spanned,
+{
+    fn span(&self) -> Span {
+        <S as Spanned>::span(&*self)
     }
 }
 

--- a/common/src/source_map.rs
+++ b/common/src/source_map.rs
@@ -20,7 +20,7 @@ pub use crate::syntax_pos::*;
 use crate::{
     errors::SourceMapper,
     rustc_data_structures::stable_hasher::StableHasher,
-    sync::{Lock, LockGuard, MappedLockGuard},
+    sync::{Lock, LockGuard, Lrc, MappedLockGuard},
 };
 use log::debug;
 #[cfg(feature = "sourcemap")]
@@ -33,10 +33,7 @@ use std::{
     hash::Hash,
     io::{self, Read},
     path::{Path, PathBuf},
-    sync::{
-        atomic::{AtomicUsize, Ordering::SeqCst},
-        Arc,
-    },
+    sync::atomic::{AtomicUsize, Ordering::SeqCst},
 };
 
 // _____________________________________________________________________________
@@ -102,8 +99,8 @@ impl StableSourceFileId {
 
 #[derive(Default)]
 pub(super) struct SourceMapFiles {
-    pub(super) source_files: Vec<Arc<SourceFile>>,
-    stable_id_to_source_file: HashMap<StableSourceFileId, Arc<SourceFile>>,
+    pub(super) source_files: Vec<Lrc<SourceFile>>,
+    stable_id_to_source_file: HashMap<StableSourceFileId, Lrc<SourceFile>>,
 }
 
 pub struct SourceMap {
@@ -156,20 +153,20 @@ impl SourceMap {
         self.file_loader.file_exists(path)
     }
 
-    pub fn load_file(&self, path: &Path) -> io::Result<Arc<SourceFile>> {
+    pub fn load_file(&self, path: &Path) -> io::Result<Lrc<SourceFile>> {
         let src = self.file_loader.read_file(path)?;
         let filename = path.to_owned().into();
         Ok(self.new_source_file(filename, src))
     }
 
-    pub fn files(&self) -> MappedLockGuard<'_, Vec<Arc<SourceFile>>> {
+    pub fn files(&self) -> MappedLockGuard<'_, Vec<Lrc<SourceFile>>> {
         LockGuard::map(self.files.borrow(), |files| &mut files.source_files)
     }
 
     pub fn source_file_by_stable_id(
         &self,
         stable_id: StableSourceFileId,
-    ) -> Option<Arc<SourceFile>> {
+    ) -> Option<Lrc<SourceFile>> {
         self.files
             .borrow()
             .stable_id_to_source_file
@@ -185,7 +182,7 @@ impl SourceMap {
 
     /// Creates a new source_file.
     /// This does not ensure that only one SourceFile exists per file name.
-    pub fn new_source_file(&self, filename: FileName, src: String) -> Arc<SourceFile> {
+    pub fn new_source_file(&self, filename: FileName, src: String) -> Lrc<SourceFile> {
         // The path is used to determine the directory for loading submodules and
         // include files, so it must be before remapping.
         // Note that filename may not be a valid path, eg it may be `<anon>` etc,
@@ -207,7 +204,7 @@ impl SourceMap {
 
         let start_pos = self.next_start_pos(src.len());
 
-        let source_file = Arc::new(SourceFile::new(
+        let source_file = Lrc::new(SourceFile::new(
             filename,
             was_remapped,
             unmapped_path,
@@ -259,7 +256,7 @@ impl SourceMap {
     /// This method exists only for optimization and it's not part of public
     /// api.
     #[doc(hidden)]
-    pub fn lookup_char_pos_with(&self, fm: Arc<SourceFile>, pos: BytePos) -> Loc {
+    pub fn lookup_char_pos_with(&self, fm: Lrc<SourceFile>, pos: BytePos) -> Loc {
         let line_info = self.lookup_line_with(fm, pos);
         match line_info {
             Ok(SourceFileAndLine { sf: f, line: a }) => {
@@ -337,7 +334,7 @@ impl SourceMap {
     }
 
     /// If the relevant source_file is empty, we don't return a line number.
-    pub fn lookup_line(&self, pos: BytePos) -> Result<SourceFileAndLine, Arc<SourceFile>> {
+    pub fn lookup_line(&self, pos: BytePos) -> Result<SourceFileAndLine, Lrc<SourceFile>> {
         let f = self.lookup_source_file(pos);
 
         self.lookup_line_with(f, pos)
@@ -350,9 +347,9 @@ impl SourceMap {
     #[doc(hidden)]
     pub fn lookup_line_with(
         &self,
-        f: Arc<SourceFile>,
+        f: Lrc<SourceFile>,
         pos: BytePos,
-    ) -> Result<SourceFileAndLine, Arc<SourceFile>> {
+    ) -> Result<SourceFileAndLine, Lrc<SourceFile>> {
         match f.lookup_line(pos) {
             Some(line) => Ok(SourceFileAndLine { sf: f, line }),
             None => Err(f),
@@ -798,7 +795,7 @@ impl SourceMap {
         }
     }
 
-    pub fn get_source_file(&self, filename: &FileName) -> Option<Arc<SourceFile>> {
+    pub fn get_source_file(&self, filename: &FileName) -> Option<Lrc<SourceFile>> {
         for sf in self.files.borrow().source_files.iter() {
             if *filename == sf.name {
                 return Some(sf.clone());
@@ -863,9 +860,9 @@ impl SourceMap {
     /// api.
     #[doc(hidden)]
     pub fn lookup_source_file_in(
-        files: &[Arc<SourceFile>],
+        files: &[Lrc<SourceFile>],
         pos: BytePos,
-    ) -> Option<Arc<SourceFile>> {
+    ) -> Option<Lrc<SourceFile>> {
         let count = files.len();
 
         // Binary search for the source_file.
@@ -891,7 +888,7 @@ impl SourceMap {
     ///
     /// This is not a public api.
     #[doc(hidden)]
-    pub fn lookup_source_file(&self, pos: BytePos) -> Arc<SourceFile> {
+    pub fn lookup_source_file(&self, pos: BytePos) -> Lrc<SourceFile> {
         let files = self.files.borrow();
         let files = &files.source_files;
         let fm = Self::lookup_source_file_in(&files, pos);
@@ -1013,7 +1010,7 @@ impl SourceMap {
         // // This method is optimized based on the fact that mapping is sorted.
         // mappings.sort_by_key(|v| v.0);
 
-        let mut cur_file: Option<Arc<SourceFile>> = None;
+        let mut cur_file: Option<Lrc<SourceFile>> = None;
         let mut src_id = 0;
 
         let mut ch_start = 0;
@@ -1137,7 +1134,7 @@ impl FilePathMapping {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use std::sync::Lrc;
 
     fn init_source_map() -> SourceMap {
         let sm = SourceMap::new(FilePathMapping::empty());
@@ -1335,7 +1332,7 @@ mod tests {
     trait SourceMapExtension {
         fn span_substr(
             &self,
-            file: &Arc<SourceFile>,
+            file: &Lrc<SourceFile>,
             source_text: &str,
             substring: &str,
             n: usize,
@@ -1345,7 +1342,7 @@ mod tests {
     impl SourceMapExtension for SourceMap {
         fn span_substr(
             &self,
-            file: &Arc<SourceFile>,
+            file: &Lrc<SourceFile>,
             source_text: &str,
             substring: &str,
             n: usize,

--- a/common/src/source_map.rs
+++ b/common/src/source_map.rs
@@ -1134,7 +1134,7 @@ impl FilePathMapping {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Lrc;
+    use crate::sync::Lrc;
 
     fn init_source_map() -> SourceMap {
         let sm = SourceMap::new(FilePathMapping::empty());

--- a/common/src/sync.rs
+++ b/common/src/sync.rs
@@ -123,7 +123,13 @@ impl<T> Lock<T> {
         }
     }
 
-    #[cfg(not(parallel_compiler))]
+    #[cfg(feature = "concurrent")]
+    #[inline(always)]
+    pub fn lock(&self) -> LockGuard<'_, T> {
+        self.0.lock()
+    }
+
+    #[cfg(not(feature = "concurrent"))]
     #[inline(always)]
     pub fn lock(&self) -> LockGuard<'_, T> {
         self.0.borrow_mut()

--- a/common/src/sync.rs
+++ b/common/src/sync.rs
@@ -52,6 +52,7 @@ use std::{
 
 #[cfg(feature = "concurrent")]
 mod concurrent {
+    pub use once_cell::sync::OnceCell;
     pub use parking_lot::{
         MappedMutexGuard as MappedLockGuard, MappedRwLockReadGuard as MappedReadGuard,
         MappedRwLockWriteGuard as MappedWriteGuard, MutexGuard as LockGuard,

--- a/common/src/sync.rs
+++ b/common/src/sync.rs
@@ -52,7 +52,7 @@ use std::{
 
 #[cfg(feature = "concurrent")]
 mod concurrent {
-    pub use once_cell::sync::OnceCell;
+    pub use once_cell::sync::{Lazy, OnceCell};
     pub use parking_lot::{
         MappedMutexGuard as MappedLockGuard, MappedRwLockReadGuard as MappedReadGuard,
         MappedRwLockWriteGuard as MappedWriteGuard, MutexGuard as LockGuard,
@@ -66,6 +66,7 @@ mod concurrent {
 
 #[cfg(not(feature = "concurrent"))]
 mod single {
+    pub use once_cell::unsync::{Lazy, OnceCell};
     /// Dummy trait because swc_common is in single thread mode.
     pub trait Send {}
     /// Dummy trait because swc_common is in single thread mode.

--- a/common/src/syntax_pos.rs
+++ b/common/src/syntax_pos.rs
@@ -10,6 +10,7 @@ use std::{
     hash::{Hash, Hasher},
     ops::{Add, Sub},
     path::PathBuf,
+    sync::Mutex,
 };
 
 mod analyze_source_file;
@@ -44,13 +45,13 @@ pub const DUMMY_SP: Span = Span {
 
 #[derive(Default)]
 pub struct Globals {
-    hygiene_data: Lock<hygiene::HygieneData>,
+    hygiene_data: Mutex<hygiene::HygieneData>,
 }
 
 impl Globals {
     pub fn new() -> Globals {
         Globals {
-            hygiene_data: Lock::new(hygiene::HygieneData::new()),
+            hygiene_data: Mutex::new(hygiene::HygieneData::new()),
         }
     }
 }

--- a/common/src/syntax_pos.rs
+++ b/common/src/syntax_pos.rs
@@ -1,5 +1,8 @@
 pub use self::hygiene::{Mark, SyntaxContext};
-use crate::{rustc_data_structures::stable_hasher::StableHasher, sync::Lock};
+use crate::{
+    rustc_data_structures::stable_hasher::StableHasher,
+    sync::{Lock, Lrc},
+};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
@@ -7,7 +10,6 @@ use std::{
     hash::{Hash, Hasher},
     ops::{Add, Sub},
     path::PathBuf,
-    sync::Arc,
 };
 
 mod analyze_source_file;
@@ -561,7 +563,7 @@ pub struct SourceFile {
     /// Indicates which crate this SourceFile was imported from.
     pub crate_of_origin: u32,
     /// The complete source code
-    pub src: Arc<String>,
+    pub src: Lrc<String>,
     /// The source code's hash
     pub src_hash: u128,
     /// The start position of this source in the SourceMap
@@ -614,7 +616,7 @@ impl SourceFile {
             name_was_remapped,
             unmapped_path: Some(unmapped_path),
             crate_of_origin: 0,
-            src: Arc::new(src),
+            src: Lrc::new(src),
             src_hash,
             start_pos,
             end_pos: Pos::from_usize(end_pos),
@@ -827,7 +829,7 @@ impl Sub for CharPos {
 #[derive(Debug, Clone)]
 pub struct Loc {
     /// Information about the original source
-    pub file: Arc<SourceFile>,
+    pub file: Lrc<SourceFile>,
     /// The (1-based) line number
     pub line: usize,
     /// The (0-based) column offset
@@ -844,18 +846,18 @@ pub struct LocWithOpt {
     pub filename: FileName,
     pub line: usize,
     pub col: CharPos,
-    pub file: Option<Arc<SourceFile>>,
+    pub file: Option<Lrc<SourceFile>>,
 }
 
 // used to be structural records. Better names, anyone?
 #[derive(Debug)]
 pub struct SourceFileAndLine {
-    pub sf: Arc<SourceFile>,
+    pub sf: Lrc<SourceFile>,
     pub line: usize,
 }
 #[derive(Debug)]
 pub struct SourceFileAndBytePos {
-    pub sf: Arc<SourceFile>,
+    pub sf: Lrc<SourceFile>,
     pub pos: BytePos,
 }
 
@@ -879,7 +881,7 @@ pub struct LineCol {
 }
 
 pub struct FileLines {
-    pub file: Arc<SourceFile>,
+    pub file: Lrc<SourceFile>,
     pub lines: Vec<LineInfo>,
 }
 

--- a/common/src/syntax_pos.rs
+++ b/common/src/syntax_pos.rs
@@ -1,8 +1,5 @@
 pub use self::hygiene::{Mark, SyntaxContext};
-use crate::{
-    rustc_data_structures::stable_hasher::StableHasher,
-    sync::{Lock, Lrc},
-};
+use crate::{rustc_data_structures::stable_hasher::StableHasher, sync::Lrc};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,

--- a/common/src/syntax_pos/hygiene.rs
+++ b/common/src/syntax_pos/hygiene.rs
@@ -165,7 +165,7 @@ impl HygieneData {
     }
 
     fn with<T, F: FnOnce(&mut HygieneData) -> T>(f: F) -> T {
-        GLOBALS.with(|globals| f(&mut *globals.hygiene_data.borrow_mut()))
+        GLOBALS.with(|globals| f(&mut *globals.hygiene_data.lock().unwrap()))
     }
 }
 

--- a/common/tests/concurrent.rs
+++ b/common/tests/concurrent.rs
@@ -1,12 +1,12 @@
 use rayon::prelude::*;
 use std::{env, path::PathBuf, sync::Arc};
-use swc_common::{FilePathMapping, SourceFile, SourceMap};
+use swc_common::{sync::Lrc, FilePathMapping, SourceFile, SourceMap};
 
 #[test]
 fn no_overlap() {
-    let cm = Arc::new(SourceMap::new(FilePathMapping::empty()));
+    let cm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
 
-    let files: Vec<Arc<SourceFile>> = (0..100000)
+    let files: Vec<Lrc<SourceFile>> = (0..100000)
         .into_par_iter()
         .map(|_| {
             let fm = cm

--- a/common/tests/concurrent.rs
+++ b/common/tests/concurrent.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "concurrent")]
+
 use rayon::prelude::*;
 use std::{env, path::PathBuf, sync::Arc};
 use swc_common::{sync::Lrc, FilePathMapping, SourceFile, SourceMap};

--- a/common/tests/source_map.rs
+++ b/common/tests/source_map.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "concurrent")]
+
 use rayon::{prelude::*, ThreadPoolBuilder};
 use swc_common::{FileName, FilePathMapping, SourceMap};
 

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecmascript"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -16,11 +16,11 @@ transforms = ["swc_ecma_transforms"]
 visit = ["swc_ecma_visit"]
 
 [dependencies]
-swc_ecma_ast = { version = "0.27.0", path ="./ast" }
-swc_ecma_codegen = { version = "0.30.0", path ="./codegen", optional = true }
-swc_ecma_parser = { version = "0.32.0", path ="./parser", optional = true }
-swc_ecma_utils = { version = "0.16", path ="./utils", optional = true }
-swc_ecma_transforms = { version = "0.17", path ="./transforms", optional = true }
-swc_ecma_visit = { version = "0.12", path ="./visit", optional = true }
+swc_ecma_ast = { version = "0.28.0", path ="./ast" }
+swc_ecma_codegen = { version = "0.31.0", path ="./codegen", optional = true }
+swc_ecma_parser = { version = "0.33.0", path ="./parser", optional = true }
+swc_ecma_utils = { version = "0.17.0", path ="./utils", optional = true }
+swc_ecma_transforms = { version = "0.18.0", path ="./transforms", optional = true }
+swc_ecma_visit = { version = "0.13.0", path ="./visit", optional = true }
 
 [dev-dependencies]

--- a/ecmascript/ast/Cargo.toml
+++ b/ecmascript/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_ast"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.88", features = ["derive"] }
 swc_atoms = { version = "0.2", path ="../../atoms" }
-swc_common = { version = "0.8", path ="../../common" }
+swc_common = { version = "0.9.0", path ="../../common" }
 enum_kind = { version = "0.2", path ="../../macros/enum_kind" }
 string_enum = { version = "0.3", path ="../../macros/string_enum" }
 is-macro = "0.1"

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_codegen"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -12,13 +12,13 @@ include = ["Cargo.toml", "src/**/*.rs"]
 [dependencies]
 bitflags = "1"
 swc_atoms = { version = "0.2", path ="../../atoms" }
-swc_common = { version = "0.8", path ="../../common" }
-swc_ecma_ast = { version = "0.27.0", path ="../ast" }
+swc_common = { version = "0.9.0", path ="../../common" }
+swc_ecma_ast = { version = "0.28.0", path ="../ast" }
 swc_ecma_codegen_macros = { version = "0.5", path ="./macros" }
 sourcemap = "6"
 num-bigint = { version = "0.2", features = ["serde"] }
 
 [dev-dependencies]
-swc_common = { version = "0.8", path ="../../common", features = ["sourcemap"] }
-swc_ecma_parser = { version = "0.32", path ="../parser" }
-testing = { version = "0.8", path ="../../testing" }
+swc_common = { version = "0.9.0", path ="../../common", features = ["sourcemap"] }
+swc_ecma_parser = { version = "0.33.0", path ="../parser" }
+testing = { version = "0.9.0", path ="../../testing" }

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -9,7 +9,9 @@ use self::{
 };
 use std::{borrow::Cow, fmt::Write, io, sync::Arc};
 use swc_atoms::JsWord;
-use swc_common::{comments::Comments, BytePos, SourceMap, Span, Spanned, SyntaxContext, DUMMY_SP};
+use swc_common::{
+    comments::Comments, sync::Lrc, BytePos, SourceMap, Span, Spanned, SyntaxContext, DUMMY_SP,
+};
 use swc_ecma_ast::*;
 use swc_ecma_codegen_macros::emitter;
 
@@ -53,7 +55,7 @@ impl<'a, N: Node> Node for &'a N {
 
 pub struct Emitter<'a> {
     pub cfg: config::Config,
-    pub cm: Arc<SourceMap>,
+    pub cm: Lrc<SourceMap>,
     pub comments: Option<&'a dyn Comments>,
     pub wr: Box<(dyn 'a + WriteJs)>,
     pub handlers: Box<(dyn 'a + Handlers)>,

--- a/ecmascript/codegen/src/tests.rs
+++ b/ecmascript/codegen/src/tests.rs
@@ -14,7 +14,7 @@ impl Handlers for Noop {}
 
 struct Builder {
     cfg: Config,
-    cm: Arc<SourceMap>,
+    cm: Lrc<SourceMap>,
     comments: SingleThreadedComments,
 }
 

--- a/ecmascript/codegen/src/text_writer/basic_impl.rs
+++ b/ecmascript/codegen/src/text_writer/basic_impl.rs
@@ -1,9 +1,6 @@
 use super::{Result, WriteJs};
-use std::{
-    io::{self, Write},
-    sync::Arc,
-};
-use swc_common::{BytePos, LineCol, SourceMap, Span};
+use std::io::{self, Write};
+use swc_common::{sync::Lrc, BytePos, LineCol, SourceMap, Span};
 
 ///
 /// -----
@@ -13,7 +10,7 @@ use swc_common::{BytePos, LineCol, SourceMap, Span};
 /// https://github.com/Microsoft/TypeScript/blob/45eaf42006/src/compiler/utilities.ts#L2548
 pub struct JsWriter<'a, W: Write> {
     /// We may use this in future...
-    _cm: Arc<SourceMap>,
+    _cm: Lrc<SourceMap>,
     indent: usize,
     line_start: bool,
     line_count: usize,
@@ -26,7 +23,7 @@ pub struct JsWriter<'a, W: Write> {
 
 impl<'a, W: Write> JsWriter<'a, W> {
     pub fn new(
-        cm: Arc<SourceMap>,
+        cm: Lrc<SourceMap>,
         new_line: &'a str,
         wr: W,
         srcmap: Option<&'a mut Vec<(BytePos, LineCol)>>,

--- a/ecmascript/codegen/src/util.rs
+++ b/ecmascript/codegen/src/util.rs
@@ -1,5 +1,5 @@
 use super::list::ListFormat;
-use std::sync::Arc;
+use std::{rc::Rc, sync::Arc};
 use swc_common::{
     errors::SourceMapper, BytePos, SourceMap, SourceMapperDyn, Span, Spanned, SyntaxContext,
 };
@@ -133,8 +133,19 @@ impl SourceMapperExt for Arc<SourceMapperDyn> {
         &**self
     }
 }
+impl SourceMapperExt for Rc<SourceMapperDyn> {
+    fn get_code_map(&self) -> &dyn SourceMapper {
+        &**self
+    }
+}
 
 impl SourceMapperExt for Arc<SourceMap> {
+    fn get_code_map(&self) -> &dyn SourceMapper {
+        &**self
+    }
+}
+
+impl SourceMapperExt for Rc<SourceMap> {
     fn get_code_map(&self) -> &dyn SourceMapper {
         &**self
     }

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.32.1"
+version = "0.33.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -14,10 +14,10 @@ default = []
 
 [dependencies]
 swc_atoms = { version = "0.2", path ="../../atoms" }
-swc_common = { version = "0.8.0", path ="../../common" }
-swc_ecma_ast = { version = "0.27.0", path ="../ast" }
+swc_common = { version = "0.9.0", path ="../../common" }
+swc_ecma_ast = { version = "0.28.0", path ="../ast" }
 swc_ecma_parser_macros = { version = "0.4.1", path ="./macros" }
-swc_ecma_visit = { version = "0.12.0", path ="../visit" }
+swc_ecma_visit = { version = "0.13.0", path ="../visit" }
 enum_kind = { version = "0.2", path ="../../macros/enum_kind" }
 unicode-xid = "0.2"
 log = "0.4"
@@ -29,7 +29,7 @@ fxhash = "0.2.1"
 
 
 [dev-dependencies]
-testing = { version = "0.8", path ="../../testing" }
+testing = { version = "0.9.0", path ="../../testing" }
 env_logger = "0.7"
 walkdir = "2"
 serde_json = "1"

--- a/ecmascript/parser/examples/lexer.rs
+++ b/ecmascript/parser/examples/lexer.rs
@@ -1,14 +1,14 @@
-use std::sync::Arc;
 use swc_common::{
     self,
     errors::{ColorConfig, Handler},
+    sync::Lrc,
     FileName, SourceMap,
 };
 use swc_ecma_parser::{lexer::Lexer, Capturing, Parser, StringInput, Syntax};
 
 fn main() {
     swc_common::GLOBALS.set(&swc_common::Globals::new(), || {
-        let cm: Arc<SourceMap> = Default::default();
+        let cm: Lrc<SourceMap> = Default::default();
         let handler = Handler::with_tty_emitter(ColorConfig::Auto, true, false, Some(cm.clone()));
 
         // Real usage

--- a/ecmascript/parser/examples/typescript.rs
+++ b/ecmascript/parser/examples/typescript.rs
@@ -1,15 +1,14 @@
-use swc_common;
-
-use std::sync::Arc;
 use swc_common::{
+    self,
     errors::{ColorConfig, Handler},
+    sync::Lrc,
     FileName, SourceMap,
 };
 use swc_ecma_parser::{lexer::Lexer, Capturing, Parser, StringInput, Syntax};
 
 fn main() {
     swc_common::GLOBALS.set(&swc_common::Globals::new(), || {
-        let cm: Arc<SourceMap> = Default::default();
+        let cm: Lrc<SourceMap> = Default::default();
         let handler = Handler::with_tty_emitter(ColorConfig::Auto, true, false, Some(cm.clone()));
 
         // Real usage

--- a/ecmascript/parser/tests/jsx.rs
+++ b/ecmascript/parser/tests/jsx.rs
@@ -9,9 +9,8 @@ use std::{
     fs::File,
     io::{self, Read},
     path::Path,
-    sync::Arc,
 };
-use swc_common::{errors::Handler, SourceMap};
+use swc_common::{errors::Handler, sync::Lrc, SourceMap};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, PResult, Parser, StringInput};
 use swc_ecma_visit::{Fold, FoldWith};
@@ -184,12 +183,12 @@ fn reference_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
     Ok(())
 }
 
-fn parse_module<'a>(cm: Arc<SourceMap>, handler: &Handler, file_name: &Path) -> Result<Module, ()> {
+fn parse_module<'a>(cm: Lrc<SourceMap>, handler: &Handler, file_name: &Path) -> Result<Module, ()> {
     with_parser(cm, handler, file_name, |p| p.parse_module())
 }
 
 fn with_parser<F, Ret>(
-    cm: Arc<SourceMap>,
+    cm: Lrc<SourceMap>,
     handler: &Handler,
     file_name: &Path,
     f: F,

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 
 [features]
 const-modules = ["dashmap"]
+jsx = ["dashmap"]
 default = []
 
 [dependencies]
@@ -23,6 +24,7 @@ dashmap = { version = "=3.5.1", optional = true }
 either = "1.5"
 fxhash = "0.2"
 indexmap = "1"
+once_cell = "1"
 serde = { version = "1", features = ["derive"] }
 ordered-float = "1.0.1"
 Inflector = { version = "0.11.4", default-features = false }

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_transforms"
-version = "0.17.3"
+version = "0.18.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -15,11 +15,11 @@ default = []
 
 [dependencies]
 swc_atoms = { version = "0.2.0", path ="../../atoms" }
-swc_common = { version = "0.8.0", path ="../../common" }
-swc_ecma_ast = { version = "0.27.0", path ="../ast" }
-swc_ecma_utils = { version = "0.16.0", path ="../utils" }
-swc_ecma_parser = { version = "0.32.0", path ="../parser" }
-swc_ecma_visit = { version = "0.12.0", path ="../visit" }
+swc_common = { version = "0.9.0", path ="../../common" }
+swc_ecma_ast = { version = "0.28.0", path ="../ast" }
+swc_ecma_utils = { version = "0.17.0", path ="../utils" }
+swc_ecma_parser = { version = "0.33.0", path ="../parser" }
+swc_ecma_visit = { version = "0.13.0", path ="../visit" }
 dashmap = { version = "=3.5.1", optional = true }
 either = "1.5"
 fxhash = "0.2"
@@ -38,8 +38,8 @@ is-macro = "0.1"
 log = "0.4.8"
 
 [dev-dependencies]
-testing = { version = "0.8", path ="../../testing" }
-swc_ecma_codegen = { version = "0.30.0", path ="../codegen" }
+testing = { version = "0.9.0", path ="../../testing" }
+swc_ecma_codegen = { version = "0.31.0", path ="../codegen" }
 tempfile = "3"
 pretty_assertions = "0.6"
 sourcemap = "6"

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [features]
 const-modules = ["dashmap"]
-jsx = ["dashmap"]
+react = ["dashmap"]
 default = []
 
 [dependencies]

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -8,6 +8,10 @@ documentation = "https://swc-project.github.io/rustdoc/swc_ecma_transforms/"
 description = "rust port of babel and closure compiler."
 edition = "2018"
 
+[features]
+const-modules = ["dashmap"]
+default = []
+
 [dependencies]
 swc_atoms = { version = "0.2.0", path ="../../atoms" }
 swc_common = { version = "0.8.0", path ="../../common" }
@@ -15,11 +19,10 @@ swc_ecma_ast = { version = "0.27.0", path ="../ast" }
 swc_ecma_utils = { version = "0.16.0", path ="../utils" }
 swc_ecma_parser = { version = "0.32.0", path ="../parser" }
 swc_ecma_visit = { version = "0.12.0", path ="../visit" }
-dashmap = "=3.5.1"
+dashmap = { version = "=3.5.1", optional = true }
 either = "1.5"
 fxhash = "0.2"
 indexmap = "1"
-once_cell = "1"
 serde = { version = "1", features = ["derive"] }
 ordered-float = "1.0.1"
 Inflector = { version = "0.11.4", default-features = false }

--- a/ecmascript/transforms/src/const_modules.rs
+++ b/ecmascript/transforms/src/const_modules.rs
@@ -1,15 +1,20 @@
-use crate::util::{drop_span, options::CM};
+#![cfg(feature = "const-module")]
+
+use crate::util::drop_span;
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use std::{collections::HashMap, sync::Arc};
 use swc_atoms::JsWord;
-use swc_common::{util::move_map::MoveMap, FileName};
+use swc_common::{sync::Lrc, util::move_map::MoveMap, FileName, SourceMap};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput};
 use swc_ecma_utils::HANDLER;
 use swc_ecma_visit::{Fold, FoldWith};
 
-pub fn const_modules(globals: HashMap<JsWord, HashMap<JsWord, String>>) -> impl Fold {
+pub fn const_modules(
+    cm: Lrc<SourceMap>,
+    globals: HashMap<JsWord, HashMap<JsWord, String>>,
+) -> impl Fold {
     ConstModules {
         globals: globals
             .into_iter()

--- a/ecmascript/transforms/src/const_modules.rs
+++ b/ecmascript/transforms/src/const_modules.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "const-module")]
+#![cfg(feature = "const-modules")]
 
 use crate::util::drop_span;
 use dashmap::DashMap;
@@ -22,7 +22,7 @@ pub fn const_modules(
                 let map = map
                     .into_iter()
                     .map(|(key, value)| {
-                        let value = parse_option(&key, value);
+                        let value = parse_option(&cm, &key, value);
 
                         (key, value)
                     })
@@ -35,10 +35,10 @@ pub fn const_modules(
     }
 }
 
-fn parse_option(name: &str, src: String) -> Arc<Expr> {
+fn parse_option(cm: &SourceMap, name: &str, src: String) -> Arc<Expr> {
     static CACHE: Lazy<DashMap<Arc<String>, Arc<Expr>>> = Lazy::new(|| DashMap::default());
 
-    let fm = CM.new_source_file(FileName::Custom(format!("<const-module-{}.js>", name)), src);
+    let fm = cm.new_source_file(FileName::Custom(format!("<const-module-{}.js>", name)), src);
     if let Some(expr) = CACHE.get(&fm.src) {
         return expr.clone();
     }

--- a/ecmascript/transforms/src/const_modules.rs
+++ b/ecmascript/transforms/src/const_modules.rs
@@ -36,10 +36,10 @@ pub fn const_modules(
 }
 
 fn parse_option(cm: &SourceMap, name: &str, src: String) -> Arc<Expr> {
-    static CACHE: Lazy<DashMap<Arc<String>, Arc<Expr>>> = Lazy::new(|| DashMap::default());
+    static CACHE: Lazy<DashMap<String, Arc<Expr>>> = Lazy::new(|| DashMap::default());
 
     let fm = cm.new_source_file(FileName::Custom(format!("<const-module-{}.js>", name)), src);
-    if let Some(expr) = CACHE.get(&fm.src) {
+    if let Some(expr) = CACHE.get(&**fm.src) {
         return expr.clone();
     }
 
@@ -66,7 +66,7 @@ fn parse_option(cm: &SourceMap, name: &str, src: String) -> Arc<Expr> {
 
     let expr = Arc::new(*expr);
 
-    CACHE.insert(fm.src.clone(), expr.clone());
+    CACHE.insert((*fm.src).clone(), expr.clone());
 
     expr
 }

--- a/ecmascript/transforms/src/helpers.rs
+++ b/ecmascript/transforms/src/helpers.rs
@@ -1,10 +1,10 @@
 use once_cell::sync::Lazy;
 use scoped_tls::scoped_thread_local;
 use std::sync::atomic::{AtomicBool, Ordering};
-use swc_common::{FileName, Mark, Span, DUMMY_SP};
+use swc_common::{FileName, FilePathMapping, Mark, SourceMap, Span, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput};
-use swc_ecma_utils::{options::CM, prepend_stmts, quote_ident, quote_str, DropSpan};
+use swc_ecma_utils::{prepend_stmts, quote_ident, quote_str, DropSpan};
 use swc_ecma_visit::{Fold, FoldWith};
 
 #[macro_export]
@@ -20,8 +20,9 @@ macro_rules! enable_helper {
 macro_rules! add_to {
     ($buf:expr, $name:ident, $b:expr, $mark:expr) => {{
         static STMTS: Lazy<Vec<Stmt>> = Lazy::new(|| {
+            let cm = SourceMap::new(FilePathMapping::empty());
             let code = include_str!(concat!("helpers/_", stringify!($name), ".js"));
-            let fm = CM.new_source_file(FileName::Custom(stringify!($name).into()), code.into());
+            let fm = cm.new_source_file(FileName::Custom(stringify!($name).into()), code.into());
             let lexer = Lexer::new(
                 Default::default(),
                 Default::default(),

--- a/ecmascript/transforms/src/lib.rs
+++ b/ecmascript/transforms/src/lib.rs
@@ -32,7 +32,6 @@ pub mod modules;
 pub mod optimization;
 pub mod pass;
 pub mod proposals;
-#[cfg(feature = "react")]
 pub mod react;
 pub mod resolver;
 pub mod scope;

--- a/ecmascript/transforms/src/lib.rs
+++ b/ecmascript/transforms/src/lib.rs
@@ -4,8 +4,9 @@
 #[macro_use]
 extern crate swc_ecma_utils;
 
+#[cfg(feature = "const-modules")]
+pub use self::const_modules::const_modules;
 pub use self::{
-    const_modules::const_modules,
     fixer::fixer,
     hygiene::hygiene,
     resolver::{resolver, resolver_with_mark},
@@ -31,6 +32,7 @@ pub mod modules;
 pub mod optimization;
 pub mod pass;
 pub mod proposals;
+#[cfg(feature = "react")]
 pub mod react;
 pub mod resolver;
 pub mod scope;

--- a/ecmascript/transforms/src/modules/umd.rs
+++ b/ecmascript/transforms/src/modules/umd.rs
@@ -6,7 +6,6 @@ use super::util::{
 };
 use crate::util::{prepend_stmts, var::VarCollector, DestructuringFinder, ExprFactory};
 use fxhash::FxHashSet;
-use std::sync::Arc;
 use swc_atoms::js_word;
 use swc_common::{sync::Lrc, Mark, SourceMap, DUMMY_SP};
 use swc_ecma_ast::*;
@@ -27,7 +26,7 @@ pub fn umd(cm: Lrc<SourceMap>, root_mark: Mark, config: Config) -> impl Fold {
 }
 
 struct Umd {
-    cm: Arc<SourceMap>,
+    cm: Lrc<SourceMap>,
     root_mark: Mark,
     in_top_level: bool,
     config: BuiltConfig,

--- a/ecmascript/transforms/src/modules/umd.rs
+++ b/ecmascript/transforms/src/modules/umd.rs
@@ -8,13 +8,13 @@ use crate::util::{prepend_stmts, var::VarCollector, DestructuringFinder, ExprFac
 use fxhash::FxHashSet;
 use std::sync::Arc;
 use swc_atoms::js_word;
-use swc_common::{Mark, SourceMap, DUMMY_SP};
+use swc_common::{sync::Lrc, Mark, SourceMap, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Fold, FoldWith, VisitWith};
 
 mod config;
 
-pub fn umd(cm: Arc<SourceMap>, root_mark: Mark, config: Config) -> impl Fold {
+pub fn umd(cm: Lrc<SourceMap>, root_mark: Mark, config: Config) -> impl Fold {
     Umd {
         config: config.build(cm.clone()),
         root_mark,

--- a/ecmascript/transforms/src/modules/umd/config.rs
+++ b/ecmascript/transforms/src/modules/umd/config.rs
@@ -1,9 +1,9 @@
 use super::super::util;
 use inflector::Inflector;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 use swc_atoms::JsWord;
-use swc_common::{FileName, SourceMap};
+use swc_common::{sync::Lrc, FileName, SourceMap};
 use swc_ecma_ast::Expr;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax};
 use swc_ecma_utils::HANDLER;
@@ -19,7 +19,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub(super) fn build(self, cm: Arc<SourceMap>) -> BuiltConfig {
+    pub(super) fn build(self, cm: Lrc<SourceMap>) -> BuiltConfig {
         BuiltConfig {
             config: self.config,
             globals: self

--- a/ecmascript/transforms/src/react.rs
+++ b/ecmascript/transforms/src/react.rs
@@ -1,11 +1,12 @@
+#![cfg(feature = "react")]
+
 pub use self::{
     display_name::display_name,
     jsx::{jsx, Options},
     jsx_self::jsx_self,
     jsx_src::jsx_src,
 };
-use std::sync::Arc;
-use swc_common::{chain, SourceMap};
+use swc_common::{chain, sync::Lrc, SourceMap};
 use swc_ecma_visit::Fold;
 
 mod display_name;
@@ -16,11 +17,11 @@ mod jsx_src;
 /// `@babel/preset-react`
 ///
 /// Preset for all React plugins.
-pub fn react(cm: Arc<SourceMap>, options: Options) -> impl Fold {
+pub fn react(cm: Lrc<SourceMap>, options: Options) -> impl Fold {
     let Options { development, .. } = options;
 
     chain!(
-        jsx(options),
+        jsx(cm.clone(), options),
         display_name(),
         jsx_src(development, cm),
         jsx_self(development)

--- a/ecmascript/transforms/src/react/jsx.rs
+++ b/ecmascript/transforms/src/react/jsx.rs
@@ -3,7 +3,7 @@ use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::{iter, mem, sync::Arc};
+use std::{iter, mem};
 use swc_atoms::{js_word, JsWord};
 use swc_common::{iter::IdentifyLast, sync::Lrc, FileName, SourceMap, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
@@ -56,10 +56,10 @@ fn default_throw_if_namespace() -> bool {
 }
 
 fn parse_option(cm: &SourceMap, name: &str, src: String) -> Box<Expr> {
-    static CACHE: Lazy<DashMap<Arc<String>, Box<Expr>>> = Lazy::new(|| DashMap::with_capacity(2));
+    static CACHE: Lazy<DashMap<String, Box<Expr>>> = Lazy::new(|| DashMap::with_capacity(2));
 
     let fm = cm.new_source_file(FileName::Custom(format!("<jsx-config-{}.js>", name)), src);
-    if let Some(expr) = CACHE.get(&fm.src) {
+    if let Some(expr) = CACHE.get(&**fm.src) {
         return expr.clone();
     }
 
@@ -78,7 +78,7 @@ fn parse_option(cm: &SourceMap, name: &str, src: String) -> Box<Expr> {
             )
         });
 
-    CACHE.insert(fm.src.clone(), expr.clone());
+    CACHE.insert((*fm.src).clone(), expr.clone());
 
     expr
 }

--- a/ecmascript/transforms/src/react/jsx/tests.rs
+++ b/ecmascript/transforms/src/react/jsx/tests.rs
@@ -6,11 +6,17 @@ use crate::{
     },
     modules::common_js::common_js,
     react::display_name,
+    tests::Tester,
 };
 use swc_common::{chain, Mark};
 
-fn tr(options: Options) -> impl Fold {
-    chain!(jsx(options), display_name(), Classes::default(), arrow(),)
+fn tr(t: &mut Tester, options: Options) -> impl Fold {
+    chain!(
+        jsx(t.cm.clone(), options),
+        display_name(),
+        Classes::default(),
+        arrow(),
+    )
 }
 
 test!(
@@ -18,7 +24,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_add_appropriate_newlines,
     r#"
 <Component
@@ -37,7 +43,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_arrow_functions,
     r#"
 var foo = function () {
@@ -67,7 +73,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_concatenates_adjacent_string_literals,
     r#"
 var x =
@@ -104,7 +110,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_display_name_assignment_expression,
     r#"var Component;
 Component = React.createClass({
@@ -127,7 +133,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_display_name_export_default,
     r#"
 export default React.createClass({
@@ -151,7 +157,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_display_name_if_missing,
     r#"
 var Whateva = React.createClass({
@@ -189,7 +195,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_display_name_object_declaration,
     r#"
 exports = {
@@ -215,7 +221,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_display_name_property_assignment,
     r#"
 exports.Component = React.createClass({
@@ -239,7 +245,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_display_name_variable_declaration,
     r#"
 var Component = React.createClass({
@@ -263,7 +269,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_dont_coerce_expression_containers,
     r#"
 <Text>
@@ -287,7 +293,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_honor_custom_jsx_comment_if_jsx_pragma_option_set,
     r#"/** @jsx dom */
 
@@ -312,7 +318,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_honor_custom_jsx_comment,
     r#"
 /** @jsx dom */
@@ -339,10 +345,13 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Options {
-        pragma: "dom".into(),
-        ..Default::default()
-    }),
+    |t| tr(
+        t,
+        Options {
+            pragma: "dom".into(),
+            ..Default::default()
+        }
+    ),
     react_honor_custom_jsx_pragma_option,
     r#"
 
@@ -365,7 +374,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_jsx_with_retainlines_option,
     r#"var div = <div>test</div>;"#,
     r#"var div = React.createElement("div", null, "test");"#
@@ -376,7 +385,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_jsx_without_retainlines_option,
     r#"var div = <div>test</div>;"#,
     r#"var div = React.createElement("div", null, "test");"#
@@ -389,7 +398,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_optimisation_react_constant_elements,
     r#"
 class App extends React.Component {
@@ -453,7 +462,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| chain!(tr(Default::default()), PropertyLiteral),
+    |t| chain!(tr(t, Default::default()), PropertyLiteral),
     react_should_add_quotes_es3,
     r#"var es3 = <F aaa new const var default foo-bar/>;"#,
     r#"
@@ -473,7 +482,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_allow_constructor_as_prop,
     r#"<Component constructor="foo" />;"#,
     r#"
@@ -488,7 +497,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_allow_deeper_js_namespacing,
     r#"<Namespace.DeepNamespace.Component />;"#,
     r#"React.createElement(Namespace.DeepNamespace.Component, null);"#
@@ -499,7 +508,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_allow_elements_as_attributes,
     r#"<div attr=<div /> />"#,
     r#"
@@ -513,7 +522,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_allow_js_namespacing,
     r#"<Namespace.Component />;"#,
     r#"React.createElement(Namespace.Component, null);"#
@@ -524,7 +533,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_allow_nested_fragments,
     r#"
 <div>
@@ -560,7 +569,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_allow_no_pragmafrag_if_frag_unused,
     r#"
 /** @jsx dom */
@@ -579,7 +588,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_allow_pragmafrag_and_frag,
     r#"
 /** @jsx dom */
@@ -600,7 +609,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_avoid_wrapping_in_extra_parens_if_not_needed,
     r#"
 var x = <div>
@@ -632,7 +641,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_convert_simple_tags,
     r#"var x = <div></div>;"#,
     r#"var x = React.createElement("div", null);"#
@@ -643,7 +652,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_convert_simple_text,
     r#"var x = <div>text</div>;"#,
     r#"var x = React.createElement("div", null, "text");"#
@@ -654,7 +663,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_escape_xhtml_jsxattribute,
     r#"
 <div id="wôw" />;
@@ -680,7 +689,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_escape_xhtml_jsxtext_1,
     r#"
 <div>wow</div>;
@@ -711,7 +720,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_escape_xhtml_jsxtext_2,
     r#"
 <div>this should not parse as unicode: \u00a0</div>;
@@ -729,7 +738,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_escape_xhtml_jsxtext_3,
     r#"
 <div>this should parse as nbsp:   </div>;
@@ -744,7 +753,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_handle_attributed_elements,
     r#"
 var HelloMessage = React.createClass({
@@ -780,7 +789,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_handle_has_own_property_correctly,
     r#"<hasOwnProperty>testing</hasOwnProperty>;"#,
     r#"React.createElement("hasOwnProperty", null, "testing");"#
@@ -791,7 +800,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_have_correct_comma_in_nested_children,
     r#"
 var x = <div>
@@ -815,7 +824,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_insert_commas_after_expressions_before_whitespace,
     r#"
 var x =
@@ -850,7 +859,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_not_add_quotes_to_identifier_names,
     r#"var e = <F aaa new const var default foo-bar/>;"#,
     r#"
@@ -870,7 +879,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_not_mangle_expressioncontainer_attribute_values,
     r#"<button data-value={"a value\n  with\nnewlines\n   and spaces"}>Button</button>;"#,
     r#"
@@ -885,7 +894,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_not_strip_nbsp_even_coupled_with_other_whitespace,
     r#"<div>&nbsp; </div>;"#,
     r#"React.createElement("div", null, "\xA0 ");"#,
@@ -897,7 +906,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_not_strip_tags_with_a_single_child_of_nbsp,
     r#"<div>&nbsp;</div>;"#,
     r#"React.createElement("div", null, "\xA0");"#,
@@ -911,7 +920,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_properly_handle_comments_between_props,
     r#"
 var x = (
@@ -942,7 +951,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_quote_jsx_attributes,
     r#"<button data-value='a value'>Button</button>;"#,
     r#"
@@ -957,11 +966,14 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Options {
-        pragma: "h".into(),
-        throw_if_namespace: false,
-        ..Default::default()
-    },),
+    |t| tr(
+        t,
+        Options {
+            pragma: "h".into(),
+            throw_if_namespace: false,
+            ..Default::default()
+        },
+    ),
     react_should_support_xml_namespaces_if_flag,
     r#"<f:image n:attr />;"#,
     r#"h("f:image", {
@@ -974,7 +986,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_should_transform_known_hyphenated_tags,
     r#"<font-face />;"#,
     r#"React.createElement("font-face", null);"#
@@ -985,7 +997,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_wraps_props_in_react_spread_for_first_spread_attributes,
     r#"
 <Component { ... x } y
@@ -1004,7 +1016,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_wraps_props_in_react_spread_for_last_spread_attributes,
     r#"<Component y={2} z { ... x } />"#,
     r#"
@@ -1020,7 +1032,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Default::default()),
+    |t| tr(t, Default::default()),
     react_wraps_props_in_react_spread_for_middle_spread_attributes,
     r#"<Component y={2} { ... x } z />"#,
     r#"
@@ -1036,10 +1048,13 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Options {
-        use_builtins: true,
-        ..Default::default()
-    },),
+    |t| tr(
+        t,
+        Options {
+            use_builtins: true,
+            ..Default::default()
+        },
+    ),
     use_builtins_assignment,
     r#"var div = <Component {...props} foo="bar" />"#,
     r#"
@@ -1054,10 +1069,13 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Options {
-        use_builtins: true,
-        ..Default::default()
-    },),
+    |t| tr(
+        t,
+        Options {
+            use_builtins: true,
+            ..Default::default()
+        },
+    ),
     issue_229,
     "const a = <>test</>
 const b = <div>test</div>",
@@ -1070,11 +1088,14 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| chain!(
-        tr(Options {
-            use_builtins: true,
-            ..Default::default()
-        }),
+    |t| chain!(
+        tr(
+            t,
+            Options {
+                use_builtins: true,
+                ..Default::default()
+            }
+        ),
         common_js(Mark::fresh(Mark::root()), Default::default())
     ),
     issue_351,
@@ -1091,10 +1112,13 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Options {
-        use_builtins: true,
-        ..Default::default()
-    }),
+    |t| tr(
+        t,
+        Options {
+            use_builtins: true,
+            ..Default::default()
+        }
+    ),
     issue_481,
     "<span> {foo}</span>;",
     "React.createElement('span', null, ' ', foo);"
@@ -1106,11 +1130,14 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| chain!(
-        tr(Options {
-            use_builtins: true,
-            ..Default::default()
-        }),
+    |t| chain!(
+        tr(
+            t,
+            Options {
+                use_builtins: true,
+                ..Default::default()
+            }
+        ),
         common_js(Mark::fresh(Mark::root()), Default::default())
     ),
     issue_517,
@@ -1136,10 +1163,13 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| tr(Options {
-        use_builtins: true,
-        ..Default::default()
-    }),
+    |t| tr(
+        t,
+        Options {
+            use_builtins: true,
+            ..Default::default()
+        }
+    ),
     issue_542,
     "let page = <p>Click <em>New melody</em> listen to a randomly generated melody</p>",
     "let page = React.createElement('p', null, 'Click ', React.createElement('em', null, 'New \

--- a/ecmascript/transforms/src/react/jsx_src.rs
+++ b/ecmascript/transforms/src/react/jsx_src.rs
@@ -1,5 +1,4 @@
-use std::sync::Arc;
-use swc_common::{FileName, SourceMap, DUMMY_SP};
+use swc_common::{sync::Lrc, FileName, SourceMap, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_visit::Fold;
 
@@ -7,12 +6,12 @@ use swc_ecma_visit::Fold;
 mod tests;
 
 /// `@babel/plugin-transform-react-jsx-source`
-pub fn jsx_src(dev: bool, cm: Arc<SourceMap>) -> impl Fold {
+pub fn jsx_src(dev: bool, cm: Lrc<SourceMap>) -> impl Fold {
     JsxSrc { cm, dev }
 }
 
 struct JsxSrc {
-    cm: Arc<SourceMap>,
+    cm: Lrc<SourceMap>,
     dev: bool,
 }
 

--- a/ecmascript/transforms/src/react/jsx_src/tests.rs
+++ b/ecmascript/transforms/src/react/jsx_src/tests.rs
@@ -1,8 +1,8 @@
 use super::*;
-use swc_common::FilePathMapping;
+use swc_common::{sync::Lrc, FilePathMapping};
 
 fn tr() -> impl Fold {
-    let cm = Arc::new(SourceMap::new(FilePathMapping::empty()));
+    let cm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
     jsx_src(true, cm)
 }
 

--- a/ecmascript/transforms/src/tests.rs
+++ b/ecmascript/transforms/src/tests.rs
@@ -7,7 +7,9 @@ use std::{
     process::Command,
     sync::{Arc, RwLock},
 };
-use swc_common::{comments::SingleThreadedComments, errors::Handler, FileName, SourceMap};
+use swc_common::{
+    comments::SingleThreadedComments, errors::Handler, sync::Lrc, FileName, SourceMap,
+};
 use swc_ecma_ast::{Pat, *};
 use swc_ecma_codegen::Emitter;
 use swc_ecma_parser::{error::Error, lexer::Lexer, Parser, StringInput, Syntax};
@@ -20,7 +22,7 @@ struct MyHandlers;
 impl swc_ecma_codegen::Handlers for MyHandlers {}
 
 pub(crate) struct Tester<'a> {
-    pub cm: Arc<SourceMap>,
+    pub cm: Lrc<SourceMap>,
     pub handler: &'a Handler,
     pub comments: SingleThreadedComments,
 }

--- a/ecmascript/transforms/tests/common/mod.rs
+++ b/ecmascript/transforms/tests/common/mod.rs
@@ -9,7 +9,9 @@ use std::{
     process::Command,
     sync::{Arc, RwLock},
 };
-use swc_common::{chain, comments::SingleThreadedComments, errors::Handler, FileName, SourceMap};
+use swc_common::{
+    chain, comments::SingleThreadedComments, errors::Handler, sync::Lrc, FileName, SourceMap,
+};
 use swc_ecma_ast::*;
 use swc_ecma_codegen::Emitter;
 use swc_ecma_parser::{error::Error, lexer::Lexer, Parser, StringInput, Syntax};
@@ -49,7 +51,7 @@ struct MyHandlers;
 impl swc_ecma_codegen::Handlers for MyHandlers {}
 
 pub struct Tester<'a> {
-    pub cm: Arc<SourceMap>,
+    pub cm: Lrc<SourceMap>,
     pub handler: &'a Handler,
     pub comments: SingleThreadedComments,
 }

--- a/ecmascript/transforms/tests/es2015_classes.rs
+++ b/ecmascript/transforms/tests/es2015_classes.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "react")]
 #![feature(test)]
 use swc_common::chain;
 use swc_ecma_parser::{EsConfig, Syntax};
@@ -2194,7 +2195,7 @@ test!(
         jsx: true,
         ..Default::default()
     }),
-    |_| chain!(tr(), jsx(Default::default())),
+    |t| chain!(tr(), jsx(t.cm.clone(), Default::default())),
     regression_2775,
     r#"
 import React, {Component} from 'react';

--- a/ecmascript/transforms/tests/optimization_const_modules.rs
+++ b/ecmascript/transforms/tests/optimization_const_modules.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "const-modules")]
 #![feature(test)]
 use common::Tester;
 use std::collections::HashMap;

--- a/ecmascript/transforms/tests/optimization_const_modules.rs
+++ b/ecmascript/transforms/tests/optimization_const_modules.rs
@@ -7,7 +7,7 @@ use swc_ecma_visit::Fold;
 #[macro_use]
 mod common;
 
-fn tr(_: &mut Tester<'_>, sources: &[(&str, &[(&str, &str)])]) -> impl Fold {
+fn tr(t: &mut Tester<'_>, sources: &[(&str, &[(&str, &str)])]) -> impl Fold {
     let mut m = HashMap::default();
 
     for (src, values) in sources {
@@ -19,7 +19,7 @@ fn tr(_: &mut Tester<'_>, sources: &[(&str, &[(&str, &str)])]) -> impl Fold {
         m.insert((*src).into(), values);
     }
 
-    const_modules(m)
+    const_modules(t.cm.clone(), m)
 }
 
 test!(

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_utils"
-version = "0.16.1"
+version = "0.17.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -11,13 +11,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-swc_ecma_ast = { version = "0.27.0", path ="../ast" }
+swc_ecma_ast = { version = "0.28.0", path ="../ast" }
 swc_atoms = { version = "0.2.0", path ="../../atoms" }
-swc_common = { version = "0.8.0", path ="../../common" }
-swc_ecma_visit = { version = "0.12", path ="../visit" }
+swc_common = { version = "0.9.0", path ="../../common" }
+swc_ecma_visit = { version = "0.13.0", path ="../visit" }
 once_cell = "1"
 scoped-tls = "1"
 unicode-xid = "0.2"
 
 [dev-dependencies]
-testing = { version = "0.8", path ="../../testing" }
+testing = { version = "0.9.0", path ="../../testing" }

--- a/ecmascript/utils/src/lib.rs
+++ b/ecmascript/utils/src/lib.rs
@@ -29,7 +29,6 @@ mod macros;
 pub mod constructor;
 mod factory;
 pub mod ident;
-pub mod options;
 mod value;
 pub mod var;
 

--- a/ecmascript/utils/src/options.rs
+++ b/ecmascript/utils/src/options.rs
@@ -1,7 +1,9 @@
-use once_cell::sync::Lazy;
 use std::sync::Arc;
-use swc_common::{FilePathMapping, SourceMap};
+use swc_common::{
+    sync::{Lazy, Lrc},
+    FilePathMapping, SourceMap,
+};
 
 /// SourceMap used by transforms.
-pub static CM: Lazy<Arc<SourceMap>> =
-    Lazy::new(|| Arc::new(SourceMap::new(FilePathMapping::empty())));
+pub static CM: Lazy<Lrc<SourceMap>> =
+    Lazy::new(|| Lrc::new(SourceMap::new(FilePathMapping::empty())));

--- a/ecmascript/utils/src/options.rs
+++ b/ecmascript/utils/src/options.rs
@@ -1,9 +1,7 @@
+use once_cell::sync::Lazy;
 use std::sync::Arc;
-use swc_common::{
-    sync::{Lazy, Lrc},
-    FilePathMapping, SourceMap,
-};
+use swc_common::{FilePathMapping, SourceMap};
 
 /// SourceMap used by transforms.
-pub static CM: Lazy<Lrc<SourceMap>> =
-    Lazy::new(|| Lrc::new(SourceMap::new(FilePathMapping::empty())));
+pub static CM: Lazy<Arc<SourceMap>> =
+    Lazy::new(|| Arc::new(SourceMap::new(FilePathMapping::empty())));

--- a/ecmascript/utils/src/options.rs
+++ b/ecmascript/utils/src/options.rs
@@ -7,4 +7,3 @@ use swc_common::{
 /// SourceMap used by transforms.
 pub static CM: Lazy<Lrc<SourceMap>> =
     Lazy::new(|| Lrc::new(SourceMap::new(FilePathMapping::empty())));
-å

--- a/ecmascript/utils/src/options.rs
+++ b/ecmascript/utils/src/options.rs
@@ -1,7 +1,0 @@
-use once_cell::sync::Lazy;
-use std::sync::Arc;
-use swc_common::{FilePathMapping, SourceMap};
-
-/// SourceMap used by transforms.
-pub static CM: Lazy<Arc<SourceMap>> =
-    Lazy::new(|| Arc::new(SourceMap::new(FilePathMapping::empty())));

--- a/ecmascript/utils/src/options.rs
+++ b/ecmascript/utils/src/options.rs
@@ -7,3 +7,4 @@ use swc_common::{
 /// SourceMap used by transforms.
 pub static CM: Lazy<Lrc<SourceMap>> =
     Lazy::new(|| Lrc::new(SourceMap::new(FilePathMapping::empty())));
+å

--- a/ecmascript/visit/Cargo.toml
+++ b/ecmascript/visit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_visit"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 swc_atoms = { version = "0.2", path = "../../atoms" }
-swc_common = { version = "0.8", path = "../../common" }
-swc_ecma_ast = { version = "0.27.0", path ="../ast" }
+swc_common = { version = "0.9.0", path = "../../common" }
+swc_ecma_ast = { version = "0.28.0", path ="../ast" }
 swc_visit = { version = "0.1", path ="../../visit" }
 num-bigint = { version = "0.2", features = ["serde"] }

--- a/spack/src/bundler/helpers/mod.rs
+++ b/spack/src/bundler/helpers/mod.rs
@@ -1,9 +1,9 @@
 use once_cell::sync::Lazy;
 use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
-use swc_common::FileName;
+use swc_common::{FileName, FilePathMapping, SourceMap};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput};
-use swc_ecma_utils::{options::CM, prepend_stmts, DropSpan};
+use swc_ecma_utils::{prepend_stmts, DropSpan};
 use swc_ecma_visit::FoldWith;
 
 #[derive(Debug, Default)]
@@ -23,9 +23,10 @@ macro_rules! define {
         $(
             fn $build(to: &mut Vec<ModuleItem>) {
                 static STMTS: Lazy<Vec<ModuleItem>> = Lazy::new(|| {
+                    let cm = SourceMap::new(FilePathMapping::empty());
                     let code = include_str!(concat!("_", stringify!($name), ".js"));
                     let fm =
-                        CM.new_source_file(FileName::Custom(stringify!($name).into()), code.into());
+                       cm.new_source_file(FileName::Custom(stringify!($name).into()), code.into());
                     let lexer = Lexer::new(
                         Default::default(),
                         Default::default(),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -76,7 +76,8 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
         self,
         globals: HashMap<JsWord, HashMap<JsWord, String>>,
     ) -> PassBuilder<'a, 'b, impl swc_ecma_visit::Fold> {
-        self.then(const_modules(globals))
+        let cm = self.cm.clone();
+        self.then(const_modules(cm, globals))
     }
 
     pub fn inline_globals(

--- a/src/config.rs
+++ b/src/config.rs
@@ -193,7 +193,7 @@ impl Options {
 
             let globals = config.globals;
 
-            Optional::new(const_modules(globals), enabled)
+            Optional::new(const_modules(cm.clone(), globals), enabled)
         };
 
         let json_parse_pass = {

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testing"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"
@@ -9,7 +9,7 @@ description = "Testing utilities for the swc project."
 edition = "2018"
 
 [dependencies]
-swc_common = { version = "0.8.0", path ="../common", features = ["tty-emitter"] }
+swc_common = { version = "0.9.0", path ="../common", features = ["tty-emitter"] }
 once_cell = "1"
 regex = "1"
 difference = "2"

--- a/testing/src/diag_errors.rs
+++ b/testing/src/diag_errors.rs
@@ -1,11 +1,12 @@
-use std::sync::{Arc, RwLock};
-use swc_common::errors::{
-    Diagnostic, DiagnosticBuilder, Emitter, Handler, HandlerFlags, SourceMapperDyn,
+use std::sync::RwLock;
+use swc_common::{
+    errors::{Diagnostic, DiagnosticBuilder, Emitter, Handler, HandlerFlags, SourceMapperDyn},
+    sync::Lrc,
 };
 
 /// Creates a new handler for testing.
 pub(crate) fn new_handler(
-    _: Arc<SourceMapperDyn>,
+    _: Lrc<SourceMapperDyn>,
     treat_err_as_bug: bool,
 ) -> (Handler, BufferedError) {
     let e = BufferedError::default();
@@ -23,7 +24,7 @@ pub(crate) fn new_handler(
 }
 
 #[derive(Clone, Default)]
-pub(crate) struct BufferedError(Arc<RwLock<Vec<Diagnostic>>>);
+pub(crate) struct BufferedError(Lrc<RwLock<Vec<Diagnostic>>>);
 
 impl Emitter for BufferedError {
     fn emit(&mut self, db: &DiagnosticBuilder) {

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -10,11 +10,11 @@ use std::{
     fs::{create_dir_all, File},
     io::Write,
     path::Path,
-    sync::Arc,
     thread,
 };
 use swc_common::{
     errors::{Diagnostic, Handler},
+    sync::Lrc,
     FilePathMapping, SourceMap,
 };
 
@@ -63,11 +63,11 @@ pub fn init() {
 /// Run test and print errors.
 pub fn run_test<F, Ret>(treat_err_as_bug: bool, op: F) -> Result<Ret, StdErr>
 where
-    F: FnOnce(Arc<SourceMap>, &Handler) -> Result<Ret, ()>,
+    F: FnOnce(Lrc<SourceMap>, &Handler) -> Result<Ret, ()>,
 {
     init();
 
-    let cm = Arc::new(SourceMap::new(FilePathMapping::empty()));
+    let cm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
     let (handler, errors) = self::string_errors::new_handler(cm.clone(), treat_err_as_bug);
     let result = swc_common::GLOBALS.set(&swc_common::Globals::new(), || op(cm, &handler));
 
@@ -80,11 +80,11 @@ where
 /// Run test and print errors.
 pub fn run_test2<F, Ret>(treat_err_as_bug: bool, op: F) -> Result<Ret, StdErr>
 where
-    F: FnOnce(Arc<SourceMap>, Handler) -> Result<Ret, ()>,
+    F: FnOnce(Lrc<SourceMap>, Handler) -> Result<Ret, ()>,
 {
     init();
 
-    let cm = Arc::new(SourceMap::new(FilePathMapping::empty()));
+    let cm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
     let (handler, errors) = self::string_errors::new_handler(cm.clone(), treat_err_as_bug);
     let result = swc_common::GLOBALS.set(&swc_common::Globals::new(), || op(cm, handler));
 
@@ -95,7 +95,7 @@ where
 }
 
 pub struct Tester {
-    pub cm: Arc<SourceMap>,
+    pub cm: Lrc<SourceMap>,
     pub globals: swc_common::Globals,
     treat_err_as_bug: bool,
 }
@@ -105,7 +105,7 @@ impl Tester {
         init();
 
         Tester {
-            cm: Arc::new(SourceMap::new(FilePathMapping::empty())),
+            cm: Lrc::new(SourceMap::new(FilePathMapping::empty())),
             globals: swc_common::Globals::new(),
             treat_err_as_bug: false,
         }
@@ -119,7 +119,7 @@ impl Tester {
     /// Run test and print errors.
     pub fn print_errors<F, Ret>(&self, op: F) -> Result<Ret, StdErr>
     where
-        F: FnOnce(Arc<SourceMap>, Handler) -> Result<Ret, ()>,
+        F: FnOnce(Lrc<SourceMap>, Handler) -> Result<Ret, ()>,
     {
         let (handler, errors) =
             self::string_errors::new_handler(self.cm.clone(), self.treat_err_as_bug);
@@ -134,7 +134,7 @@ impl Tester {
     /// Run test and collect errors.
     pub fn errors<F, Ret>(&self, op: F) -> Result<Ret, Vec<Diagnostic>>
     where
-        F: FnOnce(Arc<SourceMap>, Handler) -> Result<Ret, ()>,
+        F: FnOnce(Lrc<SourceMap>, Handler) -> Result<Ret, ()>,
     {
         let (handler, errors) =
             self::diag_errors::new_handler(self.cm.clone(), self.treat_err_as_bug);

--- a/testing/src/string_errors.rs
+++ b/testing/src/string_errors.rs
@@ -3,11 +3,14 @@ use std::{
     io::{self, Write},
     sync::{Arc, RwLock},
 };
-use swc_common::errors::{EmitterWriter, Handler, HandlerFlags, SourceMapperDyn};
+use swc_common::{
+    errors::{EmitterWriter, Handler, HandlerFlags, SourceMapperDyn},
+    sync::Lrc,
+};
 
 /// Creates a new handler for testing.
 pub(crate) fn new_handler(
-    cm: Arc<SourceMapperDyn>,
+    cm: Lrc<SourceMapperDyn>,
     treat_err_as_bug: bool,
 ) -> (Handler, BufferedError) {
     let buf: BufferedError = Default::default();


### PR DESCRIPTION
Dropping dependency on parking_lot is much harder than I thought. <del> Changing it to std::sync is easy, but I'm trying to make parser fully single threaded (with cargo feature). </del>



cc @ry @bartlomieju 

Is changing `Rc` to `Arc` based on cargo feature acceptable?
I mean, the type is basically `Rc<RefCell<T>>`, but it becomes `Arc<Mutex<T>>` when cargo feature is enabled.
This can break code if some of dependency passes Rc to SourceMap and you specify `features = ["concurrent"]`


I can expose some type aliases to prevent breakage, just like [rustc does](https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc_data_structures/sync.rs.html). However this may cause global slowdown if one of the dependency enables the feature. (Well, I think it's not the case for deno, but just FYI)