### PR TITLE
Port @babel/preset-modules to SWC

### DIFF
--- a/ecmascript/preset_env/src/transform_data.rs
+++ b/ecmascript/preset_env/src/transform_data.rs
@@ -169,16 +169,12 @@ pub(crate) static BUGFIX_FEATURES: Lazy<HashMap<Feature, BrowserData<Option<Vers
         FEATURES
             .clone()
             .into_iter()
-            .chain(
-                map.into_iter()
-                    .map(|(feature, version)| {
-                        (
-                            feature,
-                            version.map_value(|version| version.map(|v| v.parse().unwrap())),
-                        )
-                    })
-                    .collect::<HashMap<Feature, BrowserData<Option<Version>>>>(),
-            )
+            .chain(map.into_iter().map(|(feature, version)| {
+                (
+                    feature,
+                    version.map_value(|version| version.map(|v| v.parse().unwrap())),
+                )
+            }))
             .collect()
     });
 

--- a/ecmascript/preset_env/src/transform_data.rs
+++ b/ecmascript/preset_env/src/transform_data.rs
@@ -4,8 +4,15 @@ use std::collections::HashMap;
 use string_enum::StringEnum;
 
 impl Feature {
-    pub fn should_enable(self, target: Versions, default: bool) -> bool {
-        let f = &FEATURES[&self];
+    pub fn should_enable(self, target: Versions, bugfixes: bool, default: bool) -> bool {
+        let f = if bugfixes {
+            &BUGFIX_FEATURES[&self]
+        } else {
+            if !FEATURES.contains_key(&self) {
+                return false;
+            }
+            &FEATURES[&self]
+        };
 
         should_enable(target, *f, default)
     }
@@ -126,6 +133,15 @@ pub enum Feature {
 
     /// `transform-unicode-escapes`
     UnicodeEscapes,
+
+    /// `bugfix/transform-async-arrows-in-class`
+    BugfixAsyncArrowsInClass,
+
+    /// `bugfix/transform-edge-default-parameters`
+    BugfixEdgeDefaultParam,
+
+    /// `bugfix/transform-tagged-template-caching`
+    BugfixTaggedTemplateCaching,
 }
 
 pub(crate) static FEATURES: Lazy<HashMap<Feature, BrowserData<Option<Version>>>> =
@@ -144,6 +160,28 @@ pub(crate) static FEATURES: Lazy<HashMap<Feature, BrowserData<Option<Version>>>>
             .collect()
     });
 
+pub(crate) static BUGFIX_FEATURES: Lazy<HashMap<Feature, BrowserData<Option<Version>>>> =
+    Lazy::new(|| {
+        let map: HashMap<Feature, BrowserData<Option<String>>> =
+            serde_json::from_str(include_str!("transform_data_bugfixes.json"))
+                .expect("failed to parse json");
+
+        FEATURES
+            .clone()
+            .into_iter()
+            .chain(
+                map.into_iter()
+                    .map(|(feature, version)| {
+                        (
+                            feature,
+                            version.map_value(|version| version.map(|v| v.parse().unwrap())),
+                        )
+                    })
+                    .collect::<HashMap<Feature, BrowserData<Option<Version>>>>(),
+            )
+            .collect()
+    });
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -155,6 +193,7 @@ mod tests {
                 ie: Some("11.0.0".parse().unwrap()),
                 ..Default::default()
             },
+            false,
             false
         ));
     }
@@ -166,7 +205,181 @@ mod tests {
                 chrome: Some("71.0.0".parse().unwrap()),
                 ..Default::default()
             },
+            false,
             true
+        ));
+    }
+
+    #[test]
+    fn tpl_lit_bugfixes() {
+        // Enable template literals pass in Safari 9 without bugfixes option
+        assert!(Feature::TemplateLiterals.should_enable(
+            BrowserData {
+                safari: Some("9.0.0".parse().unwrap()),
+                ..Default::default()
+            },
+            false,
+            false
+        ));
+
+        assert!(!Feature::BugfixTaggedTemplateCaching.should_enable(
+            BrowserData {
+                safari: Some("10.0.0".parse().unwrap()),
+                ..Default::default()
+            },
+            false,
+            false
+        ));
+
+        // Don't enable it with the bugfixes option. Bugfix pass enabled instead.
+        assert!(!Feature::TemplateLiterals.should_enable(
+            BrowserData {
+                safari: Some("9.0.0".parse().unwrap()),
+                ..Default::default()
+            },
+            true,
+            false
+        ));
+
+        assert!(Feature::BugfixTaggedTemplateCaching.should_enable(
+            BrowserData {
+                safari: Some("9.0.0".parse().unwrap()),
+                ..Default::default()
+            },
+            true,
+            false
+        ));
+
+        assert!(!Feature::BugfixTaggedTemplateCaching.should_enable(
+            BrowserData {
+                safari: Some("13.0.0".parse().unwrap()),
+                ..Default::default()
+            },
+            true,
+            false
+        ));
+    }
+
+    #[test]
+    fn edge_default_param_bug() {
+        // Enable params pass in Edge 17 without bugfixes option
+        assert!(Feature::Parameters.should_enable(
+            BrowserData {
+                edge: Some("17.0.0".parse().unwrap()),
+                ..Default::default()
+            },
+            false,
+            false
+        ));
+
+        assert!(!Feature::BugfixEdgeDefaultParam.should_enable(
+            BrowserData {
+                edge: Some("17.0.0".parse().unwrap()),
+                ..Default::default()
+            },
+            false,
+            false
+        ));
+
+        // Don't enable it with the bugfixes option. Bugfix pass enabled instead.
+        assert!(!Feature::Parameters.should_enable(
+            BrowserData {
+                edge: Some("17.0.0".parse().unwrap()),
+                ..Default::default()
+            },
+            true,
+            false
+        ));
+
+        assert!(Feature::BugfixEdgeDefaultParam.should_enable(
+            BrowserData {
+                edge: Some("17.0.0".parse().unwrap()),
+                ..Default::default()
+            },
+            true,
+            false
+        ));
+
+        assert!(!Feature::BugfixEdgeDefaultParam.should_enable(
+            BrowserData {
+                edge: Some("18.0.0".parse().unwrap()),
+                ..Default::default()
+            },
+            true,
+            false
+        ));
+    }
+
+    #[test]
+    fn async_arrows_in_class_bug() {
+        // Enable async to generator pass in Safari 10.1 without bugfixes option
+        assert!(Feature::AsyncToGenerator.should_enable(
+            BrowserData {
+                safari: Some("10.1.0".parse().unwrap()),
+                ..Default::default()
+            },
+            false,
+            false
+        ));
+
+        assert!(!Feature::BugfixAsyncArrowsInClass.should_enable(
+            BrowserData {
+                safari: Some("10.1.0".parse().unwrap()),
+                ..Default::default()
+            },
+            false,
+            false
+        ));
+
+        // Don't enable it with the bugfixes option. Bugfix pass enabled instead.
+        assert!(!Feature::AsyncToGenerator.should_enable(
+            BrowserData {
+                safari: Some("10.1.0".parse().unwrap()),
+                ..Default::default()
+            },
+            true,
+            false
+        ));
+
+        assert!(Feature::BugfixAsyncArrowsInClass.should_enable(
+            BrowserData {
+                safari: Some("10.1.0".parse().unwrap()),
+                ..Default::default()
+            },
+            true,
+            false
+        ));
+
+        assert!(!Feature::BugfixAsyncArrowsInClass.should_enable(
+            BrowserData {
+                safari: Some("11.1.0".parse().unwrap()),
+                ..Default::default()
+            },
+            true,
+            false
+        ));
+    }
+
+    #[test]
+    fn block_scoping() {
+        // Enable block scoping pass in Safari 10 without bugfixes option
+        assert!(Feature::BlockScoping.should_enable(
+            BrowserData {
+                safari: Some("10.0.0".parse().unwrap()),
+                ..Default::default()
+            },
+            false,
+            false
+        ));
+
+        // Don't enable it with the bugfixes option.
+        assert!(!Feature::BlockScoping.should_enable(
+            BrowserData {
+                safari: Some("10.0.0".parse().unwrap()),
+                ..Default::default()
+            },
+            true,
+            false
         ));
     }
 }

--- a/ecmascript/preset_env/src/transform_data_bugfixes.json
+++ b/ecmascript/preset_env/src/transform_data_bugfixes.json
@@ -1,0 +1,79 @@
+{
+  "transform-async-to-generator": {
+    "chrome": "55",
+    "opera": "42",
+    "edge": "15",
+    "firefox": "52",
+    "safari": "10.1",
+    "node": "7.6",
+    "ios": "10.3",
+    "samsung": "6",
+    "electron": "1.6"
+  },
+  "bugfix/transform-async-arrows-in-class": {
+    "chrome": "55",
+    "opera": "42",
+    "edge": "15",
+    "firefox": "52",
+    "safari": "11",
+    "node": "7.6",
+    "ios": "11",
+    "samsung": "6",
+    "electron": "1.6"
+  },
+  "transform-parameters": {
+    "chrome": "49",
+    "opera": "36",
+    "edge": "15",
+    "firefox": "53",
+    "safari": "10",
+    "node": "6",
+    "ios": "10",
+    "samsung": "5",
+    "electron": "0.37"
+  },
+  "bugfix/transform-edge-default-parameters": {
+    "chrome": "49",
+    "opera": "36",
+    "edge": "18",
+    "firefox": "52",
+    "safari": "10",
+    "node": "6",
+    "ios": "10",
+    "samsung": "5",
+    "electron": "0.37"
+  },
+  "transform-block-scoping": {
+    "chrome": "49",
+    "opera": "36",
+    "edge": "14",
+    "firefox": "51",
+    "safari": "10",
+    "node": "6",
+    "ios": "10",
+    "samsung": "5",
+    "electron": "0.37"
+  },
+  "transform-template-literals": {
+    "chrome": "41",
+    "opera": "28",
+    "edge": "13",
+    "firefox": "34",
+    "safari": "9",
+    "node": "4",
+    "ios": "9",
+    "samsung": "3.4",
+    "electron": "0.21"
+  },
+  "bugfix/transform-tagged-template-caching": {
+    "chrome": "41",
+    "opera": "28",
+    "edge": "12",
+    "firefox": "34",
+    "safari": "13",
+    "node": "4",
+    "ios": "13",
+    "samsung": "3.4",
+    "electron": "0.21"
+  }
+}

--- a/ecmascript/preset_env/tests/test.rs
+++ b/ecmascript/preset_env/tests/test.rs
@@ -190,6 +190,7 @@ fn exec(c: PresetConfig, dir: PathBuf) -> Result<(), Error> {
                     loose: true,
                     // TODO
                     dynamic_import: true,
+                    bugfixes: false,
                     include: c.include,
                     exclude: c.exclude,
                     core_js: match c.corejs {

--- a/ecmascript/transforms/compat/src/bugfixes.rs
+++ b/ecmascript/transforms/compat/src/bugfixes.rs
@@ -1,11 +1,17 @@
 pub use self::async_arrows_in_class::async_arrows_in_class;
 pub use self::edge_default_param::edge_default_param;
+pub use self::template_literal_caching::template_literal_caching;
 use swc_common::chain;
 use swc_ecma_visit::Fold;
 
 mod async_arrows_in_class;
 mod edge_default_param;
+mod template_literal_caching;
 
 pub fn bugfixes() -> impl Fold {
-  chain!(async_arrows_in_class(), edge_default_param())
+    chain!(
+        async_arrows_in_class(),
+        edge_default_param(),
+        template_literal_caching()
+    )
 }

--- a/ecmascript/transforms/compat/src/bugfixes.rs
+++ b/ecmascript/transforms/compat/src/bugfixes.rs
@@ -1,0 +1,9 @@
+pub use self::edge_default_param::edge_default_param;
+use swc_common::chain;
+use swc_ecma_visit::Fold;
+
+mod edge_default_param;
+
+pub fn bugfixes() -> impl Fold {
+  edge_default_param()
+}

--- a/ecmascript/transforms/compat/src/bugfixes.rs
+++ b/ecmascript/transforms/compat/src/bugfixes.rs
@@ -1,9 +1,11 @@
+pub use self::async_arrows_in_class::async_arrows_in_class;
 pub use self::edge_default_param::edge_default_param;
 use swc_common::chain;
 use swc_ecma_visit::Fold;
 
+mod async_arrows_in_class;
 mod edge_default_param;
 
 pub fn bugfixes() -> impl Fold {
-  edge_default_param()
+  chain!(async_arrows_in_class(), edge_default_param())
 }

--- a/ecmascript/transforms/compat/src/bugfixes/async_arrows_in_class.rs
+++ b/ecmascript/transforms/compat/src/bugfixes/async_arrows_in_class.rs
@@ -1,0 +1,154 @@
+use crate::es2015::arrow;
+use swc_ecma_ast::*;
+use swc_ecma_visit::{noop_fold_type, Fold, FoldWith};
+
+/// Safari 10.3 had an issue where async arrow function expressions within any
+/// class method would throw. After an initial fix, any references to the
+/// instance via `this` within those methods would also throw. This is fixed by
+/// converting arrow functions in class methods into equivalent function
+/// expressions. See https://bugs.webkit.org/show_bug.cgi?id=166879
+pub fn async_arrows_in_class() -> impl Fold {
+    AsyncArrowsInClass::default()
+}
+#[derive(Default, Clone, Copy)]
+struct AsyncArrowsInClass {
+    in_class_method: bool,
+}
+
+impl Fold for AsyncArrowsInClass {
+    noop_fold_type!();
+
+    fn fold_constructor(&mut self, n: Constructor) -> Constructor {
+        self.in_class_method = true;
+        let res = n.fold_children_with(self);
+        self.in_class_method = false;
+        res
+    }
+
+    fn fold_class_method(&mut self, n: ClassMethod) -> ClassMethod {
+        self.in_class_method = true;
+        let res = n.fold_children_with(self);
+        self.in_class_method = false;
+        res
+    }
+
+    fn fold_expr(&mut self, n: Expr) -> Expr {
+        let n = n.fold_children_with(self);
+        if !self.in_class_method {
+            return n;
+        }
+
+        match n {
+            Expr::Arrow(ref a) => {
+                if a.is_async {
+                    n.fold_with(&mut arrow())
+                } else {
+                    n
+                }
+            }
+            _ => n,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use swc_ecma_transforms_testing::test;
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| async_arrows_in_class(),
+        async_arrows,
+        r#"
+        class Foo {
+            constructor() {
+                this.x = async () => await 1;
+            }
+            bar() {
+                (async () => { })();
+            }
+        }"#,
+        r#"
+        class Foo {
+            constructor() {
+                this.x = async function () {
+                    return await 1;
+                };
+            }
+          
+            bar() {
+                (async function () {})();
+            }
+        }"#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| async_arrows_in_class(),
+        callback,
+        r#"
+        class Foo {
+            foo() {
+                bar(async () => await 1);
+            }
+        }"#,
+        r#"
+        class Foo {
+            foo() {
+              bar(async function () {
+                  return await 1;
+              });
+            }
+        }"#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| async_arrows_in_class(),
+        this,
+        r#"
+        class Foo {
+            constructor() {
+                this.x = () => async () => await this;
+            }
+        }"#,
+        r#"
+        class Foo {
+            constructor() {          
+              this.x = () => (async function () {
+                  return await this;
+              }).bind(this);
+            }
+        }"#
+    );
+
+    // TODO: handle arguments and super. This isn't handled in general for arrow
+    // functions atm...
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| async_arrows_in_class(),
+        non_async_arrow,
+        r#"
+        class Foo {
+            constructor() {
+                this.x = () => {};
+            }
+        }"#,
+        r#"
+        class Foo {
+            constructor() {
+                this.x = () => {};
+            }
+        }"#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| async_arrows_in_class(),
+        non_class_async_arrow,
+        "let x = async () => await 1;",
+        "let x = async () => await 1;"
+    );
+}

--- a/ecmascript/transforms/compat/src/bugfixes/edge_default_param.rs
+++ b/ecmascript/transforms/compat/src/bugfixes/edge_default_param.rs
@@ -21,11 +21,7 @@ impl Fold for EdgeDefaultParam {
         let params = n.params.fold_with(self);
         self.in_arrow = false;
 
-        let body = match n.body {
-            BlockStmtOrExpr::BlockStmt(b) => BlockStmtOrExpr::BlockStmt(b.fold_with(self)),
-            BlockStmtOrExpr::Expr(e) => BlockStmtOrExpr::Expr(e.fold_with(self)),
-        };
-
+        let body = n.body.fold_with(self);
         ArrowExpr { params, body, ..n }
     }
 

--- a/ecmascript/transforms/compat/src/bugfixes/edge_default_param.rs
+++ b/ecmascript/transforms/compat/src/bugfixes/edge_default_param.rs
@@ -1,0 +1,102 @@
+use swc_ecma_ast::*;
+use swc_ecma_visit::{noop_fold_type, Fold, FoldWith};
+
+/// Converts destructured parameters with default values to non-shorthand
+/// syntax. This fixes the only arguments-related bug in ES Modules-supporting
+/// browsers (Edge 16 & 17). Use this plugin instead of
+/// @babel/plugin-transform-parameters when targeting ES Modules.
+pub fn edge_default_param() -> impl Fold {
+    EdgeDefaultParam::default()
+}
+#[derive(Default, Clone, Copy)]
+struct EdgeDefaultParam {
+    in_arrow: bool,
+}
+
+impl Fold for EdgeDefaultParam {
+    noop_fold_type!();
+
+    fn fold_arrow_expr(&mut self, n: ArrowExpr) -> ArrowExpr {
+        self.in_arrow = true;
+        let params = n.params.fold_with(self);
+        self.in_arrow = false;
+
+        let body = match n.body {
+            BlockStmtOrExpr::BlockStmt(b) => BlockStmtOrExpr::BlockStmt(b.fold_with(self)),
+            BlockStmtOrExpr::Expr(e) => BlockStmtOrExpr::Expr(e.fold_with(self)),
+        };
+
+        ArrowExpr { params, body, ..n }
+    }
+
+    fn fold_object_pat(&mut self, n: ObjectPat) -> ObjectPat {
+        let n = n.fold_children_with(self);
+        if !self.in_arrow {
+            return n;
+        }
+
+        let props = n
+            .props
+            .into_iter()
+            .map(|prop| match prop {
+                ObjectPatProp::Assign(assign_pat) => {
+                    if let Some(value) = assign_pat.value {
+                        ObjectPatProp::KeyValue(KeyValuePatProp {
+                            key: PropName::Ident(assign_pat.key.clone()),
+                            value: Box::new(Pat::Assign(AssignPat {
+                                span: assign_pat.span,
+                                left: Box::new(Pat::Ident(BindingIdent::from(
+                                    assign_pat.key.clone(),
+                                ))),
+                                right: value.clone(),
+                                type_ann: None,
+                            })),
+                        })
+                    } else {
+                        ObjectPatProp::Assign(assign_pat)
+                    }
+                }
+                _ => prop,
+            })
+            .collect();
+        ObjectPat { props, ..n }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use swc_ecma_transforms_testing::test;
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| edge_default_param(),
+        destructured_default_value,
+        "const f = ({ a = 1 }) => a;",
+        "const f = ({ a: a = 1 }) => a;"
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| edge_default_param(),
+        destructured_no_default_value,
+        "const f = ({ a }) => a;",
+        "const f = ({ a }) => a;"
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| edge_default_param(),
+        nested_default_value,
+        "const f = ({ a: { b = 1 } }) => [a, b];",
+        "const f = ({ a: { b: b = 1 } }) => [a, b];"
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| edge_default_param(),
+        non_arguments,
+        "const f = () => { const { a = 1 } = {}; };",
+        "const f = () => { const { a = 1 } = {}; };"
+    );
+}

--- a/ecmascript/transforms/compat/src/bugfixes/template_literal_caching.rs
+++ b/ecmascript/transforms/compat/src/bugfixes/template_literal_caching.rs
@@ -1,0 +1,308 @@
+use swc_common::DUMMY_SP;
+use swc_ecma_ast::*;
+use swc_ecma_utils::{prepend_stmts, private_ident};
+use swc_ecma_visit::{noop_fold_type, Fold, FoldWith};
+
+// Converts destructured parameters with default values to non-shorthand syntax.
+// This fixes the only Tagged Templates-related bug in ES Modules-supporting
+// browsers (Safari 10 & 11).
+//
+// Bug 1: Safari 10/11 doesn't reliably return the same Strings value.
+// The value changes depending on invocation and function optimization state.
+//   function f() { return Object`` }
+//   f() === new f()  // false, should be true.
+//
+// Bug 2: Safari 10/11 use the same cached strings value when the string parts
+// are the same. This behavior comes from an earlier version of the spec, and
+// can cause tricky bugs.
+//   Object``===Object``  // true, should be false.
+//
+// Benchmarks: https://jsperf.com/compiled-tagged-template-performance
+pub fn template_literal_caching() -> impl Fold {
+    TemplateLiteralCaching::default()
+}
+#[derive(Default, Clone)]
+struct TemplateLiteralCaching {
+    decls: Vec<VarDeclarator>,
+    helper_ident: Option<Ident>,
+}
+
+impl TemplateLiteralCaching {
+    fn create_binding(&mut self, name: Ident, init: Option<Expr>) {
+        let init = if let Some(init) = init {
+            Some(Box::new(init))
+        } else {
+            None
+        };
+        self.decls.push(VarDeclarator {
+            span: DUMMY_SP,
+            name: Pat::Ident(BindingIdent::from(name.clone())),
+            init,
+            definite: false,
+        })
+    }
+
+    fn create_var_decl(&mut self) -> Option<Stmt> {
+        if self.decls.len() > 0 {
+            return Some(Stmt::Decl(Decl::Var(VarDecl {
+                span: DUMMY_SP,
+                kind: VarDeclKind::Let,
+                declare: false,
+                decls: self.decls.clone(),
+            })));
+        }
+        None
+    }
+}
+
+impl Fold for TemplateLiteralCaching {
+    noop_fold_type!();
+
+    fn fold_expr(&mut self, n: Expr) -> Expr {
+        let n = n.fold_children_with(self);
+        match n {
+            Expr::TaggedTpl(n) => {
+                if self.helper_ident.is_none() {
+                    // Create an identity function helper:
+                    //   identity = t => t
+                    let helper_ident = private_ident!("_");
+                    let t = private_ident!("t");
+                    self.helper_ident = Some(helper_ident.clone());
+                    self.create_binding(
+                        helper_ident.clone(),
+                        Some(Expr::Arrow(ArrowExpr {
+                            span: DUMMY_SP,
+                            params: vec![Pat::Ident(BindingIdent::from(t.clone()))],
+                            body: BlockStmtOrExpr::Expr(Box::new(Expr::Ident(t.clone()))),
+                            is_async: false,
+                            is_generator: false,
+                            type_params: None,
+                            return_type: None,
+                        })),
+                    )
+                }
+
+                let helper_ident = self.helper_ident.as_ref().unwrap();
+
+                // Use the identity function helper to get a reference to the template's
+                // Strings. We replace all expressions with `0` ensure Strings has
+                // the same shape.   identity`a${0}`
+                let template = TaggedTpl {
+                    span: DUMMY_SP,
+                    tag: Box::new(Expr::Ident(helper_ident.clone())),
+                    quasis: n.quasis,
+                    exprs: n
+                        .exprs
+                        .clone()
+                        .into_iter()
+                        .map(|_| {
+                            Box::new(Expr::Lit(Lit::Num(Number {
+                                span: DUMMY_SP,
+                                value: 0.0,
+                            })))
+                        })
+                        .collect(),
+                    type_params: None,
+                };
+
+                // Install an inline cache at the callsite using the global variable:
+                //   _t || (_t = identity`a${0}`)
+                let t = private_ident!("t");
+                self.create_binding(t.clone(), None);
+                let inline_cache = Expr::Bin(BinExpr {
+                    span: DUMMY_SP,
+                    op: BinaryOp::LogicalOr,
+                    left: Box::new(Expr::Ident(t.clone())),
+                    right: Box::new(Expr::Assign(AssignExpr {
+                        span: DUMMY_SP,
+                        op: AssignOp::Assign,
+                        left: PatOrExpr::Pat(Box::new(Pat::Ident(BindingIdent::from(t.clone())))),
+                        right: Box::new(Expr::TaggedTpl(template)),
+                    })),
+                });
+
+                // The original tag function becomes a plain function call.
+                // The expressions omitted from the cached Strings tag are
+                // directly applied as arguments.
+                //   tag(_t || (_t = Object`a${0}`), 'hello')
+                Expr::Call(CallExpr {
+                    span: DUMMY_SP,
+                    callee: ExprOrSuper::Expr(n.tag),
+                    args: vec![ExprOrSpread {
+                        expr: Box::new(inline_cache),
+                        spread: None,
+                    }]
+                    .into_iter()
+                    .chain(n.exprs.into_iter().map(|expr| ExprOrSpread {
+                        expr: expr.clone(),
+                        spread: None,
+                    }))
+                    .collect(),
+                    type_args: None,
+                })
+            }
+            _ => n,
+        }
+    }
+
+    fn fold_module(&mut self, n: Module) -> Module {
+        let mut body = n.body.fold_children_with(self);
+        if let Some(var) = self.create_var_decl() {
+            prepend_stmts(&mut body, vec![ModuleItem::Stmt(var)].drain(..))
+        }
+
+        Module { body, ..n }
+    }
+
+    fn fold_script(&mut self, n: Script) -> Script {
+        let mut body = n.body.fold_children_with(self);
+        if let Some(var) = self.create_var_decl() {
+            prepend_stmts(&mut body, vec![var].drain(..))
+        }
+
+        Script { body, ..n }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use swc_ecma_transforms_testing::test;
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| template_literal_caching(),
+        single_tag,
+        "t`a`;",
+        r#"
+        let _ = t => t, t1;
+        t(t1 || (t1 = _`a`));
+        "#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| template_literal_caching(),
+        single_tag_empty,
+        "x``;",
+        r#"
+        let _ = t => t, t;
+        x(t || (t = _``));
+        "#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| template_literal_caching(),
+        multiple_tags,
+        r#"
+        t`a`;
+        x``;
+        "#,
+        r#"
+        let _ = t => t, t2, t1;
+        t(t2 || (t2 = _`a`));
+        x(t1 || (t1 = _``));
+        "#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| template_literal_caching(),
+        function_scoped_tag,
+        "const f = t => t`a`;",
+        r#"
+        let _ = t => t, t;
+        const f = t1 => t1(t || (t = _`a`));
+        "#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| template_literal_caching(),
+        dynamic_tag,
+        "fn()``;",
+        r#"
+        let _ = t => t, t;
+        fn()(t || (t = _``));
+        "#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| template_literal_caching(),
+        dynamic_expressions,
+        "const f = t => t`a${1}b${t}${[\"hello\"]}`;",
+        r#"
+        let _ = t => t, t;
+        const f = t1 => t1(t || (t = _`a${0}b${0}${0}`), 1, t1, ["hello"]);
+        "#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| template_literal_caching(),
+        same_tag_safari_11,
+        "x`a` === x`a`;",
+        r#"
+        let _ = t => t, t, t1;
+        x(t || (t = _`a`)) === x(t1 || (t1 = _`a`));
+        "#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| template_literal_caching(),
+        shared_strings_safari_11,
+        "x`a` === y`a`;",
+        r#"
+        let _ = t => t, t, t1;
+        x(t || (t = _`a`)) === y(t1 || (t1 = _`a`));
+        "#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| template_literal_caching(),
+        template_literals,
+        r#"
+        `a`;
+        t(`a`);
+        t;
+        `a`;
+        "#,
+        r#"
+        `a`;
+        t(`a`);
+        t;
+        `a`;
+        "#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| template_literal_caching(),
+        prevent_tag_collision,
+        r#"
+        const _ = 1;
+        t``;
+        "#,
+        r#"
+        let _ = t => t, t1;
+
+        const _1 = 1;
+        t(t1 || (t1 = _``));
+        "#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| template_literal_caching(),
+        block_scoped_tag,
+        "for (let t of []) t`a`;",
+        r#"
+        let _ = t => t, t;
+        for (let t1 of []) t1(t || (t = _`a`));
+        "#
+    );
+}

--- a/ecmascript/transforms/compat/src/lib.rs
+++ b/ecmascript/transforms/compat/src/lib.rs
@@ -1,11 +1,13 @@
 //! New-generation javascript to old-javascript compiler.
 
 pub use self::{
-    es2015::es2015, es2016::es2016, es2017::es2017, es2018::es2018, es2020::es2020, es3::es3,
+    bugfixes::bugfixes, es2015::es2015, es2016::es2016, es2017::es2017, es2018::es2018,
+    es2020::es2020, es3::es3,
 };
 
 #[macro_use]
 mod macros;
+pub mod bugfixes;
 pub mod es2015;
 pub mod es2016;
 pub mod es2017;

--- a/ecmascript/transforms/react/src/jsx/mod.rs
+++ b/ecmascript/transforms/react/src/jsx/mod.rs
@@ -169,6 +169,7 @@ where
             expr: parse_classic_option(&cm, "pragmaFrag", options.pragma_frag),
         },
         use_builtins: options.use_builtins,
+        use_spread: options.use_spread,
         throw_if_namespace: options.throw_if_namespace,
         top_level_node: true,
     })
@@ -198,6 +199,7 @@ where
     comments: Option<C>,
     pragma_frag: ExprOrSpread,
     use_builtins: bool,
+    use_spread: bool,
     throw_if_namespace: bool,
 }
 
@@ -586,6 +588,10 @@ where
     fn fold_attrs_for_old_classic(&mut self, attrs: Vec<JSXAttrOrSpread>) -> Box<Expr> {
         if attrs.is_empty() {
             return Box::new(Expr::Lit(Lit::Null(Null { span: DUMMY_SP })));
+        }
+
+        if self.use_spread {
+            return self.fold_attrs_for_next_classic(attrs);
         }
 
         let is_complex = attrs.iter().any(|a| match *a {

--- a/ecmascript/transforms/react/src/jsx/mod.rs
+++ b/ecmascript/transforms/react/src/jsx/mod.rs
@@ -50,7 +50,7 @@ impl Default for Runtime {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct Options {

--- a/ecmascript/transforms/react/src/jsx/tests.rs
+++ b/ecmascript/transforms/react/src/jsx/tests.rs
@@ -1105,6 +1105,24 @@ test!(
     |t| tr(
         t,
         Options {
+            use_spread: true,
+            ..Default::default()
+        },
+    ),
+    use_spread_assignment,
+    r#"<Component y={2} { ...x } z />"#,
+    r#"
+React.createElement(Component, {y: 2, ...x, z: true});"#
+);
+
+test!(
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+        jsx: true,
+        ..Default::default()
+    }),
+    |t| tr(
+        t,
+        Options {
             use_builtins: true,
             ..Default::default()
         },

--- a/src/config.rs
+++ b/src/config.rs
@@ -824,7 +824,9 @@ impl Merge for GlobalPassOption {
 
 impl Merge for react::Options {
     fn merge(&mut self, from: &Self) {
-        *self = from.clone();
+        if *from != react::Options::default() {
+            *self = from.clone();
+        }
     }
 }
 


### PR DESCRIPTION
This is a port of [@babel/preset-modules](https://github.com/babel/preset-modules) to SWC. As with the original, this produces smaller output when targeting browsers supporting esmodules that just works around browser bugs as opposed to compiling to ES5. This was later [integrated](https://babeljs.io/blog/2020/03/16/7.9.0#babelpreset-envs-bugfixes-option-11083httpsgithubcombabelbabelpull11083) into `@babel/preset-env`, and I think that would be a good idea for SWC's preset-env as well.

This is just an initial PR to get feedback on the approach and whether this would even be accepted into SWC. Also left some questions below.

- [x] **transform-async-arrows-in-class**
- [x] **transform-edge-default-parameters**
- [ ] **~~transform-edge-function-name~~** - I think this is unnecessary since SWC already does a lot less than Babel's function-name plugin so it's already basically equivalent to the bugfixes option.
- [x] **transform-jsx-spread** - Implemented the `use_spread` option of the existing JSX pass rather than building a separate pass. 
- [ ] **~~transform-safari-block-shadowing~~** - not needed, SWC always renames shadowed variable declarations, even with let
- [ ] **~~transform-safari-for-shadowing~~** - same as above
- [x] **transform-tagged-template-caching**

cc. @developit