### PR TITLE
Note feature requirement in examples/usage.rs

### DIFF
--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -7,6 +7,8 @@ use swc_common::{
 
 fn main() {
     let cm = Arc::<SourceMap>::default();
+    
+    // Note: with_tty_emitter requires swc_common with feature tty-emitter.
     let handler = Arc::new(Handler::with_tty_emitter(
         ColorConfig::Auto,
         true,


### PR DESCRIPTION
A small thing I noticed while trying to independently create something relatively similar to `usage.rs` 