### PR TITLE
Expose load_transformed() and TransformedModule.

### DIFF
--- a/bundler/src/bundler/export.rs
+++ b/bundler/src/bundler/export.rs
@@ -45,7 +45,7 @@ pub(super) struct RawExports {
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct Exports {
+pub struct Exports {
     pub items: Vec<Specifier>,
     pub reexports: Vec<(Source, Vec<Specifier>)>,
 }

--- a/bundler/src/bundler/helpers/mod.rs
+++ b/bundler/src/bundler/helpers/mod.rs
@@ -6,7 +6,7 @@ use swc_ecma_parser::{lexer::Lexer, Parser, StringInput};
 use swc_ecma_utils::{drop_span, prepend_stmts};
 
 #[derive(Debug, Default)]
-pub(crate) struct Helpers {
+pub struct Helpers {
     /// `__spack_require__`
     pub require: AtomicBool,
 }

--- a/bundler/src/bundler/load.rs
+++ b/bundler/src/bundler/load.rs
@@ -21,7 +21,7 @@ use swc_ecma_transforms::resolver_with_mark;
 use swc_ecma_visit::{noop_visit_type, FoldWith, Node, Visit, VisitWith};
 /// Module after applying transformations.
 #[derive(Debug, Clone)]
-pub(crate) struct TransformedModule {
+pub struct TransformedModule {
     pub id: ModuleId,
     pub fm: Lrc<SourceFile>,
     pub module: Lrc<Module>,
@@ -61,7 +61,7 @@ where
     ///
     /// We apply transforms at this phase to make cache efficient.
     /// As we cache in this phase, changing dependency does not affect cache.
-    pub(super) fn load_transformed(
+    pub fn load_transformed(
         &self,
         file_name: &FileName,
     ) -> Result<Option<TransformedModule>, Error> {
@@ -366,14 +366,14 @@ where
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct Imports {
+pub struct Imports {
     /// If imported ids are empty, it is a side-effect import.
     pub specifiers: Vec<(Source, Vec<Specifier>)>,
 }
 
 /// Clone is relatively cheap
 #[derive(Debug, Clone, Is)]
-pub(crate) enum Specifier {
+pub enum Specifier {
     Specific {
         local: Id,
         alias: Option<Id>,
@@ -386,7 +386,7 @@ pub(crate) enum Specifier {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct Source {
+pub struct Source {
     pub is_loaded_synchronously: bool,
     pub is_unconditional: bool,
 

--- a/bundler/src/bundler/mod.rs
+++ b/bundler/src/bundler/mod.rs
@@ -13,9 +13,10 @@ mod finalize;
 mod helpers;
 mod import;
 mod keywords;
-mod load;
+pub mod load;
 mod optimize;
 mod scope;
+
 #[cfg(test)]
 pub(crate) mod tests;
 
@@ -92,7 +93,7 @@ where
     /// Used to mark a variable declaration as injected.
     pub(crate) injected_ctxt: SyntaxContext,
 
-    scope: Scope,
+    pub scope: Scope,
 
     hook: Box<dyn 'a + Hook>,
 }

--- a/bundler/src/bundler/scope.rs
+++ b/bundler/src/bundler/scope.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use swc_common::{sync::Lrc, FileName};
 
 #[derive(Debug, Default)]
-pub(super) struct Scope {
+pub struct Scope {
     pub module_id_gen: ModuleIdGenerator,
 
     loaded_modules: CloneMap<ModuleId, ()>,

--- a/bundler/src/id.rs
+++ b/bundler/src/id.rs
@@ -25,7 +25,7 @@ impl fmt::Debug for ModuleId {
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct ModuleIdGenerator {
+pub struct ModuleIdGenerator {
     v: AtomicU32,
     /// `(module_id, local_mark, export_mark)`
     cache: Lock<HashMap<FileName, (ModuleId, Mark, Mark)>>,

--- a/bundler/src/lib.rs
+++ b/bundler/src/lib.rs
@@ -6,7 +6,7 @@ pub use self::{
     resolve::Resolve,
 };
 
-mod bundler;
+pub mod bundler;
 mod debug;
 mod dep_graph;
 mod hash;
@@ -17,3 +17,5 @@ mod load;
 mod modules;
 mod resolve;
 mod util;
+
+pub use bundler::load::TransformedModule;

--- a/spack/src/lib.rs
+++ b/spack/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(or_patterns)]
 #![cfg_attr(test, feature(test))]
 
 #[cfg(test)]


### PR DESCRIPTION
To allow external programs to use the bundler transform phase to
generate a module graph.