### PR TITLE
Fix block scoping of class declarations

### DIFF
--- a/ecmascript/transforms/base/src/resolver/mod.rs
+++ b/ecmascript/transforms/base/src/resolver/mod.rs
@@ -1337,6 +1337,9 @@ impl VisitMut for Hoister<'_, '_> {
     }
 
     fn visit_mut_class_decl(&mut self, node: &mut ClassDecl) {
+        if self.in_block {
+            return;
+        }
         self.resolver.in_type = false;
         self.resolver
             .visit_mut_binding_ident(&mut node.ident, Some(VarDeclKind::Let));

--- a/ecmascript/transforms/base/src/resolver/tests.rs
+++ b/ecmascript/transforms/base/src/resolver/tests.rs
@@ -2513,3 +2513,31 @@ to!(
     Test = 2;
     "#
 );
+
+to!(
+    block_scope_class,
+    r#"
+    const g = 20;
+
+    function baz() {
+        {
+            class g {}
+            console.log(g);
+        }
+
+        return g;
+    }
+    "#,
+    r#"
+    const g = 20;
+
+    function baz() {
+        {
+            class g1 {}
+            console.log(g1);
+        }
+
+        return g;
+    }
+    "#
+);


### PR DESCRIPTION
This fixes an issue where class declarations were not properly block scoped.

```js
const g = 20;

function baz() {
  {
    class g {}
  }

  return g;
}
```

was compiling to:

```js
const g1 = 20; // <- this is wrong
function baz() {
    {
        class g1 {}
    }
    return g;  // <- this is wrong
}
```

This was caused by the resolver hoisting class declarations when it shouldn't. Now they are ignored if within a block statement, just like `let`/`const` var declarations.