### PR TITLE
Add es2020 to JscTarget in types.ts

### DIFF
--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -281,7 +281,8 @@ export type JscTarget =
   | "es2016"
   | "es2017"
   | "es2018"
-  | "es2019";
+  | "es2019"
+  | "es2020";
 
 export type ParserConfig = TsParserConfig | EsParserConfig;
 export interface TsParserConfig {


### PR DESCRIPTION
This target is supported in the Rust code, but the TS types haven't been updated yet.