### PR TITLE
Fix codegen for JSX spread props

### DIFF
--- a/ecmascript/codegen/src/jsx.rs
+++ b/ecmascript/codegen/src/jsx.rs
@@ -79,7 +79,11 @@ impl<'a> Emitter<'a> {
     fn emit_jsx_attr_or_spread(&mut self, node: &JSXAttrOrSpread) -> Result {
         match *node {
             JSXAttrOrSpread::JSXAttr(ref n) => emit!(n),
-            JSXAttrOrSpread::SpreadElement(ref n) => emit!(n),
+            JSXAttrOrSpread::SpreadElement(ref n) => {
+                punct!("{");
+                emit!(n);
+                punct!("}");
+            }
         }
     }
 


### PR DESCRIPTION
Codegen for JSX spread props currently produces invalid code.

```
<a ...x />
```

This PR fixes that so it outputs:

```
<a {...x} />
```