### PR TITLE
Fix sourcemaps of multi line block comments

### DIFF
--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.49.0"
+version = "0.49.1"
 
 [dependencies]
 bitflags = "1"

--- a/ecmascript/codegen/src/comments.rs
+++ b/ecmascript/codegen/src/comments.rs
@@ -23,7 +23,7 @@ macro_rules! write_comments {
                         $e.wr.write_comment(cmt.span, " ")?;
                     }
                     $e.wr.write_comment(cmt.span, "/*")?;
-                    $e.wr.write_comment(cmt.span, &cmt.text)?;
+                    $e.wr.write_lit(cmt.span, &cmt.text)?;
                     $e.wr.write_comment(cmt.span, "*/")?;
                     $e.wr.write_space()?;
                 }


### PR DESCRIPTION
Before:
<img width="1385" alt="Screen Shot 2021-03-28 at 8 47 42 AM" src="https://user-images.githubusercontent.com/19409/112752952-8d6b6900-8fa3-11eb-8177-3070896d9170.png">

After:
<img width="1385" alt="Screen Shot 2021-03-28 at 8 49 03 AM" src="https://user-images.githubusercontent.com/19409/112752955-92301d00-8fa3-11eb-83c1-3552e20a6f12.png">

Again, happy to add tests if you point me where they should go. 😄 