### PR TITLE
fix: put comments in file with only shebang and comments in the correct map

### DIFF
--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.62.0"
+version = "0.62.1"
 
 [features]
 default = []

--- a/ecmascript/parser/src/lexer/state.rs
+++ b/ecmascript/parser/src/lexer/state.rs
@@ -154,7 +154,6 @@ impl<I: Input> Tokens for Lexer<'_, I> {
 impl<'a, I: Input> Iterator for Lexer<'a, I> {
     type Item = TokenAndSpan;
     fn next(&mut self) -> Option<Self::Item> {
-        let was_first = self.state.is_first;
         let mut start = self.cur_pos();
 
         let res = (|| -> Result<Option<_>, _> {
@@ -194,9 +193,10 @@ impl<'a, I: Input> Iterator for Lexer<'a, I> {
                         {
                             let comments = self.comments.as_mut().unwrap();
 
-                            // if the file had no tokens, then treat any comments in the leading
-                            // comments buffer as leading. Otherwise treat them as trailing.
-                            if was_first {
+                            // if the file had no tokens and no shebang, then treat any
+                            // comments in the leading comments buffer as leading.
+                            // Otherwise treat them as trailing.
+                            if last == BytePos(0) {
                                 comments.add_leading(last, c);
                             } else {
                                 comments.add_trailing(last, c);


### PR DESCRIPTION
Caused by #1879. I missed this scenario earlier.

Luckily, nobody is going to write files like this.