### PR TITLE
fix(es/codegen): Fix newlines in tagged template literals

### DIFF
--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.58.0"
+version = "0.58.1"
 
 [dependencies]
 bitflags = "1"

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -1190,20 +1190,7 @@ impl<'a> Emitter<'a> {
 
         self.emit_leading_comments_of_span(node.span(), false)?;
 
-        punct!("`");
-        let i = 0;
-
-        for i in 0..(node.quasis.len() + node.exprs.len()) {
-            if i % 2 == 0 {
-                emit!(node.quasis[i / 2]);
-            } else {
-                punct!("${");
-                emit!(node.exprs[i / 2]);
-                punct!("}");
-            }
-        }
-
-        punct!("`");
+        self.emit_tpl_elem_and_quasis(&node, false)?;
     }
 
     #[emitter]
@@ -1212,7 +1199,26 @@ impl<'a> Emitter<'a> {
 
         emit!(node.tag);
         emit!(node.type_params);
-        emit!(node.tpl);
+        self.emit_tpl_elem_and_quasis(&node.tpl, true)?;
+    }
+
+    fn emit_tpl_elem_and_quasis(&mut self, tpl: &Tpl, tagged: bool) -> Result {
+        punct!(self, "`");
+        let i = 0;
+
+        for i in 0..(tpl.quasis.len() + tpl.exprs.len()) {
+            if i % 2 == 0 {
+                emit!(self, tpl.quasis[i / 2]);
+            } else {
+                punct!(self, "${");
+                emit!(self, tpl.exprs[i / 2]);
+                punct!(self, "}");
+            }
+        }
+
+        punct!(self, "`");
+
+        Ok(())
     }
 
     #[emitter]

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -1208,7 +1208,14 @@ impl<'a> Emitter<'a> {
 
         for i in 0..(tpl.quasis.len() + tpl.exprs.len()) {
             if i % 2 == 0 {
-                emit!(self, tpl.quasis[i / 2]);
+                let elem = &tpl.quasis[i / 2];
+
+                if tagged {
+                    self.wr
+                        .write_str_lit(elem.span, &unescape_tpl_lit(&elem.raw.value))?;
+                } else {
+                    emit!(self, elem);
+                }
             } else {
                 punct!(self, "${");
                 emit!(self, tpl.exprs[i / 2]);

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -1211,8 +1211,7 @@ impl<'a> Emitter<'a> {
                 let elem = &tpl.quasis[i / 2];
 
                 if tagged {
-                    self.wr
-                        .write_str_lit(elem.span, &unescape_tpl_lit(&elem.raw.value))?;
+                    self.wr.write_str_lit(elem.span, &elem.raw.value)?;
                 } else {
                     emit!(self, elem);
                 }

--- a/ecmascript/codegen/src/tests.rs
+++ b/ecmascript/codegen/src/tests.rs
@@ -642,6 +642,14 @@ fn test_escape_with_source_str() {
     );
 }
 
+#[test]
+fn issue_1791() {
+    check_latest(
+        "f`
+`", "",
+    );
+}
+
 #[derive(Debug, Clone)]
 struct Buf(Arc<RwLock<Vec<u8>>>);
 impl Write for Buf {

--- a/ecmascript/codegen/src/tests.rs
+++ b/ecmascript/codegen/src/tests.rs
@@ -646,7 +646,8 @@ fn test_escape_with_source_str() {
 fn issue_1791() {
     check_latest(
         "f`
-`", "",
+`;", "f`
+`;",
     );
 }
 

--- a/ecmascript/transforms/module/Cargo.toml
+++ b/ecmascript/transforms/module/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.20.0"
+version = "0.20.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
swc_ecma_codegen:
 - Fix codegen of tagged template literals. (Closes #1791)
