### PR TITLE
Don't replace missing object members with undefined

### DIFF
--- a/ecmascript/transforms/optimization/Cargo.toml
+++ b/ecmascript/transforms/optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.15.2"
+version = "0.15.3"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/ecmascript/transforms/optimization/src/simplify/branch/tests.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/tests.rs
@@ -1340,6 +1340,7 @@ fn test_object_literal() {
     test("({a:1})", "");
     test("({a:foo()})", "foo()");
     test("({'a':foo()})", "foo()");
+    test("({}).foo", "({}).foo");
     // Object-spread may trigger getters.
     test_same("({...a})");
     test_same("({...foo()})");

--- a/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
@@ -249,11 +249,13 @@ impl SimplifyExpr {
                                 once(Box::new(Expr::Object(ObjectLit { props, span }))),
                             )
                         }
-                        None => preserve_effects(
-                            span,
-                            *undefined(span),
-                            once(Box::new(Expr::Object(ObjectLit { props, span }))),
-                        ),
+                        None => Expr::Member(MemberExpr {
+                            obj: ExprOrSuper::Expr(Box::new(Expr::Object(ObjectLit {
+                                props,
+                                span,
+                            }))),
+                            ..e
+                        }),
                     }
                 }
                 _ => Expr::Member(MemberExpr {


### PR DESCRIPTION
In general, `{}.foo` shouldn't be replaced with `undefined` because
1. the properties on the object prototype aren't undefined (`{}.constructor` itself, `{}.hasOwnProperty`, ...) and
2. hypothetically, the object's prototype could have been modified: `({}.__proto__).foo = 2; console.log({}.foo)`

Instead, only member accesses for properties that actually exists should be replaced

The fix seems to work, but I'm not so sure about the added test: reverting the change to the simplifier, this is the test output:
```
---- simplify::branch::tests::test_object_literal stdout ----
----- Actual -----
----- Actual -----
----- Actual -----
----- Actual -----
----- Actual -----
>>>>> Orig <<<<<
({}).foo
>>>>> Code <<<<<

thread 'simplify::branch::tests::test_object_literal' panicked at 'assertion failed: `(left == right)`
            ({
}).foo;
```
shouldn't it say something like `Expected: '({}).foo', Actual: 'undefined'`?