### PR TITLE
Implement Spanned for TokenAndSpan

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.43.2"
+version = "0.43.3"
 
 [features]
 default = []

--- a/ecmascript/parser/src/token.rs
+++ b/ecmascript/parser/src/token.rs
@@ -10,7 +10,7 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
 };
 use swc_atoms::{js_word, JsWord};
-use swc_common::Span;
+use swc_common::{Span, Spanned};
 pub(crate) use swc_ecma_ast::AssignOp as AssignOpToken;
 use swc_ecma_ast::BinaryOp;
 
@@ -216,6 +216,13 @@ pub struct TokenAndSpan {
     /// Had a line break before this token?
     pub had_line_break: bool,
     pub span: Span,
+}
+
+impl Spanned for TokenAndSpan {
+    #[inline(always)]
+    fn span(&self) -> Span {
+        self.span
+    }
 }
 
 #[derive(Kind, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
It would be nice if `TokenAndSpan` implemented `Spanned` because then tokens can be used in places that just need a span.