### PR TITLE
fix(es): Fixes for the type checker

### DIFF
--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.43.0"
+version = "0.43.1"
 
 [dependencies]
 bitflags = "1"

--- a/ecmascript/codegen/src/typescript.rs
+++ b/ecmascript/codegen/src/typescript.rs
@@ -317,6 +317,10 @@ impl<'a> Emitter<'a> {
 
         emit!(n.id);
 
+        if let Some(type_params) = &n.type_params {
+            emit!(type_params);
+        }
+
         if !n.extends.is_empty() {
             space!();
 

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 fxhash = "0.2.1"

--- a/ecmascript/transforms/base/src/resolver/tests.rs
+++ b/ecmascript/transforms/base/src/resolver/tests.rs
@@ -1824,3 +1824,17 @@ to!(
 
     "
 );
+
+to_ts!(
+    as_operator_ambiguity,
+    "
+    interface A<T> { x: T; }
+    interface B { m: string; }
+
+    // Make sure this is a type assertion to an array type, and not nested comparison operators.
+    var x: any;
+    var y = x as A<B>[];
+    var z = y[0].m; // z should be string
+    ",
+    ""
+);

--- a/ecmascript/transforms/base/src/resolver/tests.rs
+++ b/ecmascript/transforms/base/src/resolver/tests.rs
@@ -1826,7 +1826,20 @@ to!(
 );
 
 to_ts!(
-    as_operator_ambiguity,
+    ts_module_name_1,
+    "
+    module A {
+        export function b() {
+            
+        }
+    }
+    A.b()
+    ",
+    ""
+);
+
+to_ts!(
+    ts_as_operator_ambiguity_1,
     "
     interface A<T> { x: T; }
     interface B { m: string; }

--- a/ecmascript/transforms/base/src/resolver/tests.rs
+++ b/ecmascript/transforms/base/src/resolver/tests.rs
@@ -1851,3 +1851,18 @@ to_ts!(
     ",
     ""
 );
+
+to_ts!(
+    ts_as_operator_ambiguity_2,
+    "
+    module Top {
+        interface A<T> { x: T; }
+        interface B { m: string; }
+
+        var x: any;
+        var y = x as A<B>[];
+        var z = y[0].m; // z should be string
+    }
+    ",
+    ""
+);

--- a/ecmascript/transforms/base/src/resolver/tests.rs
+++ b/ecmascript/transforms/base/src/resolver/tests.rs
@@ -1828,19 +1828,23 @@ to!(
 to_ts!(
     ts_module_name_1,
     "
-    module A {
-        export function b() {
-            
+    module Top {
+        module A {
+            export function b() {
+                
+            }
         }
+        A.b()
     }
-    A.b()
     ",
     "
-    module A__0 {
-        export function b() {
+    module Top {
+        module A__2 {
+            export function b__0() {
+            }
         }
-    }
-    A__0.b();
+        A__2.b();
+    }    
     "
 );
 
@@ -1855,7 +1859,17 @@ to_ts!(
     var y = x as A<B>[];
     var z = y[0].m; // z should be string
     ",
-    ""
+    "
+    interface A<T__2> {
+        x: T__2;
+    }
+    interface B {
+        m: string;
+    }
+    var x: any;
+    var y = x as A<B>[];
+    var z = y[0].m;
+    "
 );
 
 to_ts!(
@@ -1870,5 +1884,18 @@ to_ts!(
         var z = y[0].m; // z should be string
     }
     ",
-    ""
+    "
+    module Top {
+        interface A__2<T__3> {
+            x: T__3;
+        }
+        interface B__2 {
+            m: string;
+        }
+        var x: any;
+        var y = x as A__2<B__2>[];
+        var z = y[0].m;
+    }
+    
+    "
 );

--- a/ecmascript/transforms/base/src/resolver/tests.rs
+++ b/ecmascript/transforms/base/src/resolver/tests.rs
@@ -1835,7 +1835,13 @@ to_ts!(
     }
     A.b()
     ",
-    ""
+    "
+    module A__0 {
+        export function b() {
+        }
+    }
+    A__0.b();
+    "
 );
 
 to_ts!(


### PR DESCRIPTION
# Tasks

swc_ecma_codegen:
 - [x] Fix codegen of typescript interfaces.

swc_ecma_transforms_base:
 - [x] ts_resolver: Handle ts module declarations.