### PR TITLE
fix: extienstion

### DIFF
--- a/spack/src/resolvers/mod.rs
+++ b/spack/src/resolvers/mod.rs
@@ -46,7 +46,7 @@ impl NodeResolver {
         }
 
         for ext in EXTENSIONS {
-            let ext_path = path.with_extension(ext);
+            let ext_path = PathBuf::from(format!("{}.{}", path.to_str().unwrap(), ext));
             if ext_path.is_file() {
                 return Ok(ext_path);
             }

--- a/spack/tests/pass/extension/input/a.a.js
+++ b/spack/tests/pass/extension/input/a.a.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/spack/tests/pass/extension/input/entry.js
+++ b/spack/tests/pass/extension/input/entry.js
@@ -1,0 +1,3 @@
+import { a } from './a.a';
+
+console.log(a);

--- a/spack/tests/pass/extension/output/entry.js
+++ b/spack/tests/pass/extension/output/entry.js
@@ -1,0 +1,2 @@
+const a = 1;
+console.log(a);


### PR DESCRIPTION
```js
import { a } from './a.a';

console.log(a);
```

./a.a.js
```js
export const a = 1;
```

The following error occurs
```
Caused by:
    0: failed to analyze module
    1: failed to resolve ./a.a from xxx/src/index.js
    2: index not found: xxx/src/./a.a
```

I don't understand why the following test failed
```
spack/tests/pass/dynmaic-imports/issue-1112
```