### PR TITLE
feat(ecmascript/codegen): fix and use omit_trailing_semi

### DIFF
--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.42.1"
+version = "0.42.2"
 
 [dependencies]
 bitflags = "1"

--- a/ecmascript/codegen/macros/src/fold.rs
+++ b/ecmascript/codegen/macros/src/fold.rs
@@ -102,8 +102,8 @@ impl Fold for InjectSelf {
             "unimplemented" => i,
 
             //TODO: Collect expect and give that list to unexpected
-            "keyword" | "emit" | "punct" | "semi" | "space" | "formatting_space" | "operator"
-            | "opt" | "opt_leading_space" => {
+            "keyword" | "emit" | "punct" | "semi" | "formatting_semi" | "space"
+            | "formatting_space" | "operator" | "opt" | "opt_leading_space" => {
                 let tokens = if i.tokens.is_empty() {
                     quote_spanned!(span => #parser)
                 } else {

--- a/ecmascript/codegen/src/decl.rs
+++ b/ecmascript/codegen/src/decl.rs
@@ -12,7 +12,7 @@ impl<'a> Emitter<'a> {
 
             Decl::Var(ref n) => {
                 emit!(n);
-                semi!(); // VarDecl is also used for for-loops
+                formatting_semi!(); // VarDecl is also used for for-loops
             }
             Decl::TsEnum(ref n) => emit!(n),
             Decl::TsInterface(ref n) => emit!(n),
@@ -113,16 +113,16 @@ mod tests {
             "function* foo(){
             yield getServiceHosts()
         }",
-            "function*foo(){yield getServiceHosts();}",
+            "function*foo(){yield getServiceHosts()}",
         );
     }
 
     #[test]
     fn single_argument_arrow_expression() {
-        assert_min("function* f(){ yield x => x}", "function*f(){yield x=>x;}");
+        assert_min("function* f(){ yield x => x}", "function*f(){yield x=>x}");
         assert_min(
             "function* f(){ yield ({x}) => x}",
-            "function*f(){yield({x})=>x;}",
+            "function*f(){yield({x})=>x}",
         );
     }
 }

--- a/ecmascript/codegen/src/expr.rs
+++ b/ecmascript/codegen/src/expr.rs
@@ -7,142 +7,142 @@ mod tests {
 
     #[test]
     fn values() {
-        assert_min("null", "null;");
-        assert_min("undefined", "undefined;");
-        assert_min("true", "true;");
-        assert_min("false", "false;");
-        assert_min("42", "42;");
-        assert_min("3.14", "3.14;");
-        assert_min(r#" 'foobar' "#, r#"'foobar';"#);
+        assert_min("null", "null");
+        assert_min("undefined", "undefined");
+        assert_min("true", "true");
+        assert_min("false", "false");
+        assert_min("42", "42");
+        assert_min("3.14", "3.14");
+        assert_min(r#" 'foobar' "#, r#"'foobar'"#);
     }
 
     #[test]
     fn bin_expr() {
-        assert_min("1+2+3+4+5", "1+2+3+4+5;");
+        assert_min("1+2+3+4+5", "1+2+3+4+5");
     }
 
     #[test]
     fn template_expression() {
-        assert_min("``", "``;");
-        assert_min("foo``", "foo``;");
-        assert_min("`foobar`", "`foobar`;");
-        assert_min("foo`bar`", "foo`bar`;");
-        assert_min("`foo${ 10 }bar${ 20 }baz`", "`foo${10}bar${20}baz`;");
-        assert_min("foo`bar${ 10 }baz`", "foo`bar${10}baz`;");
-        assert_min("foo`${ 10 }`", "foo`${10}`;");
+        assert_min("``", "``");
+        assert_min("foo``", "foo``");
+        assert_min("`foobar`", "`foobar`");
+        assert_min("foo`bar`", "foo`bar`");
+        assert_min("`foo${ 10 }bar${ 20 }baz`", "`foo${10}bar${20}baz`");
+        assert_min("foo`bar${ 10 }baz`", "foo`bar${10}baz`");
+        assert_min("foo`${ 10 }`", "foo`${10}`");
     }
 
     #[test]
     fn sequence_expression() {
-        assert_min("foo, bar, baz;", "foo,bar,baz;");
-        assert_min("1, 2, 3;", "1,2,3;");
-        assert_min("1,2,3+4;", "1,2,3+4;");
-        assert_min("1+2,3,4;", "1+2,3,4;");
-        assert_min("1+(2,3,4);", "1+(2,3,4);");
-        assert_min("(1,2,3)+4;", "(1,2,3)+4;");
+        assert_min("foo, bar, baz;", "foo,bar,baz");
+        assert_min("1, 2, 3;", "1,2,3");
+        assert_min("1,2,3+4;", "1,2,3+4");
+        assert_min("1+2,3,4;", "1+2,3,4");
+        assert_min("1+(2,3,4);", "1+(2,3,4)");
+        assert_min("(1,2,3)+4;", "(1,2,3)+4");
     }
 
     #[test]
     fn binary_expression() {
-        assert_min("a = 10", "a=10;");
-        assert_min("a == 10", "a==10;");
-        assert_min("a === 10", "a===10;");
-        assert_min("a != 10", "a!=10;");
-        assert_min("a !== 10", "a!==10;");
-        assert_min("a += 10", "a+=10;");
-        assert_min("a -= 10", "a-=10;");
-        assert_min("a <<= 10", "a<<=10;");
-        assert_min("a >>= 10", "a>>=10;");
-        assert_min("a >>>= 10", "a>>>=10;");
-        assert_min("2 + 2", "2+2;");
-        assert_min("2 - 2", "2-2;");
-        assert_min("2 * 2", "2*2;");
-        assert_min("2 / 2", "2/2;");
-        assert_min("2 % 2", "2%2;");
-        assert_min("2 ** 2", "2**2;");
-        assert_min("2 << 2", "2<<2;");
-        assert_min("2 >> 2", "2>>2;");
-        assert_min("2 >>> 2", "2>>>2;");
-        assert_min("foo in bar", "foo in bar;");
-        assert_min("foo instanceof Foo", "foo instanceof Foo;");
+        assert_min("a = 10", "a=10");
+        assert_min("a == 10", "a==10");
+        assert_min("a === 10", "a===10");
+        assert_min("a != 10", "a!=10");
+        assert_min("a !== 10", "a!==10");
+        assert_min("a += 10", "a+=10");
+        assert_min("a -= 10", "a-=10");
+        assert_min("a <<= 10", "a<<=10");
+        assert_min("a >>= 10", "a>>=10");
+        assert_min("a >>>= 10", "a>>>=10");
+        assert_min("2 + 2", "2+2");
+        assert_min("2 - 2", "2-2");
+        assert_min("2 * 2", "2*2");
+        assert_min("2 / 2", "2/2");
+        assert_min("2 % 2", "2%2");
+        assert_min("2 ** 2", "2**2");
+        assert_min("2 << 2", "2<<2");
+        assert_min("2 >> 2", "2>>2");
+        assert_min("2 >>> 2", "2>>>2");
+        assert_min("foo in bar", "foo in bar");
+        assert_min("foo instanceof Foo", "foo instanceof Foo");
     }
 
     #[test]
     fn prefix_expression() {
-        assert_min("+foo", "+foo;");
-        assert_min("-foo", "-foo;");
-        assert_min("!foo", "!foo;");
-        assert_min("~foo", "~foo;");
-        assert_min("++foo", "++foo;");
-        assert_min("--foo", "--foo;");
-        assert_min("new foo", "new foo;");
-        assert_min("void foo", "void foo;");
-        assert_min("typeof foo", "typeof foo;");
+        assert_min("+foo", "+foo");
+        assert_min("-foo", "-foo");
+        assert_min("!foo", "!foo");
+        assert_min("~foo", "~foo");
+        assert_min("++foo", "++foo");
+        assert_min("--foo", "--foo");
+        assert_min("new foo", "new foo");
+        assert_min("void foo", "void foo");
+        assert_min("typeof foo", "typeof foo");
     }
 
     #[test]
     fn postfix_expression() {
-        assert_min("foo++", "foo++;");
-        assert_min("foo--", "foo--;");
+        assert_min("foo++", "foo++");
+        assert_min("foo--", "foo--");
     }
 
     #[test]
     fn conditional_expression() {
-        assert_min("true ? foo : bar", "true?foo:bar;")
+        assert_min("true ? foo : bar", "true?foo:bar")
     }
 
     #[test]
     fn function_expression() {
-        assert_min("(function () {})", "(function(){});");
-        assert_min("(function foo() {})", "(function foo(){});");
+        assert_min("(function () {})", "(function(){})");
+        assert_min("(function foo() {})", "(function foo(){})");
     }
 
     #[test]
     #[ignore]
     fn class_expression() {
-        assert_min("(class {})", "(class{});");
-        assert_min("(class Foo {})", "(class Foo{});");
-        assert_min("(class extends Foo {})", "(class extends Foo{});");
-        assert_min("(class Foo extends Bar {})", "(class Foo extends Bar{});");
+        assert_min("(class {})", "(class{})");
+        assert_min("(class Foo {})", "(class Foo{})");
+        assert_min("(class extends Foo {})", "(class extends Foo{})");
+        assert_min("(class Foo extends Bar {})", "(class Foo extends Bar{})");
     }
 
     #[test]
     fn call_expression() {
-        assert_min("foobar();", "foobar();");
-        assert_min("foobar(1, 2, 3);", "foobar(1,2,3);");
+        assert_min("foobar();", "foobar()");
+        assert_min("foobar(1, 2, 3);", "foobar(1,2,3)");
     }
 
     #[test]
     fn member_expression() {
-        assert_min("foo.bar", "foo.bar;");
-        assert_min("this.bar", "this.bar;");
-        assert_min("10..fooz", "10..fooz;");
-        assert_min("foo[10]", "foo[10];");
-        assert_min(r#"foo["bar"]"#, r#"foo["bar"];"#);
+        assert_min("foo.bar", "foo.bar");
+        assert_min("this.bar", "this.bar");
+        assert_min("10..fooz", "10..fooz");
+        assert_min("foo[10]", "foo[10]");
+        assert_min(r#"foo["bar"]"#, r#"foo["bar"]"#);
     }
 
     #[test]
     fn array_expression() {
-        assert_min("[]", "[];");
-        assert_min("[foo]", "[foo];");
-        assert_min("[foo,bar]", "[foo,bar];");
-        assert_min("[foo,bar,baz]", "[foo,bar,baz];");
+        assert_min("[]", "[]");
+        assert_min("[foo]", "[foo]");
+        assert_min("[foo,bar]", "[foo,bar]");
+        assert_min("[foo,bar,baz]", "[foo,bar,baz]");
     }
 
     #[test]
     fn array_spread() {
-        assert_min("[...foo,...bar]", "[...foo,...bar];");
+        assert_min("[...foo,...bar]", "[...foo,...bar]");
     }
 
     #[test]
     fn sparse_array_expression() {
-        assert_min("[]", "[];");
-        assert_min("[,]", "[,];");
-        assert_min("[1,]", "[1,];");
-        assert_min("[,1]", "[,1];");
-        assert_min("[,,];", "[,,];");
-        assert_min("[1,,];", "[1,,];");
-        assert_min("[,,1];", "[,,1];");
+        assert_min("[]", "[]");
+        assert_min("[,]", "[,]");
+        assert_min("[1,]", "[1,]");
+        assert_min("[,1]", "[,1]");
+        assert_min("[,,];", "[,,]");
+        assert_min("[1,,];", "[1,,]");
+        assert_min("[,,1];", "[,,1]");
     }
 
     // #[test]
@@ -158,41 +158,41 @@ mod tests {
 
     #[test]
     fn object_expression() {
-        assert_min("({});", "({});");
-        assert_min("({ foo });", "({foo});");
-        assert_min("({ foo: 10 });", "({foo:10});");
-        assert_min("({ foo, bar });", "({foo,bar});");
-        assert_min("({ foo: 10, bar: 20 });", "({foo:10,bar:20});");
-        assert_min("({ foo: 10, bar() {} });", "({foo:10,bar(){}});");
-        assert_min("({ foo(bar, baz) {} });", "({foo(bar,baz){}});");
+        assert_min("({});", "({})");
+        assert_min("({ foo });", "({foo})");
+        assert_min("({ foo: 10 });", "({foo:10})");
+        assert_min("({ foo, bar });", "({foo,bar})");
+        assert_min("({ foo: 10, bar: 20 });", "({foo:10,bar:20})");
+        assert_min("({ foo: 10, bar() {} });", "({foo:10,bar(){}})");
+        assert_min("({ foo(bar, baz) {} });", "({foo(bar,baz){}})");
         // let expected = "({\n    foo: true,\n    bar: false\n});";
         // assert_pretty("({ foo: true, bar: false })", expected);
     }
 
     #[test]
     fn binding_power() {
-        assert_min("1 + 2 * 3;", "1+2*3;");
-        assert_min("1 + 2 * 3;", "1+2*3;");
-        assert_min("(1 + 2) * 3;", "(1+2)*3;");
+        assert_min("1 + 2 * 3;", "1+2*3");
+        assert_min("1 + 2 * 3;", "1+2*3");
+        assert_min("(1 + 2) * 3;", "(1+2)*3");
         assert_min(
             "(denominator / divider * 100).toFixed(2);",
-            "(denominator/divider*100).toFixed(2);",
+            "(denominator/divider*100).toFixed(2)",
         );
-        assert_min("(1 + 1)[0];", "(1+1)[0];");
-        assert_min("2 * 2 / 2;", "2*2/2;");
-        assert_min("2 * (2 / 2);", "2*(2/2);");
-        assert_min("2 * 2 / 2;", "2*2/2;");
+        assert_min("(1 + 1)[0];", "(1+1)[0]");
+        assert_min("2 * 2 / 2;", "2*2/2");
+        assert_min("2 * (2 / 2);", "2*(2/2)");
+        assert_min("2 * 2 / 2;", "2*2/2");
     }
 
     #[test]
     fn regression_increments() {
-        assert_min("x++ + ++y", "x++ + ++y;");
+        assert_min("x++ + ++y", "x++ + ++y");
     }
 
     #[test]
     fn bigint_property_key() {
-        assert_min("({ 1n: 2 });", "({1n:2});");
-        assert_min("(class C { 1n = 1 });", "(class C{1n=1;});");
-        assert_min("(class C { 1n () { } });", "(class C{1n(){}});");
+        assert_min("({ 1n: 2 });", "({1n:2})");
+        assert_min("(class C { 1n = 1 });", "(class C{1n=1})");
+        assert_min("(class C { 1n () { } });", "(class C{1n(){}})");
     }
 }

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -129,7 +129,7 @@ impl<'a> Emitter<'a> {
         keyword!("default");
         space!();
         emit!(node.expr);
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]
@@ -145,7 +145,7 @@ impl<'a> Emitter<'a> {
             DefaultDecl::Fn(ref n) => emit!(n),
             DefaultDecl::TsInterfaceDecl(ref n) => emit!(n),
         }
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]
@@ -210,7 +210,7 @@ impl<'a> Emitter<'a> {
 
         formatting_space!();
         emit!(node.src);
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]
@@ -330,7 +330,7 @@ impl<'a> Emitter<'a> {
             formatting_space!();
             emit!(src);
         }
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]
@@ -344,7 +344,7 @@ impl<'a> Emitter<'a> {
         keyword!("from");
         space!();
         emit!(node.src);
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]
@@ -948,7 +948,7 @@ impl<'a> Emitter<'a> {
             formatting_space!();
             emit!(body);
         } else {
-            semi!()
+            formatting_semi!()
         }
     }
 
@@ -977,7 +977,7 @@ impl<'a> Emitter<'a> {
             emit!(value);
         }
 
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]
@@ -1020,7 +1020,7 @@ impl<'a> Emitter<'a> {
             emit!(v);
         }
 
-        semi!();
+        formatting_semi!();
     }
 
     fn emit_accesibility(&mut self, n: Option<Accessibility>) -> Result {
@@ -1050,7 +1050,7 @@ impl<'a> Emitter<'a> {
         if let Some(body) = &n.body {
             emit!(body);
         } else {
-            semi!();
+            formatting_semi!();
         }
     }
 
@@ -1129,7 +1129,7 @@ impl<'a> Emitter<'a> {
             formatting_space!();
             emit!(body);
         } else {
-            semi!()
+            formatting_semi!()
         }
     }
 
@@ -1896,7 +1896,7 @@ impl<'a> Emitter<'a> {
     #[emitter]
     fn emit_expr_stmt(&mut self, e: &ExprStmt) -> Result {
         emit!(e.expr);
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]
@@ -1916,7 +1916,7 @@ impl<'a> Emitter<'a> {
     fn emit_empty_stmt(&mut self, node: &EmptyStmt) -> Result {
         self.emit_leading_comments_of_pos(node.span().lo())?;
 
-        punct!(";");
+        semi!();
     }
 
     #[emitter]
@@ -1924,7 +1924,7 @@ impl<'a> Emitter<'a> {
         self.emit_leading_comments_of_pos(node.span().lo())?;
 
         keyword!("debugger");
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]
@@ -1962,7 +1962,7 @@ impl<'a> Emitter<'a> {
                 punct!(")");
             }
         }
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]
@@ -1983,7 +1983,7 @@ impl<'a> Emitter<'a> {
             space!();
             emit!(label);
         }
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]
@@ -1993,7 +1993,7 @@ impl<'a> Emitter<'a> {
             space!();
             emit!(label);
         }
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]
@@ -2101,7 +2101,7 @@ impl<'a> Emitter<'a> {
         keyword!("throw");
         space!();
         emit!(node.arg);
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]

--- a/ecmascript/codegen/src/macros.rs
+++ b/ecmascript/codegen/src/macros.rs
@@ -68,11 +68,23 @@ macro_rules! formatting_space {
     };
 }
 
-macro_rules! semi {
+/// This macro *may* emit a semicolon, if it's required in this context.
+macro_rules! formatting_semi {
     ($emitter:expr) => {
         punct!($emitter, ";")
     };
     ($emitter:expr, ) => {
         punct!($emitter, ";")
+    };
+}
+
+/// This macro *always* emits a semicolon, as it's required by the structure we
+/// emit.
+macro_rules! semi {
+    ($emitter:expr) => {
+        $emitter.wr.write_punct(";")?;
+    };
+    ($emitter:expr, ) => {
+        $emitter.wr.write_punct(";")?;
     };
 }

--- a/ecmascript/codegen/src/stmt.rs
+++ b/ecmascript/codegen/src/stmt.rs
@@ -8,13 +8,13 @@ mod tests {
     #[test]
     fn block_statement() {
         assert_min("{}", "{}");
-        assert_min("{foo;}", "{foo;}");
+        assert_min("{foo;}", "{foo}");
     }
 
     #[test]
     fn labeled_statement() {
         assert_min("foo: {}", "foo:{}");
-        assert_min("foo: bar;", "foo:bar;");
+        assert_min("foo: bar;", "foo:bar");
     }
 
     #[test]
@@ -24,45 +24,42 @@ mod tests {
 
     #[test]
     fn declaration_statement() {
-        assert_min("var foo;", "var foo;");
-        assert_min("let foo;", "let foo;");
-        assert_min("const foo;", "const foo;");
-        assert_min("var foo = 10;", "var foo=10;");
-        assert_min("let foo = 10;", "let foo=10;");
-        assert_min("const foo = 10;", "const foo=10;");
-        assert_min("var foo, bar;", "var foo,bar;");
-        assert_min("let foo, bar;", "let foo,bar;");
-        assert_min("const foo, bar;", "const foo,bar;");
-        assert_min("var foo = 10, bar = 20;", "var foo=10,bar=20;");
-        assert_min("let foo = 10, bar = 20;", "let foo=10,bar=20;");
-        assert_min("const foo = 10, bar = 20;", "const foo=10,bar=20;");
-        assert_min("const a = {...foo};", "const a={...foo};");
+        assert_min("var foo;", "var foo");
+        assert_min("let foo;", "let foo");
+        assert_min("const foo;", "const foo");
+        assert_min("var foo = 10;", "var foo=10");
+        assert_min("let foo = 10;", "let foo=10");
+        assert_min("const foo = 10;", "const foo=10");
+        assert_min("var foo, bar;", "var foo,bar");
+        assert_min("let foo, bar;", "let foo,bar");
+        assert_min("const foo, bar;", "const foo,bar");
+        assert_min("var foo = 10, bar = 20;", "var foo=10,bar=20");
+        assert_min("let foo = 10, bar = 20;", "let foo=10,bar=20");
+        assert_min("const foo = 10, bar = 20;", "const foo=10,bar=20");
+        assert_min("const a = {...foo};", "const a={...foo}");
     }
 
     #[test]
     fn if_statement() {
-        assert_min("if (true) foo;", "if(true)foo;");
-        assert_min("if (true) { foo; }", "if(true){foo;}");
-        assert_min("if (true) foo; else bar;", "if(true)foo;else bar;");
-        assert_min(
-            "if (true) { foo; } else { bar; }",
-            "if(true){foo;}else{bar;}",
-        );
-        assert_min("if (true) foo; else { bar; }", "if(true)foo;else{bar;}");
-        assert_min("if (true) { foo; } else bar;", "if(true){foo;}else bar;");
-        assert_min("if (true) y(); else x++;", "if(true)y();else x++;");
-        assert_min("if (true) y(); else x--;", "if(true)y();else x--;");
+        assert_min("if (true) foo;", "if(true)foo");
+        assert_min("if (true) { foo; }", "if(true){foo}");
+        assert_min("if (true) foo; else bar;", "if(true)foo;else bar");
+        assert_min("if (true) { foo; } else { bar; }", "if(true){foo}else{bar}");
+        assert_min("if (true) foo; else { bar; }", "if(true)foo;else{bar}");
+        assert_min("if (true) { foo; } else bar;", "if(true){foo}else bar");
+        assert_min("if (true) y(); else x++;", "if(true)y();else x++");
+        assert_min("if (true) y(); else x--;", "if(true)y();else x--");
     }
 
     #[test]
     fn while_statement() {
-        assert_min("while (true) foo;", "while(true)foo;");
-        assert_min("while (true) { foo; }", "while(true){foo;}");
+        assert_min("while (true) foo;", "while(true)foo");
+        assert_min("while (true) { foo; }", "while(true){foo}");
     }
 
     #[test]
     fn do_statement() {
-        assert_min("do { foo; } while (true)", "do{foo;}while(true)");
+        assert_min("do { foo; } while (true)", "do{foo}while(true)");
         assert_min("do foo; while (true)", "do foo;while(true)");
     }
 
@@ -75,6 +72,20 @@ mod tests {
         assert_min("for (let foo in bar){}", "for(let foo in bar){}");
         assert_min("for (foo of bar){}", "for(foo of bar){}");
         assert_min("for (let foo of bar){}", "for(let foo of bar){}");
+    }
+
+    #[test]
+    fn for_statement_pretty() {
+        assert_pretty(
+            "for (var i = 0; i < 10; i++) {}",
+            "for(var i = 0; i < 10; i++){\n}",
+        );
+        assert_pretty("for (i = 0; i < 10; i++) {}", "for(i = 0; i < 10; i++){\n}");
+        assert_pretty("for (;;) {}", "for(;;){\n}");
+        assert_pretty("for (foo in bar){}", "for(foo in bar){\n}");
+        assert_pretty("for (let foo in bar){}", "for(let foo in bar){\n}");
+        assert_pretty("for (foo of bar){}", "for (foo of bar){\n}");
+        assert_pretty("for (let foo of bar){}", "for (let foo of bar){\n}");
     }
 
     #[test]
@@ -91,12 +102,12 @@ mod tests {
 
     #[test]
     fn issue_204_01() {
-        assert_min(r#"'\r\n';"#, r#"'\r\n';"#);
+        assert_min(r#"'\r\n';"#, r#"'\r\n'"#);
     }
 
     #[test]
     fn issue_204_02() {
-        assert_min(r#"const a = fn() + '\r\n';"#, r#"const a=fn()+'\r\n';"#);
+        assert_min(r#"const a = fn() + '\r\n';"#, r#"const a=fn()+'\r\n'"#);
     }
 
     #[test]
@@ -105,7 +116,7 @@ mod tests {
             "#!/usr/bin/env node
 let x = 4;",
             "#!/usr/bin/env node
-let x=4;",
+let x=4",
         );
     }
 
@@ -123,7 +134,7 @@ const Link = 'Boo';",
     fn issue_266() {
         assert_min(
             "'Q' + +x1 + ',' + +y1 + ',' + (this._x1 = +x) + ',' + (this._y1 = +y);",
-            "'Q'+ +x1+','+ +y1+','+(this._x1=+x)+','+(this._y1=+y);",
+            "'Q'+ +x1+','+ +y1+','+(this._x1=+x)+','+(this._y1=+y)",
         );
     }
 }

--- a/ecmascript/codegen/src/tests.rs
+++ b/ecmascript/codegen/src/tests.rs
@@ -1,6 +1,7 @@
 use self::swc_ecma_parser::{EsConfig, Parser, StringInput, Syntax};
 use super::*;
 use crate::config::Config;
+use crate::text_writer::omit_trailing_semi;
 use std::{
     fmt::{self, Debug, Display, Formatter},
     io::Write,
@@ -20,10 +21,17 @@ impl Builder {
     where
         F: FnOnce(&mut Emitter<'_>) -> Ret,
     {
+        let writer = text_writer::JsWriter::new(self.cm.clone(), "\n", s, None);
+        let writer: Box<dyn WriteJs> = if self.cfg.minify {
+            Box::new(omit_trailing_semi(writer))
+        } else {
+            Box::new(writer)
+        };
+
         let mut e = Emitter {
             cfg: self.cfg,
             cm: self.cm.clone(),
-            wr: Box::new(text_writer::JsWriter::new(self.cm.clone(), "\n", s, None)),
+            wr: writer,
             comments: Some(&self.comments),
         };
 

--- a/ecmascript/codegen/src/text_writer/semicolon.rs
+++ b/ecmascript/codegen/src/text_writer/semicolon.rs
@@ -53,7 +53,11 @@ impl<W: WriteJs> WriteJs for OmitTrailingSemi<W> {
     with_semi!(write_str_lit(span: Span, s: &str));
     with_semi!(write_str(s: &str));
     with_semi!(write_symbol(span: Span, s: &str));
-    with_semi!(write_punct(s: &'static str));
+
+    fn write_punct(&mut self, s: &'static str) -> Result {
+        self.pending_semi = false;
+        Ok(self.inner.write_punct(s)?)
+    }
 }
 
 impl<W: WriteJs> OmitTrailingSemi<W> {

--- a/ecmascript/codegen/src/typescript.rs
+++ b/ecmascript/codegen/src/typescript.rs
@@ -467,7 +467,7 @@ impl<'a> Emitter<'a> {
         punct!(":");
         space!();
         emit!(n.type_ann);
-        semi!();
+        formatting_semi!();
 
         self.wr.write_line()?;
         self.wr.decrease_indent()?;
@@ -802,7 +802,7 @@ impl<'a> Emitter<'a> {
 
         emit!(n.type_ann);
 
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]
@@ -847,7 +847,7 @@ impl<'a> Emitter<'a> {
             TsTypeElement::TsMethodSignature(n) => emit!(n),
             TsTypeElement::TsIndexSignature(n) => emit!(n),
         }
-        semi!();
+        formatting_semi!();
     }
 
     #[emitter]
@@ -991,7 +991,7 @@ mod tests {
     fn qualified_type() {
         assert_min_typescript(
             "var memory: WebAssembly.Memory;",
-            "var memory:WebAssembly.Memory;",
+            "var memory:WebAssembly.Memory",
         );
     }
 }


### PR DESCRIPTION
swc_ecma_codegen:
- Use omit_trailing_semi in 'assert_min' tests, to identify bugs.
  Before this, no code was using this method - and it had some serious bugs.
- Omit semicolons when writing punctuation, as it's permitted to do so.
- Use two macros ('semi', 'formatting_semi') to distinguish between required
  semicolons, as used in for(...), and optional ones that are used between
  statements.

This commit does not enforce the use of omit_trailing_semi when cfg.minify is used (except in tests using assert_min), and as such should not modify the behavior of existing apps. This can be confirmed by the `test262` suite still passing.