### PR TITLE
Update Visitor.ts

### DIFF
--- a/node-swc/src/Visitor.ts
+++ b/node-swc/src/Visitor.ts
@@ -1184,8 +1184,8 @@ export default class Visitor {
   }
 
   visitObjectExpression(n: ObjectExpression): Expression {
-    if (n.properties) {
-      n.properties = this.visitObjectProperties(n.properties);
+    if (n.props) {
+      n.props = this.visitObjectProperties(n.props);
     }
     return n;
   }
@@ -1656,7 +1656,7 @@ export default class Visitor {
   }
 
   visitObjectPattern(n: ObjectPattern): Pattern {
-    n.properties = this.visitObjectPatternProperties(n.properties);
+    n.props = this.visitObjectPatternProperties(n.props);
     n.typeAnnotation = this.visitTsTypeAnnotation(n.typeAnnotation);
     return n;
   }

--- a/node-swc/src/Visitor.ts
+++ b/node-swc/src/Visitor.ts
@@ -1656,7 +1656,7 @@ export default class Visitor {
   }
 
   visitObjectPattern(n: ObjectPattern): Pattern {
-    n.props = this.visitObjectPatternProperties(n.props);
+    n.properties = this.visitObjectPatternProperties(n.properties);
     n.typeAnnotation = this.visitTsTypeAnnotation(n.typeAnnotation);
     return n;
   }

--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -802,7 +802,7 @@ export interface ArrayExpression extends ExpressionBase {
 export interface ObjectExpression extends ExpressionBase {
   type: "ObjectExpression";
 
-  properties: (Property | SpreadElement)[];
+  props: (Property | SpreadElement)[];
 }
 
 export interface Argument {


### PR DESCRIPTION
#### Bug:
Adding a custom visitor breaks swc builds.

#### Solution:
`Visitor.visitObjectPattern` was changing n.props, 
`Visitor.visitObjectExpression` uses n.properties.

changed `Visitor.visitObjectExpression` to use n.props too.

Example that breaks the build:
```javascript
import V from '@swc/core/Visitor.js'
const Visitor = V.default

export default class LinkWrapper extends Visitor {
  // this makes the build work without changing swc core.
  /*
  visitObjectExpression(n: ObjectExpression): Expression {
    if (n.props) {
      n.props = this.visitObjectProperties(n.props);
    }
    return n;
  }
  */

  // without visitObjectExpression above, swc breaks in Visitor.visitObjectPatternProperties
  visitCallExpression(e) {
    if (e.callee.type !== 'MemberExpression') {
      return e
    }

    console.log('memberexpression', e.callee.object.type, e.callee.object.value)

    return e
  }
}

```

 usage in js:
```javascript
const swcOptions = {
  /// ...
  plugin: m => new LinkWrapper().visitModule(m),
}
```

thanks for this tool, took my dev build from ~1.5 seconds to 200ms.
off to (re)create my custom babel Visitor tasks for swc now :)

edit: replaced properties with props, not vice versa