### PR TITLE
@swc/helpers exports typeOf instead of typeof

### DIFF
--- a/ecmascript/transforms/base/src/quote.rs
+++ b/ecmascript/transforms/base/src/quote.rs
@@ -2,14 +2,14 @@
 #[doc(hidden)]
 #[macro_export]
 macro_rules! external_name {
+    ("typeof") => {
+        "typeOf"
+    };
     ("instanceof") => {
         "_instanceof"
     };
     ("throw") => {
         "_throw"
-    };
-    ("extends") => {
-        "_extends"
     };
     ($s:literal) => {
         $s

--- a/tests/fixture/issue-1557/case1/output/index.js
+++ b/tests/fixture/issue-1557/case1/output/index.js
@@ -1,2 +1,2 @@
 import * as swcHelpers from "@swc/helpers";
-var a = swcHelpers["typeof"](0);
+var a = swcHelpers.typeOf(0);

--- a/tests/fixture/pr-1579/checkingExtend/input/.swcrc
+++ b/tests/fixture/pr-1579/checkingExtend/input/.swcrc
@@ -1,0 +1,6 @@
+{
+  "jsc": {
+    "externalHelpers": true,
+    "target": "es3"
+  }
+}

--- a/tests/fixture/pr-1579/checkingExtend/input/index.js
+++ b/tests/fixture/pr-1579/checkingExtend/input/index.js
@@ -1,0 +1,2 @@
+const a = {};
+const {...b} = a;

--- a/tests/fixture/pr-1579/checkingExtend/output/index.js
+++ b/tests/fixture/pr-1579/checkingExtend/output/index.js
@@ -1,0 +1,5 @@
+import * as swcHelpers from "@swc/helpers";
+var a = {
+};
+var b = swcHelpers["extends"]({
+}, a);


### PR DESCRIPTION
Hello,

I've made a typo in #1557 in the expected output since `@swc/helpers` exports a `typeOf` function (note the capital `O`).
Also the `_extends` does not exists. It is exposed as `extends` instead.

I can't find what source code triggers the use of `extends` ... I've tried object spread (uses `objectSpread`), Object.assign (unchanged), class inheritance doesn't seem to fit what the code was written for.

I cannot run the tests as of now to make sure nothing broke. I'll have to do that in a later day.