### PR TITLE
fix(ci): insert *_bg files in @swc/wasm-web (#1291)

### DIFF
--- a/.github/workflows/publish-wasm-web.yml
+++ b/.github/workflows/publish-wasm-web.yml
@@ -43,6 +43,10 @@ jobs:
           sed -i'' -e 's/"name": "@swc\/wasm"/"name": "@swc\/wasm-web"/g' package.json
         working-directory: wasm/pkg
 
+      - name: Include *_bg files
+        run: jq '.files += ["wasm_bg.js", "wasm_bg.wasm.d.ts"]' package.json
+        working-directory: wasm/pkg
+
       - name: Publish
         run: |
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc


### PR DESCRIPTION
As described by #1291, right now `@swc/wasm-web` cannot be used after installation because `@swc/wasm-web` does not include files that wasm-bindgen produces when it gets published.

This happens due to a bug in wasm-pack (https://github.com/rustwasm/wasm-pack/issues/837).

Therefore, the simplest solution would just be including the `files` manually in `package.json` before publishing.
Initially I thought the only file that needs to be included would be `wasm_bg.js`, but `wasm_bg.wasm.d.ts` comes along with the build output too, so there's no reason not to include it as a part of API.

This would allow #50 to get going too.

Would close #1291 if it gets merged

cc @kdy1 