### PR TITLE
bundler: Fix dead code elimination

### DIFF
--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.10.3"
+version = "0.10.4"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/bundler/tests/fixture/issue-1156-1/input/entry.ts
+++ b/bundler/tests/fixture/issue-1156-1/input/entry.ts
@@ -1,0 +1,15 @@
+import { d, D } from "./q.ts";
+
+class A {
+  private s: D = d();
+
+  a() {
+    this.s.resolve();
+  }
+
+  b() {
+    this.s = d();
+  }
+}
+
+new A();

--- a/bundler/tests/fixture/issue-1156-1/input/q.ts
+++ b/bundler/tests/fixture/issue-1156-1/input/q.ts
@@ -1,0 +1,12 @@
+export interface D {
+    resolve: any;
+    reject: any;
+}
+
+export function d(): D {
+    let methods;
+    const promise = new Promise((resolve, reject) => {
+        methods = { resolve, reject };
+    });
+    return Object.assign(promise, methods);
+}

--- a/bundler/tests/fixture/issue-1156-1/output/entry.ts
+++ b/bundler/tests/fixture/issue-1156-1/output/entry.ts
@@ -1,0 +1,20 @@
+function d() {
+    let methods;
+    const promise = new Promise((resolve, reject)=>{
+        methods = {
+            resolve,
+            reject
+        };
+    });
+    return Object.assign(promise, methods);
+}
+class A {
+    s = d();
+    a() {
+        this.s.resolve();
+    }
+    b() {
+        this.s = d();
+    }
+}
+new A();

--- a/bundler/tests/fixture/issue-1156-2/input/entry.ts
+++ b/bundler/tests/fixture/issue-1156-2/input/entry.ts
@@ -1,0 +1,12 @@
+import { d, D } from "./q.ts";
+
+class A {
+  private s: D = d();
+
+  a() {
+    this.s.resolve();
+  }
+
+}
+
+new A();

--- a/bundler/tests/fixture/issue-1156-2/input/q.ts
+++ b/bundler/tests/fixture/issue-1156-2/input/q.ts
@@ -1,0 +1,12 @@
+export interface D {
+    resolve: any;
+    reject: any;
+}
+
+export function d(): D {
+    let methods;
+    const promise = new Promise((resolve, reject) => {
+        methods = { resolve, reject };
+    });
+    return Object.assign(promise, methods);
+}

--- a/bundler/tests/fixture/issue-1156-2/output/entry.ts
+++ b/bundler/tests/fixture/issue-1156-2/output/entry.ts
@@ -1,0 +1,17 @@
+function d() {
+    let methods;
+    const promise = new Promise((resolve, reject)=>{
+        methods = {
+            resolve,
+            reject
+        };
+    });
+    return Object.assign(promise, methods);
+}
+class A {
+    s = d();
+    a() {
+        this.s.resolve();
+    }
+}
+new A();

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.9.2"
+version = "0.9.3"
 
 [features]
 codegen = ["swc_ecma_codegen"]

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.25.2"
+version = "0.25.3"
 
 [features]
 const-modules = ["dashmap"]

--- a/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
@@ -542,6 +542,19 @@ impl VisitMut for Dce<'_> {
         self.mark(&mut node.arg);
     }
 
+    fn visit_mut_var_declarator(&mut self, d: &mut VarDeclarator) {
+        if self.is_marked(d.span) {
+            return;
+        }
+
+        if d.init.is_none() {
+            d.span = d.span.apply_mark(self.config.used_mark);
+            self.mark(&mut d.name);
+        }
+
+        d.visit_mut_children_with(self);
+    }
+
     fn visit_mut_var_decl(&mut self, mut var: &mut VarDecl) {
         if self.is_marked(var.span) {
             return;

--- a/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
@@ -2,7 +2,7 @@ use self::side_effect::{ImportDetector, SideEffectVisitor};
 use crate::pass::RepeatedJsPass;
 use fxhash::FxHashSet;
 use retain_mut::RetainMut;
-use std::{any::type_name, borrow::Cow, mem::take};
+use std::{any::type_name, borrow::Cow, fmt::Debug, mem::take};
 use swc_atoms::JsWord;
 use swc_common::{
     chain,
@@ -614,7 +614,7 @@ impl VisitMut for Dce<'_> {
 impl Dce<'_> {
     fn visit_mut_stmt_like<T>(&mut self, items: &mut Vec<T>)
     where
-        T: StmtLike + VisitMutWith<Self> + Spanned + std::fmt::Debug,
+        T: Debug + StmtLike + VisitMutWith<Self> + Spanned + std::fmt::Debug,
         T: for<'any> VisitWith<SideEffectVisitor<'any>> + VisitWith<ImportDetector>,
         Vec<T>: VisitMutWith<Self>,
     {
@@ -673,6 +673,7 @@ impl Dce<'_> {
                 };
 
                 if !preserved.contains(&idx) {
+                    log::trace!("Dropping {}: {:?}", idx, item);
                     self.dropped = true;
                     idx += 1;
                     return None;

--- a/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
@@ -158,7 +158,7 @@ impl VisitMut for Dce<'_> {
 
         if self.marking_phase || self.included.contains(&node.ident.to_id()) {
             node.class.span = node.class.span.apply_mark(self.config.used_mark);
-            self.mark(&mut node.class.super_class);
+            self.mark(&mut node.class);
         }
 
         node.visit_mut_children_with(self)

--- a/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/mod.rs
@@ -547,11 +547,6 @@ impl VisitMut for Dce<'_> {
             return;
         }
 
-        if d.init.is_none() {
-            d.span = d.span.apply_mark(self.config.used_mark);
-            self.mark(&mut d.name);
-        }
-
         d.visit_mut_children_with(self);
     }
 
@@ -607,6 +602,10 @@ impl VisitMut for Dce<'_> {
     }
 
     fn visit_mut_stmts(&mut self, n: &mut Vec<Stmt>) {
+        if !self.decl_dropping_phase {
+            n.visit_mut_children_with(self);
+            return;
+        }
         self.visit_mut_stmt_like(n)
     }
 }

--- a/ecmascript/transforms/src/optimization/simplify/dce/side_effect.rs
+++ b/ecmascript/transforms/src/optimization/simplify/dce/side_effect.rs
@@ -100,6 +100,19 @@ impl Visit for SideEffectVisitor<'_> {
         node.visit_children_with(self)
     }
 
+    fn visit_var_declarator(&mut self, n: &VarDeclarator, _: &dyn Node) {
+        if self.found {
+            return;
+        }
+
+        if n.init.is_none() {
+            self.found = true;
+            return;
+        }
+
+        n.visit_children_with(self);
+    }
+
     fn visit_assign_expr(&mut self, node: &AssignExpr, _: &dyn Node) {
         if self.found {
             return;

--- a/ecmascript/transforms/src/resolver.rs
+++ b/ecmascript/transforms/src/resolver.rs
@@ -768,10 +768,12 @@ impl<'a> VisitMut for Resolver<'a> {
     fn visit_mut_class_prop(&mut self, p: &mut ClassProp) {
         p.decorators.visit_mut_with(self);
 
-        let old = self.ident_type;
-        self.ident_type = IdentType::Binding;
-        p.key.visit_mut_with(self);
-        self.ident_type = old;
+        if p.computed {
+            let old = self.ident_type;
+            self.ident_type = IdentType::Binding;
+            p.key.visit_mut_with(self);
+            self.ident_type = old;
+        }
 
         let old = self.ident_type;
         self.ident_type = IdentType::Ref;

--- a/ecmascript/transforms/src/resolver/tests.rs
+++ b/ecmascript/transforms/src/resolver/tests.rs
@@ -1450,7 +1450,7 @@ new A();
     "
 );
 
-identical_ts!(
+to_ts!(
     ts_resolver_nested_type_ref,
     "
 import { Nullable } from 'nullable';
@@ -1458,6 +1458,15 @@ import { SomeOther } from 'some';
 import { Another } from 'some';
 class A extends Nullable {
     other: Nullable<Another>;
+}
+new A();
+    ",
+    "
+import { Nullable } from 'nullable';
+import { SomeOther } from 'some';
+import { Another } from 'some';
+class A extends Nullable {
+    other__0: Nullable<Another>;
 }
 new A();
     "

--- a/ecmascript/transforms/tests/optimization_simplify.rs
+++ b/ecmascript/transforms/tests/optimization_simplify.rs
@@ -492,5 +492,26 @@ test!(
       
     new A();
     ",
-    ""
+    "
+    function d() {
+        let methods;
+        const promise = new Promise((resolve, reject)=>{
+            methods = {
+                resolve,
+                reject
+            };
+        });
+        return Object.assign(promise, methods);
+    }
+    class A {
+        s = d();
+        a() {
+            this.s.resolve();
+        }
+        b() {
+            this.s = d();
+        }
+    }
+    new A();
+    "
 );

--- a/ecmascript/transforms/tests/optimization_simplify_dce.rs
+++ b/ecmascript/transforms/tests/optimization_simplify_dce.rs
@@ -631,3 +631,96 @@ test!(
     }
     "
 );
+
+test!(
+    Syntax::Typescript(TsConfig {
+        decorators: true,
+        ..Default::default()
+    }),
+    |_| chain!(strip(), resolver(), dce(Default::default()),),
+    issue_1156_2,
+    "
+    interface D {
+        resolve: any;
+        reject: any;
+    }
+    
+    function d(): D {
+        let methods;
+        const promise = new Promise((resolve, reject) => {
+          methods = { resolve, reject };
+        });
+        return Object.assign(promise, methods);
+    }
+
+    class A {
+        private s: D = d();
+      
+        a() {
+            this.s.resolve();
+        }
+      
+        b() {
+            this.s = d();
+        }
+    }
+      
+    new A();
+    ",
+    ""
+);
+
+test!(
+    Syntax::Typescript(TsConfig {
+        decorators: true,
+        ..Default::default()
+    }),
+    |_| chain!(strip(), resolver(), dce(Default::default()),),
+    issue_1156_3,
+    "
+    function d() {
+        let methods;
+        const promise = new Promise((resolve, reject) => {
+          methods = { resolve, reject };
+        });
+        return Object.assign(promise, methods);
+    }
+
+    d()
+    ",
+    ""
+);
+
+test!(
+    Syntax::Typescript(TsConfig {
+        decorators: true,
+        ..Default::default()
+    }),
+    |_| chain!(strip(), resolver(), dce(Default::default()),),
+    issue_1156_4,
+    "
+    interface D {
+        resolve: any;
+        reject: any;
+    }
+    
+    function d(): D {
+        let methods;
+        const promise = new Promise((resolve, reject) => {
+          methods = { resolve, reject };
+        });
+        return Object.assign(promise, methods);
+    }
+
+    class A {
+        private s: D = d();
+      
+        a() {
+            this.s.resolve();
+        }
+    }
+      
+    new A();
+    ",
+    ""
+);

--- a/ecmascript/transforms/tests/optimization_simplify_dce.rs
+++ b/ecmascript/transforms/tests/optimization_simplify_dce.rs
@@ -756,6 +756,22 @@ test!(
     new A();
     ",
     "
-    
+    function d() {
+        let methods;
+        const promise = new Promise((resolve, reject)=>{
+            methods = {
+                resolve,
+                reject
+            };
+        });
+        return Object.assign(promise, methods);
+    }
+    class A {
+        s = d();
+        a() {
+            this.s.resolve();
+        }
+    }
+    new A();
     "
 );

--- a/ecmascript/transforms/tests/optimization_simplify_dce.rs
+++ b/ecmascript/transforms/tests/optimization_simplify_dce.rs
@@ -667,7 +667,28 @@ test!(
       
     new A();
     ",
-    ""
+    "
+    function d() {
+        let methods;
+        const promise = new Promise((resolve, reject)=>{
+            methods = {
+                resolve,
+                reject
+            };
+        });
+        return Object.assign(promise, methods);
+    }
+    class A {
+        s = d();
+        a() {
+            this.s.resolve();
+        }
+        b() {
+            this.s = d();
+        }
+    }
+    new A();
+    "
 );
 
 test!(
@@ -688,7 +709,19 @@ test!(
 
     d()
     ",
-    ""
+    "
+    function d() {
+        let methods;
+        const promise = new Promise((resolve, reject)=>{
+            methods = {
+                resolve,
+                reject
+            };
+        });
+        return Object.assign(promise, methods);
+    }
+    d();
+    "
 );
 
 test!(
@@ -722,5 +755,7 @@ test!(
       
     new A();
     ",
-    ""
+    "
+    
+    "
 );

--- a/ecmascript/transforms/tests/optimization_simplify_inlining.rs
+++ b/ecmascript/transforms/tests/optimization_simplify_inlining.rs
@@ -2170,3 +2170,62 @@ test!(
     }
     "
 );
+
+test!(
+    Syntax::Typescript(TsConfig {
+        decorators: true,
+        ..Default::default()
+    }),
+    |_| chain!(strip(), resolver(), inlining(Default::default())),
+    issue_1156_2,
+    "
+    interface D {
+        resolve: any;
+        reject: any;
+    }
+    
+    function d(): D {
+        let methods;
+        const promise = new Promise((resolve, reject) => {
+          methods = { resolve, reject };
+        });
+        return Object.assign(promise, methods);
+    }
+
+    class A {
+        private s: D = d();
+      
+        a() {
+            this.s.resolve();
+        }
+      
+        b() {
+            this.s = d();
+        }
+    }
+      
+    new A();
+    ",
+    "
+    function d() {
+        let methods;
+        const promise = new Promise((resolve, reject)=>{
+            methods = {
+                resolve,
+                reject
+            };
+        });
+        return Object.assign(promise, methods);
+    }
+    class A {
+        s = d();
+        a() {
+            this.s.resolve();
+        }
+        b() {
+            this.s = d();
+        }
+    }
+    new A();
+    "
+);


### PR DESCRIPTION
swc_bundler:
 - Fix dce bug. (Closes #1156)

swc_ecma_transforms:
 - resolver: Ignore non-computed class properties.
 - dce: Handle usages in class property initializers.

---


### Initial hygiene

```js
function d#4() {
    let methods#5;
    const promise#5 = new Promise#4((resolve#6, reject#6)=>{
        methods#5 = {
            resolve#6,
            reject#6
        };
    });
    return Object#4.assign#0(promise#5, methods#5);
}
class A#3 {
    s#3 = d#4();
    a#0() {
        this.s#0.resolve#0();
    }
    b#0() {
        this.s#0 = d#4();
    }
}
new A#3();
```