### PR TITLE
account for empty pattern properties

### DIFF
--- a/node-swc/src/Visitor.ts
+++ b/node-swc/src/Visitor.ts
@@ -1656,7 +1656,7 @@ export default class Visitor {
   }
 
   visitObjectPattern(n: ObjectPattern): Pattern {
-    n.props = this.visitObjectPatternProperties(n.props);
+    n.props = this.visitObjectPatternProperties(n.props || []);
     n.typeAnnotation = this.visitTsTypeAnnotation(n.typeAnnotation);
     return n;
   }


### PR DESCRIPTION
This currently crashes https://github.com/preactjs/wmr/pull/321/files#diff-fd4936a99dc4faf7e48aac7b7ee5624bfea4cd45e225ddae7c5ed73a3e08eddeR20 when calling `super.visitModule`