### PR TITLE
fix(es/parser): Fix parsing of abstract class over multiple lines

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.60.0"
+version = "0.60.1"
 
 [features]
 default = []

--- a/ecmascript/parser/src/parser/stmt/module_item.rs
+++ b/ecmascript/parser/src/parser/stmt/module_item.rs
@@ -341,7 +341,7 @@ impl<'a, I: Tokens> Parser<I> {
             if self.input.syntax().typescript() {
                 if is!(self, "abstract")
                     && peeked_is!(self, "class")
-                    && !self.input.had_line_break_before_cur()
+                    && !self.input.has_linebreak_between_cur_and_peeked()
                 {
                     let class_start = cur_pos!(self);
                     assert_and_bump!(self, "abstract");

--- a/ecmascript/parser/src/parser/stmt/module_item.rs
+++ b/ecmascript/parser/src/parser/stmt/module_item.rs
@@ -339,7 +339,10 @@ impl<'a, I: Tokens> Parser<I> {
 
         if !type_only && export_ns.is_none() && eat!(self, "default") {
             if self.input.syntax().typescript() {
-                if is!(self, "abstract") && peeked_is!(self, "class") {
+                if is!(self, "abstract")
+                    && peeked_is!(self, "class")
+                    && !self.input.had_line_break_before_cur()
+                {
                     let class_start = cur_pos!(self);
                     assert_and_bump!(self, "abstract");
                     let _ = cur!(self, true);

--- a/ecmascript/parser/src/parser/typescript.rs
+++ b/ecmascript/parser/src/parser/typescript.rs
@@ -2304,7 +2304,7 @@ impl<I: Tokens> Parser<I> {
     ) -> PResult<Option<Decl>> {
         match value {
             js_word!("abstract") => {
-                if next || is!(self, "class") {
+                if next || (is!(self, "class") && !self.input.had_line_break_before_cur()) {
                     if next {
                         bump!(self);
                     }

--- a/ecmascript/parser/tests/typescript/tsc/classes/classDeclarations/classAbstractKeyword/classAbstractSingleLineDecl/input.ts.json
+++ b/ecmascript/parser/tests/typescript/tsc/classes/classDeclarations/classAbstractKeyword/classAbstractSingleLineDecl/input.ts.json
@@ -33,6 +33,24 @@
       "implements": []
     },
     {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 21,
+        "end": 29,
+        "ctxt": 0
+      },
+      "expression": {
+        "type": "Identifier",
+        "span": {
+          "start": 21,
+          "end": 29,
+          "ctxt": 0
+        },
+        "value": "abstract",
+        "optional": false
+      }
+    },
+    {
       "type": "ClassDeclaration",
       "identifier": {
         "type": "Identifier",
@@ -46,17 +64,35 @@
       },
       "declare": false,
       "span": {
-        "start": 21,
+        "start": 30,
         "end": 40,
         "ctxt": 0
       },
       "decorators": [],
       "body": [],
       "superClass": null,
-      "isAbstract": true,
+      "isAbstract": false,
       "typeParams": null,
       "superTypeParams": null,
       "implements": []
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 42,
+        "end": 50,
+        "ctxt": 0
+      },
+      "expression": {
+        "type": "Identifier",
+        "span": {
+          "start": 42,
+          "end": 50,
+          "ctxt": 0
+        },
+        "value": "abstract",
+        "optional": false
+      }
     },
     {
       "type": "ClassDeclaration",
@@ -72,14 +108,14 @@
       },
       "declare": false,
       "span": {
-        "start": 42,
+        "start": 52,
         "end": 62,
         "ctxt": 0
       },
       "decorators": [],
       "body": [],
       "superClass": null,
-      "isAbstract": true,
+      "isAbstract": false,
       "typeParams": null,
       "superTypeParams": null,
       "implements": []


### PR DESCRIPTION

swc_ecma_parser:
 - Don't allow `abstract` and `class` to be on different lines.