### PR TITLE
feat(es/transforms) simplify: do not fold do-while loops with conditional stoppers

### DIFF
--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -851,6 +851,10 @@ impl Fold for Remover {
             }
 
             Stmt::DoWhile(s) => {
+                if has_conditional_stopper(&[Stmt::DoWhile(s.clone())]) {
+                    return Stmt::DoWhile(s);
+                }
+
                 if let Known(v) = s.test.as_pure_bool() {
                     if v {
                         // `for(;;);` is shorter than `do ; while(true);`

--- a/ecmascript/transforms/optimization/src/simplify/branch/tests.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/tests.rs
@@ -308,6 +308,12 @@ fn test_fold_useless_do_extra() {
 }
 
 #[test]
+fn test_no_fold_do_with_conditional_stopper() {
+    test_same("do { if (Date.now() > 0) break; } while (0);");
+    test_same("do { if (Date.now() > 0) continue; } while (0);");
+}
+
+#[test]
 fn test_fold_empty_do() {
     test("do { } while(true);", "for (;;);");
 }


### PR DESCRIPTION
This prevents the simplify pass from folding do-while loops with constant conditions when the body has a conditional stoppers. Previously, this folded the loop but left behind `break;` and `continue;` statements, creating invalid JavaScript.

I'm not sure it's possible to rewrite all possible loops to behave identically as when they had these stoppers, so this skips folding entirely.

Test Plan: Added unit test.