### PR TITLE
fix(es/parser/typescript): allow `override` with `static`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.17.0"
+version = "0.18.0"
 
 [lib]
 name = "swc"
@@ -31,11 +31,11 @@ sourcemap = "6"
 swc_atoms = {version = "0.2", path = "./atoms"}
 swc_common = {version = "0.10.16", path = "./common", features = ["sourcemap", "concurrent"]}
 swc_ecma_ast = {version = "0.43.1", path = "./ecmascript/ast"}
-swc_ecma_codegen = {version = "0.52.3", path = "./ecmascript/codegen"}
-swc_ecma_ext_transforms = {version = "0.12.2", path = "./ecmascript/ext-transforms"}
-swc_ecma_parser = {version = "0.54.3", path = "./ecmascript/parser"}
-swc_ecma_preset_env = {version = "0.17.0", path = "./ecmascript/preset_env"}
-swc_ecma_transforms = {version = "0.47.0", path = "./ecmascript/transforms", features = [
+swc_ecma_codegen = {version = "0.53.0", path = "./ecmascript/codegen"}
+swc_ecma_ext_transforms = {version = "0.13.0", path = "./ecmascript/ext-transforms"}
+swc_ecma_parser = {version = "0.55.0", path = "./ecmascript/parser"}
+swc_ecma_preset_env = {version = "0.18.0", path = "./ecmascript/preset_env"}
+swc_ecma_transforms = {version = "0.48.0", path = "./ecmascript/transforms", features = [
   "compat",
   "module",
   "optimization",

--- a/babel/compat/Cargo.toml
+++ b/babel/compat/Cargo.toml
@@ -18,13 +18,13 @@ rayon = "1.5.0"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1.0.62"
 swc = {path = "../.."}
-swc_atoms = {version = "0.2.5", path = "../../atoms"}
+swc_atoms = {path = "../../atoms"}
 swc_babel_ast = {path = "../ast"}
 swc_babel_visit = {path = "../visit"}
-swc_common = {version = "0.10.9", path = "../../common", features = ["tty-emitter", "sourcemap"]}
-swc_ecma_ast = {version = "0.43", path = "../../ecmascript/ast"}
-swc_ecma_parser = {version = "0.54.2", path = "../../ecmascript/parser"}
-swc_ecma_visit = {version = "0.29.1", path = "../../ecmascript/visit"}
+swc_common = {path = "../../common", features = ["tty-emitter", "sourcemap"]}
+swc_ecma_ast = {path = "../../ecmascript/ast"}
+swc_ecma_parser = {path = "../../ecmascript/parser"}
+swc_ecma_visit = {path = "../../ecmascript/visit"}
 swc_node_base = {path = "../../node/base"}
 
 [dev-dependencies]

--- a/babel/compat/Cargo.toml
+++ b/babel/compat/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 description = "Compatibility layer between babel and swc"
+documentation = "https://rustdoc.swc.rs/swc_babel_compat/"
 edition = "2018"
-license = "MIT"
+license = "Apache-2.0/MIT"
 name = "swc_babel_compat"
-publish = false
+repository = "https://github.com/swc-project/swc.git"
 version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -9,7 +9,7 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/**/*.js"]
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.34.0"
+version = "0.35.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -34,9 +34,9 @@ retain_mut = "0.1.2"
 swc_atoms = {version = "0.2.4", path = "../atoms"}
 swc_common = {version = "0.10.16", path = "../common"}
 swc_ecma_ast = {version = "0.43.1", path = "../ecmascript/ast"}
-swc_ecma_codegen = {version = "0.52.3", path = "../ecmascript/codegen"}
-swc_ecma_parser = {version = "0.54.3", path = "../ecmascript/parser"}
-swc_ecma_transforms = {version = "0.47.0", path = "../ecmascript/transforms", features = ["optimization"]}
+swc_ecma_codegen = {version = "0.53.0", path = "../ecmascript/codegen"}
+swc_ecma_parser = {version = "0.55.0", path = "../ecmascript/parser"}
+swc_ecma_transforms = {version = "0.48.0", path = "../ecmascript/transforms", features = ["optimization"]}
 swc_ecma_utils = {version = "0.34.1", path = "../ecmascript/utils"}
 swc_ecma_visit = {version = "0.29.1", path = "../ecmascript/visit"}
 
@@ -45,7 +45,7 @@ hex = "0.4"
 ntest = "0.7.2"
 reqwest = {version = "0.10.8", features = ["blocking"]}
 sha-1 = "0.9"
-swc_ecma_transforms = {version = "0.47.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
+swc_ecma_transforms = {version = "0.48.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
 tempfile = "3.1.0"
 testing = {version = "0.10.5", path = "../testing"}
 url = "2.1.1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_common"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.10.18"
+version = "0.10.19"
 
 [features]
 concurrent = ["parking_lot"]

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.33.0"
+version = "0.34.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -28,10 +28,10 @@ typescript = ["swc_ecma_transforms/typescript"]
 
 [dependencies]
 swc_ecma_ast = {version = "0.43.1", path = "./ast"}
-swc_ecma_codegen = {version = "0.52.3", path = "./codegen", optional = true}
-swc_ecma_dep_graph = {version = "0.22.2", path = "./dep-graph", optional = true}
-swc_ecma_parser = {version = "0.54.3", path = "./parser", optional = true}
-swc_ecma_transforms = {version = "0.47.0", path = "./transforms", optional = true}
+swc_ecma_codegen = {version = "0.53.0", path = "./codegen", optional = true}
+swc_ecma_dep_graph = {version = "0.23.0", path = "./dep-graph", optional = true}
+swc_ecma_parser = {version = "0.55.0", path = "./parser", optional = true}
+swc_ecma_transforms = {version = "0.48.0", path = "./transforms", optional = true}
 swc_ecma_utils = {version = "0.34.1", path = "./utils", optional = true}
 swc_ecma_visit = {version = "0.29.1", path = "./visit", optional = true}
 

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.52.5"
+version = "0.53.0"
 
 [dependencies]
 bitflags = "1"
@@ -17,7 +17,7 @@ swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
 swc_ecma_ast = {version = "0.43.1", path = "../ast"}
 swc_ecma_codegen_macros = {version = "0.5.2", path = "./macros"}
-swc_ecma_parser = {version = "0.54.3", path = "../parser"}
+swc_ecma_parser = {version = "0.55.0", path = "../parser"}
 
 [dev-dependencies]
 swc_common = {version = "0.10.16", path = "../../common", features = ["sourcemap"]}

--- a/ecmascript/dep-graph/Cargo.toml
+++ b/ecmascript/dep-graph/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_dep_graph"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.22.2"
+version = "0.23.0"
 
 [dependencies]
 swc_atoms = {version = "0.2", path = "../../atoms"}
@@ -15,5 +15,5 @@ swc_ecma_ast = {version = "0.43.1", path = "../ast"}
 swc_ecma_visit = {version = "0.29.1", path = "../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.54.3", path = "../parser"}
+swc_ecma_parser = {version = "0.55.0", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/ext-transforms/Cargo.toml
+++ b/ecmascript/ext-transforms/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_ext_transforms/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ext_transforms"
-version = "0.12.2"
+version = "0.13.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,6 +14,6 @@ phf = {version = "0.8.0", features = ["macros"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
 swc_ecma_ast = {version = "0.43.1", path = "../ast"}
-swc_ecma_parser = {version = "0.54.3", path = "../parser"}
+swc_ecma_parser = {version = "0.55.0", path = "../parser"}
 swc_ecma_utils = {version = "0.34.1", path = "../utils"}
 swc_ecma_visit = {version = "0.29.1", path = "../visit"}

--- a/ecmascript/jsdoc/Cargo.toml
+++ b/ecmascript/jsdoc/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/jsdoc/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "jsdoc"
-version = "0.22.3"
+version = "0.23.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -19,6 +19,6 @@ swc_common = {version = "0.10.16", path = "../../common"}
 anyhow = "1"
 dashmap = "4.0.2"
 swc_ecma_ast = {version = "0.43.1", path = "../ast"}
-swc_ecma_parser = {version = "0.54.3", path = "../parser"}
+swc_ecma_parser = {version = "0.55.0", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.54.4"
+version = "0.55.0"
 
 [features]
 default = []

--- a/ecmascript/parser/tests/typescript-errors/class/override-with-static/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/class/override-with-static/input.ts
@@ -1,3 +1,3 @@
 class C extends B {
-  static override t() {}
+  override static t() {}
 }

--- a/ecmascript/parser/tests/typescript-errors/class/override-with-static/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/class/override-with-static/input.ts.stderr
@@ -1,6 +1,6 @@
-error: 'static' modifier cannot be used with 'override' modifier.
- --> $DIR/tests/typescript-errors/class/override-with-static/input.ts:2:10
+error: 'static' modifier must precede 'override' modifier.
+ --> $DIR/tests/typescript-errors/class/override-with-static/input.ts:2:12
   |
-2 |   static override t() {}
-  |          ^^^^^^^^
+2 |   override static t() {}
+  |            ^^^^^^
 

--- a/ecmascript/parser/tests/typescript/class/modifier-override/input.ts
+++ b/ecmascript/parser/tests/typescript/class/modifier-override/input.ts
@@ -7,4 +7,5 @@ class MyClass1 extends BaseClass {
   override readonly abstract size = 5;
   abstract override readonly size = 5;
   private abstract override readonly size = 5;
+  static override show() {}
 }

--- a/ecmascript/parser/tests/typescript/class/modifier-override/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/modifier-override/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Script",
   "span": {
     "start": 0,
-    "end": 277,
+    "end": 305,
     "ctxt": 0
   },
   "body": [
@@ -21,7 +21,7 @@
       "declare": false,
       "span": {
         "start": 0,
-        "end": 277,
+        "end": 305,
         "ctxt": 0
       },
       "decorators": [],
@@ -353,6 +353,52 @@
           "readonly": true,
           "declare": false,
           "definite": false
+        },
+        {
+          "type": "ClassMethod",
+          "span": {
+            "start": 278,
+            "end": 303,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 294,
+              "end": 298,
+              "ctxt": 0
+            },
+            "value": "show",
+            "optional": false
+          },
+          "function": {
+            "params": [],
+            "decorators": [],
+            "span": {
+              "start": 278,
+              "end": 303,
+              "ctxt": 0
+            },
+            "body": {
+              "type": "BlockStatement",
+              "span": {
+                "start": 301,
+                "end": 303,
+                "ctxt": 0
+              },
+              "stmts": []
+            },
+            "generator": false,
+            "async": false,
+            "typeParameters": null,
+            "returnType": null
+          },
+          "kind": "method",
+          "isStatic": true,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": true
         }
       ],
       "superClass": {

--- a/ecmascript/preset_env/Cargo.toml
+++ b/ecmascript/preset_env/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_preset_env/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_preset_env"
-version = "0.17.0"
+version = "0.18.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,13 +22,13 @@ string_enum = {version = "0.3.1", path = "../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
 swc_ecma_ast = {version = "0.43.1", path = "../ast"}
-swc_ecma_transforms = {version = "0.47.0", path = "../transforms", features = ["compat", "proposal"]}
+swc_ecma_transforms = {version = "0.48.0", path = "../transforms", features = ["compat", "proposal"]}
 swc_ecma_utils = {version = "0.34.1", path = "../utils"}
 swc_ecma_visit = {version = "0.29.1", path = "../visit"}
 walkdir = "2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
-swc_ecma_codegen = {version = "0.52.3", path = "../codegen"}
-swc_ecma_parser = {version = "0.54.3", path = "../parser"}
+swc_ecma_codegen = {version = "0.53.0", path = "../codegen"}
+swc_ecma_parser = {version = "0.55.0", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.47.0"
+version = "0.48.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -24,14 +24,14 @@ typescript = ["swc_ecma_transforms_typescript"]
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
 swc_ecma_ast = {version = "0.43.1", path = "../ast"}
-swc_ecma_parser = {version = "0.54.3", path = "../parser"}
-swc_ecma_transforms_base = {version = "0.12.6", path = "./base"}
-swc_ecma_transforms_compat = {version = "0.14.0", path = "./compat", optional = true}
-swc_ecma_transforms_module = {version = "0.14.0", path = "./module", optional = true}
-swc_ecma_transforms_optimization = {version = "0.17.0", path = "./optimization", optional = true}
-swc_ecma_transforms_proposal = {version = "0.14.0", path = "./proposal", optional = true}
-swc_ecma_transforms_react = {version = "0.15.0", path = "./react", optional = true}
-swc_ecma_transforms_typescript = {version = "0.16.0", path = "./typescript", optional = true}
+swc_ecma_parser = {version = "0.55.0", path = "../parser"}
+swc_ecma_transforms_base = {version = "0.13.0", path = "./base"}
+swc_ecma_transforms_compat = {version = "0.15.0", path = "./compat", optional = true}
+swc_ecma_transforms_module = {version = "0.15.0", path = "./module", optional = true}
+swc_ecma_transforms_optimization = {version = "0.18.0", path = "./optimization", optional = true}
+swc_ecma_transforms_proposal = {version = "0.15.0", path = "./proposal", optional = true}
+swc_ecma_transforms_react = {version = "0.16.0", path = "./react", optional = true}
+swc_ecma_transforms_typescript = {version = "0.17.0", path = "./typescript", optional = true}
 swc_ecma_utils = {version = "0.34.1", path = "../utils"}
 swc_ecma_visit = {version = "0.29.1", path = "../visit"}
 unicode-xid = "0.2"
@@ -39,8 +39,8 @@ unicode-xid = "0.2"
 [dev-dependencies]
 pretty_assertions = "0.6"
 sourcemap = "6"
-swc_ecma_codegen = {version = "0.52.3", path = "../codegen"}
-swc_ecma_transforms_testing = {version = "0.12.3", path = "./testing"}
+swc_ecma_codegen = {version = "0.53.0", path = "../codegen"}
+swc_ecma_transforms_testing = {version = "0.13.0", path = "./testing"}
 tempfile = "3"
 testing = {version = "0.10.5", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.12.14"
+version = "0.13.0"
 
 [dependencies]
 fxhash = "0.2.1"
@@ -17,10 +17,10 @@ smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.54.3", path = "../../parser"}
+swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
 swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.52.3", path = "../../codegen"}
+swc_ecma_codegen = {version = "0.53.0", path = "../../codegen"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.14.2"
+version = "0.15.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -21,12 +21,12 @@ smallvec = "1.6.0"
 swc_atoms = {version = "0.2.5", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.12.6", path = "../base"}
+swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
 swc_ecma_transforms_macros = {version = "0.2.1", path = "../macros"}
 swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.54.3", path = "../../parser"}
-swc_ecma_transforms_testing = {version = "0.12.3", path = "../testing"}
+swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
+swc_ecma_transforms_testing = {version = "0.13.0", path = "../testing"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/module/Cargo.toml
+++ b/ecmascript/transforms/module/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.14.0"
+version = "0.15.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -17,12 +17,12 @@ serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.54.3", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.12.6", path = "../base"}
+swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
 swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.14.0", path = "../compat"}
-swc_ecma_transforms_testing = {version = "0.12.3", path = "../testing/"}
+swc_ecma_transforms_compat = {version = "0.15.0", path = "../compat"}
+swc_ecma_transforms_testing = {version = "0.13.0", path = "../testing/"}
 testing = {version = "0.10.5", path = "../../../testing/"}

--- a/ecmascript/transforms/optimization/Cargo.toml
+++ b/ecmascript/transforms/optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.17.0"
+version = "0.18.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -20,16 +20,16 @@ serde_json = "1.0.61"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.54.3", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.12.6", path = "../base"}
+swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
 swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.14.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.14.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.14.0", path = "../proposal"}
-swc_ecma_transforms_react = {version = "0.15.0", path = "../react"}
-swc_ecma_transforms_testing = {version = "0.12.3", path = "../testing"}
-swc_ecma_transforms_typescript = {version = "0.16.0", path = "../typescript"}
+swc_ecma_transforms_compat = {version = "0.15.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.15.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.15.0", path = "../proposal"}
+swc_ecma_transforms_react = {version = "0.16.0", path = "../react"}
+swc_ecma_transforms_testing = {version = "0.13.0", path = "../testing"}
+swc_ecma_transforms_typescript = {version = "0.17.0", path = "../typescript"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/proposal/Cargo.toml
+++ b/ecmascript/transforms/proposal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_proposal"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.14.0"
+version = "0.15.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -23,12 +23,12 @@ swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
 swc_ecma_loader = {version = "0.4.1", path = "../../loader", optional = true}
-swc_ecma_parser = {version = "0.54.3", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.12.6", path = "../base"}
+swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
 swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.14.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.14.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.12.3", path = "../testing"}
+swc_ecma_transforms_compat = {version = "0.15.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.15.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.13.0", path = "../testing"}

--- a/ecmascript/transforms/react/Cargo.toml
+++ b/ecmascript/transforms/react/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_react"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.15.1"
+version = "0.16.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -22,14 +22,14 @@ string_enum = {version = "0.3.1", path = "../../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.54.3", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.12.6", path = "../base"}
+swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
 swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.52.3", path = "../../codegen/"}
-swc_ecma_transforms_compat = {version = "0.14.0", path = "../compat/"}
-swc_ecma_transforms_module = {version = "0.14.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.12.3", path = "../testing/"}
+swc_ecma_codegen = {version = "0.53.0", path = "../../codegen/"}
+swc_ecma_transforms_compat = {version = "0.15.0", path = "../compat/"}
+swc_ecma_transforms_module = {version = "0.15.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.13.0", path = "../testing/"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/testing/Cargo.toml
+++ b/ecmascript/transforms/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.12.3"
+version = "0.13.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,9 +16,9 @@ serde = "1"
 serde_json = "1"
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_codegen = {version = "0.52.3", path = "../../codegen"}
-swc_ecma_parser = {version = "0.54.3", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.12.6", path = "../base"}
+swc_ecma_codegen = {version = "0.53.0", path = "../../codegen"}
+swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
 swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
 tempfile = "3.1.0"

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.16.0"
+version = "0.17.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -15,16 +15,16 @@ serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.54.3", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.12.6", path = "../base"}
+swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
 swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
 swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.52.3", path = "../../codegen"}
-swc_ecma_transforms_compat = {version = "0.14.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.14.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.14.0", path = "../proposal/"}
-swc_ecma_transforms_testing = {version = "0.12.3", path = "../testing"}
+swc_ecma_codegen = {version = "0.53.0", path = "../../codegen"}
+swc_ecma_transforms_compat = {version = "0.15.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.15.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.15.0", path = "../proposal/"}
+swc_ecma_transforms_testing = {version = "0.13.0", path = "../testing"}
 testing = {version = "0.10.5", path = "../../../testing"}
 walkdir = "2.3.1"


### PR DESCRIPTION
Previously, TypeScript didn't allow `override` with `static`, but it seems that it was changed later: [TypeScript playground](https://www.typescriptlang.org/play?ts=4.3.0-dev.20210508#code/MYGwhgzhAEBC0G8BQ1oQC5nQS2NdAFAJSIC+S5SokMAwgIzQCmAHukwHYAmM8yqAewBuTAE6jsXJmkw48hEgnKVqUaLQBMzNpx5xEKGVlzRhYiVPzEyFIA).

Also, this PR enforces order between `override` and `static`.