### PR TITLE
resolver: Fix handling of constructor parameters

### DIFF
--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.23.6"
+version = "0.23.7"
 
 [features]
 const-modules = ["dashmap"]

--- a/ecmascript/transforms/src/resolver.rs
+++ b/ecmascript/transforms/src/resolver.rs
@@ -1015,7 +1015,4 @@ impl VisitMut for Hoister<'_, '_> {
 
     #[inline]
     fn visit_mut_param(&mut self, _: &mut Param) {}
-
-    #[inline]
-    fn visit_mut_ts_param_prop(&mut self, _: &mut TsParamProp) {}
 }

--- a/ecmascript/transforms/src/resolver.rs
+++ b/ecmascript/transforms/src/resolver.rs
@@ -1015,4 +1015,7 @@ impl VisitMut for Hoister<'_, '_> {
 
     #[inline]
     fn visit_mut_param(&mut self, _: &mut Param) {}
+
+    #[inline]
+    fn visit_mut_ts_param_prop(&mut self, _: &mut TsParamProp) {}
 }

--- a/ecmascript/transforms/src/resolver.rs
+++ b/ecmascript/transforms/src/resolver.rs
@@ -1006,4 +1006,7 @@ impl VisitMut for Hoister<'_, '_> {
 
     #[inline]
     fn visit_mut_pat_or_expr(&mut self, _: &mut PatOrExpr) {}
+
+    #[inline]
+    fn visit_mut_param(&mut self, _: &mut Param) {}
 }

--- a/ecmascript/transforms/src/resolver.rs
+++ b/ecmascript/transforms/src/resolver.rs
@@ -615,6 +615,12 @@ impl<'a> VisitMut for Resolver<'a> {
         self.cur_defining = folder.cur_defining;
     }
 
+    fn visit_mut_param(&mut self, param: &mut Param) {
+        self.in_type = false;
+        self.ident_type = IdentType::Binding;
+        param.visit_mut_children_with(self);
+    }
+
     fn visit_mut_block_stmt(&mut self, block: &mut BlockStmt) {
         let child_mark = Mark::fresh(self.mark);
 


### PR DESCRIPTION
Currently constructor parameters have syntax context before `visit_mut_param` is called.

--- 
Related to https://github.com/denoland/deno_lint/pull/304 and https://github.com/denoland/deno_lint/pull/307