### PR TITLE
fix(strip): Combine typescript_class_properties() into strip()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.10.0"
+version = "0.11.0"
 
 [lib]
 name = "swc"
@@ -31,10 +31,10 @@ swc_atoms = {version = "0.2", path = "./atoms"}
 swc_common = {version = "0.10.10", path = "./common", features = ["sourcemap", "concurrent"]}
 swc_ecma_ast = {version = "0.40.0", path = "./ecmascript/ast"}
 swc_ecma_codegen = {version = "0.48.0", path = "./ecmascript/codegen"}
-swc_ecma_ext_transforms = {version = "0.7.0", path = "./ecmascript/ext-transforms"}
+swc_ecma_ext_transforms = {version = "0.8.0", path = "./ecmascript/ext-transforms"}
 swc_ecma_parser = {version = "0.50.0", path = "./ecmascript/parser"}
-swc_ecma_preset_env = {version = "0.10.0", path = "./ecmascript/preset_env"}
-swc_ecma_transforms = {version = "0.40.0", path = "./ecmascript/transforms", features = [
+swc_ecma_preset_env = {version = "0.11.0", path = "./ecmascript/preset_env"}
+swc_ecma_transforms = {version = "0.41.0", path = "./ecmascript/transforms", features = [
   "compat",
   "module",
   "optimization",
@@ -42,7 +42,7 @@ swc_ecma_transforms = {version = "0.40.0", path = "./ecmascript/transforms", fea
   "react",
   "typescript",
 ]}
-swc_ecma_utils = {version = "0.30.0", path = "./ecmascript/utils"}
+swc_ecma_utils = {version = "0.31.0", path = "./ecmascript/utils"}
 swc_ecma_visit = {version = "0.26.0", path = "./ecmascript/visit"}
 swc_visit = {version = "0.2.3", path = "./visit"}
 

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -9,7 +9,7 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/**/*.js"]
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.27.0"
+version = "0.28.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -35,8 +35,8 @@ swc_common = {version = "0.10.10", path = "../common"}
 swc_ecma_ast = {version = "0.40.0", path = "../ecmascript/ast"}
 swc_ecma_codegen = {version = "0.48.0", path = "../ecmascript/codegen"}
 swc_ecma_parser = {version = "0.50.0", path = "../ecmascript/parser"}
-swc_ecma_transforms = {version = "0.40.0", path = "../ecmascript/transforms", features = ["optimization"]}
-swc_ecma_utils = {version = "0.30.0", path = "../ecmascript/utils"}
+swc_ecma_transforms = {version = "0.41.0", path = "../ecmascript/transforms", features = ["optimization"]}
+swc_ecma_utils = {version = "0.31.0", path = "../ecmascript/utils"}
 swc_ecma_visit = {version = "0.26.0", path = "../ecmascript/visit"}
 
 [dev-dependencies]
@@ -44,7 +44,7 @@ hex = "0.4"
 ntest = "0.7.2"
 reqwest = {version = "0.10.8", features = ["blocking"]}
 sha-1 = "0.9"
-swc_ecma_transforms = {version = "0.40.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
+swc_ecma_transforms = {version = "0.41.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
 tempfile = "3.1.0"
 testing = {version = "0.10.3", path = "../testing"}
 url = "2.1.1"

--- a/bundler/tests/fixture/deno-9591/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-9591/output/entry.inlined.ts
@@ -1327,7 +1327,7 @@ function common(paths, sep2 = SEP) {
     const prefix = parts.slice(0, endOfPrefix).join(sep2);
     return prefix.endsWith(sep2) ? prefix : `${prefix}${sep2}`;
 }
-const path1 = isWindows ? mod1 : mod2;
+const path = isWindows ? mod1 : mod2;
 const regExpEscapeChars = [
     "!",
     "$",
@@ -1344,7 +1344,7 @@ const regExpEscapeChars = [
     "{",
     "|"
 ];
-const { basename: basename2 , delimiter: delimiter2 , dirname: dirname2 , extname: extname2 , format: format2 , fromFileUrl: fromFileUrl2 , isAbsolute: isAbsolute2 , join: join2 , normalize: normalize2 , parse: parse3 , relative: relative2 , resolve: resolve2 , sep: sep2 , toFileUrl: toFileUrl2 , toNamespacedPath: toNamespacedPath2 ,  } = path1;
+const { basename: basename2 , delimiter: delimiter2 , dirname: dirname2 , extname: extname2 , format: format2 , fromFileUrl: fromFileUrl2 , isAbsolute: isAbsolute2 , join: join2 , normalize: normalize2 , parse: parse3 , relative: relative2 , resolve: resolve2 , sep: sep2 , toFileUrl: toFileUrl2 , toNamespacedPath: toNamespacedPath2 ,  } = path;
 const rangeEscapeChars = [
     "-",
     "\\",
@@ -1851,26 +1851,26 @@ const MIN_BUF_SIZE = 16;
 const CR = "\r".charCodeAt(0);
 const LF = "\n".charCodeAt(0);
 class BufferFullError extends Error {
-    name = "BufferFullError";
     constructor(partial){
         super("Buffer full");
         this.partial = partial;
+        this.name = "BufferFullError";
     }
 }
 class PartialReadError extends Deno.errors.UnexpectedEof {
-    name = "PartialReadError";
     constructor(){
         super("Encountered UnexpectedEof, data only partially read");
+        this.name = "PartialReadError";
     }
 }
 class BufReader {
-    r = 0;
-    w = 0;
-    eof = false;
     static create(r, size = 4096) {
         return r instanceof BufReader ? r : new BufReader(r, size);
     }
     constructor(rd1, size1 = 4096){
+        this.r = 0;
+        this.w = 0;
+        this.eof = false;
         if (size1 < 16) {
             size1 = MIN_BUF_SIZE;
         }
@@ -2073,8 +2073,6 @@ class BufReader {
     }
 }
 class AbstractBufBase {
-    usedBufferBytes = 0;
-    err = null;
     size() {
         return this.buf.byteLength;
     }
@@ -2083,6 +2081,10 @@ class AbstractBufBase {
     }
     buffered() {
         return this.usedBufferBytes;
+    }
+    constructor(){
+        this.usedBufferBytes = 0;
+        this.err = null;
     }
 }
 class BufWriter extends AbstractBufBase {
@@ -2257,11 +2259,11 @@ class WriterHandler extends BaseHandler {
     #encoder=new TextEncoder();
 }
 class FileHandler extends WriterHandler {
-    _encoder = new TextEncoder();
     #unloadCallback=()=>this.destroy()
     ;
     constructor(levelName3, options3){
         super(levelName3, options3);
+        this._encoder = new TextEncoder();
         this._filename = options3.filename;
         this._mode = options3.mode ? options3.mode : "a";
         this._openOptions = {
@@ -5925,10 +5927,10 @@ class ADLMap {
     }
 }
 class Manifest {
-    jsonBinding = createJsonBinding(RESOLVER, texprManifest());
-    tasks = new ADLMap([], (k1, k2)=>k1 === k2
-    );
     constructor(dir, filename = ".manifest.json"){
+        this.jsonBinding = createJsonBinding(RESOLVER, texprManifest());
+        this.tasks = new ADLMap([], (k1, k2)=>k1 === k2
+        );
         this.filename = mod3.join(dir, filename);
     }
     async load() {
@@ -5957,10 +5959,10 @@ class Manifest {
     }
 }
 class TaskManifest {
-    lastExecution = null;
-    trackedFiles = new ADLMap([], (k1, k2)=>k1 === k2
-    );
     constructor(data1){
+        this.lastExecution = null;
+        this.trackedFiles = new ADLMap([], (k1, k2)=>k1 === k2
+        );
         this.trackedFiles = new ADLMap(data1.trackedFiles, (k1, k2)=>k1 === k2
         );
         this.lastExecution = data1.lastExecution;
@@ -5982,9 +5984,9 @@ class TaskManifest {
     }
 }
 class AsyncQueue {
-    inProgress = 0;
-    queue = [];
     constructor(concurrency){
+        this.inProgress = 0;
+        this.queue = [];
         this.concurrency = concurrency;
     }
     async schedule(t) {
@@ -6017,16 +6019,16 @@ class AsyncQueue {
     }
 }
 class ExecContext {
-    taskRegister = new Map();
-    targetRegister = new Map();
-    doneTasks = new Set();
-    inprogressTasks = new Set();
-    internalLogger = mod4.getLogger("internal");
-    taskLogger = mod4.getLogger("task");
-    userLogger = mod4.getLogger("user");
     constructor(manifest, args){
         this.manifest = manifest;
         this.args = args;
+        this.taskRegister = new Map();
+        this.targetRegister = new Map();
+        this.doneTasks = new Set();
+        this.inprogressTasks = new Set();
+        this.internalLogger = mod4.getLogger("internal");
+        this.taskLogger = mod4.getLogger("task");
+        this.userLogger = mod4.getLogger("user");
         if (args["verbose"] !== undefined) {
             this.internalLogger.levelName = "INFO";
         }
@@ -6071,8 +6073,8 @@ async function statPath(path1) {
     }
 }
 class Task {
-    taskManifest = null;
     constructor(taskParams){
+        this.taskManifest = null;
         this.name = taskParams.name;
         this.action = taskParams.action;
         this.description = taskParams.description;
@@ -6199,11 +6201,11 @@ class Task {
     }
 }
 class TrackedFile {
-    path = "";
     #getHash;
     #getTimestamp;
-    fromTask = null;
     constructor(fileParams){
+        this.path = "";
+        this.fromTask = null;
         this.path = mod3.posix.resolve(fileParams.path);
         this.#getHash = fileParams.getHash || getFileSha1Sum;
         this.#getTimestamp = fileParams.getTimestamp || getFileTimestamp;
@@ -6293,9 +6295,9 @@ class TrackedFile {
     }
 }
 class TrackedFilesAsync {
-    kind = 'trackedfilesasync';
     constructor(gen){
         this.gen = gen;
+        this.kind = 'trackedfilesasync';
     }
     async getTrackedFiles() {
         return this.gen();

--- a/bundler/tests/fixture/deno-9591/output/entry.ts
+++ b/bundler/tests/fixture/deno-9591/output/entry.ts
@@ -1335,7 +1335,7 @@ function common(paths, sep2 = SEP) {
     const prefix = parts.slice(0, endOfPrefix).join(sep2);
     return prefix.endsWith(sep2) ? prefix : `${prefix}${sep2}`;
 }
-const path1 = isWindows ? mod1 : mod2;
+const path = isWindows ? mod1 : mod2;
 const regExpEscapeChars = [
     "!",
     "$",
@@ -1354,7 +1354,7 @@ const regExpEscapeChars = [
 ];
 const win32 = mod1;
 const posix = mod2;
-const { basename: basename2 , delimiter: delimiter2 , dirname: dirname2 , extname: extname2 , format: format2 , fromFileUrl: fromFileUrl2 , isAbsolute: isAbsolute2 , join: join2 , normalize: normalize2 , parse: parse3 , relative: relative2 , resolve: resolve2 , sep: sep2 , toFileUrl: toFileUrl2 , toNamespacedPath: toNamespacedPath2 ,  } = path1;
+const { basename: basename2 , delimiter: delimiter2 , dirname: dirname2 , extname: extname2 , format: format2 , fromFileUrl: fromFileUrl2 , isAbsolute: isAbsolute2 , join: join2 , normalize: normalize2 , parse: parse3 , relative: relative2 , resolve: resolve2 , sep: sep2 , toFileUrl: toFileUrl2 , toNamespacedPath: toNamespacedPath2 ,  } = path;
 const rangeEscapeChars = [
     "-",
     "\\",
@@ -1862,26 +1862,26 @@ const MAX_CONSECUTIVE_EMPTY_READS = 100;
 const CR = "\r".charCodeAt(0);
 const LF = "\n".charCodeAt(0);
 class BufferFullError extends Error {
-    name = "BufferFullError";
     constructor(partial){
         super("Buffer full");
         this.partial = partial;
+        this.name = "BufferFullError";
     }
 }
 class PartialReadError extends Deno.errors.UnexpectedEof {
-    name = "PartialReadError";
     constructor(){
         super("Encountered UnexpectedEof, data only partially read");
+        this.name = "PartialReadError";
     }
 }
 class BufReader {
-    r = 0;
-    w = 0;
-    eof = false;
     static create(r, size = DEFAULT_BUF_SIZE) {
         return r instanceof BufReader ? r : new BufReader(r, size);
     }
     constructor(rd1, size1 = DEFAULT_BUF_SIZE){
+        this.r = 0;
+        this.w = 0;
+        this.eof = false;
         if (size1 < MIN_BUF_SIZE) {
             size1 = MIN_BUF_SIZE;
         }
@@ -2084,8 +2084,6 @@ class BufReader {
     }
 }
 class AbstractBufBase {
-    usedBufferBytes = 0;
-    err = null;
     size() {
         return this.buf.byteLength;
     }
@@ -2094,6 +2092,10 @@ class AbstractBufBase {
     }
     buffered() {
         return this.usedBufferBytes;
+    }
+    constructor(){
+        this.usedBufferBytes = 0;
+        this.err = null;
     }
 }
 class BufWriter extends AbstractBufBase {
@@ -2268,11 +2270,11 @@ class WriterHandler extends BaseHandler {
     #encoder=new TextEncoder();
 }
 class FileHandler extends WriterHandler {
-    _encoder = new TextEncoder();
     #unloadCallback=()=>this.destroy()
     ;
     constructor(levelName3, options3){
         super(levelName3, options3);
+        this._encoder = new TextEncoder();
         this._filename = options3.filename;
         this._mode = options3.mode ? options3.mode : "a";
         this._openOptions = {
@@ -5937,10 +5939,10 @@ class ADLMap {
     }
 }
 class Manifest {
-    jsonBinding = createJsonBinding(RESOLVER, texprManifest());
-    tasks = new ADLMap([], (k1, k2)=>k1 === k2
-    );
     constructor(dir, filename = ".manifest.json"){
+        this.jsonBinding = createJsonBinding(RESOLVER, texprManifest());
+        this.tasks = new ADLMap([], (k1, k2)=>k1 === k2
+        );
         this.filename = mod3.join(dir, filename);
     }
     async load() {
@@ -5969,10 +5971,10 @@ class Manifest {
     }
 }
 class TaskManifest {
-    lastExecution = null;
-    trackedFiles = new ADLMap([], (k1, k2)=>k1 === k2
-    );
     constructor(data1){
+        this.lastExecution = null;
+        this.trackedFiles = new ADLMap([], (k1, k2)=>k1 === k2
+        );
         this.trackedFiles = new ADLMap(data1.trackedFiles, (k1, k2)=>k1 === k2
         );
         this.lastExecution = data1.lastExecution;
@@ -5994,9 +5996,9 @@ class TaskManifest {
     }
 }
 class AsyncQueue {
-    inProgress = 0;
-    queue = [];
     constructor(concurrency){
+        this.inProgress = 0;
+        this.queue = [];
         this.concurrency = concurrency;
     }
     async schedule(t) {
@@ -6029,16 +6031,16 @@ class AsyncQueue {
     }
 }
 class ExecContext {
-    taskRegister = new Map();
-    targetRegister = new Map();
-    doneTasks = new Set();
-    inprogressTasks = new Set();
-    internalLogger = mod4.getLogger("internal");
-    taskLogger = mod4.getLogger("task");
-    userLogger = mod4.getLogger("user");
     constructor(manifest, args){
         this.manifest = manifest;
         this.args = args;
+        this.taskRegister = new Map();
+        this.targetRegister = new Map();
+        this.doneTasks = new Set();
+        this.inprogressTasks = new Set();
+        this.internalLogger = mod4.getLogger("internal");
+        this.taskLogger = mod4.getLogger("task");
+        this.userLogger = mod4.getLogger("user");
         if (args["verbose"] !== undefined) {
             this.internalLogger.levelName = "INFO";
         }
@@ -6083,8 +6085,8 @@ async function statPath(path1) {
     }
 }
 class Task {
-    taskManifest = null;
     constructor(taskParams){
+        this.taskManifest = null;
         this.name = taskParams.name;
         this.action = taskParams.action;
         this.description = taskParams.description;
@@ -6211,11 +6213,11 @@ class Task {
     }
 }
 class TrackedFile {
-    path = "";
     #getHash;
     #getTimestamp;
-    fromTask = null;
     constructor(fileParams){
+        this.path = "";
+        this.fromTask = null;
         this.path = mod3.posix.resolve(fileParams.path);
         this.#getHash = fileParams.getHash || getFileSha1Sum;
         this.#getTimestamp = fileParams.getTimestamp || getFileTimestamp;
@@ -6305,9 +6307,9 @@ class TrackedFile {
     }
 }
 class TrackedFilesAsync {
-    kind = 'trackedfilesasync';
     constructor(gen){
         this.gen = gen;
+        this.kind = 'trackedfilesasync';
     }
     async getTrackedFiles() {
         return this.gen();

--- a/bundler/tests/fixture/deno-9620/case1/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-9620/case1/output/entry.inlined.ts
@@ -126,8 +126,8 @@ class StringReader extends Deno.Buffer {
     }
 }
 class MultiReader {
-    currentIndex = 0;
     constructor(...readers){
+        this.currentIndex = 0;
         this.readers = readers;
     }
     async read(p) {
@@ -1225,26 +1225,26 @@ const MIN_BUF_SIZE = 16;
 const CR = "\r".charCodeAt(0);
 const LF = "\n".charCodeAt(0);
 class BufferFullError extends Error {
-    name = "BufferFullError";
     constructor(partial){
         super("Buffer full");
         this.partial = partial;
+        this.name = "BufferFullError";
     }
 }
 class PartialReadError extends Deno.errors.UnexpectedEof {
-    name = "PartialReadError";
     constructor(){
         super("Encountered UnexpectedEof, data only partially read");
+        this.name = "PartialReadError";
     }
 }
 class BufReader {
-    r = 0;
-    w = 0;
-    eof = false;
     static create(r, size = 4096) {
         return r instanceof BufReader ? r : new BufReader(r, size);
     }
     constructor(rd1, size1 = 4096){
+        this.r = 0;
+        this.w = 0;
+        this.eof = false;
         if (size1 < 16) {
             size1 = MIN_BUF_SIZE;
         }
@@ -1447,8 +1447,6 @@ class BufReader {
     }
 }
 class AbstractBufBase {
-    usedBufferBytes = 0;
-    err = null;
     size() {
         return this.buf.byteLength;
     }
@@ -1457,6 +1455,10 @@ class AbstractBufBase {
     }
     buffered() {
         return this.usedBufferBytes;
+    }
+    constructor(){
+        this.usedBufferBytes = 0;
+        this.err = null;
     }
 }
 class BufWriter extends AbstractBufBase {
@@ -1704,11 +1706,11 @@ function scanUntilBoundary(buf, dashBoundary, newLineDashBoundary, total, eof) {
     return buf.length;
 }
 class PartReader {
-    n = 0;
-    total = 0;
     constructor(mr, headers2){
         this.mr = mr;
         this.headers = headers2;
+        this.n = 0;
+        this.total = 0;
     }
     async read(p) {
         const br = this.mr.bufReader;
@@ -1785,12 +1787,13 @@ function skipLWSPChar(u) {
     return ret.slice(0, j);
 }
 class MultipartReader {
-    newLine = encoder.encode("\r\n");
-    newLineDashBoundary = encoder.encode(`\r\n--${this.boundary}`);
-    dashBoundaryDash = encoder.encode(`--${this.boundary}--`);
-    dashBoundary = encoder.encode(`--${this.boundary}`);
     constructor(reader1, boundary){
         this.boundary = boundary;
+        this.newLine = encoder.encode("\r\n");
+        this.newLineDashBoundary = encoder.encode(`\r\n--${this.boundary}`);
+        this.dashBoundaryDash = encoder.encode(`--${this.boundary}--`);
+        this.dashBoundary = encoder.encode(`--${this.boundary}`);
+        this.partsRead = 0;
         this.bufReader = new BufReader(reader1);
     }
     async readForm(maxMemory = 10 << 20) {
@@ -1872,7 +1875,6 @@ class MultipartReader {
         }
         return multipartFormData(fileMap, valueMap);
     }
-    partsRead = 0;
     async nextPart() {
         if (this.currentPart) {
             this.currentPart.close();
@@ -1965,12 +1967,12 @@ function multipartFormData(fileMap, valueMap) {
     };
 }
 class PartWriter {
-    closed = false;
-    headersWritten = false;
     constructor(writer3, boundary1, headers1, isFirstBoundary){
         this.writer = writer3;
         this.boundary = boundary1;
         this.headers = headers1;
+        this.closed = false;
+        this.headersWritten = false;
         let buf = "";
         if (isFirstBoundary) {
             buf += `--${boundary1}\r\n`;
@@ -2014,9 +2016,9 @@ class MultipartWriter {
     get boundary() {
         return this._boundary;
     }
-    isClosed = false;
     constructor(writer4, boundary2){
         this.writer = writer4;
+        this.isClosed = false;
         if (boundary2 !== void 0) {
             this._boundary = checkBoundary(boundary2);
         } else {

--- a/bundler/tests/fixture/deno-9620/case1/output/entry.ts
+++ b/bundler/tests/fixture/deno-9620/case1/output/entry.ts
@@ -126,8 +126,8 @@ class StringReader extends Deno.Buffer {
     }
 }
 class MultiReader {
-    currentIndex = 0;
     constructor(...readers){
+        this.currentIndex = 0;
         this.readers = readers;
     }
     async read(p) {
@@ -1234,26 +1234,26 @@ const MAX_CONSECUTIVE_EMPTY_READS = 100;
 const CR = "\r".charCodeAt(0);
 const LF = "\n".charCodeAt(0);
 class BufferFullError extends Error {
-    name = "BufferFullError";
     constructor(partial){
         super("Buffer full");
         this.partial = partial;
+        this.name = "BufferFullError";
     }
 }
 class PartialReadError extends Deno.errors.UnexpectedEof {
-    name = "PartialReadError";
     constructor(){
         super("Encountered UnexpectedEof, data only partially read");
+        this.name = "PartialReadError";
     }
 }
 class BufReader {
-    r = 0;
-    w = 0;
-    eof = false;
     static create(r, size = DEFAULT_BUF_SIZE) {
         return r instanceof BufReader ? r : new BufReader(r, size);
     }
     constructor(rd1, size1 = DEFAULT_BUF_SIZE){
+        this.r = 0;
+        this.w = 0;
+        this.eof = false;
         if (size1 < MIN_BUF_SIZE) {
             size1 = MIN_BUF_SIZE;
         }
@@ -1456,8 +1456,6 @@ class BufReader {
     }
 }
 class AbstractBufBase {
-    usedBufferBytes = 0;
-    err = null;
     size() {
         return this.buf.byteLength;
     }
@@ -1466,6 +1464,10 @@ class AbstractBufBase {
     }
     buffered() {
         return this.usedBufferBytes;
+    }
+    constructor(){
+        this.usedBufferBytes = 0;
+        this.err = null;
     }
 }
 class BufWriter extends AbstractBufBase {
@@ -1713,11 +1715,11 @@ function scanUntilBoundary(buf, dashBoundary, newLineDashBoundary, total, eof) {
     return buf.length;
 }
 class PartReader {
-    n = 0;
-    total = 0;
     constructor(mr, headers2){
         this.mr = mr;
         this.headers = headers2;
+        this.n = 0;
+        this.total = 0;
     }
     async read(p) {
         const br = this.mr.bufReader;
@@ -1794,12 +1796,13 @@ function skipLWSPChar(u) {
     return ret.slice(0, j);
 }
 class MultipartReader {
-    newLine = encoder.encode("\r\n");
-    newLineDashBoundary = encoder.encode(`\r\n--${this.boundary}`);
-    dashBoundaryDash = encoder.encode(`--${this.boundary}--`);
-    dashBoundary = encoder.encode(`--${this.boundary}`);
     constructor(reader1, boundary){
         this.boundary = boundary;
+        this.newLine = encoder.encode("\r\n");
+        this.newLineDashBoundary = encoder.encode(`\r\n--${this.boundary}`);
+        this.dashBoundaryDash = encoder.encode(`--${this.boundary}--`);
+        this.dashBoundary = encoder.encode(`--${this.boundary}`);
+        this.partsRead = 0;
         this.bufReader = new BufReader(reader1);
     }
     async readForm(maxMemory = 10 << 20) {
@@ -1881,7 +1884,6 @@ class MultipartReader {
         }
         return multipartFormData(fileMap, valueMap);
     }
-    partsRead = 0;
     async nextPart() {
         if (this.currentPart) {
             this.currentPart.close();
@@ -1974,12 +1976,12 @@ function multipartFormData(fileMap, valueMap) {
     };
 }
 class PartWriter {
-    closed = false;
-    headersWritten = false;
     constructor(writer3, boundary1, headers1, isFirstBoundary){
         this.writer = writer3;
         this.boundary = boundary1;
         this.headers = headers1;
+        this.closed = false;
+        this.headersWritten = false;
         let buf = "";
         if (isFirstBoundary) {
             buf += `--${boundary1}\r\n`;
@@ -2023,9 +2025,9 @@ class MultipartWriter {
     get boundary() {
         return this._boundary;
     }
-    isClosed = false;
     constructor(writer4, boundary2){
         this.writer = writer4;
+        this.isClosed = false;
         if (boundary2 !== void 0) {
             this._boundary = checkBoundary(boundary2);
         } else {

--- a/bundler/tests/fixture/issue-1156-1/output/entry.inlined.ts
+++ b/bundler/tests/fixture/issue-1156-1/output/entry.inlined.ts
@@ -9,11 +9,13 @@ function d() {
     return Object.assign(promise, methods);
 }
 class A {
-    s = d();
     a() {
         this.s.resolve();
     }
     b() {
+        this.s = d();
+    }
+    constructor(){
         this.s = d();
     }
 }

--- a/bundler/tests/fixture/issue-1156-1/output/entry.ts
+++ b/bundler/tests/fixture/issue-1156-1/output/entry.ts
@@ -9,11 +9,13 @@ function d() {
     return Object.assign(promise, methods);
 }
 class A {
-    s = d();
     a() {
         this.s.resolve();
     }
     b() {
+        this.s = d();
+    }
+    constructor(){
         this.s = d();
     }
 }

--- a/bundler/tests/fixture/issue-1156-2/output/entry.inlined.ts
+++ b/bundler/tests/fixture/issue-1156-2/output/entry.inlined.ts
@@ -9,9 +9,11 @@ function d() {
     return Object.assign(promise, methods);
 }
 class A {
-    s = d();
     a() {
         this.s.resolve();
+    }
+    constructor(){
+        this.s = d();
     }
 }
 new A();

--- a/bundler/tests/fixture/issue-1156-2/output/entry.ts
+++ b/bundler/tests/fixture/issue-1156-2/output/entry.ts
@@ -9,9 +9,11 @@ function d() {
     return Object.assign(promise, methods);
 }
 class A {
-    s = d();
     a() {
         this.s.resolve();
+    }
+    constructor(){
+        this.s = d();
     }
 }
 new A();

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.26.0"
+version = "0.27.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -31,8 +31,8 @@ swc_ecma_ast = {version = "0.40.0", path = "./ast"}
 swc_ecma_codegen = {version = "0.48.0", path = "./codegen", optional = true}
 swc_ecma_dep_graph = {version = "0.18.0", path = "./dep-graph", optional = true}
 swc_ecma_parser = {version = "0.50.0", path = "./parser", optional = true}
-swc_ecma_transforms = {version = "0.40.0", path = "./transforms", optional = true}
-swc_ecma_utils = {version = "0.30.0", path = "./utils", optional = true}
+swc_ecma_transforms = {version = "0.41.0", path = "./transforms", optional = true}
+swc_ecma_utils = {version = "0.31.0", path = "./utils", optional = true}
 swc_ecma_visit = {version = "0.26.0", path = "./visit", optional = true}
 
 [dev-dependencies]

--- a/ecmascript/ext-transforms/Cargo.toml
+++ b/ecmascript/ext-transforms/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://swc.rs/rustdoc/swc_ecma_ext_transforms/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ext_transforms"
-version = "0.7.0"
+version = "0.8.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,5 +15,5 @@ swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.10", path = "../../common"}
 swc_ecma_ast = {version = "0.40.0", path = "../ast"}
 swc_ecma_parser = {version = "0.50.0", path = "../parser"}
-swc_ecma_utils = {version = "0.30.0", path = "../utils"}
+swc_ecma_utils = {version = "0.31.0", path = "../utils"}
 swc_ecma_visit = {version = "0.26.0", path = "../visit"}

--- a/ecmascript/preset_env/Cargo.toml
+++ b/ecmascript/preset_env/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://swc.rs/rustdoc/swc_ecma_preset_env/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_preset_env"
-version = "0.10.0"
+version = "0.11.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,8 +21,8 @@ string_enum = {version = "0.3.1", path = "../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.10", path = "../../common"}
 swc_ecma_ast = {version = "0.40.0", path = "../ast"}
-swc_ecma_transforms = {version = "0.40.0", path = "../transforms", features = ["compat", "proposal"]}
-swc_ecma_utils = {version = "0.30.0", path = "../utils"}
+swc_ecma_transforms = {version = "0.41.0", path = "../transforms", features = ["compat", "proposal"]}
+swc_ecma_utils = {version = "0.31.0", path = "../utils"}
 swc_ecma_visit = {version = "0.26.0", path = "../visit"}
 walkdir = "2"
 

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.40.0"
+version = "0.41.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -25,14 +25,14 @@ swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.10.10", path = "../../common"}
 swc_ecma_ast = {version = "0.40.0", path = "../ast"}
 swc_ecma_parser = {version = "0.50.0", path = "../parser"}
-swc_ecma_transforms_base = {version = "0.7.0", path = "./base"}
-swc_ecma_transforms_compat = {version = "0.8.0", path = "./compat", optional = true}
-swc_ecma_transforms_module = {version = "0.8.0", path = "./module", optional = true}
-swc_ecma_transforms_optimization = {version = "0.10.0", path = "./optimization", optional = true}
-swc_ecma_transforms_proposal = {version = "0.8.0", path = "./proposal", optional = true}
-swc_ecma_transforms_react = {version = "0.9.0", path = "./react", optional = true}
-swc_ecma_transforms_typescript = {version = "0.9.0", path = "./typescript", optional = true}
-swc_ecma_utils = {version = "0.30.0", path = "../utils"}
+swc_ecma_transforms_base = {version = "0.8.0", path = "./base"}
+swc_ecma_transforms_compat = {version = "0.9.0", path = "./compat", optional = true}
+swc_ecma_transforms_module = {version = "0.9.0", path = "./module", optional = true}
+swc_ecma_transforms_optimization = {version = "0.11.0", path = "./optimization", optional = true}
+swc_ecma_transforms_proposal = {version = "0.9.0", path = "./proposal", optional = true}
+swc_ecma_transforms_react = {version = "0.10.0", path = "./react", optional = true}
+swc_ecma_transforms_typescript = {version = "0.10.0", path = "./typescript", optional = true}
+swc_ecma_utils = {version = "0.31.0", path = "../utils"}
 swc_ecma_visit = {version = "0.26.0", path = "../visit"}
 unicode-xid = "0.2"
 
@@ -40,7 +40,7 @@ unicode-xid = "0.2"
 pretty_assertions = "0.6"
 sourcemap = "6"
 swc_ecma_codegen = {version = "0.48.0", path = "../codegen"}
-swc_ecma_transforms_testing = {version = "0.7.0", path = "./testing"}
+swc_ecma_transforms_testing = {version = "0.8.0", path = "./testing"}
 tempfile = "3"
 testing = {version = "0.10.3", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies]
 fxhash = "0.2.1"
@@ -18,7 +18,7 @@ swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.40.0", path = "../../ast"}
 swc_ecma_parser = {version = "0.50.0", path = "../../parser"}
-swc_ecma_utils = {version = "0.30.0", path = "../../utils"}
+swc_ecma_utils = {version = "0.31.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.26.0", path = "../../visit"}
 
 [dev-dependencies]

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.8.0"
+version = "0.9.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -21,12 +21,12 @@ smallvec = "1.6.0"
 swc_atoms = {version = "0.2.5", path = "../../../atoms"}
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.40.0", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.7.0", path = "../base"}
+swc_ecma_transforms_base = {version = "0.8.0", path = "../base"}
 swc_ecma_transforms_macros = {version = "0.2.1", path = "../macros"}
-swc_ecma_utils = {version = "0.30.0", path = "../../utils"}
+swc_ecma_utils = {version = "0.31.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.26.0", path = "../../visit"}
 
 [dev-dependencies]
 swc_ecma_parser = {version = "0.50.0", path = "../../parser"}
-swc_ecma_transforms_testing = {version = "0.7.0", path = "../testing"}
+swc_ecma_transforms_testing = {version = "0.8.0", path = "../testing"}
 testing = {version = "0.10.3", path = "../../../testing"}

--- a/ecmascript/transforms/compat/src/es2020/class_properties.rs
+++ b/ecmascript/transforms/compat/src/es2020/class_properties.rs
@@ -758,9 +758,10 @@ impl ClassProperties {
                 }
             });
 
-        if let Some(c) = constructor {
+        if let Some(mut c) = constructor {
             // Prepend properties
-            Some(inject_after_super(c, constructor_exprs))
+            inject_after_super(&mut c, constructor_exprs);
+            Some(c)
         } else {
             None
         }

--- a/ecmascript/transforms/module/Cargo.toml
+++ b/ecmascript/transforms/module/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.8.0"
+version = "0.9.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -18,11 +18,11 @@ swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.40.0", path = "../../ast"}
 swc_ecma_parser = {version = "0.50.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.7.0", path = "../base"}
-swc_ecma_utils = {version = "0.30.0", path = "../../utils"}
+swc_ecma_transforms_base = {version = "0.8.0", path = "../base"}
+swc_ecma_utils = {version = "0.31.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.26.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.8.0", path = "../compat"}
-swc_ecma_transforms_testing = {version = "0.7.0", path = "../testing/"}
+swc_ecma_transforms_compat = {version = "0.9.0", path = "../compat"}
+swc_ecma_transforms_testing = {version = "0.8.0", path = "../testing/"}
 testing = {version = "0.10.3", path = "../../../testing/"}

--- a/ecmascript/transforms/optimization/Cargo.toml
+++ b/ecmascript/transforms/optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.10.0"
+version = "0.11.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -21,15 +21,15 @@ swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.40.0", path = "../../ast"}
 swc_ecma_parser = {version = "0.50.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.7.0", path = "../base"}
-swc_ecma_utils = {version = "0.30.0", path = "../../utils"}
+swc_ecma_transforms_base = {version = "0.8.0", path = "../base"}
+swc_ecma_utils = {version = "0.31.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.26.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.8.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.8.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.8.0", path = "../proposal"}
-swc_ecma_transforms_react = {version = "0.9.0", path = "../react"}
-swc_ecma_transforms_testing = {version = "0.7.0", path = "../testing"}
-swc_ecma_transforms_typescript = {version = "0.9.0", path = "../typescript"}
+swc_ecma_transforms_compat = {version = "0.9.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.9.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.9.0", path = "../proposal"}
+swc_ecma_transforms_react = {version = "0.10.0", path = "../react"}
+swc_ecma_transforms_testing = {version = "0.8.0", path = "../testing"}
+swc_ecma_transforms_typescript = {version = "0.10.0", path = "../typescript"}
 testing = {version = "0.10.0", path = "../../../testing"}

--- a/ecmascript/transforms/optimization/tests/simplify.rs
+++ b/ecmascript/transforms/optimization/tests/simplify.rs
@@ -511,11 +511,13 @@ test!(
         return Object.assign(promise, methods);
     }
     class A {
-        s = d();
         a() {
             this.s.resolve();
         }
         b() {
+            this.s = d();
+        }
+        constructor(){
             this.s = d();
         }
     }

--- a/ecmascript/transforms/optimization/tests/simplify_dce.rs
+++ b/ecmascript/transforms/optimization/tests/simplify_dce.rs
@@ -677,11 +677,13 @@ test!(
         return Object.assign(promise, methods);
     }
     class A {
-        s = d();
         a() {
             this.s.resolve();
         }
         b() {
+            this.s = d();
+        }
+        constructor(){
             this.s = d();
         }
     }
@@ -765,9 +767,11 @@ test!(
         return Object.assign(promise, methods);
     }
     class A {
-        s = d();
         a() {
             this.s.resolve();
+        }
+        constructor(){
+            this.s = d();
         }
     }
     new A();

--- a/ecmascript/transforms/optimization/tests/simplify_inlining.rs
+++ b/ecmascript/transforms/optimization/tests/simplify_inlining.rs
@@ -2215,11 +2215,13 @@ test!(
         return Object.assign(promise, methods);
     }
     class A {
-        s = d();
         a() {
             this.s.resolve();
         }
         b() {
+            this.s = d();
+        }
+        constructor(){
             this.s = d();
         }
     }

--- a/ecmascript/transforms/proposal/Cargo.toml
+++ b/ecmascript/transforms/proposal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_proposal"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.8.0"
+version = "0.9.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -24,11 +24,11 @@ swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.40.0", path = "../../ast"}
 swc_ecma_loader = {version = "0.1.0", path = "../../loader", optional = true}
 swc_ecma_parser = {version = "0.50.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.7.0", path = "../base"}
-swc_ecma_utils = {version = "0.30.0", path = "../../utils"}
+swc_ecma_transforms_base = {version = "0.8.0", path = "../base"}
+swc_ecma_utils = {version = "0.31.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.26.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.8.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.8.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.7.0", path = "../testing"}
+swc_ecma_transforms_compat = {version = "0.9.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.9.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.8.0", path = "../testing"}

--- a/ecmascript/transforms/proposal/src/decorators.rs
+++ b/ecmascript/transforms/proposal/src/decorators.rs
@@ -279,7 +279,7 @@ impl Decorators {
                         ClassMember::Constructor(c) => c,
                         _ => unreachable!(),
                     };
-                    c = inject_after_super(c, vec![initialize_call]);
+                    inject_after_super(&mut c, vec![initialize_call]);
 
                     ClassMember::Constructor(c)
                 }

--- a/ecmascript/transforms/react/Cargo.toml
+++ b/ecmascript/transforms/react/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_react"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.9.0"
+version = "0.10.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -20,12 +20,12 @@ swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.40.0", path = "../../ast"}
 swc_ecma_parser = {version = "0.50.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.7.0", path = "../base"}
-swc_ecma_utils = {version = "0.30.0", path = "../../utils"}
+swc_ecma_transforms_base = {version = "0.8.0", path = "../base"}
+swc_ecma_utils = {version = "0.31.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.26.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.8.0", path = "../compat/"}
-swc_ecma_transforms_module = {version = "0.8.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.7.0", path = "../testing/"}
+swc_ecma_transforms_compat = {version = "0.9.0", path = "../compat/"}
+swc_ecma_transforms_module = {version = "0.9.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.8.0", path = "../testing/"}
 testing = {version = "0.10.3", path = "../../../testing"}

--- a/ecmascript/transforms/testing/Cargo.toml
+++ b/ecmascript/transforms/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.7.0"
+version = "0.8.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,8 +18,8 @@ swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.40.0", path = "../../ast"}
 swc_ecma_codegen = {version = "0.48.0", path = "../../codegen"}
 swc_ecma_parser = {version = "0.50.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.7.0", path = "../base"}
-swc_ecma_utils = {version = "0.30.0", path = "../../utils"}
+swc_ecma_transforms_base = {version = "0.8.0", path = "../base"}
+swc_ecma_utils = {version = "0.31.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.26.0", path = "../../visit"}
 tempfile = "3.1.0"
 testing = {version = "0.10.3", path = "../../../testing"}

--- a/ecmascript/transforms/tests/decorators.rs
+++ b/ecmascript/transforms/tests/decorators.rs
@@ -470,7 +470,7 @@ class B {
 class B {
   bar() {}
   constructor() {
-    _defineProperty(this, "foo", 2);
+    this.foo = 2;
   }
 
 }

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.9.0"
+version = "0.10.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -16,15 +16,15 @@ swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.40.0", path = "../../ast"}
 swc_ecma_parser = {version = "0.50.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.7.0", path = "../base"}
-swc_ecma_utils = {version = "0.30.0", path = "../../utils"}
+swc_ecma_transforms_base = {version = "0.8.0", path = "../base"}
+swc_ecma_utils = {version = "0.31.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.26.0", path = "../../visit"}
 
 [dev-dependencies]
 swc_ecma_codegen = {version = "0.48.0", path = "../../codegen"}
-swc_ecma_transforms_compat = {version = "0.8.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.8.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.8.0", path = "../proposal/"}
-swc_ecma_transforms_testing = {version = "0.7.0", path = "../testing"}
+swc_ecma_transforms_compat = {version = "0.9.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.9.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.9.0", path = "../proposal/"}
+swc_ecma_transforms_testing = {version = "0.8.0", path = "../testing"}
 testing = {version = "0.10.3", path = "../../../testing"}
 walkdir = "2.3.1"

--- a/ecmascript/transforms/typescript/src/strip.rs
+++ b/ecmascript/transforms/typescript/src/strip.rs
@@ -203,7 +203,6 @@ impl Strip {
         let mut new_body = vec![];
         for member in take(&mut class.body) {
             match member {
-                ClassMember::ClassProp(class_field) if class_field.value.is_none() => {}
                 // This handling is for non-static fields only. Also preserve
                 // fields with decorators for now, these should be transformed
                 // differently during the `decorators()` pass.

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.30.0"
+version = "0.31.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ecmascript/utils/src/constructor.rs
+++ b/ecmascript/utils/src/constructor.rs
@@ -13,6 +13,12 @@ pub fn inject_after_super(c: &mut Constructor, exprs: Vec<Box<Expr>>) {
 
     c.body = std::mem::take(&mut c.body).fold_with(&mut folder);
     if !folder.injected {
+        if c.body.is_none() {
+            c.body = Some(BlockStmt {
+                span: DUMMY_SP,
+                stmts: vec![],
+            });
+        }
         // there was no super() call
         prepend_stmts(
             &mut c.body.as_mut().unwrap().stmts,

--- a/ecmascript/utils/src/constructor.rs
+++ b/ecmascript/utils/src/constructor.rs
@@ -4,14 +4,14 @@ use swc_common::DUMMY_SP;
 use swc_ecma_ast::*;
 use swc_ecma_visit::{noop_fold_type, noop_visit_mut_type, Fold, FoldWith, VisitMut, VisitMutWith};
 
-pub fn inject_after_super(mut c: Constructor, exprs: Vec<Box<Expr>>) -> Constructor {
+pub fn inject_after_super(c: &mut Constructor, exprs: Vec<Box<Expr>>) {
     // Allow using super multiple time
     let mut folder = Injector {
         exprs: &exprs,
         injected: false,
     };
 
-    c.body = c.body.fold_with(&mut folder);
+    c.body = std::mem::take(&mut c.body).fold_with(&mut folder);
     if !folder.injected {
         // there was no super() call
         prepend_stmts(
@@ -19,7 +19,6 @@ pub fn inject_after_super(mut c: Constructor, exprs: Vec<Box<Expr>>) -> Construc
             exprs.into_iter().map(|v| v.into_stmt()),
         );
     }
-    c
 }
 
 struct Injector<'a> {


### PR DESCRIPTION
@kdy1 This implements `use_define_for_class_fields: true` as correctly specified in #1472. It also adds the behaviour of the `typescript_class_properties()` pass directly into `strip()` in case of `use_define_for_class_fields: false`. This aligns with tsc. The `typescript_class_properties()` is redundant and should be removed.

However, I can't figure out how to copy the static class field handling from `typescript_class_fields()` to `strip()`. So I left some TODOs and haven't removed it yet. Help would be appreciated.