### PR TITLE
Invalid template escape in ES2018+

### DIFF
--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.11.3"
+version = "0.12.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -29,9 +29,9 @@ retain_mut = "=0.1.1"
 swc_atoms = {version = "0.2.4", path = "../atoms"}
 swc_common = {version = "0.10.0", path = "../common"}
 swc_ecma_ast = {version = "0.33.0", path = "../ecmascript/ast"}
-swc_ecma_codegen = {version = "0.37.0", path = "../ecmascript/codegen"}
-swc_ecma_parser = {version = "0.39.0", path = "../ecmascript/parser"}
-swc_ecma_transforms = {version = "0.26.1", path = "../ecmascript/transforms"}
+swc_ecma_codegen = {version = "0.38.0", path = "../ecmascript/codegen"}
+swc_ecma_parser = {version = "0.40.0", path = "../ecmascript/parser"}
+swc_ecma_transforms = {version = "0.27.0", path = "../ecmascript/transforms"}
 swc_ecma_utils = {version = "0.23.0", path = "../ecmascript/utils"}
 swc_ecma_visit = {version = "0.19.0", path = "../ecmascript/visit"}
 

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.10.1"
+version = "0.11.0"
 
 [features]
 codegen = ["swc_ecma_codegen"]
@@ -21,10 +21,10 @@ react = ["swc_ecma_transforms", "swc_ecma_transforms/react"]
 
 [dependencies]
 swc_ecma_ast = {version = "0.33.0", path = "./ast"}
-swc_ecma_codegen = {version = "0.37.0", path = "./codegen", optional = true}
-swc_ecma_dep_graph = {version = "0.5.0", path = "./dep-graph", optional = true}
-swc_ecma_parser = {version = "0.39.0", path = "./parser", optional = true}
-swc_ecma_transforms = {version = "0.26.1", path = "./transforms", optional = true}
+swc_ecma_codegen = {version = "0.38.0", path = "./codegen", optional = true}
+swc_ecma_dep_graph = {version = "0.6.0", path = "./dep-graph", optional = true}
+swc_ecma_parser = {version = "0.40.0", path = "./parser", optional = true}
+swc_ecma_transforms = {version = "0.27.0", path = "./transforms", optional = true}
 swc_ecma_utils = {version = "0.23.0", path = "./utils", optional = true}
 swc_ecma_visit = {version = "0.19.0", path = "./visit", optional = true}
 

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.37.0"
+version = "0.38.0"
 
 [dependencies]
 bitflags = "1"
@@ -20,5 +20,5 @@ swc_ecma_codegen_macros = {version = "0.5", path = "./macros"}
 
 [dev-dependencies]
 swc_common = {version = "0.10.0", path = "../../common", features = ["sourcemap"]}
-swc_ecma_parser = {version = "0.39.0", path = "../parser"}
+swc_ecma_parser = {version = "0.40.0", path = "../parser"}
 testing = {version = "0.10.0", path = "../../testing"}

--- a/ecmascript/dep-graph/Cargo.toml
+++ b/ecmascript/dep-graph/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_dep_graph"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
 swc_atoms = {version = "0.2", path = "../../atoms"}
@@ -15,5 +15,5 @@ swc_ecma_ast = {version = "0.33.0", path = "../ast"}
 swc_ecma_visit = {version = "0.19.0", path = "../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.39.0", path = "../parser"}
+swc_ecma_parser = {version = "0.40.0", path = "../parser"}
 testing = {version = "0.10.0", path = "../../testing"}

--- a/ecmascript/jsdoc/Cargo.toml
+++ b/ecmascript/jsdoc/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://swc.rs/rustdoc/jsdoc/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "jsdoc"
-version = "0.7.0"
+version = "0.8.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -19,6 +19,6 @@ swc_common = {version = "0.10.0", path = "../../common"}
 anyhow = "1"
 dashmap = "3"
 swc_ecma_ast = {version = "0.33.0", path = "../ast"}
-swc_ecma_parser = {version = "0.39.0", path = "../parser"}
+swc_ecma_parser = {version = "0.40.0", path = "../parser"}
 testing = {version = "0.10.0", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.39.0"
+version = "0.40.0"
 
 [features]
 default = []

--- a/ecmascript/parser/src/lexer/state.rs
+++ b/ecmascript/parser/src/lexer/state.rs
@@ -679,3 +679,12 @@ pub(crate) fn lex_tokens(syntax: Syntax, s: &'static str) -> Vec<Token> {
     })
     .unwrap()
 }
+
+#[cfg(test)]
+pub(crate) fn lex_tokens_with_target(
+    syntax: Syntax,
+    target: JscTarget,
+    s: &'static str,
+) -> Vec<Token> {
+    with_lexer(syntax, target, s, |l| Ok(l.map(|ts| ts.token).collect())).unwrap()
+}

--- a/ecmascript/parser/src/lexer/state.rs
+++ b/ecmascript/parser/src/lexer/state.rs
@@ -636,7 +636,8 @@ pub enum TokenContext {
 
 #[cfg(test)]
 pub(crate) fn with_lexer<F, Ret>(
-    syntax: crate::Syntax,
+    syntax: Syntax,
+    target: JscTarget,
     s: &str,
     f: F,
 ) -> Result<Ret, ::testing::StdErr>
@@ -644,7 +645,7 @@ where
     F: FnOnce(&mut Lexer<'_, crate::lexer::input::StringInput<'_>>) -> Result<Ret, ()>,
 {
     crate::with_test_sess(s, |_, fm| {
-        let mut l = Lexer::new(syntax, Default::default(), fm, None);
+        let mut l = Lexer::new(syntax, target, fm, None);
         let res = f(&mut l);
 
         let c = vec![TokenContext::BraceStmt];
@@ -656,13 +657,13 @@ where
 
 #[cfg(test)]
 pub(crate) fn lex(syntax: Syntax, s: &'static str) -> Vec<TokenAndSpan> {
-    with_lexer(syntax, s, |l| Ok(l.collect())).unwrap()
+    with_lexer(syntax, Default::default(), s, |l| Ok(l.collect())).unwrap()
 }
 
 /// lex `s` within module context.
 #[cfg(test)]
 pub(crate) fn lex_module(syntax: Syntax, s: &'static str) -> Vec<TokenAndSpan> {
-    with_lexer(syntax, s, |l| {
+    with_lexer(syntax, Default::default(), s, |l| {
         l.ctx.strict = true;
         l.ctx.module = true;
 
@@ -673,5 +674,8 @@ pub(crate) fn lex_module(syntax: Syntax, s: &'static str) -> Vec<TokenAndSpan> {
 
 #[cfg(test)]
 pub(crate) fn lex_tokens(syntax: Syntax, s: &'static str) -> Vec<Token> {
-    with_lexer(syntax, s, |l| Ok(l.map(|ts| ts.token).collect())).unwrap()
+    with_lexer(syntax, Default::default(), s, |l| {
+        Ok(l.map(|ts| ts.token).collect())
+    })
+    .unwrap()
 }

--- a/ecmascript/parser/src/lexer/tests.rs
+++ b/ecmascript/parser/src/lexer/tests.rs
@@ -1079,6 +1079,7 @@ fn lex_colors_js(b: &mut Bencher) {
     b.iter(|| {
         let _ = with_lexer(
             Syntax::default(),
+            Default::default(),
             include_str!("../../colors.js"),
             |lexer| {
                 for t in lexer {
@@ -1097,6 +1098,7 @@ fn lex_colors_ts(b: &mut Bencher) {
     b.iter(|| {
         let _ = with_lexer(
             Syntax::Typescript(Default::default()),
+            Default::default(),
             include_str!("../../colors.js"),
             |lexer| {
                 for t in lexer {
@@ -1118,7 +1120,7 @@ fn bench(b: &mut Bencher, syntax: Syntax, s: &str) {
     b.bytes = s.len() as _;
 
     b.iter(|| {
-        let _ = with_lexer(syntax, s, |lexer| {
+        let _ = with_lexer(syntax, Default::default(), s, |lexer| {
             for t in lexer {
                 black_box(t);
             }

--- a/ecmascript/parser/src/parser/expr.rs
+++ b/ecmascript/parser/src/parser/expr.rs
@@ -835,7 +835,7 @@ impl<'a, I: Tokens> Parser<I> {
                         value: raw,
                         has_escape,
                     },
-                    Some(Str {
+                    cooked.map(|cooked| Str {
                         span: span!(start),
                         value: cooked,
                         has_escape,

--- a/ecmascript/parser/src/token.rs
+++ b/ecmascript/parser/src/token.rs
@@ -70,7 +70,7 @@ pub enum Token {
     BackQuote,
     Template {
         raw: JsWord,
-        cooked: JsWord,
+        cooked: Option<JsWord>,
         has_escape: bool,
     },
     /// ':'

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.26.1"
+version = "0.27.0"
 
 [features]
 const-modules = ["dashmap"]
@@ -21,7 +21,7 @@ either = "1.5"
 fxhash = "0.2"
 indexmap = "1"
 is-macro = "0.1"
-jsdoc = {version = "0.7.0", path = "../jsdoc"}
+jsdoc = {version = "0.8.0", path = "../jsdoc"}
 log = "0.4.8"
 once_cell = "1"
 ordered-float = "1.0.1"
@@ -35,7 +35,7 @@ smallvec = "1"
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.10.0", path = "../../common"}
 swc_ecma_ast = {version = "0.33.0", path = "../ast"}
-swc_ecma_parser = {version = "0.39.0", path = "../parser"}
+swc_ecma_parser = {version = "0.40.0", path = "../parser"}
 swc_ecma_transforms_macros = {version = "0.1.1", path = "./macros"}
 swc_ecma_utils = {version = "0.23.0", path = "../utils"}
 swc_ecma_visit = {version = "0.19.0", path = "../visit"}
@@ -44,7 +44,7 @@ unicode-xid = "0.2"
 [dev-dependencies]
 pretty_assertions = "0.6"
 sourcemap = "6"
-swc_ecma_codegen = {version = "0.37.0", path = "../codegen"}
+swc_ecma_codegen = {version = "0.38.0", path = "../codegen"}
 tempfile = "3"
 testing = {version = "0.10.0", path = "../../testing"}
 walkdir = "2"

--- a/visit/src/lib.rs
+++ b/visit/src/lib.rs
@@ -3,12 +3,6 @@ pub use swc_visit_macros::define;
 
 pub mod util;
 
-/// Visit all children nodes
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct All<V> {
-    pub visitor: V,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Optional<V> {
     pub enabled: bool,

--- a/visit/src/lib.rs
+++ b/visit/src/lib.rs
@@ -3,6 +3,12 @@ pub use swc_visit_macros::define;
 
 pub mod util;
 
+/// Visit all children nodes
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct All<V> {
+    pub visitor: V,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Optional<V> {
     pub enabled: bool,


### PR DESCRIPTION
Fixes #78.

When there's an error reading escaped characters, we return `None` for the cooked value and continue reading.

I think I'm on the right track here, but this is my first pull of any size so please let me know if I should do things differently. I'm happy to change it up.