### PR TITLE
Improve performance of swc

### DIFF
--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -1646,12 +1646,6 @@ impl<'a> Emitter<'a> {
 
     #[emitter]
     fn emit_pat(&mut self, node: &Pat) -> Result {
-        #[cold]
-        #[inline(never)]
-        fn invalid() -> ! {
-            unimplemented!("emit Pat::Invalid")
-        }
-
         match *node {
             Pat::Array(ref n) => emit!(n),
             Pat::Assign(ref n) => emit!(n),
@@ -1659,7 +1653,7 @@ impl<'a> Emitter<'a> {
             Pat::Ident(ref n) => emit!(n),
             Pat::Object(ref n) => emit!(n),
             Pat::Rest(ref n) => emit!(n),
-            Pat::Invalid(..) => invalid(),
+            Pat::Invalid(..) => invalid_pat(),
         }
     }
 
@@ -2421,4 +2415,10 @@ fn escape(s: &str) -> Cow<str> {
             .replace("\09", "\\x009")
             .replace("\0", "\\0"),
     )
+}
+
+#[cold]
+#[inline(never)]
+fn invalid_pat() -> ! {
+    unimplemented!("emit Pat::Invalid")
 }

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -1646,6 +1646,12 @@ impl<'a> Emitter<'a> {
 
     #[emitter]
     fn emit_pat(&mut self, node: &Pat) -> Result {
+        #[cold]
+        #[inline(never)]
+        fn invalid() -> ! {
+            unimplemented!("emit Pat::Invalid")
+        }
+
         match *node {
             Pat::Array(ref n) => emit!(n),
             Pat::Assign(ref n) => emit!(n),
@@ -1653,7 +1659,7 @@ impl<'a> Emitter<'a> {
             Pat::Ident(ref n) => emit!(n),
             Pat::Object(ref n) => emit!(n),
             Pat::Rest(ref n) => emit!(n),
-            Pat::Invalid(..) => unimplemented!("emit Pat::Invalid"),
+            Pat::Invalid(..) => invalid(),
         }
     }
 

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.35.0"
+version = "0.35.1"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/parser/src/parser/input.rs
+++ b/ecmascript/parser/src/parser/input.rs
@@ -313,7 +313,7 @@ impl<I: Tokens> Buffer<I> {
     }
 
     /// Get current token. Returns `None` only on eof.
-    #[inline(always)]
+    #[inline]
     pub fn cur(&mut self) -> Option<&Token> {
         if self.cur.is_none() {
             self.bump_inner();
@@ -321,7 +321,7 @@ impl<I: Tokens> Buffer<I> {
         self.cur.as_ref().map(|item| &item.token)
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn is(&mut self, expected: &Token) -> bool {
         match self.cur() {
             Some(t) => *expected == *t,
@@ -329,7 +329,7 @@ impl<I: Tokens> Buffer<I> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn peeked_is(&mut self, expected: &Token) -> bool {
         match self.peek() {
             Some(t) => *expected == *t,
@@ -337,7 +337,7 @@ impl<I: Tokens> Buffer<I> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn eat(&mut self, expected: &Token) -> bool {
         let v = self.is(expected);
         if v {
@@ -346,13 +346,19 @@ impl<I: Tokens> Buffer<I> {
         v
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn eat_keyword(&mut self, kwd: Keyword) -> bool {
-        self.eat(&Word(Word::Keyword(kwd)))
+        match self.cur() {
+            Some(Token::Word(Word::Keyword(k))) if *k == kwd => {
+                self.bump();
+                true
+            }
+            _ => false,
+        }
     }
 
     /// Returns start of current token.
-    #[inline(always)]
+    #[inline]
     pub fn cur_pos(&mut self) -> BytePos {
         let _ = self.cur();
         self.cur
@@ -364,7 +370,7 @@ impl<I: Tokens> Buffer<I> {
             })
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn cur_span(&self) -> Span {
         let data = self
             .cur
@@ -376,50 +382,50 @@ impl<I: Tokens> Buffer<I> {
     }
 
     /// Returns last byte position of previous token.
-    #[inline(always)]
+    #[inline]
     pub fn last_pos(&self) -> BytePos {
         self.prev_span.hi
     }
 
     /// Returns span of the previous token.
-    #[inline(always)]
+    #[inline]
     pub fn prev_span(&self) -> Span {
         self.prev_span
     }
 
-    #[inline(always)]
+    #[inline]
     pub(crate) fn get_ctx(&self) -> Context {
         self.iter.ctx()
     }
 
-    #[inline(always)]
+    #[inline]
     pub(crate) fn set_ctx(&mut self, ctx: Context) {
         self.iter.set_ctx(ctx);
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn syntax(&self) -> Syntax {
         self.iter.syntax()
     }
-    #[inline(always)]
+    #[inline]
     pub fn target(&self) -> JscTarget {
         self.iter.target()
     }
 
-    #[inline(always)]
+    #[inline]
     pub(crate) fn set_expr_allowed(&mut self, allow: bool) {
         self.iter.set_expr_allowed(allow)
     }
 
-    #[inline(always)]
+    #[inline]
     pub(crate) fn token_context(&self) -> &lexer::TokenContexts {
         self.iter.token_context()
     }
-    #[inline(always)]
+    #[inline]
     pub(crate) fn token_context_mut(&mut self) -> &mut lexer::TokenContexts {
         self.iter.token_context_mut()
     }
-    #[inline(always)]
+    #[inline]
     pub(crate) fn set_token_context(&mut self, c: lexer::TokenContexts) {
         self.iter.set_token_context(c)
     }

--- a/ecmascript/parser/src/parser/input.rs
+++ b/ecmascript/parser/src/parser/input.rs
@@ -260,13 +260,18 @@ impl<I: Tokens> Buffer<I> {
 
     /// Returns current token.
     pub fn bump(&mut self) -> Token {
+        #[cold]
+        #[inline(never)]
+        fn invalid_state() -> ! {
+            unreachable!(
+                "Current token is `None`. Parser should not call bump() without knowing current \
+                 token"
+            )
+        }
+
         let prev = match self.cur.take() {
             Some(t) => t,
-
-            None => unreachable!(
-                "Current token is `None`. Parser should not call bump()without knowing current \
-                 token"
-            ),
+            None => invalid_state(),
         };
         self.prev_span = prev.span;
 

--- a/ecmascript/parser/src/parser/macros.rs
+++ b/ecmascript/parser/src/parser/macros.rs
@@ -43,19 +43,14 @@ macro_rules! is {
     }};
 
     ($p:expr,';') => {{
-        $p.input.is(&Token::Semi)
-            || eof!($p)
-            || is!($p, '}')
-            || $p.input.had_line_break_before_cur()
-        // match $p.input.cur() {
-        //     Some(&Token::Semi) | None | Some(&tok!('}')) => true,
-        //     _ => $p.input.had_line_break_before_cur(),
-        // }
+        match $p.input.cur() {
+            Some(&Token::Semi) | None | Some(&tok!('}')) => true,
+            _ => $p.input.had_line_break_before_cur(),
+        }
     }};
 
     ($p:expr, $t:tt) => {
-        $p.input.is(&tok!($t))
-        // is_exact!($p, $t)
+        is_exact!($p, $t)
     };
 }
 
@@ -88,11 +83,10 @@ macro_rules! peeked_is {
     }};
 
     ($p:expr, $t:tt) => {
-        $p.input.peeked_is(&tok!($t))
-        // match peek!($p).ok() {
-        //     Some(&token_including_semi!($t)) => true,
-        //     _ => false,
-        // }
+        match peek!($p).ok() {
+            Some(&token_including_semi!($t)) => true,
+            _ => false,
+        }
     };
 }
 
@@ -135,15 +129,14 @@ macro_rules! assert_and_bump {
 macro_rules! eat {
     ($p:expr, ';') => {{
         log::trace!("eat(';'): cur={:?}", cur!($p, false));
-        $p.input.eat(&Token::Semi)
-            || eof!($p)
-            || is!($p, '}')
-            || $p.input.had_line_break_before_cur()
-        // match $p.input.cur() {
-        //     Some(&Token::Semi) => true,
-        //     None | Some(&tok!('}')) => true,
-        //     _ => $p.input.had_line_break_before_cur(),
-        // }
+        match $p.input.cur() {
+            Some(&Token::Semi) => {
+                $p.input.bump();
+                true
+            }
+            None | Some(&tok!('}')) => true,
+            _ => $p.input.had_line_break_before_cur(),
+        }
     }};
 
     ($p:expr, $t:tt) => {{

--- a/ecmascript/parser/src/parser/util.rs
+++ b/ecmascript/parser/src/parser/util.rs
@@ -114,6 +114,7 @@ impl<'a, I: Tokens> Parser<I> {
     }
 
     /// Parse with given closure
+    #[inline(always)]
     pub(super) fn parse_with<F, Ret>(&mut self, f: F) -> PResult<Ret>
     where
         F: FnOnce(&mut Self) -> PResult<Ret>,

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = "1"
 smallvec = "1"
 is-macro = "0.1"
 log = "0.4.8"
+retain_mut = "=0.1.1"
 
 [dev-dependencies]
 testing = { version = "0.9.0", path ="../../testing" }

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_transforms"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
@@ -11,7 +11,7 @@ use swc_common::{
 };
 use swc_ecma_ast::*;
 use swc_ecma_utils::{find_ids, ident::IdentLike, Id, StmtLike};
-use swc_ecma_visit::{as_folder, noop_visit_mut_type, FoldWith, VisitMut, VisitMutWith, VisitWith};
+use swc_ecma_visit::{as_folder, noop_visit_mut_type, VisitMut, VisitMutWith, VisitWith};
 
 macro_rules! preserve {
     ($name:ident, $T:ty) => {
@@ -610,6 +610,7 @@ impl Dce<'_> {
     where
         T: StmtLike + VisitMutWith<Self> + Spanned + std::fmt::Debug,
         T: for<'any> VisitWith<SideEffectVisitor<'any>> + VisitWith<ImportDetector>,
+        Vec<T>: VisitMutWith<Self>,
     {
         if self.marking_phase {
             items.visit_mut_children_with(self);
@@ -643,7 +644,7 @@ impl Dce<'_> {
             });
 
             if !self.changed {
-                items = items.move_map(|item| item.fold_with(self));
+                items.visit_mut_children_with(self);
             }
 
             if !self.changed {

--- a/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
@@ -427,7 +427,7 @@ impl VisitMut for Dce<'_> {
         }
     }
 
-    fn visit_mut_member_expr(&mut self, mut e: &mut MemberExpr) {
+    fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
         if self.is_marked(e.span()) {
             return;
         }
@@ -601,7 +601,7 @@ impl VisitMut for Dce<'_> {
 }
 
 impl Dce<'_> {
-    fn visit_mut_stmt_like<T>(&mut self, mut items: &mut Vec<T>)
+    fn visit_mut_stmt_like<T>(&mut self, items: &mut Vec<T>)
     where
         T: StmtLike + VisitMutWith<Self> + Spanned + std::fmt::Debug,
         T: for<'any> VisitWith<SideEffectVisitor<'any>> + VisitWith<ImportDetector>,
@@ -622,7 +622,7 @@ impl Dce<'_> {
 
             self.changed = false;
             let mut idx = 0u32;
-            items.iter_mut().for_each(|mut item| {
+            items.iter_mut().for_each(|item| {
                 if !preserved.contains(&idx) {
                     if self.should_include(&*item) {
                         preserved.insert(idx);

--- a/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
@@ -644,6 +644,7 @@ impl Dce<'_> {
         {
             let mut idx = 0;
             let taken = take(items);
+            // We use take because of try_into_stmt
             *items = taken.move_flat_map(|mut item| {
                 self.drop_unused_decls(&mut item);
                 let item = match item.try_into_stmt() {

--- a/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
@@ -11,15 +11,12 @@ use swc_common::{
 };
 use swc_ecma_ast::*;
 use swc_ecma_utils::{find_ids, ident::IdentLike, Id, StmtLike};
-use swc_ecma_visit::{
-    as_folder, noop_fold_type, noop_visit_mut_type, Fold, FoldWith, VisitMut, VisitWith,
-};
+use swc_ecma_visit::{as_folder, noop_visit_mut_type, FoldWith, VisitMut, VisitMutWith, VisitWith};
 
 macro_rules! preserve {
     ($name:ident, $T:ty) => {
-        fn $name(&mut self, mut node: $T) -> $T {
+        fn $name(&mut self, node: &mut $T) {
             node.span = node.span.apply_mark(self.config.used_mark);
-            node
         }
     };
 }
@@ -56,14 +53,14 @@ pub fn dce<'a>(config: Config<'a>) -> impl RepeatedJsPass + 'a {
     let used_mark = config.used_mark;
 
     chain!(
-        Dce {
+        as_folder(Dce {
             config,
             dropped: false,
             included: Default::default(),
             changed: false,
             marking_phase: false,
             decl_dropping_phase: false,
-        },
+        }),
         as_folder(UsedMarkRemover { used_mark })
     )
 }
@@ -133,73 +130,65 @@ impl Repeated for Dce<'_> {
     }
 }
 
-impl Fold for Dce<'_> {
-    noop_fold_type!();
+impl VisitMut for Dce<'_> {
+    noop_visit_mut_type!();
 
-    preserve!(fold_debugger_stmt, DebuggerStmt);
-    preserve!(fold_with_stmt, WithStmt);
-    preserve!(fold_break_stmt, BreakStmt);
-    preserve!(fold_continue_stmt, ContinueStmt);
+    preserve!(visit_mut_debugger_stmt, DebuggerStmt);
+    preserve!(visit_mut_with_stmt, WithStmt);
+    preserve!(visit_mut_break_stmt, BreakStmt);
+    preserve!(visit_mut_continue_stmt, ContinueStmt);
 
-    preserve!(fold_ts_export_assignment, TsExportAssignment);
-
-    fn fold_block_stmt(&mut self, node: BlockStmt) -> BlockStmt {
+    fn visit_mut_block_stmt(&mut self, node: &mut BlockStmt) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
-
-        let mut stmts = node.stmts.fold_with(self);
+        node.stmts.visit_mut_with(self);
 
         let mut span = node.span;
-        if self.marking_phase || stmts.iter().any(|stmt| self.is_marked(stmt.span())) {
+        if self.marking_phase || node.stmts.iter().any(|stmt| self.is_marked(stmt.span())) {
             span = span.apply_mark(self.config.used_mark);
-            stmts = self.fold_in_marking_phase(stmts);
+            self.mark(&mut node.stmts);
         }
-
-        BlockStmt { span, stmts }
     }
 
-    fn fold_class_decl(&mut self, mut node: ClassDecl) -> ClassDecl {
+    fn visit_mut_class_decl(&mut self, node: &mut ClassDecl) {
         if self.is_marked(node.span()) {
-            return node;
+            return;
         }
 
         if self.marking_phase || self.included.contains(&node.ident.to_id()) {
             node.class.span = node.class.span.apply_mark(self.config.used_mark);
-            node.class.super_class = self.fold_in_marking_phase(node.class.super_class);
+            self.mark(&mut node.class.super_class);
         }
 
-        node.fold_children_with(self)
+        node.visit_mut_children_with(self)
     }
 
-    fn fold_do_while_stmt(&mut self, mut node: DoWhileStmt) -> DoWhileStmt {
+    fn visit_mut_do_while_stmt(&mut self, node: &mut DoWhileStmt) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
-        node = node.fold_children_with(self);
+        node.visit_mut_children_with(self);
 
         if self.is_marked(node.test.span()) || self.is_marked(node.body.span()) {
             node.span = node.span.apply_mark(self.config.used_mark);
 
-            node.test = self.fold_in_marking_phase(node.test);
-            node.body = self.fold_in_marking_phase(node.body);
+            self.mark(&mut node.test);
+            self.mark(&mut node.body);
         }
-
-        node
     }
 
-    fn fold_export_all(&mut self, mut node: ExportAll) -> ExportAll {
+    fn visit_mut_export_all(&mut self, node: &mut ExportAll) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
         node.span = node.span.apply_mark(self.config.used_mark);
-        node
     }
 
-    fn fold_export_decl(&mut self, mut node: ExportDecl) -> ExportDecl {
+    fn visit_mut_export_decl(&mut self, node: &mut ExportDecl) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
         let i = match node.decl {
@@ -208,7 +197,7 @@ impl Fold for Dce<'_> {
             // Preserve types
             Decl::TsInterface(_) | Decl::TsTypeAlias(_) | Decl::TsEnum(_) | Decl::TsModule(_) => {
                 node.span = node.span.apply_mark(self.config.used_mark);
-                return node;
+                return;
             }
 
             // Preserve only exported variables
@@ -224,7 +213,7 @@ impl Fold for Dce<'_> {
                             || self.should_preserve_export(&name.0)
                         {
                             d.span = d.span.apply_mark(self.config.used_mark);
-                            d.init = self.fold_in_marking_phase(d.init);
+                            self.mark(&mut d.init);
                             return Some(d);
                         }
                     }
@@ -241,88 +230,76 @@ impl Fold for Dce<'_> {
 
                 node.decl = Decl::Var(v);
 
-                return node;
+                return;
             }
         };
 
         if self.should_preserve_export(&i.sym) {
             node.span = node.span.apply_mark(self.config.used_mark);
-            node.decl = self.fold_in_marking_phase(node.decl);
+            self.mark(&mut node.decl);
         }
-
-        node
     }
 
-    fn fold_export_default_decl(&mut self, mut node: ExportDefaultDecl) -> ExportDefaultDecl {
+    fn visit_mut_export_default_decl(&mut self, node: &mut ExportDefaultDecl) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
         // TODO: Export only when it's required. (i.e. check self.used_exports)
 
         node.span = node.span.apply_mark(self.config.used_mark);
-        node.decl = self.fold_in_marking_phase(node.decl);
-
-        node
+        self.mark(&mut node.decl);
     }
 
-    fn fold_export_default_expr(&mut self, mut node: ExportDefaultExpr) -> ExportDefaultExpr {
+    fn visit_mut_export_default_expr(&mut self, node: &mut ExportDefaultExpr) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
         if self.should_preserve_export(&js_word!("default")) {
             node.span = node.span.apply_mark(self.config.used_mark);
-            node.expr = self.fold_in_marking_phase(node.expr);
+            self.mark(&mut node.expr);
         }
-
-        node
     }
 
-    fn fold_expr_stmt(&mut self, node: ExprStmt) -> ExprStmt {
+    fn visit_mut_expr_stmt(&mut self, node: &mut ExprStmt) {
         log::debug!("ExprStmt ->");
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
         if self.should_include(&node.expr) {
             log::debug!("\tIncluded");
-            let stmt = ExprStmt {
-                span: node.span.apply_mark(self.config.used_mark),
-                expr: self.fold_in_marking_phase(node.expr),
-            };
-            return stmt;
+            node.span = node.span.apply_mark(self.config.used_mark);
+            self.mark(&mut node.expr);
+            return;
         }
 
-        node.fold_children_with(self)
+        node.visit_mut_children_with(self)
     }
 
-    fn fold_fn_decl(&mut self, mut f: FnDecl) -> FnDecl {
+    fn visit_mut_fn_decl(&mut self, mut f: &mut FnDecl) {
         if self.is_marked(f.span()) {
-            return f;
+            return;
         }
 
         if self.marking_phase || self.included.contains(&f.ident.to_id()) {
             f.function.span = f.function.span.apply_mark(self.config.used_mark);
-            f.function.params = self.fold_in_marking_phase(f.function.params);
-            f.function.body = self.fold_in_marking_phase(f.function.body);
-            return f;
+            self.mark(&mut f.function.params);
+            self.mark(&mut f.function.body);
+            return;
         }
 
-        f.fold_children_with(self)
+        f.visit_mut_children_with(self)
     }
 
-    fn fold_for_in_stmt(&mut self, mut node: ForInStmt) -> ForInStmt {
+    fn visit_mut_for_in_stmt(&mut self, node: &mut ForInStmt) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
-        node = ForInStmt {
-            span: node.span,
-            left: node.left,
-            right: node.right.fold_with(self),
-            body: node.body.fold_with(self),
-        };
+        node.right.visit_mut_with(self);
+        node.body.visit_mut_with(self);
 
         if self.should_include(&node.left)
             || self.is_marked(node.left.span())
@@ -331,26 +308,19 @@ impl Fold for Dce<'_> {
         {
             node.span = node.span.apply_mark(self.config.used_mark);
 
-            node.left = self.fold_in_marking_phase(node.left);
-            node.right = self.fold_in_marking_phase(node.right);
-            node.body = self.fold_in_marking_phase(node.body);
+            self.mark(&mut node.left);
+            self.mark(&mut node.right);
+            self.mark(&mut node.body);
         }
-
-        node
     }
 
-    fn fold_for_of_stmt(&mut self, mut node: ForOfStmt) -> ForOfStmt {
+    fn visit_mut_for_of_stmt(&mut self, node: &mut ForOfStmt) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
-        node = ForOfStmt {
-            span: node.span,
-            await_token: node.await_token,
-            left: node.left,
-            right: node.right.fold_with(self),
-            body: node.body.fold_with(self),
-        };
+        node.right.visit_mut_with(self);
+        node.body.visit_mut_with(self);
 
         if self.should_include(&node.left)
             || self.is_marked(node.left.span())
@@ -359,20 +329,18 @@ impl Fold for Dce<'_> {
         {
             node.span = node.span.apply_mark(self.config.used_mark);
 
-            node.left = self.fold_in_marking_phase(node.left);
-            node.right = self.fold_in_marking_phase(node.right);
-            node.body = self.fold_in_marking_phase(node.body);
+            self.mark(&mut node.left);
+            self.mark(&mut node.right);
+            self.mark(&mut node.body);
         }
-
-        node
     }
 
-    fn fold_for_stmt(&mut self, mut node: ForStmt) -> ForStmt {
+    fn visit_mut_for_stmt(&mut self, node: &mut ForStmt) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
-        node = node.fold_children_with(self);
+        node.visit_mut_children_with(self);
 
         if node.test.is_none()
             || self.is_marked(node.init.span())
@@ -382,18 +350,16 @@ impl Fold for Dce<'_> {
         {
             node.span = node.span.apply_mark(self.config.used_mark);
 
-            node.test = self.fold_in_marking_phase(node.test);
-            node.init = self.fold_in_marking_phase(node.init);
-            node.update = self.fold_in_marking_phase(node.update);
-            node.body = self.fold_in_marking_phase(node.body);
+            self.mark(&mut node.test);
+            self.mark(&mut node.init);
+            self.mark(&mut node.update);
+            self.mark(&mut node.body);
         }
-
-        node
     }
 
-    fn fold_ident(&mut self, i: Ident) -> Ident {
+    fn visit_mut_ident(&mut self, i: &mut Ident) {
         if self.is_marked(i.span) {
-            return i;
+            return;
         }
 
         if self.marking_phase {
@@ -402,16 +368,14 @@ impl Fold for Dce<'_> {
                 self.changed = true;
             }
         }
-
-        i
     }
 
-    fn fold_if_stmt(&mut self, node: IfStmt) -> IfStmt {
+    fn visit_mut_if_stmt(&mut self, node: &mut IfStmt) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
-        let mut node: IfStmt = node.fold_children_with(self);
+        node.visit_mut_children_with(self);
 
         if self.is_marked(node.test.span())
             || self.is_marked(node.cons.span())
@@ -419,28 +383,26 @@ impl Fold for Dce<'_> {
         {
             node.span = node.span.apply_mark(self.config.used_mark);
 
-            node.test = self.fold_in_marking_phase(node.test);
-            node.cons = self.fold_in_marking_phase(node.cons);
-            node.alt = self.fold_in_marking_phase(node.alt);
+            self.mark(&mut node.test);
+            self.mark(&mut node.cons);
+            self.mark(&mut node.alt);
         }
-
-        node
     }
 
-    fn fold_import_decl(&mut self, mut import: ImportDecl) -> ImportDecl {
+    fn visit_mut_import_decl(&mut self, mut import: &mut ImportDecl) {
         // Do not mark import as used while ignoring imports
         if !self.decl_dropping_phase {
-            return import;
+            return;
         }
 
         if self.is_marked(import.span) {
-            return import;
+            return;
         }
 
         // Side effect import
         if import.specifiers.is_empty() {
             import.span = import.span.apply_mark(self.config.used_mark);
-            return import;
+            return;
         }
 
         // Drop unused imports.
@@ -450,41 +412,35 @@ impl Fold for Dce<'_> {
         if !import.specifiers.is_empty() {
             import.span = import.span.apply_mark(self.config.used_mark);
         }
-
-        import
     }
 
-    fn fold_labeled_stmt(&mut self, mut node: LabeledStmt) -> LabeledStmt {
+    fn visit_mut_labeled_stmt(&mut self, node: &mut LabeledStmt) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
-        node.body = node.body.fold_with(self);
+        node.body.visit_mut_with(self);
 
         if self.is_marked(node.body.span()) {
             node.span = node.span.apply_mark(self.config.used_mark);
-            node.body = self.fold_in_marking_phase(node.body);
+            self.mark(&mut node.body);
         }
-
-        node
     }
 
-    fn fold_member_expr(&mut self, mut e: MemberExpr) -> MemberExpr {
+    fn visit_mut_member_expr(&mut self, mut e: &mut MemberExpr) {
         if self.is_marked(e.span()) {
-            return e;
+            return;
         }
 
-        e.obj = e.obj.fold_with(self);
+        e.obj.visit_mut_with(self);
         if e.computed {
-            e.prop = e.prop.fold_with(self);
+            e.prop.visit_mut_with(self);
         }
-
-        e
     }
 
-    fn fold_named_export(&mut self, mut node: NamedExport) -> NamedExport {
+    fn visit_mut_named_export(&mut self, node: &mut NamedExport) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
         // Export only when it's required.
@@ -498,46 +454,40 @@ impl Fold for Dce<'_> {
 
         if !node.specifiers.is_empty() {
             node.span = node.span.apply_mark(self.config.used_mark);
-            node.specifiers = self.fold_in_marking_phase(node.specifiers);
+            self.mark(&mut node.specifiers);
         }
-
-        node
     }
 
-    fn fold_return_stmt(&mut self, mut node: ReturnStmt) -> ReturnStmt {
+    fn visit_mut_return_stmt(&mut self, node: &mut ReturnStmt) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
         node.span = node.span.apply_mark(self.config.used_mark);
-        node.arg = self.fold_in_marking_phase(node.arg);
-
-        node
+        self.mark(&mut node.arg);
     }
 
-    fn fold_switch_case(&mut self, mut node: SwitchCase) -> SwitchCase {
+    fn visit_mut_switch_case(&mut self, node: &mut SwitchCase) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
-        node = node.fold_children_with(self);
+        node.visit_mut_children_with(self);
 
         if self.is_marked(node.test.span()) || node.cons.iter().any(|v| self.is_marked(v.span())) {
             node.span = node.span.apply_mark(self.config.used_mark);
 
-            node.test = self.fold_in_marking_phase(node.test);
-            node.cons = self.fold_in_marking_phase(node.cons);
+            self.mark(&mut node.test);
+            self.mark(&mut node.cons);
         }
-
-        node
     }
 
-    fn fold_switch_stmt(&mut self, mut node: SwitchStmt) -> SwitchStmt {
+    fn visit_mut_switch_stmt(&mut self, node: &mut SwitchStmt) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
-        node = node.fold_children_with(self);
+        node.visit_mut_children_with(self);
 
         // TODO: Handle fallthrough
         //  Drop useless switch case.
@@ -549,33 +499,29 @@ impl Fold for Dce<'_> {
             || node.cases.iter().any(|case| self.is_marked(case.span))
         {
             node.span = node.span.apply_mark(self.config.used_mark);
-            node.cases = self.fold_in_marking_phase(node.cases);
+            self.mark(&mut node.cases);
         }
-
-        node
     }
 
-    fn fold_throw_stmt(&mut self, mut node: ThrowStmt) -> ThrowStmt {
+    fn visit_mut_throw_stmt(&mut self, node: &mut ThrowStmt) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
         node.span = node.span.apply_mark(self.config.used_mark);
 
-        let mut node = node.fold_children_with(self);
+        node.visit_mut_children_with(self);
 
         if self.is_marked(node.arg.span()) {
-            node.arg = self.fold_in_marking_phase(node.arg)
+            self.mark(&mut node.arg)
         }
-
-        node
     }
 
-    fn fold_try_stmt(&mut self, mut node: TryStmt) -> TryStmt {
+    fn visit_mut_try_stmt(&mut self, node: &mut TryStmt) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
-        node = node.fold_children_with(self);
+        node.visit_mut_children_with(self);
 
         if self.is_marked(node.block.span())
             || self.is_marked(node.handler.span())
@@ -583,31 +529,27 @@ impl Fold for Dce<'_> {
         {
             node.span = node.span.apply_mark(self.config.used_mark);
 
-            node.block = self.fold_in_marking_phase(node.block);
-            node.handler = self.fold_in_marking_phase(node.handler);
-            node.finalizer = self.fold_in_marking_phase(node.finalizer);
+            self.mark(&mut node.block);
+            self.mark(&mut node.handler);
+            self.mark(&mut node.finalizer);
         }
-
-        node
     }
 
-    fn fold_update_expr(&mut self, mut node: UpdateExpr) -> UpdateExpr {
+    fn visit_mut_update_expr(&mut self, node: &mut UpdateExpr) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
         node.span = node.span.apply_mark(self.config.used_mark);
-        node.arg = self.fold_in_marking_phase(node.arg);
-
-        node
+        self.mark(&mut node.arg);
     }
 
-    fn fold_var_decl(&mut self, mut var: VarDecl) -> VarDecl {
+    fn visit_mut_var_decl(&mut self, mut var: &mut VarDecl) {
         if self.is_marked(var.span) {
-            return var;
+            return;
         }
 
-        var = var.fold_children_with(self);
+        var.visit_mut_children_with(self);
 
         var.decls = var.decls.move_flat_map(|decl| {
             if self.is_marked(decl.span()) {
@@ -623,8 +565,8 @@ impl Fold for Dce<'_> {
 
             Some(VarDeclarator {
                 span: decl.span.apply_mark(self.config.used_mark),
-                init: self.fold_in_marking_phase(decl.init),
-                name: self.fold_in_marking_phase(decl.name),
+                init: self.mark(decl.init),
+                name: self.mark(decl.name),
                 ..decl
             })
         });
@@ -639,40 +581,39 @@ impl Fold for Dce<'_> {
         };
     }
 
-    fn fold_while_stmt(&mut self, mut node: WhileStmt) -> WhileStmt {
+    fn visit_mut_while_stmt(&mut self, node: &mut WhileStmt) {
         if self.is_marked(node.span) {
-            return node;
+            return;
         }
 
-        node = node.fold_children_with(self);
+        node.visit_mut_children_with(self);
 
         if self.is_marked(node.test.span()) || self.is_marked(node.body.span()) {
             node.span = node.span.apply_mark(self.config.used_mark);
 
-            node.test = self.fold_in_marking_phase(node.test);
-            node.body = self.fold_in_marking_phase(node.body);
+            self.mark(&mut node.test);
+            self.mark(&mut node.body);
         }
-
-        node
     }
 
-    fn fold_module_items(&mut self, n: Vec<ModuleItem>) -> Vec<ModuleItem> {
-        self.fold_stmt_like(n)
+    fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
+        self.visit_mut_stmt_like(n)
     }
 
-    fn fold_stmts(&mut self, n: Vec<Stmt>) -> Vec<Stmt> {
-        self.fold_stmt_like(n)
+    fn visit_mut_stmts(&mut self, n: &mut Vec<Stmt>) {
+        self.visit_mut_stmt_like(n)
     }
 }
 
 impl Dce<'_> {
-    fn fold_stmt_like<T>(&mut self, mut items: Vec<T>) -> Vec<T>
+    fn visit_mut_stmt_like<T>(&mut self, mut items: &mut Vec<T>)
     where
-        T: StmtLike + FoldWith<Self> + Spanned + std::fmt::Debug,
+        T: StmtLike + VisitMutWith<Self> + Spanned + std::fmt::Debug,
         T: for<'any> VisitWith<SideEffectVisitor<'any>> + VisitWith<ImportDetector>,
     {
         if self.marking_phase {
-            return items.move_map(|item| item.fold_with(self));
+            items.visit_mut_children_with(self);
+            return;
         }
 
         let old = self.changed;
@@ -800,28 +741,24 @@ impl Dce<'_> {
     //        ret
     //    }
 
-    pub fn fold_in_marking_phase<T>(&mut self, node: T) -> T
+    pub fn mark<T>(&mut self, node: &mut T)
     where
-        T: FoldWith<Self>,
+        T: VisitMutWith<Self>,
     {
         let old = self.marking_phase;
         self.marking_phase = true;
         log::info!("Marking: {}", type_name::<T>());
-        let node = node.fold_with(self);
+        node.visit_mut_with(self);
         self.marking_phase = old;
-
-        node
     }
 
-    pub fn drop_unused_decls<T>(&mut self, node: T) -> T
+    pub fn drop_unused_decls<T>(&mut self, node: &mut T)
     where
-        T: FoldWith<Self>,
+        T: VisitMutWith<Self>,
     {
         let old = self.decl_dropping_phase;
         self.decl_dropping_phase = true;
-        let node = node.fold_with(self);
+        node.visit_mut_with(self);
         self.decl_dropping_phase = old;
-
-        node
     }
 }

--- a/ecmascript/utils/src/constructor.rs
+++ b/ecmascript/utils/src/constructor.rs
@@ -1,5 +1,5 @@
 use crate::{prepend_stmts, ExprFactory};
-use std::iter;
+use std::{iter, mem::replace};
 use swc_common::DUMMY_SP;
 use swc_ecma_ast::*;
 use swc_ecma_visit::{noop_fold_type, noop_visit_mut_type, Fold, FoldWith, VisitMut, VisitMutWith};
@@ -134,6 +134,7 @@ impl VisitMut for ExprInjector<'_> {
                         .unwrap_or_else(|| private_ident!("_temp")),
                 );
                 self.injected = true;
+                let e = replace(expr, Expr::Invalid(Invalid { span: DUMMY_SP }));
 
                 *expr = Expr::Seq(SeqExpr {
                     span: DUMMY_SP,
@@ -143,7 +144,7 @@ impl VisitMut for ExprInjector<'_> {
                             self.injected_tmp.as_ref().cloned().unwrap(),
                         ))),
                         op: op!("="),
-                        right: Box::new(expr),
+                        right: Box::new(e),
                     })))
                     .chain(self.exprs.iter().cloned())
                     .chain(iter::once(Box::new(Expr::Ident(

--- a/ecmascript/utils/src/constructor.rs
+++ b/ecmascript/utils/src/constructor.rs
@@ -2,7 +2,7 @@ use crate::{prepend_stmts, ExprFactory};
 use std::iter;
 use swc_common::DUMMY_SP;
 use swc_ecma_ast::*;
-use swc_ecma_visit::{Fold, FoldWith};
+use swc_ecma_visit::{noop_fold_type, noop_visit_mut_type, Fold, FoldWith, VisitMut, VisitMutWith};
 
 pub fn inject_after_super(mut c: Constructor, exprs: Vec<Box<Expr>>) -> Constructor {
     // Allow using super multiple time
@@ -28,6 +28,8 @@ struct Injector<'a> {
 }
 
 impl<'a> Fold for Injector<'a> {
+    noop_fold_type!();
+
     fn fold_class(&mut self, c: Class) -> Class {
         c
     }
@@ -67,7 +69,7 @@ impl<'a> Fold for Injector<'a> {
                 injected: false,
                 exprs: self.exprs,
             };
-            let stmt = stmt.fold_children_with(&mut folder);
+            let mut stmt = stmt.fold_children_with(&mut folder);
             self.injected |= folder.injected;
             if folder.injected {
                 buf.push(stmt);
@@ -77,7 +79,7 @@ impl<'a> Fold for Injector<'a> {
                     exprs: self.exprs,
                     injected_tmp: None,
                 };
-                let stmt = stmt.fold_with(&mut folder);
+                stmt.visit_mut_with(&mut folder);
 
                 self.injected |= folder.injected;
 
@@ -109,19 +111,17 @@ struct ExprInjector<'a> {
     injected_tmp: Option<Ident>,
 }
 
-impl Fold for ExprInjector<'_> {
-    fn fold_class(&mut self, c: Class) -> Class {
-        let super_class = c.super_class.fold_with(self);
+impl VisitMut for ExprInjector<'_> {
+    noop_visit_mut_type!();
 
-        Class { super_class, ..c }
+    fn visit_mut_class(&mut self, c: &mut Class) {
+        c.super_class.visit_mut_with(self);
     }
 
-    fn fold_constructor(&mut self, n: Constructor) -> Constructor {
-        n
-    }
+    fn visit_mut_constructor(&mut self, _: &mut Constructor) {}
 
-    fn fold_expr(&mut self, expr: Expr) -> Expr {
-        let expr = expr.fold_children_with(self);
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        expr.visit_mut_children_with(self);
 
         match expr {
             Expr::Call(CallExpr {
@@ -135,7 +135,7 @@ impl Fold for ExprInjector<'_> {
                 );
                 self.injected = true;
 
-                Expr::Seq(SeqExpr {
+                *expr = Expr::Seq(SeqExpr {
                     span: DUMMY_SP,
                     exprs: iter::once(Box::new(Expr::Assign(AssignExpr {
                         span: DUMMY_SP,
@@ -152,11 +152,9 @@ impl Fold for ExprInjector<'_> {
                     .collect(),
                 })
             }
-            _ => expr,
+            _ => {}
         }
     }
 
-    fn fold_function(&mut self, n: Function) -> Function {
-        n
-    }
+    fn visit_mut_function(&mut self, _: &mut Function) {}
 }


### PR DESCRIPTION
swc_ecma_parser:
 - Make macros uses match instead of `PartialEq`

swc_ecma_codegen:
 - Move panic condition

### Initial profiling result


```
+   66.49%     0.00%  spack-cli  [unknown]           [k] 0xffffffffffffffff                                                                                                                                ◆
+   18.73%    18.71%  spack-cli  spack-cli           [.] <swc_ecma_parser::token::Token as core::cmp::PartialEq>::eq                                                                                       ▒
+   18.27%     0.00%  spack-cli  anon                [.] 0x00007f4940c551b3                                                                                                                                ▒
+   15.94%     0.02%  spack-cli  [kernel.kallsyms]   [k] 0xffffffff97c0008c                                                                                                                                ▒
+   13.00%     0.04%  spack-cli  [kernel.kallsyms]   [k] 0xffffffff97004417                                                                                                                                ▒
+   12.81%     0.00%  spack-cli  libc-2.27.so        [.] __memcpy_sse2_unaligned_erms (inlined)                                                                                                            ▒
+   12.71%    12.71%  spack-cli  libc-2.27.so        [.] __memmove_sse2_unaligned_erms                                                                                                                     ▒
+    8.80%     0.10%  spack-cli  spack-cli           [.] <swc_ecma_ast::expr::Expr as swc_ecma_visit::FoldWith<V>>::fold_children_with                                                                     ▒
+    8.80%     0.00%  spack-cli  spack-cli           [.] swc_ecma_transforms::hygiene::Hygiene::fold_fn                                                                                                    ▒
+    8.72%     0.02%  spack-cli  spack-cli           [.] <swc_ecma_transforms::hygiene::Hygiene as swc_ecma_visit::Fold>::fold_expr                                                                        ▒
+    8.67%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_stmt                                                                                                                         ▒
+    8.21%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::Fold::fold_decl                                                                                                                   ▒
+    8.12%     0.00%  spack-cli  spack-cli           [.] <alloc::vec::Vec<T> as swc_visit::util::move_map::MoveMap<T>>::move_map                                                                           ▒
+    8.08%     7.97%  spack-cli  spack-cli           [.] <swc_ecma_transforms::hygiene::Hygiene as swc_ecma_visit::Fold>::fold_ident                                                                       ▒
+    7.97%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_pat                                                                                                                          ▒
+    7.48%     0.08%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_stmt                                                                                                                         ▒
+    7.31%     0.01%  spack-cli  spack-cli           [.] swc_ecma_transforms::optimization::simplify::dce::Dce::fold_stmt_like                                                                             ▒
+    7.14%     0.01%  spack-cli  spack-cli           [.] rayon_core::registry::WorkerThread::wait_until_cold                                                                                               ▒
+    7.12%     0.00%  spack-cli  spack-cli           [.] std::sys_common::backtrace::__rust_begin_short_backtrace                                                                                          ▒
+    7.10%     0.30%  spack-cli  spack-cli           [.] swc_common::syntax_pos::hygiene::SyntaxContext::remove_mark                                                                                       ▒
+    6.95%     0.66%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_expr                                                                                                                         ▒
+    6.87%     0.00%  spack-cli  spack-cli           [.] core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h30b442826de02ded                                                          ▒
+    6.82%     0.00%  spack-cli  spack-cli           [.] std::sys::unix::thread::Thread::new::thread_start                                                                                                 ▒
+    6.78%     0.00%  spack-cli  spack-cli           [.] <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once (inlined)                                                                     ▒
+    6.78%     0.00%  spack-cli  libpthread-2.27.so  [.] start_thread                                                                                                                                      ▒
+    6.72%     0.00%  spack-cli  libc-2.27.so        [.] __GI___clone (inlined)                                                                                                                            ▒
+    6.58%     0.16%  spack-cli  spack-cli           [.] <swc_bundler::bundler::import::ImportHandler<L,R> as swc_ecma_visit::Fold>::fold_expr                                                             ▒
+    6.51%     0.69%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_expr                                                                                                                         ▒
+    6.27%     0.00%  spack-cli  libpthread-2.27.so  [.] __GI___pthread_mutex_unlock (inlined)                                                                                                             ▒
+    6.24%     0.00%  spack-cli  libpthread-2.27.so  [.] __pthread_mutex_unlock_usercnt (inlined)                                                                                                          ▒
+    6.17%     0.23%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::expr::ops::<impl swc_ecma_parser::parser::Parser<I>>::parse_unary_expr                                                   ▒
+    6.08%     0.00%  spack-cli  spack-cli           [.] <spack::resolvers::NodeResolver as swc_bundler::resolve::Resolve>::resolve                                                                        ▒
+    6.08%     0.00%  spack-cli  spack-cli           [.] swc_bundler::bundler::import::<impl swc_bundler::bundler::Bundler<L,R>>::resolve                                                                  ▒
+    6.08%     0.02%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::expr::<impl swc_ecma_parser::parser::Parser<I>>::parse_lhs_expr                                                          ▒
+    6.03%     0.11%  spack-cli  libpthread-2.27.so  [.] __lll_unlock_wake                                                                                                                                 ▒
+    5.93%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_transforms::optimization::simplify::dce::Dce as swc_ecma_visit::Fold>::fold_block_stmt                                                  ▒
+    5.67%     0.02%  spack-cli  spack-cli           [.] swc_bundler::bundler::load::_$LT$impl$u20$swc_bundler..bundler..Bundler$LT$L$C$R$GT$$GT$::load_transformed::_$u7b$$u7b$closure$u7d$$u7d$::hfe3695c▒
+    5.51%     0.00%  spack-cli  spack-cli           [.] swc_bundler::bundler::import::ImportHandler<L,R>::ctxt_for                                                                                        ▒
+    5.29%     0.02%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::expr::ops::<impl swc_ecma_parser::parser::Parser<I>>::parse_bin_expr                                                     ▒
+    5.25%     0.02%  spack-cli  spack-cli           [.] rayon::iter::plumbing::bridge_producer_consumer::helper                                                                                           ▒
+    5.20%     0.00%  spack-cli  [kernel.kallsyms]   [k] 0xffffffff9714c65f                                                                                                                                ▒
+    5.10%     0.00%  spack-cli  spack-cli           [.] rayon_core::join::join_context::_$u7b$$u7b$closure$u7d$$u7d$::ha56c2010b0ef0349                                                                   ▒
+    5.07%     0.00%  spack-cli  spack-cli           [.] swc_bundler::bundler::load::_$LT$impl$u20$swc_bundler..bundler..Bundler$LT$L$C$R$GT$$GT$::load_transformed::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u▒
+    5.05%     0.00%  spack-cli  libc-2.27.so        [.] __GI___libc_malloc (inlined)                                                                                                                      ▒
+    5.05%     0.00%  spack-cli  libc-2.27.so        [.] __GI___sched_yield (inlined)                                                                                                                      ▒
```

### Profiling result after removing usage of partialeq

I also disabled rayon.

```
+   26.17%    25.84%  spack-cli  libc-2.27.so        [.] __memmove_sse2_unaligned_erms                                                                                                                     ◆
+   10.64%     0.00%  spack-cli  [unknown]           [.] 0x000112a100000001                                                                                                                                ▒
+    6.96%     6.84%  spack-cli  libc-2.27.so        [.] malloc                                                                                                                                            ▒
+    6.83%     0.77%  spack-cli  [kernel.kallsyms]   [k] entry_SYSCALL_64_after_hwframe                                                                                                                    ▒
+    6.41%     0.00%  spack-cli  [unknown]           [.] 0x0000000000000001                                                                                                                                ▒
+    6.10%     0.00%  spack-cli  [unknown]           [k] 0000000000000000                                                                                                                                  ▒
+    5.78%     1.26%  spack-cli  [kernel.kallsyms]   [k] do_syscall_64                                                                                                                                     ▒
+    5.66%     0.00%  spack-cli  spack-cli           [.] spack::resolvers::NodeResolver::wrap                                                                                                              ▒
+    5.66%     0.00%  spack-cli  libc-2.27.so        [.] __lxstat64                                                                                                                                        ▒
+    5.44%     5.44%  spack-cli  spack-cli           [.] swc_ecma_visit::visit_expr                                                                                                                        ▒
+    5.44%     0.00%  spack-cli  [unknown]           [.] 0xffc25f90ffc25dd4                                                                                                                                ▒
+    4.41%     2.11%  spack-cli  libc-2.27.so        [.] _int_malloc                                                                                                                                       ▒
+    4.38%     0.00%  spack-cli  [kernel.kallsyms]   [k] page_fault                                                                                                                                        ▒
+    4.38%     0.00%  spack-cli  [kernel.kallsyms]   [k] do_page_fault                                                                                                                                     ▒
+    4.38%     2.27%  spack-cli  [kernel.kallsyms]   [k] __do_page_fault                                                                                                                                   ▒
+    3.99%     3.99%  spack-cli  libc-2.27.so        [.] cfree@GLIBC_2.2.5                                                                                                                                 ▒
+    3.96%     3.96%  spack-cli  spack-cli           [.] swc_ecma_transforms::hygiene::ops::Operator::rename_ident                                                                                         ▒
+    3.58%     0.08%  spack-cli  [kernel.kallsyms]   [k] vfs_statx                                                                                                                                         ▒
+    3.43%     0.00%  spack-cli  [kernel.kallsyms]   [k] user_path_at_empty                                                                                                                                ▒
+    3.04%     3.04%  spack-cli  spack-cli           [.] swc_ecma_parser::lexer::Lexer<I>::read_token                                                                                                      ▒
+    2.97%     0.00%  spack-cli  [kernel.kallsyms]   [k] filename_lookup                                                                                                                                   ▒
+    2.91%     0.00%  spack-cli  [unknown]           [.] 0x0000010100010000                                                                                                                                ▒
+    2.89%     0.00%  spack-cli  [kernel.kallsyms]   [k] path_lookupat                                                                                                                                     ▒
+    2.38%     2.23%  spack-cli  [kernel.kallsyms]   [k] syscall_return_via_sysret                                                                                                                         ▒
+    2.19%     0.00%  spack-cli  spack-cli           [.] std::ffi::c_str::CString::from_vec_unchecked                                                                                                      ▒
+    2.13%     0.00%  spack-cli  [unknown]           [.] 0x00563d364e9d6000                                                                                                                                ▒
+    2.12%     0.00%  spack-cli  [kernel.kallsyms]   [k] handle_mm_fault                                                                                                                                   ▒
+    2.08%     2.08%  spack-cli  spack-cli           [.] swc_ecma_visit::visit_mut_expr                                                                                                                    ▒
+    2.06%     0.15%  spack-cli  [kernel.kallsyms]   [k] __handle_mm_fault                                                                                                                                 ▒
+    2.00%     0.00%  spack-cli  libc-2.27.so        [.] syscall                                                                                                                                           ▒
+    1.97%     1.97%  spack-cli  [kernel.kallsyms]   [k] nmi                                                                                                                                               ▒
+    1.97%     0.00%  spack-cli  [kernel.kallsyms]   [k] __x64_sys_newlstat                                                                                                                                ▒
+    1.97%     0.00%  spack-cli  [kernel.kallsyms]   [k] __do_sys_newlstat                                                                                                                                 ▒
+    1.94%     1.94%  spack-cli  spack-cli           [.] swc_ecma_parser::lexer::state::<impl core::iter::traits::iterator::Iterator for swc_ecma_parser::lexer::Lexer<I>>::next                           ▒
+    1.90%     1.90%  spack-cli  [kernel.kallsyms]   [k] __page_set_anon_rmap                                                                                                                              ▒
+    1.90%     0.00%  spack-cli  [kernel.kallsyms]   [k] page_add_new_anon_rmap                                                                                                                            ▒
+    1.89%     0.27%  spack-cli  [kernel.kallsyms]   [k] __x64_sys_statx                                                                                                                                   ▒
+    1.77%     1.77%  spack-cli  spack-cli           [.] dashmap::DashMap<K,V,S>::remove                                                                                                                   ▒
+    1.76%     1.76%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_function                                                                                                                     ▒
+    1.74%     0.00%  spack-cli  [unknown]           [.] 0x0000563d368967a0                                                                                                                                ▒
+    1.73%     1.73%  spack-cli  spack-cli           [.] swc_ecma_parser::lexer::util::<impl swc_ecma_parser::lexer::Lexer<I>>::skip_space                                                                 ▒
+    1.65%     1.65%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_expr                                                                                                                         ▒
+    1.62%     0.00%  spack-cli  [kernel.kallsyms]   [k] __do_sys_statx                                                                                                                                    ▒
+    1.57%     1.57%  spack-cli  spack-cli           [.] swc_common::syntax_pos::hygiene::SyntaxContext::remove_mark                                                                                       ▒
+    1.45%     0.00%  spack-cli  [unknown]           [.] 0x4c000000e8ba6024                                                                                                                                ▒
+    1.41%     0.00%  spack-cli  [unknown]           [.] 0x00000001000033f3                                                                                                                                ▒
+    1.34%     1.34%  spack-cli  spack-cli           [.] swc_ecma_visit::visit_mut_expr                                                                                                                    ▒
+    1.29%     0.38%  spack-cli  [kernel.kallsyms]   [k] link_path_walk.part.33                                                                                                                            ▒
+    1.21%     0.00%  spack-cli  [unknown]           [.] 0x0000563d36652410                                                                                                                                ▒
+    1.20%     1.20%  spack-cli  spack-cli           [.] swc_ecma_visit::visit_mut_stmt                                                                                                                    ▒
+    1.12%     1.12%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::stmt::<impl swc_ecma_parser::parser::Parser<I>>::parse_stmt_internal                                                     ▒
+    1.10%     0.00%  spack-cli  [unknown]           [.] 0x000001f100000002                                                                                                                                

```

### After migrating dce and ExprInjector

```
+   98.57%     0.00%  spack-cli  [unknown]           [.] 0xffffffffffffffff
+   54.72%     0.00%  spack-cli  spack-cli           [.] swc_bundler::bundler::usage_analysis::<impl swc_bundler::bundler::Bundler<L,R>>::drop_unused
+   54.72%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_ast::module::Module as swc_ecma_visit::FoldWith<V>>::fold_with
+   54.72%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_transforms::optimization::simplify::dce::Dce as swc_ecma_visit::VisitMut>::visit_mut_module_items
+   54.56%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::visit_mut_stmt
+   54.56%     0.70%  spack-cli  spack-cli           [.] swc_ecma_visit::visit_mut_expr
+   54.56%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_transforms::optimization::simplify::dce::Dce as swc_ecma_visit::VisitMut>::visit_mut_block_stmt
+   54.56%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::VisitMut::visit_mut_fn_expr
+   54.56%     0.00%  spack-cli  spack-cli           [.] swc_ecma_transforms::optimization::simplify::dce::Dce::visit_mut_stmt_like
+   53.91%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_transforms::optimization::simplify::dce::Dce as swc_ecma_visit::VisitMut>::visit_mut_fn_decl
+   53.70%     1.32%  spack-cli  spack-cli           [.] swc_common::syntax_pos::hygiene::SyntaxContext::remove_mark
+   52.54%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_transforms::optimization::simplify::dce::Dce as swc_ecma_visit::VisitMut>::visit_mut_var_decl
+   52.38%    52.38%  spack-cli  libpthread-2.27.so  [.] __pthread_mutex_lock
+   52.38%     0.00%  spack-cli  libpthread-2.27.so  [.] __GI___pthread_mutex_lock (inlined)
+   51.90%     0.00%  spack-cli  spack-cli           [.] swc_bundler::bundler::chunk::export::_$LT$impl$u20$swc_bundler..bundler..Bundler$LT$L$C$R$GT$$GT$::merge_reexports::_$u7b$$u7b$closure$u7d$$u7d$::_
+   35.14%    35.14%  spack-cli  libc-2.27.so        [.] __memmove_sse2_unaligned_erms
+   35.14%     0.00%  spack-cli  libc-2.27.so        [.] __memcpy_sse2_unaligned_erms (inlined)
+   33.26%     0.00%  spack-cli  spack-cli           [.] <swc_bundler::bundler::import::ImportHandler<L,R> as swc_ecma_visit::Fold>::fold_expr
+   33.26%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_expr
+   32.56%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_stmt
+   31.21%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_function
+   30.68%     0.00%  spack-cli  spack-cli           [.] <swc_bundler::bundler::import::ImportHandler<L,R> as swc_ecma_visit::Fold>::fold_var_declarator
+    3.06%     0.00%  spack-cli  spack-cli           [.] swc_bundler::bundler::import::<impl swc_bundler::bundler::Bundler<L,R>>::resolve
+    3.06%     0.00%  spack-cli  spack-cli           [.] <spack::resolvers::NodeResolver as swc_bundler::resolve::Resolve>::resolve
+    2.66%     0.00%  spack-cli  spack-cli           [.] swc_bundler::bundler::load::_$LT$impl$u20$swc_bundler..bundler..Bundler$LT$L$C$R$GT$$GT$::analyze::_$u7b$$u7b$closure$u7d$$u7d$::hbb186b10c88129e0
+    2.57%     0.00%  spack-cli  spack-cli           [.] swc_bundler::bundler::import::ImportHandler<L,R>::ctxt_for
+    2.31%     0.56%  spack-cli  spack-cli           [.] <swc_ecma_transforms::typescript::strip::Strip as swc_ecma_visit::Fold>::fold_expr
+    2.31%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_expr
+    2.17%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::VisitMut::visit_mut_module_item
+    1.83%     1.63%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_expr
+    1.83%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_transforms::compat::es2015::sticky_regex::StickyRegex as swc_ecma_visit::Fold>::fold_expr
+    1.78%     0.00%  spack-cli  spack-cli           [.] <swc_visit::AndThen<A,B> as swc_ecma_visit::Fold>::fold_module
+    1.73%     0.00%  spack-cli  [unknown]           [k] 0xffffffff97c0008c
+    1.73%     0.00%  spack-cli  [unknown]           [k] 0xffffffff97004417
+    1.63%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::Fold::fold_module
+    1.63%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::Fold::fold_decl
+    1.63%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_function
+    1.63%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_stmt
+    1.58%     0.00%  spack-cli  spack-cli           [.] spack::resolvers::NodeResolver::wrap
+    1.58%     0.00%  spack-cli  libc-2.27.so        [.] __GI___realpath (inlined)
+    1.58%     0.00%  spack-cli  libc-2.27.so        [.] __GI___lxstat (inlined)
+    1.50%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_transforms::typescript::strip::Strip as swc_ecma_visit::Fold>::fold_stmt
+    1.50%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_transforms::typescript::strip::Strip as swc_ecma_visit::Fold>::fold_stmts
+    1.14%     0.00%  spack-cli  libc-2.27.so        [.] __GI___libc_malloc (inlined)
+    1.13%     0.00%  spack-cli  spack-cli           [.] spack::resolvers::NodeResolver::resolve_node_modules
+    1.13%     0.48%  spack-cli  libc-2.27.so        [.] _int_malloc
+    1.08%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_class_member
+    1.08%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_function
+    1.08%     0.00%  spack-cli  spack-cli           [.] swc_ecma_transforms::compat::es2020::opt_chaining::OptChaining::fold_stmt_like
+    1.08%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_stmt
+    1.08%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::Fold::fold_if_stmt
+    1.08%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_transforms::compat::es2020::opt_chaining::OptChaining as swc_ecma_visit::Fold>::fold_expr
```

Using -a option of perf:

```
+   52.76%     0.00%  spack-cli  spack-cli           [.] spack_cli::main                                                                                                                                   ▒
+   49.41%     0.00%  spack-cli  libc-2.27.so        [.] __libc_start_main                                                                                                                                 ▒
+   49.41%     0.00%  spack-cli  spack-cli           [.] main                                                                                                                                              ▒
+   49.41%     0.00%  spack-cli  spack-cli           [.] std::sys_common::backtrace::__rust_begin_short_backtrace                                                                                          ◆
+   49.15%     0.00%  spack-cli  spack-cli           [.] swc_ecma_codegen::Emitter::emit_stmt                                                                                                              ▒
+   49.15%     0.00%  spack-cli  spack-cli           [.] swc_ecma_codegen::Emitter::emit_expr                                                                                                              ▒
+   49.15%     0.00%  spack-cli  spack-cli           [.] swc_ecma_codegen::Emitter::emit_list5                                                                                                             ▒
+   49.15%     0.00%  spack-cli  spack-cli           [.] swc_ecma_codegen::Emitter::emit_expr_or_spread                                                                                                    ▒
+   49.15%     0.00%  spack-cli  spack-cli           [.] swc_ecma_codegen::Emitter::emit_fn_expr                                                                                                           ▒
+   49.15%     0.26%  spack-cli  spack-cli           [.] swc_ecma_codegen::text_writer::basic_impl::JsWriter<W>::raw_write                                                                                 ▒
+   49.15%     0.26%  spack-cli  spack-cli           [.] swc_ecma_codegen::text_writer::basic_impl::JsWriter<W>::write                                                                                     ▒
+   49.15%     0.00%  spack-cli  spack-cli           [.] _start                                                                                                                                            ▒
+   49.08%    49.08%  spack-cli  [unknown]           [k] 0xffffffff97c01540                                                                                                                                ▒
+   48.92%     0.00%  spack-cli  [unknown]           [.] 0xffffffffffffffff                                                                                                                                ▒
+   48.89%     0.00%  spack-cli  spack-cli           [.] swc_ecma_codegen::Emitter::emit_module                                                                                                            ▒
+   48.89%     0.00%  spack-cli  spack-cli           [.] std::rt::lang_start_internal::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h2e4724ad57d8e861 (inlined)                             ▒
+   48.62%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_codegen::text_writer::basic_impl::JsWriter<W> as swc_ecma_codegen::text_writer::WriteJs>::write_keyword                                 ▒
+   30.21%     0.00%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::expr::<impl swc_ecma_parser::parser::Parser<I>>::parse_assignment_expr                                                   ▒
+   30.09%     0.00%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::expr::<impl swc_ecma_parser::parser::Parser<I>>::parse_assignment_expr_base                                              ▒
+   30.09%     0.00%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::expr::ops::<impl swc_ecma_parser::parser::Parser<I>>::parse_bin_expr                                                     ▒
+   30.09%     0.00%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::expr::ops::<impl swc_ecma_parser::parser::Parser<I>>::parse_unary_expr                                                   ▒
+   30.09%     0.00%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::expr::<impl swc_ecma_parser::parser::Parser<I>>::parse_lhs_expr                                                          ▒
+   29.71%     0.00%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::expr::<impl swc_ecma_parser::parser::Parser<I>>::parse_expr                                                              ▒
+   29.71%     0.67%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::expr::<impl swc_ecma_parser::parser::Parser<I>>::parse_subscript                                                         ▒
+   29.71%     0.00%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::expr::<impl swc_ecma_parser::parser::Parser<I>>::parse_member_expr_or_new_expr                                           ▒
+   29.30%     0.00%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::input::Buffer<I>::bump_inner                                                                                             ▒
+   29.30%     0.00%  spack-cli  spack-cli           [.] swc_ecma_parser::lexer::state::<impl core::iter::traits::iterator::Iterator for swc_ecma_parser::lexer::Lexer<I>>::next                           ▒
+   29.30%     0.00%  spack-cli  spack-cli           [.] swc_ecma_parser::lexer::Lexer<I>::read_token                                                                                                      ▒
+   29.04%    29.04%  spack-cli  spack-cli           [.] swc_ecma_parser::lexer::Lexer<I>::read_word_as_str                                                                                                ▒
+   29.04%     0.00%  spack-cli  spack-cli           [.] swc_ecma_parser::parser::expr::ops::<impl swc_ecma_parser::parser::Parser<I>>::parse_bin_op_recursively                                           ▒
+    3.77%     0.00%  spack-cli  libc-2.27.so        [.] __memcpy_sse2_unaligned_erms (inlined)                                                                                                            ▒
+    3.70%     0.00%  spack-cli  spack-cli           [.] swc_bundler::bundler::chunk::<impl swc_bundler::bundler::Bundler<L,R>>::chunk                                                                     ▒
+    3.51%     3.51%  spack-cli  libc-2.27.so        [.] __memmove_sse2_unaligned_erms                                                                                                                     ▒
+    2.61%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_stmt                                                                                                                         ▒
+    2.40%     0.26%  spack-cli  spack-cli           [.] swc_bundler::bundler::Bundler<L,R>::run                                                                                                           ▒
+    2.35%     0.26%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_expr                                                                                                                         ▒
+    2.16%     1.06%  spack-cli  spack-cli           [.] swc_ecma_visit::visit_mut_expr                                                                                                                    ▒
+    2.16%     0.00%  spack-cli  spack-cli           [.] swc_ecma_transforms::optimization::simplify::dce::Dce::visit_mut_stmt_like                                                                        ▒
+    2.16%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_transforms::optimization::simplify::dce::Dce as swc_ecma_visit::VisitMut>::visit_mut_block_stmt                                         ▒
+    2.16%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_transforms::optimization::simplify::dce::Dce as swc_ecma_visit::VisitMut>::visit_mut_module_items                                       ▒
+    1.95%     0.00%  spack-cli  libc-2.27.so        [.] __GI___libc_malloc (inlined)                                                                                                                      ▒
+    1.92%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_ast::function::Function as core::clone::Clone>::clone                                                                                   ▒
+    1.92%     0.00%  spack-cli  spack-cli           [.] alloc::slice::<impl [T]>::to_vec                                                                                                                  ▒
+    1.92%     0.52%  spack-cli  spack-cli           [.] <swc_ecma_ast::stmt::Stmt as core::clone::Clone>::clone                                                                                           ▒
+    1.88%     0.00%  spack-cli  spack-cli           [.] <swc_ecma_ast::module::Module as swc_ecma_visit::FoldWith<V>>::fold_with                                                                          ▒
+    1.87%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::visit_mut_stmt                                                                                                                    ▒
+    1.82%     0.00%  spack-cli  spack-cli           [.] swc_ecma_visit::fold_function                                                                                                                     ▒
+    1.66%     0.56%  spack-cli  spack-cli           [.] <swc_ecma_ast::expr::Expr as core::clone::Clone>::clone                                                                                           ▒
```


---

Closes #976 