### PR TITLE
Allow preset-env to take a config path

### DIFF
--- a/bundler/tests/fixture/deno-8574/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-8574/output/entry.inlined.ts
@@ -660,7 +660,7 @@ var getGlobal = function() {
 };
 var global = getGlobal();
 var nodeFetch = global.fetch.bind(global);
-const VERSION1 = "5.4.13";
+const VERSION1 = "5.4.14";
 function getBufferResponse(response) {
     return response.arrayBuffer();
 }

--- a/bundler/tests/fixture/deno-8574/output/entry.ts
+++ b/bundler/tests/fixture/deno-8574/output/entry.ts
@@ -678,7 +678,7 @@ var getGlobal = function() {
 };
 var global = getGlobal();
 var nodeFetch = global.fetch.bind(global);
-const VERSION1 = "5.4.13";
+const VERSION1 = "5.4.14";
 function getBufferResponse(response) {
     return response.arrayBuffer();
 }

--- a/ecmascript/preset_env/tests/test.rs
+++ b/ecmascript/preset_env/tests/test.rs
@@ -199,6 +199,7 @@ fn exec(c: PresetConfig, dir: PathBuf) -> Result<(), Error> {
                     force_all_transforms: c.force_all_transforms,
                     shipped_proposals: c.shipped_proposals,
                     targets: c.targets,
+                    path: std::env::current_dir().unwrap(),
                 },
             );
 

--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -245,6 +245,8 @@ export interface EnvConfig {
 
   targets?: any;
 
+  path?: string;
+
   shippedProposals?: boolean;
 
   /**


### PR DESCRIPTION
This allows a path to be passed where preset-env will look for the `browserslist` node module and any browserslist config files (e.g. `.browserslistrc`, `package.json`, etc)

This is useful when your build system and/or some of your node_modules aren't in your project (current) directory.

If not specified, then it will default to the current directory of the process, which was the default behaviour before this change.