### PR TITLE
[typescript] 4.1 mapped type 'as' clause

### DIFF
--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.9.3"
+version = "0.9.4"
 
 [features]
 codegen = ["swc_ecma_codegen"]

--- a/ecmascript/ast/src/typescript.rs
+++ b/ecmascript/ast/src/typescript.rs
@@ -660,6 +660,8 @@ pub struct TsMappedType {
     #[serde(default)]
     pub readonly: Option<TruePlusMinus>,
     pub type_param: TsTypeParam,
+    #[serde(default, rename = "nameType")]
+    pub name_type: Option<Box<TsType>>,
     #[serde(default)]
     pub optional: Option<TruePlusMinus>,
     #[serde(default, rename = "typeAnnotation")]

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.38.0"
+version = "0.38.1"
 
 [features]
 default = []

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -1405,6 +1405,11 @@ impl<I: Tokens> Parser<I> {
 
         expect!('[');
         let type_param = self.parse_ts_mapped_type_param()?;
+        let name_type = if eat!("as") {
+            Some(self.parse_ts_type()?)
+        } else {
+            None
+        };
         expect!(']');
 
         let mut optional = None;
@@ -1429,6 +1434,7 @@ impl<I: Tokens> Parser<I> {
             readonly,
             optional,
             type_param,
+            name_type,
             type_ann,
         })
     }

--- a/ecmascript/parser/tests/typescript/es2019/from-entries/input.ts.json
+++ b/ecmascript/parser/tests/typescript/es2019/from-entries/input.ts.json
@@ -237,6 +237,7 @@
                   },
                   "default": null
                 },
+                "nameType": null,
                 "optional": null,
                 "typeAnnotation": {
                   "type": "TsTypeReference",

--- a/ecmascript/parser/tests/typescript/types/mapped/input.ts
+++ b/ecmascript/parser/tests/typescript/types/mapped/input.ts
@@ -2,3 +2,4 @@ let map: { [P in string]: number; };
 let map: { readonly [P in string]?: number; };
 let map: { +readonly [P in string]+?: number; };
 let map: { -readonly [P in string]-?: number };
+let map: { [P in string as string]: number };

--- a/ecmascript/parser/tests/typescript/types/mapped/input.ts.json
+++ b/ecmascript/parser/tests/typescript/types/mapped/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 180,
+    "end": 226,
     "ctxt": 0
   },
   "body": [
@@ -75,6 +75,7 @@
                   },
                   "default": null
                 },
+                "nameType": null,
                 "optional": null,
                 "typeAnnotation": {
                   "type": "TsKeywordType",
@@ -163,6 +164,7 @@
                   },
                   "default": null
                 },
+                "nameType": null,
                 "optional": true,
                 "typeAnnotation": {
                   "type": "TsKeywordType",
@@ -251,6 +253,7 @@
                   },
                   "default": null
                 },
+                "nameType": null,
                 "optional": "+",
                 "typeAnnotation": {
                   "type": "TsKeywordType",
@@ -339,6 +342,7 @@
                   },
                   "default": null
                 },
+                "nameType": null,
                 "optional": "-",
                 "typeAnnotation": {
                   "type": "TsKeywordType",

--- a/ecmascript/parser/tests/typescript/types/mapped/input.ts.json
+++ b/ecmascript/parser/tests/typescript/types/mapped/input.ts.json
@@ -357,6 +357,103 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 181,
+        "end": 226,
+        "ctxt": 0
+      },
+      "kind": "let",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 185,
+            "end": 225,
+            "ctxt": 0
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 185,
+              "end": 188,
+              "ctxt": 0
+            },
+            "value": "map",
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 188,
+                "end": 225,
+                "ctxt": 0
+              },
+              "typeAnnotation": {
+                "type": "TsMappedType",
+                "span": {
+                  "start": 190,
+                  "end": 225,
+                  "ctxt": 0
+                },
+                "readonly": null,
+                "typeParam": {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 193,
+                    "end": 204,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 193,
+                      "end": 194,
+                      "ctxt": 0
+                    },
+                    "value": "P",
+                    "typeAnnotation": null,
+                    "optional": false
+                  },
+                  "constraint": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 198,
+                      "end": 204,
+                      "ctxt": 0
+                    },
+                    "kind": "string"
+                  },
+                  "default": null
+                },
+                "nameType": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 208,
+                    "end": 214,
+                    "ctxt": 0
+                  },
+                  "kind": "string"
+                },
+                "optional": null,
+                "typeAnnotation": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 217,
+                    "end": 223,
+                    "ctxt": 0
+                  },
+                  "kind": "number"
+                }
+              }
+            },
+            "optional": false
+          },
+          "init": null,
+          "definite": false
+        }
+      ]
     }
   ],
   "interpreter": null

--- a/ecmascript/visit/src/lib.rs
+++ b/ecmascript/visit/src/lib.rs
@@ -1525,6 +1525,7 @@ define!({
         pub span: Span,
         pub readonly: Option<TruePlusMinus>,
         pub type_param: TsTypeParam,
+        pub name_type: Option<Box<TsType>>,
         pub optional: Option<TruePlusMinus>,
         pub type_ann: Option<Box<TsType>>,
     }


### PR DESCRIPTION
Syntax:

```ts
let map: { [P in string as string]: number };
```