### PR TITLE
fix(es): fix error message with TS1173

### DIFF
--- a/ecmascript/parser/src/error.rs
+++ b/ecmascript/parser/src/error.rs
@@ -203,6 +203,7 @@ pub enum SyntaxError {
     TS1164,
     TS1171,
     TS1172,
+    TS1173,
     TS1174,
     TS1175,
     TS1183,
@@ -499,6 +500,7 @@ impl SyntaxError {
                 "A comma expression is not allowed in a computed property name".into()
             }
             SyntaxError::TS1172 => "`extends` clause already seen.".into(),
+            SyntaxError::TS1173 => "'extends' clause must precede 'implements' clause.".into(),
             SyntaxError::TS1174 => "Classes can only extend a single class".into(),
             SyntaxError::TS1175 => "`implements` clause already seen".into(),
             SyntaxError::TS1183 => {

--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -139,9 +139,9 @@ impl<'a, I: Tokens> Parser<I> {
                 }
             }
 
-            // Handle TS1175
+            // Handle TS1173
             if p.input.syntax().typescript() && eat!(p, "extends") {
-                p.emit_err(p.input.prev_span(), SyntaxError::TS1175);
+                p.emit_err(p.input.prev_span(), SyntaxError::TS1173);
 
                 let sc = p.parse_lhs_expr()?;
                 let type_params = if p.input.syntax().typescript() && is!(p, '<') {

--- a/ecmascript/parser/tests/typescript-errors/class/implements-before-extends/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/class/implements-before-extends/input.ts
@@ -1,0 +1,1 @@
+class C implements A extends B {}

--- a/ecmascript/parser/tests/typescript-errors/class/implements-before-extends/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/class/implements-before-extends/input.ts.stderr
@@ -1,0 +1,6 @@
+error: 'extends' clause must precede 'implements' clause.
+ --> $DIR/tests/typescript-errors/class/implements-before-extends/input.ts:1:22
+  |
+1 | class C implements A extends B {}
+  |                      ^^^^^^^
+


### PR DESCRIPTION
For this case:

```ts
class C implements A extends B {}
```

It should be TS1173, not TS1175.