### PR TITLE
Type annotation in catch binding

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.33.0"
+version = "0.33.1"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -595,9 +595,9 @@ impl<'a, I: Tokens> Parser<I> {
                     | Pat::Object(ObjectPat { type_ann, .. })
                     | Pat::Assign(AssignPat { type_ann, .. }) => {
                         *type_ann = Some(TsTypeAnn {
-                            span: span!(type_ann_span,),
+                            span: span!(type_ann_start),
                             type_ann: ty,
-                        })
+                        });
                     }
                     Pat::Invalid(_) => {}
                     Pat::Expr(_) => {}

--- a/ecmascript/parser/tests/span/ts/stmt/try-catch-unknown.ts
+++ b/ecmascript/parser/tests/span/ts/stmt/try-catch-unknown.ts
@@ -1,0 +1,3 @@
+try {
+} catch (e: unknown) {
+}

--- a/ecmascript/parser/tests/span/ts/stmt/try-catch-unknown.ts.spans
+++ b/ecmascript/parser/tests/span/ts/stmt/try-catch-unknown.ts.spans
@@ -1,0 +1,86 @@
+warning: Module
+ --> $DIR/tests/span/ts/stmt/try-catch-unknown.ts:1:1
+  |
+1 | / try {
+2 | | } catch (e: unknown) {
+3 | | }
+  | |_^
+
+warning: ModuleItem
+ --> $DIR/tests/span/ts/stmt/try-catch-unknown.ts:1:1
+  |
+1 | / try {
+2 | | } catch (e: unknown) {
+3 | | }
+  | |_^
+
+warning: Stmt
+ --> $DIR/tests/span/ts/stmt/try-catch-unknown.ts:1:1
+  |
+1 | / try {
+2 | | } catch (e: unknown) {
+3 | | }
+  | |_^
+
+warning: TryStmt
+ --> $DIR/tests/span/ts/stmt/try-catch-unknown.ts:1:1
+  |
+1 | / try {
+2 | | } catch (e: unknown) {
+3 | | }
+  | |_^
+
+warning: BlockStmt
+ --> $DIR/tests/span/ts/stmt/try-catch-unknown.ts:1:5
+  |
+1 |   try {
+  |  _____^
+2 | | } catch (e: unknown) {
+  | |_^
+
+warning: CatchClause
+ --> $DIR/tests/span/ts/stmt/try-catch-unknown.ts:2:3
+  |
+2 |   } catch (e: unknown) {
+  |  ___^
+3 | | }
+  | |_^
+
+warning: Pat
+ --> $DIR/tests/span/ts/stmt/try-catch-unknown.ts:2:10
+  |
+2 | } catch (e: unknown) {
+  |          ^
+
+warning: Ident
+ --> $DIR/tests/span/ts/stmt/try-catch-unknown.ts:2:10
+  |
+2 | } catch (e: unknown) {
+  |          ^
+
+warning: TsTypeAnn
+ --> $DIR/tests/span/ts/stmt/try-catch-unknown.ts:2:11
+  |
+2 | } catch (e: unknown) {
+  |           ^^^^^^^^^
+
+warning: TsType
+ --> $DIR/tests/span/ts/stmt/try-catch-unknown.ts:2:13
+  |
+2 | } catch (e: unknown) {
+  |             ^^^^^^^
+
+warning: TsKeywordType
+ --> $DIR/tests/span/ts/stmt/try-catch-unknown.ts:2:13
+  |
+2 | } catch (e: unknown) {
+  |             ^^^^^^^
+
+warning: BlockStmt
+ --> $DIR/tests/span/ts/stmt/try-catch-unknown.ts:2:22
+  |
+2 |   } catch (e: unknown) {
+  |  ______________________^
+3 | | }
+  | |_^
+

--- a/ecmascript/parser/tests/typescript/v4/issue-941/input.ts
+++ b/ecmascript/parser/tests/typescript/v4/issue-941/input.ts
@@ -1,0 +1,3 @@
+try {
+} catch (e: unknown) {
+}


### PR DESCRIPTION
swc_ecma_parser:
 - Support catch binding with type anntation (Closes #941)