### PR TITLE
Fix Visitor.ts properties

### DIFF
--- a/node-swc/src/Visitor.ts
+++ b/node-swc/src/Visitor.ts
@@ -722,7 +722,7 @@ export default class Visitor {
 
   visitTsEnumDeclaration(n: TsEnumDeclaration): Declaration {
     n.id = this.visitIdentifier(n.id);
-    n.member = this.visitTsEnumMembers(n.member);
+    n.members = this.visitTsEnumMembers(n.members);
     return n;
   }
 
@@ -1656,7 +1656,7 @@ export default class Visitor {
   }
 
   visitObjectPattern(n: ObjectPattern): Pattern {
-    n.props = this.visitObjectPatternProperties(n.props);
+    n.properties = this.visitObjectPatternProperties(n.properties);
     n.typeAnnotation = this.visitTsTypeAnnotation(n.typeAnnotation);
     return n;
   }

--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -1402,7 +1402,7 @@ export interface ArrayPattern extends Node, HasSpan, PatternBase {
 export interface ObjectPattern extends Node, HasSpan, PatternBase {
   type: "ObjectPattern";
 
-  props: ObjectPatternProperty[];
+  properties: ObjectPatternProperty[];
 }
 
 export interface AssignmentPattern extends Node, HasSpan, PatternBase {
@@ -2029,7 +2029,7 @@ export interface TsEnumDeclaration extends Node, HasSpan {
   declare: boolean;
   is_const: boolean;
   id: Identifier;
-  member: TsEnumMember[];
+  members: TsEnumMember[];
 }
 
 export interface TsEnumMember extends Node, HasSpan {


### PR DESCRIPTION
It seems that the types for `TsEnumDeclaration` and `ObjectPattern` are slightly off. I found this when parsing a large TypeScript codebase and then debugging the issue. This PR fixes the types and implementation files.