### PR TITLE
fix(es/tranforms/base): resolver: Handle function declarations in ts modules

### DIFF
--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.12.12"
+version = "0.12.13"
 
 [dependencies]
 fxhash = "0.2.1"

--- a/ecmascript/transforms/base/src/resolver/mod.rs
+++ b/ecmascript/transforms/base/src/resolver/mod.rs
@@ -134,6 +134,7 @@ struct Resolver<'a> {
     ident_type: IdentType,
     handle_types: bool,
     in_type: bool,
+    in_ts_module: bool,
 }
 
 impl<'a> Resolver<'a> {
@@ -145,6 +146,7 @@ impl<'a> Resolver<'a> {
             ident_type: IdentType::Ref,
             handle_types,
             in_type: false,
+            in_ts_module: false,
         }
     }
 
@@ -814,7 +816,7 @@ impl<'a> VisitMut for Resolver<'a> {
     }
 
     fn visit_mut_module_items(&mut self, stmts: &mut Vec<ModuleItem>) {
-        if self.current.kind != ScopeKind::Fn {
+        if !self.in_ts_module && self.current.kind != ScopeKind::Fn {
             return stmts.visit_mut_children_with(self);
         }
 
@@ -1062,6 +1064,7 @@ impl<'a> VisitMut for Resolver<'a> {
             Scope::new(ScopeKind::Block, Some(&self.current)),
             self.handle_types,
         );
+        child_folder.in_ts_module = true;
 
         decl.body.visit_mut_children_with(&mut child_folder);
     }

--- a/ecmascript/transforms/base/src/resolver/mod.rs
+++ b/ecmascript/transforms/base/src/resolver/mod.rs
@@ -583,7 +583,9 @@ impl<'a> VisitMut for Resolver<'a> {
             Scope::new(ScopeKind::Fn, Some(&self.current)),
             self.handle_types,
         );
+
         if let Some(ident) = &mut e.ident {
+            self.in_type = false;
             folder.visit_mut_binding_ident(ident, None)
         }
         e.function.visit_mut_with(&mut folder);

--- a/ecmascript/transforms/base/src/resolver/tests.rs
+++ b/ecmascript/transforms/base/src/resolver/tests.rs
@@ -1937,7 +1937,7 @@ to_ts!(
     "
     module Top {
         module A__2 {
-            export function b__0() {
+            export function b__3() {
             }
         }
         A__2.b();
@@ -1989,9 +1989,9 @@ to_ts!(
         interface B__2 {
             m__0: string;
         }
-        var x: any;
-        var y = x as A__2<B__2>[];
-        var z = y[0].m;
+        var x__2: any;
+        var y__2 = x__2 as A__2<B__2>[];
+        var z__2 = y__2[0].m;
     }
     
     "
@@ -2778,6 +2778,21 @@ to_ts!(
     }
     ",
     "
-    
+    module M {
+        export class A__2 {
+            name__0: string;
+        }
+        export function F2__2(x__3: number): string {
+            return x__3.toString();
+        }
+    }
+    module N {
+        export class A__4 {
+            id__0: number;
+        }
+        export function F2__4(x__5: number): string {
+            return x__5.toString();
+        }
+    }
     "
 );

--- a/ecmascript/transforms/base/src/resolver/tests.rs
+++ b/ecmascript/transforms/base/src/resolver/tests.rs
@@ -2757,3 +2757,27 @@ to!(
     }
     "
 );
+
+to_ts!(
+    ts_if_do_while_statements_01,
+    "
+    module M {
+        export class A {
+            name: string;
+        }
+    
+        export function F2(x: number): string { return x.toString(); }
+    }
+    
+    module N {
+        export class A {
+            id: number;
+        }
+    
+        export function F2(x: number): string { return x.toString(); }
+    }
+    ",
+    "
+    
+    "
+);


### PR DESCRIPTION

swc_ecma_transforms_base:
 - [x] `resolver`: Handle function names in ts modules correctly.