### PR TITLE
fix(es): disallow `override` in non-subclass

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ sourcemap = "6"
 swc_atoms = {version = "0.2", path = "./atoms"}
 swc_common = {version = "0.10.10", path = "./common", features = ["sourcemap", "concurrent"]}
 swc_ecma_ast = {version = "0.43.0", path = "./ecmascript/ast"}
-swc_ecma_codegen = {version = "0.51.0", path = "./ecmascript/codegen"}
-swc_ecma_ext_transforms = {version = "0.11.0", path = "./ecmascript/ext-transforms"}
-swc_ecma_parser = {version = "0.53.0", path = "./ecmascript/parser"}
-swc_ecma_preset_env = {version = "0.14.0", path = "./ecmascript/preset_env"}
-swc_ecma_transforms = {version = "0.44.0", path = "./ecmascript/transforms", features = [
+swc_ecma_codegen = {version = "0.52.0", path = "./ecmascript/codegen"}
+swc_ecma_ext_transforms = {version = "0.12.0", path = "./ecmascript/ext-transforms"}
+swc_ecma_parser = {version = "0.54.0", path = "./ecmascript/parser"}
+swc_ecma_preset_env = {version = "0.15.0", path = "./ecmascript/preset_env"}
+swc_ecma_transforms = {version = "0.45.0", path = "./ecmascript/transforms", features = [
   "compat",
   "module",
   "optimization",

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -9,7 +9,7 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/**/*.js"]
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.31.0"
+version = "0.32.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -33,9 +33,9 @@ retain_mut = "0.1.2"
 swc_atoms = {version = "0.2.4", path = "../atoms"}
 swc_common = {version = "0.10.10", path = "../common"}
 swc_ecma_ast = {version = "0.43.0", path = "../ecmascript/ast"}
-swc_ecma_codegen = {version = "0.51.0", path = "../ecmascript/codegen"}
-swc_ecma_parser = {version = "0.53.0", path = "../ecmascript/parser"}
-swc_ecma_transforms = {version = "0.44.0", path = "../ecmascript/transforms", features = ["optimization"]}
+swc_ecma_codegen = {version = "0.52.0", path = "../ecmascript/codegen"}
+swc_ecma_parser = {version = "0.54.0", path = "../ecmascript/parser"}
+swc_ecma_transforms = {version = "0.45.0", path = "../ecmascript/transforms", features = ["optimization"]}
 swc_ecma_utils = {version = "0.34.0", path = "../ecmascript/utils"}
 swc_ecma_visit = {version = "0.29.0", path = "../ecmascript/visit"}
 
@@ -44,7 +44,7 @@ hex = "0.4"
 ntest = "0.7.2"
 reqwest = {version = "0.10.8", features = ["blocking"]}
 sha-1 = "0.9"
-swc_ecma_transforms = {version = "0.44.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
+swc_ecma_transforms = {version = "0.45.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
 tempfile = "3.1.0"
 testing = {version = "0.10.3", path = "../testing"}
 url = "2.1.1"

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.30.0"
+version = "0.31.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -28,10 +28,10 @@ typescript = ["swc_ecma_transforms/typescript"]
 
 [dependencies]
 swc_ecma_ast = {version = "0.43.0", path = "./ast"}
-swc_ecma_codegen = {version = "0.51.0", path = "./codegen", optional = true}
-swc_ecma_dep_graph = {version = "0.21.0", path = "./dep-graph", optional = true}
-swc_ecma_parser = {version = "0.53.0", path = "./parser", optional = true}
-swc_ecma_transforms = {version = "0.44.0", path = "./transforms", optional = true}
+swc_ecma_codegen = {version = "0.52.0", path = "./codegen", optional = true}
+swc_ecma_dep_graph = {version = "0.22.0", path = "./dep-graph", optional = true}
+swc_ecma_parser = {version = "0.54.0", path = "./parser", optional = true}
+swc_ecma_transforms = {version = "0.45.0", path = "./transforms", optional = true}
 swc_ecma_utils = {version = "0.34.0", path = "./utils", optional = true}
 swc_ecma_visit = {version = "0.29.0", path = "./visit", optional = true}
 

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.51.0"
+version = "0.52.0"
 
 [dependencies]
 bitflags = "1"
@@ -17,7 +17,7 @@ swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.10", path = "../../common"}
 swc_ecma_ast = {version = "0.43.0", path = "../ast"}
 swc_ecma_codegen_macros = {version = "0.5.2", path = "./macros"}
-swc_ecma_parser = {version = "0.53.0", path = "../parser"}
+swc_ecma_parser = {version = "0.54.0", path = "../parser"}
 
 [dev-dependencies]
 swc_common = {version = "0.10.10", path = "../../common", features = ["sourcemap"]}

--- a/ecmascript/dep-graph/Cargo.toml
+++ b/ecmascript/dep-graph/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_dep_graph"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.21.0"
+version = "0.22.0"
 
 [dependencies]
 swc_atoms = {version = "0.2", path = "../../atoms"}
@@ -15,5 +15,5 @@ swc_ecma_ast = {version = "0.43.0", path = "../ast"}
 swc_ecma_visit = {version = "0.29.0", path = "../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.53.0", path = "../parser"}
+swc_ecma_parser = {version = "0.54.0", path = "../parser"}
 testing = {version = "0.10.3", path = "../../testing"}

--- a/ecmascript/ext-transforms/Cargo.toml
+++ b/ecmascript/ext-transforms/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_ext_transforms/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ext_transforms"
-version = "0.11.0"
+version = "0.12.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,6 +14,6 @@ phf = {version = "0.8.0", features = ["macros"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.10", path = "../../common"}
 swc_ecma_ast = {version = "0.43.0", path = "../ast"}
-swc_ecma_parser = {version = "0.53.0", path = "../parser"}
+swc_ecma_parser = {version = "0.54.0", path = "../parser"}
 swc_ecma_utils = {version = "0.34.0", path = "../utils"}
 swc_ecma_visit = {version = "0.29.0", path = "../visit"}

--- a/ecmascript/jsdoc/Cargo.toml
+++ b/ecmascript/jsdoc/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/jsdoc/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "jsdoc"
-version = "0.21.0"
+version = "0.22.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -19,6 +19,6 @@ swc_common = {version = "0.10.10", path = "../../common"}
 anyhow = "1"
 dashmap = "3"
 swc_ecma_ast = {version = "0.43.0", path = "../ast"}
-swc_ecma_parser = {version = "0.53.0", path = "../parser"}
+swc_ecma_parser = {version = "0.54.0", path = "../parser"}
 testing = {version = "0.10.3", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.53.0"
+version = "0.54.0"
 
 [features]
 default = []

--- a/ecmascript/parser/src/error.rs
+++ b/ecmascript/parser/src/error.rs
@@ -221,6 +221,7 @@ pub enum SyntaxError {
     TS2483,
     TS2491,
     TS2703,
+    TS4112,
     TSTypeAnnotationAfterAssign,
 }
 
@@ -537,6 +538,9 @@ impl SyntaxError {
             }
             SyntaxError::TS2491 => "The left-hand side of a 'for...in' statement cannot be a \
                                     destructuring pattern"
+                .into(),
+            SyntaxError::TS4112 => "This member cannot have an 'override' modifier because its \
+                                    containing class does not extend another class."
                 .into(),
             SyntaxError::TSTypeAnnotationAfterAssign => {
                 "Type annotations must come before default assignments".into()

--- a/ecmascript/parser/src/lib.rs
+++ b/ecmascript/parser/src/lib.rs
@@ -402,6 +402,7 @@ pub struct Context {
 
     in_parameters: bool,
 
+    has_super_class: bool,
     in_method: bool,
     in_class_prop: bool,
 

--- a/ecmascript/parser/tests/typescript-errors/class/duplicated-modifiers/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/class/duplicated-modifiers/input.ts
@@ -1,4 +1,4 @@
-class C {
+class C extends B {
   readonly readonly size = 0;
   abstract abstract t() {}
   override override e() {}

--- a/ecmascript/parser/tests/typescript-errors/class/override-in-non-subclass/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/class/override-in-non-subclass/input.ts
@@ -1,0 +1,11 @@
+class A {
+  override t() {}
+}
+
+class B extends C {
+  m() {
+    class D {
+      override k() {}
+    }
+  }
+}

--- a/ecmascript/parser/tests/typescript-errors/class/override-in-non-subclass/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/class/override-in-non-subclass/input.ts.stderr
@@ -1,0 +1,12 @@
+error: This member cannot have an 'override' modifier because its containing class does not extend another class.
+ --> $DIR/tests/typescript-errors/class/override-in-non-subclass/input.ts:2:3
+  |
+2 |   override t() {}
+  |   ^^^^^^^^
+
+error: This member cannot have an 'override' modifier because its containing class does not extend another class.
+ --> $DIR/tests/typescript-errors/class/override-in-non-subclass/input.ts:8:7
+  |
+8 |       override k() {}
+  |       ^^^^^^^^
+

--- a/ecmascript/parser/tests/typescript-errors/class/override-on-constructor/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/class/override-on-constructor/input.ts
@@ -1,3 +1,3 @@
-class C {
+class C extends B {
   override constructor() {}
 }

--- a/ecmascript/parser/tests/typescript-errors/class/override-with-static/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/class/override-with-static/input.ts
@@ -1,3 +1,3 @@
-class C {
+class C extends B {
   static override t() {}
 }

--- a/ecmascript/preset_env/Cargo.toml
+++ b/ecmascript/preset_env/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_preset_env/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_preset_env"
-version = "0.14.0"
+version = "0.15.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,13 +21,13 @@ string_enum = {version = "0.3.1", path = "../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.10", path = "../../common"}
 swc_ecma_ast = {version = "0.43.0", path = "../ast"}
-swc_ecma_transforms = {version = "0.44.0", path = "../transforms", features = ["compat", "proposal"]}
+swc_ecma_transforms = {version = "0.45.0", path = "../transforms", features = ["compat", "proposal"]}
 swc_ecma_utils = {version = "0.34.0", path = "../utils"}
 swc_ecma_visit = {version = "0.29.0", path = "../visit"}
 walkdir = "2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
-swc_ecma_codegen = {version = "0.51.0", path = "../codegen"}
-swc_ecma_parser = {version = "0.53.0", path = "../parser"}
+swc_ecma_codegen = {version = "0.52.0", path = "../codegen"}
+swc_ecma_parser = {version = "0.54.0", path = "../parser"}
 testing = {version = "0.10.3", path = "../../testing"}

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.44.0"
+version = "0.45.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -24,14 +24,14 @@ typescript = ["swc_ecma_transforms_typescript"]
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.10.10", path = "../../common"}
 swc_ecma_ast = {version = "0.43.0", path = "../ast"}
-swc_ecma_parser = {version = "0.53.0", path = "../parser"}
-swc_ecma_transforms_base = {version = "0.11.0", path = "./base"}
-swc_ecma_transforms_compat = {version = "0.12.0", path = "./compat", optional = true}
-swc_ecma_transforms_module = {version = "0.12.0", path = "./module", optional = true}
-swc_ecma_transforms_optimization = {version = "0.14.0", path = "./optimization", optional = true}
-swc_ecma_transforms_proposal = {version = "0.12.0", path = "./proposal", optional = true}
-swc_ecma_transforms_react = {version = "0.13.0", path = "./react", optional = true}
-swc_ecma_transforms_typescript = {version = "0.13.0", path = "./typescript", optional = true}
+swc_ecma_parser = {version = "0.54.0", path = "../parser"}
+swc_ecma_transforms_base = {version = "0.12.0", path = "./base"}
+swc_ecma_transforms_compat = {version = "0.13.0", path = "./compat", optional = true}
+swc_ecma_transforms_module = {version = "0.13.0", path = "./module", optional = true}
+swc_ecma_transforms_optimization = {version = "0.15.0", path = "./optimization", optional = true}
+swc_ecma_transforms_proposal = {version = "0.13.0", path = "./proposal", optional = true}
+swc_ecma_transforms_react = {version = "0.14.0", path = "./react", optional = true}
+swc_ecma_transforms_typescript = {version = "0.14.0", path = "./typescript", optional = true}
 swc_ecma_utils = {version = "0.34.0", path = "../utils"}
 swc_ecma_visit = {version = "0.29.0", path = "../visit"}
 unicode-xid = "0.2"
@@ -39,8 +39,8 @@ unicode-xid = "0.2"
 [dev-dependencies]
 pretty_assertions = "0.6"
 sourcemap = "6"
-swc_ecma_codegen = {version = "0.51.0", path = "../codegen"}
-swc_ecma_transforms_testing = {version = "0.11.0", path = "./testing"}
+swc_ecma_codegen = {version = "0.52.0", path = "../codegen"}
+swc_ecma_transforms_testing = {version = "0.12.0", path = "./testing"}
 tempfile = "3"
 testing = {version = "0.10.3", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.11.0"
+version = "0.12.0"
 
 [dependencies]
 fxhash = "0.2.1"
@@ -17,10 +17,10 @@ smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.53.0", path = "../../parser"}
+swc_ecma_parser = {version = "0.54.0", path = "../../parser"}
 swc_ecma_utils = {version = "0.34.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.51.0", path = "../../codegen"}
+swc_ecma_codegen = {version = "0.52.0", path = "../../codegen"}
 testing = {version = "0.10.3", path = "../../../testing"}

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.12.0"
+version = "0.13.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -21,12 +21,12 @@ smallvec = "1.6.0"
 swc_atoms = {version = "0.2.5", path = "../../../atoms"}
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.0", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.11.0", path = "../base"}
+swc_ecma_transforms_base = {version = "0.12.0", path = "../base"}
 swc_ecma_transforms_macros = {version = "0.2.1", path = "../macros"}
 swc_ecma_utils = {version = "0.34.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.53.0", path = "../../parser"}
-swc_ecma_transforms_testing = {version = "0.11.0", path = "../testing"}
+swc_ecma_parser = {version = "0.54.0", path = "../../parser"}
+swc_ecma_transforms_testing = {version = "0.12.0", path = "../testing"}
 testing = {version = "0.10.3", path = "../../../testing"}

--- a/ecmascript/transforms/module/Cargo.toml
+++ b/ecmascript/transforms/module/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.12.0"
+version = "0.13.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -17,12 +17,12 @@ serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.53.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.11.0", path = "../base"}
+swc_ecma_parser = {version = "0.54.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.12.0", path = "../base"}
 swc_ecma_utils = {version = "0.34.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.12.0", path = "../compat"}
-swc_ecma_transforms_testing = {version = "0.11.0", path = "../testing/"}
+swc_ecma_transforms_compat = {version = "0.13.0", path = "../compat"}
+swc_ecma_transforms_testing = {version = "0.12.0", path = "../testing/"}
 testing = {version = "0.10.3", path = "../../../testing/"}

--- a/ecmascript/transforms/optimization/Cargo.toml
+++ b/ecmascript/transforms/optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.14.0"
+version = "0.15.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -20,16 +20,16 @@ serde_json = "1.0.61"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.53.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.11.0", path = "../base"}
+swc_ecma_parser = {version = "0.54.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.12.0", path = "../base"}
 swc_ecma_utils = {version = "0.34.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.12.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.12.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.12.0", path = "../proposal"}
-swc_ecma_transforms_react = {version = "0.13.0", path = "../react"}
-swc_ecma_transforms_testing = {version = "0.11.0", path = "../testing"}
-swc_ecma_transforms_typescript = {version = "0.13.0", path = "../typescript"}
+swc_ecma_transforms_compat = {version = "0.13.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.13.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.13.0", path = "../proposal"}
+swc_ecma_transforms_react = {version = "0.14.0", path = "../react"}
+swc_ecma_transforms_testing = {version = "0.12.0", path = "../testing"}
+swc_ecma_transforms_typescript = {version = "0.14.0", path = "../typescript"}
 testing = {version = "0.10.0", path = "../../../testing"}

--- a/ecmascript/transforms/proposal/Cargo.toml
+++ b/ecmascript/transforms/proposal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_proposal"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.12.0"
+version = "0.13.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -23,12 +23,12 @@ swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.0", path = "../../ast"}
 swc_ecma_loader = {version = "0.4.0", path = "../../loader", optional = true}
-swc_ecma_parser = {version = "0.53.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.11.0", path = "../base"}
+swc_ecma_parser = {version = "0.54.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.12.0", path = "../base"}
 swc_ecma_utils = {version = "0.34.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.12.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.12.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.11.0", path = "../testing"}
+swc_ecma_transforms_compat = {version = "0.13.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.13.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.12.0", path = "../testing"}

--- a/ecmascript/transforms/react/Cargo.toml
+++ b/ecmascript/transforms/react/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_react"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.13.0"
+version = "0.14.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -22,13 +22,13 @@ string_enum = {version = "0.3.1", path = "../../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.53.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.11.0", path = "../base"}
+swc_ecma_parser = {version = "0.54.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.12.0", path = "../base"}
 swc_ecma_utils = {version = "0.34.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.12.0", path = "../compat/"}
-swc_ecma_transforms_module = {version = "0.12.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.11.0", path = "../testing/"}
+swc_ecma_transforms_compat = {version = "0.13.0", path = "../compat/"}
+swc_ecma_transforms_module = {version = "0.13.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.12.0", path = "../testing/"}
 testing = {version = "0.10.3", path = "../../../testing"}

--- a/ecmascript/transforms/testing/Cargo.toml
+++ b/ecmascript/transforms/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.11.0"
+version = "0.12.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,9 +16,9 @@ serde = "1"
 serde_json = "1"
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.0", path = "../../ast"}
-swc_ecma_codegen = {version = "0.51.0", path = "../../codegen"}
-swc_ecma_parser = {version = "0.53.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.11.0", path = "../base"}
+swc_ecma_codegen = {version = "0.52.0", path = "../../codegen"}
+swc_ecma_parser = {version = "0.54.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.12.0", path = "../base"}
 swc_ecma_utils = {version = "0.34.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.0", path = "../../visit"}
 tempfile = "3.1.0"

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.13.0"
+version = "0.14.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -15,16 +15,16 @@ serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.10", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.53.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.11.0", path = "../base"}
+swc_ecma_parser = {version = "0.54.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.12.0", path = "../base"}
 swc_ecma_utils = {version = "0.34.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.51.0", path = "../../codegen"}
-swc_ecma_transforms_compat = {version = "0.12.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.12.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.12.0", path = "../proposal/"}
-swc_ecma_transforms_testing = {version = "0.11.0", path = "../testing"}
+swc_ecma_codegen = {version = "0.52.0", path = "../../codegen"}
+swc_ecma_transforms_compat = {version = "0.13.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.13.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.13.0", path = "../proposal/"}
+swc_ecma_transforms_testing = {version = "0.12.0", path = "../testing"}
 testing = {version = "0.10.3", path = "../../../testing"}
 walkdir = "2.3.1"


### PR DESCRIPTION
With this PR, the code below will be invalid:

```ts
class C {
  override t() {}
}
```