### PR TITLE
Reduce size of parser

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.33.0"
+version = "0.33.1"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"


### PR DESCRIPTION
# Meta

Cargo version: `cargo 1.46.0-nightly (c26576f9a 2020-06-23)`

Command: `cargo  bloat -p swc_ecma_parser --release --full-fn --example typescript && ll ../../target/release/examples/typescript`


## First run

```
   Compiling swc_ecma_parser v0.33.1 (/Users/kdy1/projects/swc/ecmascript/parser)
    Finished release [optimized] target(s) in 49.56s
    Analyzing target/release/examples/typescript

 File  .text     Size            Crate Name
 2.4%   4.7%  43.0KiB  swc_ecma_parser swc_ecma_parser::parser::stmt::<impl swc_ecma_parser::parser::Parser<I>>::parse_stmt_internal::hfe8d1e0e22b990cc
 1.4%   2.6%  24.1KiB  swc_ecma_parser swc_ecma_parser::parser::stmt::module_item::<impl swc_ecma_parser::parser::Parser<I>>::parse_export::h4ba8e3c2674a44a1
 1.4%   2.6%  24.0KiB  swc_ecma_parser swc_ecma_parser::parser::expr::<impl swc_ecma_parser::parser::Parser<I>>::parse_primary_expr::h800ec1d8800c269c
 1.0%   1.9%  17.0KiB  swc_ecma_parser swc_ecma_parser::parser::typescript::<impl swc_ecma_parser::parser::Parser<I>>::parse_ts_non_array_type::hf23293593da8a319
 0.9%   1.7%  15.9KiB       swc_common swc_common::errors::emitter::EmitterWriter::emit_message_default::hf1f3b10dceb155ba
 0.8%   1.6%  14.8KiB  swc_ecma_parser swc_ecma_parser::parser::class_and_fn::<impl swc_ecma_parser::parser::Parser<I>>::parse_class_member_with_is_static::h73f48f5741f00739
 0.7%   1.3%  12.4KiB        [Unknown] _add_ranges
 0.7%   1.3%  11.7KiB        [Unknown] _read_line_info
 0.6%   1.3%  11.5KiB  swc_ecma_parser swc_ecma_parser::parser::stmt::module_item::<impl swc_ecma_parser::parser::Parser<I>>::parse_import::h5e014fdcb752ec90
 0.6%   1.2%  11.0KiB  swc_ecma_parser swc_ecma_parser::parser::expr::<impl swc_ecma_parser::parser::Parser<I>>::parse_args_or_pats::h8a78b5e0d3dbacf8
 0.6%   1.1%  10.0KiB       swc_common <swc_common::errors::emitter::EmitterWriter as swc_common::errors::emitter::Emitter>::emit::hde5dcc5fed8506cb
 0.5%   1.0%   8.8KiB  swc_ecma_parser swc_ecma_parser::lexer::jsx::<impl swc_ecma_parser::lexer::Lexer<I>>::read_jsx_entity::hbee8fd9a955b68a1
 0.5%   0.9%   8.6KiB              std ___rdos_backtrace_dwarf_add
 0.5%   0.9%   8.3KiB       typescript typescript::main::h86ab71da4430d611
 0.5%   0.9%   8.2KiB  swc_ecma_parser swc_ecma_parser::parser::expr::<impl swc_ecma_parser::parser::Parser<I>>::parse_subscripts::h762d35217afcf3fa
 0.5%   0.9%   8.2KiB  swc_ecma_parser swc_ecma_parser::parser::expr::<impl swc_ecma_parser::parser::Parser<I>>::parse_paren_expr_or_arrow_fn::h2f559b32ea6457c6
 0.5%   0.9%   8.1KiB              std core::fmt::float::float_to_decimal_common_shortest::hb8686c0ed2898524
 0.5%   0.9%   8.0KiB  swc_ecma_parser swc_ecma_parser::parser::jsx::<impl swc_ecma_parser::parser::Parser<I>>::parse_jsx_element_at::h161b377c5e7598d0
 0.4%   0.8%   7.8KiB swc_ecma_parser? <swc_ecma_parser::parser::input::Capturing<I> as core::iter::traits::iterator::Iterator>::next::ha2b3c19a9e29a615
 0.4%   0.8%   7.5KiB        [Unknown] _read_attribute
36.8%  71.3% 653.6KiB                  And 2783 smaller methods. Use -n N to show more.
51.7% 100.0% 917.1KiB                  .text section size, the file size is 1.7MiB
-rwxr-xr-x  1 kdy1  staff   1.7M  8  4 13:47 ../../target/release/examples/typescript

```


Size: 1816932