### PR TITLE
Fix span of arrow expression with type params

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.45.4"
+version = "0.45.5"
 
 [features]
 default = []

--- a/ecmascript/parser/src/parser/expr.rs
+++ b/ecmascript/parser/src/parser/expr.rs
@@ -75,9 +75,11 @@ impl<'a, I: Tokens> Parser<I> {
                 let mut arrow = p.parse_assignment_expr_base()?;
                 match *arrow {
                     Expr::Arrow(ArrowExpr {
+                        ref mut span,
                         ref mut type_params,
                         ..
                     }) => {
+                        *span = Span::new(type_parameters.span.lo, span.hi, Default::default());
                         *type_params = Some(type_parameters);
                     }
                     _ => unexpected!(p, "("),

--- a/ecmascript/parser/tests/span/ts/expr/arrow-type-params.ts
+++ b/ecmascript/parser/tests/span/ts/expr/arrow-type-params.ts
@@ -1,0 +1,1 @@
+const a = <T>(value: T): any => {};

--- a/ecmascript/parser/tests/span/ts/expr/arrow-type-params.ts.spans
+++ b/ecmascript/parser/tests/span/ts/expr/arrow-type-params.ts.spans
@@ -1,0 +1,150 @@
+warning: Module
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:1
+  |
+1 | const a = <T>(value: T): any => {};
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: ModuleItem
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:1
+  |
+1 | const a = <T>(value: T): any => {};
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: Stmt
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:1
+  |
+1 | const a = <T>(value: T): any => {};
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: Decl
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:1
+  |
+1 | const a = <T>(value: T): any => {};
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: VarDecl
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:1
+  |
+1 | const a = <T>(value: T): any => {};
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: VarDeclarator
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:7
+  |
+1 | const a = <T>(value: T): any => {};
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: Pat
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:7
+  |
+1 | const a = <T>(value: T): any => {};
+  |       ^
+
+warning: Ident
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:7
+  |
+1 | const a = <T>(value: T): any => {};
+  |       ^
+
+warning: Expr
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:11
+  |
+1 | const a = <T>(value: T): any => {};
+  |           ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: ArrowExpr
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:11
+  |
+1 | const a = <T>(value: T): any => {};
+  |           ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: Pat
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:15
+  |
+1 | const a = <T>(value: T): any => {};
+  |               ^^^^^^^^
+
+warning: Ident
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:15
+  |
+1 | const a = <T>(value: T): any => {};
+  |               ^^^^^^^^
+
+warning: TsTypeAnn
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:20
+  |
+1 | const a = <T>(value: T): any => {};
+  |                    ^^^
+
+warning: TsType
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:22
+  |
+1 | const a = <T>(value: T): any => {};
+  |                      ^
+
+warning: TsTypeRef
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:22
+  |
+1 | const a = <T>(value: T): any => {};
+  |                      ^
+
+warning: TsEntityName
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:22
+  |
+1 | const a = <T>(value: T): any => {};
+  |                      ^
+
+warning: Ident
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:22
+  |
+1 | const a = <T>(value: T): any => {};
+  |                      ^
+
+warning: BlockStmtOrExpr
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:33
+  |
+1 | const a = <T>(value: T): any => {};
+  |                                 ^^
+
+warning: BlockStmt
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:33
+  |
+1 | const a = <T>(value: T): any => {};
+  |                                 ^^
+
+warning: TsTypeParamDecl
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:11
+  |
+1 | const a = <T>(value: T): any => {};
+  |           ^^^
+
+warning: TsTypeParam
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:12
+  |
+1 | const a = <T>(value: T): any => {};
+  |            ^
+
+warning: Ident
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:12
+  |
+1 | const a = <T>(value: T): any => {};
+  |            ^
+
+warning: TsTypeAnn
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:24
+  |
+1 | const a = <T>(value: T): any => {};
+  |                        ^^^^^
+
+warning: TsType
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:26
+  |
+1 | const a = <T>(value: T): any => {};
+  |                          ^^^
+
+warning: TsKeywordType
+ --> $DIR/tests/span/ts/expr/arrow-type-params.ts:1:26
+  |
+1 | const a = <T>(value: T): any => {};
+  |                          ^^^
+

--- a/ecmascript/parser/tests/typescript/arrow-function/generic-tsx/input.ts.json
+++ b/ecmascript/parser/tests/typescript/arrow-function/generic-tsx/input.ts.json
@@ -16,7 +16,7 @@
       "expression": {
         "type": "ArrowFunctionExpression",
         "span": {
-          "start": 64,
+          "start": 61,
           "end": 78,
           "ctxt": 0
         },

--- a/ecmascript/parser/tests/typescript/arrow-function/generic/input.ts.json
+++ b/ecmascript/parser/tests/typescript/arrow-function/generic/input.ts.json
@@ -16,7 +16,7 @@
       "expression": {
         "type": "ArrowFunctionExpression",
         "span": {
-          "start": 3,
+          "start": 0,
           "end": 17,
           "ctxt": 0
         },

--- a/ecmascript/parser/tests/typescript/custom/tsx-issue-573/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/custom/tsx-issue-573/input.tsx.json
@@ -37,7 +37,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 38,
+              "start": 11,
               "end": 49,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/issue-1252/case1/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/issue-1252/case1/input.tsx.json
@@ -44,7 +44,7 @@
             "init": {
               "type": "ArrowFunctionExpression",
               "span": {
-                "start": 23,
+                "start": 20,
                 "end": 117,
                 "ctxt": 0
               },

--- a/ecmascript/parser/tests/typescript/tsc/interfaces/interfaceDeclarations/interfaceWithPropertyOfEveryType/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/interfaces/interfaceDeclarations/interfaceWithPropertyOfEveryType/input.ts.json
@@ -1437,7 +1437,7 @@
                 "value": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 477,
+                    "start": 474,
                     "end": 488,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/Generics/parserCastVersusArrowFunction1/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/Generics/parserCastVersusArrowFunction1/input.ts.json
@@ -37,7 +37,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 11,
+              "start": 8,
               "end": 18,
               "ctxt": 0
             },
@@ -192,7 +192,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 46,
+              "start": 43,
               "end": 54,
               "ctxt": 0
             },
@@ -288,7 +288,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 67,
+              "start": 64,
               "end": 78,
               "ctxt": 0
             },
@@ -395,7 +395,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 91,
+              "start": 88,
               "end": 110,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/pedantic/noUncheckedIndexedAccess/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/pedantic/noUncheckedIndexedAccess/input.ts.json
@@ -5996,7 +5996,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 3272,
+              "start": 3236,
               "end": 3308,
               "ctxt": 0
             },
@@ -6184,7 +6184,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 3371,
+              "start": 3335,
               "end": 3407,
               "ctxt": 0
             },
@@ -6372,7 +6372,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 3470,
+              "start": 3434,
               "end": 3589,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/statements/for-inStatements/for-inStatements/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/statements/for-inStatements/for-inStatements/input.ts.json
@@ -1407,7 +1407,7 @@
         "expression": {
           "type": "ArrowFunctionExpression",
           "span": {
-            "start": 494,
+            "start": 491,
             "end": 505,
             "ctxt": 0
           },

--- a/ecmascript/parser/tests/typescript/tsc/statements/for-inStatements/for-inStatementsInvalid/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/statements/for-inStatements/for-inStatementsInvalid/input.ts.json
@@ -1192,7 +1192,7 @@
         "expression": {
           "type": "ArrowFunctionExpression",
           "span": {
-            "start": 449,
+            "start": 446,
             "end": 460,
             "ctxt": 0
           },

--- a/ecmascript/parser/tests/typescript/tsc/statements/switchStatements/switchStatements/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/statements/switchStatements/switchStatements/input.ts.json
@@ -641,7 +641,7 @@
           "test": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 369,
+              "start": 366,
               "end": 386,
               "ctxt": 0
             },
@@ -749,7 +749,7 @@
               "expression": {
                 "type": "ArrowFunctionExpression",
                 "span": {
-                  "start": 401,
+                  "start": 398,
                   "end": 418,
                   "ctxt": 0
                 },
@@ -1493,7 +1493,7 @@
       "discriminant": {
         "type": "ArrowFunctionExpression",
         "span": {
-          "start": 919,
+          "start": 916,
           "end": 936,
           "ctxt": 0
         },
@@ -1601,7 +1601,7 @@
           "expression": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 954,
+              "start": 951,
               "end": 966,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/statements/throwStatements/throwInEnclosingStatements/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/statements/throwStatements/throwInEnclosingStatements/input.ts.json
@@ -92,7 +92,7 @@
       "expression": {
         "type": "ArrowFunctionExpression",
         "span": {
-          "start": 68,
+          "start": 65,
           "end": 90,
           "ctxt": 0
         },

--- a/ecmascript/parser/tests/typescript/tsc/statements/throwStatements/throwStatements/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/statements/throwStatements/throwStatements/input.ts.json
@@ -2302,7 +2302,7 @@
       "argument": {
         "type": "ArrowFunctionExpression",
         "span": {
-          "start": 1294,
+          "start": 1291,
           "end": 1305,
           "ctxt": 0
         },

--- a/ecmascript/parser/tests/typescript/tsc/types/conditional/conditionalTypes1/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/conditional/conditionalTypes1/input.ts.json
@@ -18557,7 +18557,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 8091,
+              "start": 8088,
               "end": 8123,
               "ctxt": 0
             },
@@ -18867,7 +18867,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 8168,
+              "start": 8165,
               "end": 8200,
               "ctxt": 0
             },
@@ -20531,7 +20531,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 8762,
+              "start": 8759,
               "end": 8786,
               "ctxt": 0
             },
@@ -20741,7 +20741,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 8803,
+              "start": 8800,
               "end": 8827,
               "ctxt": 0
             },
@@ -21319,7 +21319,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 8951,
+              "start": 8948,
               "end": 8975,
               "ctxt": 0
             },
@@ -21529,7 +21529,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 8992,
+              "start": 8989,
               "end": 9016,
               "ctxt": 0
             },
@@ -21967,7 +21967,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 9129,
+              "start": 9126,
               "end": 9161,
               "ctxt": 0
             },
@@ -22177,7 +22177,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 9178,
+              "start": 9175,
               "end": 9210,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/intersection/intersectionsAndEmptyObjects/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/intersection/intersectionsAndEmptyObjects/input.ts.json
@@ -1734,7 +1734,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 735,
+              "start": 689,
               "end": 796,
               "ctxt": 0
             },
@@ -2084,7 +2084,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 844,
+              "start": 822,
               "end": 862,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/keyof/keyofAndIndexedAccess/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/keyof/keyofAndIndexedAccess/input.ts.json
@@ -26329,7 +26329,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 11244,
+              "start": 11197,
               "end": 11331,
               "ctxt": 0
             },
@@ -40531,7 +40531,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 17220,
+              "start": 17148,
               "end": 17279,
               "ctxt": 0
             },
@@ -40981,7 +40981,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 17355,
+              "start": 17294,
               "end": 17414,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/mapped/isomorphicMappedTypeInference/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/mapped/isomorphicMappedTypeInference/input.ts.json
@@ -6839,7 +6839,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 3166,
+              "start": 3163,
               "end": 3208,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/mapped/mappedTypeConstraints/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/mapped/mappedTypeConstraints/input.ts.json
@@ -2327,7 +2327,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 753,
+              "start": 730,
               "end": 828,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/callSignaturesWithAccessibilityModifiersOnParameters/input.ts.json
@@ -394,7 +394,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 238,
+              "start": 235,
               "end": 264,
               "ctxt": 0
             },
@@ -1040,7 +1040,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 510,
+              "start": 507,
               "end": 544,
               "ctxt": 0
             },
@@ -2393,7 +2393,7 @@
                 "value": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 1064,
+                    "start": 1061,
                     "end": 1098,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/callSignaturesWithDuplicateParameters/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/callSignaturesWithDuplicateParameters/input.ts.json
@@ -394,7 +394,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 168,
+              "start": 165,
               "end": 187,
               "ctxt": 0
             },
@@ -1040,7 +1040,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 373,
+              "start": 370,
               "end": 392,
               "ctxt": 0
             },
@@ -2393,7 +2393,7 @@
                 "value": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 762,
+                    "start": 759,
                     "end": 781,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/parametersWithNoAnnotationAreAny/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/parametersWithNoAnnotationAreAny/input.ts.json
@@ -288,7 +288,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 99,
+              "start": 96,
               "end": 107,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint/input.ts.json
@@ -1223,7 +1223,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 410,
+              "start": 394,
               "end": 457,
               "ctxt": 0
             },
@@ -1510,7 +1510,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 484,
+              "start": 468,
               "end": 531,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint2/input.ts.json
@@ -2655,7 +2655,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 1009,
+              "start": 993,
               "end": 1195,
               "ctxt": 0
             },
@@ -2805,7 +2805,7 @@
                             "init": {
                               "type": "ArrowFunctionExpression",
                               "span": {
-                                "start": 1116,
+                                "start": 1090,
                                 "end": 1187,
                                 "ctxt": 0
                               },
@@ -3288,7 +3288,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 1222,
+              "start": 1206,
               "end": 1408,
               "ctxt": 0
             },
@@ -3438,7 +3438,7 @@
                             "init": {
                               "type": "ArrowFunctionExpression",
                               "span": {
-                                "start": 1329,
+                                "start": 1303,
                                 "end": 1400,
                                 "ctxt": 0
                               },

--- a/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4/input.ts.json
@@ -2293,7 +2293,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 853,
+              "start": 837,
               "end": 1058,
               "ctxt": 0
             },
@@ -2538,7 +2538,7 @@
                             "init": {
                               "type": "ArrowFunctionExpression",
                               "span": {
-                                "start": 979,
+                                "start": 953,
                                 "end": 1050,
                                 "ctxt": 0
                               },
@@ -3021,7 +3021,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 1085,
+              "start": 1069,
               "end": 1280,
               "ctxt": 0
             },
@@ -3171,7 +3171,7 @@
                             "init": {
                               "type": "ArrowFunctionExpression",
                               "span": {
-                                "start": 1201,
+                                "start": 1175,
                                 "end": 1272,
                                 "ctxt": 0
                               },

--- a/ecmascript/parser/tests/typescript/tsc/types/specifyingTypes/typeLiterals/functionLiteral/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/specifyingTypes/typeLiterals/functionLiteral/input.ts.json
@@ -492,7 +492,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 182,
+              "start": 179,
               "end": 193,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments/input.ts.json
@@ -482,7 +482,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 239,
+              "start": 233,
               "end": 274,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/callGenericFunctionWithZeroTypeArguments/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/callGenericFunctionWithZeroTypeArguments/input.ts.json
@@ -260,7 +260,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 152,
+              "start": 149,
               "end": 181,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction/input.ts.json
@@ -2476,7 +2476,7 @@
                 "expression": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 734,
+                    "start": 731,
                     "end": 745,
                     "ctxt": 0
                   },
@@ -2805,7 +2805,7 @@
                 "expression": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 827,
+                    "start": 811,
                     "end": 838,
                     "ctxt": 0
                   },
@@ -2974,7 +2974,7 @@
                 "expression": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 861,
+                    "start": 855,
                     "end": 878,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2/input.ts.json
@@ -1409,7 +1409,7 @@
                 "expression": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 525,
+                    "start": 522,
                     "end": 536,
                     "ctxt": 0
                   },
@@ -1559,7 +1559,7 @@
                 "expression": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 581,
+                    "start": 575,
                     "end": 598,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3/input.ts.json
@@ -2460,7 +2460,7 @@
                 "expression": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 744,
+                    "start": 726,
                     "end": 755,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints/input.ts.json
@@ -1254,7 +1254,7 @@
                 "value": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 523,
+                    "start": 507,
                     "end": 614,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints2/input.ts.json
@@ -2725,7 +2725,7 @@
                 "value": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 1475,
+                    "start": 1449,
                     "end": 1574,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints3/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints3/input.ts.json
@@ -2411,7 +2411,7 @@
                 "value": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 1182,
+                    "start": 1156,
                     "end": 1297,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints4/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints4/input.ts.json
@@ -1257,7 +1257,7 @@
                 "value": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 436,
+                    "start": 420,
                     "end": 540,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints5/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints5/input.ts.json
@@ -1703,7 +1703,7 @@
                 "value": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 602,
+                    "start": 576,
                     "end": 702,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithoutConstraints/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithoutConstraints/input.ts.json
@@ -1178,7 +1178,7 @@
                 "value": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 394,
+                    "start": 391,
                     "end": 497,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/typeParameterDirectlyConstrainedToItself/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/typeParameterDirectlyConstrainedToItself/input.ts.json
@@ -803,7 +803,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 313,
+              "start": 300,
               "end": 322,
               "ctxt": 0
             },
@@ -906,7 +906,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 348,
+              "start": 332,
               "end": 357,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself/input.ts.json
@@ -1199,7 +1199,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 430,
+              "start": 404,
               "end": 439,
               "ctxt": 0
             },
@@ -1342,7 +1342,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 488,
+              "start": 449,
               "end": 497,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/typeParameterUsedAsConstraint/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/typeParameterUsedAsConstraint/input.ts.json
@@ -2209,7 +2209,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 756,
+              "start": 740,
               "end": 765,
               "ctxt": 0
             },
@@ -2333,7 +2333,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 791,
+              "start": 775,
               "end": 800,
               "ctxt": 0
             },
@@ -2457,7 +2457,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 839,
+              "start": 810,
               "end": 848,
               "ctxt": 0
             },
@@ -2600,7 +2600,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 887,
+              "start": 858,
               "end": 896,
               "ctxt": 0
             },
@@ -2743,7 +2743,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 935,
+              "start": 906,
               "end": 944,
               "ctxt": 0
             },
@@ -2907,7 +2907,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 983,
+              "start": 954,
               "end": 992,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope/input.ts.json
@@ -105,7 +105,7 @@
           "value": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 38,
+              "start": 35,
               "end": 91,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures/input.ts.json
@@ -773,7 +773,7 @@
         "right": {
           "type": "ArrowFunctionExpression",
           "span": {
-            "start": 327,
+            "start": 324,
             "end": 338,
             "ctxt": 0
           },
@@ -1054,7 +1054,7 @@
         "right": {
           "type": "ArrowFunctionExpression",
           "span": {
-            "start": 400,
+            "start": 397,
             "end": 411,
             "ctxt": 0
           },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures2/input.ts.json
@@ -924,7 +924,7 @@
               "value": {
                 "type": "ArrowFunctionExpression",
                 "span": {
-                  "start": 356,
+                  "start": 353,
                   "end": 366,
                   "ctxt": 0
                 },
@@ -1377,7 +1377,7 @@
               "value": {
                 "type": "ArrowFunctionExpression",
                 "span": {
-                  "start": 475,
+                  "start": 472,
                   "end": 486,
                   "ctxt": 0
                 },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters/input.ts.json
@@ -7196,7 +7196,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 2854,
+                              "start": 2851,
                               "end": 2864,
                               "ctxt": 0
                             },
@@ -7292,7 +7292,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 2923,
+                              "start": 2920,
                               "end": 2938,
                               "ctxt": 0
                             },
@@ -7427,7 +7427,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 2997,
+                              "start": 2994,
                               "end": 3011,
                               "ctxt": 0
                             },
@@ -7562,7 +7562,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 3074,
+                              "start": 3071,
                               "end": 3084,
                               "ctxt": 0
                             },
@@ -7658,7 +7658,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 3144,
+                              "start": 3141,
                               "end": 3159,
                               "ctxt": 0
                             },
@@ -7793,7 +7793,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 3219,
+                              "start": 3216,
                               "end": 3233,
                               "ctxt": 0
                             },
@@ -7928,7 +7928,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 3290,
+                              "start": 3287,
                               "end": 3300,
                               "ctxt": 0
                             },
@@ -8024,7 +8024,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 3356,
+                              "start": 3353,
                               "end": 3371,
                               "ctxt": 0
                             },
@@ -8159,7 +8159,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 3427,
+                              "start": 3424,
                               "end": 3441,
                               "ctxt": 0
                             },
@@ -8294,7 +8294,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 3501,
+                              "start": 3498,
                               "end": 3521,
                               "ctxt": 0
                             },
@@ -8467,7 +8467,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 3585,
+                              "start": 3582,
                               "end": 3595,
                               "ctxt": 0
                             },
@@ -8563,7 +8563,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 3651,
+                              "start": 3648,
                               "end": 3673,
                               "ctxt": 0
                             },
@@ -8736,7 +8736,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 3729,
+                              "start": 3726,
                               "end": 3743,
                               "ctxt": 0
                             },
@@ -8871,7 +8871,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 3803,
+                              "start": 3800,
                               "end": 3823,
                               "ctxt": 0
                             },
@@ -9044,7 +9044,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 3882,
+                              "start": 3879,
                               "end": 3892,
                               "ctxt": 0
                             },
@@ -9140,7 +9140,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 3948,
+                              "start": 3945,
                               "end": 3970,
                               "ctxt": 0
                             },
@@ -9313,7 +9313,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 4026,
+                              "start": 4023,
                               "end": 4040,
                               "ctxt": 0
                             },
@@ -9448,7 +9448,7 @@
                           "right": {
                             "type": "ArrowFunctionExpression",
                             "span": {
-                              "start": 4099,
+                              "start": 4096,
                               "end": 4119,
                               "ctxt": 0
                             },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/nullIsSubtypeOfEverythingButUndefined/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/nullIsSubtypeOfEverythingButUndefined/input.ts.json
@@ -1412,7 +1412,7 @@
             "consequent": {
               "type": "ArrowFunctionExpression",
               "span": {
-                "start": 651,
+                "start": 648,
                 "end": 673,
                 "ctxt": 0
               },
@@ -1588,7 +1588,7 @@
             "alternate": {
               "type": "ArrowFunctionExpression",
               "span": {
-                "start": 709,
+                "start": 706,
                 "end": 731,
                 "ctxt": 0
               },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameter/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameter/input.ts.json
@@ -2779,7 +2779,7 @@
                   "consequent": {
                     "type": "ArrowFunctionExpression",
                     "span": {
-                      "start": 1136,
+                      "start": 1133,
                       "end": 1158,
                       "ctxt": 0
                     },
@@ -2961,7 +2961,7 @@
                   "alternate": {
                     "type": "ArrowFunctionExpression",
                     "span": {
-                      "start": 1192,
+                      "start": 1189,
                       "end": 1214,
                       "ctxt": 0
                     },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints2/input.ts.json
@@ -4964,7 +4964,7 @@
                   "consequent": {
                     "type": "ArrowFunctionExpression",
                     "span": {
-                      "start": 2052,
+                      "start": 2049,
                       "end": 2074,
                       "ctxt": 0
                     },
@@ -5146,7 +5146,7 @@
                   "alternate": {
                     "type": "ArrowFunctionExpression",
                     "span": {
-                      "start": 2114,
+                      "start": 2111,
                       "end": 2136,
                       "ctxt": 0
                     },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures/input.ts.json
@@ -409,7 +409,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 216,
+                          "start": 213,
                           "end": 228,
                           "ctxt": 0
                         },
@@ -939,7 +939,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 480,
+                          "start": 477,
                           "end": 492,
                           "ctxt": 0
                         },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures2/input.ts.json
@@ -6397,7 +6397,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 2666,
+              "start": 2663,
               "end": 2679,
               "ctxt": 0
             },
@@ -6838,7 +6838,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 2963,
+              "start": 2960,
               "end": 2977,
               "ctxt": 0
             },
@@ -7287,7 +7287,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 3110,
+              "start": 3107,
               "end": 3121,
               "ctxt": 0
             },
@@ -7702,7 +7702,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 3256,
+              "start": 3250,
               "end": 3273,
               "ctxt": 0
             },
@@ -8208,7 +8208,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 3424,
+              "start": 3418,
               "end": 3453,
               "ctxt": 0
             },
@@ -8777,7 +8777,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 3639,
+              "start": 3604,
               "end": 3668,
               "ctxt": 0
             },
@@ -9428,7 +9428,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 3861,
+              "start": 3826,
               "end": 3900,
               "ctxt": 0
             },
@@ -10183,7 +10183,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 4109,
+              "start": 4074,
               "end": 4167,
               "ctxt": 0
             },
@@ -11128,7 +11128,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 4404,
+              "start": 4369,
               "end": 4490,
               "ctxt": 0
             },
@@ -12147,7 +12147,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 4712,
+              "start": 4693,
               "end": 4731,
               "ctxt": 0
             },
@@ -12681,7 +12681,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 4909,
+              "start": 4893,
               "end": 4926,
               "ctxt": 0
             },
@@ -13335,7 +13335,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 5144,
+              "start": 5121,
               "end": 5190,
               "ctxt": 0
             },
@@ -14082,7 +14082,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 5404,
+              "start": 5378,
               "end": 5431,
               "ctxt": 0
             },
@@ -14775,7 +14775,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 5621,
+              "start": 5618,
               "end": 5647,
               "ctxt": 0
             },
@@ -15418,7 +15418,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 5823,
+              "start": 5820,
               "end": 5842,
               "ctxt": 0
             },
@@ -15644,7 +15644,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 5906,
+              "start": 5890,
               "end": 5919,
               "ctxt": 0
             },
@@ -15867,7 +15867,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 5965,
+              "start": 5962,
               "end": 5994,
               "ctxt": 0
             },
@@ -16150,7 +16150,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 6046,
+              "start": 6043,
               "end": 6075,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures3/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures3/input.ts.json
@@ -4063,7 +4063,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 2056,
+                          "start": 2050,
                           "end": 2075,
                           "ctxt": 0
                         },
@@ -4327,7 +4327,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 2127,
+                          "start": 2121,
                           "end": 2146,
                           "ctxt": 0
                         },
@@ -4519,7 +4519,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 2170,
+                          "start": 2164,
                           "end": 2189,
                           "ctxt": 0
                         },
@@ -4772,7 +4772,7 @@
                 "init": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 2285,
+                    "start": 2230,
                     "end": 2324,
                     "ctxt": 0
                   },
@@ -5567,7 +5567,7 @@
                 "init": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 2550,
+                    "start": 2515,
                     "end": 2623,
                     "ctxt": 0
                   },
@@ -6544,7 +6544,7 @@
                 "init": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 2860,
+                    "start": 2841,
                     "end": 2882,
                     "ctxt": 0
                   },
@@ -7085,7 +7085,7 @@
                 "init": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 3063,
+                    "start": 3044,
                     "end": 3086,
                     "ctxt": 0
                   },
@@ -8009,7 +8009,7 @@
                 "init": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 3393,
+                    "start": 3366,
                     "end": 3436,
                     "ctxt": 0
                   },
@@ -8511,7 +8511,7 @@
                 "init": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 3605,
+                    "start": 3602,
                     "end": 3635,
                     "ctxt": 0
                   },
@@ -9132,7 +9132,7 @@
                 "init": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 3820,
+                    "start": 3804,
                     "end": 3844,
                     "ctxt": 0
                   },
@@ -9578,7 +9578,7 @@
                 "init": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 4012,
+                    "start": 4009,
                     "end": 4041,
                     "ctxt": 0
                   },
@@ -9861,7 +9861,7 @@
                 "init": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 4097,
+                    "start": 4094,
                     "end": 4128,
                     "ctxt": 0
                   },
@@ -10440,7 +10440,7 @@
                 "init": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 4476,
+                    "start": 4473,
                     "end": 4490,
                     "ctxt": 0
                   },
@@ -10914,7 +10914,7 @@
                 "init": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 4712,
+                    "start": 4709,
                     "end": 4731,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures4/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures4/input.ts.json
@@ -4445,7 +4445,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 1604,
+              "start": 1601,
               "end": 1623,
               "ctxt": 0
             },
@@ -4603,7 +4603,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 1641,
+              "start": 1638,
               "end": 1660,
               "ctxt": 0
             },
@@ -4969,7 +4969,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 1754,
+              "start": 1751,
               "end": 1768,
               "ctxt": 0
             },
@@ -5110,7 +5110,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 1786,
+              "start": 1783,
               "end": 1800,
               "ctxt": 0
             },
@@ -5459,7 +5459,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 1894,
+              "start": 1891,
               "end": 1911,
               "ctxt": 0
             },
@@ -5609,7 +5609,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 1929,
+              "start": 1926,
               "end": 1942,
               "ctxt": 0
             },
@@ -5940,7 +5940,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 2039,
+              "start": 2033,
               "end": 2057,
               "ctxt": 0
             },
@@ -6127,7 +6127,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 2078,
+              "start": 2072,
               "end": 2096,
               "ctxt": 0
             },
@@ -6522,7 +6522,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 2193,
+              "start": 2187,
               "end": 2222,
               "ctxt": 0
             },
@@ -6750,7 +6750,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 2243,
+              "start": 2237,
               "end": 2272,
               "ctxt": 0
             },
@@ -7186,7 +7186,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 2398,
+              "start": 2363,
               "end": 2427,
               "ctxt": 0
             },
@@ -7452,7 +7452,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 2458,
+              "start": 2442,
               "end": 2493,
               "ctxt": 0
             },
@@ -7886,7 +7886,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 2591,
+              "start": 2585,
               "end": 2643,
               "ctxt": 0
             },
@@ -8234,7 +8234,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 2662,
+              "start": 2659,
               "end": 2714,
               "ctxt": 0
             },
@@ -8769,7 +8769,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 2821,
+              "start": 2815,
               "end": 2854,
               "ctxt": 0
             },
@@ -9044,7 +9044,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 2873,
+              "start": 2870,
               "end": 2905,
               "ctxt": 0
             },
@@ -9506,7 +9506,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 3022,
+              "start": 3006,
               "end": 3054,
               "ctxt": 0
             },
@@ -9779,7 +9779,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 3086,
+              "start": 3070,
               "end": 3118,
               "ctxt": 0
             },
@@ -10260,7 +10260,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 3222,
+              "start": 3219,
               "end": 3251,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments/input.ts.json
@@ -270,7 +270,7 @@
                 "expression": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 227,
+                    "start": 224,
                     "end": 239,
                     "ctxt": 0
                   },
@@ -423,7 +423,7 @@
                 "expression": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 272,
+                    "start": 269,
                     "end": 284,
                     "ctxt": 0
                   },
@@ -1292,7 +1292,7 @@
                 "expression": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 600,
+                    "start": 597,
                     "end": 611,
                     "ctxt": 0
                   },
@@ -1809,7 +1809,7 @@
                 "expression": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 707,
+                    "start": 704,
                     "end": 719,
                     "ctxt": 0
                   },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments5/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments5/input.ts.json
@@ -354,7 +354,7 @@
                 "value": {
                   "type": "ArrowFunctionExpression",
                   "span": {
-                    "start": 250,
+                    "start": 247,
                     "end": 262,
                     "ctxt": 0
                   },
@@ -595,7 +595,7 @@
                       "value": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 337,
+                          "start": 334,
                           "end": 355,
                           "ctxt": 0
                         },
@@ -1386,7 +1386,7 @@
                       "value": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 584,
+                          "start": 581,
                           "end": 596,
                           "ctxt": 0
                         },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments/input.ts.json
@@ -416,7 +416,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 397,
+                          "start": 394,
                           "end": 408,
                           "ctxt": 0
                         },
@@ -1734,7 +1734,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 1046,
+                          "start": 1043,
                           "end": 1058,
                           "ctxt": 0
                         },
@@ -1887,7 +1887,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 1114,
+                          "start": 1111,
                           "end": 1133,
                           "ctxt": 0
                         },
@@ -2535,7 +2535,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 1421,
+                          "start": 1418,
                           "end": 1433,
                           "ctxt": 0
                         },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments2/input.ts.json
@@ -348,7 +348,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 379,
+                          "start": 373,
                           "end": 411,
                           "ctxt": 0
                         },
@@ -883,7 +883,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 559,
+                          "start": 556,
                           "end": 570,
                           "ctxt": 0
                         },
@@ -1326,7 +1326,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 698,
+                          "start": 695,
                           "end": 716,
                           "ctxt": 0
                         },
@@ -1869,7 +1869,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 855,
+                          "start": 852,
                           "end": 866,
                           "ctxt": 0
                         },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericClassWithFunctionTypedMemberArguments/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericClassWithFunctionTypedMemberArguments/input.ts.json
@@ -458,7 +458,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 324,
+                          "start": 321,
                           "end": 336,
                           "ctxt": 0
                         },
@@ -631,7 +631,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 375,
+                          "start": 372,
                           "end": 387,
                           "ctxt": 0
                         },
@@ -1260,7 +1260,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 584,
+                          "start": 581,
                           "end": 595,
                           "ctxt": 0
                         },
@@ -2359,7 +2359,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 1025,
+                          "start": 1022,
                           "end": 1036,
                           "ctxt": 0
                         },
@@ -3022,7 +3022,7 @@
                       "expression": {
                         "type": "ArrowFunctionExpression",
                         "span": {
-                          "start": 1217,
+                          "start": 1214,
                           "end": 1229,
                           "ctxt": 0
                         },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericContextualTypes1/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericContextualTypes1/input.ts.json
@@ -4347,7 +4347,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 1039,
+              "start": 1033,
               "end": 1079,
               "ctxt": 0
             },
@@ -4655,7 +4655,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 1104,
+              "start": 1101,
               "end": 1153,
               "ctxt": 0
             },

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/unionAndIntersectionInference1/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/unionAndIntersectionInference1/input.ts.json
@@ -4113,7 +4113,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 1829,
+              "start": 1826,
               "end": 1837,
               "ctxt": 0
             },
@@ -4197,7 +4197,7 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 1860,
+              "start": 1854,
               "end": 1895,
               "ctxt": 0
             },


### PR DESCRIPTION
Should include the type parameters.