### PR TITLE
Fix: removed space before extends keyword on class declaration

### DIFF
--- a/common/src/private/mod.rs
+++ b/common/src/private/mod.rs
@@ -1,3 +1,3 @@
-//! This module is private module and can be changed without notice.  
+//! This module is private module and can be changed without notice.
 
-pub use serde::__private as serde;
+pub use ::serde::__private as serde;

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.55.3"
+version = "0.55.4"
 
 [dependencies]
 bitflags = "1"

--- a/ecmascript/codegen/src/decl.rs
+++ b/ecmascript/codegen/src/decl.rs
@@ -37,7 +37,6 @@ impl<'a> Emitter<'a> {
         space!();
         emit!(node.ident);
         emit!(node.class.type_params);
-        formatting_space!();
 
         self.emit_class_trailing(&node.class)?;
     }

--- a/ecmascript/codegen/src/decl.rs
+++ b/ecmascript/codegen/src/decl.rs
@@ -118,6 +118,15 @@ mod tests {
     }
 
     #[test]
+    fn issue_1764() {
+        assert_min(
+            "class Hoge {};
+class HogeFuga extends Hoge {};",
+            "class Hoge{};class HogeFuga extends Hoge {};",
+        );
+    }
+
+    #[test]
     fn single_argument_arrow_expression() {
         assert_min("function* f(){ yield x => x}", "function*f(){yield x=>x}");
         assert_min(

--- a/ecmascript/codegen/src/decl.rs
+++ b/ecmascript/codegen/src/decl.rs
@@ -121,7 +121,7 @@ mod tests {
         assert_min(
             "class Hoge {};
 class HogeFuga extends Hoge {};",
-            "class Hoge{};class HogeFuga extends Hoge {};",
+            "class Hoge{};class HogeFuga extends Hoge{};",
         );
     }
 

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -835,6 +835,7 @@ impl<'a> Emitter<'a> {
     #[emitter]
     fn emit_class_trailing(&mut self, node: &Class) -> Result {
         if node.super_class.is_some() {
+            space!();
             keyword!("extends");
             space!();
             emit!(node.super_class);

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -823,10 +823,6 @@ impl<'a> Emitter<'a> {
             space!();
             emit!(i);
             emit!(node.class.type_params);
-
-            formatting_space!();
-        } else {
-            space!();
         }
 
         self.emit_class_trailing(&node.class)?;
@@ -839,9 +835,9 @@ impl<'a> Emitter<'a> {
             keyword!("extends");
             space!();
             emit!(node.super_class);
-            space!();
         }
 
+        formatting_space!();
         punct!("{");
         self.emit_list(node.span, Some(&node.body), ListFormat::ClassMembers)?;
         punct!("}");


### PR DESCRIPTION
## Motivation

Fix: #1764 

I fixed the error that with minify option and es2016 ~ 2020 target option `swc` outputs invalid javascript code due to removed space before `extends` keyword on class declaration.

if something wrong (incorrect approach or not enough test case...), please feel free to close this PR or point it out 🙏