### PR TITLE
Fix #1277: publish @swc/wasm-web package

### DIFF
--- a/.github/workflows/publish-wasm-web.yml
+++ b/.github/workflows/publish-wasm-web.yml
@@ -1,0 +1,52 @@
+name: Publish (wasm for web)
+
+env:
+  CARGO_INCREMENTAL: 0
+  CI: "1"
+
+on:
+  create:
+    tags:
+      - v*
+
+jobs:
+  build:
+    name: Build - wasm for web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/
+            **/target/
+          key: ${{ runner.os }}-publish-integration
+
+      - name: Install node dependencies
+        run: npm i
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build
+        run: (cd wasm && wasm-pack build  --release --scope=swc)
+
+      - name: Rename
+        run: |
+          sed -i'' -e 's/"name": "@swc\/wasm"/"name": "@swc\/wasm-web"/g' package.json
+        working-directory: wasm/pkg
+
+      - name: Publish
+        run: |
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+          (cd wasm/pkg && npm publish)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The @swc/wasm package is meant for use in Node.js projects. Web pages cannot
use this package as it relies on Node.js specific modules (fs, in particular).
A Web-based project that would benefit from having a Web compatible @swc/wasm
version is astexplorer.net, which displays the AST emitted by various parsers.

When wasm-pack adds support for an "all" target exposing Web+Node support, the
build step will be simpler: everything will go to @swc/wasm. For now, we have
to change the package name in the generated package.json file.