### PR TITLE
Enable react, const-modules features to swc_ecmascript

### DIFF
--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -20,7 +20,7 @@ swc_ecma_ast = { version = "0.29.0", path ="./ast" }
 swc_ecma_codegen = { version = "0.33.0", path ="./codegen", optional = true }
 swc_ecma_parser = { version = "0.35.0", path ="./parser", optional = true }
 swc_ecma_utils = { version = "0.19.0", path ="./utils", optional = true }
-swc_ecma_transforms = { version = "0.21.0", path ="./transforms", optional = true }
+swc_ecma_transforms = { version = "0.21.0", path ="./transforms", optional = true, features = ["const-modules", "react"] }
 swc_ecma_visit = { version = "0.15.0", path ="./visit", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Using `swc_ecmascript::transforms::react` is currently not possible, because proper features were not specified.