### PR TITLE
Fix regenerator transform for yield* expressions

### DIFF
--- a/ecmascript/transforms/compat/src/es2015/regenerator/case.rs
+++ b/ecmascript/transforms/compat/src/es2015/regenerator/case.rs
@@ -712,7 +712,7 @@ impl CaseHandler<'_> {
                     let result = self.make_var();
                     let name = match &result {
                         Expr::Member(m) => match &*m.prop {
-                            Expr::Ident(id) => id.sym.clone(),
+                            Expr::Ident(id) if !m.computed => id.sym.clone(),
                             _ => unreachable!(),
                         },
                         _ => unreachable!(),

--- a/ecmascript/transforms/compat/src/es2015/regenerator/case.rs
+++ b/ecmascript/transforms/compat/src/es2015/regenerator/case.rs
@@ -710,6 +710,13 @@ impl CaseHandler<'_> {
 
                 if arg.is_some() && e.delegate {
                     let result = self.make_var();
+                    let name = match &result {
+                        Expr::Member(m) => match &*m.prop {
+                            Expr::Ident(id) => id.sym.clone(),
+                            _ => unreachable!(),
+                        },
+                        _ => unreachable!(),
+                    };
 
                     let ret = ReturnStmt {
                         // Preserve span
@@ -723,7 +730,13 @@ impl CaseHandler<'_> {
                                 .as_callee(),
                             args: vec![
                                 arg.unwrap().as_arg(),
-                                result.clone().as_arg(),
+                                Lit::Str(Str {
+                                    span: DUMMY_SP,
+                                    value: name,
+                                    has_escape: false,
+                                    kind: Default::default(),
+                                })
+                                .as_arg(),
                                 after.to_stmt_index().as_arg(),
                             ],
                             type_args: Default::default(),

--- a/ecmascript/transforms/compat/tests/es2015_regenerator.rs
+++ b/ecmascript/transforms/compat/tests/es2015_regenerator.rs
@@ -1015,7 +1015,7 @@ export function myGenerator() {
                     1,
                     2,
                     3
-                ], _ctx.t0, 1);
+                ], \"t0\", 1);
             case 1:
             case 'end':
                 return _ctx.stop();
@@ -1023,6 +1023,21 @@ export function myGenerator() {
     }, _marked);
 }
 "
+);
+
+test_exec!(
+    syntax(),
+    |_| es2015::regenerator(Mark::fresh(Mark::root())),
+    delegate_context,
+    "function* a() {
+        yield 5;
+        return 7;
+    }
+    function* b() {
+        let x = yield* a();
+        yield (x + 1);
+    }
+    expect([...b()]).toEqual([5, 8]);"
 );
 
 test_exec!(

--- a/ecmascript/transforms/module/tests/common_js.rs
+++ b/ecmascript/transforms/module/tests/common_js.rs
@@ -4499,7 +4499,7 @@ function myGenerator() {
                   1,
                   2,
                   3
-              ], \"to\", 1);
+              ], \"t0 \", 1);
           case 1:
           case 'end':
               return _ctx.stop();

--- a/ecmascript/transforms/module/tests/common_js.rs
+++ b/ecmascript/transforms/module/tests/common_js.rs
@@ -4499,7 +4499,7 @@ function myGenerator() {
                   1,
                   2,
                   3
-              ], \"t0 \", 1);
+              ], \"t0\", 1);
           case 1:
           case 'end':
               return _ctx.stop();

--- a/ecmascript/transforms/module/tests/common_js.rs
+++ b/ecmascript/transforms/module/tests/common_js.rs
@@ -4499,7 +4499,7 @@ function myGenerator() {
                   1,
                   2,
                   3
-              ], _ctx.t0, 1);
+              ], \"to\", 1);
           case 1:
           case 'end':
               return _ctx.stop();


### PR DESCRIPTION
This fixes an issue in the regenerator transform, where the context variable member expression was passed to `delegateYield` rather than the name of that variable. This broke yield expressions where the result was used. See the added test for details: previously it output `[5, NaN]` instead of `[5, 8]`.