### PR TITLE
Fix bugs

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -76,12 +76,15 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/swc-project/ts-parser-test-ref.git ecmascript/parser/tests/typescript/tsc
 
-      - name: Run cargo test
+      - name: Run fast cargo test
         run: |
           export PATH="$PATH:$HOME/npm/bin"
           EXEC=0 cargo test --color always --all --exclude node --exclude wasm
-          cargo test --color always --all --exclude node --exclude wasm
 
+      - name: Run slow cargo test
+        run: |
+          export PATH="$PATH:$HOME/npm/bin"
+          cargo test --color always --all --exclude node --exclude wasm
   #
   deploy-docs:
     runs-on: ubuntu-latest

--- a/benches/typescript.rs
+++ b/benches/typescript.rs
@@ -107,39 +107,6 @@ fn config_for_file(b: &mut Bencher) {
 }
 
 /// This benchmark exists to know exact execution time of each pass.
-#[bench]
-fn config_transforms(b: &mut Bencher) {
-    let c = mk();
-    let module = parse(&c);
-
-    b.iter(|| {
-        let program = module.clone();
-
-        let mut config = c
-            .config_for_file(
-                &Options {
-                    config: Some(Config {
-                        jsc: JscConfig {
-                            target: JscTarget::Es2016,
-                            syntax: Some(Syntax::Typescript(TsConfig {
-                                ..Default::default()
-                            })),
-                            ..Default::default()
-                        },
-                        module: None,
-                        ..Default::default()
-                    }),
-                    swcrc: false,
-                    is_module: true,
-                    ..Default::default()
-                },
-                &FileName::Real("rxjs/src/internal/observable/dom/AjaxObservable.ts".into()),
-            )
-            .unwrap();
-        let program = c.run_transform(true, || program.fold_with(&mut config.pass));
-        black_box(program)
-    });
-}
 
 fn bench_codegen(b: &mut Bencher, _target: JscTarget) {
     let c = mk();
@@ -220,3 +187,52 @@ compat!(full_es2017, JscTarget::Es2017);
 compat!(full_es2018, JscTarget::Es2018);
 compat!(full_es2019, JscTarget::Es2019);
 compat!(full_es2020, JscTarget::Es2020);
+
+macro_rules! tr_only {
+    ($name:ident, $target:expr) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            let c = mk();
+            let module = parse(&c);
+
+            b.iter(|| {
+                let program = module.clone();
+
+                let mut config = c
+                    .config_for_file(
+                        &Options {
+                            config: Some(Config {
+                                jsc: JscConfig {
+                                    target: JscTarget::Es2016,
+                                    syntax: Some(Syntax::Typescript(TsConfig {
+                                        ..Default::default()
+                                    })),
+                                    ..Default::default()
+                                },
+                                module: None,
+                                ..Default::default()
+                            }),
+                            swcrc: false,
+                            is_module: true,
+                            ..Default::default()
+                        },
+                        &FileName::Real(
+                            "rxjs/src/internal/observable/dom/AjaxObservable.ts".into(),
+                        ),
+                    )
+                    .unwrap();
+                let program = c.run_transform(true, || program.fold_with(&mut config.pass));
+                black_box(program)
+            });
+        }
+    };
+}
+
+tr_only!(transforms_es3, JscTarget::Es3);
+tr_only!(transforms_es5, JscTarget::Es5);
+tr_only!(transforms_es2015, JscTarget::Es2015);
+tr_only!(transforms_es2016, JscTarget::Es2016);
+tr_only!(transforms_es2017, JscTarget::Es2017);
+tr_only!(transforms_es2018, JscTarget::Es2018);
+tr_only!(transforms_es2019, JscTarget::Es2019);
+tr_only!(transforms_es2020, JscTarget::Es2020);

--- a/benches/typescript.rs
+++ b/benches/typescript.rs
@@ -236,3 +236,14 @@ tr_only!(transforms_es2017, JscTarget::Es2017);
 tr_only!(transforms_es2018, JscTarget::Es2018);
 tr_only!(transforms_es2019, JscTarget::Es2019);
 tr_only!(transforms_es2020, JscTarget::Es2020);
+
+#[bench]
+fn parser(b: &mut Bencher) {
+    let c = mk();
+
+    //TODO: Use target
+
+    b.iter(|| {
+        black_box(parse(&c));
+    })
+}

--- a/benches/typescript.rs
+++ b/benches/typescript.rs
@@ -203,7 +203,7 @@ macro_rules! tr_only {
                         &Options {
                             config: Some(Config {
                                 jsc: JscConfig {
-                                    target: %target,
+                                    target: $target,
                                     syntax: Some(Syntax::Typescript(TsConfig {
                                         ..Default::default()
                                     })),

--- a/benches/typescript.rs
+++ b/benches/typescript.rs
@@ -203,7 +203,7 @@ macro_rules! tr_only {
                         &Options {
                             config: Some(Config {
                                 jsc: JscConfig {
-                                    target: JscTarget::Es2016,
+                                    target: %target,
                                     syntax: Some(Syntax::Typescript(TsConfig {
                                         ..Default::default()
                                     })),

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.23.2"
+version = "0.23.3"
 
 [features]
 const-modules = ["dashmap"]

--- a/ecmascript/transforms/src/fixer.rs
+++ b/ecmascript/transforms/src/fixer.rs
@@ -340,10 +340,10 @@ impl VisitMut for Fixer<'_> {
 
     fn visit_mut_stmt(&mut self, stmt: &mut Stmt) {
         match stmt {
-            Stmt::Expr(expr) => {
+            Stmt::Expr(expr_stmt) => {
                 let old = self.ctx;
                 self.ctx = Context::Default;
-                expr.visit_mut_with(self);
+                expr_stmt.visit_mut_with(self);
                 self.ctx = old;
             }
             _ => stmt.visit_mut_children_with(self),

--- a/ecmascript/transforms/src/fixer.rs
+++ b/ecmascript/transforms/src/fixer.rs
@@ -441,7 +441,13 @@ impl Fixer<'_> {
                                     }
                                 }
                             }
-                            _ => buf.push(expr.take()),
+                            _ => {
+                                if is_last {
+                                    buf.push(expr.take());
+                                } else {
+                                    buf.extend(ignore_return_value(expr.take()));
+                                }
+                            }
                         }
                     }
 
@@ -594,7 +600,6 @@ impl Fixer<'_> {
 }
 
 fn ignore_return_value(expr: Box<Expr>) -> Option<Box<Expr>> {
-    dbg!(&*expr);
     match *expr {
         Expr::Ident(..) | Expr::Fn(..) | Expr::Lit(..) => None,
         Expr::Seq(SeqExpr { span, exprs }) => {

--- a/ecmascript/transforms/src/optimization/simplify/expr/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/expr/mod.rs
@@ -671,14 +671,6 @@ impl SimplifyExpr {
 
             op!("~") => {
                 if let Known(value) = arg.as_number() {
-                    println!(
-                        "Value: {} -> {} -> {} -> {}",
-                        value,
-                        value as u32,
-                        !(value as u32),
-                        !(value as u32) as i32
-                    );
-                    println!("{}", value as i32 as u32);
                     if value.fract() == 0.0 {
                         return Expr::Lit(Lit::Num(Number {
                             span,

--- a/ecmascript/transforms/src/typescript/strip.rs
+++ b/ecmascript/transforms/src/typescript/strip.rs
@@ -650,42 +650,6 @@ impl VisitMut for Strip {
 
                 new_stack.extend(res)
             }
-    fn visit_mut_expr(&mut self, e: &mut Expr) {
-        match e {
-            Expr::TsAs(TsAsExpr { expr, .. })
-            | Expr::TsNonNull(TsNonNullExpr { expr, .. })
-            | Expr::TsTypeAssertion(TsTypeAssertion { expr, .. })
-            | Expr::TsConstAssertion(TsConstAssertion { expr, .. })
-            | Expr::TsTypeCast(TsTypeCastExpr { expr, .. }) => {
-                expr.visit_mut_with(self);
-                *e = (**expr).take();
-            }
-            _ => {}
-        }
-
-        e.map_with_mut(|expr| {
-            let expr = match expr {
-                Expr::Member(MemberExpr {
-                    span,
-                    mut obj,
-                    mut prop,
-                    computed,
-                }) => {
-                    obj.visit_mut_with(self);
-
-                    let prop = if computed {
-                        prop.visit_mut_with(self);
-                        prop
-                    } else {
-                        match *prop {
-                            Expr::Ident(i) => Box::new(Expr::Ident(Ident {
-                                optional: false,
-                                type_ann: None,
-                                ..i
-                            })),
-                            _ => prop,
-                        }
-                    };
 
             if new_stack.is_empty() {
                 return;

--- a/ecmascript/transforms/src/typescript/strip.rs
+++ b/ecmascript/transforms/src/typescript/strip.rs
@@ -650,6 +650,42 @@ impl VisitMut for Strip {
 
                 new_stack.extend(res)
             }
+    fn visit_mut_expr(&mut self, e: &mut Expr) {
+        match e {
+            Expr::TsAs(TsAsExpr { expr, .. })
+            | Expr::TsNonNull(TsNonNullExpr { expr, .. })
+            | Expr::TsTypeAssertion(TsTypeAssertion { expr, .. })
+            | Expr::TsConstAssertion(TsConstAssertion { expr, .. })
+            | Expr::TsTypeCast(TsTypeCastExpr { expr, .. }) => {
+                expr.visit_mut_with(self);
+                *e = (**expr).take();
+            }
+            _ => {}
+        }
+
+        e.map_with_mut(|expr| {
+            let expr = match expr {
+                Expr::Member(MemberExpr {
+                    span,
+                    mut obj,
+                    mut prop,
+                    computed,
+                }) => {
+                    obj.visit_mut_with(self);
+
+                    let prop = if computed {
+                        prop.visit_mut_with(self);
+                        prop
+                    } else {
+                        match *prop {
+                            Expr::Ident(i) => Box::new(Expr::Ident(Ident {
+                                optional: false,
+                                type_ann: None,
+                                ..i
+                            })),
+                            _ => prop,
+                        }
+                    };
 
             if new_stack.is_empty() {
                 return;

--- a/ecmascript/transforms/tests/es2020_optional_chaining.rs
+++ b/ecmascript/transforms/tests/es2020_optional_chaining.rs
@@ -568,3 +568,13 @@ test!(
     "var ref;
 (ref = test.a) === null || ref === void 0 ? void 0 : ref.b.c.d.e.f.g.h.i"
 );
+
+// https://github.com/Brooooooklyn/swc-node/issues/62
+test!(
+    syntax(),
+    |_| tr(()),
+    swc_node_issue_62,
+    "a.focus?.()",
+    "var ref;
+    (ref = a.focus) === null || ref === void 0 ? void 0 : ref.call(a);"
+);

--- a/ecmascript/transforms/tests/es2020_optional_chaining.rs
+++ b/ecmascript/transforms/tests/es2020_optional_chaining.rs
@@ -115,12 +115,12 @@ function test(foo) {
     foo === null || foo === void 0 ? void 0 : (ref = foo.bar) === null || ref === void 0 ? void 0 : ref.baz;
     foo === null || foo === void 0 ? void 0 : foo(foo);
     foo === null || foo === void 0 ? void 0 : foo.bar();
-    (ref1 = foo.bar) === null || ref1 === void 0 ? void 0 : ref1.call(ref1, foo.bar, false);
-    foo === null || foo === void 0 ? void 0 : (ref2 = foo.bar) === null || ref2 === void 0 ? void 0 : ref2.call(ref2, foo.bar, true);
+    (ref1 = foo.bar) === null || ref1 === void 0 ? void 0 : ref1.call(foo, foo.bar, false);
+    foo === null || foo === void 0 ? void 0 : (ref2 = foo.bar) === null || ref2 === void 0 ? void 0 : ref2.call(foo, foo.bar, true);
     (ref3 = foo.bar) === null || ref3 === void 0 ? void 0 : ref3.baz(foo.bar, false);
     foo === null || foo === void 0 ? void 0 : (ref4 = foo.bar) === null || ref4 === void 0 ? void 0 : ref4.baz(foo.bar, true);
-    (ref5 = foo.bar) === null || ref5 === void 0 ? void 0 : (ref6 = ref5.baz) === null || ref6 === void 0 ? void 0 : ref6.call(ref6, foo.bar, false);
-    foo === null || foo === void 0 ? void 0 : (ref7 = foo.bar) === null || ref7 === void 0 ? void 0 : (ref8 = ref7.baz) === null || ref8 === void 0 ? void 0 : ref8.call(ref8, foo.bar, true);
+    (ref5 = foo.bar) === null || ref5 === void 0 ? void 0 : (ref6 = ref5.baz) === null || ref6 === void 0 ? void 0 : ref6.call(ref5, foo.bar, false);
+    foo === null || foo === void 0 ? void 0 : (ref7 = foo.bar) === null || ref7 === void 0 ? void 0 : (ref8 = ref7.baz) === null || ref8 === void 0 ? void 0 : ref8.call(ref7, foo.bar, true);
 }
 "#
 );
@@ -302,15 +302,14 @@ foo?.bar?.()?.baz
 var ref, ref1, ref2, ref3, ref4, ref5, ref6, ref7, ref8;
 foo === null || foo === void 0 ? void 0 : foo(foo);
 foo === null || foo === void 0 ? void 0 : foo.bar();
-(ref = foo.bar) === null || ref === void 0 ? void 0 : ref.call(ref, foo.bar, false);
-foo === null || foo === void 0 ? void 0 : (ref1 = foo.bar) === null || ref1 === void 0 ? void 0 : ref1.call(ref1, foo.bar, true);
+(ref = foo.bar) === null || ref === void 0 ? void 0 : ref.call(foo, foo.bar, false);
+foo === null || foo === void 0 ? void 0 : (ref1 = foo.bar) === null || ref1 === void 0 ? void 0 : ref1.call(foo, foo.bar, true);
 foo === null || foo === void 0 ? void 0 : foo().bar;
 foo === null || foo === void 0 ? void 0 : (ref2 = foo()) === null || ref2 === void 0 ? void 0 : ref2.bar;
-(ref3 = foo.bar) === null || ref3 === void 0 ? void 0 : ref3.call(ref3).baz;
-(ref4 = foo.bar) === null || ref4 === void 0 ? void 0 : (ref5 = ref4.call(ref4)) === null || ref5 === void 0 ? void 0 : ref5.baz;
-foo === null || foo === void 0 ? void 0 : (ref6 = foo.bar) === null || ref6 === void 0 ? void 0 : ref6.call(ref6).baz;
-foo === null || foo === void 0 ? void 0 : (ref7 = foo.bar) === null || ref7 === void 0 ? void 0 : (ref8 = ref7.call(ref7)) === null || ref8 === void 0 ? void 0 : ref8.baz;
-"#
+(ref3 = foo.bar) === null || ref3 === void 0 ? void 0 : ref3.call(foo).baz;
+(ref4 = foo.bar) === null || ref4 === void 0 ? void 0 : (ref5 = ref4.call(foo)) === null || ref5 === void 0 ? void 0 : ref5.baz;
+foo === null || foo === void 0 ? void 0 : (ref6 = foo.bar) === null || ref6 === void 0 ? void 0 : ref6.call(foo).baz;
+foo === null || foo === void 0 ? void 0 : (ref7 = foo.bar) === null || ref7 === void 0 ? void 0 : (ref8 = ref7.call(foo)) === null || ref8 === void 0 ? void 0 : ref8.baz;"#
 );
 
 // general_unary_exec
@@ -539,7 +538,7 @@ a === null || a === void 0
     ? void 0
     : (ref1 = ref.c) === null || ref1 === void 0
       ? void 0
-      : ref1.call(ref1);"
+      : ref1.call(ref);"
 );
 
 test!(


### PR DESCRIPTION
swc_ecma_transforms:
 - Fix `this` in optional chaining expression. (https://github.com/Brooooooklyn/swc-node/issues/62)
 - Optimize typescript stripper
 - Optimize fixer


---

Note: Tasks to do are determined by looking at the perf report.

---

### Benchmark


#### Baseline
```
test full_es2016                  ... bench:   2,305,810 ns/iter (+/- 286,352)
```

#### After removing map_with_mut in typescript::strip#visit_mut_expr

```
test full_es2016                  ... bench:   1,975,390 ns/iter (+/- 168,977)
```


#### After reducing the number of branches in fixer

I added some transform-only benchmarks.

```
test full_es2016                  ... bench:   1,825,710 ns/iter (+/- 27,324)
test transforms_es2016            ... bench:     877,426 ns/iter (+/- 80,775)
test parser                       ... bench:     776,628 ns/iter (+/- 19,839)
test codegen_es2016               ... bench:     137,076 ns/iter (+/- 1,126)
```