### PR TITLE
Fix column positions in generated sourcemaps

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_common"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.10.12"
+version = "0.10.13"
 
 [features]
 concurrent = ["parking_lot"]

--- a/common/src/source_map.rs
+++ b/common/src/source_map.rs
@@ -1061,8 +1061,9 @@ impl SourceMap {
                 pos,
                 linebpos,
             );
-            let chpos = { self.calc_extra_bytes(&f, &mut ch_start, pos) };
-            let linechpos = { self.calc_extra_bytes(&f, &mut line_ch_start, linebpos) };
+            let chpos = pos.to_u32() - self.calc_extra_bytes(&f, &mut ch_start, pos);
+            let linechpos =
+                linebpos.to_u32() - self.calc_extra_bytes(&f, &mut line_ch_start, linebpos);
 
             let mut col = max(chpos, linechpos) - min(chpos, linechpos);
 


### PR DESCRIPTION
I noticed that all mappings were pointing to column zero in the original source. This was because the result of `calc_extra_bytes` was used rather than subtracting from the original position. I copied this logic from the `bytepos_to_file_charpos_with` function in the same file.

Before:
<img width="1385" alt="image" src="https://user-images.githubusercontent.com/19409/111078656-fb586080-84cc-11eb-889d-4325017e2543.png">

After:
<img width="1385" alt="Screen Shot 2021-03-14 at 1 52 00 PM" src="https://user-images.githubusercontent.com/19409/111078657-ff847e00-84cc-11eb-8e29-46493d7f1c3d.png">

Notice the red mappings point to the corresponding source in the original rather than a single mapping for the whole line.

I'm happy to add tests, but I didn't see an existing one to base it off of. Let me know.