### PR TITLE
fix(strip): Don't treat type-only exports as concrete references

### DIFF
--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.8.3"
+version = "0.8.4"
 
 [features]
 codegen = ["swc_ecma_codegen"]

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.24.3"
+version = "0.24.4"
 
 [features]
 const-modules = ["dashmap"]

--- a/ecmascript/transforms/tests/typescript_strip.rs
+++ b/ecmascript/transforms/tests/typescript_strip.rs
@@ -3095,3 +3095,18 @@ test!(
     import './types';
     "
 );
+
+test!(
+    Syntax::Typescript(TsConfig {
+        decorators: true,
+        ..Default::default()
+    }),
+    |_| strip(),
+    issue_1124,
+    "
+    import { Type } from './types';
+    export type { Type };
+    ",
+    "
+    "
+);


### PR DESCRIPTION
Fixes #1124.