### PR TITLE
fix(es/transforsm/compat): Transform private field access in private methods

### DIFF
--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.17.1"
+version = "0.17.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/ecmascript/transforms/compat/tests/es2020_class_properties.rs
+++ b/ecmascript/transforms/compat/tests/es2020_class_properties.rs
@@ -5283,25 +5283,51 @@ test!(
     |_| chain!(class_properties(), async_to_generator()),
     issue_1694_2,
     "
+class MyClass {
+    static #get() {
+        return 1
+    }
+    constructor() {
+        MyClass.#get(foo);
+    }
+}
+",
+    "
+  var _get = new WeakSet();
   class MyClass {
-      static #get() {
-          return 1
-      }
-      constructor() {
-          MyClass.#get(foo);
+      constructor(){
+          _get.add(this);
+          _classStaticPrivateMethodGet(MyClass, MyClass, get).call(MyClass, foo);
       }
   }
-  ",
+  function get() {
+      return 1;
+  }
+  "
+);
+
+test!(
+    syntax(),
+    |_| chain!(class_properties(), async_to_generator()),
+    issue_1702_1,
     "
-    var _get = new WeakSet();
-    class MyClass {
-        constructor(){
-            _get.add(this);
-            _classStaticPrivateMethodGet(MyClass, MyClass, get).call(MyClass, foo);
-        }
+    class Foo {
+      #y;
+      static #z = 3;
+    
+      constructor() {
+        this.x = 1;
+        this.#y = 2;
+        this.#sssss();
+      }
+    
+      #sssss() {
+        console.log(this.x, this.#y, Foo.#z);
+      }
     }
-    function get() {
-        return 1;
-    }
+    
+    const instance = new Foo();
+    ",
+    "
     "
 );

--- a/ecmascript/transforms/compat/tests/es2020_class_properties.rs
+++ b/ecmascript/transforms/compat/tests/es2020_class_properties.rs
@@ -5329,5 +5329,28 @@ test!(
     const instance = new Foo();
     ",
     "
+    var _sssss = new WeakSet();
+    class Foo {
+        constructor(){
+            _y.set(this, {
+                writable: true,
+                value: void 0
+            });
+            _sssss.add(this);
+            this.x = 1;
+            _classPrivateFieldSet(this, _y, 2);
+            _classPrivateMethodGet(this, _sssss, sssss).call(this);
+        }
+    }
+    var _y = new WeakMap();
+    var _z = {
+        writable: true,
+        value: 3
+    };
+    function sssss() {
+        console.log(this.x, _classPrivateFieldGet(this, _y), _classStaticPrivateFieldSpecGet(Foo, \
+     Foo, _z));
+    }
+    const instance = new Foo();
     "
 );


### PR DESCRIPTION


swc_ecma_transforms_compat:
 - [x] `class_properties`: Handle private field accesses in private methods. (Closes #1702)