### PR TITLE
Single argument arrow functions

### DIFF
--- a/ecmascript/codegen/src/decl.rs
+++ b/ecmascript/codegen/src/decl.rs
@@ -102,3 +102,27 @@ impl<'a> Emitter<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::assert_min;
+
+    #[test]
+    fn issue_275() {
+        assert_min(
+            "function* foo(){
+            yield getServiceHosts()
+        }",
+            "function*foo(){yield getServiceHosts();}",
+        );
+    }
+
+    #[test]
+    fn single_argument_arrow_expression() {
+        assert_min("function* f(){ yield x => x}", "function*f(){yield x=>x;}");
+        assert_min(
+            "function* f(){ yield ({x}) => x}",
+            "function*f(){yield({x})=>x;}",
+        );
+    }
+}

--- a/ecmascript/codegen/src/decl.rs
+++ b/ecmascript/codegen/src/decl.rs
@@ -59,9 +59,11 @@ impl<'a> Emitter<'a> {
         keyword!("function");
         if node.function.is_generator {
             punct!("*");
+            formatting_space!();
+        } else {
+            space!();
         }
 
-        space!();
         emit!(node.ident);
 
         self.emit_fn_trailing(&node.function)?;

--- a/ecmascript/codegen/src/expr.rs
+++ b/ecmascript/codegen/src/expr.rs
@@ -198,4 +198,13 @@ mod tests {
             "function* foo(){yield getServiceHosts();}",
         );
     }
+
+    #[test]
+    fn single_argument_arrow_expression() {
+        assert_min("function* f(){ yield x => x}", "function* f(){yield x=>x\n;}");
+        assert_min(
+            "function* f(){ yield ({x}) => x}",
+            "function* f(){yield({x })=>x\n;}",
+        );
+    }
 }

--- a/ecmascript/codegen/src/expr.rs
+++ b/ecmascript/codegen/src/expr.rs
@@ -195,16 +195,16 @@ mod tests {
             "function* foo(){
             yield getServiceHosts()
         }",
-            "function* foo(){yield getServiceHosts();}",
+            "function*foo(){yield getServiceHosts();}",
         );
     }
 
     #[test]
     fn single_argument_arrow_expression() {
-        assert_min("function* f(){ yield x => x}", "function* f(){yield x=>x;}");
+        assert_min("function* f(){ yield x => x}", "function*f(){yield x=>x;}");
         assert_min(
             "function* f(){ yield ({x}) => x}",
-            "function* f(){yield({x})=>x;}",
+            "function*f(){yield({x})=>x;}",
         );
     }
 }

--- a/ecmascript/codegen/src/expr.rs
+++ b/ecmascript/codegen/src/expr.rs
@@ -201,10 +201,10 @@ mod tests {
 
     #[test]
     fn single_argument_arrow_expression() {
-        assert_min("function* f(){ yield x => x}", "function* f(){yield x=>x\n;}");
+        assert_min("function* f(){ yield x => x}", "function* f(){yield x=>x;}");
         assert_min(
             "function* f(){ yield ({x}) => x}",
-            "function* f(){yield({x})=>x\n;}",
+            "function* f(){yield({x})=>x;}",
         );
     }
 }

--- a/ecmascript/codegen/src/expr.rs
+++ b/ecmascript/codegen/src/expr.rs
@@ -204,7 +204,7 @@ mod tests {
         assert_min("function* f(){ yield x => x}", "function* f(){yield x=>x\n;}");
         assert_min(
             "function* f(){ yield ({x}) => x}",
-            "function* f(){yield({x })=>x\n;}",
+            "function* f(){yield({x})=>x\n;}",
         );
     }
 }

--- a/ecmascript/codegen/src/expr.rs
+++ b/ecmascript/codegen/src/expr.rs
@@ -188,23 +188,4 @@ mod tests {
     fn regression_increments() {
         assert_min("x++ + ++y", "x++ + ++y;");
     }
-
-    #[test]
-    fn issue_275() {
-        assert_min(
-            "function* foo(){
-            yield getServiceHosts()
-        }",
-            "function*foo(){yield getServiceHosts();}",
-        );
-    }
-
-    #[test]
-    fn single_argument_arrow_expression() {
-        assert_min("function* f(){ yield x => x}", "function*f(){yield x=>x;}");
-        assert_min(
-            "function* f(){ yield ({x}) => x}",
-            "function*f(){yield({x})=>x;}",
-        );
-    }
 }

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -644,9 +644,20 @@ impl<'a> Emitter<'a> {
         if node.is_generator {
             punct!("*")
         }
-        punct!("(");
+
+        let parens = !self.cfg.minify
+            || match node.params.as_slice() {
+                [Pat::Ident(_)] => false,
+                _ => true,
+            };
+
+        if parens {
+            punct!("(");
+        }
         self.emit_list(node.span, Some(&node.params), ListFormat::CommaListElements)?;
-        punct!(")");
+        if parens {
+            punct!(")");
+        }
 
         punct!("=>");
         emit!(node.body);

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -1125,7 +1125,9 @@ impl<'a> Emitter<'a> {
                 self.wr.increase_indent()?;
                 emit!(expr);
                 self.wr.decrease_indent()?;
-                self.wr.write_line()?;
+                if !self.cfg.minify {
+                    self.wr.write_line()?;
+                }
             }
         }
     }

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -1819,7 +1819,7 @@ impl<'a> Emitter<'a> {
         self.emit_leading_comments_of_pos(node.span().lo())?;
 
         emit!(node.key);
-        space!();
+        formatting_space!();
         if let Some(ref value) = node.value {
             punct!("=");
             emit!(node.value);

--- a/ecmascript/codegen/src/util.rs
+++ b/ecmascript/codegen/src/util.rs
@@ -197,8 +197,10 @@ impl StartsWithAlphaNum for Expr {
                 _ => false,
             },
 
-            // TODO(kdy1): Support `v => {}`
-            Expr::Arrow(ArrowExpr { .. }) => false,
+            Expr::Arrow(ref expr) => match expr.params.as_slice() {
+                [p] => p.starts_with_alpha_num(),
+                _ => false,
+            },
 
             Expr::Tpl(_) | Expr::Update(_) | Expr::Array(_) | Expr::Object(_) | Expr::Paren(_) => {
                 false


### PR DESCRIPTION
I started with a TODO and found a few minify improvements.

* Remove parens from arrow functions when possible
* Remove space after prop keys when minifying
* Remove line break after expressions when minifying
* Remove space after generator `*` when minifying

Plenty more to do, but this is a good start!