### PR TITLE
Improve performance of parser

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,35 +1,35 @@
 [package]
-name = "swc_common"
-version = "0.10.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
-license = "Apache-2.0/MIT"
-repository = "https://github.com/swc-project/swc.git"
-documentation = "https://swc-project.github.io/rustdoc/swc_common/"
 description = "Common utilities for the swc project."
+documentation = "https://swc-project.github.io/rustdoc/swc_common/"
 edition = "2018"
+license = "Apache-2.0/MIT"
+name = "swc_common"
+repository = "https://github.com/swc-project/swc.git"
+version = "0.10.1"
 
 [features]
-tty-emitter = ["atty", "termcolor"]
 concurrent = ["parking_lot"]
 default = []
+tty-emitter = ["atty", "termcolor"]
 
 [dependencies]
-ast_node = { version = "0.7", path = "../macros/ast_node" }
-from_variant = { version = "0.1", path = "../macros/from_variant" }
-swc_visit = { version = "0.2.0", path = "../visit" }
-once_cell = "1"
-either = "1.5"
-scoped-tls = { version = "1" }
-unicode-width = "0.1.4"
+ast_node = {version = "0.7", path = "../macros/ast_node"}
+atty = {version = "0.2", optional = true}
 cfg-if = "0.1.2"
-log = "0.4"
-atty = { version = "0.2", optional = true }
-owning_ref = "0.4"
-parking_lot = { version = "0.7.1", optional = true }
-termcolor = { version = "1.0", optional = true }
-serde = { version = "1", features = ["derive"] }
+either = "1.5"
+from_variant = {version = "0.1", path = "../macros/from_variant"}
 fxhash = "0.2.1"
-sourcemap = { version = "6", optional = true }
+log = "0.4"
+once_cell = "1"
+owning_ref = "0.4"
+parking_lot = {version = "0.7.1", optional = true}
+scoped-tls = {version = "1"}
+serde = {version = "1", features = ["derive"]}
+sourcemap = {version = "6", optional = true}
+swc_visit = {version = "0.2.0", path = "../visit"}
+termcolor = {version = "1.0", optional = true}
+unicode-width = "0.1.4"
 
 [dev-dependencies]
 rayon = "1"

--- a/common/src/input.rs
+++ b/common/src/input.rs
@@ -185,6 +185,29 @@ pub trait Input: Clone {
         F: FnMut(char) -> bool;
 
     fn reset_to(&mut self, to: BytePos);
+
+    /// Implementors can override the method to make it faster.
+    fn is_byte(&mut self, c: u8) -> bool {
+        match self.cur() {
+            Some(ch) => ch == c as char,
+            _ => false,
+        }
+    }
+
+    /// Implementors can override the method to make it faster.
+    fn eat_byte(&mut self, c: u8) -> bool {
+        match self.cur() {
+            Some(ch) => {
+                if ch == c as char {
+                    self.bump();
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/common/src/input.rs
+++ b/common/src/input.rs
@@ -66,16 +66,10 @@ impl<'a> Input for StringInput<'a> {
 
     #[inline]
     fn bump(&mut self) {
-        #[cold]
-        #[inline(never)]
-        fn error() {
-            unreachable!("bump should not be called when cur() == None");
-        }
-
         if let Some((i, c)) = self.iter.next() {
             self.last_pos = self.start_pos + BytePos((i + c.len_utf8()) as u32);
         } else {
-            error()
+            unreachable!("bump should not be called when cur() == None");
         }
     }
 
@@ -180,25 +174,6 @@ impl<'a> Input for StringInput<'a> {
             self.iter.as_str().as_bytes()[0] == c
         }
     }
-
-    fn eat_all_bytes(&mut self, c: u8) -> bool {
-        let pos = self.iter.as_str().bytes().position(|b| b != c);
-
-        // dbg!(pos);
-
-        if let Some(pos) = pos {
-            for _ in 0..pos {
-                self.iter.next();
-            }
-            // self.iter = self.iter.as_str()[pos..].char_indices();
-            self.last_pos = self.last_pos + BytePos(pos as _);
-            // dbg!(self.last_pos);
-
-            true
-        } else {
-            false
-        }
-    }
 }
 
 pub trait Input: Clone {
@@ -246,23 +221,6 @@ pub trait Input: Clone {
         } else {
             false
         }
-    }
-
-    /// Eats `c` from the start as many as it can.
-    ///
-    /// Returns true if input had eaten any.
-    #[inline]
-    fn eat_all_bytes(&mut self, c: u8) -> bool {
-        let mut eaten = false;
-        loop {
-            if self.is_byte(c) {
-                self.bump();
-                eaten = true;
-            } else {
-                break;
-            }
-        }
-        eaten
     }
 }
 

--- a/common/src/input.rs
+++ b/common/src/input.rs
@@ -49,18 +49,22 @@ impl<'a> From<&'a SourceFile> for StringInput<'a> {
 }
 
 impl<'a> Input for StringInput<'a> {
+    #[inline]
     fn cur(&mut self) -> Option<char> {
         self.iter.clone().nth(0).map(|i| i.1)
     }
 
+    #[inline]
     fn peek(&mut self) -> Option<char> {
         self.iter.clone().nth(1).map(|i| i.1)
     }
 
+    #[inline]
     fn peek_ahead(&mut self) -> Option<char> {
         self.iter.clone().nth(2).map(|i| i.1)
     }
 
+    #[inline]
     fn bump(&mut self) {
         if let Some((i, c)) = self.iter.next() {
             self.last_pos = self.start_pos + BytePos((i + c.len_utf8()) as u32);
@@ -69,6 +73,7 @@ impl<'a> Input for StringInput<'a> {
         }
     }
 
+    #[inline]
     fn is_at_start(&self) -> bool {
         self.orig_start == self.last_pos
     }
@@ -81,10 +86,12 @@ impl<'a> Input for StringInput<'a> {
             .unwrap_or(self.last_pos)
     }
 
+    #[inline]
     fn last_pos(&self) -> BytePos {
         self.last_pos
     }
 
+    #[inline]
     fn slice(&mut self, start: BytePos, end: BytePos) -> &str {
         assert!(start <= end, "Cannot slice {:?}..{:?}", start, end);
         let s = self.orig;
@@ -148,6 +155,7 @@ impl<'a> Input for StringInput<'a> {
         Some(self.last_pos)
     }
 
+    #[inline]
     fn reset_to(&mut self, to: BytePos) {
         let orig = self.orig;
         let idx = (to - self.orig_start).0 as usize;
@@ -156,6 +164,15 @@ impl<'a> Input for StringInput<'a> {
         self.iter = s.char_indices();
         self.start_pos = to;
         self.last_pos = to;
+    }
+
+    #[inline]
+    fn is_byte(&mut self, c: u8) -> bool {
+        if self.iter.as_str().len() == 0 {
+            false
+        } else {
+            self.iter.as_str().as_bytes()[0] == c
+        }
     }
 }
 
@@ -198,16 +215,11 @@ pub trait Input: Clone {
     /// Implementors can override the method to make it faster.
     #[inline]
     fn eat_byte(&mut self, c: u8) -> bool {
-        match self.cur() {
-            Some(ch) => {
-                if ch == c as char {
-                    self.bump();
-                    true
-                } else {
-                    false
-                }
-            }
-            _ => false,
+        if self.is_byte(c) {
+            self.bump();
+            true
+        } else {
+            false
         }
     }
 }

--- a/common/src/input.rs
+++ b/common/src/input.rs
@@ -66,10 +66,16 @@ impl<'a> Input for StringInput<'a> {
 
     #[inline]
     fn bump(&mut self) {
+        #[cold]
+        #[inline(never)]
+        fn error() {
+            unreachable!("bump should not be called when cur() == None");
+        }
+
         if let Some((i, c)) = self.iter.next() {
             self.last_pos = self.start_pos + BytePos((i + c.len_utf8()) as u32);
         } else {
-            unreachable!("bump should not be called when cur() == None");
+            error()
         }
     }
 
@@ -174,6 +180,25 @@ impl<'a> Input for StringInput<'a> {
             self.iter.as_str().as_bytes()[0] == c
         }
     }
+
+    fn eat_all_bytes(&mut self, c: u8) -> bool {
+        let pos = self.iter.as_str().bytes().position(|b| b != c);
+
+        // dbg!(pos);
+
+        if let Some(pos) = pos {
+            for _ in 0..pos {
+                self.iter.next();
+            }
+            // self.iter = self.iter.as_str()[pos..].char_indices();
+            self.last_pos = self.last_pos + BytePos(pos as _);
+            // dbg!(self.last_pos);
+
+            true
+        } else {
+            false
+        }
+    }
 }
 
 pub trait Input: Clone {
@@ -221,6 +246,23 @@ pub trait Input: Clone {
         } else {
             false
         }
+    }
+
+    /// Eats `c` from the start as many as it can.
+    ///
+    /// Returns true if input had eaten any.
+    #[inline]
+    fn eat_all_bytes(&mut self, c: u8) -> bool {
+        let mut eaten = false;
+        loop {
+            if self.is_byte(c) {
+                self.bump();
+                eaten = true;
+            } else {
+                break;
+            }
+        }
+        eaten
     }
 }
 

--- a/common/src/input.rs
+++ b/common/src/input.rs
@@ -187,6 +187,7 @@ pub trait Input: Clone {
     fn reset_to(&mut self, to: BytePos);
 
     /// Implementors can override the method to make it faster.
+    #[inline]
     fn is_byte(&mut self, c: u8) -> bool {
         match self.cur() {
             Some(ch) => ch == c as char,
@@ -195,6 +196,7 @@ pub trait Input: Clone {
     }
 
     /// Implementors can override the method to make it faster.
+    #[inline]
     fn eat_byte(&mut self, c: u8) -> bool {
         match self.cur() {
             Some(ch) => {

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecmascript"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_ecma_parser"
-version = "0.36.1"
+version = "0.36.2"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/swc-project/swc.git"

--- a/ecmascript/parser/src/lexer/mod.rs
+++ b/ecmascript/parser/src/lexer/mod.rs
@@ -372,7 +372,7 @@ impl<'a, I: Input> Lexer<'a, I> {
                     self.input.bump();
 
                     // Handle -->
-                    if self.state.had_line_break && c == '-' && self.eat('>') {
+                    if self.state.had_line_break && c == '-' && self.eat(b'>') {
                         if self.ctx.module {
                             return self.error(start, SyntaxError::LegacyCommentInModule)?;
                         }
@@ -513,7 +513,7 @@ impl<'a, I: Input> Lexer<'a, I> {
                 raw.push_str("\r");
                 self.bump(); // remove '\r'
 
-                if self.cur() == Some('\n') {
+                if self.eat(b'\n') {
                     raw.push_str("\n");
                     self.bump();
                 }
@@ -615,7 +615,11 @@ impl<'a, I: Input> Lexer<'a, I> {
         // Divide operator
         self.bump();
 
-        Ok(Some(if self.eat('=') { tok!("/=") } else { tok!('/') }))
+        Ok(Some(if self.eat(b'=') {
+            tok!("/=")
+        } else {
+            tok!('/')
+        }))
     }
 
     fn read_token_lt_gt(&mut self) -> LexResult<Option<Token>> {
@@ -626,7 +630,7 @@ impl<'a, I: Input> Lexer<'a, I> {
         self.bump();
 
         // XML style comment. `<!--`
-        if c == '<' && self.is('!') && self.peek() == Some('-') && self.peek_ahead() == Some('-') {
+        if c == '<' && self.is(b'!') && self.peek() == Some('-') && self.peek_ahead() == Some('-') {
             self.skip_line_comment(3);
             self.skip_space()?;
             if self.ctx.module {
@@ -649,7 +653,7 @@ impl<'a, I: Input> Lexer<'a, I> {
             }
         }
 
-        let token = if self.eat('=') {
+        let token = if self.eat(b'=') {
             match op {
                 Lt => BinOp(LtEq),
                 Gt => BinOp(GtEq),
@@ -722,7 +726,7 @@ impl<'a, I: Input> Lexer<'a, I> {
                     // unicode escape
                     '\\' => {
                         l.bump();
-                        if !l.is('u') {
+                        if !l.is(b'u') {
                             l.error_span(pos_span(start), SyntaxError::ExpectedUnicodeEscape)?
                         }
                         has_escape = true;
@@ -755,12 +759,12 @@ impl<'a, I: Input> Lexer<'a, I> {
 
         raw.push_str("u");
 
-        if self.eat('{') {
+        if self.eat(b'{') {
             raw.push('{');
             // let cp_start = self.cur_pos();
             let c = self.read_code_point(raw)?;
 
-            if !self.eat('}') {
+            if !self.eat(b'}') {
                 self.error(start, SyntaxError::InvalidUnicodeEscape)?
             }
             raw.push('}');
@@ -882,7 +886,7 @@ impl<'a, I: Input> Lexer<'a, I> {
         // Default::default());
 
         // input is terminated without following `/`
-        if !self.is('/') {
+        if !self.is(b'/') {
             self.error(start, SyntaxError::UnterminatedRegxp)?;
         }
 

--- a/ecmascript/parser/src/lexer/mod.rs
+++ b/ecmascript/parser/src/lexer/mod.rs
@@ -699,26 +699,6 @@ impl<'a, I: Input> Lexer<'a, I> {
 
         self.with_buf(|l, buf| {
             let mut has_escape = false;
-            {
-                // Optimize for idents without escpae
-                let s = l.input.uncons_while(|c| {
-                    if c.is_ident_part() {
-                        return true;
-                    }
-                    if c == '\\' {
-                        has_escape = true;
-                    }
-                    false
-                });
-
-                if !has_escape {
-                    return Ok((s.into(), false));
-                }
-                if !s.is_empty() {
-                    first = false;
-                }
-                buf.push_str(s);
-            };
 
             while let Some(c) = {
                 // Optimization
@@ -745,6 +725,7 @@ impl<'a, I: Input> Lexer<'a, I> {
                         if !l.is('u') {
                             l.error_span(pos_span(start), SyntaxError::ExpectedUnicodeEscape)?
                         }
+                        has_escape = true;
                         let c = l.read_unicode_escape(start, &mut Raw(None))?;
                         let valid = if first {
                             c.is_ident_start()

--- a/ecmascript/parser/src/lexer/mod.rs
+++ b/ecmascript/parser/src/lexer/mod.rs
@@ -515,7 +515,6 @@ impl<'a, I: Input> Lexer<'a, I> {
 
                 if self.eat(b'\n') {
                     raw.push_str("\n");
-                    self.bump();
                 }
                 return Ok(None);
             }

--- a/ecmascript/parser/src/lexer/number.rs
+++ b/ecmascript/parser/src/lexer/number.rs
@@ -116,7 +116,7 @@ impl<'a, I: Input> Lexer<'a, I> {
         // 1e2 = 100
         // 1e+2 = 100
         // 1e-2 = 0.01
-        if self.eat('e') || self.eat('E') {
+        if self.eat(b'e') || self.eat(b'E') {
             let next = match self.cur() {
                 Some(next) => next,
                 None => {
@@ -158,8 +158,7 @@ impl<'a, I: Input> Lexer<'a, I> {
         self.bump(); // x
 
         let (val, s) = self.read_number_no_dot_as_str(radix)?;
-        if self.cur() == Some('n') {
-            self.input.bump();
+        if self.eat(b'n') {
             return Ok(Either::Right(s));
         }
 

--- a/ecmascript/parser/src/lexer/util.rs
+++ b/ecmascript/parser/src/lexer/util.rs
@@ -126,12 +126,13 @@ impl<'a, I: Input> Lexer<'a, I> {
         while let Some(c) = self.cur() {
             match c {
                 // white spaces
-                _ if c.is_ws() => {}
-
+                '\u{0009}' | '\u{000b}' | '\u{000c}' | '\u{0020}' | '\u{00a0}' | '\u{feff}' => {}
                 // line breaks
                 _ if c.is_line_break() => {
                     self.state.had_line_break = true;
                 }
+                _ if c.is_whitespace() => {}
+
                 '/' => {
                     if self.peek() == Some('/') {
                         self.skip_line_comment(2);

--- a/ecmascript/parser/src/lexer/util.rs
+++ b/ecmascript/parser/src/lexer/util.rs
@@ -62,17 +62,12 @@ impl<'a, I: Input> Lexer<'a, I> {
         self.input.bump()
     }
 
-    pub(super) fn is(&mut self, c: char) -> bool {
-        self.cur() == Some(c)
+    pub(super) fn is(&mut self, c: u8) -> bool {
+        self.input.is_byte(c)
     }
 
-    pub(super) fn eat(&mut self, c: char) -> bool {
-        if self.is(c) {
-            self.bump();
-            true
-        } else {
-            false
-        }
+    pub(super) fn eat(&mut self, c: u8) -> bool {
+        self.input.eat_byte(c)
     }
 
     pub(super) fn cur(&mut self) -> Option<char> {

--- a/ecmascript/parser/src/lexer/util.rs
+++ b/ecmascript/parser/src/lexer/util.rs
@@ -305,7 +305,7 @@ pub trait CharExt: Copy {
             None => return false,
         };
         // TODO: Use Unicode ID instead of XID.
-        c == '$' || c == '\u{200c}' || c == '\u{200d}' || c.is_ascii_alphanumeric() || {
+        c == '$' || c == '_' || c == '\u{200c}' || c == '\u{200d}' || c.is_ascii_alphanumeric() || {
             if c.is_ascii() {
                 false
             } else {

--- a/ecmascript/parser/src/lexer/util.rs
+++ b/ecmascript/parser/src/lexer/util.rs
@@ -289,7 +289,13 @@ pub trait CharExt: Copy {
             None => return false,
         };
         // TODO: Use Unicode ID instead of XID.
-        c == '$' || c == '_' || c.is_ascii_alphabetic() || UnicodeXID::is_xid_start(c)
+        c == '$' || c == '_' || c.is_ascii_alphabetic() || {
+            if c.is_ascii() {
+                false
+            } else {
+                UnicodeXID::is_xid_start(c)
+            }
+        }
     }
 
     /// Test whether a given character is part of an identifier.
@@ -299,11 +305,13 @@ pub trait CharExt: Copy {
             None => return false,
         };
         // TODO: Use Unicode ID instead of XID.
-        c == '$'
-            || c == '\u{200c}'
-            || c == '\u{200d}'
-            || c.is_ascii_alphanumeric()
-            || UnicodeXID::is_xid_continue(c)
+        c == '$' || c == '\u{200c}' || c == '\u{200d}' || c.is_ascii_alphanumeric() || {
+            if c.is_ascii() {
+                false
+            } else {
+                UnicodeXID::is_xid_continue(c)
+            }
+        }
     }
 
     /// See https://tc39.github.io/ecma262/#sec-line-terminators

--- a/ecmascript/parser/src/lexer/util.rs
+++ b/ecmascript/parser/src/lexer/util.rs
@@ -283,6 +283,7 @@ pub trait CharExt: Copy {
     /// Test whether a given character code starts an identifier.
     ///
     /// https://tc39.github.io/ecma262/#prod-IdentifierStart
+    #[inline]
     fn is_ident_start(self) -> bool {
         let c = match self.to_char() {
             Some(c) => c,
@@ -299,6 +300,7 @@ pub trait CharExt: Copy {
     }
 
     /// Test whether a given character is part of an identifier.
+    #[inline]
     fn is_ident_part(self) -> bool {
         let c = match self.to_char() {
             Some(c) => c,
@@ -315,6 +317,7 @@ pub trait CharExt: Copy {
     }
 
     /// See https://tc39.github.io/ecma262/#sec-line-terminators
+    #[inline]
     fn is_line_break(self) -> bool {
         let c = match self.to_char() {
             Some(c) => c,
@@ -327,6 +330,7 @@ pub trait CharExt: Copy {
     }
 
     /// See https://tc39.github.io/ecma262/#sec-white-space
+    #[inline]
     fn is_ws(self) -> bool {
         let c = match self.to_char() {
             Some(c) => c,

--- a/ecmascript/parser/src/lexer/util.rs
+++ b/ecmascript/parser/src/lexer/util.rs
@@ -128,10 +128,9 @@ impl<'a, I: Input> Lexer<'a, I> {
                 // white spaces
                 '\u{0009}' | '\u{000b}' | '\u{000c}' | '\u{0020}' | '\u{00a0}' | '\u{feff}' => {}
                 // line breaks
-                _ if c.is_line_break() => {
+                '\r' | '\n' | '\u{2028}' | '\u{2029}' => {
                     self.state.had_line_break = true;
                 }
-                _ if c.is_whitespace() => {}
 
                 '/' => {
                     if self.peek() == Some('/') {
@@ -143,6 +142,8 @@ impl<'a, I: Input> Lexer<'a, I> {
                     }
                     break;
                 }
+
+                _ if c.is_whitespace() => {}
 
                 _ => break,
             }

--- a/ecmascript/parser/src/lexer/util.rs
+++ b/ecmascript/parser/src/lexer/util.rs
@@ -123,7 +123,11 @@ impl<'a, I: Input> Lexer<'a, I> {
     ///
     /// See https://tc39.github.io/ecma262/#sec-white-space
     pub(super) fn skip_space(&mut self) -> LexResult<()> {
-        while let Some(c) = self.cur() {
+        while let Some(c) = {
+            self.input.eat_all_bytes(b' ');
+
+            self.cur()
+        } {
             match c {
                 // white spaces
                 _ if c.is_ws() => {}

--- a/ecmascript/parser/src/lexer/util.rs
+++ b/ecmascript/parser/src/lexer/util.rs
@@ -123,11 +123,7 @@ impl<'a, I: Input> Lexer<'a, I> {
     ///
     /// See https://tc39.github.io/ecma262/#sec-white-space
     pub(super) fn skip_space(&mut self) -> LexResult<()> {
-        while let Some(c) = {
-            self.input.eat_all_bytes(b' ');
-
-            self.cur()
-        } {
+        while let Some(c) = self.cur() {
             match c {
                 // white spaces
                 _ if c.is_ws() => {}

--- a/ecmascript/parser/src/lexer/util.rs
+++ b/ecmascript/parser/src/lexer/util.rs
@@ -128,33 +128,21 @@ impl<'a, I: Input> Lexer<'a, I> {
     ///
     /// See https://tc39.github.io/ecma262/#sec-white-space
     pub(super) fn skip_space(&mut self) -> LexResult<()> {
-        let mut had_line_break = false;
-        self.input.find(|c| match c {
-            // white spaces
-            _ if c.is_ws() => false,
-
-            // line breaks
-            _ if c.is_line_break() => {
-                had_line_break = true;
-                false
-            }
-
-            _ => true,
-        });
-        if had_line_break {
-            self.state.had_line_break = true;
-        }
-
         while let Some(c) = self.cur() {
             match c {
+                // white spaces
+                _ if c.is_ws() => {}
+
+                // line breaks
+                _ if c.is_line_break() => {
+                    self.state.had_line_break = true;
+                }
                 '/' => {
                     if self.peek() == Some('/') {
                         self.skip_line_comment(2);
-                        self.skip_space()?;
                         continue;
                     } else if self.peek() == Some('*') {
                         self.skip_block_comment()?;
-                        self.skip_space()?;
                         continue;
                     }
                     break;
@@ -162,6 +150,8 @@ impl<'a, I: Input> Lexer<'a, I> {
 
                 _ => break,
             }
+
+            self.bump();
         }
 
         Ok(())

--- a/ecmascript/parser/src/parser/expr.rs
+++ b/ecmascript/parser/src/parser/expr.rs
@@ -211,7 +211,7 @@ impl<'a, I: Tokens> Parser<I> {
     pub(super) fn parse_primary_expr(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(parse_primary_expr);
 
-        let _ = cur!(false);
+        let _ = self.input.cur();
         let start = cur_pos!();
 
         let can_be_arrow = self
@@ -220,99 +220,103 @@ impl<'a, I: Tokens> Parser<I> {
             .map(|s| s == start)
             .unwrap_or(false);
 
-        if eat!("this") {
-            return Ok(Box::new(Expr::This(ThisExpr { span: span!(start) })));
-        }
-
-        if is!("import") {
-            let import = self.parse_ident_name()?;
-            if self.input.syntax().import_meta() && is!('.') {
-                return self
-                    .parse_import_meta_prop(import)
-                    .map(Expr::MetaProp)
-                    .map(Box::new);
-            }
-
-            return self.parse_dynamic_import(start, import);
-        }
-
-        if is!("async") {
-            if peeked_is!("function") && !self.input.has_linebreak_between_cur_and_peeked() {
-                // handle `async function` expression
-                return self.parse_async_fn_expr();
-            }
-
-            if can_be_arrow && self.input.syntax().typescript() && peeked_is!('<') {
-                // try parsing `async<T>() => {}`
-                if let Some(res) = self.try_parse_ts(|p| {
-                    let start = cur_pos!();
-                    assert_and_bump!("async");
-                    p.try_parse_ts_generic_async_arrow_fn(start)
-                }) {
-                    return Ok(Box::new(Expr::Arrow(res)));
+        match self.input.cur() {
+            Some(tok) => match tok {
+                tok!("this") => {
+                    self.input.bump();
+                    return Ok(Box::new(Expr::This(ThisExpr { span: span!(start) })));
                 }
-            }
 
-            if can_be_arrow && peeked_is!('(') {
-                expect!("async");
-                let async_span = self.input.prev_span();
-                return self.parse_paren_expr_or_arrow_fn(can_be_arrow, Some(async_span));
-            }
-        }
+                tok!("import") => {
+                    let import = self.parse_ident_name()?;
+                    if self.input.syntax().import_meta() && is!('.') {
+                        return self
+                            .parse_import_meta_prop(import)
+                            .map(Expr::MetaProp)
+                            .map(Box::new);
+                    }
 
-        if is!('[') {
-            return self.parse_array_lit();
-        }
-        if is!('{') {
-            return self.parse_object();
+                    return self.parse_dynamic_import(start, import);
+                }
+
+                tok!("async") => {
+                    if peeked_is!("function") && !self.input.has_linebreak_between_cur_and_peeked()
+                    {
+                        // handle `async function` expression
+                        return self.parse_async_fn_expr();
+                    }
+
+                    if can_be_arrow && self.input.syntax().typescript() && peeked_is!('<') {
+                        // try parsing `async<T>() => {}`
+                        if let Some(res) = self.try_parse_ts(|p| {
+                            let start = cur_pos!();
+                            assert_and_bump!("async");
+                            p.try_parse_ts_generic_async_arrow_fn(start)
+                        }) {
+                            return Ok(Box::new(Expr::Arrow(res)));
+                        }
+                    }
+
+                    if can_be_arrow && peeked_is!('(') {
+                        expect!("async");
+                        let async_span = self.input.prev_span();
+                        return self.parse_paren_expr_or_arrow_fn(can_be_arrow, Some(async_span));
+                    }
+                }
+
+                tok!('[') => {
+                    return self.parse_array_lit();
+                }
+
+                tok!('{') => {
+                    return self.parse_object();
+                }
+
+                // Handle FunctionExpression and GeneratorExpression
+                tok!("function") => {
+                    return self.parse_fn_expr();
+                }
+
+                // Literals
+                tok!("null")
+                | tok!("true")
+                | tok!("false")
+                | Token::Num(..)
+                | Token::BigInt(..)
+                | Token::Str { .. } => {
+                    return Ok(Box::new(Expr::Lit(self.parse_lit()?)));
+                }
+
+                // Regexp
+                Token::Regex(..) => match bump!() {
+                    Token::Regex(exp, flags) => {
+                        return Ok(Box::new(Expr::Lit(Lit::Regex(Regex {
+                            span: span!(start),
+                            exp,
+                            flags,
+                        }))));
+                    }
+                    _ => unreachable!(),
+                },
+
+                tok!('`') => {
+                    // parse template literal
+                    return Ok(Box::new(Expr::Tpl(self.parse_tpl()?)));
+                }
+
+                tok!('(') => {
+                    return self.parse_paren_expr_or_arrow_fn(can_be_arrow, None);
+                }
+
+                _ => {}
+            },
+            None => {}
         }
 
         let decorators = self.parse_decorators(false)?;
 
-        // Handle FunctionExpression and GeneratorExpression
-        if is!("function") {
-            return self.parse_fn_expr();
-        } else if is!("class") {
+        if is!("class") {
             return self.parse_class_expr(start, decorators);
-        }
-
-        // Literals
-        if match cur!(false) {
-            Ok(&tok!("null"))
-            | Ok(&tok!("true"))
-            | Ok(&tok!("false"))
-            | Ok(&Token::Num(..))
-            | Ok(&Token::BigInt(..))
-            | Ok(Token::Str { .. }) => true,
-            _ => false,
-        } {
-            return Ok(Box::new(Expr::Lit(self.parse_lit()?)));
-        }
-
-        // Regexp
-        if match cur!(false) {
-            Ok(&Token::Regex(..)) => true,
-            _ => false,
-        } {
-            match bump!() {
-                Token::Regex(exp, flags) => {
-                    return Ok(Box::new(Expr::Lit(Lit::Regex(Regex {
-                        span: span!(start),
-                        exp,
-                        flags,
-                    }))));
-                }
-                _ => unreachable!(),
-            }
-        }
-
-        if is!('`') {
-            // parse template literal
-            return Ok(Box::new(Expr::Tpl(self.parse_tpl()?)));
-        }
-
-        if is!('(') {
-            return self.parse_paren_expr_or_arrow_fn(can_be_arrow, None);
         }
 
         if is!("let") || (self.input.syntax().typescript() && is!(IdentName)) || is!(IdentRef) {

--- a/ecmascript/parser/src/parser/util.rs
+++ b/ecmascript/parser/src/parser/util.rs
@@ -1,7 +1,68 @@
 use super::*;
+use crate::token::Keyword;
 use swc_atoms::js_word;
 
 impl Context {
+    pub(crate) fn is_reserved(self, word: &Word) -> bool {
+        match *word {
+            Word::Keyword(Keyword::Let) => self.strict,
+            Word::Keyword(Keyword::Await) => self.in_async || self.strict,
+            Word::Keyword(Keyword::Yield) => self.in_generator || self.strict,
+
+            Word::Null
+            | Word::True
+            | Word::False
+            | Word::Keyword(Keyword::Break)
+            | Word::Keyword(Keyword::Case)
+            | Word::Keyword(Keyword::Catch)
+            | Word::Keyword(Keyword::Continue)
+            | Word::Keyword(Keyword::Debugger)
+            | Word::Keyword(Keyword::Default_)
+            | Word::Keyword(Keyword::Do)
+            | Word::Keyword(Keyword::Export)
+            | Word::Keyword(Keyword::Else)
+            | Word::Keyword(Keyword::Finally)
+            | Word::Keyword(Keyword::For)
+            | Word::Keyword(Keyword::Function)
+            | Word::Keyword(Keyword::If)
+            | Word::Keyword(Keyword::Return)
+            | Word::Keyword(Keyword::Switch)
+            | Word::Keyword(Keyword::Throw)
+            | Word::Keyword(Keyword::Try)
+            | Word::Keyword(Keyword::Var)
+            | Word::Keyword(Keyword::Const)
+            | Word::Keyword(Keyword::While)
+            | Word::Keyword(Keyword::With)
+            | Word::Keyword(Keyword::New)
+            | Word::Keyword(Keyword::This)
+            | Word::Keyword(Keyword::Super)
+            | Word::Keyword(Keyword::Class)
+            | Word::Keyword(Keyword::Extends)
+            | Word::Keyword(Keyword::Import)
+            | Word::Keyword(Keyword::In)
+            | Word::Keyword(Keyword::InstanceOf)
+            | Word::Keyword(Keyword::TypeOf)
+            | Word::Keyword(Keyword::Void)
+            | Word::Keyword(Keyword::Delete) => true,
+
+            // Future reserved word
+            Word::Ident(js_word!("enum")) => true,
+
+            Word::Ident(js_word!("implements"))
+            | Word::Ident(js_word!("package"))
+            | Word::Ident(js_word!("protected"))
+            | Word::Ident(js_word!("interface"))
+            | Word::Ident(js_word!("private"))
+            | Word::Ident(js_word!("public"))
+                if self.strict =>
+            {
+                true
+            }
+
+            _ => false,
+        }
+    }
+
     pub fn is_reserved_word(self, word: &JsWord) -> bool {
         match *word {
             js_word!("let") => self.strict,


### PR DESCRIPTION
## Initial lexer performance
```
test lexer::tests::lex_colors_js               ... bench:      26,520 ns/iter (+/- 9,030) = 43 MB/s
test lexer::tests::lex_colors_ts               ... bench:      26,708 ns/iter (+/- 669) = 43 MB/s
test lexer::tests::lex_dec_lit                 ... bench:      65,231 ns/iter (+/- 970) = 8 MB/s
test lexer::tests::lex_escaped_char            ... bench:       6,966 ns/iter (+/- 128) = 33 MB/s
test lexer::tests::lex_ident                   ... bench:      26,627 ns/iter (+/- 1,253) = 21 MB/s
test lexer::tests::lex_large_number            ... bench:      19,789 ns/iter (+/- 534) = 11 MB/s
test lexer::tests::lex_legact_octal_lit        ... bench:      91,708 ns/iter (+/- 1,362) = 6 MB/s
test lexer::tests::lex_long_ident              ... bench:       4,199 ns/iter (+/- 85) = 113 MB/s
test lexer::tests::lex_regex                   ... bench:       8,643 ns/iter (+/- 144) = 17 MB/s
test lexer::tests::lex_semicolons              ... bench:     135,916 ns/iter (+/- 2,197) = 13 MB/s
```

## After ascii optimization

```
test lexer::tests::lex_colors_js               ... bench:      25,649 ns/iter (+/- 2,109) = 45 MB/s
test lexer::tests::lex_colors_ts               ... bench:      25,876 ns/iter (+/- 237) = 44 MB/s
test lexer::tests::lex_dec_lit                 ... bench:      67,877 ns/iter (+/- 1,130) = 7 MB/s
test lexer::tests::lex_escaped_char            ... bench:       7,576 ns/iter (+/- 279) = 30 MB/s
test lexer::tests::lex_ident                   ... bench:      24,669 ns/iter (+/- 244) = 22 MB/s
test lexer::tests::lex_large_number            ... bench:      20,754 ns/iter (+/- 2,325) = 10 MB/s
test lexer::tests::lex_legact_octal_lit        ... bench:      93,841 ns/iter (+/- 1,305) = 6 MB/s
test lexer::tests::lex_long_ident              ... bench:       4,561 ns/iter (+/- 94) = 104 MB/s
test lexer::tests::lex_regex                   ... bench:       8,611 ns/iter (+/- 1,579) = 18 MB/s
test lexer::tests::lex_semicolons              ... bench:     105,534 ns/iter (+/- 5,907) = 17 MB/s
```

### After removing wrong optimization in `read_word_as_str`

```
test lexer::tests::lex_colors_js               ... bench:      24,661 ns/iter (+/- 264) = 46 MB/s
test lexer::tests::lex_colors_ts               ... bench:      24,712 ns/iter (+/- 523) = 46 MB/s
test lexer::tests::lex_dec_lit                 ... bench:      63,026 ns/iter (+/- 2,060) = 8 MB/s
test lexer::tests::lex_escaped_char            ... bench:       6,949 ns/iter (+/- 889) = 33 MB/s
test lexer::tests::lex_ident                   ... bench:      23,894 ns/iter (+/- 1,355) = 23 MB/s
test lexer::tests::lex_large_number            ... bench:      19,238 ns/iter (+/- 347) = 11 MB/s
test lexer::tests::lex_legact_octal_lit        ... bench:      87,562 ns/iter (+/- 3,667) = 6 MB/s
test lexer::tests::lex_long_ident              ... bench:       4,432 ns/iter (+/- 112) = 107 MB/s
test lexer::tests::lex_regex                   ... bench:       7,945 ns/iter (+/- 394) = 19 MB/s
test lexer::tests::lex_semicolons              ... bench:      96,317 ns/iter (+/- 2,444) = 19 MB/s
```

### After adding inline

```
test lexer::tests::lex_colors_js               ... bench:      24,551 ns/iter (+/- 701) = 47 MB/s
test lexer::tests::lex_colors_ts               ... bench:      24,949 ns/iter (+/- 7,295) = 46 MB/s
test lexer::tests::lex_dec_lit                 ... bench:      62,327 ns/iter (+/- 734) = 8 MB/s
test lexer::tests::lex_escaped_char            ... bench:       7,073 ns/iter (+/- 104) = 32 MB/s
test lexer::tests::lex_ident                   ... bench:      23,956 ns/iter (+/- 481) = 23 MB/s
test lexer::tests::lex_large_number            ... bench:      19,059 ns/iter (+/- 1,107) = 11 MB/s
test lexer::tests::lex_legact_octal_lit        ... bench:      90,779 ns/iter (+/- 3,574) = 6 MB/s
test lexer::tests::lex_long_ident              ... bench:       4,447 ns/iter (+/- 72) = 106 MB/s
test lexer::tests::lex_regex                   ... bench:       8,017 ns/iter (+/- 128) = 19 MB/s
test lexer::tests::lex_semicolons              ... bench:      96,080 ns/iter (+/- 2,390) = 19 MB/s

```

### Baseline for lexer performance

```
test angular       ... bench:  14,032,845 ns/iter (+/- 2,618,442) = 51 MB/s
test backbone      ... bench:   1,845,859 ns/iter (+/- 821,471) = 32 MB/s
test colors        ... bench:      30,071 ns/iter (+/- 8,199) = 38 MB/s
test jquery        ... bench:   9,005,276 ns/iter (+/- 2,257,499) = 29 MB/s
test jquery_mobile ... bench:  14,765,527 ns/iter (+/- 3,800,016) = 30 MB/s
test mootools      ... bench:   7,303,173 ns/iter (+/- 2,145,621) = 21 MB/s
test underscore    ... bench:   1,524,935 ns/iter (+/- 223,030) = 28 MB/s
test yui           ... bench:   8,172,519 ns/iter (+/- 1,928,539) = 41 MB/s
```


### After ascii optimization

I changed some parts of lexer to work with byte instead of char.

```
test angular       ... bench:  10,811,003 ns/iter (+/- 1,482,822) = 66 MB/s
test backbone      ... bench:   1,998,636 ns/iter (+/- 928,390) = 30 MB/s
test colors        ... bench:      26,790 ns/iter (+/- 3,411) = 43 MB/s
test jquery        ... bench:   8,206,829 ns/iter (+/- 1,367,117) = 32 MB/s
test jquery_mobile ... bench:  12,997,307 ns/iter (+/- 1,559,951) = 34 MB/s
test mootools      ... bench:   7,195,759 ns/iter (+/- 2,110,055) = 22 MB/s
test underscore    ... bench:   1,457,760 ns/iter (+/- 13,685) = 29 MB/s
test yui           ... bench:   6,430,216 ns/iter (+/- 1,641,020) = 52 MB/s

```

### After making keyword lexing faster

Previous impl creates `JsWord` and converted it into keyword :)
I don't know why I was such lazy, but I fixed it anyway.

```
test angular       ... bench:   9,571,435 ns/iter (+/- 466,983) = 75 MB/s
test backbone      ... bench:   1,370,984 ns/iter (+/- 61,407) = 43 MB/s
test colors        ... bench:      21,354 ns/iter (+/- 843) = 54 MB/s
test jquery        ... bench:   7,451,739 ns/iter (+/- 299,895) = 36 MB/s
test jquery_mobile ... bench:  12,125,868 ns/iter (+/- 354,864) = 37 MB/s
test mootools      ... bench:   5,902,485 ns/iter (+/- 198,905) = 27 MB/s
test underscore    ... bench:   1,191,789 ns/iter (+/- 61,073) = 36 MB/s
test yui           ... bench:   7,342,329 ns/iter (+/- 102,193) = 46 MB/s
```


### Baseline for parser

```
test angular          ... bench:  28,546,408 ns/iter (+/- 9,048,341) = 25 MB/s
test angular_ts       ... bench:  32,415,280 ns/iter (+/- 4,809,052) = 22 MB/s
test backbone         ... bench:   4,113,307 ns/iter (+/- 656,662) = 14 MB/s
test backbone_ts      ... bench:   4,185,279 ns/iter (+/- 684,611) = 14 MB/s
test colors           ... bench:      72,065 ns/iter (+/- 10,394) = 16 MB/s
test colors_ts        ... bench:      64,925 ns/iter (+/- 1,140) = 17 MB/s
test jquery           ... bench:  23,206,153 ns/iter (+/- 3,700,224) = 11 MB/s
test jquery_mobile    ... bench:  36,288,682 ns/iter (+/- 6,031,766) = 12 MB/s
test jquery_mobile_ts ... bench:  37,104,999 ns/iter (+/- 5,948,459) = 12 MB/s
test jquery_ts        ... bench:  26,216,268 ns/iter (+/- 3,724,721) = 10 MB/s
test large            ... bench:     894,625 ns/iter (+/- 20,068) = 5 MB/s
test mootools         ... bench:  18,456,129 ns/iter (+/- 2,944,629) = 8 MB/s
test mootools_ts      ... bench:  19,072,284 ns/iter (+/- 2,892,291) = 8 MB/s
test underscore       ... bench:   3,787,685 ns/iter (+/- 582,680) = 11 MB/s
test underscore_ts    ... bench:   4,189,735 ns/iter (+/- 604,984) = 10 MB/s
test yui              ... bench:  16,532,152 ns/iter (+/- 2,570,311) = 20 MB/s
test yui_ts           ... bench:  17,706,670 ns/iter (+/- 2,884,282) = 19 MB/s
```

### After optimizing parse_primary_expr

```
test angular          ... bench:  27,067,654 ns/iter (+/- 3,904,212) = 26 MB/s
test angular_ts       ... bench:  29,543,385 ns/iter (+/- 4,093,929) = 24 MB/s
test backbone         ... bench:   3,865,621 ns/iter (+/- 591,432) = 15 MB/s
test backbone_ts      ... bench:   4,322,681 ns/iter (+/- 583,417) = 13 MB/s
test colors           ... bench:      67,511 ns/iter (+/- 782) = 17 MB/s
test colors_ts        ... bench:      69,072 ns/iter (+/- 9,364) = 16 MB/s
test jquery           ... bench:  21,676,669 ns/iter (+/- 3,218,923) = 12 MB/s
test jquery_mobile    ... bench:  35,866,274 ns/iter (+/- 5,232,480) = 12 MB/s
test jquery_mobile_ts ... bench:  35,868,294 ns/iter (+/- 5,154,427) = 12 MB/s
test jquery_ts        ... bench:  22,262,265 ns/iter (+/- 3,387,292) = 12 MB/s
test large            ... bench:     728,133 ns/iter (+/- 5,605) = 6 MB/s
test mootools         ... bench:  18,547,388 ns/iter (+/- 2,571,215) = 8 MB/s
test mootools_ts      ... bench:  20,170,346 ns/iter (+/- 2,803,543) = 7 MB/s
test underscore       ... bench:   3,358,521 ns/iter (+/- 496,402) = 12 MB/s
test underscore_ts    ... bench:   4,011,983 ns/iter (+/- 551,207) = 10 MB/s
test yui              ... bench:  15,861,491 ns/iter (+/- 2,327,605) = 21 MB/s
test yui_ts           ... bench:  16,641,472 ns/iter (+/- 2,630,265) = 20 MB/s
```

### After optimizing skip_space

```
test angular          ... bench:  26,050,513 ns/iter (+/- 5,822,522) = 27 MB/s
test angular_ts       ... bench:  27,010,412 ns/iter (+/- 11,632,935) = 26 MB/s
test backbone         ... bench:   3,350,210 ns/iter (+/- 172,170) = 17 MB/s
test backbone_ts      ... bench:   3,569,779 ns/iter (+/- 165,606) = 16 MB/s
test colors           ... bench:      53,089 ns/iter (+/- 2,680) = 21 MB/s
test colors_ts        ... bench:      54,438 ns/iter (+/- 2,023) = 21 MB/s
test jquery           ... bench:  19,466,370 ns/iter (+/- 668,417) = 13 MB/s
test jquery_mobile    ... bench:  31,501,930 ns/iter (+/- 7,064,350) = 14 MB/s
test jquery_mobile_ts ... bench:  34,467,660 ns/iter (+/- 14,276,566) = 13 MB/s
test jquery_ts        ... bench:  21,525,053 ns/iter (+/- 9,270,297) = 12 MB/s
test large            ... bench:     715,374 ns/iter (+/- 10,540) = 7 MB/s
test mootools         ... bench:  16,998,838 ns/iter (+/- 7,986,295) = 9 MB/s
test mootools_ts      ... bench:  15,614,933 ns/iter (+/- 680,101) = 10 MB/s
test underscore       ... bench:   3,029,955 ns/iter (+/- 135,441) = 14 MB/s
test underscore_ts    ... bench:   3,219,333 ns/iter (+/- 117,416) = 13 MB/s
test yui              ... bench:  14,324,433 ns/iter (+/- 450,292) = 23 MB/s
test yui_ts           ... bench:  18,065,076 ns/iter (+/- 3,243,760) = 18 MB/s
```