### PR TITLE
Fix precedence of yield expression inside ternary

### DIFF
--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.12.4"
+version = "0.12.5"
 
 [dependencies]
 fxhash = "0.2.1"

--- a/ecmascript/transforms/base/src/fixer.rs
+++ b/ecmascript/transforms/base/src/fixer.rs
@@ -557,9 +557,11 @@ impl Fixer<'_> {
 
             Expr::Cond(expr) => {
                 match &mut *expr.test {
-                    Expr::Seq(..) | Expr::Assign(..) | Expr::Cond(..) | Expr::Arrow(..) => {
-                        self.wrap(&mut expr.test)
-                    }
+                    Expr::Seq(..)
+                    | Expr::Assign(..)
+                    | Expr::Cond(..)
+                    | Expr::Arrow(..)
+                    | Expr::Yield(..) => self.wrap(&mut expr.test),
 
                     Expr::Object(..) | Expr::Fn(..) | Expr::Class(..) => {
                         if self.ctx == Context::Default {
@@ -1160,6 +1162,13 @@ var store = global[SHARED] || (global[SHARED] = {});
         param_seq,
         "function t(x = ({}, 2)) {
             return x;
+        }"
+    );
+
+    identical!(
+        yield_expr_cond,
+        "function *test1(foo) {
+            return (yield foo) ? 'bar' : 'baz';
         }"
     );
 }


### PR DESCRIPTION
The `yield` expression has a lower precedence than the conditional operator, so needs parentheses.