### PR TITLE
v1.2.46: Prevent regression.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -82,7 +82,7 @@ jobs:
           # Download three.js
           git clone --depth 1 https://github.com/mrdoob/three.js.git -b r117 integration-tests/three-js/repo
 
-          swc --sync --extensions '.js' integration-tests/three-js/repo/ -d integration-tests/three-js/build/
+          swc --sync integration-tests/three-js/repo/ -d integration-tests/three-js/build/
           # swc integration-tests/three-js/repo/src/ -d integration-tests/three-js/repo/build/
           # swc integration-tests/three-js/repo/test/unit/**/*.js -d integration-tests/three-js/repo/test/unit/build/
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -70,7 +70,7 @@ jobs:
           export PATH="$PATH:$HOME/npm/bin"
 
           npm run build:dev
-          npm i -g @swc/cli@0.1.32
+          npm i -g @swc/cli@0.1.33
           npm link
 
       - name: (swc) three.js


### PR DESCRIPTION
To prevent regression related to cli updates, we ensure that cli ignores errors with specific error mesages.
