### PR TITLE
Fix parenthesization of sequence expressions in callee and function params

### DIFF
--- a/bundler/tests/fixture/deno-9212/case1/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-9212/case1/output/entry.inlined.ts
@@ -1143,7 +1143,7 @@ var ia = Bn((re1)=>{
     }(function(e, n) {
         if (e.namespaceURI !== Nl.svg || "innerHTML" in e) e.innerHTML = n;
         else {
-            for((qt = qt || document.createElement("div"), qt.innerHTML = "<svg>" + n.valueOf().toString() + "</svg>", n = qt.firstChild); e.firstChild;)e.removeChild(e.firstChild);
+            for(qt = qt || document.createElement("div"), qt.innerHTML = "<svg>" + n.valueOf().toString() + "</svg>", n = qt.firstChild; e.firstChild;)e.removeChild(e.firstChild);
             for(; n.firstChild;)e.appendChild(n.firstChild);
         }
     });
@@ -2464,7 +2464,7 @@ var ia = Bn((re1)=>{
                     for(var f = d, p; f !== null;){
                         p = f;
                         var m = p.stateNode;
-                        if ((p.tag === 5 && m !== null && (p = m, a !== null && (m = et(f, a), m != null && S.push(vt(f, m, p)))), c)) break;
+                        if (p.tag === 5 && m !== null && (p = m, a !== null && (m = et(f, a), m != null && S.push(vt(f, m, p)))), c) break;
                         f = f.return;
                     }
                     0 < S.length && (h = new k(h, E, null, t, y), _1.push({
@@ -2475,11 +2475,11 @@ var ia = Bn((re1)=>{
             }
             if ((n & 7) == 0) {
                 e: {
-                    if ((h = e === "mouseover" || e === "pointerover", k = e === "mouseout" || e === "pointerout", h && (n & 16) == 0 && (E = t.relatedTarget || t.fromElement) && (be2(E) || E[Cn]))) break e;
+                    if (h = e === "mouseover" || e === "pointerover", k = e === "mouseout" || e === "pointerout", h && (n & 16) == 0 && (E = t.relatedTarget || t.fromElement) && (be2(E) || E[Cn])) break e;
                     if ((k || h) && (h = y.window === y ? y : (h = y.ownerDocument) ? h.defaultView || h.parentWindow : window, k ? (E = t.relatedTarget || t.toElement, k = d, E = E ? be2(E) : null, E !== null && (c = qe1(E), E !== c || E.tag !== 5 && E.tag !== 6) && (E = null)) : (k = null, E = d), k !== E)) {
-                        if ((S = au, m = "onMouseLeave", a = "onMouseEnter", f = "mouse", (e === "pointerout" || e === "pointerover") && (S = cu, m = "onPointerLeave", a = "onPointerEnter", f = "pointer"), c = k == null ? h : En(k), p = E == null ? h : En(E), h = new S(m, f + "leave", k, t, y), h.target = c, h.relatedTarget = p, m = null, be2(y) === d && (S = new S(a, f + "enter", E, t, y), S.target = p, S.relatedTarget = c, m = S), c = m, k && E)) n: {
-                            for((S = k, a = E, f = 0, p = S); p; p = _n(p))f++;
-                            for((p = 0, m = a); m; m = _n(m))p++;
+                        if (S = au, m = "onMouseLeave", a = "onMouseEnter", f = "mouse", (e === "pointerout" || e === "pointerover") && (S = cu, m = "onPointerLeave", a = "onPointerEnter", f = "pointer"), c = k == null ? h : En(k), p = E == null ? h : En(E), h = new S(m, f + "leave", k, t, y), h.target = c, h.relatedTarget = p, m = null, be2(y) === d && (S = new S(a, f + "enter", E, t, y), S.target = p, S.relatedTarget = c, m = S), c = m, k && E) n: {
+                            for(S = k, a = E, f = 0, p = S; p; p = _n(p))f++;
+                            for(p = 0, m = a; m; m = _n(m))p++;
                             for(; 0 < f - p;)S = _n(S), f--;
                             for(; 0 < p - f;)a = _n(a), p--;
                             for(; f--;){
@@ -2493,7 +2493,7 @@ var ia = Bn((re1)=>{
                     }
                 }
                 e: {
-                    if ((h = d ? En(d) : window, k = h.nodeName && h.nodeName.toLowerCase(), k === "select" || k === "input" && h.type === "file")) var C = Lf;
+                    if (h = d ? En(d) : window, k = h.nodeName && h.nodeName.toLowerCase(), k === "select" || k === "input" && h.type === "file") var C = Lf;
                     else if (yu(h)) {
                         if (ku) C = Rf;
                         else {
@@ -2507,7 +2507,7 @@ var ia = Bn((re1)=>{
                     }
                     w && w(e, h, d), e === "focusout" && (w = h._wrapperState) && w.controlled && h.type === "number" && El(h, "number", h.value);
                 }
-                switch((w = d ? En(d) : window, e)){
+                switch(w = d ? En(d) : window, e){
                     case "focusin":
                         (yu(w) || w.contentEditable === "true") && (xn = w, ti = d, mt = null);
                         break;
@@ -3667,31 +3667,31 @@ var ia = Bn((re1)=>{
     }, Qf = {
         readContext: ie,
         useCallback: function(e, n) {
-            return (ln().memoizedState = [
+            return ln().memoizedState = [
                 e,
                 n === void 0 ? null : n
-            ], e);
+            ], e;
         },
         useContext: ie,
         useEffect: vs,
         useImperativeHandle: function(e, n, t) {
-            return (t = t != null ? t.concat([
+            return t = t != null ? t.concat([
                 e
-            ]) : null, zi(4, 2, gs.bind(null, n, e), t));
+            ]) : null, zi(4, 2, gs.bind(null, n, e), t);
         },
         useLayoutEffect: function(e, n) {
             return zi(4, 2, e, n);
         },
         useMemo: function(e, n) {
             var t = ln();
-            return (n = n === void 0 ? null : n, e = e(), t.memoizedState = [
+            return n = n === void 0 ? null : n, e = e(), t.memoizedState = [
                 e,
                 n
-            ], e);
+            ], e;
         },
         useReducer: function(e, n, t) {
             var r = ln();
-            return (n = t !== void 0 ? t(n) : n, r.memoizedState = r.baseState = n, e = r.queue = {
+            return n = t !== void 0 ? t(n) : n, r.memoizedState = r.baseState = n, e = r.queue = {
                 pending: null,
                 dispatch: null,
                 lastRenderedReducer: e,
@@ -3699,14 +3699,14 @@ var ia = Bn((re1)=>{
             }, e = e.dispatch = Oi.bind(null, D, e), [
                 r.memoizedState,
                 e
-            ]);
+            ];
         },
         useRef: hs,
         useState: Lt,
         useDebugValue: Ri,
         useDeferredValue: function(e) {
             var n = Lt(e), t = n[0], r = n[1];
-            return (vs(function() {
+            return vs(function() {
                 var l = ue.transition;
                 ue.transition = 1;
                 try {
@@ -3716,36 +3716,36 @@ var ia = Bn((re1)=>{
                 }
             }, [
                 e
-            ]), t);
+            ]), t;
         },
         useTransition: function() {
             var e = Lt(!1), n = e[0];
-            return (e = Xf.bind(null, e[1]), hs(e), [
+            return e = Xf.bind(null, e[1]), hs(e), [
                 e,
                 n
-            ]);
+            ];
         },
         useMutableSource: function(e, n, t) {
             var r = ln();
-            return (r.memoizedState = {
+            return r.memoizedState = {
                 refs: {
                     getSnapshot: n,
                     setSnapshot: null
                 },
                 source: e,
                 subscribe: t
-            }, ps(r, e, n, t));
+            }, ps(r, e, n, t);
         },
         useOpaqueIdentifier: function() {
             if (ve1) {
                 var e = !1, n = Uf(function() {
-                    throw (e || (e = !0, t("r:" + (ai++).toString(36))), Error(v(355)));
+                    throw e || (e = !0, t("r:" + (ai++).toString(36))), Error(v(355));
                 }), t = Lt(n)[1];
-                return ((D.mode & 2) == 0 && (D.flags |= 516, Dr(5, function() {
+                return (D.mode & 2) == 0 && (D.flags |= 516, Dr(5, function() {
                     t("r:" + (ai++).toString(36));
-                }, void 0, null)), n);
+                }, void 0, null)), n;
             }
-            return (n = "r:" + (ai++).toString(36), Lt(n), n);
+            return n = "r:" + (ai++).toString(36), Lt(n), n;
         },
         unstable_isNewReconciler: !1
     }, $f = {
@@ -3764,7 +3764,7 @@ var ia = Bn((re1)=>{
         useDebugValue: Ri,
         useDeferredValue: function(e) {
             var n = Pt(ye1), t = n[0], r = n[1];
-            return (Ur(function() {
+            return Ur(function() {
                 var l = ue.transition;
                 ue.transition = 1;
                 try {
@@ -3774,7 +3774,7 @@ var ia = Bn((re1)=>{
                 }
             }, [
                 e
-            ]), t);
+            ]), t;
         },
         useTransition: function() {
             var e = Pt(ye1)[0];
@@ -3804,7 +3804,7 @@ var ia = Bn((re1)=>{
         useDebugValue: Ri,
         useDeferredValue: function(e) {
             var n = Tt(ye1), t = n[0], r = n[1];
-            return (Ur(function() {
+            return Ur(function() {
                 var l = ue.transition;
                 ue.transition = 1;
                 try {
@@ -3814,7 +3814,7 @@ var ia = Bn((re1)=>{
                 }
             }, [
                 e
-            ]), t);
+            ]), t;
         },
         useTransition: function() {
             var e = Tt(ye1)[0];
@@ -5258,7 +5258,7 @@ var ia = Bn((re1)=>{
             Yr || jt === null || ((g1.flags & 8) != 0 ? $o(g1, jt) && (Yr = !0) : g1.tag === 13 && rc(e, g1) && $o(g1, jt) && (Yr = !0));
             var n = g1.flags;
             (n & 256) != 0 && bf(e, g1), (n & 512) == 0 || $e1 || ($e1 = !0, yt(97, function() {
-                return (Ye(), null);
+                return Ye(), null;
             })), g1 = g1.nextEffect;
         }
     }
@@ -5271,12 +5271,12 @@ var ia = Bn((re1)=>{
     }
     function ec(e, n) {
         eo.push(n, e), $e1 || ($e1 = !0, yt(97, function() {
-            return (Ye(), null);
+            return Ye(), null;
         }));
     }
     function Bs(e, n) {
         no.push(n, e), $e1 || ($e1 = !0, yt(97, function() {
-            return (Ye(), null);
+            return Ye(), null;
         }));
     }
     function cc() {

--- a/bundler/tests/fixture/deno-9212/case1/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-9212/case1/output/entry.inlined.ts
@@ -5820,7 +5820,7 @@ var ia = Bn((re1)=>{
         scheduleUpdate: null,
         currentDispatcherRef: Ge.ReactCurrentDispatcher,
         findHostInstanceByFiber: function(e) {
-            return (e = Qo(e), e === null ? null : e.stateNode);
+            return e = Qo(e), e === null ? null : e.stateNode;
         },
         findFiberByHostInstance: Ft.findFiberByHostInstance || vc,
         findHostInstancesForRefresh: null,

--- a/bundler/tests/fixture/deno-9212/case1/output/entry.ts
+++ b/bundler/tests/fixture/deno-9212/case1/output/entry.ts
@@ -1143,7 +1143,7 @@ var ia = Bn((re1)=>{
     }(function(e, n) {
         if (e.namespaceURI !== Nl.svg || "innerHTML" in e) e.innerHTML = n;
         else {
-            for((qt = qt || document.createElement("div"), qt.innerHTML = "<svg>" + n.valueOf().toString() + "</svg>", n = qt.firstChild); e.firstChild;)e.removeChild(e.firstChild);
+            for(qt = qt || document.createElement("div"), qt.innerHTML = "<svg>" + n.valueOf().toString() + "</svg>", n = qt.firstChild; e.firstChild;)e.removeChild(e.firstChild);
             for(; n.firstChild;)e.appendChild(n.firstChild);
         }
     });
@@ -2464,7 +2464,7 @@ var ia = Bn((re1)=>{
                     for(var f = d, p; f !== null;){
                         p = f;
                         var m = p.stateNode;
-                        if ((p.tag === 5 && m !== null && (p = m, a !== null && (m = et(f, a), m != null && S.push(vt(f, m, p)))), c)) break;
+                        if (p.tag === 5 && m !== null && (p = m, a !== null && (m = et(f, a), m != null && S.push(vt(f, m, p)))), c) break;
                         f = f.return;
                     }
                     0 < S.length && (h = new k(h, E, null, t, y), _1.push({
@@ -2475,11 +2475,11 @@ var ia = Bn((re1)=>{
             }
             if ((n & 7) == 0) {
                 e: {
-                    if ((h = e === "mouseover" || e === "pointerover", k = e === "mouseout" || e === "pointerout", h && (n & 16) == 0 && (E = t.relatedTarget || t.fromElement) && (be2(E) || E[Cn]))) break e;
+                    if (h = e === "mouseover" || e === "pointerover", k = e === "mouseout" || e === "pointerout", h && (n & 16) == 0 && (E = t.relatedTarget || t.fromElement) && (be2(E) || E[Cn])) break e;
                     if ((k || h) && (h = y.window === y ? y : (h = y.ownerDocument) ? h.defaultView || h.parentWindow : window, k ? (E = t.relatedTarget || t.toElement, k = d, E = E ? be2(E) : null, E !== null && (c = qe1(E), E !== c || E.tag !== 5 && E.tag !== 6) && (E = null)) : (k = null, E = d), k !== E)) {
-                        if ((S = au, m = "onMouseLeave", a = "onMouseEnter", f = "mouse", (e === "pointerout" || e === "pointerover") && (S = cu, m = "onPointerLeave", a = "onPointerEnter", f = "pointer"), c = k == null ? h : En(k), p = E == null ? h : En(E), h = new S(m, f + "leave", k, t, y), h.target = c, h.relatedTarget = p, m = null, be2(y) === d && (S = new S(a, f + "enter", E, t, y), S.target = p, S.relatedTarget = c, m = S), c = m, k && E)) n: {
-                            for((S = k, a = E, f = 0, p = S); p; p = _n(p))f++;
-                            for((p = 0, m = a); m; m = _n(m))p++;
+                        if (S = au, m = "onMouseLeave", a = "onMouseEnter", f = "mouse", (e === "pointerout" || e === "pointerover") && (S = cu, m = "onPointerLeave", a = "onPointerEnter", f = "pointer"), c = k == null ? h : En(k), p = E == null ? h : En(E), h = new S(m, f + "leave", k, t, y), h.target = c, h.relatedTarget = p, m = null, be2(y) === d && (S = new S(a, f + "enter", E, t, y), S.target = p, S.relatedTarget = c, m = S), c = m, k && E) n: {
+                            for(S = k, a = E, f = 0, p = S; p; p = _n(p))f++;
+                            for(p = 0, m = a; m; m = _n(m))p++;
                             for(; 0 < f - p;)S = _n(S), f--;
                             for(; 0 < p - f;)a = _n(a), p--;
                             for(; f--;){
@@ -2493,7 +2493,7 @@ var ia = Bn((re1)=>{
                     }
                 }
                 e: {
-                    if ((h = d ? En(d) : window, k = h.nodeName && h.nodeName.toLowerCase(), k === "select" || k === "input" && h.type === "file")) var C = Lf;
+                    if (h = d ? En(d) : window, k = h.nodeName && h.nodeName.toLowerCase(), k === "select" || k === "input" && h.type === "file") var C = Lf;
                     else if (yu(h)) {
                         if (ku) C = Rf;
                         else {
@@ -2507,7 +2507,7 @@ var ia = Bn((re1)=>{
                     }
                     w && w(e, h, d), e === "focusout" && (w = h._wrapperState) && w.controlled && h.type === "number" && El(h, "number", h.value);
                 }
-                switch((w = d ? En(d) : window, e)){
+                switch(w = d ? En(d) : window, e){
                     case "focusin":
                         (yu(w) || w.contentEditable === "true") && (xn = w, ti = d, mt = null);
                         break;
@@ -3667,31 +3667,31 @@ var ia = Bn((re1)=>{
     }, Qf = {
         readContext: ie,
         useCallback: function(e, n) {
-            return (ln().memoizedState = [
+            return ln().memoizedState = [
                 e,
                 n === void 0 ? null : n
-            ], e);
+            ], e;
         },
         useContext: ie,
         useEffect: vs,
         useImperativeHandle: function(e, n, t) {
-            return (t = t != null ? t.concat([
+            return t = t != null ? t.concat([
                 e
-            ]) : null, zi(4, 2, gs.bind(null, n, e), t));
+            ]) : null, zi(4, 2, gs.bind(null, n, e), t);
         },
         useLayoutEffect: function(e, n) {
             return zi(4, 2, e, n);
         },
         useMemo: function(e, n) {
             var t = ln();
-            return (n = n === void 0 ? null : n, e = e(), t.memoizedState = [
+            return n = n === void 0 ? null : n, e = e(), t.memoizedState = [
                 e,
                 n
-            ], e);
+            ], e;
         },
         useReducer: function(e, n, t) {
             var r = ln();
-            return (n = t !== void 0 ? t(n) : n, r.memoizedState = r.baseState = n, e = r.queue = {
+            return n = t !== void 0 ? t(n) : n, r.memoizedState = r.baseState = n, e = r.queue = {
                 pending: null,
                 dispatch: null,
                 lastRenderedReducer: e,
@@ -3699,14 +3699,14 @@ var ia = Bn((re1)=>{
             }, e = e.dispatch = Oi.bind(null, D, e), [
                 r.memoizedState,
                 e
-            ]);
+            ];
         },
         useRef: hs,
         useState: Lt,
         useDebugValue: Ri,
         useDeferredValue: function(e) {
             var n = Lt(e), t = n[0], r = n[1];
-            return (vs(function() {
+            return vs(function() {
                 var l = ue.transition;
                 ue.transition = 1;
                 try {
@@ -3716,36 +3716,36 @@ var ia = Bn((re1)=>{
                 }
             }, [
                 e
-            ]), t);
+            ]), t;
         },
         useTransition: function() {
             var e = Lt(!1), n = e[0];
-            return (e = Xf.bind(null, e[1]), hs(e), [
+            return e = Xf.bind(null, e[1]), hs(e), [
                 e,
                 n
-            ]);
+            ];
         },
         useMutableSource: function(e, n, t) {
             var r = ln();
-            return (r.memoizedState = {
+            return r.memoizedState = {
                 refs: {
                     getSnapshot: n,
                     setSnapshot: null
                 },
                 source: e,
                 subscribe: t
-            }, ps(r, e, n, t));
+            }, ps(r, e, n, t);
         },
         useOpaqueIdentifier: function() {
             if (ve1) {
                 var e = !1, n = Uf(function() {
-                    throw (e || (e = !0, t("r:" + (ai++).toString(36))), Error(v(355)));
+                    throw e || (e = !0, t("r:" + (ai++).toString(36))), Error(v(355));
                 }), t = Lt(n)[1];
-                return ((D.mode & 2) == 0 && (D.flags |= 516, Dr(5, function() {
+                return (D.mode & 2) == 0 && (D.flags |= 516, Dr(5, function() {
                     t("r:" + (ai++).toString(36));
-                }, void 0, null)), n);
+                }, void 0, null)), n;
             }
-            return (n = "r:" + (ai++).toString(36), Lt(n), n);
+            return n = "r:" + (ai++).toString(36), Lt(n), n;
         },
         unstable_isNewReconciler: !1
     }, $f = {
@@ -3764,7 +3764,7 @@ var ia = Bn((re1)=>{
         useDebugValue: Ri,
         useDeferredValue: function(e) {
             var n = Pt(ye1), t = n[0], r = n[1];
-            return (Ur(function() {
+            return Ur(function() {
                 var l = ue.transition;
                 ue.transition = 1;
                 try {
@@ -3774,7 +3774,7 @@ var ia = Bn((re1)=>{
                 }
             }, [
                 e
-            ]), t);
+            ]), t;
         },
         useTransition: function() {
             var e = Pt(ye1)[0];
@@ -3804,7 +3804,7 @@ var ia = Bn((re1)=>{
         useDebugValue: Ri,
         useDeferredValue: function(e) {
             var n = Tt(ye1), t = n[0], r = n[1];
-            return (Ur(function() {
+            return Ur(function() {
                 var l = ue.transition;
                 ue.transition = 1;
                 try {
@@ -3814,7 +3814,7 @@ var ia = Bn((re1)=>{
                 }
             }, [
                 e
-            ]), t);
+            ]), t;
         },
         useTransition: function() {
             var e = Tt(ye1)[0];
@@ -5258,7 +5258,7 @@ var ia = Bn((re1)=>{
             Yr || jt === null || ((g1.flags & 8) != 0 ? $o(g1, jt) && (Yr = !0) : g1.tag === 13 && rc(e, g1) && $o(g1, jt) && (Yr = !0));
             var n = g1.flags;
             (n & 256) != 0 && bf(e, g1), (n & 512) == 0 || $e1 || ($e1 = !0, yt(97, function() {
-                return (Ye(), null);
+                return Ye(), null;
             })), g1 = g1.nextEffect;
         }
     }
@@ -5271,12 +5271,12 @@ var ia = Bn((re1)=>{
     }
     function ec(e, n) {
         eo.push(n, e), $e1 || ($e1 = !0, yt(97, function() {
-            return (Ye(), null);
+            return Ye(), null;
         }));
     }
     function Bs(e, n) {
         no.push(n, e), $e1 || ($e1 = !0, yt(97, function() {
-            return (Ye(), null);
+            return Ye(), null;
         }));
     }
     function cc() {

--- a/bundler/tests/fixture/deno-9212/case1/output/entry.ts
+++ b/bundler/tests/fixture/deno-9212/case1/output/entry.ts
@@ -5820,7 +5820,7 @@ var ia = Bn((re1)=>{
         scheduleUpdate: null,
         currentDispatcherRef: Ge.ReactCurrentDispatcher,
         findHostInstanceByFiber: function(e) {
-            return (e = Qo(e), e === null ? null : e.stateNode);
+            return e = Qo(e), e === null ? null : e.stateNode;
         },
         findFiberByHostInstance: Ft.findFiberByHostInstance || vc,
         findHostInstancesForRefresh: null,

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.12.1"
+version = "0.12.3"
 
 [dependencies]
 fxhash = "0.2.1"

--- a/ecmascript/transforms/compat/src/es2015/block_scoping.rs
+++ b/ecmascript/transforms/compat/src/es2015/block_scoping.rs
@@ -1321,7 +1321,7 @@ expect(foo()).toBe(false);
             ].every(function(x) {
                 return x != i;
             }));
-            if (i1 % 2 === 0) return (i = i1, "continue");
+            if (i1 % 2 === 0) return i = i1, "continue";
             i = i1, void 0;
         };
         for(var i = 0; i < 5; i++){
@@ -1356,7 +1356,7 @@ expect(foo()).toBe(false);
             ].every(function(x) {
                 return x != i;
             }));
-            if (i1 % 2 === 0) return (i = i1, "break");
+            if (i1 % 2 === 0) return i = i1, "break";
             i = i1, void 0;
         };
         for(var i = 0; i < 5; i++){


### PR DESCRIPTION
This fixes an issue where parentheses would be removed around sequence expressions when they shouldn't, specifically in the case of a call expression callee, and a default value for a function param.

For example:

```ts
let x = ({}, () => 2)();
```

was compiling to:

```ts
let x = {
}, ()=>2
();
```

which is a syntax error.

A similar issue was seen with default assignment patterns in parameters. The fix was to ensure the correct context is set when visiting a sequence expression so that parentheses are added when needed. I checked a bunch of other places where commas are allowed and these were the ones I found, but there could be more.