### PR TITLE
Fix ambiguous name compiler error.

### DIFF
--- a/common/src/private/mod.rs
+++ b/common/src/private/mod.rs
@@ -1,3 +1,3 @@
-//! This module is private module and can be changed without notice.  
+//! This module is private module and can be changed without notice.
 
-pub use serde::__private as serde;
+pub use ::serde::__private as serde;


### PR DESCRIPTION
When trying to compile against `swc` (`cargo +nightly run`) I ran into this error:

```
error[E0432]: unresolved import `serde::__private`
 --> /home/muji/git/consensys/swc/common/src/private/mod.rs:3:9
  |
3 | pub use serde::__private as serde;
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^ no `__private` in `__private`

error[E0659]: `serde` is ambiguous (name vs any other name during import resolution)
 --> /home/muji/git/consensys/swc/common/src/private/mod.rs:3:9
  |
3 | pub use serde::__private as serde;
  |         ^^^^^ ambiguous name
  |
  = note: `serde` could refer to a crate passed with `--extern`
  = help: use `::serde` to refer to this crate unambiguously
note: `serde` could also refer to the module imported here
 --> /home/muji/git/consensys/swc/common/src/private/mod.rs:3:9
  |
3 | pub use serde::__private as serde;
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^
  = help: use `self::serde` to refer to this module unambiguously

error: aborting due to 2 previous errors
```

This PR resolves the issue.