### PR TITLE
Enable or_patterns feature for swc_ecma_loader.

### DIFF
--- a/ecmascript/loader/src/lib.rs
+++ b/ecmascript/loader/src/lib.rs
@@ -1,2 +1,3 @@
+#![feature(or_patterns)]
 pub mod resolve;
 pub mod resolvers;


### PR DESCRIPTION
So that I can compile against the `swc_ecma_loader` crate to use `NodeResolver`.