### PR TITLE
Fix wrong VariableDeclarationKind typescript definition

### DIFF
--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -805,7 +805,7 @@ export interface ObjectExpression extends ExpressionBase {
 }
 
 export interface Argument {
-  spread: Span;
+  spread?: Span;
   expression: Expression;
 }
 

--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -728,7 +728,7 @@ export interface VariableDeclaration extends Node, HasSpan {
   declarations: VariableDeclarator[];
 }
 
-export type VariableDeclarationKind = "get" | "let" | "const";
+export type VariableDeclarationKind = "var" | "let" | "const";
 
 export interface VariableDeclarator extends Node, HasSpan {
   type: "VariableDeclarator";


### PR DESCRIPTION
```ts
export type VariableDeclarationKind = "get" | "let" | "const";
```
obviously should be
```ts
export type VariableDeclarationKind = "var" | "let" | "const";
```