### PR TITLE
fix(import): allow namespace import with default import 

### DIFF
--- a/ecmascript/transforms/module/Cargo.toml
+++ b/ecmascript/transforms/module/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.26.1"
+version = "0.26.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/ecmascript/transforms/module/src/import_analysis.rs
+++ b/ecmascript/transforms/module/src/import_analysis.rs
@@ -101,9 +101,11 @@ impl Visit for ImportAnalyzer {
             let mut has_non_default = false;
             for s in &import.specifiers {
                 match *s {
-                    ImportSpecifier::Namespace(..) => unreachable!(
-                        "import * as foo cannot be used with other type of import specifiers"
-                    ),
+                    ImportSpecifier::Namespace(ref _ns) => {
+                        if &*import.src.value != "@swc/helpers" {
+                            scope.import_types.insert(import.src.value.clone(), true);
+                        }
+                    }
                     ImportSpecifier::Default(_) => {
                         scope
                             .import_types

--- a/tests/fixture/issue-1938/cjs/input/.swcrc
+++ b/tests/fixture/issue-1938/cjs/input/.swcrc
@@ -1,0 +1,13 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true,
+      "dynamicImport": true,
+      "decorators": false
+    }
+  },
+  "module": {
+    "type": "commonjs"
+  }
+}

--- a/tests/fixture/issue-1938/cjs/input/index.js
+++ b/tests/fixture/issue-1938/cjs/input/index.js
@@ -1,0 +1,4 @@
+import foo, * as action from './actions';
+
+console.log(action);
+console.log(foo);

--- a/tests/fixture/issue-1938/cjs/output/index.js
+++ b/tests/fixture/issue-1938/cjs/output/index.js
@@ -1,0 +1,27 @@
+"use strict";
+var action = _interopRequireWildcard(require("./actions"));
+function _interopRequireWildcard(obj) {
+    if (obj && obj.__esModule) {
+        return obj;
+    } else {
+        var newObj = {
+        };
+        if (obj != null) {
+            for(var key in obj){
+                if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                    var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {
+                    };
+                    if (desc.get || desc.set) {
+                        Object.defineProperty(newObj, key, desc);
+                    } else {
+                        newObj[key] = obj[key];
+                    }
+                }
+            }
+        }
+        newObj.default = obj;
+        return newObj;
+    }
+}
+console.log(action);
+console.log(action.default);

--- a/tests/fixture/issue-1938/esm/input/.swcrc
+++ b/tests/fixture/issue-1938/esm/input/.swcrc
@@ -1,0 +1,10 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true,
+      "dynamicImport": true,
+      "decorators": false
+    }
+  }
+}

--- a/tests/fixture/issue-1938/esm/input/index.js
+++ b/tests/fixture/issue-1938/esm/input/index.js
@@ -1,0 +1,4 @@
+import foo, * as action from './actions';
+
+console.log(action);
+console.log(foo);

--- a/tests/fixture/issue-1938/esm/output/index.js
+++ b/tests/fixture/issue-1938/esm/output/index.js
@@ -1,0 +1,3 @@
+import foo, * as action from './actions';
+console.log(action);
+console.log(foo);


### PR DESCRIPTION
- closes #1938 

This PR attempts to allow named wildcard imports when there are multiple import specifiers. Currently it is unreachable code paths, but it is possible to have imports like

```
import foo, * as actions from '...'
```

to have default import with named imports. PR treats namespace same as single import with namespace case. 

I feel this may not be feasible approach, or brings redundant code paths and would like to update as needed.

