### PR TITLE
Fix missing GITHUB_TOKEN in publish stage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,10 @@ jobs:
         shell: bash
         run: npm run artifacts
 
-      - uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+      - name: Publish
+        run: |
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+          npm publish
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
We need publish `@swc/core-[platform]` in prepublish script,  not sure wheather `JS-DevTools/npm-publish@v1` support it, so I change it to traditional old way