### PR TITLE
docs: Fixed documentation link URL in to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ swc is a super-fast typescript / javascript compiler written in rust.
 
 # Documentation
 
-Check out the documentation [in the website](https://swc.rs/docs/).
+Check out the documentation [in the website](https://swc.rs/docs/installation/).
 
 # Features
 


### PR DESCRIPTION
- The URL `https://swc.rs/docs/` shows a 404.

<img width="657" alt="back" src="https://user-images.githubusercontent.com/22195501/106617748-83ddfb80-6534-11eb-908a-782a1739dfc1.png">

- Now the URL points to the docs start page `https://swc.rs/docs/installation/`.

<img width="729" alt="ok" src="https://user-images.githubusercontent.com/22195501/106617820-90625400-6534-11eb-9397-faf76d066ad3.png">
