### PR TITLE
Remove unnecessary question mark

### DIFF
--- a/ecmascript/parser/src/lexer/mod.rs
+++ b/ecmascript/parser/src/lexer/mod.rs
@@ -215,7 +215,6 @@ impl<'a, I: Input> Lexer<'a, I> {
                     '{' => LBrace,
                     '}' => RBrace,
                     '@' => At,
-                    '?' => QuestionMark,
                     _ => unreachable!(),
                 }));
             }


### PR DESCRIPTION
`c` can never be a question mark at this point since the match arm doesn't include it.