### PR TITLE
feat(swc): Add import resolvers

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -49,7 +49,7 @@ jobs:
           tool: "cargo"
           # Where the output from the benchmark tool is stored
           output-file-path: output.txt
-          external-data-json-path: ./raw-data/benchmark-data.json
+          external-data-json-path: ./raw-data/$GITHUB_SHA/benchmark-data.json
           # Workflow will fail when an alert happens
           fail-on-alert: true
           # GitHub API token to make a commit comment
@@ -67,8 +67,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           branch: gh-pages
           folder: raw-data
-          clean: true
-          git-config-email: kdy1997.dev@gmail.com
+          git-config-email: github-bot@swc.rs
           repository-name: swc-project/raw-data
           commit-message: "Update"
           single-commit: true

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -247,7 +247,7 @@ jobs:
           branch: gh-pages
           folder: target/doc
           clean: true
-          git-config-email: kdy1997.dev@gmail.com
+          git-config-email: github-bot@swc.rs
           repository-name: swc-project/rustdoc
           commit-message: "Update"
           single-commit: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -89,7 +89,7 @@ jobs:
           git clone --depth 1 https://github.com/mrdoob/three.js.git -b r117 integration-tests/three-js/repo
 
           swc --sync integration-tests/three-js/repo/ -d integration-tests/three-js/build/
-          # swc integration-tests/three-js/repo/src/ -d integration-tests/three-js/repo/build/
+          swc integration-tests/three-js/repo/src/ -d integration-tests/three-js/repo/build/
           # swc integration-tests/three-js/repo/test/unit/**/*.js -d integration-tests/three-js/repo/test/unit/build/
 
           (cd integration-tests/three-js/build/test && qunit -r failonlyreporter unit/three.source.unit.js)

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -104,7 +104,7 @@ jobs:
           npm i -g qunit failonlyreporter
 
           # Download
-          git clone --depth 1 https://github.com/reduxjs/redux.git integration-tests/redux/repo
+          git clone --depth 1 https://github.com/reduxjs/redux.git -b v4.1.0 integration-tests/redux/repo
           swc --sync integration-tests/redux/repo/src/ -d integration-tests/redux/repo/lib/
           echo "module.exports=require('./index')" > integration-tests/redux/repo/lib/redux.js
           swc --sync integration-tests/redux/repo/src/ -d integration-tests/redux/repo/test/

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -89,7 +89,7 @@ jobs:
           git clone --depth 1 https://github.com/mrdoob/three.js.git -b r117 integration-tests/three-js/repo
 
           swc --sync integration-tests/three-js/repo/ -d integration-tests/three-js/build/
-          swc integration-tests/three-js/repo/src/ -d integration-tests/three-js/repo/build/
+          # swc integration-tests/three-js/repo/src/ -d integration-tests/three-js/repo/build/
           # swc integration-tests/three-js/repo/test/unit/**/*.js -d integration-tests/three-js/repo/test/unit/build/
 
           (cd integration-tests/three-js/build/test && qunit -r failonlyreporter unit/three.source.unit.js)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.24.1"
+version = "0.25.0"
 
 [lib]
 name = "swc"
@@ -23,19 +23,22 @@ base64 = "0.12.0"
 dashmap = "4.0.2"
 either = "1"
 log = {version = "0.4", features = ["release_max_level_info"]}
+lru = "0.6.1"
 once_cell = "1"
 regex = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "./atoms"}
+swc_bundler = {version = "0.42.0", path = "./bundler"}
 swc_common = {version = "0.10.16", path = "./common", features = ["sourcemap", "concurrent"]}
 swc_ecma_ast = {version = "0.46.0", path = "./ecmascript/ast"}
 swc_ecma_codegen = {version = "0.59.1", path = "./ecmascript/codegen"}
 swc_ecma_ext_transforms = {version = "0.18.1", path = "./ecmascript/ext-transforms"}
+swc_ecma_loader = {version = "0.8.0", path = "./ecmascript/loader", features = ["lru", "node", "tsc"]}
 swc_ecma_parser = {version = "0.60.2", path = "./ecmascript/parser"}
-swc_ecma_preset_env = {version = "0.24.1", path = "./ecmascript/preset-env"}
-swc_ecma_transforms = {version = "0.54.1", path = "./ecmascript/transforms", features = [
+swc_ecma_preset_env = {version = "0.25.0", path = "./ecmascript/preset-env"}
+swc_ecma_transforms = {version = "0.55.0", path = "./ecmascript/transforms", features = [
   "compat",
   "module",
   "optimization",

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -9,7 +9,7 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/**/*.js"]
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.41.1"
+version = "0.42.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -35,8 +35,9 @@ swc_atoms = {version = "0.2.4", path = "../atoms"}
 swc_common = {version = "0.10.16", path = "../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ecmascript/ast"}
 swc_ecma_codegen = {version = "0.59.1", path = "../ecmascript/codegen"}
+swc_ecma_loader = {version = "0.8.0", path = "../ecmascript/loader"}
 swc_ecma_parser = {version = "0.60.2", path = "../ecmascript/parser"}
-swc_ecma_transforms = {version = "0.54.1", path = "../ecmascript/transforms", features = ["optimization"]}
+swc_ecma_transforms = {version = "0.55.0", path = "../ecmascript/transforms", features = ["optimization"]}
 swc_ecma_utils = {version = "0.37.2", path = "../ecmascript/utils"}
 swc_ecma_visit = {version = "0.32.1", path = "../ecmascript/visit"}
 
@@ -45,7 +46,7 @@ hex = "0.4"
 ntest = "0.7.2"
 reqwest = {version = "0.10.8", features = ["blocking"]}
 sha-1 = "0.9"
-swc_ecma_transforms = {version = "0.54.1", path = "../ecmascript/transforms", features = ["react", "typescript"]}
+swc_ecma_transforms = {version = "0.55.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
 tempfile = "3.1.0"
 testing = {version = "0.10.5", path = "../testing"}
 url = "2.1.1"

--- a/bundler/src/resolve.rs
+++ b/bundler/src/resolve.rs
@@ -1,18 +1,1 @@
-use anyhow::Error;
-use swc_common::FileName;
-
-pub trait Resolve: swc_common::sync::Send + swc_common::sync::Sync {
-    fn resolve(&self, base: &FileName, module_specifier: &str) -> Result<FileName, Error>;
-}
-
-impl<T: ?Sized + Resolve> Resolve for Box<T> {
-    fn resolve(&self, base: &FileName, module_specifier: &str) -> Result<FileName, Error> {
-        (**self).resolve(base, module_specifier)
-    }
-}
-
-impl<'a, T: ?Sized + Resolve> Resolve for &'a T {
-    fn resolve(&self, base: &FileName, module_specifier: &str) -> Result<FileName, Error> {
-        (**self).resolve(base, module_specifier)
-    }
-}
+pub use swc_ecma_loader::resolve::Resolve;

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.40.2"
+version = "0.41.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -31,9 +31,9 @@ typescript = ["swc_ecma_transforms/typescript"]
 swc_ecma_ast = {version = "0.46.0", path = "./ast"}
 swc_ecma_codegen = {version = "0.59.1", path = "./codegen", optional = true}
 swc_ecma_dep_graph = {version = "0.28.1", path = "./dep-graph", optional = true}
-swc_ecma_minifier = {version = "0.6.1", path = "./minifier", optional = true}
+swc_ecma_minifier = {version = "0.7.0", path = "./minifier", optional = true}
 swc_ecma_parser = {version = "0.60.2", path = "./parser", optional = true}
-swc_ecma_transforms = {version = "0.54.1", path = "./transforms", optional = true}
+swc_ecma_transforms = {version = "0.55.0", path = "./transforms", optional = true}
 swc_ecma_utils = {version = "0.37.2", path = "./utils", optional = true}
 swc_ecma_visit = {version = "0.32.1", path = "./visit", optional = true}
 

--- a/ecmascript/loader/Cargo.toml
+++ b/ecmascript/loader/Cargo.toml
@@ -6,11 +6,27 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_loader"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.7.1"
+version = "0.8.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+all-features = true
+
+[features]
+default = []
+
+# Enable node js resolver
+node = ["normpath", "serde", "serde_json"]
+# Enable support for `paths` of tsconfig.json
+tsc = ["dashmap", "once_cell", "regex"]
 
 [dependencies]
+anyhow = "1.0.41"
+dashmap = {version = "4.0.2", optional = true}
+lru = {version = "0.6.5", optional = true}
+once_cell = {version = "1.8.0", optional = true}
+regex = {version = "1", optional = true}
+serde = {version = "1.0.126", optional = true}
+serde_json = {version = "1.0.64", optional = true}
 swc_atoms = {version = "0.2.3", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ast"}
@@ -18,3 +34,6 @@ swc_ecma_visit = {version = "0.32.1", path = "../visit"}
 
 [dev-dependencies]
 testing = {version = "0.10.5", path = "../../testing"}
+
+[target.'cfg(windows)'.dependencies]
+normpath = {version = "0.2", optional = true}

--- a/ecmascript/loader/src/lib.rs
+++ b/ecmascript/loader/src/lib.rs
@@ -1,7 +1,2 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+pub mod resolve;
+pub mod resolvers;

--- a/ecmascript/loader/src/resolve.rs
+++ b/ecmascript/loader/src/resolve.rs
@@ -1,0 +1,25 @@
+use anyhow::Error;
+use std::sync::Arc;
+use swc_common::sync::{Send, Sync};
+use swc_common::FileName;
+
+pub trait Resolve: Send + Sync {
+    fn resolve(&self, base: &FileName, module_specifier: &str) -> Result<FileName, Error>;
+}
+
+macro_rules! impl_ref {
+    ($R:ident, $T:ty) => {
+        impl<$R> Resolve for $T
+        where
+            R: ?Sized + Resolve,
+        {
+            fn resolve(&self, base: &FileName, src: &str) -> Result<FileName, Error> {
+                (**self).resolve(base, src)
+            }
+        }
+    };
+}
+
+impl_ref!(R, &'_ R);
+impl_ref!(R, Box<R>);
+impl_ref!(R, Arc<R>);

--- a/ecmascript/loader/src/resolvers/lru.rs
+++ b/ecmascript/loader/src/resolvers/lru.rs
@@ -1,0 +1,68 @@
+use crate::resolve::Resolve;
+use anyhow::Error;
+use lru::LruCache;
+use std::sync::Mutex;
+use swc_common::FileName;
+
+#[derive(Debug)]
+pub struct CachingResolver<R>
+where
+    R: Resolve,
+{
+    cache: Mutex<LruCache<(FileName, String), FileName>>,
+    inner: R,
+}
+
+impl<R> Default for CachingResolver<R>
+where
+    R: Resolve + Default,
+{
+    fn default() -> Self {
+        Self::new(40, Default::default())
+    }
+}
+
+impl<R> CachingResolver<R>
+where
+    R: Resolve,
+{
+    pub fn new(cap: usize, inner: R) -> Self {
+        Self {
+            cache: Mutex::new(LruCache::new(cap)),
+            inner,
+        }
+    }
+}
+
+impl<R> Resolve for CachingResolver<R>
+where
+    R: Resolve,
+{
+    fn resolve(&self, base: &FileName, src: &str) -> Result<FileName, Error> {
+        {
+            let lock = self.cache.lock();
+            match lock {
+                Ok(mut lock) => {
+                    //
+                    if let Some(v) = lock.get(&(base.clone(), src.to_string())) {
+                        return Ok(v.clone());
+                    }
+                }
+                Err(_) => {}
+            }
+        }
+
+        let resolved = self.inner.resolve(base, src)?;
+        {
+            let lock = self.cache.lock();
+            match lock {
+                Ok(mut lock) => {
+                    lock.put((base.clone(), src.to_string()), resolved.clone());
+                }
+                Err(_) => {}
+            }
+        }
+
+        Ok(resolved)
+    }
+}

--- a/ecmascript/loader/src/resolvers/mod.rs
+++ b/ecmascript/loader/src/resolvers/mod.rs
@@ -1,0 +1,6 @@
+#[cfg(feature = "lru")]
+pub mod lru;
+#[cfg(feature = "node")]
+pub mod node;
+#[cfg(feature = "tsc")]
+pub mod tsc;

--- a/ecmascript/loader/src/resolvers/tsc.rs
+++ b/ecmascript/loader/src/resolvers/tsc.rs
@@ -1,0 +1,169 @@
+use crate::resolve::Resolve;
+use anyhow::{bail, Context, Error};
+use dashmap::DashMap;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::path::PathBuf;
+use swc_common::FileName;
+
+#[derive(Debug)]
+enum Pattern {
+    Regex(Regex),
+    /// No wildcard.
+    Exact(String),
+}
+
+/// Support for `paths` of `tsconfig.json`.
+///
+/// See https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping
+#[derive(Debug)]
+pub struct TsConfigResolver<R>
+where
+    R: Resolve,
+{
+    inner: R,
+    base_url: PathBuf,
+    paths: Vec<(Pattern, Vec<String>)>,
+}
+
+impl<R> TsConfigResolver<R>
+where
+    R: Resolve,
+{
+    ///
+    /// # Parameters
+    ///
+    /// ## base_url
+    ///
+    /// See https://www.typescriptlang.org/tsconfig#baseUrl
+    ///
+    /// The typescript documentation says `This must be specified if "paths"
+    /// is.`.
+    ///
+    /// ## `paths`
+    ///
+    /// Pass `paths` map from `tsconfig.json`.
+    ///
+    /// See https://www.typescriptlang.org/tsconfig#paths
+    ///
+    /// Note that this is not a hashmap because value is not used as a hash map.
+    pub fn new(inner: R, base_url: PathBuf, paths: Vec<(String, Vec<String>)>) -> Self {
+        let paths = paths
+            .into_iter()
+            .map(|(from, to)| {
+                assert!(
+                    !to.is_empty(),
+                    "value of `paths.{}` should not be an empty array",
+                    from,
+                );
+
+                let pat = if from.contains('*') {
+                    if from.as_bytes().iter().rposition(|&c| c == b'*')
+                        != from.as_bytes().iter().position(|&c| c == b'*')
+                    {
+                        panic!("`paths.{}` should have only one wildcard", from)
+                    }
+
+                    Pattern::Regex(compile_regex(from))
+                } else {
+                    assert_eq!(
+                        to.len(),
+                        1,
+                        "value of `paths.{}` should be an array with one element because the src \
+                         path does not contains * (wildcard)",
+                        from,
+                    );
+
+                    Pattern::Exact(from)
+                };
+
+                (pat, to)
+            })
+            .collect();
+
+        Self {
+            inner,
+            base_url,
+            paths,
+        }
+    }
+}
+
+impl<R> Resolve for TsConfigResolver<R>
+where
+    R: Resolve,
+{
+    fn resolve(&self, base: &FileName, src: &str) -> Result<FileName, Error> {
+        // https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping
+        for (from, to) in &self.paths {
+            match from {
+                Pattern::Regex(from) => {
+                    let captures = from.captures(src);
+                    let captures = match captures {
+                        Some(v) => v,
+                        None => continue,
+                    };
+                    let capture = captures.iter().next().flatten().expect(
+                        "capture group should be created by initializer of TsConfigResolver",
+                    );
+                    let mut errors = vec![];
+                    for target in to {
+                        let replaced = target.replace('*', capture.as_str());
+                        let rel = format!("./{}", replaced);
+
+                        let res = self.inner.resolve(base, &rel).with_context(|| {
+                            format!(
+                                "failed to resolve `{}`, which is expanded from `{}`",
+                                replaced, src
+                            )
+                        });
+                        errors.push(match res {
+                            Ok(v) => return Ok(v),
+                            Err(err) => err,
+                        })
+                    }
+
+                    bail!(
+                        "`{}` matched `{}` (from tsconfig.paths) but failed to resolve:\n{:?}",
+                        src,
+                        from.as_str(),
+                        errors
+                    )
+                }
+                Pattern::Exact(from) => {
+                    // Should be exactly matched
+                    if src == from {
+                        return self
+                            .inner
+                            .resolve(base, &format!("./{}", &to[0]))
+                            .with_context(|| {
+                                format!(
+                                    "tried to resolve `{}` because `{}` was exactly matched",
+                                    to[0], from
+                                )
+                            });
+                    }
+                }
+            }
+        }
+
+        self.inner.resolve(base, src)
+    }
+}
+
+fn compile_regex(src: String) -> Regex {
+    static CACHE: Lazy<DashMap<String, Regex>> = Lazy::new(|| Default::default());
+
+    if !CACHE.contains_key(&*src) {
+        // Create capture group
+        let regex_pat = src.replace("*", "(.*)");
+        let re = Regex::new(&regex_pat).unwrap_or_else(|err| {
+            panic!("failed to compile `{}` as a pattern: {:?}", regex_pat, err)
+        });
+        CACHE.insert(src.clone(), re);
+    }
+
+    let re = CACHE.get(&*src).unwrap();
+
+    (*re).clone()
+}

--- a/ecmascript/loader/tests/tsc_resolver.rs
+++ b/ecmascript/loader/tests/tsc_resolver.rs
@@ -1,0 +1,96 @@
+#![cfg(feature = "tsc")]
+
+use anyhow::anyhow;
+use anyhow::Error;
+use std::collections::HashMap;
+use swc_common::FileName;
+use swc_ecma_loader::resolve::Resolve;
+use swc_ecma_loader::resolvers::tsc::TsConfigResolver;
+
+#[test]
+fn base_dir_exact() {}
+
+#[test]
+fn base_dir_wildcard() {}
+
+#[test]
+fn exact() {
+    let mut map = HashMap::default();
+    map.insert("jquery".to_string(), "fail".to_string());
+    map.insert(
+        "./node_modules/jquery/dist/jquery".to_string(),
+        "success".to_string(),
+    );
+    let r = TsConfigResolver::new(
+        TestResolver(map),
+        ".".into(),
+        vec![(
+            "jquery".into(),
+            vec!["node_modules/jquery/dist/jquery".into()],
+        )],
+    );
+
+    {
+        let resolved = r
+            .resolve(&FileName::Anon, "jquery")
+            .expect("should resolve");
+
+        assert_eq!(resolved, FileName::Custom("success".into()));
+    }
+
+    {
+        let err = r
+            .resolve(&FileName::Anon, "unrelated")
+            .expect_err("should not touch error");
+
+        assert!(
+            err.source().is_none(),
+            "should not touch error if src is not related"
+        );
+    }
+}
+
+#[test]
+fn pattern_1() {
+    let mut map = HashMap::default();
+    map.insert("./folder1/file1".to_string(), "success-1".to_string());
+    map.insert("./folder1/file2".to_string(), "success-2".to_string());
+    map.insert(
+        "./generated/folder2/file3".to_string(),
+        "success-3".to_string(),
+    );
+
+    let r = TsConfigResolver::new(
+        TestResolver(map),
+        ".".into(),
+        vec![("*".into(), vec!["*".into(), "generated/*".into()])],
+    );
+
+    {
+        let resolved = r
+            .resolve(&FileName::Anon, "folder1/file2")
+            .expect("should resolve");
+
+        assert_eq!(resolved, FileName::Custom("success-2".into()));
+    }
+
+    {
+        let resolved = r
+            .resolve(&FileName::Anon, "folder2/file3")
+            .expect("should resolve");
+
+        assert_eq!(resolved, FileName::Custom("success-3".into()));
+    }
+}
+
+struct TestResolver(HashMap<String, String>);
+
+impl Resolve for TestResolver {
+    fn resolve(&self, _: &FileName, src: &str) -> Result<FileName, Error> {
+        self.0
+            .get(src)
+            .cloned()
+            .map(FileName::Custom)
+            .ok_or_else(|| anyhow!("failed to resolve `{}`", src))
+    }
+}

--- a/ecmascript/minifier/Cargo.toml
+++ b/ecmascript/minifier/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "src/lists/*.json"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_minifier"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.6.1"
+version = "0.7.0"
 
 [features]
 debug = []
@@ -27,7 +27,7 @@ swc_common = {version = "0.10.8", path = "../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ast"}
 swc_ecma_codegen = {version = "0.59.1", path = "../codegen"}
 swc_ecma_parser = {version = "0.60.2", path = "../parser"}
-swc_ecma_transforms = {version = "0.54.1", path = "../transforms/", features = ["optimization"]}
+swc_ecma_transforms = {version = "0.55.0", path = "../transforms/", features = ["optimization"]}
 swc_ecma_transforms_base = {version = "0.19.1", path = "../transforms/base"}
 swc_ecma_utils = {version = "0.37.2", path = "../utils"}
 swc_ecma_visit = {version = "0.32.1", path = "../visit"}

--- a/ecmascript/preset-env/Cargo.toml
+++ b/ecmascript/preset-env/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_preset_env/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_preset_env"
-version = "0.24.1"
+version = "0.25.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,7 +22,7 @@ string_enum = {version = "0.3.1", path = "../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ast"}
-swc_ecma_transforms = {version = "0.54.1", path = "../transforms", features = ["compat", "proposal"]}
+swc_ecma_transforms = {version = "0.55.0", path = "../transforms", features = ["compat", "proposal"]}
 swc_ecma_utils = {version = "0.37.2", path = "../utils"}
 swc_ecma_visit = {version = "0.32.1", path = "../visit"}
 walkdir = "2"

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.54.1"
+version = "0.55.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -27,11 +27,11 @@ swc_ecma_ast = {version = "0.46.0", path = "../ast"}
 swc_ecma_parser = {version = "0.60.2", path = "../parser"}
 swc_ecma_transforms_base = {version = "0.19.1", path = "./base"}
 swc_ecma_transforms_compat = {version = "0.21.1", path = "./compat", optional = true}
-swc_ecma_transforms_module = {version = "0.21.1", path = "./module", optional = true}
-swc_ecma_transforms_optimization = {version = "0.24.1", path = "./optimization", optional = true}
-swc_ecma_transforms_proposal = {version = "0.21.1", path = "./proposal", optional = true}
-swc_ecma_transforms_react = {version = "0.22.1", path = "./react", optional = true}
-swc_ecma_transforms_typescript = {version = "0.23.1", path = "./typescript", optional = true}
+swc_ecma_transforms_module = {version = "0.22.0", path = "./module", optional = true}
+swc_ecma_transforms_optimization = {version = "0.25.0", path = "./optimization", optional = true}
+swc_ecma_transforms_proposal = {version = "0.22.0", path = "./proposal", optional = true}
+swc_ecma_transforms_react = {version = "0.23.0", path = "./react", optional = true}
+swc_ecma_transforms_typescript = {version = "0.24.0", path = "./typescript", optional = true}
 swc_ecma_utils = {version = "0.37.2", path = "../utils"}
 swc_ecma_visit = {version = "0.32.1", path = "../visit"}
 unicode-xid = "0.2"

--- a/ecmascript/transforms/module/Cargo.toml
+++ b/ecmascript/transforms/module/Cargo.toml
@@ -6,17 +6,20 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.21.1"
+version = "0.22.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 Inflector = "0.11.4"
+anyhow = "1.0.41"
 fxhash = "0.2.1"
 indexmap = "1.6.1"
+pathdiff = "0.2.0"
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../../ast"}
+swc_ecma_loader = {version = "0.8.0", path = "../../loader", features = ["node"]}
 swc_ecma_parser = {version = "0.60.2", path = "../../parser"}
 swc_ecma_transforms_base = {version = "0.19.1", path = "../base"}
 swc_ecma_utils = {version = "0.37.2", path = "../../utils"}

--- a/ecmascript/transforms/module/src/common_js.rs
+++ b/ecmascript/transforms/module/src/common_js.rs
@@ -22,10 +22,7 @@ use swc_ecma_utils::{var::VarCollector, DestructuringFinder, ExprFactory};
 use swc_ecma_visit::{noop_fold_type, Fold, FoldWith, VisitWith};
 
 pub fn common_js(root_mark: Mark, config: Config, scope: Option<Rc<RefCell<Scope>>>) -> impl Fold {
-    let scope: Rc<RefCell<Scope>> = match scope {
-        Some(scope) => scope,
-        None => Rc::new(RefCell::new(Scope::default())),
-    };
+    let scope = scope.unwrap_or_default();
     CommonJs {
         root_mark,
         config,
@@ -40,14 +37,17 @@ pub fn common_js_with_resolver<R>(
     base: FileName,
     root_mark: Mark,
     config: Config,
+    scope: Option<Rc<RefCell<Scope>>>,
 ) -> impl Fold
 where
     R: ImportResolver,
 {
+    let scope = scope.unwrap_or_default();
+
     CommonJs {
         root_mark,
         config,
-        scope: Default::default(),
+        scope,
         in_top_level: Default::default(),
         resolver: Some((resolver, base)),
     }

--- a/ecmascript/transforms/module/src/lib.rs
+++ b/ecmascript/transforms/module/src/lib.rs
@@ -9,4 +9,5 @@ pub mod util;
 pub mod amd;
 pub mod common_js;
 pub mod import_analysis;
+pub mod path;
 pub mod umd;

--- a/ecmascript/transforms/module/src/path.rs
+++ b/ecmascript/transforms/module/src/path.rs
@@ -88,7 +88,8 @@ where
 
         debug_assert!(
             !rel_path.is_absolute(),
-            "Path should not absolute (in swc repository)"
+            "Path should not be absolute (in swc repository) but found {}",
+            rel_path.display()
         );
 
         {

--- a/ecmascript/transforms/module/src/path.rs
+++ b/ecmascript/transforms/module/src/path.rs
@@ -86,14 +86,6 @@ where
             None => return Ok(module_specifier.into()),
         };
 
-        debug_assert!(
-            !rel_path.is_absolute(),
-            "Path should not be absolute (in swc repository) but found {}\nbase: {}\ntarget: {}",
-            rel_path.display(),
-            base.display(),
-            target.display(),
-        );
-
         {
             // Check for `node_modules`.
 
@@ -111,6 +103,15 @@ where
                 }
             }
         }
+
+        debug_assert!(
+            !rel_path.is_absolute(),
+            "Resolved path should not be absolute (in swc repository) but found {}\nbase: \
+             {}\ntarget: {}",
+            rel_path.display(),
+            base.display(),
+            target.display(),
+        );
 
         let s = rel_path.to_string_lossy();
         let s = if s.starts_with('.') || s.starts_with("/") {

--- a/ecmascript/transforms/module/src/path.rs
+++ b/ecmascript/transforms/module/src/path.rs
@@ -86,6 +86,11 @@ where
             None => return Ok(module_specifier.into()),
         };
 
+        debug_assert!(
+            !rel_path.is_absolute(),
+            "Path should not absolute (in swc repository)"
+        );
+
         {
             // Check for `node_modules`.
 

--- a/ecmascript/transforms/module/src/path.rs
+++ b/ecmascript/transforms/module/src/path.rs
@@ -88,8 +88,10 @@ where
 
         debug_assert!(
             !rel_path.is_absolute(),
-            "Path should not be absolute (in swc repository) but found {}",
-            rel_path.display()
+            "Path should not be absolute (in swc repository) but found {}\nbase: {}\ntarget: {}",
+            rel_path.display(),
+            base.display(),
+            target.display(),
         );
 
         {

--- a/ecmascript/transforms/module/src/path.rs
+++ b/ecmascript/transforms/module/src/path.rs
@@ -1,0 +1,136 @@
+use anyhow::Error;
+use pathdiff::diff_paths;
+use std::{borrow::Cow, path::Component, sync::Arc};
+use swc_atoms::JsWord;
+use swc_common::FileName;
+use swc_ecma_loader::resolve::Resolve;
+
+pub trait ImportResolver {
+    /// Resolves `target` as a string usable by the modules pass.
+    fn resolve_import(&self, base: &FileName, module_specifier: &str) -> Result<JsWord, Error>;
+}
+
+/// [ImportResolver] implementation which just uses orignal source.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoopImportResolver;
+
+impl ImportResolver for NoopImportResolver {
+    fn resolve_import(&self, _: &FileName, module_specifier: &str) -> Result<JsWord, Error> {
+        Ok(module_specifier.into())
+    }
+}
+
+/// [ImportResolver] implementation for node.js
+///
+/// Supports [FileName::Real] for `base`, [FileName::Real] and
+/// [FileName::Custom] for `target`. ([FileName::Custom] is used for core
+/// modules)
+#[derive(Debug, Clone, Default)]
+pub struct NodeImportResolver<R>
+where
+    R: Resolve,
+{
+    resolver: R,
+}
+
+impl<R> NodeImportResolver<R>
+where
+    R: Resolve,
+{
+    pub fn new(resolver: R) -> Self {
+        Self { resolver }
+    }
+}
+
+impl<R> ImportResolver for NodeImportResolver<R>
+where
+    R: Resolve,
+{
+    fn resolve_import(&self, base: &FileName, module_specifier: &str) -> Result<JsWord, Error> {
+        let target = self.resolver.resolve(base, module_specifier);
+        let target = match target {
+            Ok(v) => v,
+            Err(_) => return Ok(module_specifier.into()),
+        };
+
+        let target = match target {
+            FileName::Real(v) => v,
+            FileName::Custom(s) => return Ok(s.into()),
+            _ => {
+                unreachable!(
+                    "Node path provider does not support using `{:?}` as a target file name",
+                    target
+                )
+            }
+        };
+        let base = match base {
+            FileName::Real(v) => v,
+            _ => {
+                unreachable!(
+                    "Node path provider does not support using `{:?}` as a base file name",
+                    base
+                )
+            }
+        };
+
+        let rel_path = diff_paths(
+            &target,
+            match base.parent() {
+                Some(v) => v,
+                None => &base,
+            },
+        );
+
+        let rel_path = match rel_path {
+            Some(v) => v,
+            None => return Ok(module_specifier.into()),
+        };
+
+        {
+            // Check for `node_modules`.
+
+            for component in rel_path.components() {
+                match component {
+                    Component::Prefix(_) => {}
+                    Component::RootDir => {}
+                    Component::CurDir => {}
+                    Component::ParentDir => {}
+                    Component::Normal(c) => {
+                        if c == "node_modules" {
+                            return Ok(module_specifier.into());
+                        }
+                    }
+                }
+            }
+        }
+
+        let s = rel_path.to_string_lossy();
+        let s = if s.starts_with('.') || s.starts_with("/") {
+            s
+        } else {
+            Cow::Owned(format!("./{}", s))
+        };
+        if cfg!(target_os = "windows") {
+            Ok(s.replace('\\', "/").into())
+        } else {
+            Ok(s.into())
+        }
+    }
+}
+
+macro_rules! impl_ref {
+    ($P:ident, $T:ty) => {
+        impl<$P> ImportResolver for $T
+        where
+            $P: ImportResolver,
+        {
+            fn resolve_import(&self, base: &FileName, target: &str) -> Result<JsWord, Error> {
+                (**self).resolve_import(base, target)
+            }
+        }
+    };
+}
+
+impl_ref!(P, &'_ P);
+impl_ref!(P, Box<P>);
+impl_ref!(P, Arc<P>);

--- a/ecmascript/transforms/module/src/util.rs
+++ b/ecmascript/transforms/module/src/util.rs
@@ -1,3 +1,5 @@
+use crate::path::ImportResolver;
+use anyhow::Context;
 use fxhash::FxHashSet;
 use indexmap::IndexMap;
 use inflector::Inflector;
@@ -8,7 +10,7 @@ use std::{
     iter,
 };
 use swc_atoms::{js_word, JsWord};
-use swc_common::{Mark, Span, SyntaxContext, DUMMY_SP};
+use swc_common::{FileName, Mark, Span, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::ext::MapWithMut;
 use swc_ecma_utils::ident::IdentLike;
@@ -737,7 +739,22 @@ impl Scope {
     }
 }
 
-pub(super) fn make_require_call(mark: Mark, src: JsWord) -> Expr {
+pub(super) fn make_require_call<R>(
+    resolver: &Option<(R, FileName)>,
+    mark: Mark,
+    src: JsWord,
+) -> Expr
+where
+    R: ImportResolver,
+{
+    let src = match resolver {
+        Some((resolver, base)) => resolver
+            .resolve_import(&base, &src)
+            .with_context(|| format!("failed to resolve import `{}`", src))
+            .unwrap(),
+        None => src,
+    };
+
     Expr::Call(CallExpr {
         span: DUMMY_SP,
         callee: quote_ident!(DUMMY_SP.apply_mark(mark), "require").as_callee(),

--- a/ecmascript/transforms/module/tests/path_node.rs
+++ b/ecmascript/transforms/module/tests/path_node.rs
@@ -1,0 +1,23 @@
+use swc_common::FileName;
+use swc_ecma_loader::resolvers::node::NodeResolver;
+use swc_ecma_transforms_module::path::{ImportResolver, NodeImportResolver};
+use testing::run_test2;
+type TestProvider = NodeImportResolver<NodeResolver>;
+
+#[test]
+fn node_modules() {
+    let provider = TestProvider::default();
+
+    run_test2(false, |cm, _| {
+        let fm = cm.new_source_file(FileName::Real("foo".into()), "".into());
+
+        let resolved = provider
+            .resolve_import(&fm.name, "core-js")
+            .expect("should success");
+
+        assert_eq!(&*resolved, "core-js");
+
+        Ok(())
+    })
+    .unwrap();
+}

--- a/ecmascript/transforms/optimization/Cargo.toml
+++ b/ecmascript/transforms/optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.24.1"
+version = "0.25.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -27,9 +27,9 @@ swc_ecma_visit = {version = "0.32.1", path = "../../visit"}
 
 [dev-dependencies]
 swc_ecma_transforms_compat = {version = "0.21.1", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.21.1", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.21.1", path = "../proposal"}
-swc_ecma_transforms_react = {version = "0.22.1", path = "../react"}
+swc_ecma_transforms_module = {version = "0.22.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.22.0", path = "../proposal"}
+swc_ecma_transforms_react = {version = "0.23.0", path = "../react"}
 swc_ecma_transforms_testing = {version = "0.19.1", path = "../testing"}
-swc_ecma_transforms_typescript = {version = "0.23.1", path = "../typescript"}
+swc_ecma_transforms_typescript = {version = "0.24.0", path = "../typescript"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/proposal/Cargo.toml
+++ b/ecmascript/transforms/proposal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_proposal"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.21.1"
+version = "0.22.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,7 +22,7 @@ smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../../ast"}
-swc_ecma_loader = {version = "0.7.1", path = "../../loader", optional = true}
+swc_ecma_loader = {version = "0.8.0", path = "../../loader", optional = true}
 swc_ecma_parser = {version = "0.60.2", path = "../../parser"}
 swc_ecma_transforms_base = {version = "0.19.1", path = "../base"}
 swc_ecma_transforms_classes = {version = "0.5.1", path = "../classes"}
@@ -31,5 +31,5 @@ swc_ecma_visit = {version = "0.32.1", path = "../../visit"}
 
 [dev-dependencies]
 swc_ecma_transforms_compat = {version = "0.21.1", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.21.1", path = "../module"}
+swc_ecma_transforms_module = {version = "0.22.0", path = "../module"}
 swc_ecma_transforms_testing = {version = "0.19.1", path = "../testing"}

--- a/ecmascript/transforms/react/Cargo.toml
+++ b/ecmascript/transforms/react/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_react"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.22.1"
+version = "0.23.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -30,6 +30,6 @@ swc_ecma_visit = {version = "0.32.1", path = "../../visit"}
 [dev-dependencies]
 swc_ecma_codegen = {version = "0.59.1", path = "../../codegen/"}
 swc_ecma_transforms_compat = {version = "0.21.1", path = "../compat/"}
-swc_ecma_transforms_module = {version = "0.21.1", path = "../module"}
+swc_ecma_transforms_module = {version = "0.22.0", path = "../module"}
 swc_ecma_transforms_testing = {version = "0.19.1", path = "../testing/"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.23.1"
+version = "0.24.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -23,8 +23,8 @@ swc_ecma_visit = {version = "0.32.1", path = "../../visit"}
 [dev-dependencies]
 swc_ecma_codegen = {version = "0.59.1", path = "../../codegen"}
 swc_ecma_transforms_compat = {version = "0.21.1", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.21.1", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.21.1", path = "../proposal/"}
+swc_ecma_transforms_module = {version = "0.22.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.22.0", path = "../proposal/"}
 swc_ecma_transforms_testing = {version = "0.19.1", path = "../testing"}
 testing = {version = "0.10.5", path = "../../../testing"}
 walkdir = "2.3.1"

--- a/native/src/bundle.rs
+++ b/native/src/bundle.rs
@@ -6,12 +6,11 @@ use anyhow::{bail, Error};
 use fxhash::FxHashMap;
 use napi::{CallContext, Env, JsObject, Status, Task};
 use serde::Deserialize;
-use spack::resolvers::NodeResolver;
 use std::{
     panic::{catch_unwind, AssertUnwindSafe},
     sync::Arc,
 };
-use swc::{config::SourceMapsConfig, Compiler, TransformOutput};
+use swc::{config::SourceMapsConfig, resolver::NodeResolver, Compiler, TransformOutput};
 use swc_atoms::js_word;
 use swc_atoms::JsWord;
 use swc_bundler::{BundleKind, Bundler, Load, ModuleRecord, Resolve};
@@ -199,7 +198,7 @@ pub(crate) fn bundle(cx: CallContext) -> napi::Result<JsObject> {
             swc: c.clone(),
             config: ConfigItem {
                 loader,
-                resolver: Box::new(NodeResolver::new()) as Box<_>,
+                resolver: Box::new(NodeResolver::default()) as Box<_>,
                 static_items,
             },
         })

--- a/spack/Cargo.toml
+++ b/spack/Cargo.toml
@@ -17,7 +17,6 @@ anyhow = "1"
 dashmap = "4.0.2"
 is-macro = "0.1.8"
 log = "0.4.8"
-lru = "0.6.1"
 once_cell = "1"
 regex = "1"
 serde = {version = "1", features = ["derive"]}
@@ -41,6 +40,3 @@ pretty_env_logger = "0.3"
 tempfile = "3"
 testing = {path = "../testing"}
 walkdir = "2.3.1"
-
-[target.'cfg(windows)'.dependencies]
-normpath = "0.2"

--- a/spack/benches/bench.rs
+++ b/spack/benches/bench.rs
@@ -5,12 +5,12 @@
 extern crate test;
 
 use anyhow::Error;
-use spack::resolvers::NodeResolver;
 use std::{
     collections::HashMap,
     hint::black_box,
     path::{Path, PathBuf},
 };
+use swc::resolver::NodeResolver;
 use swc_atoms::js_word;
 use swc_bundler::{Bundler, Load, ModuleData, ModuleRecord};
 use swc_common::{sync::Lrc, FileName, SourceMap, Span, GLOBALS};
@@ -39,7 +39,7 @@ fn run_bench(b: &mut Bencher, entry: &Path) {
                     globals,
                     cm.clone(),
                     Loader { cm: cm.clone() },
-                    NodeResolver::new(),
+                    NodeResolver::default(),
                     swc_bundler::Config {
                         ..Default::default()
                     },

--- a/spack/src/lib.rs
+++ b/spack/src/lib.rs
@@ -8,4 +8,3 @@ extern crate swc_node_base;
 
 pub mod config;
 pub mod loaders;
-pub mod resolvers;

--- a/spack/src/loaders/swc.rs
+++ b/spack/src/loaders/swc.rs
@@ -125,7 +125,7 @@ impl Load for SwcLoader {
                                     }
                                 },
                                 external_helpers: true,
-                                ..c.jsc
+                                ..c.jsc.clone()
                             },
                             module: None,
                             minify: Some(false),

--- a/spack/tests/fixture.rs
+++ b/spack/tests/fixture.rs
@@ -3,7 +3,7 @@
 extern crate test;
 
 use anyhow::Error;
-use spack::{loaders::swc::SwcLoader, resolvers::NodeResolver};
+use spack::loaders::swc::SwcLoader;
 use std::{
     collections::HashMap,
     env,
@@ -12,7 +12,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use swc::config::SourceMapsConfig;
+use swc::{config::SourceMapsConfig, resolver::NodeResolver};
 use swc_atoms::js_word;
 use swc_bundler::{BundleKind, Bundler, Config, ModuleRecord};
 use swc_common::{FileName, Span, GLOBALS};
@@ -139,7 +139,7 @@ fn reference_tests(tests: &mut Vec<TestDescAndFn>, errors: bool) -> Result<(), i
                         compiler.globals(),
                         cm.clone(),
                         &loader,
-                        NodeResolver::new(),
+                        NodeResolver::default(),
                         Config {
                             require: true,
                             disable_inliner: true,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,5 +1,4 @@
-use crate::config::{GlobalPassOption, JscTarget, ModuleConfig};
-use crate::SwcImportResolver;
+use crate::config::{CompiledPaths, GlobalPassOption, JscTarget, ModuleConfig};
 use compat::es2020::export_namespace_from;
 use either::Either;
 use std::cell::RefCell;
@@ -130,7 +129,7 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
     ///  - fixer if enabled
     pub fn finalize<'cmt>(
         self,
-        resolver: SwcImportResolver,
+        paths: CompiledPaths,
         base: &FileName,
         syntax: Syntax,
         module: Option<ModuleConfig>,
@@ -198,7 +197,7 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
             Optional::new(helpers::inject_helpers(), self.inject_helpers),
             ModuleConfig::build(
                 self.cm.clone(),
-                resolver,
+                paths,
                 base,
                 self.global_mark,
                 module,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -196,8 +196,14 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
                 need_interop_analysis
             ),
             Optional::new(helpers::inject_helpers(), self.inject_helpers),
-            ModuleConfig::build(self.cm.clone(), self.global_mark, module, Rc::clone(&scope)),
-            ModuleConfig::build(self.cm.clone(), resolver, base, self.global_mark, module),
+            ModuleConfig::build(
+                self.cm.clone(),
+                resolver,
+                base,
+                self.global_mark,
+                module,
+                Rc::clone(&scope)
+            ),
             Optional::new(
                 hygiene_with_config(self.hygiene.clone().unwrap_or_default()),
                 self.hygiene.is_some()

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -131,7 +131,7 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
     pub fn finalize<'cmt>(
         self,
         resolver: SwcImportResolver,
-        base: FileName,
+        base: &FileName,
         syntax: Syntax,
         module: Option<ModuleConfig>,
         comments: Option<&'cmt dyn Comments>,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,10 +1,12 @@
 use crate::config::{GlobalPassOption, JscTarget, ModuleConfig};
+use crate::SwcImportResolver;
 use compat::es2020::export_namespace_from;
 use either::Either;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::{collections::HashMap, sync::Arc};
 use swc_atoms::JsWord;
+use swc_common::FileName;
 use swc_common::{chain, comments::Comments, errors::Handler, Mark, SourceMap};
 use swc_ecma_parser::Syntax;
 use swc_ecma_transforms::hygiene::hygiene_with_config;
@@ -128,6 +130,8 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
     ///  - fixer if enabled
     pub fn finalize<'cmt>(
         self,
+        resolver: SwcImportResolver,
+        base: FileName,
         syntax: Syntax,
         module: Option<ModuleConfig>,
         comments: Option<&'cmt dyn Comments>,
@@ -193,6 +197,7 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
             ),
             Optional::new(helpers::inject_helpers(), self.inject_helpers),
             ModuleConfig::build(self.cm.clone(), self.global_mark, module, Rc::clone(&scope)),
+            ModuleConfig::build(self.cm.clone(), resolver, base, self.global_mark, module),
             Optional::new(
                 hygiene_with_config(self.hygiene.clone().unwrap_or_default()),
                 self.hygiene.is_some()

--- a/src/config.rs
+++ b/src/config.rs
@@ -175,7 +175,7 @@ impl Options {
     pub fn build<'a>(
         &self,
         cm: &Arc<SourceMap>,
-        base: FileName,
+        base: &FileName,
         handler: &Handler,
         is_module: bool,
         config: Option<Config>,
@@ -625,11 +625,18 @@ impl ModuleConfig {
     pub fn build(
         cm: Arc<SourceMap>,
         resolver: SwcImportResolver,
-        base: FileName,
+        base: &FileName,
         root_mark: Mark,
         config: Option<ModuleConfig>,
         scope: RustRc<RefCell<Scope>>,
     ) -> Box<dyn swc_ecma_visit::Fold> {
+        let base = match base {
+            FileName::Real(v) => {
+                FileName::Real(v.canonicalize().unwrap_or_else(|_| v.to_path_buf()))
+            }
+            _ => base.clone(),
+        };
+
         match config {
             None | Some(ModuleConfig::Es6) => Box::new(noop()),
             Some(ModuleConfig::CommonJs(config)) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,8 +22,8 @@ use swc_ecma_ext_transforms::jest;
 use swc_ecma_loader::resolvers::{lru::CachingResolver, node::NodeResolver, tsc::TsConfigResolver};
 pub use swc_ecma_parser::JscTarget;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
+use swc_ecma_transforms::modules::path::NodeImportResolver;
 use swc_ecma_transforms::{hygiene, modules::util::Scope};
-use swc_ecma_transforms::{hygiene, modules::path::NodeImportResolver};
 use swc_ecma_transforms::{
     modules,
     optimization::const_modules,
@@ -632,16 +632,15 @@ impl ModuleConfig {
     ) -> Box<dyn swc_ecma_visit::Fold> {
         match config {
             None | Some(ModuleConfig::Es6) => Box::new(noop()),
-            Some(ModuleConfig::CommonJs(config)) => Box::new(modules::common_js::common_js(
-                root_mark,
-                config,
-                Some(scope),
-            )),
-            Some(ModuleConfig::Umd(config)) => Box::new(modules::umd::umd(cm, root_mark, config)),
-            Some(ModuleConfig::Amd(config)) => Box::new(modules::amd::amd(config)),
-            Some(ModuleConfig::CommonJs(config)) => Box::new(
-                modules::common_js::common_js_with_resolver(resolver, base, root_mark, config),
-            ),
+            Some(ModuleConfig::CommonJs(config)) => {
+                Box::new(modules::common_js::common_js_with_resolver(
+                    resolver,
+                    base,
+                    root_mark,
+                    config,
+                    Some(scope),
+                ))
+            }
             Some(ModuleConfig::Umd(config)) => Box::new(modules::umd::umd_with_resolver(
                 resolver, base, cm, root_mark, config,
             )),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,7 @@ impl Compiler {
 
             let built = opts.build(
                 &self.cm,
-                name.clone(),
+                name,
                 &self.handler,
                 opts.is_module,
                 Some(config),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,7 +419,6 @@ impl Compiler {
                 Some(v) => v,
                 None => return Ok(None),
             };
-            eprintln!("DEBUG\n\n\n{}\n\n\n=====", name);
 
             let built = opts.build(
                 &self.cm,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,15 +24,24 @@ use swc_common::{
 };
 use swc_ecma_ast::Program;
 use swc_ecma_codegen::{self, Emitter, Node};
+use swc_ecma_loader::resolvers::{lru::CachingResolver, node::NodeResolver, tsc::TsConfigResolver};
 use swc_ecma_parser::{lexer::Lexer, Parser, Syntax};
 use swc_ecma_transforms::{
     helpers::{self, Helpers},
+    modules::path::NodeImportResolver,
     pass::noop,
 };
 use swc_ecma_visit::FoldWith;
 
 mod builder;
 pub mod config;
+pub mod resolver {
+    use swc_ecma_loader::resolvers::lru::CachingResolver;
+
+    pub type NodeResolver = CachingResolver<swc_ecma_loader::resolvers::node::NodeResolver>;
+}
+
+type SwcImportResolver = Arc<NodeImportResolver<CachingResolver<TsConfigResolver<NodeResolver>>>>;
 
 pub struct Compiler {
     /// swc uses rustc's span interning.
@@ -410,8 +419,11 @@ impl Compiler {
                 Some(v) => v,
                 None => return Ok(None),
             };
+            eprintln!("DEBUG\n\n\n{}\n\n\n=====", name);
+
             let built = opts.build(
                 &self.cm,
+                name.clone(),
                 &self.handler,
                 opts.is_module,
                 Some(config),

--- a/tests/fixture/paths/cjs-001/input/.swcrc
+++ b/tests/fixture/paths/cjs-001/input/.swcrc
@@ -1,0 +1,10 @@
+{
+    "jsc": {
+        "paths": {
+            "*": ["src/*", "src2/*"]
+        }
+    },
+    "module": {
+        "type": "commonjs"
+    }
+}

--- a/tests/fixture/paths/cjs-001/input/index.ts
+++ b/tests/fixture/paths/cjs-001/input/index.ts
@@ -1,0 +1,3 @@
+import 'dep';
+import 'dep-2';
+

--- a/tests/fixture/paths/cjs-001/input/src/dep.ts
+++ b/tests/fixture/paths/cjs-001/input/src/dep.ts
@@ -1,0 +1,1 @@
+console.log('src/dep.ts')

--- a/tests/fixture/paths/cjs-001/input/src2/dep-2.ts
+++ b/tests/fixture/paths/cjs-001/input/src2/dep-2.ts
@@ -1,0 +1,1 @@
+console.log('src2/dep-2.ts')

--- a/tests/fixture/paths/cjs-001/output/dep-2.ts
+++ b/tests/fixture/paths/cjs-001/output/dep-2.ts
@@ -1,0 +1,2 @@
+"use strict";
+console.log('src2/dep-2.ts');

--- a/tests/fixture/paths/cjs-001/output/dep.ts
+++ b/tests/fixture/paths/cjs-001/output/dep.ts
@@ -1,0 +1,2 @@
+"use strict";
+console.log('src/dep.ts');

--- a/tests/fixture/paths/cjs-001/output/index.ts
+++ b/tests/fixture/paths/cjs-001/output/index.ts
@@ -1,0 +1,3 @@
+"use strict";
+require("./src/dep.ts");
+require("./src2/dep-2.ts");


### PR DESCRIPTION
swc_ecma_loader:
 - [x] Add `Resolve`. 
 - [x] Add `TsConfigResolver`. 

swc_ecma_transforms_module:
 - [x] Use `Resolve` for remapping import paths.
 - [x] Add `ImportResolver`.
 - [x] Add `NodeImprortResolver`.

swc:
 - [x] Add `paths` to `.swcrc`.
 - [x] Use `paths`. (Closes #379, Closes #702)
 - [x] Canonicalize file names.
