### PR TITLE
fix(es/parser): don't allow type annotation after assign

### DIFF
--- a/ecmascript/parser/src/error.rs
+++ b/ecmascript/parser/src/error.rs
@@ -217,6 +217,7 @@ pub enum SyntaxError {
     TS2483,
     TS2491,
     TS2703,
+    TSTypeAnnotationAfterAssign,
 }
 
 impl SyntaxError {
@@ -522,6 +523,9 @@ impl SyntaxError {
             SyntaxError::TS2491 => "The left-hand side of a 'for...in' statement cannot be a \
                                     destructuring pattern"
                 .into(),
+            SyntaxError::TSTypeAnnotationAfterAssign => {
+                "Type annotations must come before default assignments".into()
+            }
         }
     }
 }

--- a/ecmascript/parser/src/parser/pat.rs
+++ b/ecmascript/parser/src/parser/pat.rs
@@ -194,11 +194,6 @@ impl<'a, I: Tokens> Parser<I> {
                     ref mut span,
                     ..
                 })
-                | Pat::Assign(AssignPat {
-                    ref mut type_ann,
-                    ref mut span,
-                    ..
-                })
                 | Pat::Ident(BindingIdent {
                     ref mut type_ann,
                     id: Ident { ref mut span, .. },
@@ -219,6 +214,16 @@ impl<'a, I: Tokens> Parser<I> {
                         *span = Span::new(pat_start, self.input.prev_span().hi, Default::default());
                     }
                     *type_ann = new_type_ann;
+                }
+                Pat::Assign(AssignPat {
+                    ref mut type_ann,
+                    ref mut span,
+                    ..
+                }) => {
+                    if let Some(_) = self.try_parse_ts_type_ann()? {
+                        *span = Span::new(pat_start, self.input.prev_span().hi, Default::default());
+                        self.emit_err(*span, SyntaxError::TSTypeAnnotationAfterAssign);
+                    }
                 }
                 Pat::Invalid(..) => {}
                 _ => unreachable!("invalid syntax: Pat: {:?}", pat),

--- a/ecmascript/parser/tests/typescript-errors/issue-1209/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/issue-1209/input.ts
@@ -1,0 +1,3 @@
+function foo(foo = bar: number) {
+  /* */
+}

--- a/ecmascript/parser/tests/typescript-errors/issue-1209/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/issue-1209/input.ts.stderr
@@ -1,0 +1,6 @@
+error: Type annotations must come before default assignments
+ --> $DIR/tests/typescript-errors/issue-1209/input.ts:1:14
+  |
+1 | function foo(foo = bar: number) {
+  |              ^^^^^^^^^^^^^^^^^
+


### PR DESCRIPTION
Fixes #1209.

I was not sure if I was supposed to return a syntax error or just emit it. 
Also TS does not have specific error for this and shows very unhelpful message, so went with this new error.