### PR TITLE
Fix named function expression handling in resolver

### DIFF
--- a/ecmascript/transforms/base/src/resolver/mod.rs
+++ b/ecmascript/transforms/base/src/resolver/mod.rs
@@ -511,12 +511,23 @@ impl<'a> VisitMut for Resolver<'a> {
     }
 
     fn visit_mut_class_expr(&mut self, n: &mut ClassExpr) {
-        let old = self.ident_type;
-        self.ident_type = IdentType::Binding;
-        n.ident.visit_mut_with(self);
-        self.ident_type = old;
+        // Create a child scope. The class name is only accessible within the class.
+        let child_mark = Mark::fresh(self.mark);
 
-        n.class.visit_mut_with(self);
+        let mut folder = Resolver::new(
+            child_mark,
+            Scope::new(ScopeKind::Fn, Some(&self.current)),
+            self.cur_defining.take(),
+            self.handle_types,
+        );
+
+        folder.ident_type = IdentType::Binding;
+        n.ident.visit_mut_with(&mut folder);
+        folder.ident_type = IdentType::Ref;
+
+        n.class.visit_mut_with(&mut folder);
+
+        self.cur_defining = folder.cur_defining;
     }
 
     fn visit_mut_class_method(&mut self, m: &mut ClassMethod) {
@@ -629,6 +640,36 @@ impl<'a> VisitMut for Resolver<'a> {
         e.function.visit_mut_with(&mut folder);
 
         self.cur_defining = folder.cur_defining;
+    }
+
+    fn visit_mut_export_default_decl(&mut self, e: &mut ExportDefaultDecl) {
+        // Treat default exported functions and classes as declarations
+        // even though they are parsed as expressions.
+        match &mut e.decl {
+            DefaultDecl::Fn(f) => {
+                if let Some(ident) = &f.ident {
+                    let child_mark = Mark::fresh(self.mark);
+
+                    // Child folder
+                    let mut folder = Resolver::new(
+                        child_mark,
+                        Scope::new(ScopeKind::Fn, Some(&self.current)),
+                        None,
+                        self.handle_types,
+                    );
+                    folder.cur_defining =
+                        Some((ident.sym.clone(), ident.span.ctxt().remove_mark()));
+                    f.function.visit_mut_with(&mut folder)
+                } else {
+                    f.visit_mut_with(self)
+                }
+            }
+            DefaultDecl::Class(c) => {
+                // Skip class expression visitor to treat as a declaration.
+                c.class.visit_mut_with(self)
+            }
+            _ => e.visit_mut_children_with(self),
+        }
     }
 
     fn visit_mut_for_in_stmt(&mut self, n: &mut ForInStmt) {
@@ -1361,5 +1402,33 @@ impl VisitMut for Hoister<'_, '_> {
         self.in_block = true;
         n.visit_mut_children_with(self);
         self.in_block = old_in_block;
+    }
+
+    fn visit_mut_export_default_decl(&mut self, node: &mut ExportDefaultDecl) {
+        // Treat default exported functions and classes as declarations
+        // even though they are parsed as expressions.
+        match &mut node.decl {
+            DefaultDecl::Fn(f) => {
+                if let Some(id) = &mut f.ident {
+                    self.resolver.in_type = false;
+                    self.resolver
+                        .visit_mut_binding_ident(id, Some(VarDeclKind::Var));
+                }
+
+                f.visit_mut_with(self)
+            }
+            DefaultDecl::Class(c) => {
+                if let Some(id) = &mut c.ident {
+                    self.resolver.in_type = false;
+                    self.resolver
+                        .visit_mut_binding_ident(id, Some(VarDeclKind::Let));
+                }
+
+                c.visit_mut_with(self)
+            }
+            _ => {
+                node.visit_mut_children_with(self);
+            }
+        }
     }
 }

--- a/ecmascript/transforms/base/src/resolver/mod.rs
+++ b/ecmascript/transforms/base/src/resolver/mod.rs
@@ -614,10 +614,6 @@ impl<'a> VisitMut for Resolver<'a> {
     }
 
     fn visit_mut_fn_expr(&mut self, e: &mut FnExpr) {
-        if let Some(ident) = &mut e.ident {
-            self.visit_mut_binding_ident(ident, None)
-        }
-
         let child_mark = Mark::fresh(self.mark);
 
         // Child folder
@@ -627,6 +623,9 @@ impl<'a> VisitMut for Resolver<'a> {
             self.cur_defining.take(),
             self.handle_types,
         );
+        if let Some(ident) = &mut e.ident {
+            folder.visit_mut_binding_ident(ident, None)
+        }
         e.function.visit_mut_with(&mut folder);
 
         self.cur_defining = folder.cur_defining;

--- a/ecmascript/transforms/base/src/resolver/tests.rs
+++ b/ecmascript/transforms/base/src/resolver/tests.rs
@@ -760,7 +760,7 @@ identical_no_block!(
 
 identical_no_block!(
     issue_292_2,
-    "__assign = Object.assign || function __assign(t) {
+    "__assign = Object.assign || function __assign1(t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
       s = arguments[i];
 
@@ -2181,7 +2181,7 @@ to_ts!(
     var x338 = (n__2: {
         (): Base[];
     })=>n__2;
-    x338(function named() {
+    x338(function named__3() {
         return [
             d1,
             d2
@@ -2423,4 +2423,44 @@ to_ts!(
         get [`hello ${a} bye`]() { return 0; }
     }
     "
+);
+
+to!(
+    fn_expr_scope,
+    r#"
+    test(function foo() {
+        foo = function foo(x) {
+            return x === 0 ? 1 : 1 + foo(x - 1);
+        };
+        return foo(10);
+    });
+    "#,
+    r#"
+    test(function foo() {
+        foo = function foo1(x) {
+            return x === 0 ? 1 : 1 + foo1(x - 1);
+        };
+        return foo(10);
+    });
+    "#
+);
+
+to!(
+    export_default_fn_decl_scope,
+    r#"
+    export default function foo() {
+        foo = function foo(x) {
+            return x === 0 ? 1 : 1 + foo(x - 1);
+        };
+        return foo(10);
+    }
+    "#,
+    r#"
+    export default function foo() {
+        foo = function foo1(x) {
+            return x === 0 ? 1 : 1 + foo1(x - 1);
+        };
+        return foo(10);
+    }
+    "#
 );

--- a/ecmascript/transforms/base/src/resolver/tests.rs
+++ b/ecmascript/transforms/base/src/resolver/tests.rs
@@ -2446,6 +2446,28 @@ to!(
 );
 
 to!(
+    class_expr_scope,
+    r#"
+    let Test = 2;
+    test(class Test {
+        hi() {
+            console.log(Test);
+        }
+    });
+    Test = 4;
+    "#,
+    r#"
+    let Test = 2;
+    test(class Test1 {
+        hi() {
+            console.log(Test1);
+        }
+    });
+    Test = 4;
+    "#
+);
+
+to!(
     export_default_fn_decl_scope,
     r#"
     export default function foo() {
@@ -2454,13 +2476,40 @@ to!(
         };
         return foo(10);
     }
+
+    foo = 2;
     "#,
     r#"
     export default function foo() {
-        foo = function foo1(x) {
-            return x === 0 ? 1 : 1 + foo1(x - 1);
+        foo = function foo(x) {
+            return x === 0 ? 1 : 1 + foo(x - 1);
         };
         return foo(10);
     }
+
+    foo = 2;
+    "#
+);
+to!(
+    export_default_class_decl_scope,
+    r#"
+    export default class Test {
+        hi() {
+            let Test = 2;
+            console.log(Test);
+        }
+    }
+
+    Test = 2;
+    "#,
+    r#"
+    export default class Test {
+        hi() {
+            let Test1 = 2;
+            console.log(Test1);
+        }
+    }
+
+    Test = 2;
     "#
 );

--- a/ecmascript/transforms/optimization/tests/simplify_inlining.rs
+++ b/ecmascript/transforms/optimization/tests/simplify_inlining.rs
@@ -1106,7 +1106,7 @@ fn test_inline_function_declaration() {
 fn test_recursive_function1() {
     test(
         "var x = 0; (function x() { return x ? x() : 3; })();",
-        "var x; (function x1() { return x1 ? x1() : 3; })();"
+        "var x; (function x1() { return x1 ? x1() : 3; })();",
     );
 }
 

--- a/ecmascript/transforms/optimization/tests/simplify_inlining.rs
+++ b/ecmascript/transforms/optimization/tests/simplify_inlining.rs
@@ -1104,7 +1104,10 @@ fn test_inline_function_declaration() {
 
 #[test]
 fn test_recursive_function1() {
-    test_same("var x = 0; (function x() { return x ? x() : 3; })();");
+    test(
+        "var x = 0; (function x() { return x ? x() : 3; })();",
+        "var x; (function x1() { return x1 ? x1() : 3; })();"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Code like the following was broken, because the function expression name was added to the outer scope rather than the inner scope.

```js
export default function foo() {
    foo = function foo(x) {
        return x === 0 ? 1 : 1 + foo(x - 1);
    };
    return foo(10);
}
```

resulted in

```js
export default function foo() {
    foo = function foo1(x) {
        return x === 0 ? 1 : 1 + foo1(x - 1);
    };
    return foo1(10); // <- this is wrong
};
```

Fixed by applying the function expression name to the inner scope instead.

(As a side note, I found it weird that `export default function foo() {}` parses as an `FnExpr` instead of a `FnDecl`. Same with classes. Babel parses them as declarations rather than expressions. Is this intentional?)