### PR TITLE
fix(es/transforms/compat): Improve performance

### DIFF
--- a/atoms/src/lib.rs
+++ b/atoms/src/lib.rs
@@ -1,3 +1,13 @@
+//! [JsWord] is an interened string.
+//!
+//! This type should be used instead of [String] for values, because lots of
+//! values are duplicated. For example, if an identifer is named `myVariable`,
+//! there will be lots of identifier usages with the value `myVariable`.
+//!
+//! This type
+//!  - makes equality comparison faster.
+//!  - reduces memory usage.
+
 #![allow(clippy::unreadable_literal)]
 
 include!(concat!(env!("OUT_DIR"), "/js_word.rs"));

--- a/common/src/syntax_pos.rs
+++ b/common/src/syntax_pos.rs
@@ -63,7 +63,20 @@ impl Globals {
     }
 }
 
-// scoped_thread_local!(pub static GLOBALS: Globals);
+/// Storage for span hygiene data.
+///
+/// This variable is used to manage identifiers or to identify nodes.
+/// Note that it's stored as a thread-local storage, but actually it's shared
+/// between threads.
+///
+/// # Usages
+///
+/// ## Span hygiene
+///
+/// [Mark]s are stored in this variable.
+///
+/// You can see the document how swc uses the span hygiene info at
+/// https://rustdoc.swc.rs/swc_ecma_transforms_base/resolver/fn.resolver_with_mark.html
 pub static GLOBALS: ::scoped_tls::ScopedKey<Globals> = ::scoped_tls::ScopedKey {
     inner: {
         thread_local!(static FOO: ::std::cell::Cell<usize> = {

--- a/ecmascript/parser/benches/parser.rs
+++ b/ecmascript/parser/benches/parser.rs
@@ -2,6 +2,7 @@
 
 extern crate test;
 
+use swc_common::comments::SingleThreadedComments;
 use swc_common::FileName;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax};
 use test::Bencher;
@@ -71,97 +72,21 @@ fn yui(b: &mut Bencher) {
     bench_module(b, Default::default(), include_str!("./files/yui-3.12.0.js"))
 }
 
-#[bench]
-fn colors_ts(b: &mut Bencher) {
-    // Copied from ratel-rust
-    bench_module(
-        b,
-        Syntax::Typescript(Default::default()),
-        include_str!("../colors.js"),
-    )
-}
-
-#[bench]
-fn angular_ts(b: &mut Bencher) {
-    bench_module(
-        b,
-        Syntax::Typescript(Default::default()),
-        include_str!("./files/angular-1.2.5.js"),
-    )
-}
-
-#[bench]
-fn backbone_ts(b: &mut Bencher) {
-    bench_module(
-        b,
-        Syntax::Typescript(Default::default()),
-        include_str!("./files/backbone-1.1.0.js"),
-    )
-}
-
-#[bench]
-fn jquery_ts(b: &mut Bencher) {
-    bench_module(
-        b,
-        Syntax::Typescript(Default::default()),
-        include_str!("./files/jquery-1.9.1.js"),
-    )
-}
-
-#[bench]
-fn jquery_mobile_ts(b: &mut Bencher) {
-    bench_module(
-        b,
-        Syntax::Typescript(Default::default()),
-        include_str!("./files/jquery.mobile-1.4.2.js"),
-    )
-}
-
-#[bench]
-fn mootools_ts(b: &mut Bencher) {
-    bench_module(
-        b,
-        Syntax::Typescript(Default::default()),
-        include_str!("./files/mootools-1.4.5.js"),
-    )
-}
-
-#[bench]
-fn underscore_ts(b: &mut Bencher) {
-    bench_module(
-        b,
-        Syntax::Typescript(Default::default()),
-        include_str!("./files/underscore-1.5.2.js"),
-    )
-}
-
-#[bench]
-fn yui_ts(b: &mut Bencher) {
-    bench_module(
-        b,
-        Syntax::Typescript(Default::default()),
-        include_str!("./files/yui-3.12.0.js"),
-    )
-}
-
-#[bench]
-fn large(b: &mut Bencher) {
-    bench_module(
-        b,
-        Syntax::Typescript(Default::default()),
-        include_str!("../../codegen/benches/large-partial.js"),
-    )
-}
-
 fn bench_module(b: &mut Bencher, syntax: Syntax, src: &'static str) {
     b.bytes = src.len() as _;
 
     let _ = ::testing::run_test(false, |cm, _| {
+        let comments = SingleThreadedComments::default();
         let fm = cm.new_source_file(FileName::Anon, src.into());
 
         b.iter(|| {
             let _ = test::black_box({
-                let lexer = Lexer::new(syntax, Default::default(), StringInput::from(&*fm), None);
+                let lexer = Lexer::new(
+                    syntax,
+                    Default::default(),
+                    StringInput::from(&*fm),
+                    Some(&comments),
+                );
                 let mut parser = Parser::new_from(lexer);
                 parser.parse_module()
             });

--- a/ecmascript/transforms/base/src/helpers/mod.rs
+++ b/ecmascript/transforms/base/src/helpers/mod.rs
@@ -60,7 +60,12 @@ macro_rules! add_to {
     }};
 }
 
-scoped_thread_local!(pub static HELPERS: Helpers);
+scoped_thread_local!(
+    /// This variable is used to manage helper scripts like `_inherits` from babel.
+    ///
+    /// The instance contains flags where each flag denotes if a helper script should be injected.
+    pub static HELPERS: Helpers
+);
 
 /// Tracks used helper methods. (e.g. __extends)
 #[derive(Debug, Default)]

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.16.1"
+version = "0.16.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/ecmascript/transforms/compat/src/es2015/block_scoped_fn.rs
+++ b/ecmascript/transforms/compat/src/es2015/block_scoped_fn.rs
@@ -1,6 +1,12 @@
 use swc_common::{Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
+use swc_ecma_transforms_base::perf::Check;
+use swc_ecma_transforms_macros::fast_path;
 use swc_ecma_utils::UsageFinder;
+use swc_ecma_visit::noop_visit_type;
+use swc_ecma_visit::Node;
+use swc_ecma_visit::Visit;
+use swc_ecma_visit::VisitWith;
 use swc_ecma_visit::{noop_fold_type, Fold, FoldWith};
 
 pub fn block_scoped_functions() -> impl Fold {
@@ -10,6 +16,7 @@ pub fn block_scoped_functions() -> impl Fold {
 #[derive(Clone, Copy)]
 struct BlockScopedFns;
 
+#[fast_path(BlockScopedFnFinder)]
 impl Fold for BlockScopedFns {
     noop_fold_type!();
 
@@ -58,6 +65,32 @@ impl Fold for BlockScopedFns {
         stmts.append(&mut extra_stmts);
 
         stmts
+    }
+}
+
+#[derive(Default)]
+struct BlockScopedFnFinder {
+    found: bool,
+}
+
+impl Visit for BlockScopedFnFinder {
+    noop_visit_type!();
+
+    fn visit_stmts(&mut self, stmts: &[Stmt], _: &dyn Node) {
+        for n in stmts {
+            n.visit_with(&Invalid { span: DUMMY_SP }, self);
+        }
+
+        self.found |= stmts.iter().any(|stmt| match stmt {
+            Stmt::Decl(Decl::Fn(..)) => true,
+            _ => false,
+        });
+    }
+}
+
+impl Check for BlockScopedFnFinder {
+    fn should_handle(&self) -> bool {
+        self.found
     }
 }
 

--- a/ecmascript/transforms/compat/src/es2015/classes/mod.rs
+++ b/ecmascript/transforms/compat/src/es2015/classes/mod.rs
@@ -14,6 +14,7 @@ use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
 use swc_ecma_transforms_base::native::is_native;
 use swc_ecma_transforms_base::perf::Check;
+use swc_ecma_transforms_macros::fast_path;
 use swc_ecma_utils::quote_expr;
 use swc_ecma_utils::quote_str;
 use swc_ecma_utils::{
@@ -951,6 +952,7 @@ fn escape_keywords(mut e: Box<Expr>) -> Box<Expr> {
     e
 }
 
+#[derive(Default)]
 struct ClassFinder {
     found: bool,
 }

--- a/ecmascript/transforms/compat/src/es2015/classes/mod.rs
+++ b/ecmascript/transforms/compat/src/es2015/classes/mod.rs
@@ -13,6 +13,7 @@ use swc_common::{Mark, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
 use swc_ecma_transforms_base::native::is_native;
+use swc_ecma_transforms_base::perf::Check;
 use swc_ecma_utils::quote_expr;
 use swc_ecma_utils::quote_str;
 use swc_ecma_utils::{
@@ -187,6 +188,7 @@ where
     }
 }
 
+#[fast_path(ClassFinder)]
 impl<C> Fold for Classes<C>
 where
     C: Comments,
@@ -202,26 +204,6 @@ where
     }
 
     fn fold_decl(&mut self, n: Decl) -> Decl {
-        fn should_work(node: &Decl) -> bool {
-            struct Visitor {
-                found: bool,
-            }
-            impl Visit for Visitor {
-                noop_visit_type!();
-
-                fn visit_class(&mut self, _: &Class, _: &dyn Node) {
-                    self.found = true
-                }
-            }
-            let mut v = Visitor { found: false };
-            node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
-            v.found
-        }
-        // fast path
-        if !should_work(&n) {
-            return n;
-        }
-
         let n = match n {
             Decl::Class(decl) => Decl::Var(self.fold_class_as_var_decl(decl.ident, decl.class)),
             _ => n,
@@ -967,4 +949,22 @@ fn escape_keywords(mut e: Box<Expr>) -> Box<Expr> {
     }
 
     e
+}
+
+struct ClassFinder {
+    found: bool,
+}
+
+impl Visit for ClassFinder {
+    noop_visit_type!();
+
+    fn visit_class(&mut self, _: &Class, _: &dyn Node) {
+        self.found = true
+    }
+}
+
+impl Check for ClassFinder {
+    fn should_handle(&self) -> bool {
+        self.found
+    }
 }

--- a/ecmascript/transforms/compat/src/es2015/destructuring.rs
+++ b/ecmascript/transforms/compat/src/es2015/destructuring.rs
@@ -3,6 +3,8 @@ use std::iter;
 use swc_common::{Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
+use swc_ecma_transforms_base::perf::Check;
+use swc_ecma_transforms_macros::fast_path;
 use swc_ecma_utils::alias_ident_for;
 use swc_ecma_utils::alias_if_required;
 use swc_ecma_utils::has_rest_pat;
@@ -454,6 +456,7 @@ impl AssignFolder {
     }
 }
 
+#[fast_path(DestructuringVisitor)]
 impl Fold for Destructuring {
     noop_fold_type!();
 
@@ -527,6 +530,7 @@ struct AssignFolder {
     ignore_return_value: Option<()>,
 }
 
+#[fast_path(DestructuringVisitor)]
 impl Fold for AssignFolder {
     noop_fold_type!();
 
@@ -1129,6 +1133,7 @@ where
     v.found
 }
 
+#[derive(Default)]
 struct DestructuringVisitor {
     found: bool,
 }
@@ -1142,5 +1147,11 @@ impl Visit for DestructuringVisitor {
             Pat::Ident(..) => {}
             _ => self.found = true,
         }
+    }
+}
+
+impl Check for DestructuringVisitor {
+    fn should_handle(&self) -> bool {
+        self.found
     }
 }

--- a/ecmascript/transforms/compat/src/es2015/duplicate_keys.rs
+++ b/ecmascript/transforms/compat/src/es2015/duplicate_keys.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use fxhash::FxHashSet;
 use swc_atoms::JsWord;
 use swc_common::Spanned;
 use swc_ecma_ast::*;
@@ -34,8 +34,8 @@ impl Fold for DuplicateKeys {
 
 #[derive(Default)]
 struct PropFolder {
-    getter_props: HashSet<JsWord>,
-    setter_props: HashSet<JsWord>,
+    getter_props: FxHashSet<JsWord>,
+    setter_props: FxHashSet<JsWord>,
 }
 
 impl Fold for PropFolder {
@@ -85,7 +85,7 @@ impl Fold for PropFolder {
 }
 
 struct PropNameFolder<'a> {
-    props: &'a mut HashSet<JsWord>,
+    props: &'a mut FxHashSet<JsWord>,
 }
 impl<'a> Fold for PropNameFolder<'a> {
     noop_fold_type!();

--- a/ecmascript/transforms/compat/src/es2015/shorthand_property.rs
+++ b/ecmascript/transforms/compat/src/es2015/shorthand_property.rs
@@ -1,5 +1,11 @@
 use swc_ecma_ast::*;
+use swc_ecma_transforms_base::perf::Check;
+use swc_ecma_transforms_macros::fast_path;
 use swc_ecma_utils::quote_ident;
+use swc_ecma_visit::noop_visit_type;
+use swc_ecma_visit::Node;
+use swc_ecma_visit::Visit;
+use swc_ecma_visit::VisitWith;
 use swc_ecma_visit::{noop_fold_type, Fold, FoldWith};
 
 /// Compile ES2015 shorthand properties to ES5
@@ -43,6 +49,7 @@ pub fn shorthand() -> impl 'static + Fold {
 #[derive(Clone, Copy)]
 struct Shorthand;
 
+#[fast_path(ShorthandFinder)]
 impl Fold for Shorthand {
     noop_fold_type!();
 
@@ -63,6 +70,27 @@ impl Fold for Shorthand {
             }),
             _ => prop,
         }
+    }
+}
+
+#[derive(Default)]
+struct ShorthandFinder {
+    found: bool,
+}
+
+impl Visit for ShorthandFinder {
+    noop_visit_type!();
+
+    fn visit_prop(&mut self, n: &Prop, _: &dyn Node) {
+        n.visit_children_with(self);
+
+        self.found |= n.is_shorthand();
+    }
+}
+
+impl Check for ShorthandFinder {
+    fn should_handle(&self) -> bool {
+        self.found
     }
 }
 

--- a/ecmascript/transforms/compat/src/es2015/shorthand_property.rs
+++ b/ecmascript/transforms/compat/src/es2015/shorthand_property.rs
@@ -84,7 +84,7 @@ impl Visit for ShorthandFinder {
     fn visit_prop(&mut self, n: &Prop, _: &dyn Node) {
         n.visit_children_with(self);
 
-        self.found |= n.is_shorthand();
+        self.found |= n.is_shorthand() || n.is_method();
     }
 }
 

--- a/ecmascript/transforms/compat/src/es2015/spread.rs
+++ b/ecmascript/transforms/compat/src/es2015/spread.rs
@@ -472,6 +472,8 @@ impl Visit for SpreadFinder {
     noop_visit_type!();
 
     fn visit_expr_or_spread(&mut self, n: &ExprOrSpread, _: &dyn Node) {
+        n.visit_children_with(self);
+
         self.found |= n.spread.is_some();
     }
 }

--- a/ecmascript/transforms/compat/src/es2015/spread.rs
+++ b/ecmascript/transforms/compat/src/es2015/spread.rs
@@ -18,6 +18,7 @@ use swc_ecma_utils::StmtLike;
 use swc_ecma_visit::noop_visit_type;
 use swc_ecma_visit::Node;
 use swc_ecma_visit::Visit;
+use swc_ecma_visit::VisitWith;
 use swc_ecma_visit::{noop_fold_type, Fold, FoldWith};
 
 pub fn spread(c: Config) -> impl Fold {

--- a/ecmascript/transforms/compat/src/reserved_words.rs
+++ b/ecmascript/transforms/compat/src/reserved_words.rs
@@ -55,12 +55,47 @@ impl VisitMut for EsReservedWord {
 }
 
 fn is_reserved(sym: &JsWord) -> bool {
-    match &**sym {
-        "enum" | "implements" | "package" | "protected" | "interface" | "private" | "public"
-        | "await" | "break" | "case" | "catch" | "class" | "const" | "continue" | "debugger"
-        | "default" | "delete" | "do" | "else" | "export" | "extends" | "finally" | "for"
-        | "function" | "if" | "in" | "instanceof" | "new" | "return" | "super" | "switch"
-        | "this" | "throw" | "try" | "typeof" | "var" | "void" | "while" | "with" | "yield" => true,
+    match *sym {
+        js_word!("enum")
+        | js_word!("implements")
+        | js_word!("package")
+        | js_word!("protected")
+        | js_word!("interface")
+        | js_word!("private")
+        | js_word!("public")
+        | js_word!("await")
+        | js_word!("break")
+        | js_word!("case")
+        | js_word!("catch")
+        | js_word!("class")
+        | js_word!("const")
+        | js_word!("continue")
+        | js_word!("debugger")
+        | js_word!("default")
+        | js_word!("delete")
+        | js_word!("do")
+        | js_word!("else")
+        | js_word!("export")
+        | js_word!("extends")
+        | js_word!("finally")
+        | js_word!("for")
+        | js_word!("function")
+        | js_word!("if")
+        | js_word!("in")
+        | js_word!("instanceof")
+        | js_word!("new")
+        | js_word!("return")
+        | js_word!("super")
+        | js_word!("switch")
+        | js_word!("this")
+        | js_word!("throw")
+        | js_word!("try")
+        | js_word!("typeof")
+        | js_word!("var")
+        | js_word!("void")
+        | js_word!("while")
+        | js_word!("with")
+        | js_word!("yield") => true,
 
         _ => false,
     }

--- a/ecmascript/utils/src/lib.rs
+++ b/ecmascript/utils/src/lib.rs
@@ -1701,8 +1701,10 @@ impl<'a> UsageFinder<'a> {
     }
 }
 
-// Used for error reporting in transform.
-scoped_thread_local!(pub static HANDLER: Handler);
+scoped_thread_local!(
+    /// Used for error reporting in transform.
+    pub static HANDLER: Handler
+);
 
 /// make a new expression which evaluates `val` preserving side effects, if any.
 pub fn preserve_effects<I>(span: Span, val: Expr, exprs: I) -> Expr


### PR DESCRIPTION
# Tasks


swc_ecma_transforms_compat:
 - [x] `classes`: Fast-path.
 - [x] `destructuring`: Fast-path.
 - [x] `sticky_regex`: Fast-path.
 - [x] `spread`: Fast-path.
 - [x] `shorthand`: Fast-path.
 - [x] `typeof_symbol`: Fast-path.
 - [x] `block_scoped_functions`: Fast path.
 - [x] `duplicate_keys`: Use fxhash.
 - [x] `instance_of`: Fast path.
 - [x] `reserved_words`: Make string comparison efficient.


## Initial

```
test base                          ... bench:     111,254 ns/iter (+/- 13,235) = 97 MB/s
test common_reserved_word          ... bench:     121,888 ns/iter (+/- 16,508) = 89 MB/s
test common_typescript             ... bench:     269,342 ns/iter (+/- 30,072) = 40 MB/s
test es2015                        ... bench:   1,766,677 ns/iter (+/- 125,103) = 6 MB/s
test es2015_arrow                  ... bench:     162,651 ns/iter (+/- 19,908) = 66 MB/s
test es2015_block_scoped_fn        ... bench:     203,907 ns/iter (+/- 25,950) = 53 MB/s
test es2015_block_scoping          ... bench:     190,847 ns/iter (+/- 22,505) = 57 MB/s
test es2015_classes                ... bench:     451,819 ns/iter (+/- 48,700) = 24 MB/s
test es2015_computed_props         ... bench:     119,147 ns/iter (+/- 18,644) = 91 MB/s
test es2015_destructuring          ... bench:     356,579 ns/iter (+/- 38,148) = 30 MB/s
test es2015_duplicate_keys         ... bench:     199,743 ns/iter (+/- 23,338) = 54 MB/s
test es2015_fn_name                ... bench:     192,128 ns/iter (+/- 19,673) = 56 MB/s
test es2015_for_of                 ... bench:     118,548 ns/iter (+/- 17,155) = 91 MB/s
test es2015_instanceof             ... bench:     133,513 ns/iter (+/- 13,504) = 81 MB/s
test es2015_parameters             ... bench:     199,903 ns/iter (+/- 21,725) = 54 MB/s
test es2015_shorthand_property     ... bench:     179,865 ns/iter (+/- 20,189) = 60 MB/s
test es2015_spread                 ... bench:     187,041 ns/iter (+/- 23,023) = 58 MB/s
test es2015_sticky_regex           ... bench:     188,447 ns/iter (+/- 25,198) = 57 MB/s
test es2015_typeof_symbol          ... bench:     135,419 ns/iter (+/- 19,231) = 80 MB/s
test es2016                        ... bench:     117,282 ns/iter (+/- 14,795) = 92 MB/s
test es2016_exponentation          ... bench:     117,254 ns/iter (+/- 17,355) = 92 MB/s
test es2017                        ... bench:     113,073 ns/iter (+/- 12,918) = 96 MB/s
test es2017_async_to_generator     ... bench:     115,553 ns/iter (+/- 15,809) = 94 MB/s
test es2018                        ... bench:     130,281 ns/iter (+/- 13,567) = 83 MB/s
test es2018_object_rest_spread     ... bench:     123,031 ns/iter (+/- 11,428) = 88 MB/s
test es2018_optional_catch_binding ... bench:     114,980 ns/iter (+/- 14,354) = 94 MB/s
test es2020                        ... bench:     337,954 ns/iter (+/- 45,369) = 32 MB/s
test es2020_class_properties       ... bench:     247,589 ns/iter (+/- 36,081) = 43 MB/s
test es2020_nullish_coalescing     ... bench:     113,015 ns/iter (+/- 9,730) = 96 MB/s
test es2020_optional_chaining      ... bench:     172,059 ns/iter (+/- 16,100) = 63 MB/s
test es3                           ... bench:     368,856 ns/iter (+/- 36,758) = 29 MB/s
test full_es2016                   ... bench:     381,481 ns/iter (+/- 40,132) = 28 MB/s
test full_es2017                   ... bench:     375,360 ns/iter (+/- 48,894) = 29 MB/s
test full_es2018                   ... bench:     368,916 ns/iter (+/- 35,474) = 29 MB/s
```


## After adding a fast path to `classes`

```
test base                          ... bench:     119,123 ns/iter (+/- 11,349) = 91 MB/s
test common_reserved_word          ... bench:     128,702 ns/iter (+/- 17,183) = 84 MB/s
test common_typescript             ... bench:     271,088 ns/iter (+/- 30,242) = 40 MB/s
test es2015                        ... bench:   1,720,555 ns/iter (+/- 175,216) = 6 MB/s
test es2015_arrow                  ... bench:     164,435 ns/iter (+/- 24,196) = 66 MB/s
test es2015_block_scoped_fn        ... bench:     200,050 ns/iter (+/- 20,588) = 54 MB/s
test es2015_block_scoping          ... bench:     192,415 ns/iter (+/- 27,862) = 56 MB/s
test es2015_classes                ... bench:     387,521 ns/iter (+/- 34,718) = 28 MB/s
test es2015_computed_props         ... bench:     117,924 ns/iter (+/- 16,929) = 92 MB/s
test es2015_destructuring          ... bench:     351,689 ns/iter (+/- 49,016) = 30 MB/s
test es2015_duplicate_keys         ... bench:     194,642 ns/iter (+/- 20,593) = 55 MB/s
test es2015_fn_name                ... bench:     196,668 ns/iter (+/- 26,409) = 55 MB/s
test es2015_for_of                 ... bench:     114,456 ns/iter (+/- 15,472) = 95 MB/s
test es2015_instanceof             ... bench:     132,189 ns/iter (+/- 15,908) = 82 MB/s
test es2015_parameters             ... bench:     204,334 ns/iter (+/- 24,661) = 53 MB/s
test es2015_shorthand_property     ... bench:     184,448 ns/iter (+/- 22,869) = 59 MB/s
test es2015_spread                 ... bench:     189,732 ns/iter (+/- 25,938) = 57 MB/s
test es2015_sticky_regex           ... bench:     190,018 ns/iter (+/- 27,346) = 57 MB/s
test es2015_typeof_symbol          ... bench:     139,368 ns/iter (+/- 19,035) = 78 MB/s
test es2016                        ... bench:     112,390 ns/iter (+/- 14,009) = 96 MB/s
test es2016_exponentation          ... bench:     114,322 ns/iter (+/- 12,903) = 95 MB/s
test es2017                        ... bench:     115,519 ns/iter (+/- 14,461) = 94 MB/s
test es2017_async_to_generator     ... bench:     113,843 ns/iter (+/- 15,975) = 95 MB/s
test es2018                        ... bench:     128,982 ns/iter (+/- 11,161) = 84 MB/s
test es2018_object_rest_spread     ... bench:     121,391 ns/iter (+/- 10,947) = 89 MB/s
test es2018_optional_catch_binding ... bench:     116,146 ns/iter (+/- 13,819) = 93 MB/s
test es2020                        ... bench:     336,522 ns/iter (+/- 33,591) = 32 MB/s
test es2020_class_properties       ... bench:     242,389 ns/iter (+/- 24,465) = 44 MB/s
test es2020_nullish_coalescing     ... bench:     114,119 ns/iter (+/- 12,118) = 95 MB/s
test es2020_optional_chaining      ... bench:     168,943 ns/iter (+/- 21,376) = 64 MB/s
test es3                           ... bench:     359,321 ns/iter (+/- 37,489) = 30 MB/s
test full_es2016                   ... bench:     380,527 ns/iter (+/- 37,205) = 28 MB/s
test full_es2017                   ... bench:     375,781 ns/iter (+/- 36,744) = 28 MB/s
test full_es2018                   ... bench:     363,945 ns/iter (+/- 31,571) = 29 MB/s
```


## After adding a fast path to `destructuring`

```
running 34 tests
test base                          ... bench:     110,978 ns/iter (+/- 12,179) = 98 MB/s
test common_reserved_word          ... bench:     124,226 ns/iter (+/- 9,441) = 87 MB/s
test common_typescript             ... bench:     272,462 ns/iter (+/- 26,837) = 39 MB/s
test es2015                        ... bench:   1,610,694 ns/iter (+/- 164,953) = 6 MB/s
test es2015_arrow                  ... bench:     169,458 ns/iter (+/- 19,944) = 64 MB/s
test es2015_block_scoped_fn        ... bench:     200,063 ns/iter (+/- 30,689) = 54 MB/s
test es2015_block_scoping          ... bench:     193,180 ns/iter (+/- 26,777) = 56 MB/s
test es2015_classes                ... bench:     387,143 ns/iter (+/- 44,264) = 28 MB/s
test es2015_computed_props         ... bench:     117,002 ns/iter (+/- 16,426) = 93 MB/s
test es2015_destructuring          ... bench:     217,475 ns/iter (+/- 19,423) = 50 MB/s
test es2015_duplicate_keys         ... bench:     197,313 ns/iter (+/- 25,820) = 55 MB/s
test es2015_fn_name                ... bench:     192,425 ns/iter (+/- 19,599) = 56 MB/s
test es2015_for_of                 ... bench:     114,706 ns/iter (+/- 13,315) = 94 MB/s
test es2015_instanceof             ... bench:     132,504 ns/iter (+/- 16,860) = 82 MB/s
test es2015_parameters             ... bench:     207,415 ns/iter (+/- 32,322) = 52 MB/s
test es2015_shorthand_property     ... bench:     184,097 ns/iter (+/- 28,718) = 59 MB/s
test es2015_spread                 ... bench:     185,806 ns/iter (+/- 18,058) = 58 MB/s
test es2015_sticky_regex           ... bench:     185,061 ns/iter (+/- 18,635) = 58 MB/s
test es2015_typeof_symbol          ... bench:     132,213 ns/iter (+/- 14,799) = 82 MB/s
test es2016                        ... bench:     112,725 ns/iter (+/- 15,487) = 96 MB/s
test es2016_exponentation          ... bench:     116,831 ns/iter (+/- 19,807) = 93 MB/s
test es2017                        ... bench:     115,354 ns/iter (+/- 13,631) = 94 MB/s
test es2017_async_to_generator     ... bench:     112,624 ns/iter (+/- 10,224) = 96 MB/s
test es2018                        ... bench:     135,870 ns/iter (+/- 16,089) = 80 MB/s
test es2018_object_rest_spread     ... bench:     123,835 ns/iter (+/- 16,963) = 87 MB/s
test es2018_optional_catch_binding ... bench:     116,783 ns/iter (+/- 17,807) = 93 MB/s
test es2020                        ... bench:     341,832 ns/iter (+/- 38,694) = 31 MB/s
test es2020_class_properties       ... bench:     245,007 ns/iter (+/- 21,921) = 44 MB/s
test es2020_nullish_coalescing     ... bench:     113,899 ns/iter (+/- 10,124) = 95 MB/s
test es2020_optional_chaining      ... bench:     166,763 ns/iter (+/- 16,423) = 65 MB/s
test es3                           ... bench:     361,489 ns/iter (+/- 44,733) = 30 MB/s
test full_es2016                   ... bench:     376,102 ns/iter (+/- 37,820) = 28 MB/s
test full_es2017                   ... bench:     372,284 ns/iter (+/- 41,281) = 29 MB/s
test full_es2018                   ... bench:     368,988 ns/iter (+/- 35,504) = 29 MB/s
```

## After adding a fast path to `sticky_regex`

```
test es2015_sticky_regex           ... bench:     109,634 ns/iter (+/- 19,760) = 99 MB/s
```


## After adding a fast path to `spread`

```
running 34 tests
test base                          ... bench:     110,467 ns/iter (+/- 14,280) = 98 MB/s
test common_reserved_word          ... bench:     120,610 ns/iter (+/- 21,053) = 90 MB/s
test common_typescript             ... bench:     262,416 ns/iter (+/- 21,867) = 41 MB/s
test es2015                        ... bench:   1,415,561 ns/iter (+/- 173,442) = 7 MB/s
test es2015_arrow                  ... bench:     159,041 ns/iter (+/- 25,010) = 68 MB/s
test es2015_block_scoped_fn        ... bench:     191,183 ns/iter (+/- 21,420) = 56 MB/s
test es2015_block_scoping          ... bench:     185,045 ns/iter (+/- 17,661) = 58 MB/s
test es2015_classes                ... bench:     376,451 ns/iter (+/- 30,514) = 28 MB/s
test es2015_computed_props         ... bench:     116,755 ns/iter (+/- 12,743) = 93 MB/s
test es2015_destructuring          ... bench:     207,133 ns/iter (+/- 19,530) = 52 MB/s
test es2015_duplicate_keys         ... bench:     190,161 ns/iter (+/- 19,727) = 57 MB/s
test es2015_fn_name                ... bench:     185,233 ns/iter (+/- 28,422) = 58 MB/s
test es2015_for_of                 ... bench:     115,010 ns/iter (+/- 18,323) = 94 MB/s
test es2015_instanceof             ... bench:     135,199 ns/iter (+/- 17,909) = 80 MB/s
test es2015_parameters             ... bench:     202,255 ns/iter (+/- 23,682) = 53 MB/s
test es2015_shorthand_property     ... bench:     180,277 ns/iter (+/- 25,541) = 60 MB/s
test es2015_spread                 ... bench:     114,339 ns/iter (+/- 19,182) = 95 MB/s
test es2015_sticky_regex           ... bench:     115,323 ns/iter (+/- 13,302) = 94 MB/s
test es2015_typeof_symbol          ... bench:     131,391 ns/iter (+/- 17,722) = 82 MB/s
test es2016                        ... bench:     114,611 ns/iter (+/- 16,855) = 95 MB/s
test es2016_exponentation          ... bench:     113,137 ns/iter (+/- 16,839) = 96 MB/s
test es2017                        ... bench:     114,441 ns/iter (+/- 15,281) = 95 MB/s
test es2017_async_to_generator     ... bench:     114,061 ns/iter (+/- 12,425) = 95 MB/s
test es2018                        ... bench:     127,693 ns/iter (+/- 9,025) = 85 MB/s
test es2018_object_rest_spread     ... bench:     120,077 ns/iter (+/- 15,942) = 90 MB/s
test es2018_optional_catch_binding ... bench:     114,473 ns/iter (+/- 15,175) = 95 MB/s
test es2020                        ... bench:     332,852 ns/iter (+/- 30,172) = 32 MB/s
test es2020_class_properties       ... bench:     240,001 ns/iter (+/- 24,858) = 45 MB/s
test es2020_nullish_coalescing     ... bench:     114,193 ns/iter (+/- 17,286) = 95 MB/s
test es2020_optional_chaining      ... bench:     169,462 ns/iter (+/- 20,051) = 64 MB/s
test es3                           ... bench:     361,264 ns/iter (+/- 35,778) = 30 MB/s
test full_es2016                   ... bench:     373,841 ns/iter (+/- 45,641) = 29 MB/s
test full_es2017                   ... bench:     365,681 ns/iter (+/- 47,326) = 29 MB/s
test full_es2018                   ... bench:     362,914 ns/iter (+/- 43,774) = 30 MB/s
```


## After adding a fast-path to `shorthand`


```
test base                          ... bench:     109,045 ns/iter (+/- 19,984) = 99 MB/s
test common_reserved_word          ... bench:     123,454 ns/iter (+/- 13,924) = 88 MB/s
test common_typescript             ... bench:     265,849 ns/iter (+/- 22,810) = 40 MB/s
test es2015                        ... bench:   1,329,596 ns/iter (+/- 75,531) = 8 MB/s
test es2015_arrow                  ... bench:     161,227 ns/iter (+/- 25,498) = 67 MB/s
test es2015_block_scoped_fn        ... bench:     196,059 ns/iter (+/- 27,339) = 55 MB/s
test es2015_block_scoping          ... bench:     186,595 ns/iter (+/- 26,355) = 58 MB/s
test es2015_classes                ... bench:     377,713 ns/iter (+/- 33,404) = 28 MB/s
test es2015_computed_props         ... bench:     112,094 ns/iter (+/- 16,380) = 97 MB/s
test es2015_destructuring          ... bench:     216,431 ns/iter (+/- 26,043) = 50 MB/s
test es2015_duplicate_keys         ... bench:     188,096 ns/iter (+/- 26,518) = 57 MB/s
test es2015_fn_name                ... bench:     187,868 ns/iter (+/- 24,676) = 57 MB/s
test es2015_for_of                 ... bench:     115,231 ns/iter (+/- 20,022) = 94 MB/s
test es2015_instanceof             ... bench:     128,972 ns/iter (+/- 12,909) = 84 MB/s
test es2015_parameters             ... bench:     196,952 ns/iter (+/- 22,703) = 55 MB/s
test es2015_shorthand_property     ... bench:     114,210 ns/iter (+/- 15,475) = 95 MB/s
test es2015_spread                 ... bench:     111,460 ns/iter (+/- 11,789) = 97 MB/s
test es2015_sticky_regex           ... bench:     116,540 ns/iter (+/- 17,669) = 93 MB/s
test es2015_typeof_symbol          ... bench:     129,232 ns/iter (+/- 10,847) = 84 MB/s
test es2016                        ... bench:     114,294 ns/iter (+/- 13,265) = 95 MB/s
test es2016_exponentation          ... bench:     113,178 ns/iter (+/- 15,223) = 96 MB/s
test es2017                        ... bench:     112,647 ns/iter (+/- 8,948) = 96 MB/s
test es2017_async_to_generator     ... bench:     110,528 ns/iter (+/- 9,492) = 98 MB/s
test es2018                        ... bench:     129,380 ns/iter (+/- 20,162) = 84 MB/s
test es2018_object_rest_spread     ... bench:     121,343 ns/iter (+/- 16,102) = 89 MB/s
test es2018_optional_catch_binding ... bench:     113,886 ns/iter (+/- 9,513) = 95 MB/s
test es2020                        ... bench:     337,599 ns/iter (+/- 42,616) = 32 MB/s
test es2020_class_properties       ... bench:     241,041 ns/iter (+/- 32,503) = 45 MB/s
test es2020_nullish_coalescing     ... bench:     118,513 ns/iter (+/- 21,243) = 91 MB/s
test es2020_optional_chaining      ... bench:     176,100 ns/iter (+/- 29,701) = 61 MB/s
test es3                           ... bench:     369,626 ns/iter (+/- 63,000) = 29 MB/s
test full_es2016                   ... bench:     382,746 ns/iter (+/- 56,262) = 28 MB/s
test full_es2017                   ... bench:     377,044 ns/iter (+/- 55,082) = 28 MB/s
test full_es2018                   ... bench:     365,537 ns/iter (+/- 49,721) = 29 MB/s
```


### After adding fast-paths to `typeof_symbol` and `block_scoped_functions`


```
test base                          ... bench:     111,699 ns/iter (+/- 22,995) = 97 MB/s
test common_reserved_word          ... bench:     124,373 ns/iter (+/- 17,009) = 87 MB/s
test common_typescript             ... bench:     262,763 ns/iter (+/- 28,433) = 41 MB/s
test es2015                        ... bench:   1,278,111 ns/iter (+/- 167,443) = 8 MB/s
test es2015_arrow                  ... bench:     165,562 ns/iter (+/- 17,693) = 65 MB/s
test es2015_block_scoped_fn        ... bench:     126,581 ns/iter (+/- 13,807) = 86 MB/s
test es2015_block_scoping          ... bench:     192,125 ns/iter (+/- 29,475) = 56 MB/s
test es2015_classes                ... bench:     373,021 ns/iter (+/- 45,325) = 29 MB/s
test es2015_computed_props         ... bench:     114,298 ns/iter (+/- 20,493) = 95 MB/s
test es2015_destructuring          ... bench:     215,121 ns/iter (+/- 25,235) = 50 MB/s
test es2015_duplicate_keys         ... bench:     194,354 ns/iter (+/- 18,901) = 56 MB/s
test es2015_fn_name                ... bench:     184,155 ns/iter (+/- 17,998) = 59 MB/s
test es2015_for_of                 ... bench:     110,387 ns/iter (+/- 10,112) = 98 MB/s
test es2015_instanceof             ... bench:     132,182 ns/iter (+/- 17,539) = 82 MB/s
test es2015_parameters             ... bench:     209,194 ns/iter (+/- 23,297) = 52 MB/s
test es2015_shorthand_property     ... bench:     113,278 ns/iter (+/- 14,347) = 96 MB/s
test es2015_spread                 ... bench:     111,437 ns/iter (+/- 10,849) = 97 MB/s
test es2015_sticky_regex           ... bench:     115,240 ns/iter (+/- 16,694) = 94 MB/s
test es2015_typeof_symbol          ... bench:     132,923 ns/iter (+/- 13,064) = 81 MB/s
test es2016                        ... bench:     114,351 ns/iter (+/- 15,971) = 95 MB/s
test es2016_exponentation          ... bench:     115,622 ns/iter (+/- 16,725) = 94 MB/s
test es2017                        ... bench:     112,396 ns/iter (+/- 14,309) = 96 MB/s
test es2017_async_to_generator     ... bench:     113,016 ns/iter (+/- 15,287) = 96 MB/s
test es2018                        ... bench:     129,416 ns/iter (+/- 19,047) = 84 MB/s
test es2018_object_rest_spread     ... bench:     123,075 ns/iter (+/- 16,372) = 88 MB/s
test es2018_optional_catch_binding ... bench:     117,407 ns/iter (+/- 16,016) = 92 MB/s
test es2020                        ... bench:     340,657 ns/iter (+/- 43,035) = 31 MB/s
test es2020_class_properties       ... bench:     236,191 ns/iter (+/- 20,927) = 46 MB/s
test es2020_nullish_coalescing     ... bench:     114,683 ns/iter (+/- 13,315) = 94 MB/s
test es2020_optional_chaining      ... bench:     165,987 ns/iter (+/- 19,508) = 65 MB/s
test es3                           ... bench:     359,162 ns/iter (+/- 50,442) = 30 MB/s
test full_es2016                   ... bench:     366,948 ns/iter (+/- 43,308) = 29 MB/s
test full_es2017                   ... bench:     372,805 ns/iter (+/- 42,187) = 29 MB/s
test full_es2018                   ... bench:     368,196 ns/iter (+/- 40,631) = 29 MB/s
```


## After adding fast path to `instanceof`


```
test base                          ... bench:     106,474 ns/iter (+/- 9,747) = 102 MB/s
test common_reserved_word          ... bench:     125,977 ns/iter (+/- 19,124) = 86 MB/s
test common_typescript             ... bench:     261,931 ns/iter (+/- 22,709) = 41 MB/s
test es2015                        ... bench:   1,260,394 ns/iter (+/- 111,879) = 8 MB/s
test es2015_arrow                  ... bench:     159,833 ns/iter (+/- 18,372) = 68 MB/s
test es2015_block_scoped_fn        ... bench:     125,100 ns/iter (+/- 11,913) = 87 MB/s
test es2015_block_scoping          ... bench:     190,232 ns/iter (+/- 23,615) = 57 MB/s
test es2015_classes                ... bench:     385,948 ns/iter (+/- 43,893) = 28 MB/s
test es2015_computed_props         ... bench:     113,896 ns/iter (+/- 14,391) = 95 MB/s
test es2015_destructuring          ... bench:     213,996 ns/iter (+/- 22,397) = 50 MB/s
test es2015_duplicate_keys         ... bench:     193,459 ns/iter (+/- 27,935) = 56 MB/s
test es2015_fn_name                ... bench:     186,991 ns/iter (+/- 24,546) = 58 MB/s
test es2015_for_of                 ... bench:     115,588 ns/iter (+/- 15,053) = 94 MB/s
test es2015_instanceof             ... bench:     124,602 ns/iter (+/- 14,651) = 87 MB/s
test es2015_parameters             ... bench:     198,420 ns/iter (+/- 30,385) = 54 MB/s
test es2015_shorthand_property     ... bench:     113,107 ns/iter (+/- 16,159) = 96 MB/s
test es2015_spread                 ... bench:     109,560 ns/iter (+/- 9,882) = 99 MB/s
test es2015_sticky_regex           ... bench:     121,220 ns/iter (+/- 23,175) = 89 MB/s
test es2015_typeof_symbol          ... bench:     139,403 ns/iter (+/- 18,804) = 78 MB/s
test es2016                        ... bench:     111,700 ns/iter (+/- 13,084) = 97 MB/s
test es2016_exponentation          ... bench:     113,351 ns/iter (+/- 14,413) = 96 MB/s
test es2017                        ... bench:     116,126 ns/iter (+/- 11,113) = 93 MB/s
test es2017_async_to_generator     ... bench:     111,316 ns/iter (+/- 14,086) = 97 MB/s
test es2018                        ... bench:     128,289 ns/iter (+/- 11,600) = 84 MB/s
test es2018_object_rest_spread     ... bench:     119,571 ns/iter (+/- 15,971) = 91 MB/s
test es2018_optional_catch_binding ... bench:     114,586 ns/iter (+/- 13,609) = 95 MB/s
test es2020                        ... bench:     335,619 ns/iter (+/- 26,526) = 32 MB/s
test es2020_class_properties       ... bench:     239,234 ns/iter (+/- 28,965) = 45 MB/s
test es2020_nullish_coalescing     ... bench:     111,718 ns/iter (+/- 9,875) = 97 MB/s
test es2020_optional_chaining      ... bench:     165,413 ns/iter (+/- 21,254) = 65 MB/s
test es3                           ... bench:     355,055 ns/iter (+/- 41,260) = 30 MB/s
test full_es2016                   ... bench:     381,573 ns/iter (+/- 38,711) = 28 MB/s
test full_es2017                   ... bench:     371,414 ns/iter (+/- 45,891) = 29 MB/s
test full_es2018                   ... bench:     360,762 ns/iter (+/- 36,169) = 30 MB/s
```


## After optimizing `reserved_words` pass

```
test base                          ... bench:     108,556 ns/iter (+/- 19,165) = 100 MB/s
test common_reserved_word          ... bench:     118,305 ns/iter (+/- 15,006) = 92 MB/s
test common_typescript             ... bench:     259,472 ns/iter (+/- 32,092) = 41 MB/s
test es2015                        ... bench:   1,259,980 ns/iter (+/- 128,118) = 8 MB/s
test es2015_arrow                  ... bench:     162,146 ns/iter (+/- 23,016) = 67 MB/s
test es2015_block_scoped_fn        ... bench:     129,236 ns/iter (+/- 15,513) = 84 MB/s
test es2015_block_scoping          ... bench:     188,041 ns/iter (+/- 25,033) = 57 MB/s
test es2015_classes                ... bench:     381,788 ns/iter (+/- 51,665) = 28 MB/s
test es2015_computed_props         ... bench:     110,898 ns/iter (+/- 8,926) = 98 MB/s
test es2015_destructuring          ... bench:     210,351 ns/iter (+/- 20,573) = 51 MB/s
test es2015_duplicate_keys         ... bench:     193,346 ns/iter (+/- 19,369) = 56 MB/s
test es2015_fn_name                ... bench:     186,713 ns/iter (+/- 23,992) = 58 MB/s
test es2015_for_of                 ... bench:     110,752 ns/iter (+/- 12,403) = 98 MB/s
test es2015_instanceof             ... bench:     121,387 ns/iter (+/- 9,982) = 89 MB/s
test es2015_parameters             ... bench:     204,662 ns/iter (+/- 18,100) = 53 MB/s
test es2015_shorthand_property     ... bench:     117,378 ns/iter (+/- 22,240) = 92 MB/s
test es2015_spread                 ... bench:     112,544 ns/iter (+/- 15,461) = 96 MB/s
test es2015_sticky_regex           ... bench:     113,180 ns/iter (+/- 12,234) = 96 MB/s
test es2015_typeof_symbol          ... bench:     132,873 ns/iter (+/- 11,901) = 81 MB/s
test es2016                        ... bench:     117,528 ns/iter (+/- 12,786) = 92 MB/s
test es2016_exponentation          ... bench:     116,447 ns/iter (+/- 18,097) = 93 MB/s
test es2017                        ... bench:     111,721 ns/iter (+/- 13,977) = 97 MB/s
test es2017_async_to_generator     ... bench:     114,503 ns/iter (+/- 13,173) = 95 MB/s
test es2018                        ... bench:     134,437 ns/iter (+/- 14,715) = 81 MB/s
test es2018_object_rest_spread     ... bench:     124,872 ns/iter (+/- 13,231) = 87 MB/s
test es2018_optional_catch_binding ... bench:     112,908 ns/iter (+/- 12,989) = 96 MB/s
test es2020                        ... bench:     331,524 ns/iter (+/- 40,993) = 32 MB/s
test es2020_class_properties       ... bench:     233,190 ns/iter (+/- 22,750) = 46 MB/s
test es2020_nullish_coalescing     ... bench:     115,222 ns/iter (+/- 18,062) = 94 MB/s
test es2020_optional_chaining      ... bench:     170,744 ns/iter (+/- 28,024) = 63 MB/s
test es3                           ... bench:     360,317 ns/iter (+/- 29,331) = 30 MB/s
test full_es2016                   ... bench:     373,828 ns/iter (+/- 35,296) = 29 MB/s
test full_es2017                   ... bench:     365,483 ns/iter (+/- 38,911) = 29 MB/s
test full_es2018                   ... bench:     355,189 ns/iter (+/- 37,006) = 30 MB/s
```