### PR TITLE
chore: switch from denolib to denoland/setup-deno github action

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: denoland/setup-deno@v1.1.0
+      - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
 

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           node-version: 14
 
-      - uses: denolib/setup-deno@v2
+      - uses: denoland/setup-deno@v1.1.0
         with:
           deno-version: v1.x
 


### PR DESCRIPTION
denolib/setup-deno is archived: https://github.com/denolib/setup-deno

It's failing the CI of my other PR, so wonder if it's related.