### PR TITLE
Fix the incorrect ExportDefaultDeclaration span.lo for `export default function` case

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.61.0"
+version = "0.61.1"
 
 [features]
 default = []

--- a/ecmascript/parser/src/parser/stmt/module_item.rs
+++ b/ecmascript/parser/src/parser/stmt/module_item.rs
@@ -384,10 +384,10 @@ impl<'a, I: Tokens> Parser<I> {
                 && peeked_is!(self, "function")
                 && !self.input.has_linebreak_between_cur_and_peeked()
             {
-                let decl = self.parse_default_async_fn(decorators)?;
+                let decl = self.parse_default_async_fn(start, decorators)?;
                 return Ok(ModuleDecl::ExportDefaultDecl(decl));
             } else if is!(self, "function") {
-                let decl = self.parse_default_fn(decorators)?;
+                let decl = self.parse_default_fn(start, decorators)?;
                 return Ok(ModuleDecl::ExportDefaultDecl(decl));
             } else if self.input.syntax().export_default_from()
                 && (is!(self, "from") || (is!(self, ',') && peeked_is!(self, '{')))

--- a/ecmascript/parser/src/parser/tests.rs
+++ b/ecmascript/parser/src/parser/tests.rs
@@ -1,4 +1,5 @@
 use crate::test_parser;
+use swc_common::BytePos;
 use swc_ecma_ast::*;
 
 fn program(src: &'static str) -> Program {
@@ -80,4 +81,55 @@ fn issue_1813() {
             Ok(())
         },
     )
+}
+
+fn parse_module_export_named_span() {
+    let m = module("export function foo() {}");
+    if let ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl { span, .. })) = &m.body[0] {
+        assert_eq!(span.lo, BytePos(0));
+    } else {
+        panic!("expected ExportDecl");
+    }
+}
+
+#[test]
+fn parse_module_export_default_fn_span() {
+    let m = module("export default function foo() {}");
+    if let ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(ExportDefaultDecl {
+        span, ..
+    })) = &m.body[0]
+    {
+        assert_eq!(span.lo, BytePos(0));
+        assert_eq!(span.hi, BytePos(32));
+    } else {
+        panic!("expected ExportDefaultDecl");
+    }
+}
+
+#[test]
+fn parse_module_export_default_async_fn_span() {
+    let m = module("export default async function foo() {}");
+    if let ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(ExportDefaultDecl {
+        span, ..
+    })) = &m.body[0]
+    {
+        assert_eq!(span.lo, BytePos(0));
+        assert_eq!(span.hi, BytePos(38));
+    } else {
+        panic!("expected ExportDefaultDecl");
+    }
+}
+
+#[test]
+fn parse_module_export_default_class_span() {
+    let m = module("export default class Foo {}");
+    if let ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(ExportDefaultDecl {
+        span, ..
+    })) = &m.body[0]
+    {
+        assert_eq!(span.lo, BytePos(0));
+        assert_eq!(span.hi, BytePos(27));
+    } else {
+        panic!("expected ExportDefaultDecl");
+    }
 }

--- a/ecmascript/parser/tests/typescript/function/export-default/input.ts.json
+++ b/ecmascript/parser/tests/typescript/function/export-default/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 15,
+        "start": 0,
         "end": 42,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsAmd/anonymousDefaultExportsAmd/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsAmd/anonymousDefaultExportsAmd/input.ts.json
@@ -33,7 +33,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 110,
+        "start": 95,
         "end": 123,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsAmd/defaultExportsGetExportedAmd/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsAmd/defaultExportsGetExportedAmd/input.ts.json
@@ -42,7 +42,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 114,
+        "start": 99,
         "end": 131,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsAmd/outFilerootDirModuleNamesAmd/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsAmd/outFilerootDirModuleNamesAmd/input.ts.json
@@ -158,7 +158,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 260,
+        "start": 245,
         "end": 289,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsCommonjs/anonymousDefaultExportsCommonjs/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsCommonjs/anonymousDefaultExportsCommonjs/input.ts.json
@@ -33,7 +33,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 115,
+        "start": 100,
         "end": 128,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsCommonjs/defaultExportsGetExportedCommonjs/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsCommonjs/defaultExportsGetExportedCommonjs/input.ts.json
@@ -42,7 +42,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 119,
+        "start": 104,
         "end": 136,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsSystem/anonymousDefaultExportsSystem/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsSystem/anonymousDefaultExportsSystem/input.ts.json
@@ -33,7 +33,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 113,
+        "start": 98,
         "end": 126,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsSystem/defaultExportsGetExportedSystem/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsSystem/defaultExportsGetExportedSystem/input.ts.json
@@ -42,7 +42,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 117,
+        "start": 102,
         "end": 134,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsSystem/outFilerootDirModuleNamesSystem/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsSystem/outFilerootDirModuleNamesSystem/input.ts.json
@@ -158,7 +158,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 266,
+        "start": 251,
         "end": 295,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsUmd/anonymousDefaultExportsUmd/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsUmd/anonymousDefaultExportsUmd/input.ts.json
@@ -33,7 +33,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 110,
+        "start": 95,
         "end": 123,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsUmd/defaultExportsGetExportedUmd/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/moduleExportsUmd/defaultExportsGetExportedUmd/input.ts.json
@@ -42,7 +42,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 114,
+        "start": 99,
         "end": 131,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/defaultExportWithOverloads01/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/defaultExportWithOverloads01/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 53,
+        "start": 38,
         "end": 66,
         "ctxt": 0
       },
@@ -42,7 +42,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 82,
+        "start": 67,
         "end": 104,
         "ctxt": 0
       },
@@ -112,7 +112,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 120,
+        "start": 105,
         "end": 150,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/defaultExportsCannotMerge01/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/defaultExportsCannotMerge01/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 73,
+        "start": 58,
         "end": 106,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/defaultExportsCannotMerge04/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/defaultExportsCannotMerge04/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 53,
+        "start": 38,
         "end": 71,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/exportAndImport-es3-amd/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/exportAndImport-es3-amd/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 66,
+        "start": 51,
         "end": 83,
         "ctxt": 0
       },
@@ -94,7 +94,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 143,
+        "start": 128,
         "end": 170,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/exportAndImport-es3/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/exportAndImport-es3/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 71,
+        "start": 56,
         "end": 88,
         "ctxt": 0
       },
@@ -94,7 +94,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 148,
+        "start": 133,
         "end": 173,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/exportAndImport-es5-amd/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/exportAndImport-es5-amd/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 66,
+        "start": 51,
         "end": 83,
         "ctxt": 0
       },
@@ -94,7 +94,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 143,
+        "start": 128,
         "end": 170,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/exportAndImport-es5/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/exportAndImport-es5/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 71,
+        "start": 56,
         "end": 88,
         "ctxt": 0
       },
@@ -94,7 +94,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 148,
+        "start": 133,
         "end": 175,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/multipleDefaultExports01/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/multipleDefaultExports01/input.ts.json
@@ -42,7 +42,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 104,
+        "start": 89,
         "end": 123,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/multipleDefaultExports02/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/multipleDefaultExports02/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 73,
+        "start": 58,
         "end": 92,
         "ctxt": 0
       },
@@ -50,7 +50,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 109,
+        "start": 94,
         "end": 128,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/multipleDefaultExports04/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/multipleDefaultExports04/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 53,
+        "start": 38,
         "end": 69,
         "ctxt": 0
       },
@@ -50,7 +50,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 86,
+        "start": 71,
         "end": 102,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/es6/modules/reExportDefaultExport/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/es6/modules/reExportDefaultExport/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 73,
+        "start": 58,
         "end": 89,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/es6/es6modulekindWithES5Target6/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/es6/es6modulekindWithES5Target6/input.ts.json
@@ -167,7 +167,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 114,
+        "start": 99,
         "end": 136,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/esnext/esnextmodulekindWithES5Target6/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/esnext/esnextmodulekindWithES5Target6/input.ts.json
@@ -167,7 +167,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 114,
+        "start": 99,
         "end": 136,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/multipleExportDefault1/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/multipleExportDefault1/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 15,
+        "start": 0,
         "end": 38,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/multipleExportDefault2/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/multipleExportDefault2/input.ts.json
@@ -54,7 +54,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 65,
+        "start": 50,
         "end": 83,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/externalModules/multipleExportDefault5/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/externalModules/multipleExportDefault5/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 15,
+        "start": 0,
         "end": 33,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/jsdoc/declarations/jsDeclarationsDefault/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsdoc/declarations/jsDeclarationsDefault/input.ts.json
@@ -26,7 +26,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 175,
+        "start": 160,
         "end": 209,
         "ctxt": 0
       },
@@ -515,7 +515,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 725,
+        "start": 710,
         "end": 743,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution13x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution13x/input.tsx.json
@@ -165,7 +165,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 240,
+        "start": 225,
         "end": 499,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution14x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution14x/input.tsx.json
@@ -165,7 +165,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 240,
+        "start": 225,
         "end": 386,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution15x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution15x/input.tsx.json
@@ -165,7 +165,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 240,
+        "start": 225,
         "end": 376,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution16x/input.tsx.json
+++ b/ecmascript/parser/tests/typescript/tsc/jsx/tsxSpreadAttributesResolution16x/input.tsx.json
@@ -165,7 +165,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 240,
+        "start": 225,
         "end": 380,
         "ctxt": 0
       },

--- a/ecmascript/parser/tests/typescript/tsc/salsa/typeFromPropertyAssignment5/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/salsa/typeFromPropertyAssignment5/input.ts.json
@@ -9,7 +9,7 @@
     {
       "type": "ExportDefaultDeclaration",
       "span": {
-        "start": 103,
+        "start": 88,
         "end": 125,
         "ctxt": 0
       },


### PR DESCRIPTION
Am I missing something or is it a bug? @kdy1 