### PR TITLE
fix(node-swc): type `Argument.spread` should be optional

### DIFF
--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -805,7 +805,7 @@ export interface ObjectExpression extends ExpressionBase {
 }
 
 export interface Argument {
-  spread: Span;
+  spread?: Span;
   expression: Expression;
 }
 


### PR DESCRIPTION
fix #1534 