### PR TITLE
Don't simplify `x instanceof Object`

### DIFF
--- a/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
@@ -471,10 +471,6 @@ impl SimplifyExpr {
                     return make_bool_expr(span, false, iter::once(right));
                 }
 
-                if right.is_ident_ref_to(js_word!("Object")) {
-                    return make_bool_expr(span, true, iter::once(left));
-                }
-
                 (left, right)
             }
 

--- a/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
@@ -466,9 +466,23 @@ impl SimplifyExpr {
                     }
                 }
 
+                fn is_obj(e: &Expr) -> bool {
+                    match *e {
+                        Expr::Array { .. }
+                        | Expr::Object { .. }
+                        | Expr::Fn { .. }
+                        | Expr::New { .. } => true,
+                        _ => false,
+                    }
+                }
+
                 // Non-object types are never instances.
                 if is_non_obj(&left) {
                     return make_bool_expr(span, false, iter::once(right));
+                }
+
+                if is_obj(&left) && right.is_ident_ref_to(js_word!("Object")) {
+                    return make_bool_expr(span, true, iter::once(left));
                 }
 
                 (left, right)

--- a/ecmascript/transforms/optimization/src/simplify/expr/tests.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/tests.rs
@@ -1148,6 +1148,7 @@ fn test_fold_instance_of() {
 
     // An unknown value should never be folded.
     fold_same("x instanceof Foo");
+    fold_same("x instanceof Object");
 }
 
 #[test]

--- a/ecmascript/transforms/optimization/src/simplify/expr/tests.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/tests.rs
@@ -1140,6 +1140,7 @@ fn test_fold_instance_of() {
 
     // These cases is foldable, but no handled currently.
     fold("new Foo() instanceof Object", "new Foo(), true;");
+
     // These would require type information to fold.
     fold_same("[] instanceof Foo");
     fold_same("({}) instanceof Foo");


### PR DESCRIPTION
An example where `... instanceof Object` isn't `true`:
```js
let x = undefined;
if (x instanceof Object) {
  console.log(x.obj);
}
```

previously, this was simplified to `if(true)`