### PR TITLE
feat(es/parser): support type-only import equals declaration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.19.0"
+version = "0.20.0"
 
 [lib]
 name = "swc"
@@ -30,12 +30,12 @@ serde_json = "1"
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "./atoms"}
 swc_common = {version = "0.10.16", path = "./common", features = ["sourcemap", "concurrent"]}
-swc_ecma_ast = {version = "0.44.0", path = "./ecmascript/ast"}
-swc_ecma_codegen = {version = "0.54.0", path = "./ecmascript/codegen"}
-swc_ecma_ext_transforms = {version = "0.14.0", path = "./ecmascript/ext-transforms"}
-swc_ecma_parser = {version = "0.56.0", path = "./ecmascript/parser"}
-swc_ecma_preset_env = {version = "0.19.0", path = "./ecmascript/preset_env"}
-swc_ecma_transforms = {version = "0.49.0", path = "./ecmascript/transforms", features = [
+swc_ecma_ast = {version = "0.45.0", path = "./ecmascript/ast"}
+swc_ecma_codegen = {version = "0.55.0", path = "./ecmascript/codegen"}
+swc_ecma_ext_transforms = {version = "0.15.0", path = "./ecmascript/ext-transforms"}
+swc_ecma_parser = {version = "0.57.0", path = "./ecmascript/parser"}
+swc_ecma_preset_env = {version = "0.20.0", path = "./ecmascript/preset_env"}
+swc_ecma_transforms = {version = "0.50.0", path = "./ecmascript/transforms", features = [
   "compat",
   "module",
   "optimization",
@@ -43,8 +43,8 @@ swc_ecma_transforms = {version = "0.49.0", path = "./ecmascript/transforms", fea
   "react",
   "typescript",
 ]}
-swc_ecma_utils = {version = "0.35.0", path = "./ecmascript/utils"}
-swc_ecma_visit = {version = "0.30.0", path = "./ecmascript/visit"}
+swc_ecma_utils = {version = "0.36.0", path = "./ecmascript/utils"}
+swc_ecma_visit = {version = "0.31.0", path = "./ecmascript/visit"}
 swc_node_base = {version = "0.1.0", path = "./node/base"}
 swc_visit = {version = "0.2.3", path = "./visit"}
 

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -9,7 +9,7 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/**/*.js"]
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.36.0"
+version = "0.37.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -33,19 +33,19 @@ relative-path = "1.2"
 retain_mut = "0.1.2"
 swc_atoms = {version = "0.2.4", path = "../atoms"}
 swc_common = {version = "0.10.16", path = "../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../ecmascript/ast"}
-swc_ecma_codegen = {version = "0.54.0", path = "../ecmascript/codegen"}
-swc_ecma_parser = {version = "0.56.0", path = "../ecmascript/parser"}
-swc_ecma_transforms = {version = "0.49.0", path = "../ecmascript/transforms", features = ["optimization"]}
-swc_ecma_utils = {version = "0.35.0", path = "../ecmascript/utils"}
-swc_ecma_visit = {version = "0.30.0", path = "../ecmascript/visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../ecmascript/ast"}
+swc_ecma_codegen = {version = "0.55.0", path = "../ecmascript/codegen"}
+swc_ecma_parser = {version = "0.57.0", path = "../ecmascript/parser"}
+swc_ecma_transforms = {version = "0.50.0", path = "../ecmascript/transforms", features = ["optimization"]}
+swc_ecma_utils = {version = "0.36.0", path = "../ecmascript/utils"}
+swc_ecma_visit = {version = "0.31.0", path = "../ecmascript/visit"}
 
 [dev-dependencies]
 hex = "0.4"
 ntest = "0.7.2"
 reqwest = {version = "0.10.8", features = ["blocking"]}
 sha-1 = "0.9"
-swc_ecma_transforms = {version = "0.49.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
+swc_ecma_transforms = {version = "0.50.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
 tempfile = "3.1.0"
 testing = {version = "0.10.5", path = "../testing"}
 url = "2.1.1"

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.35.0"
+version = "0.36.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -27,12 +27,12 @@ react = ["swc_ecma_transforms/react"]
 typescript = ["swc_ecma_transforms/typescript"]
 
 [dependencies]
-swc_ecma_ast = {version = "0.44.0", path = "./ast"}
-swc_ecma_codegen = {version = "0.54.0", path = "./codegen", optional = true}
-swc_ecma_dep_graph = {version = "0.24.0", path = "./dep-graph", optional = true}
-swc_ecma_parser = {version = "0.56.0", path = "./parser", optional = true}
-swc_ecma_transforms = {version = "0.49.0", path = "./transforms", optional = true}
-swc_ecma_utils = {version = "0.35.0", path = "./utils", optional = true}
-swc_ecma_visit = {version = "0.30.0", path = "./visit", optional = true}
+swc_ecma_ast = {version = "0.45.0", path = "./ast"}
+swc_ecma_codegen = {version = "0.55.0", path = "./codegen", optional = true}
+swc_ecma_dep_graph = {version = "0.25.0", path = "./dep-graph", optional = true}
+swc_ecma_parser = {version = "0.57.0", path = "./parser", optional = true}
+swc_ecma_transforms = {version = "0.50.0", path = "./transforms", optional = true}
+swc_ecma_utils = {version = "0.36.0", path = "./utils", optional = true}
+swc_ecma_visit = {version = "0.31.0", path = "./visit", optional = true}
 
 [dev-dependencies]

--- a/ecmascript/ast/Cargo.toml
+++ b/ecmascript/ast/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ast"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.44.0"
+version = "0.45.0"
 
 [features]
 default = []

--- a/ecmascript/ast/src/typescript.rs
+++ b/ecmascript/ast/src/typescript.rs
@@ -911,6 +911,7 @@ pub struct TsImportEqualsDecl {
     pub span: Span,
     pub declare: bool,
     pub is_export: bool,
+    pub is_type_only: bool,
     pub id: Ident,
     pub module_ref: TsModuleRef,
 }

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.54.0"
+version = "0.55.0"
 
 [dependencies]
 bitflags = "1"
@@ -15,9 +15,9 @@ num-bigint = {version = "0.2", features = ["serde"]}
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../ast"}
+swc_ecma_ast = {version = "0.45.0", path = "../ast"}
 swc_ecma_codegen_macros = {version = "0.5.2", path = "./macros"}
-swc_ecma_parser = {version = "0.56.0", path = "../parser"}
+swc_ecma_parser = {version = "0.57.0", path = "../parser"}
 
 [dev-dependencies]
 swc_common = {version = "0.10.16", path = "../../common", features = ["sourcemap"]}

--- a/ecmascript/codegen/src/typescript.rs
+++ b/ecmascript/codegen/src/typescript.rs
@@ -250,7 +250,17 @@ impl<'a> Emitter<'a> {
         }
 
         keyword!("import");
+        space!();
+
+        if n.is_type_only {
+            keyword!("type");
+            space!();
+        }
+
+        emit!(n.id);
+
         formatting_space!();
+
         punct!("=");
         formatting_space!();
 

--- a/ecmascript/dep-graph/Cargo.toml
+++ b/ecmascript/dep-graph/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_dep_graph"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.24.0"
+version = "0.25.0"
 
 [dependencies]
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../ast"}
-swc_ecma_visit = {version = "0.30.0", path = "../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../ast"}
+swc_ecma_visit = {version = "0.31.0", path = "../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.56.0", path = "../parser"}
+swc_ecma_parser = {version = "0.57.0", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/ext-transforms/Cargo.toml
+++ b/ecmascript/ext-transforms/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_ext_transforms/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ext_transforms"
-version = "0.14.0"
+version = "0.15.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,7 +13,7 @@ version = "0.14.0"
 phf = {version = "0.8.0", features = ["macros"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../ast"}
-swc_ecma_parser = {version = "0.56.0", path = "../parser"}
-swc_ecma_utils = {version = "0.35.0", path = "../utils"}
-swc_ecma_visit = {version = "0.30.0", path = "../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../ast"}
+swc_ecma_parser = {version = "0.57.0", path = "../parser"}
+swc_ecma_utils = {version = "0.36.0", path = "../utils"}
+swc_ecma_visit = {version = "0.31.0", path = "../visit"}

--- a/ecmascript/jsdoc/Cargo.toml
+++ b/ecmascript/jsdoc/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/jsdoc/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "jsdoc"
-version = "0.24.0"
+version = "0.25.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,7 +18,7 @@ swc_common = {version = "0.10.16", path = "../../common"}
 [dev-dependencies]
 anyhow = "1"
 dashmap = "4.0.2"
-swc_ecma_ast = {version = "0.44.0", path = "../ast"}
-swc_ecma_parser = {version = "0.56.0", path = "../parser"}
+swc_ecma_ast = {version = "0.45.0", path = "../ast"}
+swc_ecma_parser = {version = "0.57.0", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/loader/Cargo.toml
+++ b/ecmascript/loader/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_loader"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.5.0"
+version = "0.6.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 swc_atoms = {version = "0.2.3", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../ast"}
-swc_ecma_visit = {version = "0.30.0", path = "../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../ast"}
+swc_ecma_visit = {version = "0.31.0", path = "../visit"}
 
 [dev-dependencies]
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.56.3"
+version = "0.57.0"
 
 [features]
 default = []
@@ -22,8 +22,8 @@ serde = {version = "1", features = ["derive"]}
 smallvec = "1"
 swc_atoms = {version = "0.2.3", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../ast"}
-swc_ecma_visit = {version = "0.30.0", path = "../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../ast"}
+swc_ecma_visit = {version = "0.31.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]

--- a/ecmascript/parser/src/parser/stmt/module_item.rs
+++ b/ecmascript/parser/src/parser/stmt/module_item.rs
@@ -45,7 +45,9 @@ impl<'a, I: Tokens> Parser<I> {
 
         if self.input.syntax().typescript() && is!(self, IdentRef) && peeked_is!(self, '=') {
             return self
-                .parse_ts_import_equals_decl(start, false)
+                .parse_ts_import_equals_decl(
+                    start, /* is_export */ false, /* is_type_only */ false,
+                )
                 .map(ModuleDecl::from)
                 .map(ModuleItem::from);
         }
@@ -81,6 +83,15 @@ impl<'a, I: Tokens> Parser<I> {
 
         if type_only {
             assert_and_bump!(self, "type");
+
+            if is!(self, IdentRef) && peeked_is!(self, '=') {
+                return self
+                    .parse_ts_import_equals_decl(
+                        start, /* is_export */ false, /* is_type_only */ true,
+                    )
+                    .map(ModuleDecl::from)
+                    .map(ModuleItem::from);
+            }
         }
 
         let mut specifiers = vec![];
@@ -262,7 +273,9 @@ impl<'a, I: Tokens> Parser<I> {
             if eat!(self, "import") {
                 // export import A = B
                 return self
-                    .parse_ts_import_equals_decl(start, /* is_export */ true)
+                    .parse_ts_import_equals_decl(
+                        start, /* is_export */ true, /* is_type_only */ false,
+                    )
                     .map(From::from);
             }
 

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -973,6 +973,7 @@ impl<I: Tokens> Parser<I> {
         &mut self,
         start: BytePos,
         is_export: bool,
+        is_type_only: bool,
     ) -> PResult<TsImportEqualsDecl> {
         debug_assert!(self.input.syntax().typescript());
 
@@ -986,6 +987,7 @@ impl<I: Tokens> Parser<I> {
             declare: false,
             id,
             is_export,
+            is_type_only,
             module_ref,
         })
     }

--- a/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/named/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/named/input.ts
@@ -1,1 +1,1 @@
-import type { MyType } = from 'commonjs-package'
+import type { MyType } = require('commonjs-package')

--- a/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/named/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/named/input.ts
@@ -1,0 +1,1 @@
+import type { MyType } = from 'commonjs-package'

--- a/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/named/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/named/input.ts.stderr
@@ -1,6 +1,6 @@
 error: Expected from, got =
  --> $DIR/tests/typescript-errors/type-only-import-equals-decl/named/input.ts:1:24
   |
-1 | import type { MyType } = from 'commonjs-package'
+1 | import type { MyType } = require('commonjs-package')
   |                        ^
 

--- a/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/named/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/named/input.ts.stderr
@@ -1,0 +1,6 @@
+error: Expected from, got =
+ --> $DIR/tests/typescript-errors/type-only-import-equals-decl/named/input.ts:1:24
+  |
+1 | import type { MyType } = from 'commonjs-package'
+  |                        ^
+

--- a/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/namespace/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/namespace/input.ts
@@ -1,1 +1,1 @@
-import type * as MyType = from 'commonjs-package'
+import type * as MyType = require('commonjs-package')

--- a/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/namespace/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/namespace/input.ts
@@ -1,0 +1,1 @@
+import type * as MyType = from 'commonjs-package'

--- a/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/namespace/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/namespace/input.ts.stderr
@@ -1,6 +1,6 @@
 error: Expected from, got =
  --> $DIR/tests/typescript-errors/type-only-import-equals-decl/namespace/input.ts:1:25
   |
-1 | import type * as MyType = from 'commonjs-package'
+1 | import type * as MyType = require('commonjs-package')
   |                         ^
 

--- a/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/namespace/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/type-only-import-equals-decl/namespace/input.ts.stderr
@@ -1,0 +1,6 @@
+error: Expected from, got =
+ --> $DIR/tests/typescript-errors/type-only-import-equals-decl/namespace/input.ts:1:25
+  |
+1 | import type * as MyType = from 'commonjs-package'
+  |                         ^
+

--- a/ecmascript/parser/tests/typescript/import/equals-require/input.ts.json
+++ b/ecmascript/parser/tests/typescript/import/equals-require/input.ts.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/import/equals-type-only/input.ts
+++ b/ecmascript/parser/tests/typescript/import/equals-type-only/input.ts
@@ -1,0 +1,1 @@
+import type MyType = require('commonjs-package')

--- a/ecmascript/parser/tests/typescript/import/equals-type-only/input.ts.json
+++ b/ecmascript/parser/tests/typescript/import/equals-type-only/input.ts.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 0,
-    "end": 31,
+    "end": 48,
     "ctxt": 0
   },
   "body": [
@@ -10,37 +10,37 @@
       "type": "TsImportEqualsDeclaration",
       "span": {
         "start": 0,
-        "end": 31,
+        "end": 48,
         "ctxt": 0
       },
       "declare": false,
-      "isExport": true,
-      "isTypeOnly": false,
+      "isExport": false,
+      "isTypeOnly": true,
       "id": {
         "type": "Identifier",
         "span": {
-          "start": 14,
-          "end": 15,
+          "start": 12,
+          "end": 18,
           "ctxt": 0
         },
-        "value": "a",
+        "value": "MyType",
         "optional": false
       },
       "moduleRef": {
         "type": "TsExternalModuleReference",
         "span": {
-          "start": 18,
-          "end": 30,
+          "start": 21,
+          "end": 48,
           "ctxt": 0
         },
         "expression": {
           "type": "StringLiteral",
           "span": {
-            "start": 26,
-            "end": 29,
+            "start": 29,
+            "end": 47,
             "ctxt": 0
           },
-          "value": "a",
+          "value": "commonjs-package",
           "hasEscape": false,
           "kind": {
             "type": "normal",

--- a/ecmascript/parser/tests/typescript/import/equals/input.ts.json
+++ b/ecmascript/parser/tests/typescript/import/equals/input.ts.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/import/export-import/input.ts.json
+++ b/ecmascript/parser/tests/typescript/import/export-import/input.ts.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": true,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/classes/classDeclarations/classAbstractKeyword/classAbstractImportInstantiation/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/classDeclarations/classAbstractKeyword/classAbstractImportInstantiation/input.ts.json
@@ -107,6 +107,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/classes/classExpressions/extendClassExpressionFromModule/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/classExpressions/extendClassExpressionFromModule/input.ts.json
@@ -59,6 +59,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports1-amd/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports1-amd/input.ts.json
@@ -472,6 +472,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports1-es6/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports1-es6/input.ts.json
@@ -472,6 +472,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports1/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports1/input.ts.json
@@ -472,6 +472,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports3-amd/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports3-amd/input.ts.json
@@ -544,6 +544,7 @@
       },
       "declare": false,
       "isExport": true,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports3-es6/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports3-es6/input.ts.json
@@ -544,6 +544,7 @@
       },
       "declare": false,
       "isExport": true,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports3/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports3/input.ts.json
@@ -544,6 +544,7 @@
       },
       "declare": false,
       "isExport": true,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports4-amd/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports4-amd/input.ts.json
@@ -37,6 +37,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -581,6 +582,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports4-es6/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports4-es6/input.ts.json
@@ -37,6 +37,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -581,6 +582,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports4/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/exportsAndImports4/input.ts.json
@@ -37,6 +37,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -581,6 +582,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/amdImportAsPrimaryExpression/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/amdImportAsPrimaryExpression/input.ts.json
@@ -102,6 +102,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/amdImportNotAsPrimaryExpression/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/amdImportNotAsPrimaryExpression/input.ts.json
@@ -452,6 +452,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -494,6 +495,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/circularReference/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/circularReference/input.ts.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -535,6 +536,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/commonJSImportAsPrimaryExpression/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/commonJSImportAsPrimaryExpression/input.ts.json
@@ -126,6 +126,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/commonJSImportNotAsPrimaryExpression/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/commonJSImportNotAsPrimaryExpression/input.ts.json
@@ -452,6 +452,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -494,6 +495,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/es6/es6modulekindWithES5Target10/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/es6/es6modulekindWithES5Target10/input.ts.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/esnext/esnextmodulekindWithES5Target10/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/esnext/esnextmodulekindWithES5Target10/input.ts.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignDottedName/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignDottedName/input.ts.json
@@ -75,6 +75,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignImportedIdentifier/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignImportedIdentifier/input.ts.json
@@ -75,6 +75,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -196,6 +197,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignTypes/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignTypes/input.ts.json
@@ -583,6 +583,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -683,6 +684,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -783,6 +785,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -883,6 +886,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -1011,6 +1015,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -1121,6 +1126,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -1205,6 +1211,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentCircularModules/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentCircularModules/input.ts.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -174,6 +175,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -333,6 +335,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentConstrainedGenericType/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentConstrainedGenericType/input.ts.json
@@ -313,6 +313,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentGenericType/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentGenericType/input.ts.json
@@ -145,6 +145,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentMergedInterface/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentMergedInterface/input.ts.json
@@ -411,6 +411,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentMergedModule/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentMergedModule/input.ts.json
@@ -387,6 +387,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentTopLevelClodule/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentTopLevelClodule/input.ts.json
@@ -182,6 +182,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentTopLevelEnumdule/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentTopLevelEnumdule/input.ts.json
@@ -191,6 +191,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentTopLevelFundule/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentTopLevelFundule/input.ts.json
@@ -169,6 +169,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentTopLevelIdentifier/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/exportAssignmentTopLevelIdentifier/input.ts.json
@@ -112,6 +112,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/exportDeclaredModule/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/exportDeclaredModule/input.ts.json
@@ -170,6 +170,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/importImportOnlyModule/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/importImportOnlyModule/input.ts.json
@@ -126,6 +126,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -209,6 +210,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/importNonExternalModule/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/importNonExternalModule/input.ts.json
@@ -94,6 +94,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/importTsBeforeDTs/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/importTsBeforeDTs/input.ts.json
@@ -145,6 +145,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/importsImplicitlyReadonly/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/importsImplicitlyReadonly/input.ts.json
@@ -245,6 +245,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/moduleScoping/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/moduleScoping/input.ts.json
@@ -283,6 +283,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/nameDelimitedBySlashes/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/nameDelimitedBySlashes/input.ts.json
@@ -64,6 +64,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/nameWithFileExtension/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/nameWithFileExtension/input.ts.json
@@ -64,6 +64,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/nameWithRelativePaths/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/nameWithRelativePaths/input.ts.json
@@ -211,6 +211,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -253,6 +254,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -295,6 +297,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/reexportClassDefinition/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/reexportClassDefinition/input.ts.json
@@ -59,6 +59,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -142,6 +143,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/relativePathMustResolve/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/relativePathMustResolve/input.ts.json
@@ -64,6 +64,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/relativePathToDeclarationFile/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/relativePathToDeclarationFile/input.ts.json
@@ -309,6 +309,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -351,6 +352,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -393,6 +395,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/topLevelAmbientModule/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/topLevelAmbientModule/input.ts.json
@@ -106,6 +106,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/topLevelFileModule/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/topLevelFileModule/input.ts.json
@@ -129,6 +129,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -171,6 +172,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/topLevelFileModuleMissing/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/topLevelFileModuleMissing/input.ts.json
@@ -72,6 +72,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/topLevelModuleDeclarationAndFile/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/topLevelModuleDeclarationAndFile/input.ts.json
@@ -189,6 +189,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/typeOnly/importEquals2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/typeOnly/importEquals2/input.ts.json
@@ -135,6 +135,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/typeOnly/importsNotUsedAsValues_error/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/typeOnly/importsNotUsedAsValues_error/input.ts.json
@@ -1694,6 +1694,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -1864,6 +1865,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -1984,6 +1986,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/typesOnlyExternalModuleStillHasInstance/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/typesOnlyExternalModuleStillHasInstance/input.ts.json
@@ -264,6 +264,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/codeGeneration/importStatements/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/codeGeneration/importStatements/input.ts.json
@@ -301,6 +301,7 @@
             },
             "declare": false,
             "isExport": false,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {
@@ -361,6 +362,7 @@
             },
             "declare": false,
             "isExport": false,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {
@@ -637,6 +639,7 @@
             },
             "declare": false,
             "isExport": false,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {
@@ -793,6 +796,7 @@
             },
             "declare": false,
             "isExport": false,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/codeGeneration/importStatementsInterfaces/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/codeGeneration/importStatementsInterfaces/input.ts.json
@@ -331,6 +331,7 @@
             },
             "declare": false,
             "isExport": false,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {
@@ -391,6 +392,7 @@
             },
             "declare": false,
             "isExport": false,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {
@@ -421,6 +423,7 @@
             },
             "declare": false,
             "isExport": false,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {
@@ -732,6 +735,7 @@
             },
             "declare": false,
             "isExport": false,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {
@@ -864,6 +868,7 @@
             },
             "declare": false,
             "isExport": false,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedImportAlias/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedImportAlias/input.ts.json
@@ -505,6 +505,7 @@
             },
             "declare": false,
             "isExport": true,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {
@@ -535,6 +536,7 @@
             },
             "declare": false,
             "isExport": false,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/circularImportAlias/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/circularImportAlias/input.ts.json
@@ -42,6 +42,7 @@
             },
             "declare": false,
             "isExport": true,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {
@@ -292,6 +293,7 @@
             },
             "declare": false,
             "isExport": true,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/exportImportAlias/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/exportImportAlias/input.ts.json
@@ -388,6 +388,7 @@
             },
             "declare": false,
             "isExport": true,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {
@@ -1219,6 +1220,7 @@
             },
             "declare": false,
             "isExport": true,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {
@@ -1936,6 +1938,7 @@
             },
             "declare": false,
             "isExport": true,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/importAliasIdentifiers/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/importAliasIdentifiers/input.ts.json
@@ -189,6 +189,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -831,6 +832,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -1497,6 +1499,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/invalidImportAliasIdentifiers/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/invalidImportAliasIdentifiers/input.ts.json
@@ -56,6 +56,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -159,6 +160,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -249,6 +251,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -351,6 +354,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/shadowedInternalModule/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/internalModules/importDeclarations/shadowedInternalModule/input.ts.json
@@ -373,6 +373,7 @@
             },
             "declare": false,
             "isExport": false,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {
@@ -703,6 +704,7 @@
             },
             "declare": false,
             "isExport": false,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsdoc/checkExportsObjectAssignProperty/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsdoc/checkExportsObjectAssignProperty/input.ts.json
@@ -1992,6 +1992,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -2679,6 +2680,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsdoc/checkExportsObjectAssignPrototypeProperty/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsdoc/checkExportsObjectAssignPrototypeProperty/input.ts.json
@@ -1286,6 +1286,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsdoc/checkObjectDefineProperty/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsdoc/checkObjectDefineProperty/input.ts.json
@@ -1729,6 +1729,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty12x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty12x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty13x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty13x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty14x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty14x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty15x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty15x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty1x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty1x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty2x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty2x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty3x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty3x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty4x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty4x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty5x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty5x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty6x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty6x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty7x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty7x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty8x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty8x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty9x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/checkJsxChildrenProperty9x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/commentEmittingInPreserveJsx1x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/commentEmittingInPreserveJsx1x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/jsxSpreadOverwritesAttributeStrictx/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/jsxSpreadOverwritesAttributeStrictx/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxAttributeResolution15x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxAttributeResolution15x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxAttributeResolution16x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxAttributeResolution16x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxDefaultAttributesResolution1x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxDefaultAttributesResolution1x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxDefaultAttributesResolution2x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxDefaultAttributesResolution2x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxDefaultAttributesResolution3x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxDefaultAttributesResolution3x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxElementResolution17x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxElementResolution17x/input.tsx.json
@@ -225,6 +225,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -267,6 +268,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxElementResolution7x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxElementResolution7x/input.tsx.json
@@ -356,6 +356,7 @@
             },
             "declare": false,
             "isExport": false,
+            "isTypeOnly": false,
             "id": {
               "type": "Identifier",
               "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType1x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType1x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType2x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType2x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType3x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType3x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType4x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType4x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType5x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType5x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType6x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType6x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType7x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType7x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType8x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType8x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType9x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxGenericAttributesType9x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxPreserveEmit1x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxPreserveEmit1x/input.tsx.json
@@ -277,6 +277,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -319,6 +320,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {
@@ -361,6 +363,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxReactComponentWithDefaultTypeParameter1x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxReactComponentWithDefaultTypeParameter1x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxReactComponentWithDefaultTypeParameter2x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxReactComponentWithDefaultTypeParameter2x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxReactComponentWithDefaultTypeParameter3x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxReactComponentWithDefaultTypeParameter3x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSfcReturnNullStrictNullChecksx/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSfcReturnNullStrictNullChecksx/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSfcReturnNullx/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSfcReturnNullx/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSfcReturnUndefinedStrictNullChecksx/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSfcReturnUndefinedStrictNullChecksx/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution10x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution10x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution11x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution11x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution12x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution12x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution13x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution13x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution14x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution14x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution15x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution15x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution16x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution16x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution1x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution1x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution2x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution2x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution3x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution3x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution4x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution4x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution5x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution5x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution6x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution6x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution7x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution7x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution8x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution8x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution9x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution9x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentOverload1x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentOverload1x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentOverload2x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentOverload2x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentOverload4x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentOverload4x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentOverload5x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentOverload5x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentOverload6x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentOverload6x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter1x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter1x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter2x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter2x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponents2x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponents2x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponents3x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponents3x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentsWithTypeArguments1x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentsWithTypeArguments1x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentsWithTypeArguments2x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentsWithTypeArguments2x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentsWithTypeArguments3x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentsWithTypeArguments3x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentsWithTypeArguments4x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentsWithTypeArguments4x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentsWithTypeArguments5x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxStatelessFunctionComponentsWithTypeArguments5x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionElementType1x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionElementType1x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionElementType2x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionElementType2x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionElementType3x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionElementType3x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionElementType4x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionElementType4x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionElementType5x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionElementType5x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionElementType6x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionElementType6x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionTypeComponent1x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionTypeComponent1x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionTypeComponent2x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxUnionTypeComponent2x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/parserImportDeclaration1/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/parser/ecmascript5/parserImportDeclaration1/input.ts.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/salsa/moduleExportAlias/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/salsa/moduleExportAlias/input.ts.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/scanner/ecmascript5/scannerImportDeclaration1/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/scanner/ecmascript5/scannerImportDeclaration1/input.ts.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes02x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes02x/input.tsx.json
@@ -15,6 +15,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/types/specifyingTypes/typeQueries/typeofANonExportedType/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/specifyingTypes/typeQueries/typeofANonExportedType/input.ts.json
@@ -1294,6 +1294,7 @@
       },
       "declare": false,
       "isExport": false,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/parser/tests/typescript/tsc/types/specifyingTypes/typeQueries/typeofAnExportedType/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/types/specifyingTypes/typeQueries/typeofAnExportedType/input.ts.json
@@ -1334,6 +1334,7 @@
       },
       "declare": false,
       "isExport": true,
+      "isTypeOnly": false,
       "id": {
         "type": "Identifier",
         "span": {

--- a/ecmascript/preset_env/Cargo.toml
+++ b/ecmascript/preset_env/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_preset_env/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_preset_env"
-version = "0.19.0"
+version = "0.20.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,14 +21,14 @@ st-map = "0.1.2"
 string_enum = {version = "0.3.1", path = "../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../ast"}
-swc_ecma_transforms = {version = "0.49.0", path = "../transforms", features = ["compat", "proposal"]}
-swc_ecma_utils = {version = "0.35.0", path = "../utils"}
-swc_ecma_visit = {version = "0.30.0", path = "../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../ast"}
+swc_ecma_transforms = {version = "0.50.0", path = "../transforms", features = ["compat", "proposal"]}
+swc_ecma_utils = {version = "0.36.0", path = "../utils"}
+swc_ecma_visit = {version = "0.31.0", path = "../visit"}
 walkdir = "2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
-swc_ecma_codegen = {version = "0.54.0", path = "../codegen"}
-swc_ecma_parser = {version = "0.56.0", path = "../parser"}
+swc_ecma_codegen = {version = "0.55.0", path = "../codegen"}
+swc_ecma_parser = {version = "0.57.0", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.49.0"
+version = "0.50.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -23,24 +23,24 @@ typescript = ["swc_ecma_transforms_typescript"]
 [dependencies]
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../ast"}
-swc_ecma_parser = {version = "0.56.0", path = "../parser"}
-swc_ecma_transforms_base = {version = "0.14.0", path = "./base"}
-swc_ecma_transforms_compat = {version = "0.16.0", path = "./compat", optional = true}
-swc_ecma_transforms_module = {version = "0.16.0", path = "./module", optional = true}
-swc_ecma_transforms_optimization = {version = "0.19.0", path = "./optimization", optional = true}
-swc_ecma_transforms_proposal = {version = "0.16.0", path = "./proposal", optional = true}
-swc_ecma_transforms_react = {version = "0.17.0", path = "./react", optional = true}
-swc_ecma_transforms_typescript = {version = "0.18.0", path = "./typescript", optional = true}
-swc_ecma_utils = {version = "0.35.0", path = "../utils"}
-swc_ecma_visit = {version = "0.30.0", path = "../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../ast"}
+swc_ecma_parser = {version = "0.57.0", path = "../parser"}
+swc_ecma_transforms_base = {version = "0.15.0", path = "./base"}
+swc_ecma_transforms_compat = {version = "0.17.0", path = "./compat", optional = true}
+swc_ecma_transforms_module = {version = "0.17.0", path = "./module", optional = true}
+swc_ecma_transforms_optimization = {version = "0.20.0", path = "./optimization", optional = true}
+swc_ecma_transforms_proposal = {version = "0.17.0", path = "./proposal", optional = true}
+swc_ecma_transforms_react = {version = "0.18.0", path = "./react", optional = true}
+swc_ecma_transforms_typescript = {version = "0.19.0", path = "./typescript", optional = true}
+swc_ecma_utils = {version = "0.36.0", path = "../utils"}
+swc_ecma_visit = {version = "0.31.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
 sourcemap = "6"
-swc_ecma_codegen = {version = "0.54.0", path = "../codegen"}
-swc_ecma_transforms_testing = {version = "0.14.0", path = "./testing"}
+swc_ecma_codegen = {version = "0.55.0", path = "../codegen"}
+swc_ecma_transforms_testing = {version = "0.15.0", path = "./testing"}
 tempfile = "3"
 testing = {version = "0.10.5", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.14.2"
+version = "0.15.0"
 
 [dependencies]
 fxhash = "0.2.1"
@@ -16,11 +16,11 @@ scoped-tls = "1.0.0"
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
-swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.57.0", path = "../../parser"}
+swc_ecma_utils = {version = "0.36.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.31.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.54.0", path = "../../codegen"}
+swc_ecma_codegen = {version = "0.55.0", path = "../../codegen"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.16.3"
+version = "0.17.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -20,13 +20,13 @@ serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2.5", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
+swc_ecma_ast = {version = "0.45.0", path = "../../ast"}
+swc_ecma_transforms_base = {version = "0.15.0", path = "../base"}
 swc_ecma_transforms_macros = {version = "0.2.1", path = "../macros"}
-swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
+swc_ecma_utils = {version = "0.36.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.31.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
-swc_ecma_transforms_testing = {version = "0.14.0", path = "../testing"}
+swc_ecma_parser = {version = "0.57.0", path = "../../parser"}
+swc_ecma_transforms_testing = {version = "0.15.0", path = "../testing"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/module/Cargo.toml
+++ b/ecmascript/transforms/module/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.16.0"
+version = "0.17.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -16,13 +16,13 @@ indexmap = "1.6.1"
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
-swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.57.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.15.0", path = "../base"}
+swc_ecma_utils = {version = "0.36.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.31.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.16.0", path = "../compat"}
-swc_ecma_transforms_testing = {version = "0.14.0", path = "../testing/"}
+swc_ecma_transforms_compat = {version = "0.17.0", path = "../compat"}
+swc_ecma_transforms_testing = {version = "0.15.0", path = "../testing/"}
 testing = {version = "0.10.5", path = "../../../testing/"}

--- a/ecmascript/transforms/optimization/Cargo.toml
+++ b/ecmascript/transforms/optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.19.2"
+version = "0.20.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -19,17 +19,17 @@ retain_mut = "0.1.2"
 serde_json = "1.0.61"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
-swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.57.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.15.0", path = "../base"}
+swc_ecma_utils = {version = "0.36.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.31.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.16.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.16.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.16.0", path = "../proposal"}
-swc_ecma_transforms_react = {version = "0.17.0", path = "../react"}
-swc_ecma_transforms_testing = {version = "0.14.0", path = "../testing"}
-swc_ecma_transforms_typescript = {version = "0.18.0", path = "../typescript"}
+swc_ecma_transforms_compat = {version = "0.17.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.17.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.17.0", path = "../proposal"}
+swc_ecma_transforms_react = {version = "0.18.0", path = "../react"}
+swc_ecma_transforms_testing = {version = "0.15.0", path = "../testing"}
+swc_ecma_transforms_typescript = {version = "0.19.0", path = "../typescript"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/proposal/Cargo.toml
+++ b/ecmascript/transforms/proposal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_proposal"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.16.0"
+version = "0.17.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,14 +21,14 @@ serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
-swc_ecma_loader = {version = "0.5.0", path = "../../loader", optional = true}
-swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
-swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../../ast"}
+swc_ecma_loader = {version = "0.6.0", path = "../../loader", optional = true}
+swc_ecma_parser = {version = "0.57.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.15.0", path = "../base"}
+swc_ecma_utils = {version = "0.36.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.31.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.16.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.16.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.14.0", path = "../testing"}
+swc_ecma_transforms_compat = {version = "0.17.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.17.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.15.0", path = "../testing"}

--- a/ecmascript/transforms/react/Cargo.toml
+++ b/ecmascript/transforms/react/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_react"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.17.1"
+version = "0.18.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -21,15 +21,15 @@ sha-1 = "0.9.4"
 string_enum = {version = "0.3.1", path = "../../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
-swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.57.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.15.0", path = "../base"}
+swc_ecma_utils = {version = "0.36.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.31.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.54.0", path = "../../codegen/"}
-swc_ecma_transforms_compat = {version = "0.16.0", path = "../compat/"}
-swc_ecma_transforms_module = {version = "0.16.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.14.0", path = "../testing/"}
+swc_ecma_codegen = {version = "0.55.0", path = "../../codegen/"}
+swc_ecma_transforms_compat = {version = "0.17.0", path = "../compat/"}
+swc_ecma_transforms_module = {version = "0.17.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.15.0", path = "../testing/"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/testing/Cargo.toml
+++ b/ecmascript/transforms/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.14.0"
+version = "0.15.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,11 +15,11 @@ ansi_term = "0.12.1"
 serde = "1"
 serde_json = "1"
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
-swc_ecma_codegen = {version = "0.54.0", path = "../../codegen"}
-swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
-swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../../ast"}
+swc_ecma_codegen = {version = "0.55.0", path = "../../codegen"}
+swc_ecma_parser = {version = "0.57.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.15.0", path = "../base"}
+swc_ecma_utils = {version = "0.36.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.31.0", path = "../../visit"}
 tempfile = "3.1.0"
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.18.2"
+version = "0.19.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -14,17 +14,17 @@ fxhash = "0.2.1"
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.56.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.14.0", path = "../base"}
-swc_ecma_utils = {version = "0.35.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.30.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.57.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.15.0", path = "../base"}
+swc_ecma_utils = {version = "0.36.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.31.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.54.0", path = "../../codegen"}
-swc_ecma_transforms_compat = {version = "0.16.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.16.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.16.0", path = "../proposal/"}
-swc_ecma_transforms_testing = {version = "0.14.0", path = "../testing"}
+swc_ecma_codegen = {version = "0.55.0", path = "../../codegen"}
+swc_ecma_transforms_compat = {version = "0.17.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.17.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.17.0", path = "../proposal/"}
+swc_ecma_transforms_testing = {version = "0.15.0", path = "../testing"}
 testing = {version = "0.10.5", path = "../../../testing"}
 walkdir = "2.3.1"

--- a/ecmascript/transforms/typescript/src/strip.rs
+++ b/ecmascript/transforms/typescript/src/strip.rs
@@ -1683,6 +1683,7 @@ impl VisitMut for Strip {
                     span,
                     declare: false,
                     is_export: false,
+                    is_type_only: false,
                     id,
                     module_ref:
                         TsModuleRef::TsExternalModuleRef(TsExternalModuleRef { span: _, expr }),

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.35.1"
+version = "0.36.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,8 +15,8 @@ once_cell = "1"
 scoped-tls = "1"
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../ast"}
-swc_ecma_visit = {version = "0.30.0", path = "../visit"}
+swc_ecma_ast = {version = "0.45.0", path = "../ast"}
+swc_ecma_visit = {version = "0.31.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]

--- a/ecmascript/visit/Cargo.toml
+++ b/ecmascript/visit/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_visit"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.30.0"
+version = "0.31.0"
 
 [dependencies]
 num-bigint = {version = "0.2", features = ["serde"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.44.0", path = "../ast"}
+swc_ecma_ast = {version = "0.45.0", path = "../ast"}
 swc_visit = {version = "0.2.3", path = "../../visit"}

--- a/ecmascript/visit/src/lib.rs
+++ b/ecmascript/visit/src/lib.rs
@@ -1633,6 +1633,7 @@ define!({
         pub span: Span,
         pub declare: bool,
         pub is_export: bool,
+        pub is_type_only: bool,
         pub id: Ident,
         pub module_ref: TsModuleRef,
     }


### PR DESCRIPTION
This is a TypeScript 4.2 feature:

```ts
import type React = require('react')
```

[TypeScript playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBDAnmApnASighgY3gXjihQEcBXYYgCgHJjcYaBKIA)

Ref: https://github.com/microsoft/TypeScript/pull/41573