### PR TITLE
Add recursive flag to load_transformed().

### DIFF
--- a/bundler/src/bundler/chunk/mod.rs
+++ b/bundler/src/bundler/chunk/mod.rs
@@ -150,7 +150,7 @@ mod tests {
             .run(|t| {
                 let module = t
                     .bundler
-                    .load_transformed(&FileName::Real("main.js".into()))?
+                    .load_transformed(&FileName::Real("main.js".into()), true)?
                     .unwrap();
                 let mut entries = AHashMap::default();
                 entries.insert("main.js".to_string(), module);

--- a/bundler/src/bundler/mod.rs
+++ b/bundler/src/bundler/mod.rs
@@ -147,7 +147,7 @@ where
             .into_iter()
             .map(|(name, path)| -> Result<_, Error> {
                 let res = self
-                    .load_transformed(&path)
+                    .load_transformed(&path, true)
                     .context("load_transformed failed")?;
                 Ok((name, res))
             })

--- a/bundler/src/bundler/tests.rs
+++ b/bundler/src/bundler/tests.rs
@@ -140,7 +140,7 @@ impl TestBuilder {
 
                 for (name, _) in self.files {
                     bundler
-                        .load_transformed(&FileName::Real(name.clone().into()))
+                        .load_transformed(&FileName::Real(name.clone().into()), true)
                         .unwrap();
                 }
 


### PR DESCRIPTION
For some analysis tasks it is useful to get a `TransformedModule` so we can get the `imports` and `exports` but not walk the entire module graph.

This adds a `recursive` option to `load_transformed()` and updates all the calls to `load_transformed()` to pass `true` to mimic the existing behavior.

This will allow us to perform import and export analysis on a single module at a time.