### PR TITLE
Support using swc_common with MIRI

### DIFF
--- a/common/src/syntax_pos/analyze_source_file.rs
+++ b/common/src/syntax_pos/analyze_source_file.rs
@@ -53,7 +53,7 @@ cfg_if::cfg_if! {
                                     lines: &mut Vec<BytePos>,
                                     multi_byte_chars: &mut Vec<MultiByteChar>,
                                     non_narrow_chars: &mut Vec<NonNarrowChar>) {
-            if is_x86_feature_detected!("sse2") {
+            if is_x86_feature_detected!("sse2") && cfg!(not(miri)) {
                 unsafe {
                     analyze_source_file_sse2(src,
                                          source_file_start_pos,


### PR DESCRIPTION
swc_common uses `is_x86_feature_detected!("sse2")` inside which makes it impossible to use swc_common with MIRI together. This is needed for example in [starlight](https://github.com/Starlight-JS/starlight) to verify JS interpreter,GC and other stuff.