### PR TITLE
feat(es/parser/typescript): allow `override` as parameter property

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.18.0"
+version = "0.19.0"
 
 [lib]
 name = "swc"
@@ -30,12 +30,12 @@ serde_json = "1"
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "./atoms"}
 swc_common = {version = "0.10.16", path = "./common", features = ["sourcemap", "concurrent"]}
-swc_ecma_ast = {version = "0.43.1", path = "./ecmascript/ast"}
-swc_ecma_codegen = {version = "0.53.0", path = "./ecmascript/codegen"}
-swc_ecma_ext_transforms = {version = "0.13.0", path = "./ecmascript/ext-transforms"}
-swc_ecma_parser = {version = "0.55.0", path = "./ecmascript/parser"}
-swc_ecma_preset_env = {version = "0.18.0", path = "./ecmascript/preset_env"}
-swc_ecma_transforms = {version = "0.48.0", path = "./ecmascript/transforms", features = [
+swc_ecma_ast = {version = "0.44.0", path = "./ecmascript/ast"}
+swc_ecma_codegen = {version = "0.54.0", path = "./ecmascript/codegen"}
+swc_ecma_ext_transforms = {version = "0.14.0", path = "./ecmascript/ext-transforms"}
+swc_ecma_parser = {version = "0.56.0", path = "./ecmascript/parser"}
+swc_ecma_preset_env = {version = "0.19.0", path = "./ecmascript/preset_env"}
+swc_ecma_transforms = {version = "0.49.0", path = "./ecmascript/transforms", features = [
   "compat",
   "module",
   "optimization",
@@ -43,8 +43,8 @@ swc_ecma_transforms = {version = "0.48.0", path = "./ecmascript/transforms", fea
   "react",
   "typescript",
 ]}
-swc_ecma_utils = {version = "0.34.1", path = "./ecmascript/utils"}
-swc_ecma_visit = {version = "0.29.1", path = "./ecmascript/visit"}
+swc_ecma_utils = {version = "0.35.0", path = "./ecmascript/utils"}
+swc_ecma_visit = {version = "0.30.0", path = "./ecmascript/visit"}
 swc_node_base = {version = "0.1.0", path = "./node/base"}
 swc_visit = {version = "0.2.3", path = "./visit"}
 

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -9,7 +9,7 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/**/*.js"]
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.35.0"
+version = "0.36.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -33,19 +33,19 @@ relative-path = "1.2"
 retain_mut = "0.1.2"
 swc_atoms = {version = "0.2.4", path = "../atoms"}
 swc_common = {version = "0.10.16", path = "../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../ecmascript/ast"}
-swc_ecma_codegen = {version = "0.53.0", path = "../ecmascript/codegen"}
-swc_ecma_parser = {version = "0.55.0", path = "../ecmascript/parser"}
-swc_ecma_transforms = {version = "0.48.0", path = "../ecmascript/transforms", features = ["optimization"]}
-swc_ecma_utils = {version = "0.34.1", path = "../ecmascript/utils"}
-swc_ecma_visit = {version = "0.29.1", path = "../ecmascript/visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../ecmascript/ast"}
+swc_ecma_codegen = {version = "0.54.0", path = "../ecmascript/codegen"}
+swc_ecma_parser = {version = "0.56.0", path = "../ecmascript/parser"}
+swc_ecma_transforms = {version = "0.49.0", path = "../ecmascript/transforms", features = ["optimization"]}
+swc_ecma_utils = {version = "0.35.0", path = "../ecmascript/utils"}
+swc_ecma_visit = {version = "0.30.0", path = "../ecmascript/visit"}
 
 [dev-dependencies]
 hex = "0.4"
 ntest = "0.7.2"
 reqwest = {version = "0.10.8", features = ["blocking"]}
 sha-1 = "0.9"
-swc_ecma_transforms = {version = "0.48.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
+swc_ecma_transforms = {version = "0.49.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
 tempfile = "3.1.0"
 testing = {version = "0.10.5", path = "../testing"}
 url = "2.1.1"

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.34.0"
+version = "0.35.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -27,12 +27,12 @@ react = ["swc_ecma_transforms/react"]
 typescript = ["swc_ecma_transforms/typescript"]
 
 [dependencies]
-swc_ecma_ast = {version = "0.43.1", path = "./ast"}
-swc_ecma_codegen = {version = "0.53.0", path = "./codegen", optional = true}
-swc_ecma_dep_graph = {version = "0.23.0", path = "./dep-graph", optional = true}
-swc_ecma_parser = {version = "0.55.0", path = "./parser", optional = true}
-swc_ecma_transforms = {version = "0.48.0", path = "./transforms", optional = true}
-swc_ecma_utils = {version = "0.34.1", path = "./utils", optional = true}
-swc_ecma_visit = {version = "0.29.1", path = "./visit", optional = true}
+swc_ecma_ast = {version = "0.44.0", path = "./ast"}
+swc_ecma_codegen = {version = "0.54.0", path = "./codegen", optional = true}
+swc_ecma_dep_graph = {version = "0.24.0", path = "./dep-graph", optional = true}
+swc_ecma_parser = {version = "0.56.0", path = "./parser", optional = true}
+swc_ecma_transforms = {version = "0.49.0", path = "./transforms", optional = true}
+swc_ecma_utils = {version = "0.35.0", path = "./utils", optional = true}
+swc_ecma_visit = {version = "0.30.0", path = "./visit", optional = true}
 
 [dev-dependencies]

--- a/ecmascript/ast/Cargo.toml
+++ b/ecmascript/ast/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ast"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.43.1"
+version = "0.44.0"
 
 [features]
 default = []

--- a/ecmascript/ast/src/typescript.rs
+++ b/ecmascript/ast/src/typescript.rs
@@ -70,6 +70,8 @@ pub struct TsParamProp {
     /// At least one of `accessibility` or `readonly` must be set.
     #[serde(default)]
     pub accessibility: Option<Accessibility>,
+    #[serde(rename = "override")]
+    pub is_override: bool,
     pub readonly: bool,
     pub param: TsParamPropParam,
 }

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.53.0"
+version = "0.54.0"
 
 [dependencies]
 bitflags = "1"
@@ -15,9 +15,9 @@ num-bigint = {version = "0.2", features = ["serde"]}
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../ast"}
+swc_ecma_ast = {version = "0.44.0", path = "../ast"}
 swc_ecma_codegen_macros = {version = "0.5.2", path = "./macros"}
-swc_ecma_parser = {version = "0.55.0", path = "../parser"}
+swc_ecma_parser = {version = "0.56.0", path = "../parser"}
 
 [dev-dependencies]
 swc_common = {version = "0.10.16", path = "../../common", features = ["sourcemap"]}

--- a/ecmascript/codegen/src/typescript.rs
+++ b/ecmascript/codegen/src/typescript.rs
@@ -612,6 +612,11 @@ impl<'a> Emitter<'a> {
 
         self.emit_accesibility(n.accessibility)?;
 
+        if n.is_override {
+            keyword!("override");
+            space!();
+        }
+
         if n.readonly {
             keyword!("readonly");
             space!();

--- a/ecmascript/dep-graph/Cargo.toml
+++ b/ecmascript/dep-graph/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_dep_graph"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.23.0"
+version = "0.24.0"
 
 [dependencies]
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../ast"}
-swc_ecma_visit = {version = "0.29.1", path = "../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../ast"}
+swc_ecma_visit = {version = "0.30.0", path = "../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.55.0", path = "../parser"}
+swc_ecma_parser = {version = "0.56.0", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/ext-transforms/Cargo.toml
+++ b/ecmascript/ext-transforms/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_ext_transforms/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ext_transforms"
-version = "0.13.0"
+version = "0.14.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,7 +13,7 @@ version = "0.13.0"
 phf = {version = "0.8.0", features = ["macros"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../ast"}
-swc_ecma_parser = {version = "0.55.0", path = "../parser"}
-swc_ecma_utils = {version = "0.34.1", path = "../utils"}
-swc_ecma_visit = {version = "0.29.1", path = "../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../ast"}
+swc_ecma_parser = {version = "0.56.0", path = "../parser"}
+swc_ecma_utils = {version = "0.35.0", path = "../utils"}
+swc_ecma_visit = {version = "0.30.0", path = "../visit"}

--- a/ecmascript/jsdoc/Cargo.toml
+++ b/ecmascript/jsdoc/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/jsdoc/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "jsdoc"
-version = "0.23.0"
+version = "0.24.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,7 +18,7 @@ swc_common = {version = "0.10.16", path = "../../common"}
 [dev-dependencies]
 anyhow = "1"
 dashmap = "4.0.2"
-swc_ecma_ast = {version = "0.43.1", path = "../ast"}
-swc_ecma_parser = {version = "0.55.0", path = "../parser"}
+swc_ecma_ast = {version = "0.44.0", path = "../ast"}
+swc_ecma_parser = {version = "0.56.0", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/loader/Cargo.toml
+++ b/ecmascript/loader/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_loader"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.4.1"
+version = "0.5.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 swc_atoms = {version = "0.2.3", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../ast"}
-swc_ecma_visit = {version = "0.29.1", path = "../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../ast"}
+swc_ecma_visit = {version = "0.30.0", path = "../visit"}
 
 [dev-dependencies]
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.55.0"
+version = "0.56.0"
 
 [features]
 default = []
@@ -22,8 +22,8 @@ serde = {version = "1", features = ["derive"]}
 smallvec = "1"
 swc_atoms = {version = "0.2.3", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../ast"}
-swc_ecma_visit = {version = "0.29.1", path = "../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../ast"}
+swc_ecma_visit = {version = "0.30.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]

--- a/ecmascript/parser/src/parser/pat.rs
+++ b/ecmascript/parser/src/parser/pat.rs
@@ -315,16 +315,17 @@ impl<'a, I: Tokens> Parser<I> {
         param_start: BytePos,
         decorators: Vec<Decorator>,
     ) -> PResult<ParamOrTsParamProp> {
-        let (accessibility, readonly) = if self.input.syntax().typescript() {
+        let (accessibility, is_override, readonly) = if self.input.syntax().typescript() {
             let accessibility = self.parse_access_modifier()?;
             (
                 accessibility,
+                self.parse_ts_modifier(&["override"])?.is_some(),
                 self.parse_ts_modifier(&["readonly"])?.is_some(),
             )
         } else {
-            (None, false)
+            (None, false, false)
         };
-        if accessibility == None && !readonly {
+        if accessibility == None && !is_override && !readonly {
             let pat = self.parse_formal_param_pat()?;
             Ok(ParamOrTsParamProp::Param(Param {
                 span: span!(self, param_start),
@@ -340,6 +341,7 @@ impl<'a, I: Tokens> Parser<I> {
             Ok(ParamOrTsParamProp::TsParamProp(TsParamProp {
                 span: span!(self, param_start),
                 accessibility,
+                is_override,
                 readonly,
                 decorators,
                 param,

--- a/ecmascript/parser/tests/typescript-errors/class/override-parameter-property/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/class/override-parameter-property/input.ts
@@ -1,0 +1,7 @@
+class C extends B {
+  constructor(override public v: string)
+  constructor(readonly override v: boolean)
+  constructor(arg: any) {
+    super()
+  }
+}

--- a/ecmascript/parser/tests/typescript-errors/class/override-parameter-property/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/class/override-parameter-property/input.ts.stderr
@@ -1,0 +1,12 @@
+error: Expected ,, got v
+ --> $DIR/tests/typescript-errors/class/override-parameter-property/input.ts:3:33
+  |
+3 |   constructor(readonly override v: boolean)
+  |                                 ^
+
+error: A parameter property is only allowed in a constructor implementation
+ --> $DIR/tests/typescript-errors/class/override-parameter-property/input.ts:2:24
+  |
+2 |   constructor(override public v: string)
+  |                        ^^^^^^^^^^^^^^^^
+

--- a/ecmascript/parser/tests/typescript/class/decorators/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/decorators/input.ts.json
@@ -91,6 +91,7 @@
                 }
               ],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/class/override-parameter-property/input.ts
+++ b/ecmascript/parser/tests/typescript/class/override-parameter-property/input.ts
@@ -1,0 +1,9 @@
+class C extends B {
+  constructor(override: Date)
+  constructor(override v: number)
+  constructor(public override v: string)
+  constructor(override readonly v: boolean)
+  constructor(arg: any) {
+    super()
+  }
+}

--- a/ecmascript/parser/tests/typescript/class/override-parameter-property/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/override-parameter-property/input.ts.json
@@ -1,0 +1,396 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 0,
+    "end": 212,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ClassDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 6,
+          "end": 7,
+          "ctxt": 0
+        },
+        "value": "C",
+        "optional": false
+      },
+      "declare": false,
+      "span": {
+        "start": 0,
+        "end": 212,
+        "ctxt": 0
+      },
+      "decorators": [],
+      "body": [
+        {
+          "type": "Constructor",
+          "span": {
+            "start": 22,
+            "end": 49,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 22,
+              "end": 33,
+              "ctxt": 0
+            },
+            "value": "constructor",
+            "optional": false
+          },
+          "params": [
+            {
+              "type": "Parameter",
+              "span": {
+                "start": 34,
+                "end": 48,
+                "ctxt": 0
+              },
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
+                "span": {
+                  "start": 34,
+                  "end": 48,
+                  "ctxt": 0
+                },
+                "value": "override",
+                "optional": false,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 42,
+                    "end": 48,
+                    "ctxt": 0
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 44,
+                      "end": 48,
+                      "ctxt": 0
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 44,
+                        "end": 48,
+                        "ctxt": 0
+                      },
+                      "value": "Date",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  }
+                }
+              }
+            }
+          ],
+          "body": null,
+          "accessibility": null,
+          "isOptional": false
+        },
+        {
+          "type": "Constructor",
+          "span": {
+            "start": 52,
+            "end": 83,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 52,
+              "end": 63,
+              "ctxt": 0
+            },
+            "value": "constructor",
+            "optional": false
+          },
+          "params": [
+            {
+              "type": "TsParameterProperty",
+              "span": {
+                "start": 64,
+                "end": 82,
+                "ctxt": 0
+              },
+              "decorators": [],
+              "accessibility": null,
+              "override": true,
+              "readonly": false,
+              "param": {
+                "type": "Identifier",
+                "span": {
+                  "start": 73,
+                  "end": 82,
+                  "ctxt": 0
+                },
+                "value": "v",
+                "optional": false,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 74,
+                    "end": 82,
+                    "ctxt": 0
+                  },
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 76,
+                      "end": 82,
+                      "ctxt": 0
+                    },
+                    "kind": "number"
+                  }
+                }
+              }
+            }
+          ],
+          "body": null,
+          "accessibility": null,
+          "isOptional": false
+        },
+        {
+          "type": "Constructor",
+          "span": {
+            "start": 86,
+            "end": 124,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 86,
+              "end": 97,
+              "ctxt": 0
+            },
+            "value": "constructor",
+            "optional": false
+          },
+          "params": [
+            {
+              "type": "TsParameterProperty",
+              "span": {
+                "start": 98,
+                "end": 123,
+                "ctxt": 0
+              },
+              "decorators": [],
+              "accessibility": "public",
+              "override": true,
+              "readonly": false,
+              "param": {
+                "type": "Identifier",
+                "span": {
+                  "start": 114,
+                  "end": 123,
+                  "ctxt": 0
+                },
+                "value": "v",
+                "optional": false,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 115,
+                    "end": 123,
+                    "ctxt": 0
+                  },
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 117,
+                      "end": 123,
+                      "ctxt": 0
+                    },
+                    "kind": "string"
+                  }
+                }
+              }
+            }
+          ],
+          "body": null,
+          "accessibility": null,
+          "isOptional": false
+        },
+        {
+          "type": "Constructor",
+          "span": {
+            "start": 127,
+            "end": 168,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 127,
+              "end": 138,
+              "ctxt": 0
+            },
+            "value": "constructor",
+            "optional": false
+          },
+          "params": [
+            {
+              "type": "TsParameterProperty",
+              "span": {
+                "start": 139,
+                "end": 167,
+                "ctxt": 0
+              },
+              "decorators": [],
+              "accessibility": null,
+              "override": true,
+              "readonly": true,
+              "param": {
+                "type": "Identifier",
+                "span": {
+                  "start": 157,
+                  "end": 167,
+                  "ctxt": 0
+                },
+                "value": "v",
+                "optional": false,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 158,
+                    "end": 167,
+                    "ctxt": 0
+                  },
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 160,
+                      "end": 167,
+                      "ctxt": 0
+                    },
+                    "kind": "boolean"
+                  }
+                }
+              }
+            }
+          ],
+          "body": null,
+          "accessibility": null,
+          "isOptional": false
+        },
+        {
+          "type": "Constructor",
+          "span": {
+            "start": 171,
+            "end": 210,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 171,
+              "end": 182,
+              "ctxt": 0
+            },
+            "value": "constructor",
+            "optional": false
+          },
+          "params": [
+            {
+              "type": "Parameter",
+              "span": {
+                "start": 183,
+                "end": 191,
+                "ctxt": 0
+              },
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
+                "span": {
+                  "start": 183,
+                  "end": 191,
+                  "ctxt": 0
+                },
+                "value": "arg",
+                "optional": false,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 186,
+                    "end": 191,
+                    "ctxt": 0
+                  },
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 188,
+                      "end": 191,
+                      "ctxt": 0
+                    },
+                    "kind": "any"
+                  }
+                }
+              }
+            }
+          ],
+          "body": {
+            "type": "BlockStatement",
+            "span": {
+              "start": 193,
+              "end": 210,
+              "ctxt": 0
+            },
+            "stmts": [
+              {
+                "type": "ExpressionStatement",
+                "span": {
+                  "start": 199,
+                  "end": 206,
+                  "ctxt": 0
+                },
+                "expression": {
+                  "type": "CallExpression",
+                  "span": {
+                    "start": 199,
+                    "end": 206,
+                    "ctxt": 0
+                  },
+                  "callee": {
+                    "type": "Super",
+                    "span": {
+                      "start": 199,
+                      "end": 204,
+                      "ctxt": 0
+                    }
+                  },
+                  "arguments": [],
+                  "typeArguments": null
+                }
+              }
+            ]
+          },
+          "accessibility": null,
+          "isOptional": false
+        }
+      ],
+      "superClass": {
+        "type": "Identifier",
+        "span": {
+          "start": 16,
+          "end": 17,
+          "ctxt": 0
+        },
+        "value": "B",
+        "optional": false
+      },
+      "isAbstract": false,
+      "typeParams": null,
+      "superTypeParams": null,
+      "implements": []
+    }
+  ],
+  "interpreter": null
+}

--- a/ecmascript/parser/tests/typescript/decorators/parameter/input.ts.json
+++ b/ecmascript/parser/tests/typescript/decorators/parameter/input.ts.json
@@ -111,6 +111,7 @@
                 }
               ],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/classConstructorAccessibility/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/classConstructorAccessibility/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -149,6 +150,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -245,6 +247,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -563,6 +566,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -698,6 +702,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -833,6 +838,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/classConstructorAccessibility2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/classConstructorAccessibility2/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -237,6 +238,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -421,6 +423,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -693,6 +696,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -1103,6 +1107,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -1513,6 +1518,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/classConstructorAccessibility3/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/classConstructorAccessibility3/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -149,6 +150,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -245,6 +247,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -341,6 +344,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/classConstructorParametersAccessibility/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/classConstructorParametersAccessibility/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -245,6 +246,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -437,6 +439,7 @@
               },
               "decorators": [],
               "accessibility": "protected",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/classConstructorParametersAccessibility2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/classConstructorParametersAccessibility2/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -245,6 +246,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -437,6 +439,7 @@
               },
               "decorators": [],
               "accessibility": "protected",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/classConstructorParametersAccessibility3/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/classConstructorParametersAccessibility3/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "protected",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -149,6 +150,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/constructorDefaultValuesReferencingThis/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/constructorDefaultValuesReferencingThis/input.ts.json
@@ -272,6 +272,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues2/input.ts.json
@@ -96,6 +96,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -432,6 +433,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/constructorParameterProperties/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/constructorParameterProperties/input.ts.json
@@ -99,6 +99,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -137,6 +138,7 @@
               },
               "decorators": [],
               "accessibility": "protected",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -577,6 +579,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -625,6 +628,7 @@
               },
               "decorators": [],
               "accessibility": "protected",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/constructorParameterProperties2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/constructorParameterProperties2/input.ts.json
@@ -359,6 +359,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -621,6 +622,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -883,6 +885,7 @@
               },
               "decorators": [],
               "accessibility": "protected",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/declarationEmitReadonly/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/declarationEmitReadonly/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": null,
+              "override": false,
               "readonly": true,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/readonlyConstructorAssignment/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/readonlyConstructorAssignment/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": null,
+              "override": false,
               "readonly": true,
               "param": {
                 "type": "Identifier",
@@ -400,6 +401,7 @@
               },
               "decorators": [],
               "accessibility": null,
+              "override": false,
               "readonly": true,
               "param": {
                 "type": "Identifier",
@@ -599,6 +601,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": true,
               "param": {
                 "type": "Identifier",
@@ -749,6 +752,7 @@
               },
               "decorators": [],
               "accessibility": null,
+              "override": false,
               "readonly": true,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/readonlyInAmbientClass/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorParameters/readonlyInAmbientClass/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": null,
+              "override": false,
               "readonly": true,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorWithExpressionLessReturn/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/constructorWithExpressionLessReturn/input.ts.json
@@ -233,6 +233,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -339,6 +340,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCall/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCall/input.ts.json
@@ -79,6 +79,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -360,6 +361,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCallWithDefineFields/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCallWithDefineFields/input.ts.json
@@ -79,6 +79,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -360,6 +361,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/superCalls/superCallInConstructorWithNoBaseType/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/constructorDeclarations/superCalls/superCallInConstructorWithNoBaseType/input.ts.json
@@ -137,6 +137,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/members/classTypes/instancePropertiesInheritedIntoClassType/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/members/classTypes/instancePropertiesInheritedIntoClassType/input.ts.json
@@ -320,6 +320,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -358,6 +359,7 @@
                     },
                     "decorators": [],
                     "accessibility": "private",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -1237,6 +1239,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -1285,6 +1288,7 @@
                     },
                     "decorators": [],
                     "accessibility": "private",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/members/classTypes/instancePropertyInClassType/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/members/classTypes/instancePropertyInClassType/input.ts.json
@@ -320,6 +320,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -358,6 +359,7 @@
                     },
                     "decorators": [],
                     "accessibility": "private",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -1155,6 +1157,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -1203,6 +1206,7 @@
                     },
                     "decorators": [],
                     "accessibility": "private",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/members/classTypes/staticPropertyNotInClassType/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/members/classTypes/staticPropertyNotInClassType/input.ts.json
@@ -274,6 +274,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -312,6 +313,7 @@
                     },
                     "decorators": [],
                     "accessibility": "private",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -1093,6 +1095,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -1141,6 +1144,7 @@
                     },
                     "decorators": [],
                     "accessibility": "private",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/members/constructorFunctionTypes/classWithStaticMembers/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/members/constructorFunctionTypes/classWithStaticMembers/input.ts.json
@@ -247,6 +247,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -285,6 +286,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext/input.ts.json
@@ -488,6 +488,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -1074,6 +1075,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -1457,6 +1459,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/propertyMemberDeclarations/defineProperty/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/propertyMemberDeclarations/defineProperty/input.ts.json
@@ -370,6 +370,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": true,
               "param": {
                 "type": "Identifier",
@@ -695,6 +696,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/propertyMemberDeclarations/initializerReferencingConstructorParameters/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/propertyMemberDeclarations/initializerReferencingConstructorParameters/input.ts.json
@@ -319,6 +319,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -523,6 +524,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -698,6 +700,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/propertyMemberDeclarations/instanceMemberInitialization/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/propertyMemberDeclarations/instanceMemberInitialization/input.ts.json
@@ -376,6 +376,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": true,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/classes/propertyMemberDeclarations/propertyOverridesAccessors5/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/propertyMemberDeclarations/propertyOverridesAccessors5/input.ts.json
@@ -149,6 +149,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/expressions/contextualTyping/generatedContextualTyping/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/expressions/contextualTyping/generatedContextualTyping/input.ts.json
@@ -17980,6 +17980,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -18170,6 +18171,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -18380,6 +18382,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -18599,6 +18602,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -18799,6 +18803,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -19019,6 +19024,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -19248,6 +19254,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -19407,6 +19414,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -19586,6 +19594,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -19794,6 +19803,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -20018,6 +20028,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -20305,6 +20316,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -20550,6 +20562,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -20740,6 +20753,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -20950,6 +20964,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -21169,6 +21184,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -21369,6 +21385,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -21589,6 +21606,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -21818,6 +21836,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -21977,6 +21996,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -22156,6 +22176,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -22364,6 +22385,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -22588,6 +22610,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -22875,6 +22898,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",

--- a/ecmascript/parser/tests/typescript/tsc/expressions/contextualTyping/superCallParameterContextualTyping1/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/expressions/contextualTyping/superCallParameterContextualTyping1/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/expressions/contextualTyping/superCallParameterContextualTyping2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/expressions/contextualTyping/superCallParameterContextualTyping2/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/expressions/superCalls/superCalls/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/expressions/superCalls/superCalls/input.ts.json
@@ -235,6 +235,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/functions/parameterInitializersForwardReferencing1/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/functions/parameterInitializersForwardReferencing1/input.ts.json
@@ -1069,6 +1069,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -1109,6 +1110,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",

--- a/ecmascript/parser/tests/typescript/tsc/functions/parameterInitializersForwardReferencing1_es6/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/functions/parameterInitializersForwardReferencing1_es6/input.ts.json
@@ -1069,6 +1069,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",
@@ -1109,6 +1110,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot/input.ts.json
@@ -295,6 +295,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -333,6 +334,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -91,6 +92,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -445,6 +447,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -483,6 +486,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndNonExportedFunctionThatShareAName/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndNonExportedFunctionThatShareAName/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -91,6 +92,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -443,6 +445,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -481,6 +484,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticVariableAndExportedVarThatShareAName/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticVariableAndExportedVarThatShareAName/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -91,6 +92,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -414,6 +416,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -452,6 +455,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticVariableAndNonExportedVarThatShareAName/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticVariableAndNonExportedVarThatShareAName/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -91,6 +92,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -406,6 +408,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -444,6 +447,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/EnumAndModuleWithSameNameAndCommonRoot/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/EnumAndModuleWithSameNameAndCommonRoot/input.ts.json
@@ -147,6 +147,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -185,6 +186,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/ModuleAndEnumWithSameNameAndCommonRoot/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/ModuleAndEnumWithSameNameAndCommonRoot/input.ts.json
@@ -87,6 +87,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -125,6 +126,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedLocalVarsOfTheSameName/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedLocalVarsOfTheSameName/input.ts.json
@@ -731,6 +731,7 @@
                               },
                               "decorators": [],
                               "accessibility": "public",
+                              "override": false,
                               "readonly": false,
                               "param": {
                                 "type": "Identifier",
@@ -779,6 +780,7 @@
                               },
                               "decorators": [],
                               "accessibility": "public",
+                              "override": false,
                               "readonly": false,
                               "param": {
                                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedLocalVarsOfTheSameName/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedLocalVarsOfTheSameName/input.ts.json
@@ -804,6 +804,7 @@
                                 },
                                 "decorators": [],
                                 "accessibility": "public",
+                                "override": false,
                                 "readonly": false,
                                 "param": {
                                   "type": "Identifier",
@@ -852,6 +853,7 @@
                                 },
                                 "decorators": [],
                                 "accessibility": "public",
+                                "override": false,
                                 "readonly": false,
                                 "param": {
                                   "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndDifferentCommonRoot/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndDifferentCommonRoot/input.ts.json
@@ -767,6 +767,7 @@
                                       },
                                       "decorators": [],
                                       "accessibility": "public",
+                                      "override": false,
                                       "readonly": false,
                                       "param": {
                                         "type": "Identifier",
@@ -841,6 +842,7 @@
                                       },
                                       "decorators": [],
                                       "accessibility": "public",
+                                      "override": false,
                                       "readonly": false,
                                       "param": {
                                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndSameCommonRoot/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndSameCommonRoot/input.ts.json
@@ -669,6 +669,7 @@
                               },
                               "decorators": [],
                               "accessibility": "public",
+                              "override": false,
                               "readonly": false,
                               "param": {
                                 "type": "Identifier",
@@ -717,6 +718,7 @@
                               },
                               "decorators": [],
                               "accessibility": "public",
+                              "override": false,
                               "readonly": false,
                               "param": {
                                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/codeGeneration/importStatements/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/codeGeneration/importStatements/input.ts.json
@@ -87,6 +87,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -125,6 +126,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportClassWhichExtendsInterfaceWithInaccessibleType/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportClassWhichExtendsInterfaceWithInaccessibleType/input.ts.json
@@ -278,6 +278,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -316,6 +317,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportClassWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportClassWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations/input.ts.json
@@ -566,6 +566,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -614,6 +615,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportClassWithInaccessibleTypeInTypeParameterConstraint/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportClassWithInaccessibleTypeInTypeParameterConstraint/input.ts.json
@@ -558,6 +558,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -606,6 +607,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportFunctionWithAccessibleTypesInParameterAndReturnTypeAnnotation/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportFunctionWithAccessibleTypesInParameterAndReturnTypeAnnotation/input.ts.json
@@ -214,6 +214,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -262,6 +263,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInParameterTypeAnnotation/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInParameterTypeAnnotation/input.ts.json
@@ -206,6 +206,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -254,6 +255,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInReturnTypeAnnotation/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInReturnTypeAnnotation/input.ts.json
@@ -207,6 +207,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -255,6 +256,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportModuleWithAccessibleTypesOnItsExportedMembers/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportModuleWithAccessibleTypesOnItsExportedMembers/input.ts.json
@@ -87,6 +87,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -125,6 +126,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInMemberTypeAnnotations/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInMemberTypeAnnotations/input.ts.json
@@ -80,6 +80,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -118,6 +119,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInNestedMemberTypeAnnotations/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInNestedMemberTypeAnnotations/input.ts.json
@@ -80,6 +80,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -118,6 +119,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedImportAlias/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedImportAlias/input.ts.json
@@ -330,6 +330,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -391,6 +392,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/exportImportAlias/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/exportImportAlias/input.ts.json
@@ -141,6 +141,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -179,6 +180,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -1084,6 +1086,7 @@
                               },
                               "decorators": [],
                               "accessibility": "public",
+                              "override": false,
                               "readonly": false,
                               "param": {
                                 "type": "Identifier",
@@ -1122,6 +1125,7 @@
                               },
                               "decorators": [],
                               "accessibility": "public",
+                              "override": false,
                               "readonly": false,
                               "param": {
                                 "type": "Identifier",
@@ -1634,6 +1638,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/importAliasIdentifiers/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/importAliasIdentifiers/input.ts.json
@@ -87,6 +87,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -125,6 +126,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/jsx/inline/inlineJsxFactoryDeclarationsLocalTypesx/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/inline/inlineJsxFactoryDeclarationsLocalTypesx/input.tsx.json
@@ -1990,6 +1990,7 @@
                 },
                 "decorators": [],
                 "accessibility": "public",
+                "override": false,
                 "readonly": false,
                 "param": {
                   "type": "Identifier",
@@ -3952,6 +3953,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/ClassDeclarations/parserClass2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/ClassDeclarations/parserClass2/input.ts.json
@@ -60,6 +60,7 @@
                 },
                 "decorators": [],
                 "accessibility": "public",
+                "override": false,
                 "readonly": false,
                 "param": {
                   "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/ErrorRecovery/IncompleteMemberVariables/parserErrorRecovery_IncompleteMemberVariable1/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/ErrorRecovery/IncompleteMemberVariables/parserErrorRecovery_IncompleteMemberVariable1/input.ts.json
@@ -217,6 +217,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -255,6 +256,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/ParameterLists/parserParameterList7/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/ParameterLists/parserParameterList7/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -114,6 +115,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -175,6 +177,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/ParameterLists/parserParameterList8/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/ParameterLists/parserParameterList8/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -114,6 +115,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -175,6 +177,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/Protected/Protected9/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/Protected/Protected9/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "protected",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/RealWorld/parserindenter/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/RealWorld/parserindenter/input.ts.json
@@ -245,6 +245,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -306,6 +307,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -354,6 +356,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -402,6 +405,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -440,6 +444,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -501,6 +506,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -549,6 +555,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/parserRealSource1/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/parserRealSource1/input.ts.json
@@ -2057,6 +2057,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/parserRealSource12/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/parserRealSource12/input.ts.json
@@ -1079,6 +1079,7 @@
                     },
                     "decorators": [],
                     "accessibility": "private",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -1135,6 +1136,7 @@
                     },
                     "decorators": [],
                     "accessibility": "private",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -1183,6 +1185,7 @@
                     },
                     "decorators": [],
                     "accessibility": "private",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -1231,6 +1234,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",
@@ -1279,6 +1283,7 @@
                     },
                     "decorators": [],
                     "accessibility": "public",
+                    "override": false,
                     "readonly": false,
                     "param": {
                       "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/parserRealSource5/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/parserRealSource5/input.ts.json
@@ -273,6 +273,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -321,6 +322,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/parserRealSource6/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/parserRealSource6/input.ts.json
@@ -150,6 +150,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -198,6 +199,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -543,6 +545,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -591,6 +594,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -629,6 +633,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -1327,6 +1332,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -1375,6 +1381,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -1423,6 +1430,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -1471,6 +1479,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -1509,6 +1518,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/parserRealSource8/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/parserRealSource8/input.ts.json
@@ -87,6 +87,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -135,6 +136,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -183,6 +185,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -1541,6 +1544,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",
@@ -1682,6 +1686,7 @@
                       },
                       "decorators": [],
                       "accessibility": "public",
+                      "override": false,
                       "readonly": false,
                       "param": {
                         "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/salsa/classCanExtendConstructorFunction/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/salsa/classCanExtendConstructorFunction/input.ts.json
@@ -1595,6 +1595,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/scanner/ecmascript5/scannerClass2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/scanner/ecmascript5/scannerClass2/input.ts.json
@@ -60,6 +60,7 @@
                 },
                 "decorators": [],
                 "accessibility": "public",
+                "override": false,
                 "readonly": false,
                 "param": {
                   "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/types/literal/literalTypesWidenInParameterPosition/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/literal/literalTypesWidenInParameterPosition/input.ts.json
@@ -91,6 +91,7 @@
               },
               "decorators": [],
               "accessibility": null,
+              "override": false,
               "readonly": true,
               "param": {
                 "type": "AssignmentPattern",

--- a/ecmascript/parser/tests/typescript/tsc/types/localTypes/localTypes2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/localTypes/localTypes2/input.ts.json
@@ -109,6 +109,7 @@
                           },
                           "decorators": [],
                           "accessibility": "public",
+                          "override": false,
                           "readonly": false,
                           "param": {
                             "type": "Identifier",
@@ -147,6 +148,7 @@
                           },
                           "decorators": [],
                           "accessibility": "public",
+                          "override": false,
                           "readonly": false,
                           "param": {
                             "type": "Identifier",
@@ -658,6 +660,7 @@
                           },
                           "decorators": [],
                           "accessibility": "public",
+                          "override": false,
                           "readonly": false,
                           "param": {
                             "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/types/localTypes/localTypes3/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/localTypes/localTypes3/input.ts.json
@@ -109,6 +109,7 @@
                           },
                           "decorators": [],
                           "accessibility": "public",
+                          "override": false,
                           "readonly": false,
                           "param": {
                             "type": "Identifier",
@@ -157,6 +158,7 @@
                           },
                           "decorators": [],
                           "accessibility": "public",
+                          "override": false,
                           "readonly": false,
                           "param": {
                             "type": "Identifier",
@@ -742,6 +744,7 @@
                           },
                           "decorators": [],
                           "accessibility": "public",
+                          "override": false,
                           "readonly": false,
                           "param": {
                             "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/types/namedTypes/optionalMethods/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/namedTypes/optionalMethods/input.ts.json
@@ -903,6 +903,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -941,6 +942,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "AssignmentPattern",

--- a/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -75,6 +76,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -155,6 +157,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -235,6 +238,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters2/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -75,6 +76,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -120,6 +122,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -142,6 +145,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -222,6 +226,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -267,6 +272,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -347,6 +353,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -392,6 +399,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/types/specifyingTypes/typeQueries/typeQueryOnClass/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/specifyingTypes/typeQueries/typeQueryOnClass/input.ts.json
@@ -171,6 +171,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -1449,6 +1450,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/types/thisType/thisTypeErrors2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/thisType/thisTypeErrors2/input.ts.json
@@ -247,6 +247,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/constraintSatisfactionWithAny/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/constraintSatisfactionWithAny/input.ts.json
@@ -1061,6 +1061,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -1364,6 +1365,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -1699,6 +1701,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/constraintSatisfactionWithEmptyObject/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/constraintSatisfactionWithEmptyObject/input.ts.json
@@ -352,6 +352,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -1065,6 +1066,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/instanceOf/narrowingGenericTypeFromInstanceof01/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/instanceOf/narrowingGenericTypeFromInstanceof01/input.ts.json
@@ -53,6 +53,7 @@
               },
               "decorators": [],
               "accessibility": "private",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericCallTypeArgumentInference/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericCallTypeArgumentInference/input.ts.json
@@ -802,6 +802,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -850,6 +851,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericCallWithConstraintsTypeArgumentInference/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/typeRelationships/typeInference/genericCallWithConstraintsTypeArgumentInference/input.ts.json
@@ -1536,6 +1536,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",
@@ -1584,6 +1585,7 @@
               },
               "decorators": [],
               "accessibility": "public",
+              "override": false,
               "readonly": false,
               "param": {
                 "type": "Identifier",

--- a/ecmascript/preset_env/Cargo.toml
+++ b/ecmascript/preset_env/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_preset_env/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_preset_env"
-version = "0.18.0"
+version = "0.19.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,14 +21,14 @@ st-map = "0.1.2"
 string_enum = {version = "0.3.1", path = "../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../ast"}
-swc_ecma_transforms = {version = "0.48.0", path = "../transforms", features = ["compat", "proposal"]}
-swc_ecma_utils = {version = "0.34.1", path = "../utils"}
-swc_ecma_visit = {version = "0.29.1", path = "../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../ast"}
+swc_ecma_transforms = {version = "0.49.0", path = "../transforms", features = ["compat", "proposal"]}
+swc_ecma_utils = {version = "0.35.0", path = "../utils"}
+swc_ecma_visit = {version = "0.30.0", path = "../visit"}
 walkdir = "2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
-swc_ecma_codegen = {version = "0.53.0", path = "../codegen"}
-swc_ecma_parser = {version = "0.55.0", path = "../parser"}
+swc_ecma_codegen = {version = "0.54.0", path = "../codegen"}
+swc_ecma_parser = {version = "0.56.0", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.48.0"
+version = "0.49.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -23,24 +23,24 @@ typescript = ["swc_ecma_transforms_typescript"]
 [dependencies]
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../ast"}
-swc_ecma_parser = {version = "0.55.0", path = "../parser"}
-swc_ecma_transforms_base = {version = "0.13.0", path = "./base"}
-swc_ecma_transforms_compat = {version = "0.15.0", path = "./compat", optional = true}
-swc_ecma_transforms_module = {version = "0.15.0", path = "./module", optional = true}
-swc_ecma_transforms_optimization = {version = "0.18.0", path = "./optimization", optional = true}
-swc_ecma_transforms_proposal = {version = "0.15.0", path = "./proposal", optional = true}
-swc_ecma_transforms_react = {version = "0.16.0", path = "./react", optional = true}
-swc_ecma_transforms_typescript = {version = "0.17.0", path = "./typescript", optional = true}
-swc_ecma_utils = {version = "0.34.1", path = "../utils"}
-swc_ecma_visit = {version = "0.29.1", path = "../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../ast"}
+swc_ecma_parser = {version = "0.56.0", path = "../parser"}
+swc_ecma_transforms_base = {version = "0.14.0", path = "./base"}
+swc_ecma_transforms_compat = {version = "0.16.0", path = "./compat", optional = true}
+swc_ecma_transforms_module = {version = "0.16.0", path = "./module", optional = true}
+swc_ecma_transforms_optimization = {version = "0.19.0", path = "./optimization", optional = true}
+swc_ecma_transforms_proposal = {version = "0.16.0", path = "./proposal", optional = true}
+swc_ecma_transforms_react = {version = "0.17.0", path = "./react", optional = true}
+swc_ecma_transforms_typescript = {version = "0.18.0", path = "./typescript", optional = true}
+swc_ecma_utils = {version = "0.35.0", path = "../utils"}
+swc_ecma_visit = {version = "0.30.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
 sourcemap = "6"
-swc_ecma_codegen = {version = "0.53.0", path = "../codegen"}
-swc_ecma_transforms_testing = {version = "0.13.0", path = "./testing"}
+swc_ecma_codegen = {version = "0.54.0", path = "../codegen"}
+swc_ecma_transforms_testing = {version = "0.14.0", path = "./testing"}
 tempfile = "3"
 testing = {version = "0.10.5", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.13.0"
+version = "0.14.0"
 
 [dependencies]
 fxhash = "0.2.1"
@@ -16,11 +16,11 @@ scoped-tls = "1.0.0"
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
-swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
+swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.53.0", path = "../../codegen"}
+swc_ecma_codegen = {version = "0.54.0", path = "../../codegen"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.15.0"
+version = "0.16.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -20,13 +20,13 @@ serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2.5", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
+swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
+swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
 swc_ecma_transforms_macros = {version = "0.2.1", path = "../macros"}
-swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
+swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
-swc_ecma_transforms_testing = {version = "0.13.0", path = "../testing"}
+swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
+swc_ecma_transforms_testing = {version = "0.14.0", path = "../testing"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/module/Cargo.toml
+++ b/ecmascript/transforms/module/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.15.0"
+version = "0.16.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -16,13 +16,13 @@ indexmap = "1.6.1"
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
-swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
+swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.15.0", path = "../compat"}
-swc_ecma_transforms_testing = {version = "0.13.0", path = "../testing/"}
+swc_ecma_transforms_compat = {version = "0.16.0", path = "../compat"}
+swc_ecma_transforms_testing = {version = "0.14.0", path = "../testing/"}
 testing = {version = "0.10.5", path = "../../../testing/"}

--- a/ecmascript/transforms/optimization/Cargo.toml
+++ b/ecmascript/transforms/optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.18.0"
+version = "0.19.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -19,17 +19,17 @@ retain_mut = "0.1.2"
 serde_json = "1.0.61"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
-swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
+swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.15.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.15.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.15.0", path = "../proposal"}
-swc_ecma_transforms_react = {version = "0.16.0", path = "../react"}
-swc_ecma_transforms_testing = {version = "0.13.0", path = "../testing"}
-swc_ecma_transforms_typescript = {version = "0.17.0", path = "../typescript"}
+swc_ecma_transforms_compat = {version = "0.16.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.16.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.16.0", path = "../proposal"}
+swc_ecma_transforms_react = {version = "0.17.0", path = "../react"}
+swc_ecma_transforms_testing = {version = "0.14.0", path = "../testing"}
+swc_ecma_transforms_typescript = {version = "0.18.0", path = "../typescript"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/proposal/Cargo.toml
+++ b/ecmascript/transforms/proposal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_proposal"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.15.0"
+version = "0.16.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,14 +21,14 @@ serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_loader = {version = "0.4.1", path = "../../loader", optional = true}
-swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
-swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
+swc_ecma_loader = {version = "0.5.0", path = "../../loader", optional = true}
+swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
+swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.15.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.15.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.13.0", path = "../testing"}
+swc_ecma_transforms_compat = {version = "0.16.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.16.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.14.0", path = "../testing"}

--- a/ecmascript/transforms/react/Cargo.toml
+++ b/ecmascript/transforms/react/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_react"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.16.0"
+version = "0.17.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -21,15 +21,15 @@ sha-1 = "0.9.4"
 string_enum = {version = "0.3.1", path = "../../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
-swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
+swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.53.0", path = "../../codegen/"}
-swc_ecma_transforms_compat = {version = "0.15.0", path = "../compat/"}
-swc_ecma_transforms_module = {version = "0.15.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.13.0", path = "../testing/"}
+swc_ecma_codegen = {version = "0.54.0", path = "../../codegen/"}
+swc_ecma_transforms_compat = {version = "0.16.0", path = "../compat/"}
+swc_ecma_transforms_module = {version = "0.16.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.14.0", path = "../testing/"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/testing/Cargo.toml
+++ b/ecmascript/transforms/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.13.0"
+version = "0.14.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,11 +15,11 @@ ansi_term = "0.12.1"
 serde = "1"
 serde_json = "1"
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_codegen = {version = "0.53.0", path = "../../codegen"}
-swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
-swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
+swc_ecma_codegen = {version = "0.54.0", path = "../../codegen"}
+swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
+swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
 tempfile = "3.1.0"
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.17.0"
+version = "0.18.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -14,17 +14,17 @@ fxhash = "0.2.1"
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.55.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.13.0", path = "../base"}
-swc_ecma_utils = {version = "0.34.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.29.1", path = "../../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
+swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.53.0", path = "../../codegen"}
-swc_ecma_transforms_compat = {version = "0.15.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.15.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.15.0", path = "../proposal/"}
-swc_ecma_transforms_testing = {version = "0.13.0", path = "../testing"}
+swc_ecma_codegen = {version = "0.54.0", path = "../../codegen"}
+swc_ecma_transforms_compat = {version = "0.16.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.16.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.16.0", path = "../proposal/"}
+swc_ecma_transforms_testing = {version = "0.14.0", path = "../testing"}
 testing = {version = "0.10.5", path = "../../../testing"}
 walkdir = "2.3.1"

--- a/ecmascript/transforms/typescript/src/strip.rs
+++ b/ecmascript/transforms/typescript/src/strip.rs
@@ -224,7 +224,7 @@ impl Strip {
                                         accessibility: param_prop.accessibility.clone(),
                                         is_abstract: false,
                                         is_optional: false,
-                                        is_override: false,
+                                        is_override: param_prop.is_override,
                                         readonly: param_prop.readonly,
                                         declare: false,
                                         definite: false,

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.34.2"
+version = "0.35.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,8 +15,8 @@ once_cell = "1"
 scoped-tls = "1"
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../ast"}
-swc_ecma_visit = {version = "0.29.1", path = "../visit"}
+swc_ecma_ast = {version = "0.44.0", path = "../ast"}
+swc_ecma_visit = {version = "0.30.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]

--- a/ecmascript/visit/Cargo.toml
+++ b/ecmascript/visit/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_visit"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.29.1"
+version = "0.30.0"
 
 [dependencies]
 num-bigint = {version = "0.2", features = ["serde"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.43.1", path = "../ast"}
+swc_ecma_ast = {version = "0.44.0", path = "../ast"}
 swc_visit = {version = "0.2.3", path = "../../visit"}

--- a/ecmascript/visit/src/lib.rs
+++ b/ecmascript/visit/src/lib.rs
@@ -1284,6 +1284,7 @@ define!({
         pub span: Span,
         pub decorators: Vec<Decorator>,
         pub accessibility: Option<Accessibility>,
+        pub is_override: bool,
         pub readonly: bool,
         pub param: TsParamPropParam,
     }


### PR DESCRIPTION
Ref: https://github.com/microsoft/TypeScript/pull/43831 .

[TypeScript playground](https://www.typescriptlang.org/play?ts=4.3.0-dev.20210508#code/MYGwhgzhAEBC0G8BQ1XQG5hNAvNA5PkgL5JKiQwDC0ApgB4AutAdgCYzzJrTAD2LCIwBOAV2CM+wgBR90tYcICWbWhiy4C+AJSIUPNBFEAHBdO37UpYkA)