### PR TITLE
feat(es/visit): Groundwork to use VisitMut instead of Fold

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.24.0"
+version = "0.24.1"
 
 [lib]
 name = "swc"
@@ -31,11 +31,11 @@ sourcemap = "6"
 swc_atoms = {version = "0.2", path = "./atoms"}
 swc_common = {version = "0.10.16", path = "./common", features = ["sourcemap", "concurrent"]}
 swc_ecma_ast = {version = "0.46.0", path = "./ecmascript/ast"}
-swc_ecma_codegen = {version = "0.59.0", path = "./ecmascript/codegen"}
-swc_ecma_ext_transforms = {version = "0.18.0", path = "./ecmascript/ext-transforms"}
-swc_ecma_parser = {version = "0.60.0", path = "./ecmascript/parser"}
-swc_ecma_preset_env = {version = "0.24.0", path = "./ecmascript/preset-env"}
-swc_ecma_transforms = {version = "0.54.0", path = "./ecmascript/transforms", features = [
+swc_ecma_codegen = {version = "0.59.1", path = "./ecmascript/codegen"}
+swc_ecma_ext_transforms = {version = "0.18.1", path = "./ecmascript/ext-transforms"}
+swc_ecma_parser = {version = "0.60.2", path = "./ecmascript/parser"}
+swc_ecma_preset_env = {version = "0.24.1", path = "./ecmascript/preset-env"}
+swc_ecma_transforms = {version = "0.54.1", path = "./ecmascript/transforms", features = [
   "compat",
   "module",
   "optimization",
@@ -43,8 +43,8 @@ swc_ecma_transforms = {version = "0.54.0", path = "./ecmascript/transforms", fea
   "react",
   "typescript",
 ]}
-swc_ecma_utils = {version = "0.37.0", path = "./ecmascript/utils"}
-swc_ecma_visit = {version = "0.32.0", path = "./ecmascript/visit"}
+swc_ecma_utils = {version = "0.37.2", path = "./ecmascript/utils"}
+swc_ecma_visit = {version = "0.32.1", path = "./ecmascript/visit"}
 swc_node_base = {version = "0.1.0", path = "./node/base"}
 swc_visit = {version = "0.2.3", path = "./visit"}
 

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -9,7 +9,7 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/**/*.js"]
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.41.0"
+version = "0.41.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -34,18 +34,18 @@ retain_mut = "0.1.2"
 swc_atoms = {version = "0.2.4", path = "../atoms"}
 swc_common = {version = "0.10.16", path = "../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ecmascript/ast"}
-swc_ecma_codegen = {version = "0.59.0", path = "../ecmascript/codegen"}
-swc_ecma_parser = {version = "0.60.0", path = "../ecmascript/parser"}
-swc_ecma_transforms = {version = "0.54.0", path = "../ecmascript/transforms", features = ["optimization"]}
-swc_ecma_utils = {version = "0.37.0", path = "../ecmascript/utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../ecmascript/visit"}
+swc_ecma_codegen = {version = "0.59.1", path = "../ecmascript/codegen"}
+swc_ecma_parser = {version = "0.60.2", path = "../ecmascript/parser"}
+swc_ecma_transforms = {version = "0.54.1", path = "../ecmascript/transforms", features = ["optimization"]}
+swc_ecma_utils = {version = "0.37.2", path = "../ecmascript/utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../ecmascript/visit"}
 
 [dev-dependencies]
 hex = "0.4"
 ntest = "0.7.2"
 reqwest = {version = "0.10.8", features = ["blocking"]}
 sha-1 = "0.9"
-swc_ecma_transforms = {version = "0.54.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
+swc_ecma_transforms = {version = "0.54.1", path = "../ecmascript/transforms", features = ["react", "typescript"]}
 tempfile = "3.1.0"
 testing = {version = "0.10.5", path = "../testing"}
 url = "2.1.1"

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.40.1"
+version = "0.40.2"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -29,12 +29,12 @@ typescript = ["swc_ecma_transforms/typescript"]
 
 [dependencies]
 swc_ecma_ast = {version = "0.46.0", path = "./ast"}
-swc_ecma_codegen = {version = "0.59.0", path = "./codegen", optional = true}
-swc_ecma_dep_graph = {version = "0.28.0", path = "./dep-graph", optional = true}
-swc_ecma_minifier = {version = "0.6.0", path = "./minifier", optional = true}
-swc_ecma_parser = {version = "0.60.0", path = "./parser", optional = true}
-swc_ecma_transforms = {version = "0.54.0", path = "./transforms", optional = true}
-swc_ecma_utils = {version = "0.37.1", path = "./utils", optional = true}
-swc_ecma_visit = {version = "0.32.0", path = "./visit", optional = true}
+swc_ecma_codegen = {version = "0.59.1", path = "./codegen", optional = true}
+swc_ecma_dep_graph = {version = "0.28.1", path = "./dep-graph", optional = true}
+swc_ecma_minifier = {version = "0.6.1", path = "./minifier", optional = true}
+swc_ecma_parser = {version = "0.60.2", path = "./parser", optional = true}
+swc_ecma_transforms = {version = "0.54.1", path = "./transforms", optional = true}
+swc_ecma_utils = {version = "0.37.2", path = "./utils", optional = true}
+swc_ecma_visit = {version = "0.32.1", path = "./visit", optional = true}
 
 [dev-dependencies]

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.59.0"
+version = "0.59.1"
 
 [dependencies]
 bitflags = "1"
@@ -17,7 +17,7 @@ swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.21", path = "../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ast"}
 swc_ecma_codegen_macros = {version = "0.5.2", path = "./macros"}
-swc_ecma_parser = {version = "0.60.0", path = "../parser"}
+swc_ecma_parser = {version = "0.60.2", path = "../parser"}
 
 [dev-dependencies]
 swc_common = {version = "0.10.16", path = "../../common", features = ["sourcemap"]}

--- a/ecmascript/dep-graph/Cargo.toml
+++ b/ecmascript/dep-graph/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_dep_graph"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.28.0"
+version = "0.28.1"
 
 [dependencies]
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ast"}
-swc_ecma_visit = {version = "0.32.0", path = "../visit"}
+swc_ecma_visit = {version = "0.32.1", path = "../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.60.0", path = "../parser"}
+swc_ecma_parser = {version = "0.60.2", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/ext-transforms/Cargo.toml
+++ b/ecmascript/ext-transforms/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_ext_transforms/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ext_transforms"
-version = "0.18.0"
+version = "0.18.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,6 +14,6 @@ phf = {version = "0.8.0", features = ["macros"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ast"}
-swc_ecma_parser = {version = "0.60.0", path = "../parser"}
-swc_ecma_utils = {version = "0.37.0", path = "../utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../visit"}
+swc_ecma_parser = {version = "0.60.2", path = "../parser"}
+swc_ecma_utils = {version = "0.37.2", path = "../utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../visit"}

--- a/ecmascript/ext-transforms/src/jest.rs
+++ b/ecmascript/ext-transforms/src/jest.rs
@@ -12,7 +12,7 @@ static HOIST_METHODS: phf::Set<&str> = phf_set![
     "deepUnmock"
 ];
 
-pub fn jest() -> impl Fold {
+pub fn jest() -> impl Fold + VisitMut {
     as_folder(Jest)
 }
 

--- a/ecmascript/jsdoc/Cargo.toml
+++ b/ecmascript/jsdoc/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/jsdoc/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "jsdoc"
-version = "0.28.0"
+version = "0.28.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -19,6 +19,6 @@ swc_common = {version = "0.10.16", path = "../../common"}
 anyhow = "1"
 dashmap = "4.0.2"
 swc_ecma_ast = {version = "0.46.0", path = "../ast"}
-swc_ecma_parser = {version = "0.60.0", path = "../parser"}
+swc_ecma_parser = {version = "0.60.2", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/loader/Cargo.toml
+++ b/ecmascript/loader/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_loader"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.7.0"
+version = "0.7.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,7 +14,7 @@ version = "0.7.0"
 swc_atoms = {version = "0.2.3", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ast"}
-swc_ecma_visit = {version = "0.32.0", path = "../visit"}
+swc_ecma_visit = {version = "0.32.1", path = "../visit"}
 
 [dev-dependencies]
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/minifier/Cargo.toml
+++ b/ecmascript/minifier/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "src/lists/*.json"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_minifier"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.6.0"
+version = "0.6.1"
 
 [features]
 debug = []
@@ -25,12 +25,12 @@ serde_regex = "1.1.0"
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.8", path = "../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ast"}
-swc_ecma_codegen = {version = "0.59.0", path = "../codegen"}
-swc_ecma_parser = {version = "0.60.0", path = "../parser"}
-swc_ecma_transforms = {version = "0.54.0", path = "../transforms/", features = ["optimization"]}
-swc_ecma_transforms_base = {version = "0.19.0", path = "../transforms/base"}
-swc_ecma_utils = {version = "0.37.0", path = "../utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../visit"}
+swc_ecma_codegen = {version = "0.59.1", path = "../codegen"}
+swc_ecma_parser = {version = "0.60.2", path = "../parser"}
+swc_ecma_transforms = {version = "0.54.1", path = "../transforms/", features = ["optimization"]}
+swc_ecma_transforms_base = {version = "0.19.1", path = "../transforms/base"}
+swc_ecma_utils = {version = "0.37.2", path = "../utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../visit"}
 
 [dev-dependencies]
 ansi_term = "0.12.1"

--- a/ecmascript/minifier/src/compress/drop_console.rs
+++ b/ecmascript/minifier/src/compress/drop_console.rs
@@ -8,7 +8,7 @@ use swc_ecma_visit::noop_visit_mut_type;
 use swc_ecma_visit::VisitMut;
 use swc_ecma_visit::VisitMutWith;
 
-pub fn drop_console() -> impl JsPass {
+pub fn drop_console() -> impl JsPass + VisitMut {
     as_folder(DropConsole { done: false })
 }
 

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.60.1"
+version = "0.60.2"
 
 [features]
 default = []
@@ -24,7 +24,7 @@ smallvec = "1"
 swc_atoms = {version = "0.2.3", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ast"}
-swc_ecma_visit = {version = "0.32.0", path = "../visit"}
+swc_ecma_visit = {version = "0.32.1", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]

--- a/ecmascript/preset-env/Cargo.toml
+++ b/ecmascript/preset-env/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_preset_env/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_preset_env"
-version = "0.24.0"
+version = "0.24.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,13 +22,13 @@ string_enum = {version = "0.3.1", path = "../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ast"}
-swc_ecma_transforms = {version = "0.54.0", path = "../transforms", features = ["compat", "proposal"]}
-swc_ecma_utils = {version = "0.37.0", path = "../utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../visit"}
+swc_ecma_transforms = {version = "0.54.1", path = "../transforms", features = ["compat", "proposal"]}
+swc_ecma_utils = {version = "0.37.2", path = "../utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../visit"}
 walkdir = "2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
-swc_ecma_codegen = {version = "0.59.0", path = "../codegen"}
-swc_ecma_parser = {version = "0.60.0", path = "../parser"}
+swc_ecma_codegen = {version = "0.59.1", path = "../codegen"}
+swc_ecma_parser = {version = "0.60.2", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.54.0"
+version = "0.54.1"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -24,23 +24,23 @@ typescript = ["swc_ecma_transforms_typescript"]
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ast"}
-swc_ecma_parser = {version = "0.60.0", path = "../parser"}
-swc_ecma_transforms_base = {version = "0.19.0", path = "./base"}
-swc_ecma_transforms_compat = {version = "0.21.0", path = "./compat", optional = true}
-swc_ecma_transforms_module = {version = "0.21.0", path = "./module", optional = true}
-swc_ecma_transforms_optimization = {version = "0.24.0", path = "./optimization", optional = true}
-swc_ecma_transforms_proposal = {version = "0.21.0", path = "./proposal", optional = true}
-swc_ecma_transforms_react = {version = "0.22.0", path = "./react", optional = true}
-swc_ecma_transforms_typescript = {version = "0.23.0", path = "./typescript", optional = true}
-swc_ecma_utils = {version = "0.37.0", path = "../utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../visit"}
+swc_ecma_parser = {version = "0.60.2", path = "../parser"}
+swc_ecma_transforms_base = {version = "0.19.1", path = "./base"}
+swc_ecma_transforms_compat = {version = "0.21.1", path = "./compat", optional = true}
+swc_ecma_transforms_module = {version = "0.21.1", path = "./module", optional = true}
+swc_ecma_transforms_optimization = {version = "0.24.1", path = "./optimization", optional = true}
+swc_ecma_transforms_proposal = {version = "0.21.1", path = "./proposal", optional = true}
+swc_ecma_transforms_react = {version = "0.22.1", path = "./react", optional = true}
+swc_ecma_transforms_typescript = {version = "0.23.1", path = "./typescript", optional = true}
+swc_ecma_utils = {version = "0.37.2", path = "../utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
 sourcemap = "6"
-swc_ecma_codegen = {version = "0.59.0", path = "../codegen"}
-swc_ecma_transforms_testing = {version = "0.19.0", path = "./testing"}
+swc_ecma_codegen = {version = "0.59.1", path = "../codegen"}
+swc_ecma_transforms_testing = {version = "0.19.1", path = "./testing"}
 tempfile = "3"
 testing = {version = "0.10.5", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.19.0"
+version = "0.19.1"
 
 [dependencies]
 fxhash = "0.2.1"
@@ -17,10 +17,10 @@ smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.60.0", path = "../../parser"}
-swc_ecma_utils = {version = "0.37.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../../visit"}
+swc_ecma_parser = {version = "0.60.2", path = "../../parser"}
+swc_ecma_utils = {version = "0.37.2", path = "../../utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.59.0", path = "../../codegen"}
+swc_ecma_codegen = {version = "0.59.1", path = "../../codegen"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/base/src/fixer.rs
+++ b/ecmascript/transforms/base/src/fixer.rs
@@ -4,7 +4,7 @@ use swc_common::{comments::Comments, Span, Spanned};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 
-pub fn fixer<'a>(comments: Option<&'a dyn Comments>) -> impl 'a + Fold {
+pub fn fixer<'a>(comments: Option<&'a dyn Comments>) -> impl 'a + Fold + VisitMut {
     as_folder(Fixer {
         comments,
         ctx: Default::default(),

--- a/ecmascript/transforms/base/src/helpers/mod.rs
+++ b/ecmascript/transforms/base/src/helpers/mod.rs
@@ -246,7 +246,7 @@ define_helpers!(Helpers {
     class_check_private_static_access: (),
 });
 
-pub fn inject_helpers() -> impl Fold {
+pub fn inject_helpers() -> impl Fold + VisitMut {
     as_folder(InjectHelpers)
 }
 

--- a/ecmascript/transforms/base/src/hygiene/mod.rs
+++ b/ecmascript/transforms/base/src/hygiene/mod.rs
@@ -190,7 +190,7 @@ pub fn hygiene() -> impl Fold + 'static {
     hygiene_with_config(Default::default())
 }
 
-pub fn hygiene_with_config(config: Config) -> impl 'static + Fold {
+pub fn hygiene_with_config(config: Config) -> impl 'static + Fold + VisitMut {
     chain!(
         as_folder(Hygiene {
             config,

--- a/ecmascript/transforms/base/src/hygiene/mod.rs
+++ b/ecmascript/transforms/base/src/hygiene/mod.rs
@@ -190,7 +190,7 @@ pub fn hygiene() -> impl Fold + 'static {
     hygiene_with_config(Default::default())
 }
 
-pub fn hygiene_with_config(config: Config) -> impl Fold + 'static {
+pub fn hygiene_with_config(config: Config) -> impl 'static + Fold {
     chain!(
         as_folder(Hygiene {
             config,

--- a/ecmascript/transforms/base/src/resolver/mod.rs
+++ b/ecmascript/transforms/base/src/resolver/mod.rs
@@ -61,7 +61,7 @@ pub fn resolver() -> impl 'static + Fold {
 /// 5. Found usage of `a` (last line), and determines that it's a
 /// reference to top-level `a`, and change syntax context of `a` on last line to
 /// top-level syntax context.
-pub fn resolver_with_mark(top_level_mark: Mark) -> impl 'static + Fold {
+pub fn resolver_with_mark(top_level_mark: Mark) -> impl 'static + Fold + VisitMut {
     assert_ne!(
         top_level_mark,
         Mark::root(),
@@ -75,7 +75,7 @@ pub fn resolver_with_mark(top_level_mark: Mark) -> impl 'static + Fold {
 }
 
 /// [resolver_with_mark] with typescript support enabled.
-pub fn ts_resolver(top_level_mark: Mark) -> impl 'static + Fold {
+pub fn ts_resolver(top_level_mark: Mark) -> impl 'static + Fold + VisitMut {
     assert_ne!(
         top_level_mark,
         Mark::root(),

--- a/ecmascript/transforms/classes/Cargo.toml
+++ b/ecmascript/transforms/classes/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_classes"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.5.0"
+version = "0.5.1"
 
 [dependencies]
 swc_atoms = {version = "0.2.6", path = "../../../atoms"}
 swc_common = {version = "0.10.20", path = "../../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.19.0", path = "../base"}
-swc_ecma_utils = {version = "0.37.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../../visit"}
+swc_ecma_transforms_base = {version = "0.19.1", path = "../base"}
+swc_ecma_utils = {version = "0.37.2", path = "../../utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../../visit"}

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.21.0"
+version = "0.21.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -21,13 +21,13 @@ smallvec = "1.6.0"
 swc_atoms = {version = "0.2.5", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.19.0", path = "../base"}
-swc_ecma_transforms_classes = {version = "0.5.0", path = "../classes"}
+swc_ecma_transforms_base = {version = "0.19.1", path = "../base"}
+swc_ecma_transforms_classes = {version = "0.5.1", path = "../classes"}
 swc_ecma_transforms_macros = {version = "0.2.1", path = "../macros"}
-swc_ecma_utils = {version = "0.37.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../../visit"}
+swc_ecma_utils = {version = "0.37.2", path = "../../utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.60.0", path = "../../parser"}
-swc_ecma_transforms_testing = {version = "0.19.0", path = "../testing"}
+swc_ecma_parser = {version = "0.60.2", path = "../../parser"}
+swc_ecma_transforms_testing = {version = "0.19.1", path = "../testing"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/compat/src/es2020/operators.rs
+++ b/ecmascript/transforms/compat/src/es2020/operators.rs
@@ -8,7 +8,7 @@ use swc_ecma_visit::{
     as_folder, noop_visit_mut_type, noop_visit_type, Fold, Node, Visit, VisitMut, VisitMutWith,
 };
 
-pub fn operators() -> impl Fold+VisitMut {
+pub fn operators() -> impl Fold + VisitMut {
     as_folder(Operators::default())
 }
 

--- a/ecmascript/transforms/compat/src/es2020/operators.rs
+++ b/ecmascript/transforms/compat/src/es2020/operators.rs
@@ -8,7 +8,7 @@ use swc_ecma_visit::{
     as_folder, noop_visit_mut_type, noop_visit_type, Fold, Node, Visit, VisitMut, VisitMutWith,
 };
 
-pub fn operators() -> impl Fold {
+pub fn operators() -> impl Fold+VisitMut {
     as_folder(Operators::default())
 }
 

--- a/ecmascript/transforms/compat/src/reserved_words.rs
+++ b/ecmascript/transforms/compat/src/reserved_words.rs
@@ -7,7 +7,7 @@ use swc_ecma_visit::{
     as_folder, noop_visit_mut_type, noop_visit_type, Fold, Node, Visit, VisitMut, VisitMutWith,
 };
 
-pub fn reserved_words() -> impl 'static + Fold {
+pub fn reserved_words() -> impl 'static + Fold + VisitMut {
     as_folder(EsReservedWord)
 }
 

--- a/ecmascript/transforms/module/Cargo.toml
+++ b/ecmascript/transforms/module/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.21.0"
+version = "0.21.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -17,12 +17,12 @@ serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.60.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.19.0", path = "../base"}
-swc_ecma_utils = {version = "0.37.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../../visit"}
+swc_ecma_parser = {version = "0.60.2", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.19.1", path = "../base"}
+swc_ecma_utils = {version = "0.37.2", path = "../../utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.21.0", path = "../compat"}
-swc_ecma_transforms_testing = {version = "0.19.0", path = "../testing/"}
+swc_ecma_transforms_compat = {version = "0.21.1", path = "../compat"}
+swc_ecma_transforms_testing = {version = "0.19.1", path = "../testing/"}
 testing = {version = "0.10.5", path = "../../../testing/"}

--- a/ecmascript/transforms/optimization/Cargo.toml
+++ b/ecmascript/transforms/optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.24.0"
+version = "0.24.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -20,16 +20,16 @@ serde_json = "1.0.61"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.60.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.19.0", path = "../base"}
-swc_ecma_utils = {version = "0.37.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../../visit"}
+swc_ecma_parser = {version = "0.60.2", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.19.1", path = "../base"}
+swc_ecma_utils = {version = "0.37.2", path = "../../utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.21.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.21.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.21.0", path = "../proposal"}
-swc_ecma_transforms_react = {version = "0.22.0", path = "../react"}
-swc_ecma_transforms_testing = {version = "0.19.0", path = "../testing"}
-swc_ecma_transforms_typescript = {version = "0.23.0", path = "../typescript"}
+swc_ecma_transforms_compat = {version = "0.21.1", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.21.1", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.21.1", path = "../proposal"}
+swc_ecma_transforms_react = {version = "0.22.1", path = "../react"}
+swc_ecma_transforms_testing = {version = "0.19.1", path = "../testing"}
+swc_ecma_transforms_typescript = {version = "0.23.1", path = "../typescript"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/optimization/src/simplify/const_propgation.rs
+++ b/ecmascript/transforms/optimization/src/simplify/const_propgation.rs
@@ -5,7 +5,7 @@ use swc_ecma_utils::{ident::IdentLike, Id};
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 
 /// This pass is kind of inliner, but it's far faster.
-pub fn constant_propagation() -> impl 'static + Fold {
+pub fn constant_propagation() -> impl 'static + Fold + VisitMut {
     as_folder(ConstPropagation::default())
 }
 

--- a/ecmascript/transforms/optimization/src/simplify/dce/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/dce/mod.rs
@@ -45,7 +45,7 @@ impl Default for Config<'_> {
     }
 }
 
-pub fn dce<'a>(config: Config<'a>) -> impl RepeatedJsPass + 'a {
+pub fn dce<'a>(config: Config<'a>) -> impl 'a + RepeatedJsPass + VisitMut {
     assert_ne!(
         config.used_mark,
         Mark::root(),

--- a/ecmascript/transforms/optimization/src/simplify/inlining/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/inlining/mod.rs
@@ -33,7 +33,7 @@ pub struct Config {}
 ///
 /// Currently all functions are treated as a black box, and all the pass gives
 /// up inlining variables across a function call or a constructor call.
-pub fn inlining(_: Config) -> impl RepeatedJsPass + 'static {
+pub fn inlining(_: Config) -> impl 'static + RepeatedJsPass + VisitMut {
     as_folder(Inlining {
         phase: Phase::Analysis,
         is_first_run: true,

--- a/ecmascript/transforms/proposal/Cargo.toml
+++ b/ecmascript/transforms/proposal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_proposal"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.21.0"
+version = "0.21.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,14 +22,14 @@ smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../../ast"}
-swc_ecma_loader = {version = "0.7.0", path = "../../loader", optional = true}
-swc_ecma_parser = {version = "0.60.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.19.0", path = "../base"}
-swc_ecma_transforms_classes = {version = "0.5.0", path = "../classes"}
-swc_ecma_utils = {version = "0.37.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../../visit"}
+swc_ecma_loader = {version = "0.7.1", path = "../../loader", optional = true}
+swc_ecma_parser = {version = "0.60.2", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.19.1", path = "../base"}
+swc_ecma_transforms_classes = {version = "0.5.1", path = "../classes"}
+swc_ecma_utils = {version = "0.37.2", path = "../../utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.21.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.21.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.19.0", path = "../testing"}
+swc_ecma_transforms_compat = {version = "0.21.1", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.21.1", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.19.1", path = "../testing"}

--- a/ecmascript/transforms/proposal/src/import_assertions.rs
+++ b/ecmascript/transforms/proposal/src/import_assertions.rs
@@ -1,7 +1,7 @@
 use swc_ecma_ast::ImportDecl;
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut};
 
-pub fn import_assertions() -> impl Fold {
+pub fn import_assertions() -> impl VisitMut + Fold {
     as_folder(ImportAssertions)
 }
 struct ImportAssertions;

--- a/ecmascript/transforms/react/Cargo.toml
+++ b/ecmascript/transforms/react/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_react"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.22.0"
+version = "0.22.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -22,14 +22,14 @@ string_enum = {version = "0.3.1", path = "../../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.60.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.19.0", path = "../base"}
-swc_ecma_utils = {version = "0.37.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../../visit"}
+swc_ecma_parser = {version = "0.60.2", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.19.1", path = "../base"}
+swc_ecma_utils = {version = "0.37.2", path = "../../utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.59.0", path = "../../codegen/"}
-swc_ecma_transforms_compat = {version = "0.21.0", path = "../compat/"}
-swc_ecma_transforms_module = {version = "0.21.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.19.0", path = "../testing/"}
+swc_ecma_codegen = {version = "0.59.1", path = "../../codegen/"}
+swc_ecma_transforms_compat = {version = "0.21.1", path = "../compat/"}
+swc_ecma_transforms_module = {version = "0.21.1", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.19.1", path = "../testing/"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/react/src/jsx/mod.rs
+++ b/ecmascript/transforms/react/src/jsx/mod.rs
@@ -157,7 +157,7 @@ fn parse_classic_option(cm: &SourceMap, name: &str, src: String) -> Box<Expr> {
 /// `@babel/plugin-transform-react-jsx`
 ///
 /// Turn JSX into React function calls
-pub fn jsx<C>(cm: Lrc<SourceMap>, comments: Option<C>, options: Options) -> impl Fold
+pub fn jsx<C>(cm: Lrc<SourceMap>, comments: Option<C>, options: Options) -> impl Fold + VisitMut
 where
     C: Comments,
 {

--- a/ecmascript/transforms/testing/Cargo.toml
+++ b/ecmascript/transforms/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.19.0"
+version = "0.19.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,10 +16,10 @@ serde = "1"
 serde_json = "1"
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../../ast"}
-swc_ecma_codegen = {version = "0.59.0", path = "../../codegen"}
-swc_ecma_parser = {version = "0.60.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.19.0", path = "../base"}
-swc_ecma_utils = {version = "0.37.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../../visit"}
+swc_ecma_codegen = {version = "0.59.1", path = "../../codegen"}
+swc_ecma_parser = {version = "0.60.2", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.19.1", path = "../base"}
+swc_ecma_utils = {version = "0.37.2", path = "../../utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../../visit"}
 tempfile = "3.1.0"
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.23.0"
+version = "0.23.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -15,16 +15,16 @@ serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.60.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.19.0", path = "../base"}
-swc_ecma_utils = {version = "0.37.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.32.0", path = "../../visit"}
+swc_ecma_parser = {version = "0.60.2", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.19.1", path = "../base"}
+swc_ecma_utils = {version = "0.37.2", path = "../../utils"}
+swc_ecma_visit = {version = "0.32.1", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.59.0", path = "../../codegen"}
-swc_ecma_transforms_compat = {version = "0.21.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.21.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.21.0", path = "../proposal/"}
-swc_ecma_transforms_testing = {version = "0.19.0", path = "../testing"}
+swc_ecma_codegen = {version = "0.59.1", path = "../../codegen"}
+swc_ecma_transforms_compat = {version = "0.21.1", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.21.1", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.21.1", path = "../proposal/"}
+swc_ecma_transforms_testing = {version = "0.19.1", path = "../testing"}
 testing = {version = "0.10.5", path = "../../../testing"}
 walkdir = "2.3.1"

--- a/ecmascript/transforms/typescript/src/strip.rs
+++ b/ecmascript/transforms/typescript/src/strip.rs
@@ -68,7 +68,7 @@ pub struct Config {
     pub no_empty_export: bool,
 }
 
-pub fn strip_with_config(config: Config) -> impl Fold {
+pub fn strip_with_config(config: Config) -> impl Fold + VisitMut {
     as_folder(Strip {
         config,
         ..Default::default()

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.37.1"
+version = "0.37.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,7 +16,7 @@ scoped-tls = "1"
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
 swc_ecma_ast = {version = "0.46.0", path = "../ast"}
-swc_ecma_visit = {version = "0.32.0", path = "../visit"}
+swc_ecma_visit = {version = "0.32.1", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]

--- a/ecmascript/visit/Cargo.toml
+++ b/ecmascript/visit/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_visit"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.32.0"
+version = "0.32.1"
 
 [dependencies]
 num-bigint = {version = "0.2", features = ["serde"]}

--- a/ecmascript/visit/src/lib.rs
+++ b/ecmascript/visit/src/lib.rs
@@ -33,6 +33,22 @@ where
     }
 }
 
+impl<A, B> VisitMut for AndThen<A, B>
+where
+    A: VisitMut,
+    B: VisitMut,
+{
+    fn visit_mut_module(&mut self, n: &mut Module) {
+        self.first.visit_mut_module(n);
+        self.second.visit_mut_module(n)
+    }
+
+    fn visit_mut_script(&mut self, n: &mut Script) {
+        self.first.visit_mut_script(n);
+        self.second.visit_mut_script(n)
+    }
+}
+
 impl<A, B> Visit for AndThen<A, B>
 where
     A: Visit,

--- a/ecmascript/visit/src/lib.rs
+++ b/ecmascript/visit/src/lib.rs
@@ -149,6 +149,35 @@ where
     }
 }
 
+macro_rules! delegate {
+    ($name:ident, $T:ty) => {
+        #[inline(always)]
+        fn $name(&mut self, n: &mut $T) {
+            n.visit_mut_with(&mut self.0);
+        }
+    };
+}
+
+/// This only proxies subset of methods.
+impl<V> VisitMut for Folder<V>
+where
+    V: VisitMut,
+{
+    delegate!(visit_mut_ident, Ident);
+    delegate!(visit_mut_span, Span);
+
+    delegate!(visit_mut_expr, Expr);
+    delegate!(visit_mut_decl, Decl);
+    delegate!(visit_mut_stmt, Stmt);
+    delegate!(visit_mut_pat, Pat);
+
+    delegate!(visit_mut_ts_type, TsType);
+
+    delegate!(visit_mut_module, Module);
+    delegate!(visit_mut_script, Script);
+    delegate!(visit_mut_program, Program);
+}
+
 macro_rules! method {
     ($name:ident, $T:ty) => {
         #[inline(always)]


### PR DESCRIPTION
swc_ecma_transforms:
 - Expose `VisitMut` if possible.

swc_ecma_visit:
 - Implement `VisitMut` for` Folder<V>`.
 - Implement `VisitMut` for `AndThen<A, B>`.





--- 

# Context

ViistMut is faster because it does not move memories.