### PR TITLE
Fix inlining nested block statements in branch simplifier

### DIFF
--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -428,13 +428,15 @@ impl Fold for Remover {
             Stmt::Block(BlockStmt { span, stmts }) => {
                 if stmts.is_empty() {
                     Stmt::Empty(EmptyStmt { span })
-                } else if stmts.len() == 1 && !is_block_scoped_stuff(&stmts[0]) {
+                } else if stmts.len() == 1
+                    && !is_block_scoped_stuff(&stmts[0])
+                    && stmt_depth(&stmts[0]) <= 1
+                {
                     stmts.into_iter().next().unwrap().fold_with(self)
                 } else {
                     Stmt::Block(BlockStmt { span, stmts })
                 }
             }
-
             Stmt::Try(TryStmt {
                 span,
                 block,
@@ -1531,4 +1533,37 @@ fn check_for_stopper(s: &[Stmt], only_conditional: bool) -> bool {
     };
     v.visit_stmts(s, &Invalid { span: DUMMY_SP } as _);
     v.found
+}
+
+/// Finds the depth of statements without hitting a block
+fn stmt_depth(s: &Stmt) -> u32 {
+    let mut depth = 0;
+
+    match s {
+        // Stop when hitting a statement we know can't increase statement depth.
+        Stmt::Block(_) | Stmt::Labeled(_) | Stmt::Switch(_) | Stmt::Decl(_) | Stmt::Expr(_) => {}
+        // Take the max depth of if statements
+        Stmt::If(i) => {
+            depth += 1;
+            if let Some(alt) = &i.alt {
+                depth += std::cmp::max(stmt_depth(&i.cons), stmt_depth(&alt));
+            } else {
+                depth += stmt_depth(&i.cons);
+            }
+        }
+        // These statements can have bodies without a wrapping block
+        Stmt::With(WithStmt { body, .. })
+        | Stmt::While(WhileStmt { body, .. })
+        | Stmt::DoWhile(DoWhileStmt { body, .. })
+        | Stmt::For(ForStmt { body, .. })
+        | Stmt::ForIn(ForInStmt { body, .. })
+        | Stmt::ForOf(ForOfStmt { body, .. }) => {
+            depth += 1;
+            depth += stmt_depth(&body);
+        }
+        // All other statements increase the depth by 1
+        _ => depth += 1,
+    }
+
+    depth
 }

--- a/ecmascript/transforms/optimization/src/simplify/branch/tests.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/tests.rs
@@ -1722,3 +1722,21 @@ c = 3;
 console.log(c);",
     );
 }
+
+#[test]
+fn nested_block_stmt() {
+    test(
+        "if (Date.now() < 0) {
+            for(let i = 0; i < 10; i++){
+                if (Date.now() < 0) {
+                    console.log(1);
+                }
+            }
+        } else {
+            console.log(2);
+        }",
+        "if (Date.now() < 0) {
+            for(let i = 0; i < 10; i++)if (Date.now() < 0) console.log(1);
+        } else console.log(2);",
+    );
+}

--- a/spack/tests/pass/issue-1328/case1/output/entry.js
+++ b/spack/tests/pass/issue-1328/case1/output/entry.js
@@ -474,8 +474,10 @@ var load = __spack_require__.bind(void 0, function(module, exports) {
                 this.method = "next";
                 this.arg = undefined;
                 this.tryEntries.forEach(resetTryEntry);
-                if (!skipTempReset) for(var name in this)// Not sure about the optimal order of these conditions:
-                if (name.charAt(0) === "t" && hasOwn.call(this, name) && !isNaN(+name.slice(1))) this[name] = undefined;
+                if (!skipTempReset) {
+                    for(var name in this)// Not sure about the optimal order of these conditions:
+                    if (name.charAt(0) === "t" && hasOwn.call(this, name) && !isNaN(+name.slice(1))) this[name] = undefined;
+                }
             },
             stop: function() {
                 this.done = true;


### PR DESCRIPTION
This fixes an issue where the branch simplifier would inline single statement blocks too aggressively, resulting in broken code. For example:

```js
if (Date.now() < 0) {
    for(let i = 0; i < 10; i++){
        if (Date.now() < 0) {
            console.log(1);
        }
    }
} else {
    console.log(2);
}
```

gets turned into

```js
if (Date.now() < 0) for(let i = 0; i < 10; i++) if (Date.now() < 0) console.log(1);
else console.log(2);
```

This results in the `else` being applied to the second `if` rather than the first.

I've attempted to solve this by computing the depth of statements in the block's first statement until hitting another block statement. If the depth is greater than 1, then it's not safe to inline the block.

Perhaps there's a better way to solve this? i.e. should the printer be handling this based on precedence?