### PR TITLE
fix(bundler): Don't load dynamic imports

### DIFF
--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.18.1"
+version = "0.18.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/bundler/src/bundler/import/mod.rs
+++ b/bundler/src/bundler/import/mod.rs
@@ -516,16 +516,19 @@ where
                         return Expr::Call(e);
                     }
 
-                    ExprOrSuper::Expr(ref e) => match &**e {
-                        Expr::Ident(Ident {
-                            sym: js_word!("import"),
-                            ..
-                        }) => {
-                            self.info.dynamic_imports.push(src.clone());
-                        }
-                        _ => {}
-                    },
-
+                    // TODO: Uncomment this after implementing an option to make swc_bundler
+                    // includes dynamic imports
+                    //
+                    //
+                    // ExprOrSuper::Expr(ref e) => match &**e {
+                    //     Expr::Ident(Ident {
+                    //         sym: js_word!("import"),
+                    //         ..
+                    //     }) => {
+                    //         self.info.dynamic_imports.push(src.clone());
+                    //     }
+                    //     _ => {}
+                    // },
                     _ => {}
                 }
 

--- a/bundler/tests/common/mod.rs
+++ b/bundler/tests/common/mod.rs
@@ -76,6 +76,7 @@ impl Load for Loader {
             Syntax::Typescript(TsConfig {
                 decorators: true,
                 tsx,
+                dynamic_import: true,
                 ..Default::default()
             }),
             JscTarget::Es2020,

--- a/bundler/tests/fixture/dynamic/input/dep.ts
+++ b/bundler/tests/fixture/dynamic/input/dep.ts
@@ -1,0 +1,3 @@
+console.log('Foo')
+
+export const a = 5;

--- a/bundler/tests/fixture/dynamic/input/entry.ts
+++ b/bundler/tests/fixture/dynamic/input/entry.ts
@@ -1,0 +1,1 @@
+const a = import('./dep')

--- a/bundler/tests/fixture/dynamic/input/entry.ts
+++ b/bundler/tests/fixture/dynamic/input/entry.ts
@@ -1,1 +1,3 @@
 const a = import('./dep')
+
+console.log(a)

--- a/bundler/tests/fixture/dynamic/output/entry.ts
+++ b/bundler/tests/fixture/dynamic/output/entry.ts
@@ -1,0 +1,2 @@
+const a = import('./dep');
+console.log(a);


### PR DESCRIPTION
I'll reenable this after implementing an option to make `swc_bundler` to include them.

---

swc_bundler:
 - Do not load dynamically imported files. 