### PR TITLE
fix(wasm-web): use jq with an explicit temp file

### DIFF
--- a/.github/workflows/publish-wasm-web.yml
+++ b/.github/workflows/publish-wasm-web.yml
@@ -44,7 +44,11 @@ jobs:
         working-directory: wasm/pkg
 
       - name: Include *_bg files
-        run: jq '.files += ["wasm_bg.js", "wasm_bg.wasm.d.ts"]' package.json > package.json
+        # We explicitly use a temporary file here as jq does not support editing files in place
+        # https://github.com/stedolan/jq/wiki/FAQ#:~:text=%22in-place%22%20editing
+        run: |
+          jq '.files += ["wasm_bg.js", "wasm_bg.wasm.d.ts"]' package.json > tmppackage.json
+          mv tmppackage.json package.json
         working-directory: wasm/pkg
 
       - name: Publish


### PR DESCRIPTION
I noticed when trying to use swc/wasm-web that some files were not being included.

It appears a fix for this was landed in https://github.com/swc-project/swc/pull/1305, however this fix does not appear to work in the github action environment due to jq not supporting editing files in place, and so no versions have been published recently.

This uses the first of two approaches suggested by jq for where "in-place" editing is desired.