### PR TITLE
Fix syntax context of super in class transform

### DIFF
--- a/ecmascript/transforms/compat/src/es2015.rs
+++ b/ecmascript/transforms/compat/src/es2015.rs
@@ -254,9 +254,9 @@ class B extends A {
         }]);
     return A;
 }();
-var B = function(A) {
+var B = function(A1) {
     'use strict';
-    _inherits(B, A);
+    _inherits(B, A1);
     function B(num) {
         _classCallCheck(this, B);
         var _this;

--- a/ecmascript/transforms/compat/tests/es2015_classes.rs
+++ b/ecmascript/transforms/compat/tests/es2015_classes.rs
@@ -329,9 +329,9 @@ function () {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -437,9 +437,9 @@ Base.prototype.test = 1;
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -599,9 +599,9 @@ let value = 2;
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -687,9 +687,9 @@ function () {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -1082,9 +1082,9 @@ function () {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -1211,9 +1211,9 @@ function () {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -1346,9 +1346,9 @@ function () {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -1507,9 +1507,9 @@ const proper = {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -1598,9 +1598,9 @@ function () {
   return Hello;
 }();
 
-var Outer = function (Hello) {
+var Outer = function (Hello1) {
   'use strict';
-  _inherits(Outer, Hello);
+  _inherits(Outer, Hello1);
 
   function Outer() {
     _classCallCheck(this, Outer);
@@ -1904,9 +1904,9 @@ Object.defineProperty(Base.prototype, 'test', {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -1973,9 +1973,9 @@ let Base = function Base() {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -2127,9 +2127,9 @@ function Point() {
 
 let ColorPoint =
 /*#__PURE__*/
-function (Point) {
+function (Point1) {
   'use strict';
-_inherits(ColorPoint, Point);
+_inherits(ColorPoint, Point1);
 
   function ColorPoint() {
     _classCallCheck(this, ColorPoint);
@@ -2354,9 +2354,9 @@ var Hello = function Hello() {
   };
 };
 
-var Outer = function (Hello) {
+var Outer = function (Hello1) {
   'use strict';
-  _inherits(Outer, Hello);
+  _inherits(Outer, Hello1);
 
   function Outer() {
     _classCallCheck(this, Outer);
@@ -2412,9 +2412,9 @@ let Base = function Base() {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -2767,9 +2767,9 @@ _classCallCheck(this, A);
 
 let B =
 /*#__PURE__*/
-function (A) {
+function (A1) {
   'use strict';
-_inherits(B, A);
+_inherits(B, A1);
 
   function B() {
     _classCallCheck(this, B);
@@ -3017,9 +3017,9 @@ var Hello = function Hello() {
   };
 };
 
-var Outer = function (Hello) {
+var Outer = function (Hello1) {
   'use strict';
-  _inherits(Outer, Hello);
+  _inherits(Outer, Hello1);
 
   function Outer() {
     _classCallCheck(this, Outer);
@@ -3501,9 +3501,9 @@ function () {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -3575,9 +3575,9 @@ let Base = function Base() {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -3681,9 +3681,9 @@ function () {
 
 var Outer =
 /*#__PURE__*/
-function (Hello) {
+function (Hello1) {
   'use strict';
-  _inherits(Outer, Hello);
+  _inherits(Outer, Hello1);
 
   function Outer() {
     _classCallCheck(this, Outer);
@@ -3831,9 +3831,9 @@ function () {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -4062,9 +4062,9 @@ let Base = function Base() {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -4174,9 +4174,9 @@ const proper = {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -4548,9 +4548,9 @@ let Base = function Base() {
 
 let Obj =
 /*#__PURE__*/
-function (Base) {
+function (Base1) {
   'use strict';
-  _inherits(Obj, Base);
+  _inherits(Obj, Base1);
 
   function Obj() {
     _classCallCheck(this, Obj);
@@ -6128,5 +6128,58 @@ test!(
       ]);
       return ColouredCanvasElement;
   }(CanvasElement);
+  "
+);
+
+test!(
+    syntax(),
+    |_| classes(),
+    super_binding,
+    "
+  class Foo {}
+  class Test extends Foo {
+    foo() {
+      console.log(Foo)
+    }
+  }
+  ",
+    "
+  let Foo = function Foo() {
+    'use strict';
+    _classCallCheck(this, Foo);
+  };
+  let Test = function(Foo1) {
+    'use strict';
+    _inherits(Test, Foo1);
+    function Test() {
+        _classCallCheck(this, Test);
+        return _possibleConstructorReturn(this, _getPrototypeOf(Test).apply(this, arguments));
+    }
+    _createClass(Test, [
+        {
+            key: 'foo',
+            value: function foo() {
+                console.log(Foo);
+            }
+        }
+    ]);
+    return Test;
+  }(Foo);
+  "
+);
+
+test_exec!(
+    syntax(),
+    |_| classes(),
+    super_binding_exec,
+    "
+  class Foo {}
+  class Test extends Foo {
+    foo() {
+      return Foo;
+    }
+  }
+  Foo = 3;
+  expect(new Test().foo()).toBe(3);
   "
 );

--- a/ecmascript/transforms/compat/tests/es2020_class_properties.rs
+++ b/ecmascript/transforms/compat/tests/es2020_class_properties.rs
@@ -582,9 +582,9 @@ var Hello = function Hello() {
   };
 };
 
-var Outer = function (Hello) {
+var Outer = function (Hello1) {
   'use strict';
-  _inherits(Outer, Hello);
+  _inherits(Outer, Hello1);
 
   function Outer() {
     _classCallCheck(this, Outer);
@@ -892,10 +892,10 @@ function () {
 
 var B =
 /*#__PURE__*/
-function (A) {
+function (A1) {
   'use strict';
 
-  _inherits(B, A);
+  _inherits(B, A1);
 
   function B() {
     _classCallCheck(this, B);
@@ -1717,10 +1717,10 @@ var _prop1 = new WeakMap();
 
 var Bar =
 /*#__PURE__*/
-function (Foo) {
+function (Foo1) {
   'use strict';  
 
-  _inherits(Bar, Foo);
+  _inherits(Bar, Foo1);
 
   function Bar() {
     _classCallCheck(this, Bar);
@@ -1779,10 +1779,10 @@ var A = function () {
 
 var B =
 /*#__PURE__*/
-function (A) {
+function (A1) {
   'use strict';
 
-  _inherits(B, A);
+  _inherits(B, A1);
 
   function B() {
     _classCallCheck(this, B);
@@ -1898,9 +1898,9 @@ var Hello = function () {
   return Hello;
 }();
 
-var Outer = function (Hello) {
+var Outer = function (Hello1) {
   'use strict';
-  _inherits(Outer, Hello);
+  _inherits(Outer, Hello1);
 
   function Outer() {
     _classCallCheck(this, Outer);
@@ -4600,10 +4600,10 @@ _defineProperty(A, "prop", 1);
 
 var B =
 /*#__PURE__*/
-function (A) {
+function (A1) {
   "use strict";
 
-  _inherits(B, A);
+  _inherits(B, A1);
 
   function B() {
     _classCallCheck(this, B);

--- a/node-swc/__tests__/module_test.js
+++ b/node-swc/__tests__/module_test.js
@@ -47,5 +47,5 @@ it("should work with amd and expternal helpers", () => {
 
     expect(out.code).toContain(`define("a",`);
     expect(out.code).toContain(`swcHelpers.classCallCheck(this, Foo);`);
-    expect(out.code).toContain(`swcHelpers.inherits(Bar, Foo);`);
+    expect(out.code).toContain(`swcHelpers.inherits(Bar, Foo1);`);
 });

--- a/tests/fixture/issue-1490/full/output/index.js
+++ b/tests/fixture/issue-1490/full/output/index.js
@@ -154,8 +154,8 @@ var Element1 = function() {
     ]);
     return Element1;
 }();
-var CanvasElement = function(Element1) {
-    _inherits(CanvasElement, Element1);
+var CanvasElement = function(Element2) {
+    _inherits(CanvasElement, Element2);
     function CanvasElement() {
         _classCallCheck(this, CanvasElement);
         return _possibleConstructorReturn(this, _getPrototypeOf(CanvasElement).apply(this, arguments));
@@ -170,8 +170,8 @@ var CanvasElement = function(Element1) {
     ]);
     return CanvasElement;
 }(_wrapNativeSuper(Element1));
-var ColouredCanvasElement = function(CanvasElement) {
-    _inherits(ColouredCanvasElement, CanvasElement);
+var ColouredCanvasElement = function(CanvasElement1) {
+    _inherits(ColouredCanvasElement, CanvasElement1);
     function ColouredCanvasElement() {
         _classCallCheck(this, ColouredCanvasElement);
         return _possibleConstructorReturn(this, _getPrototypeOf(ColouredCanvasElement).apply(this, arguments));
@@ -186,8 +186,8 @@ var ColouredCanvasElement = function(CanvasElement) {
     ]);
     return ColouredCanvasElement;
 }(CanvasElement);
-var ColouredSquare = function(ColouredCanvasElement) {
-    _inherits(ColouredSquare, ColouredCanvasElement);
+var ColouredSquare = function(ColouredCanvasElement1) {
+    _inherits(ColouredSquare, ColouredCanvasElement1);
     function ColouredSquare() {
         _classCallCheck(this, ColouredSquare);
         return _possibleConstructorReturn(this, _getPrototypeOf(ColouredSquare).apply(this, arguments));

--- a/tests/fixture/issue-1505/case1/output/index.ts
+++ b/tests/fixture/issue-1505/case1/output/index.ts
@@ -49,9 +49,9 @@ var MyClass = function MyClass() {
     _classCallCheck(this, MyClass);
 };
 export var fn = function() {
-    var _class = function(MyClass) {
+    var _class = function(MyClass1) {
         "use strict";
-        _inherits(_class, MyClass);
+        _inherits(_class, MyClass1);
         function _class() {
             _classCallCheck(this, _class);
             return _possibleConstructorReturn(this, _getPrototypeOf(_class).apply(this, arguments));

--- a/tests/fixture/issue-1505/case2/output/index.ts
+++ b/tests/fixture/issue-1505/case2/output/index.ts
@@ -49,9 +49,9 @@ var MyClass = function MyClass() {
     _classCallCheck(this, MyClass);
 };
 export var fn = function() {
-    var _class = function(MyClass) {
+    var _class = function(MyClass1) {
         "use strict";
-        _inherits(_class, MyClass);
+        _inherits(_class, MyClass1);
         function _class() {
             _classCallCheck(this, _class);
             return _possibleConstructorReturn(this, _getPrototypeOf(_class).apply(this, arguments));

--- a/tests/fixture/issue-1505/case3/output/index.tsx
+++ b/tests/fixture/issue-1505/case3/output/index.tsx
@@ -53,9 +53,9 @@ var ComponentType = function ComponentType() {
     _classCallCheck(this, ComponentType);
 };
 var withTeamsForUser = function(_WrappedComponent) {
-    var _class = function(Component) {
+    var _class = function(Component1) {
         "use strict";
-        _inherits(_class, Component);
+        _inherits(_class, Component1);
         function _class() {
             _classCallCheck(this, _class);
             return _possibleConstructorReturn(this, _getPrototypeOf(_class).apply(this, arguments));

--- a/tests/fixture/issue-1505/tsx-default/output/index.ts
+++ b/tests/fixture/issue-1505/tsx-default/output/index.ts
@@ -49,9 +49,9 @@ var MyClass = function MyClass() {
     _classCallCheck(this, MyClass);
 };
 export var fn = function() {
-    var _class = function(MyClass) {
+    var _class = function(MyClass1) {
         "use strict";
-        _inherits(_class, MyClass);
+        _inherits(_class, MyClass1);
         function _class() {
             _classCallCheck(this, _class);
             return _possibleConstructorReturn(this, _getPrototypeOf(_class).apply(this, arguments));


### PR DESCRIPTION
When transforming classes, the super class is passed as a parameter to the iife wrapper for the class. However, this parameter should have a separate syntax context from the original identifier of the super class passed to the call. Currently, re-assigning the super binding has no effect within the class body because of this. For example:

```js
class Foo {}
class Test extends Foo {
  foo() {
    console.log(Foo);
  }
}
Foo = 3;
new Foo().foo();
```

should log `3` but it currently logs the original `Foo` function. This is now transformed to:

```js
let Test = function(Foo1) {
  'use strict';
  _inherits(Test, Foo1);
  function Test() {
      _classCallCheck(this, Test);
      return _possibleConstructorReturn(this, _getPrototypeOf(Test).apply(this, arguments));
  }
  _createClass(Test, [
      {
          key: 'foo',
          value: function foo() {
              console.log(Foo);
          }
      }
  ]);
  return Test;
}(Foo);
Foo = 3;
new Foo().foo();
```

note that the parameter is renamed to `Foo1` (and passed to `_inherits`), but the `console.log` still references `Foo`. This preserves the correct semantics.