### PR TITLE
fix(es/transforms): Handle enum in namespaces

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,7 +50,7 @@ jobs:
           # Download three.js
           git clone --depth 1 https://github.com/mrdoob/three.js.git -b r117 integration-tests/three-js/repo
 
-          swc --sync integration-tests/three-js/repo/ -d integration-tests/three-js/build/
+          swc --sync --extensions js integration-tests/three-js/repo/ -d integration-tests/three-js/build/
           # swc integration-tests/three-js/repo/src/ -d integration-tests/three-js/repo/build/
           # swc integration-tests/three-js/repo/test/unit/**/*.js -d integration-tests/three-js/repo/test/unit/build/
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,7 +50,7 @@ jobs:
           # Download three.js
           git clone --depth 1 https://github.com/mrdoob/three.js.git -b r117 integration-tests/three-js/repo
 
-          swc --sync --extensions js integration-tests/three-js/repo/ -d integration-tests/three-js/build/
+          swc --sync --extensions '.js' integration-tests/three-js/repo/ -d integration-tests/three-js/build/
           # swc integration-tests/three-js/repo/src/ -d integration-tests/three-js/repo/build/
           # swc integration-tests/three-js/repo/test/unit/**/*.js -d integration-tests/three-js/repo/test/unit/build/
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,7 +38,7 @@ jobs:
           export PATH="$PATH:$HOME/npm/bin"
 
           npm run build:dev
-          npm i -g @swc/cli@0.1.31
+          npm i -g @swc/cli@0.1.32
           npm link
 
       - name: (swc) three.js

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,7 +38,7 @@ jobs:
           export PATH="$PATH:$HOME/npm/bin"
 
           npm run build:dev
-          npm i -g @swc/cli
+          npm i -g @swc/cli@0.1.31
           npm link
 
       - name: (swc) three.js

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.2.0"
+version = "0.3.0"
 
 [lib]
 name = "swc"

--- a/benches/typescript.rs
+++ b/benches/typescript.rs
@@ -226,6 +226,7 @@ macro_rules! tr_only {
                             "rxjs/src/internal/observable/dom/AjaxObservable.ts".into(),
                         ),
                     )
+                    .unwrap()
                     .unwrap();
                 let program = c.run_transform(true, || program.fold_with(&mut config.pass));
                 black_box(program)

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.3.0"
+version = "0.3.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/ecmascript/transforms/typescript/src/strip.rs
+++ b/ecmascript/transforms/typescript/src/strip.rs
@@ -554,7 +554,7 @@ impl Strip {
                                                     span: DUMMY_SP,
                                                     kind: v.kind,
                                                     declare: false,
-                                                    decls:  vec![decl],
+                                                    decls: vec![decl],
                                                 })))
                                             }
                                             _ => {}

--- a/ecmascript/transforms/typescript/src/strip.rs
+++ b/ecmascript/transforms/typescript/src/strip.rs
@@ -527,6 +527,7 @@ impl Strip {
         body.body.visit_mut_with(self);
 
         let private_name = private_ident!(module_name.sym.clone());
+        let mut delayed_vars = vec![];
 
         for item in body.body {
             // Drop
@@ -543,7 +544,24 @@ impl Strip {
                             for decl in v.decls {
                                 let init = match decl.init {
                                     Some(v) => v,
-                                    None => continue,
+                                    None => {
+                                        // We should handle enums
+
+                                        match &decl.name {
+                                            Pat::Ident(name) => {
+                                                delayed_vars.push(name.clone());
+                                                init_stmts.push(Stmt::Decl(Decl::Var(VarDecl {
+                                                    span: DUMMY_SP,
+                                                    kind: v.kind,
+                                                    declare: false,
+                                                    decls:  vec![decl],
+                                                })))
+                                            }
+                                            _ => {}
+                                        }
+
+                                        continue;
+                                    }
                                 };
                                 match decl.name {
                                     Pat::Ident(name) => {
@@ -624,6 +642,35 @@ impl Strip {
                 ModuleItem::Stmt(stmt) => init_stmts.push(stmt),
                 _ => {}
             }
+        }
+
+        if !delayed_vars.is_empty() {
+            init_stmts.push(Stmt::Expr(ExprStmt {
+                span: DUMMY_SP,
+                expr: Box::new(Expr::Seq(SeqExpr {
+                    span: DUMMY_SP,
+                    exprs: delayed_vars
+                        .into_iter()
+                        .map(|id| {
+                            //
+                            let mut prop = id.clone();
+                            prop.span.ctxt = SyntaxContext::empty();
+                            Expr::Assign(AssignExpr {
+                                span: DUMMY_SP,
+                                op: op!("="),
+                                left: PatOrExpr::Expr(Box::new(Expr::Member(MemberExpr {
+                                    span: DUMMY_SP,
+                                    obj: private_name.clone().as_obj(),
+                                    prop: Box::new(Expr::Ident(prop)),
+                                    computed: false,
+                                }))),
+                                right: Box::new(Expr::Ident(id)),
+                            })
+                        })
+                        .map(Box::new)
+                        .collect(),
+                })),
+            }))
         }
 
         let init_fn_expr = FnExpr {
@@ -1192,6 +1239,7 @@ impl VisitMut for Strip {
                             }],
                         }),
                     })));
+
                     self.handle_enum(e, &mut stmts)
                 }
                 ModuleItem::Stmt(Stmt::Decl(Decl::TsEnum(e))) => {

--- a/ecmascript/transforms/typescript/tests/strip.rs
+++ b/ecmascript/transforms/typescript/tests/strip.rs
@@ -3409,3 +3409,20 @@ to!(
     })(util || (util = {}));
     "
 );
+
+to!(
+    issue_1329,
+    "
+    namespace Test {
+        export enum DummyValues {
+            A = 'A',
+            B = 'B',
+        }
+    }
+      
+    console(Test.DummyValues.A);
+    ",
+    "
+   
+    "
+);

--- a/ecmascript/transforms/typescript/tests/strip.rs
+++ b/ecmascript/transforms/typescript/tests/strip.rs
@@ -3418,11 +3418,22 @@ to!(
             A = 'A',
             B = 'B',
         }
-    }
+      }
       
     console(Test.DummyValues.A);
     ",
     "
-   
+    var Test;
+    (function(Test1) {
+        var DummyValues;
+        (function(DummyValues) {
+            DummyValues['A'] = 'A';
+            DummyValues['B'] = 'B';
+        })(DummyValues || (DummyValues = {
+        }));
+        Test1.DummyValues = DummyValues;
+    })(Test || (Test = {
+    }));
+    console(Test.DummyValues.A);
     "
 );

--- a/src/config.rs
+++ b/src/config.rs
@@ -392,18 +392,19 @@ impl Default for Rc {
 }
 
 impl Rc {
-    pub fn into_config(self, filename: Option<&Path>) -> Result<Config, Error> {
-        let mut cs = match self {
+    /// This method returns `Ok(None)` if the file should be ignored.
+    pub fn into_config(self, filename: Option<&Path>) -> Result<Option<Config>, Error> {
+        let cs = match self {
             Rc::Single(c) => match filename {
                 Some(filename) => {
                     if c.matches(filename)? {
-                        return Ok(c);
+                        return Ok(Some(c));
                     } else {
-                        bail!("not matched")
+                        return Ok(None);
                     }
                 }
                 // TODO
-                None => return Ok(c),
+                None => return Ok(Some(c)),
             },
             Rc::Multi(cs) => cs,
         };
@@ -412,12 +413,12 @@ impl Rc {
             Some(filename) => {
                 for c in cs {
                     if c.matches(filename)? {
-                        return Ok(c);
+                        return Ok(Some(c));
                     }
                 }
             }
             // TODO
-            None => return Ok(cs.remove(0)),
+            None => return Ok(None),
         }
 
         bail!("not matched")

--- a/tests/projects.rs
+++ b/tests/projects.rs
@@ -66,6 +66,8 @@ fn project(dir: &str) {
                     continue;
                 }
 
+                let fm = cm.load_file(entry.path()).expect("failed to load file");
+
                 if c.config_for_file(
                     &Options {
                         swcrc: true,
@@ -73,14 +75,14 @@ fn project(dir: &str) {
 
                         ..Default::default()
                     },
-                    &entry.path(),
-                )?
+                    &fm.name,
+                )
+                .expect("failed to read config")
                 .is_none()
                 {
                     continue;
                 }
 
-                let fm = cm.load_file(entry.path()).expect("failed to load file");
                 match c.process_js_file(
                     fm,
                     &Options {

--- a/tests/projects.rs
+++ b/tests/projects.rs
@@ -66,6 +66,20 @@ fn project(dir: &str) {
                     continue;
                 }
 
+                if c.config_for_file(
+                    &Options {
+                        swcrc: true,
+                        is_module: true,
+
+                        ..Default::default()
+                    },
+                    &entry.path(),
+                )?
+                .is_none()
+                {
+                    continue;
+                }
+
                 let fm = cm.load_file(entry.path()).expect("failed to load file");
                 match c.process_js_file(
                     fm,


### PR DESCRIPTION
swc_ecma_transforms_typescript:
 - [x] Handle enums in namespaces. (Closes #1329)

swc:
 - [x] Exclude files based on .swcrc.