### PR TITLE
Fix bugs

### DIFF
--- a/ecmascript/transforms/src/compat/es2020/class_properties.rs
+++ b/ecmascript/transforms/src/compat/es2020/class_properties.rs
@@ -443,7 +443,7 @@ impl ClassProperties {
                                         MemberExpr {
                                             span: DUMMY_SP,
                                             obj: ident.clone().as_obj(),
-                                            computed: false,
+                                            computed: prop.computed,
                                             prop: key,
                                         }
                                         .into(),
@@ -460,7 +460,7 @@ impl ClassProperties {
                                     MemberExpr {
                                         span: DUMMY_SP,
                                         obj: ThisExpr { span: DUMMY_SP }.as_obj(),
-                                        computed: false,
+                                        computed: prop.computed,
                                         prop: key,
                                     }
                                     .into(),

--- a/ecmascript/transforms/src/compat/es2020/nullish_coalescing/mod.rs
+++ b/ecmascript/transforms/src/compat/es2020/nullish_coalescing/mod.rs
@@ -50,6 +50,16 @@ impl NullishCoalescing {
 impl Fold for NullishCoalescing {
     noop_fold_type!();
 
+    /// Prevents #1123
+    fn fold_block_stmt(&mut self, s: BlockStmt) -> BlockStmt {
+        s.fold_children_with(&mut NullishCoalescing::default())
+    }
+
+    /// Prevents #1123
+    fn fold_switch_case(&mut self, s: SwitchCase) -> SwitchCase {
+        s.fold_children_with(&mut NullishCoalescing::default())
+    }
+
     fn fold_module_items(&mut self, n: Vec<ModuleItem>) -> Vec<ModuleItem> {
         self.fold_stmt_like(n)
     }

--- a/ecmascript/transforms/src/compat/es2020/opt_chaining.rs
+++ b/ecmascript/transforms/src/compat/es2020/opt_chaining.rs
@@ -133,8 +133,6 @@ impl OptChaining {
 
     /// Only called from [Fold].
     fn handle_call(&mut self, e: CallExpr) -> Result<CondExpr, Expr> {
-        dbg!("Call");
-
         match e.callee {
             ExprOrSuper::Expr(callee) if callee.is_opt_chain() => {
                 let callee = callee.opt_chain().unwrap();
@@ -152,8 +150,6 @@ impl OptChaining {
             ExprOrSuper::Expr(callee) if callee.is_member() => {
                 let callee = callee.member().unwrap();
                 let callee = self.handle_member(callee);
-
-                dbg!(&callee);
 
                 return match callee {
                     Ok(expr) => Ok(CondExpr {
@@ -261,7 +257,6 @@ impl OptChaining {
     }
 
     fn unwrap(&mut self, e: OptChainExpr) -> CondExpr {
-        dbg!("unwrap()");
         let span = e.span;
         let cons = undefined(span);
 

--- a/ecmascript/transforms/src/compat/es2020/opt_chaining.rs
+++ b/ecmascript/transforms/src/compat/es2020/opt_chaining.rs
@@ -30,7 +30,10 @@ impl Fold for OptChaining {
                 Ok(v) => v,
                 Err(v) => v,
             },
-            Expr::Call(e) => validate!(self.handle_call(e)),
+            Expr::Call(e) => match self.handle_call(e).map(Expr::Cond) {
+                Ok(v) => v,
+                Err(v) => v,
+            },
             _ => e,
         };
 
@@ -129,28 +132,32 @@ impl OptChaining {
     }
 
     /// Only called from [Fold].
-    fn handle_call(&mut self, e: CallExpr) -> Expr {
+    fn handle_call(&mut self, e: CallExpr) -> Result<CondExpr, Expr> {
+        dbg!("Call");
+
         match e.callee {
             ExprOrSuper::Expr(callee) if callee.is_opt_chain() => {
                 let callee = callee.opt_chain().unwrap();
                 let expr = self.unwrap(callee);
 
-                return CondExpr {
+                return Ok(CondExpr {
                     span: DUMMY_SP,
                     alt: Box::new(Expr::Call(CallExpr {
                         callee: ExprOrSuper::Expr(expr.alt),
                         ..e
                     })),
                     ..expr
-                }
-                .into();
+                });
             }
             ExprOrSuper::Expr(callee) if callee.is_member() => {
                 let callee = callee.member().unwrap();
                 let callee = self.handle_member(callee);
 
+                dbg!(&callee);
+
                 return match callee {
-                    Ok(expr) => Expr::Cond(CondExpr {
+                    Ok(expr) => Ok(CondExpr {
+                        span: e.span,
                         alt: Box::new(Expr::Call(CallExpr {
                             span: DUMMY_SP,
                             callee: expr.alt.as_callee(),
@@ -159,16 +166,16 @@ impl OptChaining {
                         })),
                         ..expr
                     }),
-                    Err(callee) => Expr::Call(CallExpr {
+                    Err(callee) => Err(Expr::Call(CallExpr {
                         callee: callee.as_callee(),
                         ..e
-                    }),
+                    })),
                 };
             }
             _ => {}
         }
 
-        Expr::Call(e)
+        Err(Expr::Call(e))
     }
 
     /// Returns `Ok` if it handled optional chaining.
@@ -177,6 +184,35 @@ impl OptChaining {
             ExprOrSuper::Expr(obj) if obj.is_member() => {
                 let obj = obj.member().unwrap();
                 let obj = self.handle_member(obj).map(Expr::Cond);
+                let (obj, handled) = match obj {
+                    Ok(v) => (v, true),
+                    Err(v) => (v, false),
+                };
+
+                match obj {
+                    Expr::Cond(obj) => {
+                        let cond_expr = CondExpr {
+                            span: DUMMY_SP,
+                            alt: Box::new(Expr::Member(MemberExpr {
+                                obj: ExprOrSuper::Expr(obj.alt),
+                                ..e
+                            })),
+                            ..obj
+                        };
+                        //
+                        return if handled {
+                            Ok(cond_expr)
+                        } else {
+                            Err(Expr::Cond(cond_expr))
+                        };
+                    }
+                    _ => ExprOrSuper::Expr(Box::new(obj)),
+                }
+            }
+
+            ExprOrSuper::Expr(obj) if obj.is_call() => {
+                let obj = obj.call().unwrap();
+                let obj = self.handle_call(obj).map(Expr::Cond);
                 let (obj, handled) = match obj {
                     Ok(v) => (v, true),
                     Err(v) => (v, false),
@@ -225,6 +261,7 @@ impl OptChaining {
     }
 
     fn unwrap(&mut self, e: OptChainExpr) -> CondExpr {
+        dbg!("unwrap()");
         let span = e.span;
         let cons = undefined(span);
 

--- a/ecmascript/transforms/tests/es2020_class_properties.rs
+++ b/ecmascript/transforms/tests/es2020_class_properties.rs
@@ -6,7 +6,7 @@ use swc_ecma_transforms::{
         es2015::{arrow, block_scoping, classes, function_name},
         es2016::exponentation,
         es2017::async_to_generator,
-        es2020::class_properties,
+        es2020::{class_properties, typescript_class_properties},
         es3::reserved_words,
     },
     proposals::decorators,
@@ -4857,4 +4857,108 @@ expect(foo.x).toBe(1);
 expect(foo.y).toBe('bar');
 
 "#
+);
+
+test!(
+    syntax(),
+    |_| typescript_class_properties(),
+    issue_1122_1,
+    "
+const identifier = 'bar';
+
+class Foo {
+  [identifier] = 5;
+}
+
+
+",
+    "
+const identifier = \"bar\";
+class Foo {
+    constructor(){
+        this[identifier] = 5;
+    }
+}
+    "
+);
+
+test!(
+    syntax(),
+    |_| typescript_class_properties(),
+    issue_1122_2,
+    "
+const identifier = 'bar';
+
+class Foo {
+  identifier = 5;
+}
+",
+    "
+    const identifier = \"bar\";
+    class Foo {
+        constructor(){
+            this.identifier = 5;
+        }
+    }
+    "
+);
+
+test!(
+    syntax(),
+    |_| typescript_class_properties(),
+    issue_1122_3,
+    "
+const identifier = 'bar';
+
+class Foo {
+  ['identifier'] = 5;
+}
+    ",
+    "
+const identifier = \"bar\";
+class Foo {
+    constructor(){
+        this[\"identifier\"] = 5;
+    }
+}
+    "
+);
+
+test!(
+    syntax(),
+    |_| typescript_class_properties(),
+    issue_1122_4,
+    "
+const identifier = 'bar';
+
+class Foo {
+  static [identifier] = 5;
+}
+  ",
+    "
+const identifier = \"bar\";
+class Foo {
+}
+Foo[identifier] = 5;
+
+    "
+);
+
+test!(
+    syntax(),
+    |_| typescript_class_properties(),
+    issue_1122_5,
+    "
+const identifier = 'bar';
+
+class Foo {
+  static identifier = 5;
+}
+  ",
+    "
+const identifier = \"bar\";
+class Foo {
+}
+Foo.identifier = 5;
+  "
 );

--- a/ecmascript/transforms/tests/es2020_optional_chaining.rs
+++ b/ecmascript/transforms/tests/es2020_optional_chaining.rs
@@ -636,8 +636,34 @@ test!(
 expect(obj?.a?.b?.c()).toBe(2)
 ",
     "
-    var ref, ref1;
+  var ref, ref1;
 expect(obj === null || obj === void 0 ? void 0 : (ref = obj.a) === null || ref === void 0 ? void 0 \
      : (ref1 = ref.b) === null || ref1 === void 0 ? void 0 : ref1.c()).toBe(2);
 "
+);
+
+test!(
+    syntax(),
+    |_| tr(()),
+    issue_1130_1,
+    "
+const result = data?.filter(item => Math.random() > 0.5).map(item => JSON.stringify(item));
+    ",
+    "
+const result = data === null || data === void 0 ? void 0 : data.filter(item => Math.random() > \
+     0.5).map(item => JSON.stringify(item));
+    "
+);
+
+test!(
+    syntax(),
+    |_| tr(()),
+    issue_1130_2,
+    "
+const r = d?.filter(i => Math.random() > 0.5).map(i => JSON.stringify(i));
+  ",
+    "
+const r = d === null || d === void 0 ? void 0 : d.filter(i => Math.random() > 0.5).map(i => \
+     JSON.stringify(i));
+  "
 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/core",
-  "version": "1.2.34",
+  "version": "1.2.35",
   "description": "Super-fast alternative for babel",
   "homepage": "https://swc.rs",
   "main": "./index.js",


### PR DESCRIPTION
swc_ecma_transforms:
 - Handle typescript class properties correctly. (Closes #1122)
 - Handle optional chaining properly. (Closes #1130)
 - Inject variables for nullisn coalescing in correct scope (Closes #1123)