### PR TITLE
remove codegen::Handlers

### DIFF
--- a/bundler/examples/path.rs
+++ b/bundler/examples/path.rs
@@ -46,16 +46,10 @@ fn main() {
         cm: cm.clone(),
         comments: None,
         wr: Box::new(JsWriter::new(cm.clone(), "\n", wr.lock(), None)),
-        handlers: Box::new(Handllers),
     };
 
     emitter.emit_module(&bundle.module).unwrap();
 }
-
-/// I should remove this...
-struct Handllers;
-
-impl swc_ecma_codegen::Handlers for Handllers {}
 
 struct PathLoader {
     cm: Lrc<SourceMap>,

--- a/bundler/src/debug/mod.rs
+++ b/bundler/src/debug/mod.rs
@@ -18,16 +18,11 @@ pub(crate) fn print_hygiene(event: &str, cm: &Lrc<SourceMap>, t: &Module) {
         cm: cm.clone(),
         comments: None,
         wr: Box::new(JsWriter::new(cm.clone(), "\n", &mut w, None)),
-        handlers: Box::new(Handlers),
     }
     .emit_module(&module)
     .unwrap();
     writeln!(w, "==================== @ ====================").unwrap();
 }
-
-impl swc_ecma_codegen::Handlers for Handlers {}
-
-struct Handlers;
 
 struct HygieneVisualizer;
 

--- a/bundler/src/hash.rs
+++ b/bundler/src/hash.rs
@@ -15,7 +15,6 @@ pub(crate) fn calc_hash(cm: Lrc<SourceMap>, m: &Module) -> Result<String, Error>
             cm,
             comments: None,
             wr: Box::new(&mut buf) as Box<dyn WriteJs>,
-            handlers: Box::new(Handlers),
         };
 
         emitter
@@ -27,9 +26,6 @@ pub(crate) fn calc_hash(cm: Lrc<SourceMap>, m: &Module) -> Result<String, Error>
     let result = buf.digest.sum64();
     Ok(radix_fmt::radix(result, 36).to_string())
 }
-
-impl swc_ecma_codegen::Handlers for Handlers {}
-struct Handlers;
 
 struct Hasher {
     digest: Digest,

--- a/ecmascript/codegen/benches/bench.rs
+++ b/ecmascript/codegen/benches/bench.rs
@@ -102,7 +102,6 @@ fn bench_emitter(b: &mut Bencher, s: &str) {
         b.iter(|| {
             let mut buf = vec![];
             {
-                let handlers = Box::new(MyHandlers);
                 let mut emitter = Emitter {
                     cfg: swc_ecma_codegen::Config {
                         ..Default::default()
@@ -115,7 +114,6 @@ fn bench_emitter(b: &mut Bencher, s: &str) {
                         &mut buf,
                         Some(&mut src_map_buf),
                     )),
-                    handlers,
                 };
 
                 let _ = emitter.emit_module(&module);
@@ -137,7 +135,3 @@ fn emit_colors(b: &mut Bencher) {
 fn emit_large(b: &mut Bencher) {
     bench_emitter(b, LARGE_PARTIAL_JS)
 }
-
-struct MyHandlers;
-
-impl swc_ecma_codegen::Handlers for MyHandlers {}

--- a/ecmascript/codegen/benches/with_parse.rs
+++ b/ecmascript/codegen/benches/with_parse.rs
@@ -101,7 +101,6 @@ fn bench_emitter(b: &mut Bencher, s: &str) {
 
             let mut buf = vec![];
             {
-                let handlers = Box::new(MyHandlers);
                 let mut emitter = Emitter {
                     cfg: swc_ecma_codegen::Config {
                         ..Default::default()
@@ -114,7 +113,6 @@ fn bench_emitter(b: &mut Bencher, s: &str) {
                         &mut buf,
                         Some(&mut src_map_buf),
                     )),
-                    handlers,
                 };
 
                 let _ = emitter.emit_module(&module);
@@ -136,7 +134,3 @@ fn colors(b: &mut Bencher) {
 fn large_partial(b: &mut Bencher) {
     bench_emitter(b, LARGE_PARTIAL_JS)
 }
-
-struct MyHandlers;
-
-impl swc_ecma_codegen::Handlers for MyHandlers {}

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -32,11 +32,6 @@ pub mod util;
 
 pub type Result = io::Result<()>;
 
-pub trait Handlers {
-    // fn on_before_emit_token(&mut self, _node: &Any) {}
-    // fn on_after_emit_token(&mut self, _node: &Any) {}
-}
-
 pub trait Node: Spanned {
     fn emit_with(&self, e: &mut Emitter<'_>) -> Result;
 }
@@ -58,7 +53,6 @@ pub struct Emitter<'a> {
     pub cm: Lrc<SourceMap>,
     pub comments: Option<&'a dyn Comments>,
     pub wr: Box<(dyn 'a + WriteJs)>,
-    pub handlers: Box<(dyn 'a + Handlers)>,
 }
 
 impl<'a> Emitter<'a> {
@@ -1431,10 +1425,6 @@ impl<'a> Emitter<'a> {
 
         let is_empty = children.is_none() || start > children.unwrap().len() || count == 0;
         if is_empty && format.contains(ListFormat::OptionalIfEmpty) {
-            // self.handlers.onBeforeEmitNodeArray(children)
-
-            // self.handlers.onAfterEmitNodeArray(children);
-
             return Ok(());
         }
 

--- a/ecmascript/codegen/src/tests.rs
+++ b/ecmascript/codegen/src/tests.rs
@@ -9,9 +9,6 @@ use std::{
 use swc_common::{comments::SingleThreadedComments, FileName, SourceMap};
 use swc_ecma_parser;
 
-struct Noop;
-impl Handlers for Noop {}
-
 struct Builder {
     cfg: Config,
     cm: Lrc<SourceMap>,
@@ -28,7 +25,6 @@ impl Builder {
             cm: self.cm.clone(),
             wr: Box::new(text_writer::JsWriter::new(self.cm.clone(), "\n", s, None)),
             comments: Some(&self.comments),
-            handlers: Box::new(Noop),
         };
 
         let ret = op(&mut e);

--- a/ecmascript/codegen/tests/test262.rs
+++ b/ecmascript/codegen/tests/test262.rs
@@ -89,10 +89,6 @@ fn add_test<F: FnOnce() + Send + 'static>(
     });
 }
 
-struct MyHandlers;
-
-impl swc_ecma_codegen::Handlers for MyHandlers {}
-
 fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
     let ref_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
@@ -148,7 +144,6 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                 );
 
                 let comments = SingleThreadedComments::default();
-                let handlers = Box::new(MyHandlers);
                 let lexer = Lexer::new(
                     Syntax::default(),
                     Default::default(),
@@ -165,7 +160,6 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                             cm, "\n", &mut wr, None,
                         )),
                         comments: Some(&comments),
-                        handlers,
                     };
 
                     // Parse source

--- a/ecmascript/preset_env/tests/test.rs
+++ b/ecmascript/preset_env/tests/test.rs
@@ -203,7 +203,6 @@ fn exec(c: PresetConfig, dir: PathBuf) -> Result<(), Error> {
             let print = |m: &Module| {
                 let mut buf = vec![];
                 {
-                    let handlers = Box::new(MyHandlers);
                     let mut emitter = Emitter {
                         cfg: swc_ecma_codegen::Config { minify: false },
                         comments: None,
@@ -214,7 +213,6 @@ fn exec(c: PresetConfig, dir: PathBuf) -> Result<(), Error> {
                             &mut buf,
                             None,
                         )),
-                        handlers,
                     };
 
                     emitter.emit_module(m).expect("failed to emit module");
@@ -344,7 +342,3 @@ fn fixtures() {
     let args: Vec<_> = env::args().collect();
     test_main(&args, tests, Some(test::Options::new()));
 }
-
-struct MyHandlers;
-
-impl swc_ecma_codegen::Handlers for MyHandlers {}

--- a/ecmascript/transforms/src/tests.rs
+++ b/ecmascript/transforms/src/tests.rs
@@ -17,10 +17,6 @@ use swc_ecma_utils::DropSpan;
 use swc_ecma_visit::{Fold, FoldWith};
 use tempfile::tempdir_in;
 
-struct MyHandlers;
-
-impl swc_ecma_codegen::Handlers for MyHandlers {}
-
 pub(crate) struct Tester<'a> {
     pub cm: Lrc<SourceMap>,
     pub handler: &'a Handler,
@@ -128,8 +124,6 @@ impl<'a> Tester<'a> {
     }
 
     pub fn print(&mut self, module: &Module) -> String {
-        let handlers = Box::new(MyHandlers);
-
         let mut wr = Buf(Arc::new(RwLock::new(vec![])));
         {
             let mut emitter = Emitter {
@@ -142,7 +136,6 @@ impl<'a> Tester<'a> {
                     None,
                 )),
                 comments: None,
-                handlers,
             };
 
             // println!("Emitting: {:?}", module);

--- a/ecmascript/transforms/tests/common/mod.rs
+++ b/ecmascript/transforms/tests/common/mod.rs
@@ -46,10 +46,6 @@ macro_rules! validate {
     }};
 }
 
-struct MyHandlers;
-
-impl swc_ecma_codegen::Handlers for MyHandlers {}
-
 pub struct Tester<'a> {
     pub cm: Lrc<SourceMap>,
     pub handler: &'a Handler,
@@ -142,8 +138,6 @@ impl<'a> Tester<'a> {
     }
 
     pub fn print(&mut self, module: &Module) -> String {
-        let handlers = Box::new(MyHandlers);
-
         let mut wr = Buf(Arc::new(RwLock::new(vec![])));
         {
             let mut emitter = Emitter {
@@ -156,7 +150,6 @@ impl<'a> Tester<'a> {
                     None,
                 )),
                 comments: None,
-                handlers,
             };
 
             // println!("Emitting: {:?}", module);

--- a/ecmascript/transforms/tests/fixer_test262.rs
+++ b/ecmascript/transforms/tests/fixer_test262.rs
@@ -109,10 +109,6 @@ fn add_test<F: FnOnce() + Send + 'static>(
     });
 }
 
-struct MyHandlers;
-
-impl swc_ecma_codegen::Handlers for MyHandlers {}
-
 fn identity_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -166,8 +162,6 @@ fn identity_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                     let mut wr = Buf(Arc::new(RwLock::new(vec![])));
                     let mut wr2 = Buf(Arc::new(RwLock::new(vec![])));
 
-                    let handlers = Box::new(MyHandlers);
-                    let handlers2 = Box::new(MyHandlers);
                     let mut parser: Parser<Lexer<StringInput>> =
                         Parser::new(Syntax::default(), (&*src).into(), None);
 
@@ -182,7 +176,6 @@ fn identity_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                                 None,
                             )),
                             comments: None,
-                            handlers,
                         };
                         let mut expected_emitter = Emitter {
                             cfg: swc_ecma_codegen::Config { minify: false },
@@ -191,7 +184,6 @@ fn identity_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                                 cm, "\n", &mut wr2, None,
                             )),
                             comments: None,
-                            handlers: handlers2,
                         };
 
                         // Parse source

--- a/ecmascript/transforms/tests/typescript_strip_correctness.rs
+++ b/ecmascript/transforms/tests/typescript_strip_correctness.rs
@@ -161,7 +161,6 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
 
                     let mut wr = Buf(Arc::new(RwLock::new(vec![])));
 
-                    let handlers = Box::new(MyHandlers);
                     {
                         let mut emitter = Emitter {
                             cfg: swc_ecma_codegen::Config { minify: false },
@@ -173,7 +172,6 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                                 None,
                             )),
                             comments: None,
-                            handlers,
                         };
 
                         // Parse source

--- a/ecmascript/transforms/tests/typescript_strip_correctness.rs
+++ b/ecmascript/transforms/tests/typescript_strip_correctness.rs
@@ -36,10 +36,6 @@ fn add_test<F: FnOnce() + Send + 'static>(
     });
 }
 
-struct MyHandlers;
-
-impl swc_ecma_codegen::Handlers for MyHandlers {}
-
 fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,7 +200,6 @@ impl Compiler {
             let src = {
                 let mut buf = vec![];
                 {
-                    let handlers = Box::new(MyHandlers);
                     let mut emitter = Emitter {
                         cfg: swc_ecma_codegen::Config { minify },
                         comments: if minify { None } else { Some(&self.comments) },
@@ -215,7 +214,6 @@ impl Compiler {
                                 None
                             },
                         )),
-                        handlers,
                     };
 
                     node.emit_with(&mut emitter)
@@ -452,10 +450,6 @@ impl Compiler {
         })
     }
 }
-
-struct MyHandlers;
-
-impl swc_ecma_codegen::Handlers for MyHandlers {}
 
 fn load_swcrc(path: &Path) -> Result<Rc, Error> {
     fn convert_json_err(e: serde_json::Error) -> Error {


### PR DESCRIPTION
`codegen::Handler` is a noop trait. It's used everytime `codegen::Emitter` must be created and there were comments that it should be removed. So I went ahead and did that. @kdy1 if you want to use that trait in the future feel free to close this PR.