### PR TITLE
Never rename exports ident

### DIFF
--- a/atoms/words.txt
+++ b/atoms/words.txt
@@ -604,6 +604,7 @@ enum
 env
 eval
 export
+exports
 extends
 false
 finally

--- a/ecmascript/transforms/src/hygiene.rs
+++ b/ecmascript/transforms/src/hygiene.rs
@@ -583,7 +583,10 @@ impl<'a> Fold for Hygiene<'a> {
 
     /// Invoked for `IdetifierRefrence` / `BindingIdentifier`
     fn fold_ident(&mut self, i: Ident) -> Ident {
-        if i.sym == js_word!("arguments") || i.sym == js_word!("undefined") {
+        if i.sym == js_word!("arguments")
+            || i.sym == js_word!("undefined")
+            || i.sym == js_word!("exports")
+        {
             return i;
         }
 

--- a/ecmascript/transforms/tests/modules_common_js.rs
+++ b/ecmascript/transforms/tests/modules_common_js.rs
@@ -4185,3 +4185,45 @@ function setup(url: string, obj: any) {
     return _url1;
 }"
 );
+
+test!(
+    ts_syntax(),
+    |_| tr(Config {
+        ..Default::default()
+    }),
+    lodash_es,
+    "import root from './_root.js';
+  import stubFalse from './stubFalse.js';
+  
+  var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
+
+  var freeModule = freeExports && typeof module == 'object' && module && !module.nodeType && \
+     module;
+  
+  var moduleExports = freeModule && freeModule.exports === freeExports;
+  
+  var Buffer = moduleExports ? root.Buffer : undefined;
+  
+  var nativeIsBuffer = Buffer ? Buffer.isBuffer : undefined;
+  
+  var isBuffer = nativeIsBuffer || stubFalse;
+  
+  export default isBuffer;
+",
+    "'use strict';
+Object.defineProperty(exports, '__esModule', {
+    value: true
+});
+exports.default = void 0;
+var _rootJs = _interopRequireDefault(require('./_root.js'));
+var _stubFalseJs = _interopRequireDefault(require('./stubFalse.js'));
+var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
+var freeModule = freeExports && typeof module == 'object' && module && !module.nodeType && module;
+var moduleExports = freeModule && freeModule.exports === freeExports;
+var Buffer = moduleExports ? _rootJs.default.Buffer : undefined;
+var nativeIsBuffer = Buffer ? Buffer.isBuffer : undefined;
+var isBuffer = nativeIsBuffer || _stubFalseJs.default;
+var _default = isBuffer;
+exports.default = _default;
+"
+);


### PR DESCRIPTION
Now `export default isBuffer; ` is transformed into `exports1.default = _default;`