### PR TITLE
feat(es/transforms/react): Fast refresh config

### DIFF
--- a/ecmascript/transforms/react/Cargo.toml
+++ b/ecmascript/transforms/react/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.12.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+base64 = "0.13.0"
 dashmap = "4.0.1"
 indexmap = "1.6.1"
 once_cell = "1.5.2"

--- a/ecmascript/transforms/react/src/jsx/mod.rs
+++ b/ecmascript/transforms/react/src/jsx/mod.rs
@@ -30,6 +30,8 @@ use swc_ecma_visit::Fold;
 use swc_ecma_visit::VisitMut;
 use swc_ecma_visit::VisitMutWith;
 
+use crate::refresh::options::{deserialize_refresh, RefreshOptions};
+
 mod static_check;
 #[cfg(test)]
 mod tests;
@@ -83,6 +85,10 @@ pub struct Options {
 
     #[serde(default)]
     pub use_spread: bool,
+
+    #[serde(default, deserialize_with = "deserialize_refresh")]
+    // default to disabled since this is still considered as experimental by now
+    pub refresh: Option<RefreshOptions>,
 }
 
 impl Default for Options {
@@ -97,6 +103,8 @@ impl Default for Options {
             development: false,
             use_builtins: false,
             use_spread: false,
+            // since this is considered experimental, we disable it by default
+            refresh: None,
         }
     }
 }

--- a/ecmascript/transforms/react/src/lib.rs
+++ b/ecmascript/transforms/react/src/lib.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 pub use self::{
     display_name::display_name,
     jsx::{jsx, Options},
@@ -17,17 +19,19 @@ mod refresh;
 /// `@babel/preset-react`
 ///
 /// Preset for all React plugins.
-pub fn react<C>(cm: Lrc<SourceMap>, comments: Option<C>, options: Options) -> impl Fold
+pub fn react<C>(cm: Lrc<SourceMap>, comments: Option<C>, mut options: Options) -> impl Fold
 where
     C: Comments + Clone,
 {
     let Options { development, .. } = options;
+
+    let refresh_options = mem::replace(&mut options.refresh, None);
 
     chain!(
         jsx(cm.clone(), comments.clone(), options),
         display_name(),
         jsx_src(development, cm.clone()),
         jsx_self(development),
-        refresh(development, cm.clone(), comments)
+        refresh(development, refresh_options, cm.clone(), comments)
     )
 }

--- a/ecmascript/transforms/react/src/refresh/mod.rs
+++ b/ecmascript/transforms/react/src/refresh/mod.rs
@@ -21,6 +21,8 @@ use util::{
     is_import_or_require, make_assign_stmt, make_call_expr, make_call_stmt, CollectIdent,
 };
 
+pub mod options;
+use options::RefreshOptions;
 mod util;
 
 #[cfg(test)]
@@ -43,7 +45,7 @@ enum Persist {
     None,
 }
 fn get_persistent_id(ident: &Ident) -> Persist {
-    if ident.as_ref().starts_with(|c: char| c.is_ascii_uppercase()) {
+    if ident.sym.starts_with(|c: char| c.is_ascii_uppercase()) {
         Persist::Component(ident.clone())
     } else {
         Persist::None
@@ -83,15 +85,18 @@ enum HookCall {
 
 /// `react-refresh/babel`
 /// https://github.com/facebook/react/blob/master/packages/react-refresh/src/ReactFreshBabelPlugin.js
-pub fn refresh<C: Comments>(dev: bool, cm: Lrc<SourceMap>, comments: Option<C>) -> impl Fold {
+pub fn refresh<C: Comments>(
+    dev: bool,
+    options: Option<RefreshOptions>,
+    cm: Lrc<SourceMap>,
+    comments: Option<C>,
+) -> impl Fold {
     Refresh {
-        dev,
+        enable: dev && options.is_some(),
         cm,
         comments,
-        should_refresh: false,
-        refresh_reg: "$RefreshReg$".to_string(),
-        refresh_sig: "$RefreshSig$".to_string(),
-        emit_full_signatures: true,
+        should_reset: false,
+        options: options.unwrap_or(Default::default()),
         used_in_jsx: HashSet::new(),
         curr_hook_fn: Vec::new(),
         scope_binding: IndexSet::new(),
@@ -99,15 +104,14 @@ pub fn refresh<C: Comments>(dev: bool, cm: Lrc<SourceMap>, comments: Option<C>) 
 }
 
 struct Refresh<C: Comments> {
-    dev: bool,
-    refresh_reg: String,
-    refresh_sig: String,
-    emit_full_signatures: bool,
+    enable: bool,
+    options: RefreshOptions,
     cm: Lrc<SourceMap>,
-    should_refresh: bool,
+    should_reset: bool,
     used_in_jsx: HashSet<JsWord>,
     comments: Option<C>,
     curr_hook_fn: Vec<FnWithHook>,
+    // bindings in current and all parent scope
     scope_binding: IndexSet<JsWord>,
 }
 
@@ -212,6 +216,8 @@ impl<C: Comments> Refresh<C> {
                 _ => {}
             }
         }
+        // The signature call is split in two parts. One part is called inside the
+        // function. This is used to signal when first render happens.
         if sign_res.len() != 0 {
             let handle = private_ident!("_s");
             body.stmts.insert(0, make_call_stmt(handle.clone()));
@@ -256,7 +262,7 @@ impl<C: Comments> Refresh<C> {
         }
     }
     fn gen_hook_handle(&self, curr_hook_fn: &Vec<FnWithHook>) -> Stmt {
-        let refresh_sig = self.refresh_sig.as_str();
+        let refresh_sig = self.options.refresh_sig.as_str();
         Stmt::Decl(Decl::Var(VarDecl {
             span: DUMMY_SP,
             kind: VarDeclKind::Var,
@@ -272,6 +278,9 @@ impl<C: Comments> Refresh<C> {
             declare: false,
         }))
     }
+    // The second call is around the function itself. This is used to associate a
+    // type with a signature.
+    // Unlike with $RefreshReg$, this needs to work for nested declarations too.
     fn gen_hook_register(&self, func: Expr, hook_fn: &mut FnWithHook) -> Expr {
         let mut args = vec![func];
         let mut sign = Vec::new();
@@ -298,7 +307,7 @@ impl<C: Comments> Refresh<C> {
         // this is just for pass test
         let has_escape = sign.len() > 1;
         let sign = sign.join("\n");
-        let sign = if self.emit_full_signatures {
+        let sign = if self.options.emit_full_signatures {
             sign
         } else {
             let mut hasher = Sha1::new();
@@ -313,7 +322,7 @@ impl<C: Comments> Refresh<C> {
             kind: StrKind::Synthesized,
         })));
 
-        let mut should_refresh = self.should_refresh;
+        let mut should_reset = self.should_reset;
 
         let mut custom_hook_in_scope = Vec::new();
         for hook in custom_hook {
@@ -325,16 +334,16 @@ impl<C: Comments> Refresh<C> {
             if let None = ident.and_then(|id| self.scope_binding.get(&id.sym)) {
                 // We don't have anything to put in the array because Hook is out ofscope.
                 // Since it could potentially have been edited, remount the component.
-                should_refresh = true;
+                should_reset = true;
             } else {
                 custom_hook_in_scope.push(hook);
             }
         }
 
-        if should_refresh || custom_hook_in_scope.len() > 0 {
+        if should_reset || custom_hook_in_scope.len() > 0 {
             args.push(Expr::Lit(Lit::Bool(Bool {
                 span: DUMMY_SP,
-                value: should_refresh,
+                value: should_reset,
             })));
         }
 
@@ -393,6 +402,7 @@ impl<C: Comments> Refresh<C> {
         {
             if self.used_in_jsx.contains(&binding.id.sym) && !is_import_or_require(init_expr) {
                 match init_expr.as_ref() {
+                    // TaggedTpl is for something like styled.div`...`
                     Expr::Arrow(_) | Expr::Fn(_) | Expr::TaggedTpl(_) | Expr::Call(_) => {
                         return Persist::Component(binding.id.clone())
                     }
@@ -500,6 +510,8 @@ impl<C: Comments> Refresh<C> {
                     hook: None,
                 })
             }
+            // export default hoc(Foo)
+            // const X = hoc(Foo)
             Expr::Ident(ident) => {
                 if let Persist::Component(_) = get_persistent_id(ident) {
                     Persist::Hoc(Hoc {
@@ -521,11 +533,11 @@ where
     C: Comments,
 {
     fn visit_span(&mut self, n: &Span, _: &dyn Node) {
-        if self.should_refresh {
+        if self.should_reset {
             return;
         }
 
-        let mut should_refresh = self.should_refresh;
+        let mut should_refresh = self.should_reset;
         if let Some(comments) = &self.comments {
             if n.hi != BytePos(0) {
                 comments.with_leading(n.hi - BytePos(1), |comments| {
@@ -542,10 +554,11 @@ where
             });
         }
 
-        self.should_refresh = should_refresh;
+        self.should_reset = should_refresh;
     }
 }
 
+// We let user do /* @refresh reset */ to reset state in the whole file.
 impl<C: Comments> Fold for Refresh<C> {
     fn fold_jsx_opening_element(&mut self, n: JSXOpeningElement) -> JSXOpeningElement {
         if let JSXElementName::Ident(ident) = &n.name {
@@ -773,7 +786,7 @@ impl<C: Comments> Fold for Refresh<C> {
     }
 
     fn fold_module_items(&mut self, module_items: Vec<ModuleItem>) -> Vec<ModuleItem> {
-        if !self.dev {
+        if !self.enable {
             return module_items;
         }
 
@@ -956,7 +969,7 @@ impl<C: Comments> Fold for Refresh<C> {
         // $RefreshReg$(_c, "Hello");
         // $RefreshReg$(_c1, "Foo");
         // ```
-        let refresh_reg = self.refresh_reg.as_str();
+        let refresh_reg = self.options.refresh_reg.as_str();
         for (handle, persistent_id) in refresh_regs {
             items.push(ModuleItem::Stmt(Stmt::Expr(ExprStmt {
                 span: DUMMY_SP,

--- a/ecmascript/transforms/react/src/refresh/options.rs
+++ b/ecmascript/transforms/react/src/refresh/options.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Deserializer, Serialize};
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct RefreshOptions {
+    #[serde(default = "default_refresh_reg")]
+    pub refresh_reg: String,
+    #[serde(default = "default_refresh_sig")]
+    pub refresh_sig: String,
+    #[serde(default = "default_emit_full_signatures")]
+    pub emit_full_signatures: bool,
+}
+
+fn default_refresh_reg() -> String {
+    "$RefreshReg$".to_string()
+}
+fn default_refresh_sig() -> String {
+    "$RefreshSig$".to_string()
+}
+fn default_emit_full_signatures() -> bool {
+    // Prefer to hash when we can
+    // This makes it deterministically compact, even if there's
+    // e.g. a useState initializer with some code inside.
+    false
+}
+
+impl Default for RefreshOptions {
+    fn default() -> Self {
+        RefreshOptions {
+            refresh_reg: default_refresh_reg(),
+            refresh_sig: default_refresh_sig(),
+            emit_full_signatures: default_emit_full_signatures(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum BoolOrRefresh {
+    Bool(bool),
+    Refresh(RefreshOptions),
+}
+pub fn deserialize_refresh<'de, D>(deserializer: D) -> Result<Option<RefreshOptions>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match BoolOrRefresh::deserialize(deserializer)? {
+        BoolOrRefresh::Refresh(refresh) => Ok(Some(refresh)),
+        BoolOrRefresh::Bool(true) => Ok(Some(Default::default())),
+        BoolOrRefresh::Bool(false) => Ok(None),
+    }
+}

--- a/ecmascript/transforms/react/src/refresh/tests.rs
+++ b/ecmascript/transforms/react/src/refresh/tests.rs
@@ -814,21 +814,21 @@ test!(
     r#"
     var _s = $RefreshSig$(), _s1 = $RefreshSig$();
 
-    export const A = React.memo(_c1 = React.forwardRef(_c = _s((props, ref) => {
+    export const A = _s(React.memo(_c1 = _s(React.forwardRef(_c = _s((props, ref) => {
       _s();
-
+    
       const [foo, setFoo] = useState(0);
       React.useEffect(() => {});
       return <h1 ref={ref}>{foo}</h1>;
-    }, "useState{[foo, setFoo](0)}\nuseEffect{}")));
+    }, "useState{[foo, setFoo](0)}\nuseEffect{}")), "useState{[foo, setFoo](0)}\nuseEffect{}")), "useState{[foo, setFoo](0)}\nuseEffect{}");
     _c2 = A;
-    export const B = React.memo(_c4 = React.forwardRef(_c3 = _s1(function (props, ref) {
+    export const B = _s1(React.memo(_c4 = _s1(React.forwardRef(_c3 = _s1(function (props, ref) {
       _s1();
-
+    
       const [foo, setFoo] = useState(0);
       React.useEffect(() => {});
       return <h1 ref={ref}>{foo}</h1>;
-    }, "useState{[foo, setFoo](0)}\nuseEffect{}")));
+    }, "useState{[foo, setFoo](0)}\nuseEffect{}")), "useState{[foo, setFoo](0)}\nuseEffect{}")), "useState{[foo, setFoo](0)}\nuseEffect{}");
     _c5 = B;
 
     function hoc() {
@@ -938,11 +938,11 @@ test!(
     _s3(Bar, "useContext{}");
 
     _c1 = Bar;
-    const Baz = memo(_c2 = _s4(() => {
+    const Baz = _s4(memo(_c2 = _s4(() => {
       _s4();
 
       return useContext(X);
-    }, "useContext{}"));
+    }, "useContext{}")), "useContext{}");
     _c3 = Baz;
 
     const Qux = () => {
@@ -1149,7 +1149,7 @@ test!(
         ..Default::default()
     }),
     tr,
-    donot_consider_require_as_hoc,
+    dont_consider_require_as_hoc,
     r#"
     const A = require('A');
     const B = foo ? require('X') : require('Y');
@@ -1240,5 +1240,32 @@ test!(
 
     $RefreshReg$(_c, "Foo");
     $RefreshReg$(_c1, "Bar");
+"#
+);
+
+test!(
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+        jsx: true,
+        ..Default::default()
+    }),
+    tr,
+    dont_consider_iife_as_hoc,
+    r#"
+    while (item) {
+      (item => {
+        useFoo();
+      })(item);
+    }
+"#,
+    r#"
+    while (item) {
+      var _s = $RefreshSig$();
+    
+      _s(item => {
+        _s();
+    
+        useFoo();
+      }, "useFoo{}", true)(item);
+    }
 "#
 );

--- a/ecmascript/transforms/react/src/refresh/tests.rs
+++ b/ecmascript/transforms/react/src/refresh/tests.rs
@@ -1031,8 +1031,8 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
-        jsx: true,
+    ::swc_ecma_parser::Syntax::Typescript(::swc_ecma_parser::TsConfig {
+        tsx: true,
         ..Default::default()
     }),
     |t| {
@@ -1047,8 +1047,10 @@ test!(
     icnlude_hook_signature_in_commonjs,
     r#"
     import {useFancyState} from './hooks';
+    import useFoo from './foo'
     export default function App() {
       const bar = useFancyState();
+      const foo = useFoo()
       return <h1>{bar}</h1>;
     }
 "#,
@@ -1059,6 +1061,7 @@ test!(
       value: true
     });    
     var _hooks = require("./hooks");
+    var _foo = _interopRequireDefault(require("./foo"));
     
     var _s = $RefreshSig$();
     
@@ -1066,12 +1069,13 @@ test!(
       _s();
     
       const bar = _hooks.useFancyState();
+      const foo = _foo.default();
       return <h1>{bar}</h1>;
     }
     exports.default = App;
     
-    _s(App, "useFancyState{bar}", false, function () {
-      return [_hooks.useFancyState];
+    _s(App, "useFancyState{bar}\nuseFoo{foo}", false, function () {
+      return [_hooks.useFancyState, _foo.default];
     });
     
     _c = App;
@@ -1143,8 +1147,8 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
-        jsx: true,
+    ::swc_ecma_parser::Syntax::Typescript(::swc_ecma_parser::TsConfig {
+        tsx: true,
         dynamic_import: true,
         ..Default::default()
     }),
@@ -1155,6 +1159,7 @@ test!(
     const B = foo ? require('X') : require('Y');
     const C = requireCond(gk, 'C');
     const D = import('D');
+    import E = require('E');
     export default function App() {
       return (
         <div>
@@ -1162,22 +1167,24 @@ test!(
           <B />
           <C />
           <D />
+          <E />
         </div>
       );
     }
 "#,
     r#"
     const A = require('A');
-
     const B = foo ? require('X') : require('Y');
     const C = requireCond(gk, 'C');
     const D = import('D');
+    import E = require('E');
     export default function App() {
       return <div>
           <A />
           <B />
           <C />
           <D />
+          <E />
         </div>;
     }
     _c = App;

--- a/ecmascript/transforms/react/src/refresh/util.rs
+++ b/ecmascript/transforms/react/src/refresh/util.rs
@@ -203,7 +203,7 @@ pub fn is_import_or_require(expr: &Expr) -> bool {
 pub fn callee_should_ignore<'a>(
     ignore: &'a HashSet<Ident>,
     callee: &ExprOrSuper,
-) -> Option<&'a Ident> {
+) -> Option<ExprOrSuper> {
     let expr = if let ExprOrSuper::Expr(expr) = callee {
         Some(expr)
     } else {
@@ -214,7 +214,9 @@ pub fn callee_should_ignore<'a>(
     } else {
         None
     }?;
-    ignore.get(ident)
+    ignore
+        .get(ident)
+        .map(|ident| ExprOrSuper::Expr(Box::new(Expr::Ident(ident.clone()))))
 }
 
 pub fn gen_custom_hook_record(elems: Vec<Option<ExprOrSpread>>) -> Expr {


### PR DESCRIPTION
Add config for react refresh. This feature is disabled by default since it's considered experimental.

I don't quite know how to write doc for swc so it would be great if you could do that for me. Config should be something like 
```json
{
  "refresh": true
}
```
or
```
{
  "refresh": {
    "emitFullSignatures": true
  }
}
```
Also this pr would require version 0.10 of `react-refresh` as a dependency to work