### PR TITLE
fix(es/transforms/compat): Fix span for comments in classes transform.

### DIFF
--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.14.0"
+version = "0.14.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/ecmascript/transforms/compat/src/es2015/classes/mod.rs
+++ b/ecmascript/transforms/compat/src/es2015/classes/mod.rs
@@ -244,14 +244,13 @@ where
     C: Comments,
 {
     fn fold_class_as_var_decl(&mut self, ident: Ident, class: Class) -> VarDecl {
-        let span = class.span;
         let rhs = self.fold_class(Some(ident.clone()), class);
 
         VarDecl {
-            span,
+            span: DUMMY_SP,
             kind: VarDeclKind::Let,
             decls: vec![VarDeclarator {
-                span,
+                span: DUMMY_SP,
                 init: Some(Box::new(rhs)),
                 // Foo in var Foo =
                 name: ident.into(),

--- a/ecmascript/transforms/compat/src/es2015/classes/mod.rs
+++ b/ecmascript/transforms/compat/src/es2015/classes/mod.rs
@@ -390,7 +390,7 @@ where
             type_args: Default::default(),
         };
         if let Some(comments) = &self.comments {
-            comments.add_pure_comment(call.span.lo);
+            comments.add_pure_comment(span.lo);
         }
 
         Expr::Call(call)

--- a/ecmascript/transforms/compat/src/es2015/classes/mod.rs
+++ b/ecmascript/transforms/compat/src/es2015/classes/mod.rs
@@ -371,11 +371,11 @@ where
         };
 
         let call = CallExpr {
-            span,
+            span: DUMMY_SP,
             callee: Expr::Fn(FnExpr {
                 ident: None,
                 function: Function {
-                    span: DUMMY_SP,
+                    span,
                     is_async: false,
                     is_generator: false,
                     params,

--- a/ecmascript/transforms/compat/src/es2015/classes/mod.rs
+++ b/ecmascript/transforms/compat/src/es2015/classes/mod.rs
@@ -369,7 +369,7 @@ where
         };
 
         let call = CallExpr {
-            span: DUMMY_SP,
+            span: class.span,
             callee: Expr::Fn(FnExpr {
                 ident: None,
                 function: Function {

--- a/ecmascript/transforms/compat/src/es2015/classes/mod.rs
+++ b/ecmascript/transforms/compat/src/es2015/classes/mod.rs
@@ -274,6 +274,8 @@ where
     /// }()
     /// ```
     fn fold_class(&mut self, class_name: Option<Ident>, class: Class) -> Expr {
+        let span = class.span;
+
         // Ident of the super class *inside* function.
         let super_ident = class
             .super_class
@@ -369,7 +371,7 @@ where
         };
 
         let call = CallExpr {
-            span: class.span,
+            span,
             callee: Expr::Fn(FnExpr {
                 ident: None,
                 function: Function {

--- a/tests/fixture/issue-1490/full/output/index.js
+++ b/tests/fixture/issue-1490/full/output/index.js
@@ -140,7 +140,7 @@ function _wrapNativeSuper(Class) {
     };
     return _wrapNativeSuper(Class);
 }
-var Element1 = function() {
+var Element1 = /*#__PURE__*/ function() {
     function Element1() {
         _classCallCheck(this, Element1);
     }
@@ -154,7 +154,7 @@ var Element1 = function() {
     ]);
     return Element1;
 }();
-var CanvasElement = function(Element2) {
+var CanvasElement = /*#__PURE__*/ function(Element2) {
     _inherits(CanvasElement, Element2);
     function CanvasElement() {
         _classCallCheck(this, CanvasElement);
@@ -170,7 +170,7 @@ var CanvasElement = function(Element2) {
     ]);
     return CanvasElement;
 }(_wrapNativeSuper(Element1));
-var ColouredCanvasElement = function(CanvasElement1) {
+var ColouredCanvasElement = /*#__PURE__*/ function(CanvasElement1) {
     _inherits(ColouredCanvasElement, CanvasElement1);
     function ColouredCanvasElement() {
         _classCallCheck(this, ColouredCanvasElement);
@@ -186,7 +186,7 @@ var ColouredCanvasElement = function(CanvasElement1) {
     ]);
     return ColouredCanvasElement;
 }(CanvasElement);
-var ColouredSquare = function(ColouredCanvasElement1) {
+var ColouredSquare = /*#__PURE__*/ function(ColouredCanvasElement1) {
     _inherits(ColouredSquare, ColouredCanvasElement1);
     function ColouredSquare() {
         _classCallCheck(this, ColouredSquare);

--- a/tests/fixture/issue-1505/case1/output/index.ts
+++ b/tests/fixture/issue-1505/case1/output/index.ts
@@ -49,7 +49,7 @@ var MyClass = function MyClass() {
     _classCallCheck(this, MyClass);
 };
 export var fn = function() {
-    var _class = function(MyClass1) {
+    var _class = /*#__PURE__*/ function(MyClass1) {
         "use strict";
         _inherits(_class, MyClass1);
         function _class() {

--- a/tests/fixture/issue-1505/case2/output/index.ts
+++ b/tests/fixture/issue-1505/case2/output/index.ts
@@ -49,7 +49,7 @@ var MyClass = function MyClass() {
     _classCallCheck(this, MyClass);
 };
 export var fn = function() {
-    var _class = function(MyClass1) {
+    var _class = /*#__PURE__*/ function(MyClass1) {
         "use strict";
         _inherits(_class, MyClass1);
         function _class() {

--- a/tests/fixture/issue-1505/case3/output/index.tsx
+++ b/tests/fixture/issue-1505/case3/output/index.tsx
@@ -53,7 +53,7 @@ var ComponentType = function ComponentType() {
     _classCallCheck(this, ComponentType);
 };
 var withTeamsForUser = function(_WrappedComponent) {
-    var _class = function(Component1) {
+    var _class = /*#__PURE__*/ function(Component1) {
         "use strict";
         _inherits(_class, Component1);
         function _class() {

--- a/tests/fixture/issue-1505/case4/output/index.tsx
+++ b/tests/fixture/issue-1505/case4/output/index.tsx
@@ -44,7 +44,7 @@ function _setPrototypeOf(o, p) {
 var _typeof = function(obj) {
     return obj && typeof Symbol !== "undefined" && obj.constructor === Symbol ? "symbol" : typeof obj;
 };
-export var a = function(Component) {
+export var a = /*#__PURE__*/ function(Component) {
     "use strict";
     _inherits(_class, Component);
     function _class() {

--- a/tests/fixture/issue-1505/case5/output/index.tsx
+++ b/tests/fixture/issue-1505/case5/output/index.tsx
@@ -45,7 +45,7 @@ var _typeof = function(obj) {
     return obj && typeof Symbol !== "undefined" && obj.constructor === Symbol ? "symbol" : typeof obj;
 };
 var withTeamsForUser = function() {
-    var _class = function(Component) {
+    var _class = /*#__PURE__*/ function(Component) {
         "use strict";
         _inherits(_class, Component);
         function _class() {

--- a/tests/fixture/issue-1505/tsx-default/output/index.ts
+++ b/tests/fixture/issue-1505/tsx-default/output/index.ts
@@ -49,7 +49,7 @@ var MyClass = function MyClass() {
     _classCallCheck(this, MyClass);
 };
 export var fn = function() {
-    var _class = function(MyClass1) {
+    var _class = /*#__PURE__*/ function(MyClass1) {
         "use strict";
         _inherits(_class, MyClass1);
         function _class() {

--- a/tests/fixture/next.js/slack-2/es5/output/index.js
+++ b/tests/fixture/next.js/slack-2/es5/output/index.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var Foo = function() {
+var Foo = /*#__PURE__*/ function() {
     "use strict";
     function Foo() {
         _classCallCheck(this, Foo);


### PR DESCRIPTION
swc_ecma_transforms_compat:
 - [x] Fix span for `PURE` comments. (Closes #1657)