### PR TITLE
Fix Glibc compatible issue with Node.js official docker images

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
 
     name: Build - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -50,6 +50,10 @@ jobs:
 
       - name: Test bindings
         run: npm test
+
+      - name: Test in lts docker
+        if: matrix.os == 'ubuntu-18.04'
+        run: docker run --rm -v $(pwd):/swc -w /swc node:10-slim sh -c "yarn test"
 
   build-windows-i686:
     name: stable - windows-i686 - node@14


### PR DESCRIPTION
https://github.com/Brooooooklyn/swc/runs/1962777574?check_suite_focus=true

Linux docker testing passed, safe to ignore the failed result in windows and macos, because I forgot to add `if: matrix.os == 'ubuntu-18.04'` condition in the linked job.

Close https://github.com/swc-project/swc/issues/1430