### PR TITLE
Fixes for typescript type checker

### DIFF
--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.36.0"
+version = "0.36.1"
 
 [dependencies]
 bitflags = "1"

--- a/ecmascript/codegen/src/typescript.rs
+++ b/ecmascript/codegen/src/typescript.rs
@@ -257,10 +257,11 @@ impl<'a> Emitter<'a> {
         self.emit_list(n.span, Some(&n.params), ListFormat::Parameters)?;
         punct!("]");
 
-        punct!(":");
-        formatting_space!();
-        emit!(n.type_ann);
-        semi!();
+        if let Some(type_ann) = &n.type_ann {
+            punct!(":");
+            formatting_space!();
+            emit!(type_ann);
+        }
     }
 
     #[emitter]

--- a/ecmascript/codegen/src/typescript.rs
+++ b/ecmascript/codegen/src/typescript.rs
@@ -82,7 +82,11 @@ impl<'a> Emitter<'a> {
     fn emit_ts_constructor_signature_decl(&mut self, n: &TsConstructSignatureDecl) -> Result {
         self.emit_leading_comments_of_pos(n.span().lo())?;
 
-        unimplemented!("emit_ts_constructor_signature_decl")
+        keyword!("constructor");
+
+        punct!("(");
+        self.emit_list(n.span, Some(&n.params), ListFormat::Parameters)?;
+        punct!(")");
     }
 
     #[emitter]


### PR DESCRIPTION
swc_ecma_codegen:
 - Fix codegen of `TsConstructorSignature`
 - Fix codegen of `TsIndexSignature`


--- 

This branch will be used as a cargo override.