### PR TITLE
fix(es/ast): Fix Reserve Words

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.26.0"
+version = "0.27.0"
 
 [lib]
 name = "swc"
@@ -30,15 +30,15 @@ serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "./atoms"}
-swc_bundler = {version = "0.44.0", path = "./bundler"}
+swc_bundler = {version = "0.45.0", path = "./bundler"}
 swc_common = {version = "0.10.16", path = "./common", features = ["sourcemap", "concurrent"]}
-swc_ecma_ast = {version = "0.47.0", path = "./ecmascript/ast"}
-swc_ecma_codegen = {version = "0.60.0", path = "./ecmascript/codegen"}
-swc_ecma_ext_transforms = {version = "0.19.0", path = "./ecmascript/ext-transforms"}
-swc_ecma_loader = {version = "0.9.0", path = "./ecmascript/loader", features = ["lru", "node", "tsc"]}
-swc_ecma_parser = {version = "0.61.0", path = "./ecmascript/parser"}
-swc_ecma_preset_env = {version = "0.27.0", path = "./ecmascript/preset-env"}
-swc_ecma_transforms = {version = "0.57.0", path = "./ecmascript/transforms", features = [
+swc_ecma_ast = {version = "0.48.0", path = "./ecmascript/ast"}
+swc_ecma_codegen = {version = "0.61.0", path = "./ecmascript/codegen"}
+swc_ecma_ext_transforms = {version = "0.20.0", path = "./ecmascript/ext-transforms"}
+swc_ecma_loader = {version = "0.10.0", path = "./ecmascript/loader", features = ["lru", "node", "tsc"]}
+swc_ecma_parser = {version = "0.62.0", path = "./ecmascript/parser"}
+swc_ecma_preset_env = {version = "0.28.0", path = "./ecmascript/preset-env"}
+swc_ecma_transforms = {version = "0.58.0", path = "./ecmascript/transforms", features = [
   "compat",
   "module",
   "optimization",
@@ -46,8 +46,8 @@ swc_ecma_transforms = {version = "0.57.0", path = "./ecmascript/transforms", fea
   "react",
   "typescript",
 ]}
-swc_ecma_utils = {version = "0.38.0", path = "./ecmascript/utils"}
-swc_ecma_visit = {version = "0.33.0", path = "./ecmascript/visit"}
+swc_ecma_utils = {version = "0.39.0", path = "./ecmascript/utils"}
+swc_ecma_visit = {version = "0.34.0", path = "./ecmascript/visit"}
 swc_node_base = {version = "0.1.0", path = "./node/base"}
 swc_visit = {version = "0.2.3", path = "./visit"}
 

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -9,7 +9,7 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/**/*.js"]
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.44.1"
+version = "0.45.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -33,20 +33,20 @@ relative-path = "1.2"
 retain_mut = "0.1.2"
 swc_atoms = {version = "0.2.4", path = "../atoms"}
 swc_common = {version = "0.10.16", path = "../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../ecmascript/ast"}
-swc_ecma_codegen = {version = "0.60.0", path = "../ecmascript/codegen"}
-swc_ecma_loader = {version = "0.9.0", path = "../ecmascript/loader"}
-swc_ecma_parser = {version = "0.61.0", path = "../ecmascript/parser"}
-swc_ecma_transforms = {version = "0.57.0", path = "../ecmascript/transforms", features = ["optimization"]}
-swc_ecma_utils = {version = "0.38.0", path = "../ecmascript/utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../ecmascript/visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../ecmascript/ast"}
+swc_ecma_codegen = {version = "0.61.0", path = "../ecmascript/codegen"}
+swc_ecma_loader = {version = "0.10.0", path = "../ecmascript/loader"}
+swc_ecma_parser = {version = "0.62.0", path = "../ecmascript/parser"}
+swc_ecma_transforms = {version = "0.58.0", path = "../ecmascript/transforms", features = ["optimization"]}
+swc_ecma_utils = {version = "0.39.0", path = "../ecmascript/utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../ecmascript/visit"}
 
 [dev-dependencies]
 hex = "0.4"
 ntest = "0.7.2"
 reqwest = {version = "0.10.8", features = ["blocking"]}
 sha-1 = "0.9"
-swc_ecma_transforms = {version = "0.57.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
+swc_ecma_transforms = {version = "0.58.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
 tempfile = "3.1.0"
 testing = {version = "0.10.5", path = "../testing"}
 url = "2.1.1"

--- a/bundler/src/bundler/keywords.rs
+++ b/bundler/src/bundler/keywords.rs
@@ -20,7 +20,7 @@ impl KeywordRenamer {
             return None;
         }
 
-        if !id.is_reserved_for_es3() {
+        if !(id.is_reserved() || id.is_reserved_in_strict_mode(true) || id.is_reserved_in_es3()) {
             return None;
         }
 

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.44.0"
+version = "0.45.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -28,13 +28,13 @@ react = ["swc_ecma_transforms/react"]
 typescript = ["swc_ecma_transforms/typescript"]
 
 [dependencies]
-swc_ecma_ast = {version = "0.47.0", path = "./ast"}
-swc_ecma_codegen = {version = "0.60.0", path = "./codegen", optional = true}
-swc_ecma_dep_graph = {version = "0.29.0", path = "./dep-graph", optional = true}
-swc_ecma_minifier = {version = "0.10.0", path = "./minifier", optional = true}
-swc_ecma_parser = {version = "0.61.0", path = "./parser", optional = true}
-swc_ecma_transforms = {version = "0.57.0", path = "./transforms", optional = true}
-swc_ecma_utils = {version = "0.38.0", path = "./utils", optional = true}
-swc_ecma_visit = {version = "0.33.0", path = "./visit", optional = true}
+swc_ecma_ast = {version = "0.48.0", path = "./ast"}
+swc_ecma_codegen = {version = "0.61.0", path = "./codegen", optional = true}
+swc_ecma_dep_graph = {version = "0.30.0", path = "./dep-graph", optional = true}
+swc_ecma_minifier = {version = "0.11.0", path = "./minifier", optional = true}
+swc_ecma_parser = {version = "0.62.0", path = "./parser", optional = true}
+swc_ecma_transforms = {version = "0.58.0", path = "./transforms", optional = true}
+swc_ecma_utils = {version = "0.39.0", path = "./utils", optional = true}
+swc_ecma_visit = {version = "0.34.0", path = "./visit", optional = true}
 
 [dev-dependencies]

--- a/ecmascript/ast/Cargo.toml
+++ b/ecmascript/ast/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ast"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.47.0"
+version = "0.48.0"
 
 [features]
 default = []

--- a/ecmascript/ast/src/ident.rs
+++ b/ecmascript/ast/src/ident.rs
@@ -82,15 +82,11 @@ impl Ident {
 }
 
 pub trait IdentExt: AsRef<str> {
-    fn is_reserved_for_es3(&self) -> bool {
+    fn is_reserved(&self) -> bool {
         [
-            "abstract",
-            "boolean",
             "break",
-            "byte",
             "case",
             "catch",
-            "char",
             "class",
             "const",
             "continue",
@@ -98,77 +94,73 @@ pub trait IdentExt: AsRef<str> {
             "default",
             "delete",
             "do",
-            "double",
             "else",
             "enum",
             "export",
             "extends",
             "false",
-            "final",
             "finally",
-            "float",
             "for",
             "function",
-            "goto",
             "if",
-            "implements",
             "import",
             "in",
             "instanceof",
-            "int",
-            "interface",
-            "long",
-            "native",
             "new",
             "null",
             "package",
-            "private",
-            "protected",
-            "public",
             "return",
-            "short",
-            "static",
             "super",
             "switch",
-            "synchronized",
             "this",
             "throw",
-            "throws",
-            "transient",
             "true",
             "try",
             "typeof",
             "var",
             "void",
-            "volatile",
             "while",
             "with",
         ]
         .contains(&self.as_ref())
     }
 
-    fn is_reserved_only_for_es3(&self) -> bool {
+    fn is_reserved_in_strict_mode(&self, is_module: bool) -> bool {
+        if is_module && self.as_ref() == "await" {
+            return true;
+        }
+        [
+            "implements",
+            "interface",
+            "let",
+            "package",
+            "private",
+            "protected",
+            "public",
+            "static",
+            "yield",
+        ]
+        .contains(&self.as_ref())
+    }
+
+    fn is_reserved_in_strict_bind(&self) -> bool {
+        ["eval", "arguments"].contains(&self.as_ref())
+    }
+
+    fn is_reserved_in_es3(&self) -> bool {
         [
             "abstract",
             "boolean",
             "byte",
             "char",
             "double",
-            "enum",
             "final",
             "float",
             "goto",
-            "implements",
             "int",
-            "interface",
             "long",
             "native",
-            "package",
-            "private",
-            "protected",
-            "public",
             "short",
-            "static",
             "synchronized",
             "throws",
             "transient",

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.60.1"
+version = "0.61.0"
 
 [dependencies]
 bitflags = "1"
@@ -15,9 +15,9 @@ num-bigint = {version = "0.2", features = ["serde"]}
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.21", path = "../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../ast"}
+swc_ecma_ast = {version = "0.48.0", path = "../ast"}
 swc_ecma_codegen_macros = {version = "0.5.2", path = "./macros"}
-swc_ecma_parser = {version = "0.61.0", path = "../parser"}
+swc_ecma_parser = {version = "0.62.0", path = "../parser"}
 
 [dev-dependencies]
 swc_common = {version = "0.10.16", path = "../../common", features = ["sourcemap"]}

--- a/ecmascript/dep-graph/Cargo.toml
+++ b/ecmascript/dep-graph/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_dep_graph"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.29.0"
+version = "0.30.0"
 
 [dependencies]
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../ast"}
-swc_ecma_visit = {version = "0.33.0", path = "../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../ast"}
+swc_ecma_visit = {version = "0.34.0", path = "../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.61.0", path = "../parser"}
+swc_ecma_parser = {version = "0.62.0", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/ext-transforms/Cargo.toml
+++ b/ecmascript/ext-transforms/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_ext_transforms/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ext_transforms"
-version = "0.19.0"
+version = "0.20.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,7 +13,7 @@ version = "0.19.0"
 phf = {version = "0.8.0", features = ["macros"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../ast"}
-swc_ecma_parser = {version = "0.61.0", path = "../parser"}
-swc_ecma_utils = {version = "0.38.0", path = "../utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../ast"}
+swc_ecma_parser = {version = "0.62.0", path = "../parser"}
+swc_ecma_utils = {version = "0.39.0", path = "../utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../visit"}

--- a/ecmascript/jsdoc/Cargo.toml
+++ b/ecmascript/jsdoc/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/jsdoc/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "jsdoc"
-version = "0.29.0"
+version = "0.30.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,7 +18,7 @@ swc_common = {version = "0.10.16", path = "../../common"}
 [dev-dependencies]
 anyhow = "1"
 dashmap = "4.0.2"
-swc_ecma_ast = {version = "0.47.0", path = "../ast"}
-swc_ecma_parser = {version = "0.61.0", path = "../parser"}
+swc_ecma_ast = {version = "0.48.0", path = "../ast"}
+swc_ecma_parser = {version = "0.62.0", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/loader/Cargo.toml
+++ b/ecmascript/loader/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_loader"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.9.1"
+version = "0.10.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -29,8 +29,8 @@ serde = {version = "1.0.126", optional = true}
 serde_json = {version = "1.0.64", optional = true}
 swc_atoms = {version = "0.2.3", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../ast"}
-swc_ecma_visit = {version = "0.33.0", path = "../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../ast"}
+swc_ecma_visit = {version = "0.34.0", path = "../visit"}
 
 [dev-dependencies]
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/minifier/Cargo.toml
+++ b/ecmascript/minifier/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "src/lists/*.json"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_minifier"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.10.1"
+version = "0.11.0"
 
 [features]
 debug = []
@@ -24,13 +24,13 @@ serde_json = "1.0.61"
 serde_regex = "1.1.0"
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.8", path = "../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../ast"}
-swc_ecma_codegen = {version = "0.60.0", path = "../codegen"}
-swc_ecma_parser = {version = "0.61.0", path = "../parser"}
-swc_ecma_transforms = {version = "0.57.0", path = "../transforms/", features = ["optimization"]}
-swc_ecma_transforms_base = {version = "0.20.0", path = "../transforms/base"}
-swc_ecma_utils = {version = "0.38.0", path = "../utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../ast"}
+swc_ecma_codegen = {version = "0.61.0", path = "../codegen"}
+swc_ecma_parser = {version = "0.62.0", path = "../parser"}
+swc_ecma_transforms = {version = "0.58.0", path = "../transforms/", features = ["optimization"]}
+swc_ecma_transforms_base = {version = "0.21.0", path = "../transforms/base"}
+swc_ecma_utils = {version = "0.39.0", path = "../utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../visit"}
 
 [dev-dependencies]
 ansi_term = "0.12.1"

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.61.3"
+version = "0.62.0"
 
 [features]
 default = []
@@ -23,8 +23,8 @@ serde = {version = "1", features = ["derive"]}
 smallvec = "1"
 swc_atoms = {version = "0.2.3", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../ast"}
-swc_ecma_visit = {version = "0.33.0", path = "../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../ast"}
+swc_ecma_visit = {version = "0.34.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]

--- a/ecmascript/preset-env/Cargo.toml
+++ b/ecmascript/preset-env/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_preset_env/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_preset_env"
-version = "0.27.0"
+version = "0.28.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,14 +21,14 @@ st-map = "0.1.2"
 string_enum = {version = "0.3.1", path = "../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../ast"}
-swc_ecma_transforms = {version = "0.57.0", path = "../transforms", features = ["compat", "proposal"]}
-swc_ecma_utils = {version = "0.38.0", path = "../utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../ast"}
+swc_ecma_transforms = {version = "0.58.0", path = "../transforms", features = ["compat", "proposal"]}
+swc_ecma_utils = {version = "0.39.0", path = "../utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../visit"}
 walkdir = "2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
-swc_ecma_codegen = {version = "0.60.0", path = "../codegen"}
-swc_ecma_parser = {version = "0.61.0", path = "../parser"}
+swc_ecma_codegen = {version = "0.61.0", path = "../codegen"}
+swc_ecma_parser = {version = "0.62.0", path = "../parser"}
 testing = {version = "0.10.5", path = "../../testing"}

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.57.0"
+version = "0.58.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -23,24 +23,24 @@ typescript = ["swc_ecma_transforms_typescript"]
 [dependencies]
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../ast"}
-swc_ecma_parser = {version = "0.61.0", path = "../parser"}
-swc_ecma_transforms_base = {version = "0.20.0", path = "./base"}
-swc_ecma_transforms_compat = {version = "0.23.0", path = "./compat", optional = true}
-swc_ecma_transforms_module = {version = "0.24.0", path = "./module", optional = true}
-swc_ecma_transforms_optimization = {version = "0.27.0", path = "./optimization", optional = true}
-swc_ecma_transforms_proposal = {version = "0.24.0", path = "./proposal", optional = true}
-swc_ecma_transforms_react = {version = "0.25.0", path = "./react", optional = true}
-swc_ecma_transforms_typescript = {version = "0.26.0", path = "./typescript", optional = true}
-swc_ecma_utils = {version = "0.38.0", path = "../utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../ast"}
+swc_ecma_parser = {version = "0.62.0", path = "../parser"}
+swc_ecma_transforms_base = {version = "0.21.0", path = "./base"}
+swc_ecma_transforms_compat = {version = "0.24.0", path = "./compat", optional = true}
+swc_ecma_transforms_module = {version = "0.25.0", path = "./module", optional = true}
+swc_ecma_transforms_optimization = {version = "0.28.0", path = "./optimization", optional = true}
+swc_ecma_transforms_proposal = {version = "0.25.0", path = "./proposal", optional = true}
+swc_ecma_transforms_react = {version = "0.26.0", path = "./react", optional = true}
+swc_ecma_transforms_typescript = {version = "0.27.0", path = "./typescript", optional = true}
+swc_ecma_utils = {version = "0.39.0", path = "../utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
 sourcemap = "6"
-swc_ecma_codegen = {version = "0.60.0", path = "../codegen"}
-swc_ecma_transforms_testing = {version = "0.20.0", path = "./testing"}
+swc_ecma_codegen = {version = "0.61.0", path = "../codegen"}
+swc_ecma_transforms_testing = {version = "0.21.0", path = "./testing"}
 tempfile = "3"
 testing = {version = "0.10.5", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.20.2"
+version = "0.21.0"
 
 [dependencies]
 fxhash = "0.2.1"
@@ -16,11 +16,11 @@ scoped-tls = "1.0.0"
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.61.0", path = "../../parser"}
-swc_ecma_utils = {version = "0.38.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.62.0", path = "../../parser"}
+swc_ecma_utils = {version = "0.39.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.60.0", path = "../../codegen"}
+swc_ecma_codegen = {version = "0.61.0", path = "../../codegen"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/classes/Cargo.toml
+++ b/ecmascript/transforms/classes/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_classes"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 swc_atoms = {version = "0.2.6", path = "../../../atoms"}
 swc_common = {version = "0.10.20", path = "../../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.20.0", path = "../base"}
-swc_ecma_utils = {version = "0.38.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../../ast"}
+swc_ecma_transforms_base = {version = "0.21.0", path = "../base"}
+swc_ecma_utils = {version = "0.39.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../../visit"}

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.23.0"
+version = "0.24.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -20,14 +20,14 @@ serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2.5", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.20.0", path = "../base"}
-swc_ecma_transforms_classes = {version = "0.6.0", path = "../classes"}
+swc_ecma_ast = {version = "0.48.0", path = "../../ast"}
+swc_ecma_transforms_base = {version = "0.21.0", path = "../base"}
+swc_ecma_transforms_classes = {version = "0.7.0", path = "../classes"}
 swc_ecma_transforms_macros = {version = "0.2.1", path = "../macros"}
-swc_ecma_utils = {version = "0.38.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../../visit"}
+swc_ecma_utils = {version = "0.39.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.61.0", path = "../../parser"}
-swc_ecma_transforms_testing = {version = "0.20.0", path = "../testing"}
+swc_ecma_parser = {version = "0.62.0", path = "../../parser"}
+swc_ecma_transforms_testing = {version = "0.21.0", path = "../testing"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/compat/src/es2015/classes/mod.rs
+++ b/ecmascript/transforms/compat/src/es2015/classes/mod.rs
@@ -924,7 +924,10 @@ fn escape_keywords(mut e: Box<Expr>) -> Box<Expr> {
     match &mut *e {
         Expr::Fn(f) => {
             if let Some(i) = &mut f.ident {
-                if i.is_reserved_for_es3() {
+                if i.is_reserved()
+                    || i.is_reserved_in_strict_mode(true)
+                    || i.is_reserved_in_strict_bind()
+                {
                     i.sym = format!("_{}", i.sym).into();
                 }
             }

--- a/ecmascript/transforms/compat/src/es2015/function_name.rs
+++ b/ecmascript/transforms/compat/src/es2015/function_name.rs
@@ -35,16 +35,12 @@ struct Renamer {
 }
 
 /// This function makes a new private identifier if required.
-fn prepare(i: Ident, force: bool) -> Ident {
-    if i.is_reserved_for_es3() || i.sym == *"await" || i.sym == *"eval" {
+fn prepare(i: Ident) -> Ident {
+    if i.is_reserved() || i.is_reserved_in_strict_mode(true) || i.is_reserved_in_strict_bind() {
         return private_ident!(i.span, format!("_{}", i.sym));
     }
 
-    if force {
-        private_ident!(i.span, i.sym)
-    } else {
-        i
-    }
+    i
 }
 
 impl Fold for FnName {
@@ -78,7 +74,7 @@ impl Fold for FnName {
                 //
                 if let PropName::Ident(ref i) = p.key {
                     Box::new(Expr::Fn(FnExpr {
-                        ident: Some(prepare(i.clone(), false)),
+                        ident: Some(prepare(i.clone())),
                         ..expr
                     }))
                 } else {
@@ -97,7 +93,7 @@ impl Fold for FnName {
         match decl.name {
             Pat::Ident(ref mut ident) => {
                 let mut folder = Renamer {
-                    name: Some(prepare(ident.id.clone(), false)),
+                    name: Some(prepare(ident.id.clone())),
                 };
                 let init = decl.init.fold_with(&mut folder);
 

--- a/ecmascript/transforms/compat/src/es3/member_expr_lits.rs
+++ b/ecmascript/transforms/compat/src/es3/member_expr_lits.rs
@@ -33,7 +33,12 @@ impl Fold for MemberExprLit {
 
         macro_rules! handle {
             ($sym:expr, $span:expr) => {
-                if $sym.is_reserved_for_es3() || !is_valid_ident(&$sym) {
+                if $sym.is_reserved()
+                    || $sym.is_reserved_in_strict_mode(true)
+                    || $sym.is_reserved_in_es3()
+                    // it's not bind, so you could use eval
+                    || !is_valid_ident(&$sym)
+                {
                     return MemberExpr {
                         computed: true,
                         prop: Box::new(Expr::Lit(Lit::Str(Str {

--- a/ecmascript/transforms/compat/src/es3/prop_lits.rs
+++ b/ecmascript/transforms/compat/src/es3/prop_lits.rs
@@ -48,7 +48,7 @@ impl Fold for PropertyLiteral {
                 kind,
                 ..
             }) => {
-                if sym.is_reserved_for_es3() || !is_valid_ident(&sym) {
+                if sym.is_reserved() || !is_valid_ident(&sym) {
                     PropName::Str(Str {
                         span,
                         value: sym,
@@ -61,7 +61,7 @@ impl Fold for PropertyLiteral {
             }
             PropName::Ident(i) => {
                 let Ident { sym, span, .. } = i;
-                if sym.is_reserved_for_es3() || sym.contains('-') || sym.contains('.') {
+                if sym.is_reserved() || sym.contains('-') || sym.contains('.') {
                     PropName::Str(Str {
                         span,
                         value: sym,

--- a/ecmascript/transforms/compat/src/es3/reserved_word.rs
+++ b/ecmascript/transforms/compat/src/es3/reserved_word.rs
@@ -75,7 +75,7 @@ fn fold_ident(preserve_import: bool, i: Ident) -> Ident {
         return i;
     }
 
-    if i.is_reserved_for_es3() {
+    if i.is_reserved_in_es3() {
         return Ident {
             sym: format!("_{}", i.sym).into(),
             ..i

--- a/ecmascript/transforms/compat/tests/es2015_classes.rs
+++ b/ecmascript/transforms/compat/tests/es2015_classes.rs
@@ -6399,3 +6399,30 @@ test!(
   }());
     "
 );
+
+test!(
+    syntax(),
+    |t| tr(t),
+    issue_1838,
+    r#"
+    class Foo {
+      let() {}
+    }
+"#,
+    r#"
+    let Foo = /*#__PURE__*/ function() {
+      "use strict";
+      function Foo() {
+          _classCallCheck(this, Foo);
+      }
+      _createClass(Foo, [
+          {
+              key: "let",
+              value: function _let() {
+              }
+          }
+      ]);
+      return Foo;
+  }();
+"#
+);

--- a/ecmascript/transforms/module/Cargo.toml
+++ b/ecmascript/transforms/module/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.24.1"
+version = "0.25.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -18,14 +18,14 @@ pathdiff = "0.2.0"
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../../ast"}
-swc_ecma_loader = {version = "0.9.0", path = "../../loader", features = ["node"]}
-swc_ecma_parser = {version = "0.61.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.20.0", path = "../base"}
-swc_ecma_utils = {version = "0.38.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../../ast"}
+swc_ecma_loader = {version = "0.10.0", path = "../../loader", features = ["node"]}
+swc_ecma_parser = {version = "0.62.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.21.0", path = "../base"}
+swc_ecma_utils = {version = "0.39.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.23.0", path = "../compat"}
-swc_ecma_transforms_testing = {version = "0.20.0", path = "../testing/"}
+swc_ecma_transforms_compat = {version = "0.24.0", path = "../compat"}
+swc_ecma_transforms_testing = {version = "0.21.0", path = "../testing/"}
 testing = {version = "0.10.5", path = "../../../testing/"}

--- a/ecmascript/transforms/optimization/Cargo.toml
+++ b/ecmascript/transforms/optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.27.2"
+version = "0.28.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -19,17 +19,17 @@ retain_mut = "0.1.2"
 serde_json = "1.0.61"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.61.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.20.0", path = "../base"}
-swc_ecma_utils = {version = "0.38.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.62.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.21.0", path = "../base"}
+swc_ecma_utils = {version = "0.39.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.23.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.24.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.24.0", path = "../proposal"}
-swc_ecma_transforms_react = {version = "0.25.0", path = "../react"}
-swc_ecma_transforms_testing = {version = "0.20.0", path = "../testing"}
-swc_ecma_transforms_typescript = {version = "0.26.0", path = "../typescript"}
+swc_ecma_transforms_compat = {version = "0.24.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.25.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.25.0", path = "../proposal"}
+swc_ecma_transforms_react = {version = "0.26.0", path = "../react"}
+swc_ecma_transforms_testing = {version = "0.21.0", path = "../testing"}
+swc_ecma_transforms_typescript = {version = "0.27.0", path = "../typescript"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/proposal/Cargo.toml
+++ b/ecmascript/transforms/proposal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_proposal"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.24.0"
+version = "0.25.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,15 +21,15 @@ serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../../ast"}
-swc_ecma_loader = {version = "0.9.0", path = "../../loader", optional = true}
-swc_ecma_parser = {version = "0.61.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.20.0", path = "../base"}
-swc_ecma_transforms_classes = {version = "0.6.0", path = "../classes"}
-swc_ecma_utils = {version = "0.38.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../../ast"}
+swc_ecma_loader = {version = "0.10.0", path = "../../loader", optional = true}
+swc_ecma_parser = {version = "0.62.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.21.0", path = "../base"}
+swc_ecma_transforms_classes = {version = "0.7.0", path = "../classes"}
+swc_ecma_utils = {version = "0.39.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.23.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.24.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.20.0", path = "../testing"}
+swc_ecma_transforms_compat = {version = "0.24.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.25.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.21.0", path = "../testing"}

--- a/ecmascript/transforms/react/Cargo.toml
+++ b/ecmascript/transforms/react/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_react"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.25.1"
+version = "0.26.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -21,15 +21,15 @@ sha-1 = "0.9.4"
 string_enum = {version = "0.3.1", path = "../../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.61.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.20.0", path = "../base"}
-swc_ecma_utils = {version = "0.38.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.62.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.21.0", path = "../base"}
+swc_ecma_utils = {version = "0.39.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.60.0", path = "../../codegen/"}
-swc_ecma_transforms_compat = {version = "0.23.0", path = "../compat/"}
-swc_ecma_transforms_module = {version = "0.24.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.20.0", path = "../testing/"}
+swc_ecma_codegen = {version = "0.61.0", path = "../../codegen/"}
+swc_ecma_transforms_compat = {version = "0.24.0", path = "../compat/"}
+swc_ecma_transforms_module = {version = "0.25.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.21.0", path = "../testing/"}
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/testing/Cargo.toml
+++ b/ecmascript/transforms/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.20.1"
+version = "0.21.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,11 +15,11 @@ ansi_term = "0.12.1"
 serde = "1"
 serde_json = "1"
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../../ast"}
-swc_ecma_codegen = {version = "0.60.0", path = "../../codegen"}
-swc_ecma_parser = {version = "0.61.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.20.0", path = "../base"}
-swc_ecma_utils = {version = "0.38.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../../ast"}
+swc_ecma_codegen = {version = "0.61.0", path = "../../codegen"}
+swc_ecma_parser = {version = "0.62.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.21.0", path = "../base"}
+swc_ecma_utils = {version = "0.39.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../../visit"}
 tempfile = "3.1.0"
 testing = {version = "0.10.5", path = "../../../testing"}

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.26.0"
+version = "0.27.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -14,17 +14,17 @@ fxhash = "0.2.1"
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.10.16", path = "../../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.61.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.20.0", path = "../base"}
-swc_ecma_utils = {version = "0.38.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.33.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.62.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.21.0", path = "../base"}
+swc_ecma_utils = {version = "0.39.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.34.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.60.0", path = "../../codegen"}
-swc_ecma_transforms_compat = {version = "0.23.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.24.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.24.0", path = "../proposal/"}
-swc_ecma_transforms_testing = {version = "0.20.0", path = "../testing"}
+swc_ecma_codegen = {version = "0.61.0", path = "../../codegen"}
+swc_ecma_transforms_compat = {version = "0.24.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.25.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.25.0", path = "../proposal/"}
+swc_ecma_transforms_testing = {version = "0.21.0", path = "../testing"}
 testing = {version = "0.10.5", path = "../../../testing"}
 walkdir = "2.3.1"

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.38.0"
+version = "0.39.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,8 +15,8 @@ once_cell = "1"
 scoped-tls = "1"
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../ast"}
-swc_ecma_visit = {version = "0.33.0", path = "../visit"}
+swc_ecma_ast = {version = "0.48.0", path = "../ast"}
+swc_ecma_visit = {version = "0.34.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]

--- a/ecmascript/visit/Cargo.toml
+++ b/ecmascript/visit/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_visit"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.33.0"
+version = "0.34.0"
 
 [dependencies]
 num-bigint = {version = "0.2", features = ["serde"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.10.16", path = "../../common"}
-swc_ecma_ast = {version = "0.47.0", path = "../ast"}
+swc_ecma_ast = {version = "0.48.0", path = "../ast"}
 swc_visit = {version = "0.2.3", path = "../../visit"}


### PR DESCRIPTION
fixes #1838 
@kdy1 two problems left:
1. I don't know what's needed to be escaped in bundler, so I just escape everything
2. What does es3/props_lit do? It seems do the opposite of `@babel/plugin-transform-property-literals`. That babel plugin transform
```js
var foo = {
  // changed
  const: function() {},
  var: function() {},

  // not changed
  default: 1,
  [a]: 2,
  foo: 1,
};
```
to
```js
var foo = {
  // changed
  "const": function () {},
  "var": function () {},
  // not changed
  "default": 1,
  [a]: 2,
  foo: 1
};
```
while swc transform string literal in prop name back to ident