### PR TITLE
fix(es/transforms/optimization): Migrate to VisitMut

### DIFF
--- a/ecmascript/minifier/Cargo.toml
+++ b/ecmascript/minifier/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "src/lists/*.json"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_minifier"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.10.0"
+version = "0.10.1"
 
 [features]
 debug = []

--- a/ecmascript/minifier/src/compress/optimize/properties.rs
+++ b/ecmascript/minifier/src/compress/optimize/properties.rs
@@ -113,7 +113,16 @@ impl Optimizer<'_> {
 
         match &*e.prop {
             Expr::Lit(Lit::Str(s)) => {
-                if s.value == js_word!("") || s.value.starts_with(|c: char| c.is_digit(10)) {
+                if s.value == js_word!("")
+                    || s.value.starts_with(|c: char| c.is_digit(10))
+                    || s.value.contains(|c: char| match c {
+                        '0'..='9' => false,
+                        'a'..='z' => false,
+                        'A'..='Z' => false,
+                        '$' => false,
+                        _ => true,
+                    })
+                {
                     return;
                 }
 

--- a/ecmascript/minifier/tests/terser/compress/functions/no_webkit/output.js
+++ b/ecmascript/minifier/tests/terser/compress/functions/no_webkit/output.js
@@ -1,5 +1,3 @@
-console.log(
-    (function () {
-        1 + 1;
-    }.a = 1)
-);
+console.log((function() {
+    2;
+}).a = 1);

--- a/ecmascript/minifier/tests/terser/compress/functions/webkit/output.js
+++ b/ecmascript/minifier/tests/terser/compress/functions/webkit/output.js
@@ -1,5 +1,3 @@
-console.log(
-    (function () {
-        1 + 1;
-    }.a = 1)
-);
+console.log((function() {
+    2;
+}).a = 1);

--- a/ecmascript/transforms/optimization/Cargo.toml
+++ b/ecmascript/transforms/optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.27.1"
+version = "0.27.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -259,9 +259,9 @@ impl VisitMut for Remover {
         p.visit_mut_children_with(self);
 
         match p {
-            Pat::Assign(p)
-                if p.right.is_undefined()
-                    || match *p.right {
+            Pat::Assign(assign)
+                if assign.right.is_undefined()
+                    || match *assign.right {
                         Expr::Unary(UnaryExpr {
                             op: op!("void"),
                             ref arg,
@@ -270,16 +270,18 @@ impl VisitMut for Remover {
                         _ => false,
                     } =>
             {
-                return *p.left;
+                *p = *assign.left.take();
+                return;
             }
 
-            Pat::Assign(p)
-                if match *p.left {
+            Pat::Assign(assign)
+                if match *assign.left {
                     Pat::Object(ref o) => o.props.is_empty(),
                     _ => false,
-                } && p.right.is_number() =>
+                } && assign.right.is_number() =>
             {
-                return *p.left;
+                *p = *assign.left.take();
+                return;
             }
 
             _ => {}

--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -57,8 +57,8 @@ struct Remover {
 impl VisitMut for Remover {
     noop_visit_mut_type!();
 
-    fn fold_array_pat(&mut self, p: ArrayPat) -> ArrayPat {
-        let mut p: ArrayPat = p.visit_mut_children_with(self);
+    fn visit_mut_array_pat(&mut self, p: &mut ArrayPat) {
+        p.visit_mut_children_with(self);
 
         let mut preserved = None;
         let len = p.elems.len();
@@ -81,8 +81,8 @@ impl VisitMut for Remover {
         ArrayPat { ..p }
     }
 
-    fn fold_expr(&mut self, e: Expr) -> Expr {
-        let e: Expr = e.visit_mut_children_with(self);
+    fn visit_mut_expr(&mut self, e: &mut Expr) {
+        e.visit_mut_children_with(self);
 
         match e {
             Expr::Assign(AssignExpr {
@@ -157,8 +157,8 @@ impl VisitMut for Remover {
         e
     }
 
-    fn fold_for_stmt(&mut self, s: ForStmt) -> ForStmt {
-        let s = s.visit_mut_children_with(self);
+    fn visit_mut_for_stmt(&mut self, s: &mut ForStmt) {
+        s.visit_mut_children_with(self);
 
         ForStmt {
             init: s.init.and_then(|e| match e {
@@ -182,8 +182,8 @@ impl VisitMut for Remover {
         }
     }
 
-    fn fold_object_pat(&mut self, p: ObjectPat) -> ObjectPat {
-        let mut p = p.visit_mut_children_with(self);
+    fn visit_mut_object_pat(&mut self, p: &mut ObjectPat) {
+        p.visit_mut_children_with(self);
 
         // Don't remove if there exists a rest pattern
         if p.props.iter().any(|p| match p {

--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -355,7 +355,9 @@ impl VisitMut for Remover {
 
                         self.changed = true;
 
-                        return Stmt::Block(BlockStmt { span, stmts }).visit_mut_with(self);
+                        let mut block = Stmt::Block(BlockStmt { span, stmts });
+                        block.visit_mut_with(self);
+                        return block;
                     }
 
                     let alt = match &alt {
@@ -567,11 +569,12 @@ impl VisitMut for Remover {
                             prepend(&mut stmts, expr.into_stmt());
                         }
 
-                        return Stmt::Block(BlockStmt {
+                        let mut block = Stmt::Block(BlockStmt {
                             span: s.span,
                             stmts,
-                        })
-                        .visit_mut_with(self);
+                        });
+                        block.visit_mut_with(self);
+                        return block;
                     }
 
                     let mut non_constant_case_idx = None;
@@ -670,11 +673,12 @@ impl VisitMut for Remover {
                                 );
                             }
 
-                            return Stmt::Block(BlockStmt {
+                            let mut block = Stmt::Block(BlockStmt {
                                 span: s.span,
                                 stmts,
-                            })
-                            .visit_mut_with(self);
+                            });
+                            block.visit_mut_with(self);
+                            return block;
                         }
                     } else if are_all_tests_known {
                         match *s.discriminant {

--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -991,9 +991,9 @@ impl Remover {
         let mut new_stmts = Vec::with_capacity(stmts.len());
 
         let mut iter = stmts.take().into_iter();
-        while let Some(stmt_like) = iter.next() {
+        while let Some(mut stmt_like) = iter.next() {
             self.normal_block = true;
-            let stmt_like = stmt_like.visit_mut_with(self);
+            stmt_like.visit_mut_with(self);
             self.normal_block = false;
 
             let stmt_like = match stmt_like.try_into_stmt() {

--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -1051,17 +1051,16 @@ impl Remover {
                             return new_stmts;
                         }
 
-                        Stmt::Block(BlockStmt { span, stmts, .. }) => {
+                        Stmt::Block(BlockStmt {
+                            span, mut stmts, ..
+                        }) => {
                             if stmts.len() == 0 {
                                 continue;
                             }
 
                             if !is_ok_to_inline_block(&stmts) {
-                                BlockStmt {
-                                    span,
-                                    stmts: stmts.visit_mut_with(self),
-                                }
-                                .into()
+                                stmts.visit_mut_with(self);
+                                BlockStmt { span, stmts }.into()
                             } else {
                                 new_stmts.extend(
                                     stmts

--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -77,8 +77,6 @@ impl VisitMut for Remover {
         if let Some(i) = preserved {
             p.elems.drain(i..);
         }
-
-        ArrayPat { ..p }
     }
 
     fn visit_mut_expr(&mut self, e: &mut Expr) {
@@ -90,15 +88,16 @@ impl VisitMut for Remover {
                 left: PatOrExpr::Pat(l),
                 right: r,
                 ..
-            }) if match &*l {
-                Pat::Ident(l) => match &*r {
+            }) if match &**l {
+                Pat::Ident(l) => match &**r {
                     Expr::Ident(r) => l.id.sym == r.sym && l.id.span.ctxt() == r.span.ctxt(),
                     _ => false,
                 },
                 _ => false,
             } =>
             {
-                return Expr::Ident(r.ident().unwrap())
+                *e = Expr::Ident(r.ident().unwrap());
+                return;
             }
 
             Expr::Assign(AssignExpr {

--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -128,10 +128,10 @@ impl VisitMut for Remover {
                 return;
             }
 
-            Expr::Cond(e)
-                if !e.test.may_have_side_effects()
-                    && (e.cons.is_undefined()
-                        || match *e.cons {
+            Expr::Cond(cond)
+                if !cond.test.may_have_side_effects()
+                    && (cond.cons.is_undefined()
+                        || match *cond.cons {
                             Expr::Unary(UnaryExpr {
                                 op: op!("void"),
                                 ref arg,
@@ -139,8 +139,8 @@ impl VisitMut for Remover {
                             }) if !arg.may_have_side_effects() => true,
                             _ => false,
                         })
-                    && (e.alt.is_undefined()
-                        || match *e.alt {
+                    && (cond.alt.is_undefined()
+                        || match *cond.alt {
                             Expr::Unary(UnaryExpr {
                                 op: op!("void"),
                                 ref arg,
@@ -149,13 +149,12 @@ impl VisitMut for Remover {
                             _ => false,
                         }) =>
             {
-                return *e.cons
+                *e = *cond.cons.take();
+                return;
             }
 
             _ => {}
         }
-
-        e
     }
 
     fn visit_mut_for_stmt(&mut self, s: &mut ForStmt) {

--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -184,6 +184,10 @@ impl VisitMut for Remover {
         });
     }
 
+    fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
+        self.fold_stmt_like(n)
+    }
+
     fn visit_mut_object_pat(&mut self, p: &mut ObjectPat) {
         p.visit_mut_children_with(self);
 
@@ -961,6 +965,10 @@ impl VisitMut for Remover {
         })
     }
 
+    fn visit_mut_stmts(&mut self, n: &mut Vec<Stmt>) {
+        self.fold_stmt_like(n)
+    }
+
     fn visit_mut_switch_stmt(&mut self, s: &mut SwitchStmt) {
         s.visit_mut_children_with(self);
 
@@ -984,14 +992,6 @@ impl VisitMut for Remover {
             s.cases.clear();
             return;
         }
-    }
-
-    fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
-        self.fold_stmt_like(n)
-    }
-
-    fn visit_mut_stmts(&mut self, n: &mut Vec<Stmt>) {
-        self.fold_stmt_like(n)
     }
 }
 

--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -190,7 +190,7 @@ impl VisitMut for Remover {
             ObjectPatProp::Rest(..) => true,
             _ => false,
         }) {
-            return p;
+            return;
         }
 
         fn is_computed(k: &PropName) -> bool {
@@ -220,8 +220,6 @@ impl VisitMut for Remover {
             }
             _ => true,
         });
-
-        p
     }
 
     fn visit_mut_object_pat_prop(&mut self, p: &mut ObjectPatProp) {
@@ -242,17 +240,16 @@ impl VisitMut for Remover {
                     _ => false,
                 } =>
             {
-                return ObjectPatProp::Assign(AssignPatProp {
-                    span,
-                    key,
+                *p = ObjectPatProp::Assign(AssignPatProp {
+                    span: *span,
+                    key: key.take(),
                     value: None,
                 });
+                return;
             }
 
             _ => {}
         }
-
-        p
     }
 
     fn visit_mut_pat(&mut self, p: &mut Pat) {

--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -224,8 +224,8 @@ impl VisitMut for Remover {
         p
     }
 
-    fn fold_object_pat_prop(&mut self, p: ObjectPatProp) -> ObjectPatProp {
-        let p = p.visit_mut_children_with(self);
+    fn visit_mut_object_pat_prop(&mut self, p: &mut ObjectPatProp) {
+        p.visit_mut_children_with(self);
 
         match p {
             ObjectPatProp::Assign(AssignPatProp {
@@ -255,8 +255,8 @@ impl VisitMut for Remover {
         p
     }
 
-    fn fold_pat(&mut self, p: Pat) -> Pat {
-        let p = p.visit_mut_children_with(self);
+    fn visit_mut_pat(&mut self, p: &mut Pat) {
+        p.visit_mut_children_with(self);
 
         match p {
             Pat::Assign(p)
@@ -288,21 +288,19 @@ impl VisitMut for Remover {
         p
     }
 
-    fn fold_seq_expr(&mut self, e: SeqExpr) -> SeqExpr {
-        let mut e: SeqExpr = e.visit_mut_children_with(self);
+    fn visit_mut_seq_expr(&mut self, e: &mut SeqExpr) {
+        e.visit_mut_children_with(self);
         if e.exprs.is_empty() {
-            return e;
+            return;
         }
 
         let last = e.exprs.pop().unwrap();
         let mut exprs = e.exprs.move_flat_map(|e| ignore_result(*e).map(Box::new));
         exprs.push(last);
-
-        SeqExpr { exprs, ..e }
     }
 
-    fn fold_stmt(&mut self, stmt: Stmt) -> Stmt {
-        let stmt = stmt.visit_mut_children_with(self);
+    fn visit_mut_stmt(&mut self, stmt: &mut Stmt) {
+        stmt.visit_mut_children_with(self);
 
         match stmt {
             Stmt::If(IfStmt {
@@ -946,8 +944,8 @@ impl VisitMut for Remover {
         }
     }
 
-    fn fold_switch_stmt(&mut self, s: SwitchStmt) -> SwitchStmt {
-        let s: SwitchStmt = s.visit_mut_children_with(self);
+    fn visit_mut_switch_stmt(&mut self, s: &mut SwitchStmt) {
+        s.visit_mut_children_with(self);
 
         if s.cases.iter().any(|case| match case.test.as_deref() {
             Some(Expr::Update(..)) => true,

--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -19,8 +19,8 @@ use swc_ecma_utils::IsEmpty;
 use swc_ecma_utils::StmtExt;
 use swc_ecma_utils::StmtLike;
 use swc_ecma_utils::Value::Known;
-use swc_ecma_visit::noop_visit_type;
-use swc_ecma_visit::{noop_fold_type, Fold, FoldWith, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_mut_type, noop_visit_type, VisitMut};
+use swc_ecma_visit::{Node, Visit, VisitWith};
 
 #[cfg(test)]
 mod tests;
@@ -28,7 +28,7 @@ mod tests;
 /// Not intended for general use. Use [simplifier] instead.
 ///
 /// Ported from `PeepholeRemoveDeadCode` of google closure compiler.
-pub fn dead_branch_remover() -> impl RepeatedJsPass + 'static {
+pub fn dead_branch_remover() -> impl RepeatedJsPass + VisitMut + 'static {
     Remover::default()
 }
 
@@ -54,8 +54,8 @@ struct Remover {
     normal_block: bool,
 }
 
-impl Fold for Remover {
-    noop_fold_type!();
+impl VisitMut for Remover {
+    noop_visit_mut_type!();
 
     fn fold_array_pat(&mut self, p: ArrayPat) -> ArrayPat {
         let mut p: ArrayPat = p.fold_children_with(self);

--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -19,7 +19,7 @@ use swc_ecma_utils::IsEmpty;
 use swc_ecma_utils::StmtExt;
 use swc_ecma_utils::StmtLike;
 use swc_ecma_utils::Value::Known;
-use swc_ecma_visit::{noop_visit_mut_type, noop_visit_type, VisitMut};
+use swc_ecma_visit::{as_folder, noop_visit_mut_type, noop_visit_type, VisitMut, VisitMutWith};
 use swc_ecma_visit::{Node, Visit, VisitWith};
 
 #[cfg(test)]
@@ -29,7 +29,7 @@ mod tests;
 ///
 /// Ported from `PeepholeRemoveDeadCode` of google closure compiler.
 pub fn dead_branch_remover() -> impl RepeatedJsPass + VisitMut + 'static {
-    Remover::default()
+    as_folder(Remover::default())
 }
 
 impl CompilerPass for Remover {
@@ -970,11 +970,11 @@ impl VisitMut for Remover {
         s
     }
 
-    fn fold_module_items(&mut self, n: Vec<ModuleItem>) -> Vec<ModuleItem> {
+    fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
         self.fold_stmt_like(n)
     }
 
-    fn fold_stmts(&mut self, n: Vec<Stmt>) -> Vec<Stmt> {
+    fn visit_mut_stmts(&mut self, n: &mut Vec<Stmt>) {
         self.fold_stmt_like(n)
     }
 }
@@ -982,7 +982,7 @@ impl VisitMut for Remover {
 impl Remover {
     fn fold_stmt_like<T>(&mut self, stmts: Vec<T>) -> Vec<T>
     where
-        T: StmtLike + VisitWith<Hoister> + FoldWith<Self>,
+        T: StmtLike + VisitWith<Hoister> + VisitMutWith<Self>,
     {
         let is_block_stmt = self.normal_block;
         self.normal_block = false;

--- a/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/mod.rs
@@ -283,8 +283,6 @@ impl VisitMut for Remover {
 
             _ => {}
         }
-
-        p
     }
 
     fn visit_mut_seq_expr(&mut self, e: &mut SeqExpr) {
@@ -430,7 +428,9 @@ impl VisitMut for Remover {
                         && !is_block_scoped_stuff(&stmts[0])
                         && stmt_depth(&stmts[0]) <= 1
                     {
-                        stmts.into_iter().next().unwrap().visit_mut_with(self)
+                        let mut v = stmts.into_iter().next().unwrap();
+                        v.visit_mut_with(self);
+                        v
                     } else {
                         Stmt::Block(BlockStmt { span, stmts })
                     }

--- a/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
@@ -26,7 +26,7 @@ use swc_ecma_utils::StringType;
 use swc_ecma_utils::SymbolType;
 use swc_ecma_utils::UndefinedType;
 use swc_ecma_utils::Value;
-use swc_ecma_visit::{noop_fold_type, Fold, FoldWith};
+use swc_ecma_visit::{noop_fold_type, Fold, FoldWith, VisitMut};
 use Value::Known;
 use Value::Unknown;
 
@@ -45,7 +45,7 @@ macro_rules! try_val {
 /// Not intended for general use. Use [simplifier] instead.
 ///
 /// Ported from `PeepholeFoldConstants` of google closure compiler.
-pub fn expr_simplifier() -> impl RepeatedJsPass + 'static {
+pub fn expr_simplifier() -> impl RepeatedJsPass + VisitMut + 'static {
     SimplifyExpr::default()
 }
 

--- a/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
@@ -1369,8 +1369,8 @@ impl VisitMut for SimplifyExpr {
     }
 
     /// Drops unused values
-    fn fold_seq_expr(&mut self, e: SeqExpr) -> SeqExpr {
-        let mut e = e.visit_mut_children_with(self);
+    fn visit_mut_seq_expr(&mut self, e: &mut SeqExpr) {
+        e.visit_mut_children_with(self);
 
         let len = e.exprs.len();
 
@@ -1426,7 +1426,7 @@ impl VisitMut for SimplifyExpr {
 
         self.changed |= len != exprs.len();
 
-        SeqExpr {
+        *e = SeqExpr {
             exprs,
             span: e.span,
         }

--- a/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
@@ -26,7 +26,7 @@ use swc_ecma_utils::StringType;
 use swc_ecma_utils::SymbolType;
 use swc_ecma_utils::UndefinedType;
 use swc_ecma_utils::Value;
-use swc_ecma_visit::{noop_fold_type, Fold, FoldWith, VisitMut};
+use swc_ecma_visit::{noop_fold_type, noop_visit_mut_type, Fold, FoldWith, VisitMut};
 use Value::Known;
 use Value::Unknown;
 
@@ -1145,14 +1145,12 @@ impl SimplifyExpr {
     }
 }
 
-impl Fold for SimplifyExpr {
-    noop_fold_type!();
+impl VisitMut for SimplifyExpr {
+    noop_visit_mut_type!();
 
     /// Currently noop
     #[inline]
-    fn fold_opt_chain_expr(&mut self, n: OptChainExpr) -> OptChainExpr {
-        n
-    }
+    fn visit_mut_opt_chain_expr(&mut self, n: &mut OptChainExpr) {}
 
     fn fold_assign_expr(&mut self, n: AssignExpr) -> AssignExpr {
         let old = self.is_modifying;

--- a/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
@@ -1500,6 +1500,13 @@ impl VisitMut for SimplifyExpr {
         n.arg.visit_mut_with(self);
         self.is_modifying = old;
     }
+
+    fn visit_mut_var_decl_or_pat(&mut self, n: &mut VarDeclOrPat) {
+        let old = self.is_modifying;
+        self.is_modifying = true;
+        n.visit_mut_children_with(self);
+        self.is_modifying = old;
+    }
 }
 
 /// make a new boolean expression preserving side effects, if any.

--- a/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
@@ -1151,7 +1151,7 @@ impl VisitMut for SimplifyExpr {
 
     /// Currently noop
     #[inline]
-    fn visit_mut_opt_chain_expr(&mut self, n: &mut OptChainExpr) {}
+    fn visit_mut_opt_chain_expr(&mut self, _: &mut OptChainExpr) {}
 
     fn visit_mut_assign_expr(&mut self, n: &mut AssignExpr) {
         let old = self.is_modifying;
@@ -1320,7 +1320,7 @@ impl VisitMut for SimplifyExpr {
                         _ => false,
                     }
                 {
-                    *p = *a.left;
+                    *p = *a.left.take();
                     return;
                 }
             }
@@ -1338,7 +1338,7 @@ impl VisitMut for SimplifyExpr {
             ExprOrSuper::Expr(e) => match &mut **e {
                 Expr::Seq(seq) => {
                     if seq.exprs.len() == 1 {
-                        let mut expr = seq.exprs.into_iter().next().unwrap();
+                        let mut expr = seq.exprs.take().into_iter().next().unwrap();
                         expr.visit_mut_with(self);
                         *e = expr;
                     } else {
@@ -1379,7 +1379,7 @@ impl VisitMut for SimplifyExpr {
         // Expressions except last one
         let mut exprs = Vec::with_capacity(e.exprs.len() + 1);
 
-        for expr in e.exprs {
+        for expr in e.exprs.take() {
             match *expr {
                 Expr::Lit(Lit::Num(n)) if self.in_callee && n.value == 0.0 => {
                     if exprs.is_empty() {
@@ -1440,7 +1440,7 @@ impl VisitMut for SimplifyExpr {
 
         if !child.vars.is_empty() {
             prepend(
-                &mut n,
+                n,
                 Stmt::Decl(Decl::Var(VarDecl {
                     span: DUMMY_SP,
                     kind: VarDeclKind::Var,
@@ -1459,7 +1459,7 @@ impl VisitMut for SimplifyExpr {
 
         if !child.vars.is_empty() {
             prepend(
-                &mut n,
+                n,
                 ModuleItem::Stmt(Stmt::Decl(Decl::Var(VarDecl {
                     span: DUMMY_SP,
                     kind: VarDeclKind::Var,

--- a/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
@@ -1324,7 +1324,7 @@ impl VisitMut for SimplifyExpr {
                     return;
                 }
             }
-            _ => p,
+            _ => {}
         }
     }
 

--- a/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
@@ -1470,23 +1470,21 @@ impl VisitMut for SimplifyExpr {
         }
     }
 
-    fn fold_stmt(&mut self, s: Stmt) -> Stmt {
+    fn visit_mut_stmt(&mut self, s: &mut Stmt) {
         let old_is_modifying = self.is_modifying;
         self.is_modifying = false;
         let old_is_arg_of_update = self.is_arg_of_update;
         self.is_arg_of_update = false;
-        let s = s.visit_mut_children_with(self);
+        s.visit_mut_children_with(self);
         self.is_arg_of_update = old_is_arg_of_update;
         self.is_modifying = old_is_modifying;
-        s
     }
 
-    fn fold_update_expr(&mut self, n: UpdateExpr) -> UpdateExpr {
+    fn visit_mut_update_expr(&mut self, n: &mut UpdateExpr) {
         let old = self.is_modifying;
         self.is_modifying = true;
-        let arg = n.arg.visit_mut_with(self);
+        n.arg.visit_mut_with(self);
         self.is_modifying = old;
-        UpdateExpr { arg, ..n }
     }
 }
 

--- a/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
@@ -495,11 +495,12 @@ impl SimplifyExpr {
                         *node
                     } else {
                         self.changed = true;
-                        let seq = SeqExpr {
+                        let mut seq = SeqExpr {
                             span,
                             exprs: vec![left, node],
-                        }
-                        .visit_mut_with(self);
+                        };
+
+                        seq.visit_mut_with(self);
 
                         Expr::Seq(seq)
                     };
@@ -1167,7 +1168,7 @@ impl VisitMut for SimplifyExpr {
         match expr {
             Expr::Unary(UnaryExpr {
                 op: op!("delete"), ..
-            }) => return expr,
+            }) => return,
             _ => {}
         }
         // fold children before doing something more.

--- a/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
@@ -1432,10 +1432,10 @@ impl VisitMut for SimplifyExpr {
         }
     }
 
-    fn fold_stmts(&mut self, mut n: Vec<Stmt>) -> Vec<Stmt> {
+    fn visit_mut_stmts(&mut self, n: &mut Vec<Stmt>) {
         let mut child = Self::default();
 
-        n = n.visit_mut_children_with(&mut child);
+        n.visit_mut_children_with(&mut child);
         self.changed |= child.changed;
 
         if !child.vars.is_empty() {
@@ -1449,14 +1449,12 @@ impl VisitMut for SimplifyExpr {
                 })),
             );
         }
-
-        n
     }
 
-    fn fold_module_items(&mut self, mut n: Vec<ModuleItem>) -> Vec<ModuleItem> {
+    fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
         let mut child = Self::default();
 
-        n = n.visit_mut_children_with(&mut child);
+        n.visit_mut_children_with(&mut child);
         self.changed |= child.changed;
 
         if !child.vars.is_empty() {
@@ -1470,8 +1468,6 @@ impl VisitMut for SimplifyExpr {
                 }))),
             );
         }
-
-        n
     }
 
     fn fold_stmt(&mut self, s: Stmt) -> Stmt {

--- a/ecmascript/transforms/optimization/src/simplify/expr/tests.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/tests.rs
@@ -1,10 +1,10 @@
-use super::SimplifyExpr;
+use super::expr_simplifier;
 use swc_ecma_transforms_testing::test_transform;
 
 fn fold(src: &str, expected: &str) {
     test_transform(
         ::swc_ecma_parser::Syntax::default(),
-        |_| SimplifyExpr::default(),
+        |_| expr_simplifier(),
         src,
         expected,
         true,


### PR DESCRIPTION

swc_ecma_transforms_optimization:
 - [x] Migrate `expr_simplifier` to `VisitMut`.
 - [x] Migrate `dead_branch_remover` to `VisitMut`.

---

This is part of minifier work, but I decided to split PR because this task can easily regress tests.