### PR TITLE
Remove wrong assertion in hygiene

### DIFF
--- a/ecmascript/transforms/src/hygiene.rs
+++ b/ecmascript/transforms/src/hygiene.rs
@@ -132,13 +132,6 @@ impl<'a> Hygiene<'a> {
         );
 
         let old = declared_symbols.entry(sym.to_boxed_str()).or_default();
-        assert!(
-            old.contains(&ctxt),
-            "{:?} does not contain {}{:?}",
-            declared_symbols,
-            sym,
-            ctxt
-        );
         old.retain(|c| *c != ctxt);
         //        debug_assert!(old.is_empty() || old.len() == 1);
 


### PR DESCRIPTION
The assertion became wrong after recent hygiene performance patch.


Closes #1038.