### PR TITLE
bundler: Handle computed accesses correctly

### DIFF
--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -36,6 +36,7 @@ swc_ecma_visit = {version = "0.19.0", path = "../ecmascript/visit"}
 
 [dev-dependencies]
 reqwest = {version = "0.10.8", features = ["blocking"]}
+tempfile = "3.1.0"
 testing = {version = "0.10.0", path = "../testing"}
 url = "2.1.1"
 walkdir = "2"

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.11.0"
+version = "0.11.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/bundler/src/bundler/chunk/computed_key.rs
+++ b/bundler/src/bundler/chunk/computed_key.rs
@@ -1,8 +1,5 @@
 use super::plan::Plan;
-use crate::{
-    bundler::load::TransformedModule, debug::print_hygiene, util::CHashSet, Bundler, Load,
-    ModuleId, Resolve,
-};
+use crate::{bundler::load::TransformedModule, util::CHashSet, Bundler, Load, ModuleId, Resolve};
 use anyhow::Error;
 use std::mem::take;
 use swc_atoms::js_word;
@@ -112,8 +109,7 @@ where
             }
         };
         let module = self.merge_imports(&plan, module_plan, module, info, merged, false)?;
-
-        print_hygiene("Imports", &self.cm, &module);
+        // print_hygiene("Imports", &self.cm, &module);
 
         Ok(module)
     }

--- a/bundler/src/bundler/chunk/export.rs
+++ b/bundler/src/bundler/chunk/export.rs
@@ -111,6 +111,19 @@ where
 
                 if let Some(id) = id_of_export_namespace_from {
                     dep = self.wrap_esm_as_a_var(plan, dep, &imported, merged, id)?;
+
+                    let module_plan;
+                    let module_plan = match plan.normal.get(&info.id) {
+                        Some(v) => v,
+                        None => {
+                            module_plan = Default::default();
+                            &module_plan
+                        }
+                    };
+
+                    dep = self
+                        .merge_imports(plan, &module_plan, dep, &info, merged, false)
+                        .context("failed to merge imports")?;
                 } else {
                     dep = self.remark_exports(dep, src.ctxt, None, false);
                 }

--- a/bundler/src/bundler/chunk/export.rs
+++ b/bundler/src/bundler/chunk/export.rs
@@ -110,7 +110,7 @@ where
                 });
 
                 if let Some(id) = id_of_export_namespace_from {
-                    dep = self.wrap_esm_as_a_var(plan, nomral_plan, dep, info, merged, id)?;
+                    dep = self.wrap_esm_as_a_var(plan, dep, &imported, merged, id)?;
                 } else {
                     dep = self.remark_exports(dep, src.ctxt, None, false);
                 }

--- a/bundler/src/bundler/chunk/export.rs
+++ b/bundler/src/bundler/chunk/export.rs
@@ -110,7 +110,7 @@ where
                 });
 
                 if let Some(id) = id_of_export_namespace_from {
-                    dep = self.wrap_esm_as_a_var(info, dep, id)?;
+                    dep = self.wrap_esm_as_a_var(plan, nomral_plan, dep, info, merged, id)?;
                 } else {
                     dep = self.remark_exports(dep, src.ctxt, None, false);
                 }

--- a/bundler/src/bundler/chunk/merge.rs
+++ b/bundler/src/bundler/chunk/merge.rs
@@ -1,7 +1,6 @@
 use super::plan::{NormalPlan, Plan};
 use crate::{
     bundler::load::{Imports, Specifier, TransformedModule},
-    debug::print_hygiene,
     id::ModuleId,
     load::Load,
     resolve::Resolve,
@@ -16,7 +15,6 @@ use std::{borrow::Cow, mem::take};
 use swc_atoms::js_word;
 use swc_common::{FileName, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_transforms::{fixer, hygiene};
 use swc_ecma_utils::prepend_stmts;
 use swc_ecma_visit::{noop_fold_type, noop_visit_mut_type, Fold, FoldWith, VisitMut, VisitMutWith};
 use util::CHashSet;
@@ -376,7 +374,7 @@ where
     }
 
     fn finalize_merging_of_entry(&self, plan: &Plan, entry: &mut Module) {
-        print_hygiene("done", &self.cm, &entry);
+        // print_hygiene("done", &self.cm, &entry);
 
         entry.body.retain_mut(|item| {
             match item {
@@ -432,14 +430,14 @@ where
 
         entry.visit_mut_with(&mut DefaultRenamer);
 
-        print_hygiene(
-            "done-clean",
-            &self.cm,
-            &entry
-                .clone()
-                .fold_with(&mut hygiene())
-                .fold_with(&mut fixer(None)),
-        );
+        // print_hygiene(
+        //     "done-clean",
+        //     &self.cm,
+        //     &entry
+        //         .clone()
+        //         .fold_with(&mut hygiene())
+        //         .fold_with(&mut fixer(None)),
+        // );
     }
 }
 

--- a/bundler/src/bundler/chunk/merge.rs
+++ b/bundler/src/bundler/chunk/merge.rs
@@ -1,6 +1,6 @@
-use super::plan::Plan;
+use super::plan::{NormalPlan, Plan};
 use crate::{
-    bundler::load::{Imports, Specifier},
+    bundler::load::{Imports, Specifier, TransformedModule},
     debug::print_hygiene,
     id::ModuleId,
     load::Load,
@@ -77,11 +77,9 @@ where
             }
 
             // We handle this kind of modules specially.
-            if self.scope.should_be_wrapped_with_a_fn(info.id) {
-                dbg!(&info.exports);
-                dbg!(&info.imports);
-                return Ok(entry);
-            }
+            // if self.scope.should_be_wrapped_with_a_fn(info.id) {
+            //     return Ok(entry);
+            // }
 
             log::debug!(
                 "Merge: ({}) {} <= {:?}",
@@ -95,270 +93,286 @@ where
 
             // print_hygiene("after: merge_reexports", &self.cm, &entry);
 
-            let to_merge: Vec<_> = info
-                .imports
-                .specifiers
-                .iter()
-                .filter(|(src, _)| {
-                    log::trace!("Checking: {} <= {}", info.fm.name, src.src.value);
-
-                    // Import and export from same file. We use export to merge it.
-                    if info
-                        .exports
-                        .reexports
-                        .iter()
-                        .any(|(es, _)| es.module_id == src.module_id)
-                    {
-                        return false;
-                    }
-
-                    // Skip if a dependency is going to be merged by other dependency
-                    module_plan.chunks.contains(&src.module_id)
-                })
-                .collect();
-
-            let (deps, transitive_deps) = util::join(
-                || {
-                    to_merge
-                        .into_par_iter()
-                        .map(|(src, specifiers)| -> Result<Option<_>, Error> {
-                            self.run(|| {
-                                if !merged.insert(src.module_id) {
-                                    log::debug!("Skipping: {} <= {}", info.fm.name, src.src.value);
-                                    return Ok(None);
-                                }
-
-                                log::debug!("Merging: {} <= {}", info.fm.name, src.src.value);
-
-                                let dep_info = self.scope.get_module(src.module_id).unwrap();
-                                info.helpers.extend(&dep_info.helpers);
-                                // In the case of
-                                //
-                                //  a <- b
-                                //  b <- c
-                                //
-                                // we change it to
-                                //
-                                // a <- b + chunk(c)
-                                //
-                                let mut dep = self
-                                    .merge_modules(plan, src.module_id, false, false, merged)
-                                    .with_context(|| {
-                                        format!(
-                                            "failed to merge: ({}):{} <= ({}):{}",
-                                            info.id, info.fm.name, src.module_id, src.src.value
-                                        )
-                                    })?;
-
-                                if dep_info.is_es6 {
-                                    // print_hygiene("dep:before:tree-shaking", &self.cm, &dep);
-
-                                    let is_acccessed_with_computed_key =
-                                        self.scope.should_be_wrapped_with_a_fn(dep_info.id);
-
-                                    // If an import with a computed key exists, we can't shake tree
-                                    if is_acccessed_with_computed_key {
-                                        let id = specifiers
-                                            .iter()
-                                            .find_map(|s| match s {
-                                                Specifier::Namespace { local, all: true } => {
-                                                    Some(local)
-                                                }
-                                                _ => None,
-                                            })
-                                            .unwrap();
-
-                                        dep = self.wrap_esm_as_a_var(
-                                            &dep_info,
-                                            dep,
-                                            id.clone().replace_mark(dep_info.mark()).into_ident(),
-                                        )?;
-                                    } else {
-                                        if let Some(imports) = info
-                                            .imports
-                                            .specifiers
-                                            .iter()
-                                            .find(|(s, _)| s.module_id == dep_info.id)
-                                            .map(|v| &v.1)
-                                        {
-                                            // print_hygiene(
-                                            //     "dep: before remarking exports",
-                                            //     &self.cm,
-                                            //     &dep,
-                                            // );
-
-                                            dep = self.remark_exports(
-                                                dep,
-                                                dep_info.ctxt(),
-                                                Some(&imports),
-                                                true,
-                                            );
-                                        }
-
-                                        // print_hygiene(
-                                        //     "dep: after remarking exports",
-                                        //     &self.cm,
-                                        //     &dep,
-                                        // );
-                                    }
-                                    // print_hygiene("dep:after:tree-shaking", &self.cm, &dep);
-
-                                    // if let Some(imports) = info
-                                    //     .imports
-                                    //     .specifiers
-                                    //     .iter()
-                                    //     .find(|(s, _)| s.module_id == dep_info.id)
-                                    //     .map(|v| &v.1)
-                                    // {
-                                    //     dep = dep.fold_with(&mut ExportRenamer {
-                                    //         mark: dep_info.mark(),
-                                    //         _exports: &dep_info.exports,
-                                    //         imports: &imports,
-                                    //         extras: vec![],
-                                    //     });
-                                    // }
-                                    // print_hygiene("dep:after:export-renamer", &self.cm, &dep);
-
-                                    dep = dep.fold_with(&mut Unexporter);
-                                }
-                                // print_hygiene("dep:before-injection", &self.cm, &dep);
-
-                                Ok(Some((dep, dep_info)))
-                            })
-                        })
-                        .collect::<Vec<_>>()
-                },
-                || {
-                    let deps = module_plan
-                        .transitive_chunks
-                        .clone()
-                        .into_par_iter()
-                        .map(|id| -> Result<_, Error> {
-                            if !merged.insert(id) {
-                                return Ok(None);
-                            }
-
-                            let dep_info = self.scope.get_module(id).unwrap();
-                            let mut dep = self.merge_modules(plan, id, false, true, merged)?;
-
-                            // print_hygiene("transitive dep", &self.cm, &dep);
-
-                            dep = self.remark_exports(dep, dep_info.ctxt(), None, true);
-                            dep = dep.fold_with(&mut Unexporter);
-
-                            // As transitive deps can have no direct relation with entry,
-                            // remark_exports is not enough.
-                            Ok(Some((dep, dep_info)))
-                        })
-                        .collect::<Vec<_>>();
-
-                    deps
-                },
-            );
-
-            let mut targets = module_plan.chunks.clone();
-
-            for (dep, is_direct) in deps
-                .into_iter()
-                .map(|v| (v, true))
-                .chain(transitive_deps.into_iter().map(|v| (v, false)))
-            {
-                let dep = dep?;
-                let dep = match dep {
-                    Some(v) => v,
-                    None => continue,
-                };
-
-                let (mut dep, dep_info) = dep;
-
-                if let Some(idx) = targets.iter().position(|v| *v == dep_info.id) {
-                    targets.remove(idx);
-                    if let Some(v) = plan.normal.get(&dep_info.id) {
-                        targets.retain(|&id| !v.chunks.contains(&id));
-                    }
-                    if let Some(v) = plan.circular.get(&dep_info.id) {
-                        targets.retain(|&id| !v.chunks.contains(&id));
-                    }
-                }
-
-                // print_hygiene("dep: before injection", &self.cm, &dep);
-
-                if dep_info.is_es6 {
-                    // print_hygiene("entry: before injection", &self.cm, &entry);
-
-                    // Replace import statement / require with module body
-                    let mut injector = Es6ModuleInjector {
-                        imported: take(&mut dep.body),
-                        ctxt: dep_info.ctxt(),
-                        is_direct,
-                    };
-                    entry.body.visit_mut_with(&mut injector);
-
-                    if injector.imported.is_empty() {
-                        // print_hygiene("entry:after:injection", &self.cm, &entry);
-
-                        log::debug!("Merged {} as an es module", info.fm.name);
-                        // print_hygiene(
-                        //     &format!("ES6: {:?} <- {:?}", info.ctxt(), dep_info.ctxt()),
-                        //     &self.cm,
-                        //     &entry,
-                        // );
-                        continue;
-                    }
-
-                    if !is_direct {
-                        prepend_stmts(&mut entry.body, injector.imported.into_iter());
-
-                        // print_hygiene("ES6", &self.cm, &entry);
-                        continue;
-                    }
-
-                    // print_hygiene("entry: failed to inject", &self.cm, &entry);
-
-                    dep.body = take(&mut injector.imported);
-                }
-
-                if self.config.require {
-                    self.merge_cjs(
-                        plan,
-                        is_entry,
-                        &mut entry,
-                        &info,
-                        Cow::Owned(dep),
-                        &dep_info,
-                        &mut targets,
-                    )?;
-                }
-            }
-
-            // if is_entry && self.config.require && !targets.is_empty() {
-            //     log::info!("Injectng remaining: {:?}", targets);
-
-            //     // Handle transitive dependencies
-            //     for target in targets.drain(..) {
-            //         log::trace!(
-            //             "Remaining: {}",
-            //             self.scope.get_module(target).unwrap().fm.name
-            //         );
-
-            //         let dep_info = self.scope.get_module(target).unwrap();
-            //         self.merge_cjs(
-            //             plan,
-            //             &mut entry,
-            //             &info,
-            //             Cow::Borrowed(&dep_info.module),
-            //             &dep_info,
-            //             &mut targets,
-            //         )?;
-            //     }
-            // }
-
-            if is_entry {
-                self.finalize_merging_of_entry(plan, &mut entry);
-            }
+            entry = self
+                .merge_imports(plan, module_plan, entry, &info, merged, is_entry)
+                .context("failed to merge imports")?;
 
             Ok(entry)
         })
+    }
+
+    pub(super) fn merge_imports(
+        &self,
+        plan: &Plan,
+        module_plan: &NormalPlan,
+        mut entry: Module,
+        info: &TransformedModule,
+        merged: &CHashSet<ModuleId>,
+        is_entry: bool,
+    ) -> Result<Module, Error> {
+        let to_merge: Vec<_> = info
+            .imports
+            .specifiers
+            .iter()
+            .filter(|(src, _)| {
+                log::trace!("Checking: {} <= {}", info.fm.name, src.src.value);
+
+                // Import and export from same file. We use export to merge it.
+                if info
+                    .exports
+                    .reexports
+                    .iter()
+                    .any(|(es, _)| es.module_id == src.module_id)
+                {
+                    return false;
+                }
+
+                // Skip if a dependency is going to be merged by other dependency
+                module_plan.chunks.contains(&src.module_id)
+            })
+            .collect();
+
+        let (deps, transitive_deps) = util::join(
+            || {
+                to_merge
+                    .into_par_iter()
+                    .map(|(src, specifiers)| -> Result<Option<_>, Error> {
+                        self.run(|| {
+                            if !merged.insert(src.module_id) {
+                                log::debug!("Skipping: {} <= {}", info.fm.name, src.src.value);
+                                return Ok(None);
+                            }
+
+                            log::debug!("Merging: {} <= {}", info.fm.name, src.src.value);
+
+                            let dep_info = self.scope.get_module(src.module_id).unwrap();
+                            info.helpers.extend(&dep_info.helpers);
+                            // In the case of
+                            //
+                            //  a <- b
+                            //  b <- c
+                            //
+                            // we change it to
+                            //
+                            // a <- b + chunk(c)
+                            //
+                            let mut dep = self
+                                .merge_modules(plan, src.module_id, false, false, merged)
+                                .with_context(|| {
+                                    format!(
+                                        "failed to merge: ({}):{} <= ({}):{}",
+                                        info.id, info.fm.name, src.module_id, src.src.value
+                                    )
+                                })?;
+
+                            if dep_info.is_es6 {
+                                // print_hygiene("dep:before:tree-shaking", &self.cm, &dep);
+
+                                let is_acccessed_with_computed_key =
+                                    self.scope.should_be_wrapped_with_a_fn(dep_info.id);
+
+                                // If an import with a computed key exists, we can't shake tree
+                                if is_acccessed_with_computed_key {
+                                    let id = specifiers
+                                        .iter()
+                                        .find_map(|s| match s {
+                                            Specifier::Namespace { local, all: true } => {
+                                                Some(local)
+                                            }
+                                            _ => None,
+                                        })
+                                        .unwrap();
+
+                                    dep = self.wrap_esm_as_a_var(
+                                        &dep_info,
+                                        dep,
+                                        id.clone().replace_mark(dep_info.mark()).into_ident(),
+                                    )?;
+                                } else {
+                                    if let Some(imports) = info
+                                        .imports
+                                        .specifiers
+                                        .iter()
+                                        .find(|(s, _)| s.module_id == dep_info.id)
+                                        .map(|v| &v.1)
+                                    {
+                                        // print_hygiene(
+                                        //     "dep: before remarking exports",
+                                        //     &self.cm,
+                                        //     &dep,
+                                        // );
+
+                                        dep = self.remark_exports(
+                                            dep,
+                                            dep_info.ctxt(),
+                                            Some(&imports),
+                                            true,
+                                        );
+                                    }
+
+                                    // print_hygiene(
+                                    //     "dep: after remarking exports",
+                                    //     &self.cm,
+                                    //     &dep,
+                                    // );
+                                }
+                                // print_hygiene("dep:after:tree-shaking", &self.cm, &dep);
+
+                                // if let Some(imports) = info
+                                //     .imports
+                                //     .specifiers
+                                //     .iter()
+                                //     .find(|(s, _)| s.module_id == dep_info.id)
+                                //     .map(|v| &v.1)
+                                // {
+                                //     dep = dep.fold_with(&mut ExportRenamer {
+                                //         mark: dep_info.mark(),
+                                //         _exports: &dep_info.exports,
+                                //         imports: &imports,
+                                //         extras: vec![],
+                                //     });
+                                // }
+                                // print_hygiene("dep:after:export-renamer", &self.cm, &dep);
+
+                                dep = dep.fold_with(&mut Unexporter);
+                            }
+                            // print_hygiene("dep:before-injection", &self.cm, &dep);
+
+                            Ok(Some((dep, dep_info)))
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            },
+            || {
+                let deps = module_plan
+                    .transitive_chunks
+                    .clone()
+                    .into_par_iter()
+                    .map(|id| -> Result<_, Error> {
+                        if !merged.insert(id) {
+                            return Ok(None);
+                        }
+
+                        let dep_info = self.scope.get_module(id).unwrap();
+                        let mut dep = self.merge_modules(plan, id, false, true, merged)?;
+
+                        // print_hygiene("transitive dep", &self.cm, &dep);
+
+                        dep = self.remark_exports(dep, dep_info.ctxt(), None, true);
+                        dep = dep.fold_with(&mut Unexporter);
+
+                        // As transitive deps can have no direct relation with entry,
+                        // remark_exports is not enough.
+                        Ok(Some((dep, dep_info)))
+                    })
+                    .collect::<Vec<_>>();
+
+                deps
+            },
+        );
+
+        let mut targets = module_plan.chunks.clone();
+
+        for (dep, is_direct) in deps
+            .into_iter()
+            .map(|v| (v, true))
+            .chain(transitive_deps.into_iter().map(|v| (v, false)))
+        {
+            let dep = dep?;
+            let dep = match dep {
+                Some(v) => v,
+                None => continue,
+            };
+
+            let (mut dep, dep_info) = dep;
+
+            if let Some(idx) = targets.iter().position(|v| *v == dep_info.id) {
+                targets.remove(idx);
+                if let Some(v) = plan.normal.get(&dep_info.id) {
+                    targets.retain(|&id| !v.chunks.contains(&id));
+                }
+                if let Some(v) = plan.circular.get(&dep_info.id) {
+                    targets.retain(|&id| !v.chunks.contains(&id));
+                }
+            }
+
+            // print_hygiene("dep: before injection", &self.cm, &dep);
+
+            if dep_info.is_es6 {
+                // print_hygiene("entry: before injection", &self.cm, &entry);
+
+                // Replace import statement / require with module body
+                let mut injector = Es6ModuleInjector {
+                    imported: take(&mut dep.body),
+                    ctxt: dep_info.ctxt(),
+                    is_direct,
+                };
+                entry.body.visit_mut_with(&mut injector);
+
+                if injector.imported.is_empty() {
+                    // print_hygiene("entry:after:injection", &self.cm, &entry);
+
+                    log::debug!("Merged {} as an es module", info.fm.name);
+                    // print_hygiene(
+                    //     &format!("ES6: {:?} <- {:?}", info.ctxt(), dep_info.ctxt()),
+                    //     &self.cm,
+                    //     &entry,
+                    // );
+                    continue;
+                }
+
+                if !is_direct {
+                    prepend_stmts(&mut entry.body, injector.imported.into_iter());
+
+                    // print_hygiene("ES6", &self.cm, &entry);
+                    continue;
+                }
+
+                // print_hygiene("entry: failed to inject", &self.cm, &entry);
+
+                dep.body = take(&mut injector.imported);
+            }
+
+            if self.config.require {
+                self.merge_cjs(
+                    plan,
+                    is_entry,
+                    &mut entry,
+                    &info,
+                    Cow::Owned(dep),
+                    &dep_info,
+                    &mut targets,
+                )?;
+            }
+        }
+
+        // if is_entry && self.config.require && !targets.is_empty() {
+        //     log::info!("Injectng remaining: {:?}", targets);
+
+        //     // Handle transitive dependencies
+        //     for target in targets.drain(..) {
+        //         log::trace!(
+        //             "Remaining: {}",
+        //             self.scope.get_module(target).unwrap().fm.name
+        //         );
+
+        //         let dep_info = self.scope.get_module(target).unwrap();
+        //         self.merge_cjs(
+        //             plan,
+        //             &mut entry,
+        //             &info,
+        //             Cow::Borrowed(&dep_info.module),
+        //             &dep_info,
+        //             &mut targets,
+        //         )?;
+        //     }
+        // }
+
+        if is_entry {
+            self.finalize_merging_of_entry(plan, &mut entry);
+        }
+
+        Ok(entry)
     }
 
     fn finalize_merging_of_entry(&self, plan: &Plan, entry: &mut Module) {

--- a/bundler/src/bundler/chunk/merge.rs
+++ b/bundler/src/bundler/chunk/merge.rs
@@ -76,11 +76,6 @@ where
                 return Ok(entry);
             }
 
-            // We handle this kind of modules specially.
-            // if self.scope.should_be_wrapped_with_a_fn(info.id) {
-            //     return Ok(entry);
-            // }
-
             log::debug!(
                 "Merge: ({}) {} <= {:?}",
                 info.id,
@@ -90,6 +85,11 @@ where
 
             self.merge_reexports(plan, module_plan, &mut entry, &info, merged)
                 .context("failed to merge reepxorts")?;
+
+            // We handle this kind of modules specially.
+            if self.scope.should_be_wrapped_with_a_fn(info.id) {
+                return Ok(entry);
+            }
 
             // print_hygiene("after: merge_reexports", &self.cm, &entry);
 
@@ -185,7 +185,6 @@ where
 
                                     dep = self.wrap_esm_as_a_var(
                                         plan,
-                                        module_plan,
                                         dep,
                                         &dep_info,
                                         merged,

--- a/bundler/src/bundler/chunk/merge.rs
+++ b/bundler/src/bundler/chunk/merge.rs
@@ -1,6 +1,7 @@
 use super::plan::Plan;
 use crate::{
     bundler::load::{Imports, Specifier},
+    debug::print_hygiene,
     id::ModuleId,
     load::Load,
     resolve::Resolve,
@@ -71,6 +72,11 @@ where
             // print_hygiene(&format!("{}", info.fm.name), &self.cm, &entry);
 
             if module_plan.chunks.is_empty() && module_plan.transitive_chunks.is_empty() {
+                return Ok(entry);
+            }
+
+            // We handle this kind of modules specially.
+            if self.scope.should_be_wrapped_with_a_fn(info.id) {
                 return Ok(entry);
             }
 
@@ -348,7 +354,6 @@ where
             // }
 
             if is_entry {
-                // print_hygiene("done", &self.cm, &entry);
                 self.finalize_merging_of_entry(plan, &mut entry);
             }
 
@@ -357,7 +362,7 @@ where
     }
 
     fn finalize_merging_of_entry(&self, plan: &Plan, entry: &mut Module) {
-        // print_hygiene("done", &self.cm, &entry);
+        print_hygiene("done", &self.cm, &entry);
 
         entry.body.retain_mut(|item| {
             match item {

--- a/bundler/src/bundler/chunk/merge.rs
+++ b/bundler/src/bundler/chunk/merge.rs
@@ -184,8 +184,11 @@ where
                                         .unwrap();
 
                                     dep = self.wrap_esm_as_a_var(
-                                        &dep_info,
+                                        plan,
+                                        module_plan,
                                         dep,
+                                        &dep_info,
+                                        merged,
                                         id.clone().replace_mark(dep_info.mark()).into_ident(),
                                     )?;
                                 } else {

--- a/bundler/src/bundler/chunk/merge.rs
+++ b/bundler/src/bundler/chunk/merge.rs
@@ -1,7 +1,6 @@
 use super::plan::{NormalPlan, Plan};
 use crate::{
     bundler::load::{Imports, Specifier, TransformedModule},
-    debug::print_hygiene,
     id::ModuleId,
     load::Load,
     resolve::Resolve,
@@ -16,7 +15,6 @@ use std::{borrow::Cow, mem::take};
 use swc_atoms::js_word;
 use swc_common::{FileName, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_transforms::{fixer, hygiene};
 use swc_ecma_utils::prepend_stmts;
 use swc_ecma_visit::{noop_fold_type, noop_visit_mut_type, Fold, FoldWith, VisitMut, VisitMutWith};
 use util::CHashSet;
@@ -124,13 +122,15 @@ where
                     .iter()
                     .any(|(es, _)| es.module_id == src.module_id)
                 {
-                    return false;
+                    return true;
                 }
 
                 // Skip if a dependency is going to be merged by other dependency
                 module_plan.chunks.contains(&src.module_id)
             })
             .collect();
+
+        dbg!(&to_merge);
 
         let (deps, transitive_deps) = util::join(
             || {
@@ -378,7 +378,7 @@ where
     }
 
     fn finalize_merging_of_entry(&self, plan: &Plan, entry: &mut Module) {
-        print_hygiene("done", &self.cm, &entry);
+        // print_hygiene("done", &self.cm, &entry);
 
         entry.body.retain_mut(|item| {
             match item {
@@ -434,14 +434,14 @@ where
 
         entry.visit_mut_with(&mut DefaultRenamer);
 
-        print_hygiene(
-            "done-clean",
-            &self.cm,
-            &entry
-                .clone()
-                .fold_with(&mut hygiene())
-                .fold_with(&mut fixer(None)),
-        );
+        // print_hygiene(
+        //     "done-clean",
+        //     &self.cm,
+        //     &entry
+        //         .clone()
+        //         .fold_with(&mut hygiene())
+        //         .fold_with(&mut fixer(None)),
+        // );
     }
 }
 

--- a/bundler/src/bundler/chunk/merge.rs
+++ b/bundler/src/bundler/chunk/merge.rs
@@ -1,6 +1,7 @@
 use super::plan::{NormalPlan, Plan};
 use crate::{
     bundler::load::{Imports, Specifier, TransformedModule},
+    debug::print_hygiene,
     id::ModuleId,
     load::Load,
     resolve::Resolve,
@@ -15,6 +16,7 @@ use std::{borrow::Cow, mem::take};
 use swc_atoms::js_word;
 use swc_common::{FileName, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
+use swc_ecma_transforms::{fixer, hygiene};
 use swc_ecma_utils::prepend_stmts;
 use swc_ecma_visit::{noop_fold_type, noop_visit_mut_type, Fold, FoldWith, VisitMut, VisitMutWith};
 use util::CHashSet;
@@ -130,8 +132,6 @@ where
             })
             .collect();
 
-        dbg!(&to_merge);
-
         let (deps, transitive_deps) = util::join(
             || {
                 to_merge
@@ -211,12 +211,6 @@ where
                                             true,
                                         );
                                     }
-
-                                    // print_hygiene(
-                                    //     "dep: after remarking exports",
-                                    //     &self.cm,
-                                    //     &dep,
-                                    // );
                                 }
                                 // print_hygiene("dep:after:tree-shaking", &self.cm, &dep);
 
@@ -314,7 +308,11 @@ where
                 if injector.imported.is_empty() {
                     // print_hygiene("entry:after:injection", &self.cm, &entry);
 
-                    log::debug!("Merged {} as an es module", info.fm.name);
+                    log::debug!(
+                        "Merged {} into {} as an es module",
+                        dep_info.fm.name,
+                        info.fm.name,
+                    );
                     // print_hygiene(
                     //     &format!("ES6: {:?} <- {:?}", info.ctxt(), dep_info.ctxt()),
                     //     &self.cm,
@@ -378,7 +376,7 @@ where
     }
 
     fn finalize_merging_of_entry(&self, plan: &Plan, entry: &mut Module) {
-        // print_hygiene("done", &self.cm, &entry);
+        print_hygiene("done", &self.cm, &entry);
 
         entry.body.retain_mut(|item| {
             match item {
@@ -434,14 +432,14 @@ where
 
         entry.visit_mut_with(&mut DefaultRenamer);
 
-        // print_hygiene(
-        //     "done-clean",
-        //     &self.cm,
-        //     &entry
-        //         .clone()
-        //         .fold_with(&mut hygiene())
-        //         .fold_with(&mut fixer(None)),
-        // );
+        print_hygiene(
+            "done-clean",
+            &self.cm,
+            &entry
+                .clone()
+                .fold_with(&mut hygiene())
+                .fold_with(&mut fixer(None)),
+        );
     }
 }
 

--- a/bundler/src/bundler/chunk/mod.rs
+++ b/bundler/src/bundler/chunk/mod.rs
@@ -9,6 +9,7 @@ use swc_ecma_visit::FoldWith;
 
 mod circular;
 mod cjs;
+mod computed_key;
 mod export;
 mod merge;
 mod plan;

--- a/bundler/src/bundler/chunk/plan/mod.rs
+++ b/bundler/src/bundler/chunk/plan/mod.rs
@@ -234,10 +234,6 @@ where
                 deps.sort();
 
                 for &dep in &deps {
-                    if done.contains(&dep) {
-                        continue;
-                    }
-
                     if let Some(circular_members) = builder.circular.get(entry) {
                         if circular_members.contains(&dep) {
                             log::debug!(
@@ -251,6 +247,10 @@ where
                             }
                             continue;
                         }
+                    }
+
+                    if done.contains(&dep) {
+                        continue;
                     }
 
                     let is_es6 = self.scope.get_module(entry).unwrap().is_es6;

--- a/bundler/src/bundler/chunk/plan/mod.rs
+++ b/bundler/src/bundler/chunk/plan/mod.rs
@@ -473,15 +473,15 @@ where
             for &id in &*path {
                 builder
                     .all_deps
-                    .insert((id, src.module_id), is_in_reexports && is_export);
+                    .insert((id, src.module_id), is_in_reexports);
             }
             builder
                 .all_deps
-                .insert((module_id, src.module_id), is_in_reexports && is_export);
+                .insert((module_id, src.module_id), is_in_reexports);
 
             if !builder.all_deps.contains_key(&(src.module_id, module_id)) {
                 path.push(module_id);
-                self.add_to_graph(builder, src.module_id, path, is_in_reexports && is_export);
+                self.add_to_graph(builder, src.module_id, path, is_export);
                 assert_eq!(path.pop(), Some(module_id));
             }
         }

--- a/bundler/src/bundler/chunk/plan/mod.rs
+++ b/bundler/src/bundler/chunk/plan/mod.rs
@@ -254,10 +254,11 @@ where
                     }
 
                     let is_es6 = self.scope.get_module(entry).unwrap().is_es6;
-                    let dependants = builder
+                    let mut dependants = builder
                         .direct_deps
                         .neighbors_directed(dep, Incoming)
                         .collect::<Vec<_>>();
+                    dependants.sort();
 
                     if metadata.get(&dep).map(|md| md.bundle_cnt).unwrap_or(0) == 1 {
                         log::debug!("{:?} depends on {:?}", entry, dep);

--- a/bundler/src/bundler/chunk/plan/mod.rs
+++ b/bundler/src/bundler/chunk/plan/mod.rs
@@ -227,10 +227,11 @@ where
             let mut done = HashSet::new();
 
             while let Some(entry) = bfs.next(&builder.direct_deps) {
-                let deps: Vec<_> = builder
+                let mut deps: Vec<_> = builder
                     .direct_deps
                     .neighbors_directed(entry, Outgoing)
                     .collect();
+                deps.sort();
 
                 for &dep in &deps {
                     if done.contains(&dep) {
@@ -295,7 +296,6 @@ where
                             // a <- b
                             // a <- c
                             let module = least_common_ancestor(&builder, &dependants);
-
                             let normal_plan = plans.normal.entry(module).or_default();
 
                             for &dep in &deps {

--- a/bundler/src/bundler/chunk/plan/tests.rs
+++ b/bundler/src/bundler/chunk/plan/tests.rs
@@ -702,7 +702,6 @@ fn circular_002() {
 }
 
 #[test]
-#[ignore = "Not deterministic yet"]
 fn deno_002() {
     suite()
         .file(
@@ -799,7 +798,13 @@ fn deno_002() {
 
             dbg!(&p);
 
-            assert_normal(t, &p, "main", &["http-server"]);
+            assert_normal_transitive(
+                t,
+                &p,
+                "main",
+                &["http-server"],
+                &["encoding-utf8", "io-bufio", "_util-assert"],
+            );
 
             assert_normal_transitive(t, &p, "http-server", &["async-mod"], &[]);
             assert_circular(t, &p, "http-server", &["http-_io"]);
@@ -810,24 +815,21 @@ fn deno_002() {
 
             assert_normal(t, &p, "_util-assert", &[]);
 
-            assert_normal_transitive(
-                t,
-                &p,
-                "http-_io",
-                &["textproto-mod", "http-http_status"],
-                &["encoding-utf8", "io-bufio", "_util-assert"],
-            );
+            assert_normal(t, &p, "http-_io", &["textproto-mod", "http-http_status"]);
             assert_circular(t, &p, "http-_io", &["http-server"]);
 
             assert_normal(t, &p, "textproto-mod", &[]);
 
             assert_normal(t, &p, "_util-assert", &[]);
 
-            assert_normal(t, &p, "async-mod", &["async-mux_async_iterator"]);
+            assert_normal(
+                t,
+                &p,
+                "async-mod",
+                &["async-mux_async_iterator", "async-deferred"],
+            );
 
             assert_normal(t, &p, "bytes-mod", &[]);
-
-            assert_normal(t, &p, "async-mux_async_iterator", &["async-deferred"]);
 
             Ok(())
         });

--- a/bundler/src/bundler/chunk/plan/tests.rs
+++ b/bundler/src/bundler/chunk/plan/tests.rs
@@ -944,9 +944,14 @@ fn deno_003() {
 
             assert_normal(t, &p, "main", &["async-mod"]);
 
-            assert_normal(t, &p, "async-mod", &["async-mux_async_iterator"]);
+            assert_normal(
+                t,
+                &p,
+                "async-mod",
+                &["async-deferred", "async-mux_async_iterator"],
+            );
 
-            assert_normal(t, &p, "async-mux_async_iterator", &["async-deferred"]);
+            assert_normal(t, &p, "async-mux_async_iterator", &[]);
 
             Ok(())
         });

--- a/bundler/src/bundler/chunk/plan/tests.rs
+++ b/bundler/src/bundler/chunk/plan/tests.rs
@@ -908,7 +908,6 @@ fn circular_root_entry_2() {
 }
 
 #[test]
-#[ignore = "Not deterministic yet"]
 fn deno_003() {
     suite()
         .file(

--- a/bundler/src/bundler/chunk/plan/tests.rs
+++ b/bundler/src/bundler/chunk/plan/tests.rs
@@ -908,6 +908,7 @@ fn circular_root_entry_2() {
 }
 
 #[test]
+#[ignore = "Not deterministic yet"]
 fn deno_003() {
     suite()
         .file(

--- a/bundler/src/bundler/chunk/plan/tests.rs
+++ b/bundler/src/bundler/chunk/plan/tests.rs
@@ -109,8 +109,8 @@ fn concurrency_001() {
 
             assert_eq!(p.circular.len(), 0);
 
-            assert_normal(t, &p, "main", &["a"]);
-            assert_normal(t, &p, "a", &["b"]);
+            assert_normal(t, &p, "main", &["a", "b"]);
+            assert_normal(t, &p, "a", &[]);
             assert_normal(t, &p, "b", &[]);
 
             Ok(())
@@ -153,8 +153,8 @@ fn concurrency_002() {
 
             assert_eq!(p.circular.len(), 0);
 
-            assert_normal(t, &p, "main", &["a"]);
-            assert_normal(t, &p, "a", &["b"]);
+            assert_normal(t, &p, "main", &["a", "b"]);
+            assert_normal(t, &p, "a", &[]);
             assert_normal(t, &p, "b", &[]);
 
             Ok(())
@@ -908,7 +908,6 @@ fn circular_root_entry_2() {
 }
 
 #[test]
-#[ignore = "Not deterministic yet"]
 fn deno_003() {
     suite()
         .file(

--- a/bundler/src/bundler/chunk/remark.rs
+++ b/bundler/src/bundler/chunk/remark.rs
@@ -4,10 +4,7 @@ use swc_atoms::{js_word, JsWord};
 use swc_common::{Mark, Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ident::IdentLike, Id, StmtLike};
-use swc_ecma_visit::{
-    noop_fold_type, noop_visit_mut_type, noop_visit_type, Fold, FoldWith, Node, Visit, VisitMut,
-    VisitMutWith, VisitWith,
-};
+use swc_ecma_visit::{noop_fold_type, noop_visit_mut_type, Fold, FoldWith, VisitMut, VisitMutWith};
 
 pub(super) type RemarkMap = HashMap<Id, SyntaxContext>;
 

--- a/bundler/src/bundler/chunk/remark.rs
+++ b/bundler/src/bundler/chunk/remark.rs
@@ -1,4 +1,4 @@
-use crate::{bundler::load::Specifier, load::Load, resolve::Resolve, Bundler};
+use crate::{bundler::load::Specifier, load::Load, resolve::Resolve, util::MapWithMut, Bundler};
 use std::collections::HashMap;
 use swc_atoms::{js_word, JsWord};
 use swc_common::{Mark, Spanned, SyntaxContext, DUMMY_SP};
@@ -132,11 +132,6 @@ impl Fold for ExportRenamer<'_> {
     }
 
     fn fold_module_item(&mut self, item: ModuleItem) -> ModuleItem {
-        let mut actual = ActualMarker {
-            dep_ctxt: self.dep_ctxt,
-            imports: self.imports,
-        };
-
         let span = item.span();
         let item: ModuleItem = item.fold_children_with(self);
 
@@ -452,9 +447,7 @@ impl Fold for ExportRenamer<'_> {
                     | Decl::TsEnum(_)
                     | Decl::TsModule(_) => ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(decl)),
 
-                    Decl::Class(mut c) => {
-                        c.ident = c.ident.fold_with(&mut actual);
-
+                    Decl::Class(c) => {
                         if self.unexport {
                             Stmt::Decl(Decl::Class(c)).into()
                         } else {
@@ -464,8 +457,7 @@ impl Fold for ExportRenamer<'_> {
                             }))
                         }
                     }
-                    Decl::Fn(mut f) => {
-                        f.ident = f.ident.fold_with(&mut actual);
+                    Decl::Fn(f) => {
                         if self.unexport {
                             Stmt::Decl(Decl::Fn(f)).into()
                         } else {
@@ -476,7 +468,11 @@ impl Fold for ExportRenamer<'_> {
                         }
                     }
                     Decl::Var(..) => {
-                        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(decl.fold_with(&mut actual)))
+                        if self.unexport {
+                            ModuleItem::Stmt(Stmt::Decl(decl.decl))
+                        } else {
+                            ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(decl))
+                        }
                     }
                 };
             }
@@ -496,91 +492,93 @@ impl Fold for ExportRenamer<'_> {
     }
 }
 
-struct ActualMarker<'a> {
-    dep_ctxt: SyntaxContext,
+// struct ActualMarker<'a, 'b> {
+//     dep_ctxt: SyntaxContext,
 
-    /// Dependant module's import
-    imports: Option<&'a [Specifier]>,
-}
+//     remark_map: &'b mut RemarkMap,
 
-impl ActualMarker<'_> {
-    fn rename(&self, ident: Ident, only_if_aliased: bool) -> Result<Ident, Ident> {
-        if self.imports.is_none() {
-            return Err(ident);
-        }
+//     /// Dependant module's import
+//     imports: Option<&'a [Specifier]>,
+// }
 
-        if let Some(mut ident) = self.imports.as_ref().unwrap().iter().find_map(|s| match s {
-            Specifier::Specific {
-                alias: Some(alias),
-                local,
-            } if *alias == ident.sym => Some(Ident::new(local.sym().clone(), ident.span)),
-            Specifier::Specific { alias: None, local }
-                if !only_if_aliased && *local == ident.sym =>
-            {
-                Some(local.clone().into_ident())
-            }
-            _ => None,
-        }) {
-            ident.span = ident.span.with_ctxt(self.dep_ctxt);
+// impl ActualMarker<'_> {
+//     fn rename(&self, ident: Ident, only_if_aliased: bool) -> Result<Ident,
+// Ident> {         if self.imports.is_none() {
+//             return Err(ident);
+//         }
 
-            return Ok(ident);
-        }
+//         if let Some(mut ident) =
+// self.imports.as_ref().unwrap().iter().find_map(|s| match s {
+// Specifier::Specific {                 alias: Some(alias),
+//                 local,
+//             } if *alias == ident.sym => Some(Ident::new(local.sym().clone(),
+// ident.span)),             Specifier::Specific { alias: None, local }
+//                 if !only_if_aliased && *local == ident.sym =>
+//             {
+//                 Some(local.clone().into_ident())
+//             }
+//             _ => None,
+//         }) {
+//             ident.span = ident.span.with_ctxt(self.dep_ctxt);
 
-        Err(ident)
-    }
-}
+//             return Ok(ident);
+//         }
 
-impl Fold for ActualMarker<'_> {
-    noop_fold_type!();
+//         Err(ident)
+//     }
+// }
 
-    fn fold_expr(&mut self, node: Expr) -> Expr {
-        node
-    }
+// impl Fold for ActualMarker<'_> {
+//     noop_fold_type!();
 
-    fn fold_ident(&mut self, ident: Ident) -> Ident {
-        match self.rename(ident, false) {
-            Ok(v) => v,
-            Err(v) => v,
-        }
-    }
+//     fn fold_expr(&mut self, node: Expr) -> Expr {
+//         node
+//     }
 
-    fn fold_private_name(&mut self, i: PrivateName) -> PrivateName {
-        i
-    }
+//     fn fold_ident(&mut self, ident: Ident) -> Ident {
+//         match self.rename(ident, false) {
+//             Ok(v) => v,
+//             Err(v) => v,
+//         }
+//     }
 
-    fn fold_export_named_specifier(&mut self, s: ExportNamedSpecifier) -> ExportNamedSpecifier {
-        if let Some(..) = s.exported {
-            ExportNamedSpecifier {
-                orig: self.fold_ident(s.orig),
-                ..s
-            }
-        } else {
-            match self.rename(s.orig.clone(), false) {
-                Ok(exported) => ExportNamedSpecifier {
-                    orig: s.orig,
-                    exported: Some(exported),
-                    ..s
-                },
-                Err(orig) => ExportNamedSpecifier { orig, ..s },
-            }
-        }
-    }
+//     fn fold_private_name(&mut self, i: PrivateName) -> PrivateName {
+//         i
+//     }
 
-    fn fold_prop(&mut self, p: Prop) -> Prop {
-        match p {
-            Prop::Shorthand(i) => match self.rename(i.clone(), false) {
-                Ok(renamed) => Prop::KeyValue(KeyValueProp {
-                    key: i.into(),
-                    value: Box::new(renamed.into()),
-                }),
-                Err(orig) => Prop::Shorthand(orig),
-            },
-            _ => p.fold_with(self),
-        }
-    }
+//     fn fold_export_named_specifier(&mut self, s: ExportNamedSpecifier) ->
+// ExportNamedSpecifier {         if let Some(..) = s.exported {
+//             ExportNamedSpecifier {
+//                 orig: self.fold_ident(s.orig),
+//                 ..s
+//             }
+//         } else {
+//             match self.rename(s.orig.clone(), false) {
+//                 Ok(exported) => ExportNamedSpecifier {
+//                     orig: s.orig,
+//                     exported: Some(exported),
+//                     ..s
+//                 },
+//                 Err(orig) => ExportNamedSpecifier { orig, ..s },
+//             }
+//         }
+//     }
 
-    // TODO: shorthand, etc
-}
+//     fn fold_prop(&mut self, p: Prop) -> Prop {
+//         match p {
+//             Prop::Shorthand(i) => match self.rename(i.clone(), false) {
+//                 Ok(renamed) => Prop::KeyValue(KeyValueProp {
+//                     key: i.into(),
+//                     value: Box::new(renamed.into()),
+//                 }),
+//                 Err(orig) => Prop::Shorthand(orig),
+//             },
+//             _ => p.fold_with(self),
+//         }
+//     }
+
+//     // TODO: shorthand, etc
+// }
 
 struct RemarkIdents<'a> {
     map: &'a RemarkMap,
@@ -594,6 +592,48 @@ impl VisitMut for RemarkIdents<'_> {
         if let Some(&ctxt) = self.map.get(&id) {
             n.span = n.span.with_ctxt(ctxt);
             log::debug!("Remark: {:?} -> {:?}", id, ctxt)
+        }
+    }
+
+    /// Handles
+    ///
+    /// ```js
+    /// function deferred#34() {
+    ///     let methods#107;
+    ///     const promise#107 = new Promise#98((resolve#108, reject#108)=>{
+    ///         methods#107 = {
+    ///             resolve#108,
+    ///             reject#108
+    ///         };
+    ///     });
+    ///     return Object#98.assign(promise#107, methods#107);
+    /// }
+    /// const deferred#34 = deferred#98;
+    /// ```
+    fn visit_mut_var_declarator(&mut self, n: &mut VarDeclarator) {
+        n.visit_mut_children_with(self);
+
+        match n {
+            VarDeclarator {
+                name: Pat::Ident(name),
+                init: Some(init),
+                definite: false,
+                ..
+            } if match &**init {
+                Expr::Ident(init) => init.sym == name.sym,
+                _ => false,
+            } && self.map.contains_key(&name.to_id()) =>
+            {
+                let name = name.take();
+                let init = init.take();
+
+                n.name = Pat::Ident(match *init {
+                    Expr::Ident(i) => i,
+                    _ => unreachable!(),
+                });
+                n.init = Some(Box::new(Expr::Ident(name)));
+            }
+            _ => {}
         }
     }
 

--- a/bundler/src/bundler/chunk/remark.rs
+++ b/bundler/src/bundler/chunk/remark.rs
@@ -121,10 +121,12 @@ impl ExportRenamer<'_> {
 impl Fold for ExportRenamer<'_> {
     noop_fold_type!();
 
+    /// no-op, as imports or exports are only related to top level nodes.
     fn fold_class(&mut self, node: Class) -> Class {
         node
     }
 
+    /// no-op, as imports or exports are only related to top level nodes.
     fn fold_function(&mut self, node: Function) -> Function {
         node
     }

--- a/bundler/src/bundler/export.rs
+++ b/bundler/src/bundler/export.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{id::Id, load::Load, resolve::Resolve};
 use std::collections::HashMap;
-use swc_atoms::js_word;
+use swc_atoms::{js_word, JsWord};
 use swc_common::{FileName, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_utils::find_ids;
@@ -63,7 +63,7 @@ where
     L: Load,
     R: Resolve,
 {
-    fn ctxt_for(&self, src: &str) -> Option<SyntaxContext> {
+    fn ctxt_for(&self, src: &JsWord) -> Option<SyntaxContext> {
         // Don't apply mark if it's a core module.
         if self
             .bundler
@@ -178,7 +178,7 @@ where
                 let ctxt = named
                     .src
                     .as_ref()
-                    .map(|s| &*s.value)
+                    .map(|s| &s.value)
                     .and_then(|src| self.ctxt_for(src));
 
                 let v = self.info.items.entry(named.src.clone()).or_default();

--- a/bundler/src/bundler/import/mod.rs
+++ b/bundler/src/bundler/import/mod.rs
@@ -127,7 +127,7 @@ where
     L: Load,
     R: Resolve,
 {
-    fn ctxt_for(&self, src: &str) -> Option<SyntaxContext> {
+    fn ctxt_for(&self, src: &JsWord) -> Option<SyntaxContext> {
         // Don't apply mark if it's a core module.
         if self
             .bundler

--- a/bundler/src/bundler/import/tests.rs
+++ b/bundler/src/bundler/import/tests.rs
@@ -1,74 +1,75 @@
-use super::ImportHandler;
-use crate::bundler::tests::suite;
-use std::path::Path;
-use swc_common::{FileName, Mark, SyntaxContext};
-use swc_ecma_visit::FoldWith;
+// use super::ImportHandler;
+// use crate::bundler::tests::suite;
+// use std::path::Path;
+// use swc_common::{FileName, Mark, SyntaxContext};
+// use swc_ecma_visit::FoldWith;
 
-#[test]
-#[ignore]
-fn ns_import_deglob_simple() {
-    suite().run(|t| {
-        let m = t.parse(
-            "
-import * as ns from 'foo';
-ns.foo();
-",
-        );
-        let mut v = ImportHandler {
-            path: &FileName::Real(Path::new("index.js").to_path_buf()),
-            bundler: &t.bundler,
-            top_level: false,
-            info: Default::default(),
-            ns_usage: Default::default(),
-            deglob_phase: false,
-            imported_idents: Default::default(),
-            module_ctxt: SyntaxContext::empty().apply_mark(Mark::fresh(Mark::root())),
-            idents_to_deglob: Default::default(),
-        };
-        let m = m.fold_with(&mut v);
-        assert!(v.info.forced_ns.is_empty());
-        assert_eq!(v.info.imports.len(), 1);
+// #[test]
+// #[ignore]
+// fn ns_import_deglob_simple() {
+//     suite().run(|t| {
+//         let m = t.parse(
+//             "
+// import * as ns from 'foo';
+// ns.foo();
+// ",
+//         );
+//         let mut v = ImportHandler {
+//             path: &FileName::Real(Path::new("index.js").to_path_buf()),
+//             bundler: &t.bundler,
+//             top_level: false,
+//             info: Default::default(),
+//             ns_usage: Default::default(),
+//             deglob_phase: false,
+//             imported_idents: Default::default(),
+//             module_ctxt:
+// SyntaxContext::empty().apply_mark(Mark::fresh(Mark::root())),             
+// idents_to_deglob: Default::default(),         };
+//         let m = m.fold_with(&mut v);
+//         assert!(v.info.forced_ns.is_empty());
+//         assert_eq!(v.info.imports.len(), 1);
 
-        t.assert_eq(&m, "foo();");
+//         t.assert_eq(&m, "foo();");
 
-        Ok(())
-    })
-}
+//         Ok(())
+//     })
+// }
 
-#[test]
-#[ignore]
-fn ns_import_deglob_multi() {
-    suite().run(|t| {
-        let m = t.parse(
-            "
-import * as ns from 'foo';
-ns.foo();
-ns.bar();
-",
-        );
-        let mut v = ImportHandler {
-            path: &FileName::Real(Path::new("index.js").to_path_buf()),
-            bundler: &t.bundler,
-            top_level: false,
-            info: Default::default(),
-            ns_usage: Default::default(),
-            deglob_phase: false,
-            imported_idents: Default::default(),
-            module_ctxt: SyntaxContext::empty().apply_mark(Mark::fresh(Mark::root())),
-            idents_to_deglob: Default::default(),
-        };
-        let m = m.fold_with(&mut v);
-        assert!(v.info.forced_ns.is_empty());
-        assert_eq!(v.info.imports.len(), 1);
-        assert_eq!(v.info.imports[0].specifiers.len(), 2);
-        assert!(!format!("{:?}", v.info.imports[0].specifiers).contains("ns"));
+// #[test]
+// #[ignore]
+// fn ns_import_deglob_multi() {
+//     suite().run(|t| {
+//         let m = t.parse(
+//             "
+// import * as ns from 'foo';
+// ns.foo();
+// ns.bar();
+// ",
+//         );
+//         let mut v = ImportHandler {
+//             path: &FileName::Real(Path::new("index.js").to_path_buf()),
+//             bundler: &t.bundler,
+//             top_level: false,
+//             info: Default::default(),
+//             ns_usage: Default::default(),
+//             deglob_phase: false,
+//             imported_idents: Default::default(),
+//             module_ctxt:
+// SyntaxContext::empty().apply_mark(Mark::fresh(Mark::root())),             
+// idents_to_deglob: Default::default(),         };
+//         let m = m.fold_with(&mut v);
+//         assert!(v.info.forced_ns.is_empty());
+//         assert_eq!(v.info.imports.len(), 1);
+//         assert_eq!(v.info.imports[0].specifiers.len(), 2);
+//         assert!(!format!("{:?}",
+// v.info.imports[0].specifiers).contains("ns"));
 
-        t.assert_eq(
-            &m,
-            "foo();
-bar();",
-        );
+//         t.assert_eq(
+//             &m,
+//             "foo();
+// bar();",
+//         );
 
-        Ok(())
-    })
-}
+//         Ok(())
+//     })
+// }

--- a/bundler/src/bundler/import/tests.rs
+++ b/bundler/src/bundler/import/tests.rs
@@ -23,7 +23,7 @@
 //             deglob_phase: false,
 //             imported_idents: Default::default(),
 //             module_ctxt:
-// SyntaxContext::empty().apply_mark(Mark::fresh(Mark::root())),             
+// SyntaxContext::empty().apply_mark(Mark::fresh(Mark::root())),
 // idents_to_deglob: Default::default(),         };
 //         let m = m.fold_with(&mut v);
 //         assert!(v.info.forced_ns.is_empty());
@@ -55,7 +55,7 @@
 //             deglob_phase: false,
 //             imported_idents: Default::default(),
 //             module_ctxt:
-// SyntaxContext::empty().apply_mark(Mark::fresh(Mark::root())),             
+// SyntaxContext::empty().apply_mark(Mark::fresh(Mark::root())),
 // idents_to_deglob: Default::default(),         };
 //         let m = m.fold_with(&mut v);
 //         assert!(v.info.forced_ns.is_empty());

--- a/bundler/src/bundler/load.rs
+++ b/bundler/src/bundler/load.rs
@@ -75,7 +75,7 @@ where
                 .context("failed to analyze module")?;
             files.dedup_by_key(|v| v.1.clone());
 
-            log::debug!("({}) Storing module: {}", v.id, file_name);
+            log::debug!("({}, {:?}) Storing module: {}", v.id, v.ctxt(), file_name);
             self.scope.store_module(v.clone());
 
             // Load dependencies and store them in the `Scope`

--- a/bundler/src/bundler/load.rs
+++ b/bundler/src/bundler/load.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
+
 use super::{export::Exports, helpers::Helpers, Bundler};
 use crate::{
     bundler::{export::RawExports, import::RawImports},
@@ -34,6 +36,8 @@ pub(super) struct TransformedModule {
     pub helpers: Lrc<Helpers>,
 
     mark: Mark,
+
+    accessed_with_computed_key: Lrc<AtomicBool>,
 }
 
 impl TransformedModule {
@@ -44,6 +48,15 @@ impl TransformedModule {
 
     pub fn ctxt(&self) -> SyntaxContext {
         SyntaxContext::empty().apply_mark(self.mark)
+    }
+
+    /// Set the module as
+    pub fn mark_as_wrapped(&self) {
+        self.accessed_with_computed_key.store(true, SeqCst);
+    }
+
+    pub fn should_be_wrapped(&self) -> bool {
+        self.accessed_with_computed_key.load(SeqCst)
     }
 }
 

--- a/bundler/src/bundler/load.rs
+++ b/bundler/src/bundler/load.rs
@@ -137,7 +137,7 @@ where
             //     println!("Resolved:\n{}\n\n", code);
             // }
 
-            let imports = self.extract_import_info(file_name, &mut module, id, mark);
+            let imports = self.extract_import_info(file_name, &mut module, mark);
 
             // {
             //     let code = self

--- a/bundler/src/bundler/load.rs
+++ b/bundler/src/bundler/load.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
-
 use super::{export::Exports, helpers::Helpers, Bundler};
 use crate::{
     bundler::{export::RawExports, import::RawImports},
@@ -36,8 +34,6 @@ pub(super) struct TransformedModule {
     pub helpers: Lrc<Helpers>,
 
     mark: Mark,
-
-    accessed_with_computed_key: Lrc<AtomicBool>,
 }
 
 impl TransformedModule {
@@ -48,15 +44,6 @@ impl TransformedModule {
 
     pub fn ctxt(&self) -> SyntaxContext {
         SyntaxContext::empty().apply_mark(self.mark)
-    }
-
-    /// Set the module as
-    pub fn mark_as_wrapped(&self) {
-        self.accessed_with_computed_key.store(true, SeqCst);
-    }
-
-    pub fn should_be_wrapped(&self) -> bool {
-        self.accessed_with_computed_key.load(SeqCst)
     }
 }
 
@@ -150,7 +137,7 @@ where
             //     println!("Resolved:\n{}\n\n", code);
             // }
 
-            let imports = self.extract_import_info(file_name, &mut module, mark);
+            let imports = self.extract_import_info(file_name, &mut module, id, mark);
 
             // {
             //     let code = self

--- a/bundler/src/bundler/mod.rs
+++ b/bundler/src/bundler/mod.rs
@@ -7,7 +7,6 @@ use swc_common::{sync::Lrc, FileName, Globals, Mark, SourceMap, SyntaxContext, D
 use swc_ecma_ast::Module;
 
 mod chunk;
-mod computed_key;
 mod export;
 mod finalize;
 mod helpers;

--- a/bundler/src/bundler/scope.rs
+++ b/bundler/src/bundler/scope.rs
@@ -3,7 +3,8 @@ use crate::{
     id::{ModuleId, ModuleIdGenerator},
     util::CloneMap,
 };
-use swc_common::FileName;
+use std::sync::atomic::{AtomicBool, Ordering};
+use swc_common::{sync::Lrc, FileName};
 
 #[derive(Debug, Default)]
 pub(super) struct Metadata {
@@ -18,6 +19,8 @@ pub(super) struct Scope {
 
     /// Cached after applying basical transformations.
     transformed_modules: CloneMap<ModuleId, TransformedModule>,
+
+    accessed_with_computed_key: CloneMap<ModuleId, Lrc<AtomicBool>>,
 }
 
 impl Scope {
@@ -39,5 +42,23 @@ impl Scope {
 
     pub fn get_module(&self, id: ModuleId) -> Option<TransformedModule> {
         Some(self.transformed_modules.get(&id)?.clone())
+    }
+
+    /// Set the module as
+    pub fn mark_as_wrapping_required(&self, id: ModuleId) {
+        if let Some(v) = self.accessed_with_computed_key.get(&id) {
+            v.store(true, Ordering::SeqCst);
+        }
+
+        self.accessed_with_computed_key
+            .insert(id, Lrc::new(AtomicBool::from(true)));
+    }
+
+    pub fn should_be_wrapped_with_a_fn(&self, id: ModuleId) -> bool {
+        if let Some(v) = self.accessed_with_computed_key.get(&id) {
+            v.load(Ordering::SeqCst)
+        } else {
+            false
+        }
     }
 }

--- a/bundler/src/bundler/scope.rs
+++ b/bundler/src/bundler/scope.rs
@@ -48,6 +48,7 @@ impl Scope {
     pub fn mark_as_wrapping_required(&self, id: ModuleId) {
         if let Some(v) = self.accessed_with_computed_key.get(&id) {
             v.store(true, Ordering::SeqCst);
+            return;
         }
 
         self.accessed_with_computed_key

--- a/bundler/src/bundler/tests.rs
+++ b/bundler/src/bundler/tests.rs
@@ -70,6 +70,7 @@ impl<'a> Tester<'a> {
             .unwrap_or_else(|| panic!("failed to find module named {}", name))
     }
 
+    #[allow(dead_code)]
     pub fn parse(&self, s: &str) -> Module {
         let fm = self
             .cm
@@ -85,6 +86,7 @@ impl<'a> Tester<'a> {
         parser.parse_module().unwrap()
     }
 
+    #[allow(dead_code)]
     pub fn assert_eq(&self, m: &Module, expected: &str) {
         let expected = self.parse(expected);
 

--- a/bundler/src/debug/mod.rs
+++ b/bundler/src/debug/mod.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use std::io::{stderr, Write};
-use swc_common::{sync::Lrc, SourceMap};
+use swc_common::{sync::Lrc, SourceMap, SyntaxContext};
 use swc_ecma_ast::{Ident, Module};
 use swc_ecma_codegen::{text_writer::JsWriter, Emitter};
 use swc_ecma_visit::{noop_fold_type, Fold, FoldWith};
@@ -30,6 +30,9 @@ impl Fold for HygieneVisualizer {
     noop_fold_type!();
 
     fn fold_ident(&mut self, node: Ident) -> Ident {
+        if node.span.ctxt == SyntaxContext::empty() {
+            return node;
+        }
         Ident {
             sym: format!("{}{:?}", node.sym, node.span.ctxt()).into(),
             ..node

--- a/bundler/src/util.rs
+++ b/bundler/src/util.rs
@@ -1,6 +1,102 @@
-use std::hash::Hash;
-use swc_common::{Span, SyntaxContext};
+use std::{hash::Hash, mem::replace};
+use swc_atoms::js_word;
+use swc_common::{Span, SyntaxContext, DUMMY_SP};
+use swc_ecma_ast::*;
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut};
+
+/// Helper for migration from [Fold] to [VisitMut]
+pub(crate) trait MapWithMut: Sized {
+    fn dummy() -> Self;
+
+    fn take(&mut self) -> Self {
+        replace(self, Self::dummy())
+    }
+
+    #[inline]
+    fn map_with_mut<F>(&mut self, op: F)
+    where
+        F: FnOnce(Self) -> Self,
+    {
+        let dummy = Self::dummy();
+        let v = replace(self, dummy);
+        let v = op(v);
+        let _dummy = replace(self, v);
+    }
+}
+
+impl MapWithMut for ModuleItem {
+    #[inline(always)]
+    fn dummy() -> Self {
+        ModuleItem::Stmt(Stmt::Empty(EmptyStmt { span: DUMMY_SP }))
+    }
+}
+
+impl MapWithMut for Stmt {
+    #[inline(always)]
+    fn dummy() -> Self {
+        Stmt::Empty(EmptyStmt { span: DUMMY_SP })
+    }
+}
+
+impl MapWithMut for Expr {
+    #[inline(always)]
+    fn dummy() -> Self {
+        Expr::Invalid(Invalid { span: DUMMY_SP })
+    }
+}
+
+impl MapWithMut for Pat {
+    #[inline(always)]
+    fn dummy() -> Self {
+        Pat::Invalid(Invalid { span: DUMMY_SP })
+    }
+}
+
+impl<T> MapWithMut for Option<T> {
+    #[inline(always)]
+    fn dummy() -> Self {
+        None
+    }
+}
+
+impl<T> MapWithMut for Vec<T> {
+    #[inline(always)]
+    fn dummy() -> Self {
+        Vec::new()
+    }
+}
+
+impl<T> MapWithMut for Box<T>
+where
+    T: MapWithMut,
+{
+    #[inline(always)]
+    fn dummy() -> Self {
+        Box::new(T::dummy())
+    }
+}
+
+impl MapWithMut for Ident {
+    fn dummy() -> Self {
+        Ident::new(js_word!(""), DUMMY_SP)
+    }
+}
+
+impl MapWithMut for ObjectPatProp {
+    fn dummy() -> Self {
+        ObjectPatProp::Assign(AssignPatProp {
+            span: DUMMY_SP,
+            key: Ident::dummy(),
+            value: None,
+        })
+    }
+}
+
+impl MapWithMut for PatOrExpr {
+    fn dummy() -> Self {
+        PatOrExpr::Pat(Box::new(Pat::Ident(Ident::dummy())))
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct CHashSet<V>

--- a/bundler/tests/deno.rs
+++ b/bundler/tests/deno.rs
@@ -37,7 +37,7 @@ fn std_0_74_9_http_server() {
 
 #[test]
 #[ignore = "Too slow"]
-fn oak_6_3_1() {
+fn oak_6_3_1_example() {
     run("https://deno.land/x/oak@v6.3.1/examples/server.ts");
 }
 
@@ -59,7 +59,7 @@ fn run(url: &str) {
         .status()
         .unwrap();
 
-    // std::mem::forget(dir);
+    std::mem::forget(dir);
 
     dbg!(output);
     assert!(output.success());

--- a/bundler/tests/deno.rs
+++ b/bundler/tests/deno.rs
@@ -25,6 +25,11 @@ fn oak_6_3_1_mod() {
     bundle("https://deno.land/x/oak@v6.3.1/mod.ts");
 }
 
+#[test]
+fn std_0_74_9_http_server() {
+    bundle("https://deno.land/std@0.74.0/http/server.ts");
+}
+
 fn bundle(url: &str) -> Module {
     let result = testing::run_test2(false, |cm, _handler| {
         GLOBALS.with(|globals| {

--- a/bundler/tests/deno.rs
+++ b/bundler/tests/deno.rs
@@ -20,6 +20,7 @@ fn oak_6_2_0_application() {
 }
 
 #[test]
+#[ignore = "Too slow"]
 fn oak_6_3_1_mod() {
     bundle("https://deno.land/x/oak@v6.3.1/mod.ts");
 }

--- a/bundler/tests/deno.rs
+++ b/bundler/tests/deno.rs
@@ -70,7 +70,7 @@ fn bundle(url: &str) -> String {
                 Resolver,
                 swc_bundler::Config {
                     require: false,
-                    disable_inliner: true,
+                    disable_inliner: false,
                     ..Default::default()
                 },
                 Box::new(Hook),

--- a/bundler/tests/deno.rs
+++ b/bundler/tests/deno.rs
@@ -19,11 +19,12 @@ use url::Url;
 
 #[test]
 #[ignore = "Too slow"]
-fn oak_6_2_0_application() {
-    run("https://deno.land/x/oak@v6.2.0/application.ts");
+fn oak_6_3_1_application() {
+    run("https://deno.land/x/oak@v6.3.1/application.ts");
 }
 
 #[test]
+#[ignore = "Too slow"]
 fn oak_6_3_1_mod() {
     run("https://deno.land/x/oak@v6.3.1/mod.ts");
 }
@@ -32,6 +33,11 @@ fn oak_6_3_1_mod() {
 #[ignore = "Too slow"]
 fn std_0_74_9_http_server() {
     run("https://deno.land/std@0.74.0/http/server.ts");
+}
+
+#[test]
+fn oak_6_3_1() {
+    run("https://deno.land/x/oak@v6.3.1/examples/server.ts");
 }
 
 fn run(url: &str) {

--- a/bundler/tests/deno.rs
+++ b/bundler/tests/deno.rs
@@ -19,6 +19,11 @@ fn oak_6_2_0_application() {
     bundle("https://deno.land/x/oak@v6.2.0/application.ts");
 }
 
+#[test]
+fn oak_6_3_1_mod() {
+    bundle("https://deno.land/x/oak@v6.3.1/mod.ts");
+}
+
 fn bundle(url: &str) -> Module {
     let result = testing::run_test2(false, |cm, _handler| {
         GLOBALS.with(|globals| {

--- a/bundler/tests/deno.rs
+++ b/bundler/tests/deno.rs
@@ -36,14 +36,17 @@ fn std_0_74_9_http_server() {
 }
 
 #[test]
+#[ignore = "Too slow"]
 fn oak_6_3_1() {
     run("https://deno.land/x/oak@v6.3.1/examples/server.ts");
 }
 
 fn run(url: &str) {
-    let src = bundle(url);
     let dir = tempfile::tempdir().expect("failed to crate temp file");
     let path = dir.path().join("main.js");
+    println!("{}", path.display());
+
+    let src = bundle(url);
     write(&path, &src).unwrap();
 
     let output = Command::new("deno")
@@ -55,6 +58,8 @@ fn run(url: &str) {
         .stderr(Stdio::piped())
         .status()
         .unwrap();
+
+    // std::mem::forget(dir);
 
     dbg!(output);
     assert!(output.success());

--- a/bundler/tests/fixture/issue-1155-1-fn/output/entry.ts
+++ b/bundler/tests/fixture/issue-1155-1-fn/output/entry.ts
@@ -1,7 +1,8 @@
 function a() {
     console.log("a");
 }
+const a1 = a;
 function b() {
-    a();
+    a1();
 }
 b();

--- a/bundler/tests/fixture/issue-1155-2-var/output/entry.ts
+++ b/bundler/tests/fixture/issue-1155-2-var/output/entry.ts
@@ -1,5 +1,6 @@
 const a = 'a';
+const a1 = a;
 function b() {
-    return a;
+    return a1;
 }
 b();

--- a/bundler/tests/fixture/issue-1155-3-class/output/entry.ts
+++ b/bundler/tests/fixture/issue-1155-3-class/output/entry.ts
@@ -1,6 +1,7 @@
 class a {
 }
+const a1 = a;
 function b() {
-    return new a();
+    return new a1();
 }
 b();

--- a/spack/Cargo.toml
+++ b/spack/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1"
 string_enum = {version = "0.3", path = "../macros/string_enum"}
 swc = {path = "../"}
 swc_atoms = {path = "../atoms"}
-swc_bundler = {path = "../bundler"}
+swc_bundler = {path = "../bundler", features = ["concurrent"]}
 swc_common = {path = "../common"}
 swc_ecma_ast = {path = "../ecmascript/ast"}
 swc_ecma_codegen = {path = "../ecmascript/codegen"}

--- a/spack/Cargo.toml
+++ b/spack/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1"
 string_enum = {version = "0.3", path = "../macros/string_enum"}
 swc = {path = "../"}
 swc_atoms = {path = "../atoms"}
-swc_bundler = {path = "../bundler", features = ["concurrent"]}
+swc_bundler = {path = "../bundler"}
 swc_common = {path = "../common"}
 swc_ecma_ast = {path = "../ecmascript/ast"}
 swc_ecma_codegen = {path = "../ecmascript/codegen"}

--- a/spack/tests/pass/deno-001/simple-4/output/entry.js
+++ b/spack/tests/pass/deno-001/simple-4/output/entry.js
@@ -1,10 +1,10 @@
 function deferred() {
 }
+const deferred1 = deferred;
 class MuxAsyncIterator {
     constructor(){
         this.signal = deferred();
     }
 }
 const MuxAsyncIterator1 = MuxAsyncIterator;
-const deferred1 = deferred;
 console.log(deferred1, MuxAsyncIterator1);

--- a/spack/tests/pass/pr-1105/example-5/output/entry.js
+++ b/spack/tests/pass/pr-1105/example-5/output/entry.js
@@ -1,2 +1,3 @@
 const a = "a";
-console.log(a);
+const a1 = a;
+console.log(a1);


### PR DESCRIPTION
swc_bundler:
 - Handle computed accesses to imports correctly.
 - Make planning deterministic.
 - Prefer exports over imports while planning.
 - Fix https://deno.land/x/oak@v6.3.1/examples/server.ts