### PR TITLE
readme: fix website docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ swc is a super-fast typescript / javascript compiler written in rust.
 
 # Documentation
 
-Check out the documentation [in the website](https://swc.rs/docs/installation).
+Check out the documentation [in the website](https://swc.rs/docs/).
 
 # Features
 


### PR DESCRIPTION
https://swc.rs/docs/ shows what https://swc.rs/docs/installation was supposed to show.