### PR TITLE
Extension for jest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,43 +2,44 @@
 members = ["ecmascript", "ecmascript/jsdoc", "native", "spack", "wasm"]
 
 [package]
-name = "swc"
-version = "0.1.0"
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
-license = "Apache-2.0/MIT"
-repository = "https://github.com/swc-project/swc.git"
-documentation = "https://swc-project.github.io/rustdoc/swc/"
 description = "Speedy web compiler"
+documentation = "https://swc-project.github.io/rustdoc/swc/"
 edition = "2018"
+license = "Apache-2.0/MIT"
+name = "swc"
+repository = "https://github.com/swc-project/swc.git"
+version = "0.0.0"
 
 [lib]
 name = "swc"
 
 [dependencies]
-swc_atoms = { path ="./atoms" }
-swc_common = { path ="./common", features = ["sourcemap", "concurrent"] }
-swc_ecma_ast = { path ="./ecmascript/ast" }
-swc_ecma_codegen = { path ="./ecmascript/codegen" }
-swc_ecma_parser = { path ="./ecmascript/parser" }
-swc_ecma_preset_env = { path ="./ecmascript/preset_env" }
-swc_ecma_transforms = { path ="./ecmascript/transforms", features = ["const-modules", "react"] }
-swc_ecma_visit = { path ="./ecmascript/visit" }
-swc_visit = { path ="./visit" }
 anyhow = "1"
-log = { version = "0.4", features = ["release_max_level_info"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+base64 = "0.12.0"
+dashmap = "3"
+either = "1"
+log = {version = "0.4", features = ["release_max_level_info"]}
 once_cell = "1"
 regex = "1"
-either = "1"
-dashmap = "3"
+serde = {version = "1", features = ["derive"]}
+serde_json = "1"
 sourcemap = "6"
-base64 = "0.12.0"
+swc_atoms = {path = "./atoms"}
+swc_common = {path = "./common", features = ["sourcemap", "concurrent"]}
+swc_ecma_ast = {path = "./ecmascript/ast"}
+swc_ecma_codegen = {path = "./ecmascript/codegen"}
+swc_ecma_ext_transforms = {path = "./ecmascript/ext-transforms"}
+swc_ecma_parser = {path = "./ecmascript/parser"}
+swc_ecma_preset_env = {path = "./ecmascript/preset_env"}
+swc_ecma_transforms = {path = "./ecmascript/transforms", features = ["const-modules", "react"]}
+swc_ecma_visit = {path = "./ecmascript/visit"}
+swc_visit = {path = "./visit"}
 
 [dev-dependencies]
-testing = { path = "./testing" }
-walkdir = "2"
 rayon = "1"
+testing = {path = "./testing"}
+walkdir = "2"
 
 [[example]]
 name = "usage"

--- a/ecmascript/ext-transforms/Cargo.toml
+++ b/ecmascript/ext-transforms/Cargo.toml
@@ -10,3 +10,9 @@ version = "0.0.0"
 
 [dependencies]
 phf = {version = "0.8.0", features = ["macros"]}
+swc_atoms = {path = "../../atoms"}
+swc_common = {path = "../../common"}
+swc_ecma_ast = {path = "../ast"}
+swc_ecma_parser = {path = "../parser"}
+swc_ecma_utils = {path = "../utils"}
+swc_ecma_visit = {path = "../visit"}

--- a/ecmascript/ext-transforms/Cargo.toml
+++ b/ecmascript/ext-transforms/Cargo.toml
@@ -9,3 +9,4 @@ version = "0.0.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+phf = {version = "0.8.0", features = ["macros"]}

--- a/ecmascript/ext-transforms/Cargo.toml
+++ b/ecmascript/ext-transforms/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+authors = ["강동윤 <kdy1997.dev@gmail.com>"]
+description = "Extensions for @swc/core (nodejs)"
+edition = "2018"
+name = "swc_ecma_ext_transforms"
+publish = false
+version = "0.0.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ecmascript/ext-transforms/src/jest.rs
+++ b/ecmascript/ext-transforms/src/jest.rs
@@ -1,0 +1,88 @@
+use crate::util::MapWithMut;
+use phf::phf_set;
+use swc_ecma_ast::*;
+use swc_ecma_utils::{prepend_stmts, StmtLike};
+use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
+
+static HOIST_METHODS: phf::Set<&str> = phf_set![
+    "mock",
+    "unmock",
+    "enableAutomock",
+    "disableAutomock",
+    "deepUnmock"
+];
+
+pub fn jest() -> impl Fold {
+    as_folder(Jest)
+}
+
+struct Jest;
+
+impl Jest {
+    fn visit_mut_stmt_like<T>(&mut self, orig: &mut Vec<T>)
+    where
+        T: StmtLike + VisitMutWith<Self>,
+    {
+        for item in &mut *orig {
+            item.visit_mut_with(self);
+        }
+
+        let items = orig.take();
+
+        let mut new = Vec::with_capacity(items.len());
+        let mut hoisted = Vec::with_capacity(8);
+        items.into_iter().for_each(|item| {
+            match item.try_into_stmt() {
+                Ok(stmt) => match &stmt {
+                    Stmt::Expr(ExprStmt { expr, .. }) => match &**expr {
+                        Expr::Call(CallExpr {
+                            callee: ExprOrSuper::Expr(callee),
+                            ..
+                        }) => match &**callee {
+                            Expr::Member(
+                                callee
+                                @
+                                MemberExpr {
+                                    computed: false, ..
+                                },
+                            ) => match &callee.obj {
+                                ExprOrSuper::Super(_) => {}
+                                ExprOrSuper::Expr(callee_obj) => match &**callee_obj {
+                                    Expr::Ident(i) if i.sym == *"jest" => match &*callee.prop {
+                                        Expr::Ident(prop) if HOIST_METHODS.contains(&*prop.sym) => {
+                                            hoisted.push(T::from_stmt(stmt));
+                                            return;
+                                        }
+                                        _ => new.push(T::from_stmt(stmt)),
+                                    },
+                                    _ => new.push(T::from_stmt(stmt)),
+                                },
+                            },
+                            _ => new.push(T::from_stmt(stmt)),
+                        },
+                        _ => new.push(T::from_stmt(stmt)),
+                    },
+
+                    _ => new.push(T::from_stmt(stmt)),
+                },
+                Err(node) => new.push(node),
+            };
+        });
+
+        prepend_stmts(&mut new, hoisted.into_iter());
+
+        *orig = new;
+    }
+}
+
+impl VisitMut for Jest {
+    noop_visit_mut_type!();
+
+    fn visit_mut_stmts(&mut self, stmts: &mut Vec<Stmt>) {
+        self.visit_mut_stmt_like(stmts)
+    }
+
+    fn visit_mut_module_items(&mut self, items: &mut Vec<ModuleItem>) {
+        self.visit_mut_stmt_like(items)
+    }
+}

--- a/ecmascript/ext-transforms/src/lib.rs
+++ b/ecmascript/ext-transforms/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/ecmascript/ext-transforms/src/lib.rs
+++ b/ecmascript/ext-transforms/src/lib.rs
@@ -1,7 +1,1 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+mod util;

--- a/ecmascript/ext-transforms/src/lib.rs
+++ b/ecmascript/ext-transforms/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod jest;
 mod util;

--- a/ecmascript/ext-transforms/src/util.rs
+++ b/ecmascript/ext-transforms/src/util.rs
@@ -1,3 +1,7 @@
+use std::mem::replace;
+use swc_atoms::js_word;
+use swc_common::DUMMY_SP;
+use swc_ecma_ast::*;
 /// Helper for migration from [Fold] to [VisitMut]
 pub(crate) trait MapWithMut: Sized {
     fn dummy() -> Self;

--- a/ecmascript/ext-transforms/src/util.rs
+++ b/ecmascript/ext-transforms/src/util.rs
@@ -1,0 +1,87 @@
+/// Helper for migration from [Fold] to [VisitMut]
+pub(crate) trait MapWithMut: Sized {
+    fn dummy() -> Self;
+
+    fn take(&mut self) -> Self {
+        replace(self, Self::dummy())
+    }
+
+    #[inline]
+    fn map_with_mut<F>(&mut self, op: F)
+    where
+        F: FnOnce(Self) -> Self,
+    {
+        let dummy = Self::dummy();
+        let v = replace(self, dummy);
+        let v = op(v);
+        let _dummy = replace(self, v);
+    }
+}
+
+impl MapWithMut for ModuleItem {
+    #[inline(always)]
+    fn dummy() -> Self {
+        ModuleItem::Stmt(Stmt::Empty(EmptyStmt { span: DUMMY_SP }))
+    }
+}
+
+impl MapWithMut for Stmt {
+    #[inline(always)]
+    fn dummy() -> Self {
+        Stmt::Empty(EmptyStmt { span: DUMMY_SP })
+    }
+}
+
+impl MapWithMut for Expr {
+    #[inline(always)]
+    fn dummy() -> Self {
+        Expr::Invalid(Invalid { span: DUMMY_SP })
+    }
+}
+
+impl MapWithMut for Pat {
+    #[inline(always)]
+    fn dummy() -> Self {
+        Pat::Invalid(Invalid { span: DUMMY_SP })
+    }
+}
+
+impl<T> MapWithMut for Option<T> {
+    #[inline(always)]
+    fn dummy() -> Self {
+        None
+    }
+}
+
+impl<T> MapWithMut for Vec<T> {
+    #[inline(always)]
+    fn dummy() -> Self {
+        Vec::new()
+    }
+}
+
+impl<T> MapWithMut for Box<T>
+where
+    T: MapWithMut,
+{
+    #[inline(always)]
+    fn dummy() -> Self {
+        Box::new(T::dummy())
+    }
+}
+
+impl MapWithMut for Ident {
+    fn dummy() -> Self {
+        Ident::new(js_word!(""), DUMMY_SP)
+    }
+}
+
+impl MapWithMut for ObjectPatProp {
+    fn dummy() -> Self {
+        ObjectPatProp::Assign(AssignPatProp {
+            span: DUMMY_SP,
+            key: Ident::dummy(),
+            value: None,
+        })
+    }
+}

--- a/node-swc/__tests__/transform/hidden_jest.js
+++ b/node-swc/__tests__/transform/hidden_jest.js
@@ -1,0 +1,20 @@
+const swc = require("../../../");
+
+it("should hoist methods", () => {
+    const src = 'console.log("Hello"); jest.mock(); console.log("World")';
+
+    expect(
+        swc.transformSync(src, {
+            jsc: {
+                transform: {
+                    hidden: {
+                        jest: true
+                    }
+                }
+            }
+        })
+            .code.trim()
+    ).toBe(`jest.mock();
+console.log(\"Hello\");
+console.log(\"World\");`);
+});

--- a/spack/src/loaders/swc.rs
+++ b/spack/src/loaders/swc.rs
@@ -82,6 +82,7 @@ impl Load for SwcLoader {
                                                 optimizer: None,
                                                 legacy_decorator: c.legacy_decorator,
                                                 decorator_metadata: c.decorator_metadata,
+                                                hidden: Default::default(),
                                             })
                                         } else {
                                             None

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ use swc_atoms::JsWord;
 pub use swc_common::chain;
 use swc_common::{comments::Comments, errors::Handler, FileName, Mark, SourceMap};
 use swc_ecma_ast::{Expr, ExprStmt, ModuleItem, Stmt};
+use swc_ecma_ext_transforms::jest;
 pub use swc_ecma_parser::JscTarget;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
 use swc_ecma_transforms::{
@@ -254,6 +255,8 @@ impl Options {
             .fixer(!self.disable_fixer)
             .preset_env(config.env)
             .finalize(syntax, config.module, comments);
+
+        let pass = chain!(pass, Optional::new(jest::jest(), transform.hidden.jest));
 
         BuiltConfig {
             minify: config.minify.unwrap_or(false),
@@ -577,6 +580,16 @@ pub struct TransformConfig {
 
     #[serde(default)]
     pub decorator_metadata: bool,
+
+    #[serde(default)]
+    pub hidden: HiddenTransformConfig,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct HiddenTransformConfig {
+    #[serde(default)]
+    pub jest: bool,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
cc @Brooooooklyn 
Because definitions of ast nodes change over time, I think this is the easiest way for end-users.
(TypeScript introduces new feature, ecmascript spec evolves)

---

Closes #1048.