### PR TITLE
fix(swc): Fix various bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.7.1"
+version = "0.8.0"
 
 [lib]
 name = "swc"

--- a/ecmascript/parser/tests/typescript/issue-1441/input.ts
+++ b/ecmascript/parser/tests/typescript/issue-1441/input.ts
@@ -1,0 +1,5 @@
+
+
+await foo()
+
+export { }

--- a/ecmascript/parser/tests/typescript/issue-1441/input.ts.json
+++ b/ecmascript/parser/tests/typescript/issue-1441/input.ts.json
@@ -1,0 +1,59 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 2,
+    "end": 25,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 2,
+        "end": 13,
+        "ctxt": 0
+      },
+      "expression": {
+        "type": "AwaitExpression",
+        "span": {
+          "start": 2,
+          "end": 13,
+          "ctxt": 0
+        },
+        "argument": {
+          "type": "CallExpression",
+          "span": {
+            "start": 8,
+            "end": 13,
+            "ctxt": 0
+          },
+          "callee": {
+            "type": "Identifier",
+            "span": {
+              "start": 8,
+              "end": 11,
+              "ctxt": 0
+            },
+            "value": "foo",
+            "optional": false
+          },
+          "arguments": [],
+          "typeArguments": null
+        }
+      }
+    },
+    {
+      "type": "ExportNamedDeclaration",
+      "span": {
+        "start": 15,
+        "end": 25,
+        "ctxt": 0
+      },
+      "specifiers": [],
+      "source": null,
+      "typeOnly": false,
+      "asserts": null
+    }
+  ],
+  "interpreter": null
+}

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.6.1"
+version = "0.6.2"
 
 [dependencies]
 fxhash = "0.2.1"

--- a/ecmascript/transforms/base/src/ext.rs
+++ b/ecmascript/transforms/base/src/ext.rs
@@ -273,6 +273,21 @@ impl MapWithMut for JSXClosingFragment {
     }
 }
 
+impl MapWithMut for Class {
+    fn dummy() -> Self {
+        Class {
+            span: DUMMY_SP,
+            decorators: Default::default(),
+            body: Default::default(),
+            super_class: Default::default(),
+            is_abstract: Default::default(),
+            type_params: Default::default(),
+            super_type_params: Default::default(),
+            implements: Default::default(),
+        }
+    }
+}
+
 /// Do not use: This is not a public api and it can be changed without a version
 /// bump.
 pub trait PatOrExprExt: AsOptExpr {

--- a/ecmascript/transforms/base/src/fixer.rs
+++ b/ecmascript/transforms/base/src/fixer.rs
@@ -694,7 +694,14 @@ mod tests {
     use super::fixer;
 
     fn run_test(from: &str, to: &str) {
-        crate::tests::test_transform(Default::default(), |_| fixer(None), from, to, true);
+        crate::tests::test_transform(
+            Default::default(),
+            |_| fixer(None),
+            from,
+            to,
+            true,
+            Default::default(),
+        );
     }
 
     macro_rules! test_fixer {

--- a/ecmascript/transforms/base/src/helpers/mod.rs
+++ b/ecmascript/transforms/base/src/helpers/mod.rs
@@ -356,6 +356,7 @@ function _throw(e) {
 }
 ",
             false,
+            Default::default(),
         )
     }
 
@@ -374,6 +375,7 @@ function _throw(e) {
 let _throw1 = null;
 ",
             false,
+            Default::default(),
         )
     }
     #[test]
@@ -388,6 +390,7 @@ let x = 4;",
 
 let x = 4;",
             false,
+            Default::default(),
         );
     }
 }

--- a/ecmascript/transforms/base/src/hygiene/mod.rs
+++ b/ecmascript/transforms/base/src/hygiene/mod.rs
@@ -646,8 +646,6 @@ impl<'a> VisitMut for Hygiene<'a> {
         self.visit_mut_fn(node.ident.clone(), &mut node.function);
     }
 
-    fn visit_mut_private_name(&mut self, _: &mut PrivateName) {}
-
     /// Invoked for `IdentifierReference` / `BindingIdentifier`
     fn visit_mut_ident(&mut self, i: &mut Ident) {
         if i.sym == js_word!("arguments") || i.sym == js_word!("undefined") {
@@ -688,6 +686,8 @@ impl<'a> VisitMut for Hygiene<'a> {
 
         folder.apply_ops(node)
     }
+
+    fn visit_mut_private_name(&mut self, _: &mut PrivateName) {}
 
     fn visit_mut_try_stmt(&mut self, node: &mut TryStmt) {
         node.block.visit_mut_children_with(self);

--- a/ecmascript/transforms/base/src/hygiene/mod.rs
+++ b/ecmascript/transforms/base/src/hygiene/mod.rs
@@ -620,10 +620,11 @@ impl<'a> VisitMut for Hygiene<'a> {
     fn visit_mut_decl(&mut self, decl: &mut Decl) {
         match decl {
             Decl::Class(cls) if self.config.keep_class_names => {
-                cls.class.visit_mut_with(self);
-
                 let mut orig_name = cls.ident.clone();
                 orig_name.span.ctxt = SyntaxContext::empty();
+
+                cls.visit_mut_children_with(self);
+
                 let class_expr = ClassExpr {
                     ident: Some(orig_name),
                     class: cls.class.take(),

--- a/ecmascript/transforms/base/src/hygiene/mod.rs
+++ b/ecmascript/transforms/base/src/hygiene/mod.rs
@@ -45,32 +45,6 @@ struct Hygiene<'a> {
 type Contexts = SmallVec<[SyntaxContext; 32]>;
 
 impl<'a> Hygiene<'a> {
-    fn convert_decl_to_keep_name(&mut self, decl: &mut Decl) {
-        match decl {
-            Decl::Class(cls) if self.config.keep_class_names => {
-                let mut orig_name = cls.ident.clone();
-                orig_name.span.ctxt = SyntaxContext::empty();
-                let class_expr = ClassExpr {
-                    ident: Some(orig_name),
-                    class: cls.class.take(),
-                };
-                let var = VarDeclarator {
-                    span: cls.class.span,
-                    name: Pat::Ident(cls.ident.clone().into()),
-                    init: Some(Box::new(Expr::Class(class_expr))),
-                    definite: false,
-                };
-                *decl = Decl::Var(VarDecl {
-                    span: cls.class.span,
-                    kind: VarDeclKind::Let,
-                    declare: false,
-                    decls: vec![var],
-                })
-            }
-            _ => {}
-        }
-    }
-
     fn add_declared_ref(&mut self, ident: Ident) {
         let ctxt = ident.span.ctxt();
 
@@ -673,18 +647,40 @@ impl<'a> VisitMut for Hygiene<'a> {
         self.visit_mut_fn(node.ident.clone(), &mut node.function);
     }
 
-    fn visit_mut_decl(&mut self, n: &mut Decl) {
-        self.convert_decl_to_keep_name(n);
+    fn visit_mut_decl(&mut self, decl: &mut Decl) {
+        match decl {
+            Decl::Class(cls) if self.config.keep_class_names => {
+                cls.class.visit_mut_with(self);
 
-        n.visit_mut_children_with(self);
+                let mut orig_name = cls.ident.clone();
+                orig_name.span.ctxt = SyntaxContext::empty();
+                let class_expr = ClassExpr {
+                    ident: Some(orig_name),
+                    class: cls.class.take(),
+                };
+
+                let var = VarDeclarator {
+                    span: cls.class.span,
+                    name: Pat::Ident(cls.ident.clone().into()),
+                    init: Some(Box::new(Expr::Class(class_expr))),
+                    definite: false,
+                };
+                *decl = Decl::Var(VarDecl {
+                    span: cls.class.span,
+                    kind: VarDeclKind::Let,
+                    declare: false,
+                    decls: vec![var],
+                });
+                return;
+            }
+            _ => {}
+        }
+
+        decl.visit_mut_children_with(self);
     }
 
     /// Invoked for `IdentifierReference` / `BindingIdentifier`
     fn visit_mut_ident(&mut self, i: &mut Ident) {
-        if i.span.ctxt == SyntaxContext::empty() {
-            return;
-        }
-
         if i.sym == js_word!("arguments") || i.sym == js_word!("undefined") {
             return;
         }

--- a/ecmascript/transforms/base/src/hygiene/mod.rs
+++ b/ecmascript/transforms/base/src/hygiene/mod.rs
@@ -623,7 +623,7 @@ impl<'a> VisitMut for Hygiene<'a> {
                 let mut orig_name = cls.ident.clone();
                 orig_name.span.ctxt = SyntaxContext::empty();
 
-                cls.visit_mut_children_with(self);
+                cls.visit_mut_with(self);
 
                 let class_expr = ClassExpr {
                     ident: Some(orig_name),

--- a/ecmascript/transforms/base/src/hygiene/mod.rs
+++ b/ecmascript/transforms/base/src/hygiene/mod.rs
@@ -617,36 +617,6 @@ impl<'a> VisitMut for Hygiene<'a> {
         self.apply_ops(c)
     }
 
-    fn visit_mut_expr(&mut self, node: &mut Expr) {
-        let old = self.ident_type;
-        self.ident_type = IdentType::Ref;
-        match node {
-            Expr::Ident(..) => node.visit_mut_children_with(self),
-            Expr::Member(e) => {
-                if e.computed {
-                    e.obj.visit_mut_with(self);
-                    e.prop.visit_mut_with(self);
-                } else {
-                    e.obj.visit_mut_with(self)
-                }
-            }
-
-            Expr::This(..) => {}
-
-            _ => node.visit_mut_children_with(self),
-        };
-
-        self.ident_type = old;
-    }
-
-    fn visit_mut_fn_decl(&mut self, node: &mut FnDecl) {
-        self.visit_mut_fn(Some(node.ident.clone()), &mut node.function);
-    }
-
-    fn visit_mut_fn_expr(&mut self, node: &mut FnExpr) {
-        self.visit_mut_fn(node.ident.clone(), &mut node.function);
-    }
-
     fn visit_mut_decl(&mut self, decl: &mut Decl) {
         match decl {
             Decl::Class(cls) if self.config.keep_class_names => {
@@ -677,6 +647,36 @@ impl<'a> VisitMut for Hygiene<'a> {
         }
 
         decl.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_expr(&mut self, node: &mut Expr) {
+        let old = self.ident_type;
+        self.ident_type = IdentType::Ref;
+        match node {
+            Expr::Ident(..) => node.visit_mut_children_with(self),
+            Expr::Member(e) => {
+                if e.computed {
+                    e.obj.visit_mut_with(self);
+                    e.prop.visit_mut_with(self);
+                } else {
+                    e.obj.visit_mut_with(self)
+                }
+            }
+
+            Expr::This(..) => {}
+
+            _ => node.visit_mut_children_with(self),
+        };
+
+        self.ident_type = old;
+    }
+
+    fn visit_mut_fn_decl(&mut self, node: &mut FnDecl) {
+        self.visit_mut_fn(Some(node.ident.clone()), &mut node.function);
+    }
+
+    fn visit_mut_fn_expr(&mut self, node: &mut FnExpr) {
+        self.visit_mut_fn(node.ident.clone(), &mut node.function);
     }
 
     /// Invoked for `IdentifierReference` / `BindingIdentifier`

--- a/ecmascript/transforms/base/src/hygiene/tests.rs
+++ b/ecmascript/transforms/base/src/hygiene/tests.rs
@@ -1215,11 +1215,18 @@ fn issue_1279() {
                         method() {
                             class Foo {}
                         }
-                    };",
+                    }",
                 )?
                 .fold_with(&mut OnceMarker::new(&[("Foo", &[mark1, mark2])])))
         },
-        "",
+        "
+        let Foo = class Foo {
+            method() {
+                let Foo1 = class Foo {
+                };
+            }
+        };
+        ",
         Config {
             keep_class_names: true,
         },

--- a/ecmascript/transforms/base/src/resolver/tests.rs
+++ b/ecmascript/transforms/base/src/resolver/tests.rs
@@ -2272,7 +2272,12 @@ fn issue_1279_1() {
             static f = 1;
             static g = Foo.f;
         }",
-        "",
+        "
+        let Foo1 = class Foo {
+            static f = 1;
+            static g = Foo.f;
+        };
+        ",
         Config {
             keep_class_names: true,
         },
@@ -2294,7 +2299,18 @@ fn issue_1279_2() {
                 }
             }
         }",
-        "",
+        "
+        let Foo1 = class Foo {
+            static f = 1;
+            static g = Foo.f;
+            method() {
+                let Foo2 = class Foo {
+                    static nested = 1;
+                    static nested2 = Foo.nested;
+                };
+            }
+        };
+        ",
         Config {
             keep_class_names: true,
         },

--- a/ecmascript/transforms/base/src/resolver/tests.rs
+++ b/ecmascript/transforms/base/src/resolver/tests.rs
@@ -1,3 +1,5 @@
+use crate::hygiene::Config;
+
 use super::*;
 use swc_common::chain;
 use swc_ecma_parser::{EsConfig, Syntax, TsConfig};
@@ -61,7 +63,20 @@ where
     F: FnOnce() -> V,
     V: Fold,
 {
-    crate::tests::test_transform(syntax, |_| tr(), src, to, true);
+    crate::tests::test_transform(syntax, |_| tr(), src, to, true, Default::default());
+}
+
+fn run_test_with_config<F, V>(
+    syntax: Syntax,
+    tr: F,
+    src: &str,
+    to: &str,
+    config: crate::hygiene::Config,
+) where
+    F: FnOnce() -> V,
+    V: Fold,
+{
+    crate::tests::test_transform(syntax, |_| tr(), src, to, true, config);
 }
 
 macro_rules! to_ts {
@@ -2247,3 +2262,41 @@ to_ts!(
     var x6: T6;
     "
 );
+
+#[test]
+fn issue_1279_1() {
+    run_test_with_config(
+        Default::default(),
+        || resolver(),
+        "class Foo {
+            static f = 1;
+            static g = Foo.f;
+        }",
+        "",
+        Config {
+            keep_class_names: true,
+        },
+    );
+}
+
+#[test]
+fn issue_1279_2() {
+    run_test_with_config(
+        Default::default(),
+        || resolver(),
+        "class Foo {
+            static f = 1;
+            static g = Foo.f;
+            method() {
+                class Foo {
+                    static nested = 1;
+                    static nested2 = Foo.nested;
+                }
+            }
+        }",
+        "",
+        Config {
+            keep_class_names: true,
+        },
+    );
+}

--- a/ecmascript/transforms/base/src/tests.rs
+++ b/ecmascript/transforms/base/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::fixer::fixer;
 use crate::helpers::HELPERS;
-use crate::hygiene::hygiene;
+use crate::hygiene::hygiene_with_config;
 use std::fmt;
 use swc_common::{
     comments::SingleThreadedComments, errors::Handler, sync::Lrc, FileName, SourceMap,
@@ -186,6 +186,7 @@ pub(crate) fn test_transform<F, P>(
     input: &str,
     expected: &str,
     ok_if_code_eq: bool,
+    hygiene_config: crate::hygiene::Config,
 ) where
     F: FnOnce(&mut Tester) -> P,
     P: Fold,
@@ -214,7 +215,7 @@ pub(crate) fn test_transform<F, P>(
         }
 
         let actual = actual
-            .fold_with(&mut hygiene())
+            .fold_with(&mut hygiene_with_config(hygiene_config))
             .fold_with(&mut fixer(None))
             .fold_with(&mut as_folder(DropSpan {
                 preserve_ctxt: false,

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.7.0"
+version = "0.7.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/ecmascript/transforms/compat/src/es2015/block_scoping.rs
+++ b/ecmascript/transforms/compat/src/es2015/block_scoping.rs
@@ -1171,52 +1171,49 @@ foo();"
     }
     return vars;
   };",
-        "module.exports = function(values) {
-    var _this = this, _loop = function(i) {
-        elem = _this.elements[i];
-        name = elem.name;
-        if (!name) return 'continue';
-        val = values[name];
-        if (val == null) val = '';
-        switch(elem.type){
-            case 'submit':
-                return 'break';
-            case 'radio':
-            case 'checkbox':
-                elem.checked = val.some(function(str) {
-                    return str.toString() == elem.value;
-                });
-                return 'break';
-            case 'select-multiple':
-                elem.fill(val);
-                return 'break';
-            case 'textarea':
-                elem.innerText = val;
-                return 'break';
-            case 'hidden':
-                return 'break';
-            default:
-                if (elem.fill) {
-                    elem.fill(val);
-                } else {
-                    elem.value = val;
+        "
+        module.exports = function(values) {
+            var _this = this, _loop = function(i) {
+                elem = _this.elements[i];
+                name = elem.name;
+                if (!name) return 'continue';
+                val = values[name];
+                if (val == null) val = '';
+                switch(elem.type){
+                    case 'submit':
+                        break;
+                    case 'radio':
+                    case 'checkbox':
+                        elem.checked = val.some(function(str) {
+                            return str.toString() == elem.value;
+                        });
+                        break;
+                    case 'select-multiple':
+                        elem.fill(val);
+                        break;
+                    case 'textarea':
+                        elem.innerText = val;
+                        break;
+                    case 'hidden':
+                        break;
+                    default:
+                        if (elem.fill) {
+                            elem.fill(val);
+                        } else {
+                            elem.value = val;
+                        }
+                        break;
                 }
-                return 'break';
-        }
-    };
-    var vars = [];
-    var elem = null, name, val;
-    for(var i = 0; i < this.elements.length; i++){
-        var _ret = _loop(i);
-        switch(_ret){
-            case 'break':
-                break;
-            case 'continue':
-                continue;
-        }
-    }
-    return vars;
-};"
+            };
+            var vars = [];
+            var elem = null, name, val;
+            for(var i = 0; i < this.elements.length; i++){
+                var _ret = _loop(i);
+                if (_ret === 'continue') continue;
+            }
+            return vars;
+        };
+        "
     );
 
     test_exec!(

--- a/ecmascript/transforms/compat/src/es2015/block_scoping.rs
+++ b/ecmascript/transforms/compat/src/es2015/block_scoping.rs
@@ -1639,7 +1639,37 @@ expect(foo()).toBe(false);
           }
         ",
         "
-        
+        export function test(items) {
+            var infoMap = new WeakMap();
+            for(var i = 0; i < items.length; i += 1){
+                var item = items[i];
+                var info = void 0;
+                switch(item.type){
+                    case 'branch1':
+                        info = item.method1();
+                        break;
+                    case 'branch2':
+                        info = item.method2();
+                        break;
+                    case 'branch3':
+                        info = item.method3(Object.fromEntries(item.subItems.map((t)=>[
+                                item.alias ?? t.name,
+                                getInfo(t)
+                            ]
+                        )));
+                        break;
+                    default:
+                        throw new Error('boom');
+                }
+                infoMap.set(item, info);
+            }
+            function getInfo(item) {
+                if (!infoMap.has(item)) {
+                    throw new Error('no info yet');
+                }
+                return infoMap.get(item);
+            }
+        }
         "
     );
 }

--- a/ecmascript/transforms/compat/src/es2015/block_scoping.rs
+++ b/ecmascript/transforms/compat/src/es2015/block_scoping.rs
@@ -1583,4 +1583,47 @@ expect(foo()).toBe(false);
         ]);
         "
     );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| block_scoping(),
+        issue_1415_1,
+        "
+        export function test(items) {
+            const infoMap = new WeakMap();
+            for (let i = 0; i < items.length; i += 1) {
+              const item = items[i];
+              let info;
+              switch (item.type) {
+                case 'branch1':
+                  info = item.method1();
+                  break;
+                case 'branch2':
+                  info = item.method2();
+                  break;
+                case 'branch3':
+                  info = item.method3(
+                    Object.fromEntries(
+                      item.subItems.map((t) => [item.alias ?? t.name, getInfo(t)])
+                    )
+                  );
+                  break;
+                default:
+                  throw new Error('boom');
+              }
+              infoMap.set(item, info); // important
+            }
+          
+            function getInfo(item) {
+              if (!infoMap.has(item)) {
+                throw new Error('no info yet');
+              }
+              return infoMap.get(item);
+            }
+          }
+        ",
+        "
+        
+        "
+    );
 }

--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -161,21 +161,6 @@ export interface Options extends Config {
   inputSourceMap?: boolean | string;
 
   /**
-   * - true to generate a sourcemap for the code and include it in the result object.
-   * - "inline" to generate a sourcemap and append it as a data URL to the end of the code, but not include it in the result object.
-   * - "both" is the same as inline, but will include the map in the result object.
-   *
-   * `swc-cli` overloads some of these to also affect how maps are written to disk:
-   *
-   * - true will write the map to a .map file on disk
-   * - "inline" will write the file directly, so it will have a data: containing the map
-   * - "both" will write the file with a data: URL and also a .map.
-   * - Note: These options are bit weird, so it may make the most sense to just use true
-   *  and handle the rest in your own code, depending on your use case.
-   */
-  sourceMaps?: boolean | "inline" | "both";
-
-  /**
    * The name to use for the file inside the source map object.
    *
    * Defaults to `path.basename(opts.filenameRelative)` when available, or `"unknown"`.
@@ -215,6 +200,21 @@ export interface Config {
   jsc?: JscConfig;
   module?: ModuleConfig;
   minify?: boolean;
+
+  /**
+   * - true to generate a sourcemap for the code and include it in the result object.
+   * - "inline" to generate a sourcemap and append it as a data URL to the end of the code, but not include it in the result object.
+   * - "both" is the same as inline, but will include the map in the result object.
+   *
+   * `swc-cli` overloads some of these to also affect how maps are written to disk:
+   *
+   * - true will write the map to a .map file on disk
+   * - "inline" will write the file directly, so it will have a data: containing the map
+   * - "both" will write the file with a data: URL and also a .map.
+   * - Note: These options are bit weird, so it may make the most sense to just use true
+   *  and handle the rest in your own code, depending on your use case.
+   */
+  sourceMaps?: boolean | "inline" | "both";
 }
 
 /**
@@ -561,7 +561,7 @@ export interface Output {
   map?: string;
 }
 
-export interface MatchPattern {}
+export interface MatchPattern { }
 
 // -------------------------------
 // ---------- Ast nodes ----------
@@ -778,7 +778,7 @@ export type Expression =
   | OptionalChainingExpression
   | Invalid;
 
-interface ExpressionBase extends Node, HasSpan {}
+interface ExpressionBase extends Node, HasSpan { }
 
 export interface OptionalChainingExpression extends ExpressionBase {
   type: "OptionalChainingExpression";

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ use swc_ecma_ast::{Expr, ExprStmt, ModuleItem, Stmt};
 use swc_ecma_ext_transforms::jest;
 pub use swc_ecma_parser::JscTarget;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
+use swc_ecma_transforms::hygiene;
 use swc_ecma_transforms::{
     compat::es2020::typescript_class_properties,
     modules,
@@ -193,6 +194,7 @@ impl Options {
             external_helpers,
             target,
             loose,
+            keep_class_names,
         } = config.jsc;
 
         let syntax = syntax.unwrap_or_default();
@@ -262,7 +264,11 @@ impl Options {
         let pass = PassBuilder::new(&cm, &handler, loose, root_mark, pass)
             .target(target)
             .skip_helper_injection(self.skip_helper_injection)
-            .hygiene(!self.disable_hygiene)
+            .hygiene(if self.disable_hygiene {
+                None
+            } else {
+                Some(hygiene::Config { keep_class_names })
+            })
             .fixer(!self.disable_fixer)
             .preset_env(config.env)
             .finalize(syntax, config.module, comments);
@@ -350,6 +356,7 @@ impl Default for Rc {
                     external_helpers: false,
                     target: Default::default(),
                     loose: false,
+                    keep_class_names: false,
                 },
                 module: None,
                 minify: None,
@@ -368,6 +375,7 @@ impl Default for Rc {
                     external_helpers: false,
                     target: Default::default(),
                     loose: false,
+                    keep_class_names: false,
                 },
                 module: None,
                 minify: None,
@@ -386,6 +394,7 @@ impl Default for Rc {
                     external_helpers: false,
                     target: Default::default(),
                     loose: false,
+                    keep_class_names: false,
                 },
                 module: None,
                 minify: None,
@@ -549,6 +558,9 @@ pub struct JscConfig {
 
     #[serde(default)]
     pub loose: bool,
+
+    #[serde(default)]
+    pub keep_class_names: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -279,6 +279,7 @@ impl Options {
             source_maps: self
                 .source_maps
                 .clone()
+                .or(config.source_maps)
                 .unwrap_or(SourceMapsConfig::Bool(false)),
             input_source_map: self.input_source_map.clone(),
         }
@@ -352,6 +353,7 @@ impl Default for Rc {
                 },
                 module: None,
                 minify: None,
+                source_maps: None,
             },
             Config {
                 env: None,
@@ -369,6 +371,7 @@ impl Default for Rc {
                 },
                 module: None,
                 minify: None,
+                source_maps: None,
             },
             Config {
                 env: None,
@@ -386,6 +389,7 @@ impl Default for Rc {
                 },
                 module: None,
                 minify: None,
+                source_maps: None,
             },
         ])
     }
@@ -445,6 +449,10 @@ pub struct Config {
 
     #[serde(default)]
     pub minify: Option<bool>,
+
+    /// Possible values are: `'inline'`, `true`, `false`.
+    #[serde(default)]
+    pub source_maps: Option<SourceMapsConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -755,6 +763,18 @@ impl Merge for Config {
         self.module.merge(&from.module);
         self.minify.merge(&from.minify);
         self.env.merge(&from.env);
+        self.source_maps.merge(&from.source_maps);
+    }
+}
+
+impl Merge for SourceMapsConfig {
+    fn merge(&mut self, from: &Self) {
+        match self {
+            SourceMapsConfig::Bool(false) => {
+                *self = from.clone();
+            }
+            _ => {}
+        }
     }
 }
 

--- a/tests/fixture/issue-1279/case1/input/.swcrc
+++ b/tests/fixture/issue-1279/case1/input/.swcrc
@@ -1,5 +1,6 @@
 {
   "jsc": {
+    "target": "es2016",
     "keepClassNames": true
   }
 }

--- a/tests/fixture/issue-1279/case1/input/.swcrc
+++ b/tests/fixture/issue-1279/case1/input/.swcrc
@@ -1,0 +1,5 @@
+{
+  "jsc": {
+    "keepClassNames": true
+  }
+}

--- a/tests/fixture/issue-1279/case1/input/index.ts
+++ b/tests/fixture/issue-1279/case1/input/index.ts
@@ -1,0 +1,8 @@
+export class Foo {
+
+    nested() {
+        class Foo { }
+
+        return new Foo()
+    }
+}

--- a/tests/fixture/issue-1279/case1/input/index.ts
+++ b/tests/fixture/issue-1279/case1/input/index.ts
@@ -1,7 +1,10 @@
 export class Foo {
 
     nested() {
-        class Foo { }
+        class Foo {
+            static foo = 'foo';
+            static bar = Foo.foo;
+        }
 
         return new Foo()
     }

--- a/tests/fixture/issue-1279/case1/output/index.ts
+++ b/tests/fixture/issue-1279/case1/output/index.ts
@@ -1,0 +1,22 @@
+function _defineProperty(obj, key, value) {
+    if (key in obj) {
+        Object.defineProperty(obj, key, {
+            value: value,
+            enumerable: true,
+            configurable: true,
+            writable: true
+        });
+    } else {
+        obj[key] = value;
+    }
+    return obj;
+}
+export let Foo = class Foo {
+    nested() {
+        let Foo1 = class Foo {
+        };
+        _defineProperty(Foo1, "foo", 'foo');
+        _defineProperty(Foo1, "bar", Foo1.foo);
+        return new Foo1();
+    }
+};

--- a/tests/fixture/issue-1441/input/.swcrc
+++ b/tests/fixture/issue-1441/input/.swcrc
@@ -1,0 +1,8 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript"
+    },
+    "target": "es2017"
+  }
+}

--- a/tests/fixture/issue-1441/input/index.ts
+++ b/tests/fixture/issue-1441/input/index.ts
@@ -1,0 +1,5 @@
+
+
+await foo()
+
+export { }

--- a/tests/fixture/issue-1441/output/index.ts
+++ b/tests/fixture/issue-1441/output/index.ts
@@ -1,0 +1,1 @@
+await foo();


### PR DESCRIPTION
# Tasks

swc:
 - [x] Use `hygiene_with_config` instead. (Closes #1279)
 - [x] Allow enabling source map with `.swcrc`. (Closes #1309)

swc_ecma_transforms_base:
 - [x] `hygiene`: Add an option to preserve class names. (#1279)

swc_ecma_transforms_compat:
 - [x] `block_scoping`: Allow using `break` in switch cases. (Closes #1415)