### PR TITLE
fix(transform/typescript): incorrectly strip import

### DIFF
--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.40.0"
+version = "0.40.1"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -34,7 +34,7 @@ swc_ecma_dep_graph = {version = "0.28.0", path = "./dep-graph", optional = true}
 swc_ecma_minifier = {version = "0.6.0", path = "./minifier", optional = true}
 swc_ecma_parser = {version = "0.60.0", path = "./parser", optional = true}
 swc_ecma_transforms = {version = "0.54.0", path = "./transforms", optional = true}
-swc_ecma_utils = {version = "0.37.0", path = "./utils", optional = true}
+swc_ecma_utils = {version = "0.37.1", path = "./utils", optional = true}
 swc_ecma_visit = {version = "0.32.0", path = "./visit", optional = true}
 
 [dev-dependencies]

--- a/ecmascript/transforms/typescript/tests/strip.rs
+++ b/ecmascript/transforms/typescript/tests/strip.rs
@@ -3983,3 +3983,26 @@ to!(
     console.log({ foo: 1 });
     "
 );
+
+to!(
+    pr_1835,
+    r#"
+    import { A } from "./a";
+    import { B } from "./b";
+    import { C } from "./c";
+
+    const { A: AB } = B;
+    const { CB = C } = B;
+
+    console.log(A, AB, CB);
+    "#,
+    r#"
+    import { A } from "./a";
+    import { B } from "./b";
+    import { C } from "./c";
+
+    const { A: AB } = B;
+    const { CB = C } = B;
+
+    console.log(A, AB, CB);"#
+);

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.37.0"
+version = "0.37.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ecmascript/utils/src/var.rs
+++ b/ecmascript/utils/src/var.rs
@@ -18,6 +18,10 @@ impl Visit for VarCollector<'_> {
 
     fn visit_function(&mut self, _: &Function, _parent: &dyn Node) {}
 
+    fn visit_key_value_pat_prop(&mut self, node: &KeyValuePatProp, _parent: &dyn Node) {
+        node.value.visit_with(node, self);
+    }
+
     fn visit_ident(&mut self, i: &Ident, _: &dyn Node) {
         self.to.push((i.sym.clone(), i.span.ctxt()))
     }


### PR DESCRIPTION
Currently when there's an import item share the same name with object destructuring in variable declaration like
```ts
import { A } from "./a";
import { B } from "./b";

const { A: AB } = B;

console.log(A, AB);
```
the first import will be striped because `swc` would consider it being shadowed by local variable, which is wrong