### PR TITLE
Remove unused TsTypeCastExpr node

### DIFF
--- a/ecmascript/ast/src/expr.rs
+++ b/ecmascript/ast/src/expr.rs
@@ -10,8 +10,8 @@ use crate::{
     prop::Prop,
     stmt::BlockStmt,
     typescript::{
-        TsAsExpr, TsConstAssertion, TsNonNullExpr, TsTypeAnn, TsTypeAssertion, TsTypeCastExpr,
-        TsTypeParamDecl, TsTypeParamInstantiation,
+        TsAsExpr, TsConstAssertion, TsNonNullExpr, TsTypeAnn, TsTypeAssertion, TsTypeParamDecl,
+        TsTypeParamInstantiation,
     },
     Invalid,
 };
@@ -139,9 +139,6 @@ pub enum Expr {
 
     #[tag("TsNonNullExpression")]
     TsNonNull(TsNonNullExpr),
-
-    #[tag("TsTypeCastExpression")]
-    TsTypeCast(TsTypeCastExpr),
 
     #[tag("TsAsExpression")]
     TsAs(TsAsExpr),
@@ -560,7 +557,6 @@ pub enum PatOrExpr {
     #[tag("TsTypeAssertion")]
     #[tag("TsConstAssertion")]
     #[tag("TsNonNullExpression")]
-    #[tag("TsTypeCastExpression")]
     #[tag("TsAsExpression")]
     #[tag("PrivateName")]
     Expr(Box<Expr>),

--- a/ecmascript/ast/src/lib.rs
+++ b/ecmascript/ast/src/lib.rs
@@ -59,9 +59,9 @@ pub use self::{
         TsNonNullExpr, TsOptionalType, TsParamProp, TsParamPropParam, TsParenthesizedType,
         TsPropertySignature, TsQualifiedName, TsRestType, TsSignatureDecl, TsThisType,
         TsThisTypeOrIdent, TsTplLitType, TsTupleElement, TsTupleType, TsType, TsTypeAliasDecl,
-        TsTypeAnn, TsTypeAssertion, TsTypeCastExpr, TsTypeElement, TsTypeLit, TsTypeOperator,
-        TsTypeOperatorOp, TsTypeParam, TsTypeParamDecl, TsTypeParamInstantiation, TsTypePredicate,
-        TsTypeQuery, TsTypeQueryExpr, TsTypeRef, TsUnionOrIntersectionType, TsUnionType,
+        TsTypeAnn, TsTypeAssertion, TsTypeElement, TsTypeLit, TsTypeOperator, TsTypeOperatorOp,
+        TsTypeParam, TsTypeParamDecl, TsTypeParamInstantiation, TsTypePredicate, TsTypeQuery,
+        TsTypeQueryExpr, TsTypeRef, TsUnionOrIntersectionType, TsUnionType,
     },
 };
 use serde::Deserialize;

--- a/ecmascript/ast/src/typescript.rs
+++ b/ecmascript/ast/src/typescript.rs
@@ -60,17 +60,6 @@ pub struct TsTypeParamInstantiation {
     pub params: Vec<Box<TsType>>,
 }
 
-#[ast_node("TsTypeCastExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub struct TsTypeCastExpr {
-    pub span: Span,
-    #[serde(rename = "expression")]
-    pub expr: Box<Expr>,
-    #[serde(rename = "typeAnnotation")]
-    pub type_ann: TsTypeAnn,
-}
-
 #[ast_node("TsParameterProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -521,7 +521,6 @@ impl<'a> Emitter<'a> {
             Expr::TsNonNull(ref n) => emit!(n),
             Expr::TsTypeAssertion(ref n) => emit!(n),
             Expr::TsConstAssertion(ref n) => emit!(n),
-            Expr::TsTypeCast(ref n) => emit!(n),
             Expr::OptChain(ref n) => emit!(n),
             Expr::Invalid(ref n) => emit!(n),
         }

--- a/ecmascript/codegen/src/typescript.rs
+++ b/ecmascript/codegen/src/typescript.rs
@@ -867,16 +867,6 @@ impl<'a> Emitter<'a> {
     }
 
     #[emitter]
-    fn emit_ts_type_cast_expr(&mut self, n: &TsTypeCastExpr) -> Result {
-        self.emit_leading_comments_of_pos(n.span().lo())?;
-
-        punct!("<");
-        emit!(n.type_ann);
-        punct!(">");
-        emit!(n.expr);
-    }
-
-    #[emitter]
     fn emit_ts_type_element(&mut self, n: &TsTypeElement) -> Result {
         match n {
             TsTypeElement::TsCallSignatureDecl(n) => emit!(n),

--- a/ecmascript/codegen/src/util.rs
+++ b/ecmascript/codegen/src/util.rs
@@ -228,8 +228,6 @@ impl StartsWithAlphaNum for Expr {
                 expr.starts_with_alpha_num()
             }
 
-            // TODO
-            Expr::TsTypeCast(..) => true,
             Expr::OptChain(ref e) => e.expr.starts_with_alpha_num(),
 
             Expr::Invalid(..) => true,

--- a/ecmascript/parser/src/parser/util.rs
+++ b/ecmascript/parser/src/parser/util.rs
@@ -308,7 +308,6 @@ pub(super) trait ExprExt {
             Expr::OptChain(OptChainExpr { ref expr, .. })
             | Expr::TsNonNull(TsNonNullExpr { ref expr, .. })
             | Expr::TsTypeAssertion(TsTypeAssertion { ref expr, .. })
-            | Expr::TsTypeCast(TsTypeCastExpr { ref expr, .. })
             | Expr::TsAs(TsAsExpr { ref expr, .. }) => {
                 expr.is_valid_simple_assignment_target(strict)
             }

--- a/ecmascript/parser/tests/span.rs
+++ b/ecmascript/parser/tests/span.rs
@@ -857,10 +857,6 @@ impl Visit for Shower<'_> {
         self.show("TsTypeAssertion", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_cast_expr(&mut self, n: &TsTypeCastExpr, _parent: &dyn Node) {
-        self.show("TsTypeCastExpr", n);
-        n.visit_children_with(self)
-    }
     fn visit_ts_type_element(&mut self, n: &TsTypeElement, _parent: &dyn Node) {
         self.show("TsTypeElement", n);
         n.visit_children_with(self)

--- a/ecmascript/transforms/base/src/resolver/mod.rs
+++ b/ecmascript/transforms/base/src/resolver/mod.rs
@@ -396,7 +396,6 @@ impl<'a> VisitMut for Resolver<'a> {
     typed_ref!(visit_mut_ts_type_query, TsTypeQuery);
     typed_ref!(visit_mut_ts_type_query_expr, TsTypeQueryExpr);
     typed_ref!(visit_mut_ts_type_operator, TsTypeOperator);
-    typed_ref!(visit_mut_ts_type_cast_expr, TsTypeCastExpr);
     typed_ref!(visit_mut_ts_type, TsType);
     typed_ref!(visit_mut_ts_type_ann, TsTypeAnn);
     typed_ref!(visit_mut_ts_type_assertion, TsTypeAssertion);

--- a/ecmascript/transforms/compat/src/es2015/destructuring.rs
+++ b/ecmascript/transforms/compat/src/es2015/destructuring.rs
@@ -1090,7 +1090,6 @@ fn can_be_null(e: &Expr) -> bool {
         Expr::TsNonNull(..) => false,
         Expr::TsAs(TsAsExpr { ref expr, .. })
         | Expr::TsTypeAssertion(TsTypeAssertion { ref expr, .. })
-        | Expr::TsTypeCast(TsTypeCastExpr { ref expr, .. })
         | Expr::TsConstAssertion(TsConstAssertion { ref expr, .. }) => can_be_null(expr),
         Expr::OptChain(ref e) => can_be_null(&e.expr),
 

--- a/ecmascript/transforms/compat/src/es2015/regenerator/case.rs
+++ b/ecmascript/transforms/compat/src/es2015/regenerator/case.rs
@@ -329,7 +329,6 @@ impl CaseHandler<'_> {
             | Expr::TsTypeAssertion(..)
             | Expr::TsConstAssertion(..)
             | Expr::TsNonNull(..)
-            | Expr::TsTypeCast(..)
             | Expr::TsAs(..)
             | Expr::PrivateName(..)
             | Expr::Invalid(..) => return e,

--- a/ecmascript/transforms/typescript/src/strip.rs
+++ b/ecmascript/transforms/typescript/src/strip.rs
@@ -144,8 +144,7 @@ impl Strip {
             Expr::TsAs(TsAsExpr { expr, .. })
             | Expr::TsNonNull(TsNonNullExpr { expr, .. })
             | Expr::TsTypeAssertion(TsTypeAssertion { expr, .. })
-            | Expr::TsConstAssertion(TsConstAssertion { expr, .. })
-            | Expr::TsTypeCast(TsTypeCastExpr { expr, .. }) => {
+            | Expr::TsConstAssertion(TsConstAssertion { expr, .. }) => {
                 expr.visit_mut_with(self);
                 let expr = *expr.take();
                 *n = expr;

--- a/ecmascript/utils/src/lib.rs
+++ b/ecmascript/utils/src/lib.rs
@@ -333,8 +333,7 @@ pub trait ExprExt {
                 op: op!("void"),
                 ref arg,
                 ..
-            })
-            | Expr::TsTypeCast(TsTypeCastExpr { expr: ref arg, .. }) => arg.is_immutable_value(),
+            }) => arg.is_immutable_value(),
 
             Expr::Ident(ref i) => {
                 i.sym == js_word!("undefined")
@@ -948,8 +947,9 @@ pub trait ExprExt {
 
             Expr::TsAs(TsAsExpr { ref expr, .. })
             | Expr::TsNonNull(TsNonNullExpr { ref expr, .. })
-            | Expr::TsTypeAssertion(TsTypeAssertion { ref expr, .. })
-            | Expr::TsTypeCast(TsTypeCastExpr { ref expr, .. }) => expr.may_have_side_effects(),
+            | Expr::TsTypeAssertion(TsTypeAssertion { ref expr, .. }) => {
+                expr.may_have_side_effects()
+            }
             Expr::OptChain(ref e) => e.expr.may_have_side_effects(),
 
             Expr::Invalid(..) => unreachable!(),
@@ -1783,7 +1783,6 @@ where
 
             Expr::TsTypeAssertion(TsTypeAssertion { expr, .. })
             | Expr::TsNonNull(TsNonNullExpr { expr, .. })
-            | Expr::TsTypeCast(TsTypeCastExpr { expr, .. })
             | Expr::TsAs(TsAsExpr { expr, .. })
             | Expr::TsConstAssertion(TsConstAssertion { expr, .. }) => add_effects(v, expr),
             Expr::OptChain(e) => add_effects(v, e.expr),

--- a/ecmascript/visit/src/lib.rs
+++ b/ecmascript/visit/src/lib.rs
@@ -237,7 +237,6 @@ macro_rules! noop_fold_type {
         noop_fold_type!(fold_ts_type_alias_decl, TsTypeAliasDecl);
         noop_fold_type!(fold_ts_type_ann, TsTypeAnn);
         noop_fold_type!(fold_ts_type_assertion, TsTypeAssertion);
-        noop_fold_type!(fold_ts_type_cast_expr, TsTypeCastExpr);
         noop_fold_type!(fold_ts_type_element, TsTypeElement);
         noop_fold_type!(fold_ts_type_lit, TsTypeLit);
         noop_fold_type!(fold_ts_type_operator, TsTypeOperator);
@@ -314,7 +313,6 @@ macro_rules! noop_visit_type {
         noop_visit_type!(visit_ts_type_alias_decl, TsTypeAliasDecl);
         noop_visit_type!(visit_ts_type_ann, TsTypeAnn);
         noop_visit_type!(visit_ts_type_assertion, TsTypeAssertion);
-        noop_visit_type!(visit_ts_type_cast_expr, TsTypeCastExpr);
         noop_visit_type!(visit_ts_type_element, TsTypeElement);
         noop_visit_type!(visit_ts_type_lit, TsTypeLit);
         noop_visit_type!(visit_ts_type_operator, TsTypeOperator);
@@ -394,7 +392,6 @@ macro_rules! noop_visit_mut_type {
         noop_visit_mut_type!(visit_mut_ts_type_alias_decl, TsTypeAliasDecl);
         noop_visit_mut_type!(visit_mut_ts_type_ann, TsTypeAnn);
         noop_visit_mut_type!(visit_mut_ts_type_assertion, TsTypeAssertion);
-        noop_visit_mut_type!(visit_mut_ts_type_cast_expr, TsTypeCastExpr);
         noop_visit_mut_type!(visit_mut_ts_type_element, TsTypeElement);
         noop_visit_mut_type!(visit_mut_ts_type_lit, TsTypeLit);
         noop_visit_mut_type!(visit_mut_ts_type_operator, TsTypeOperator);
@@ -573,7 +570,6 @@ define!({
         TsTypeAssertion(TsTypeAssertion),
         TsConstAssertion(TsConstAssertion),
         TsNonNull(TsNonNullExpr),
-        TsTypeCast(TsTypeCastExpr),
         TsAs(TsAsExpr),
         PrivateName(PrivateName),
         OptChain(OptChainExpr),
@@ -1283,11 +1279,6 @@ define!({
     pub struct TsTypeParamInstantiation {
         pub span: Span,
         pub params: Vec<Box<TsType>>,
-    }
-    pub struct TsTypeCastExpr {
-        pub span: Span,
-        pub expr: Box<Expr>,
-        pub type_ann: TsTypeAnn,
     }
     pub struct TsParamProp {
         pub span: Span,

--- a/node-swc/src/Visitor.ts
+++ b/node-swc/src/Visitor.ts
@@ -144,7 +144,6 @@ import {
   TsTypeAliasDeclaration,
   TsTypeAnnotation,
   TsTypeAssertion,
-  TsTypeCastExpression,
   TsTypeElement,
   TsTypeParameter,
   TsTypeParameterDeclaration,
@@ -1069,8 +1068,6 @@ export default class Visitor {
         return this.visitTsNonNullExpression(n);
       case "TsTypeAssertion":
         return this.visitTsTypeAssertion(n);
-      case "TsTypeCastExpression":
-        return this.visitTsTypeCastExpression(n);
       case "UnaryExpression":
         return this.visitUnaryExpression(n);
       case "UpdateExpression":
@@ -1119,12 +1116,6 @@ export default class Visitor {
 
   visitUnaryExpression(n: UnaryExpression): Expression {
     n.argument = this.visitExpression(n.argument);
-    return n;
-  }
-
-  visitTsTypeCastExpression(n: TsTypeCastExpression): Expression {
-    n.expression = this.visitExpression(n.expression);
-    n.typeAnnotation = this.visitTsTypeAnnotation(n.typeAnnotation)!;
     return n;
   }
 

--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -773,7 +773,6 @@ export type Expression =
   | JSXFragment
   | TsTypeAssertion
   | TsNonNullExpression
-  | TsTypeCastExpression
   | TsAsExpression
   | PrivateName
   | OptionalChainingExpression
@@ -1689,13 +1688,6 @@ export interface TsTypeParameterInstantiation extends Node, HasSpan {
   type: "TsTypeParameterInstantiation";
 
   params: TsType[];
-}
-
-export interface TsTypeCastExpression extends Node, HasSpan {
-  type: "TsTypeCastExpression";
-
-  expression: Expression;
-  typeAnnotation: TsTypeAnnotation;
 }
 
 export interface TsParameterProperty extends Node, HasSpan, HasDecorator {


### PR DESCRIPTION
This is never used. `TsTypeAssertion` is the actual node.