### PR TITLE
Change order of transforms in react preset

### DIFF
--- a/ecmascript/transforms/react/src/lib.rs
+++ b/ecmascript/transforms/react/src/lib.rs
@@ -31,11 +31,11 @@ where
     let refresh_options = mem::replace(&mut options.refresh, None);
 
     chain!(
-        jsx(cm.clone(), comments.clone(), options),
-        display_name(),
         jsx_src(development, cm.clone()),
         jsx_self(development),
-        pure_annotations(comments.clone()),
-        refresh(development, refresh_options, cm.clone(), comments)
+        refresh(development, refresh_options, cm.clone(), comments.clone()),
+        jsx(cm.clone(), comments.clone(), options),
+        display_name(),
+        pure_annotations(comments),
     )
 }


### PR DESCRIPTION
Closes #1638

`jsx_src`, `jsx_self` and `refresh` visit the JSX nodes, so they need to run before the JSX transpliation.