### PR TITLE
avoid removing plugin

### DIFF
--- a/node-swc/src/index.ts
+++ b/node-swc/src/index.ts
@@ -106,18 +106,17 @@ export class Compiler {
     }
 
 
-    const plugin = options.plugin;
-    delete options.plugin;
+    const { plugin, ...newOptions } = options;
 
     if (plugin) {
       const m =
         typeof src === "string"
           ? await this.parse(src, options?.jsc?.parser)
           : src;
-      return this.transform(plugin(m), options);
+      return this.transform(plugin(m), newOptions);
     }
 
-    return bindings.transform(isModule ? JSON.stringify(src) : src, isModule, toBuffer(options))
+    return bindings.transform(isModule ? JSON.stringify(src) : src, isModule, toBuffer(newOptions))
   }
 
   transformSync(src: string | Program, options?: Options): Output {
@@ -129,8 +128,7 @@ export class Compiler {
     }
 
 
-    const plugin = options.plugin;
-    delete options.plugin;
+    const { plugin, ...newOptions } = options;
 
     if (plugin) {
       const m =
@@ -153,8 +151,7 @@ export class Compiler {
     }
 
 
-    const plugin = options.plugin;
-    delete options.plugin;
+    const { plugin, ...newOptions } = options;
 
     if (plugin) {
       const m = await this.parseFile(path, options?.jsc?.parser);
@@ -172,8 +169,7 @@ export class Compiler {
     }
 
 
-    const plugin = options?.plugin;
-    delete options?.plugin;
+    const { plugin, ...newOptions } = options;
 
     if (plugin) {
       const m = this.parseFileSync(path, options?.jsc?.parser);

--- a/node-swc/src/index.ts
+++ b/node-swc/src/index.ts
@@ -133,13 +133,13 @@ export class Compiler {
     if (plugin) {
       const m =
         typeof src === "string" ? this.parseSync(src, options?.jsc?.parser) : src;
-      return this.transformSync(plugin(m), options);
+      return this.transformSync(plugin(m), newOptions);
     }
 
     return bindings.transformSync(
       isModule ? JSON.stringify(src) : src,
       isModule,
-      toBuffer(options),
+      toBuffer(newOptions),
     )
   }
 
@@ -155,10 +155,10 @@ export class Compiler {
 
     if (plugin) {
       const m = await this.parseFile(path, options?.jsc?.parser);
-      return this.transform(plugin(m), options);
+      return this.transform(plugin(m), newOptions);
     }
 
-    return bindings.transformFile(path, false, toBuffer(options))
+    return bindings.transformFile(path, false, toBuffer(newOptions))
   }
 
   transformFileSync(path: string, options?: Options): Output {
@@ -173,10 +173,10 @@ export class Compiler {
 
     if (plugin) {
       const m = this.parseFileSync(path, options?.jsc?.parser);
-      return this.transformSync(plugin(m), options);
+      return this.transformSync(plugin(m), newOptions);
     }
 
-    return bindings.transformFileSync(path, /* isModule */ false, toBuffer(options));
+    return bindings.transformFileSync(path, /* isModule */ false, toBuffer(newOptions));
   }
 
 


### PR DESCRIPTION
When trying out the rollup swc-plugin I got confused why my `options.plugin` would dissapear during concurrent runs