### PR TITLE
fix(es/transforms): Fix bugs

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -43,6 +43,16 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
 
+      - name: Strip (linux)
+        shell: bash
+        if: matrix.os == 'ubuntu-18.04'
+        run: strip swc.*.node
+
+      - name: Strip (mac os x)
+        shell: bash
+        if: matrix.os == 'macos-latest'
+        run: strip -x swc.*.node
+
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["strip"]
-
 [workspace]
 members = ["ecmascript", "ecmascript/jsdoc", "node/binding", "wasm"]
 
@@ -63,7 +61,6 @@ name = "usage"
 [profile.release]
 codegen-units = 1
 lto = true
-strip = 'symbols'
 # debug = true
 # opt-level = 'z'
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.29.1"
+version = "0.30.0"
 
 [lib]
 name = "swc"

--- a/bundler/tests/fixture/deno-8574/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-8574/output/entry.inlined.ts
@@ -100,7 +100,7 @@ function drainQueue() {
     while(len){
         currentQueue = queue;
         queue = [];
-        while((++queueIndex) < len){
+        while(++queueIndex < len){
             if (currentQueue) {
                 currentQueue[queueIndex].run();
             }

--- a/bundler/tests/fixture/deno-8574/output/entry.ts
+++ b/bundler/tests/fixture/deno-8574/output/entry.ts
@@ -100,7 +100,7 @@ function drainQueue() {
     while(len){
         currentQueue = queue;
         queue = [];
-        while((++queueIndex) < len){
+        while(++queueIndex < len){
             if (currentQueue) {
                 currentQueue[queueIndex].run();
             }

--- a/bundler/tests/fixture/deno-9212/case1/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-9212/case1/output/entry.inlined.ts
@@ -5126,7 +5126,7 @@ Add a <Suspense fallback=...> component higher in the tree to provide a loading 
                         for(var a; S !== u || i !== 0 && S.nodeType !== 3 || (_4 = y + i), S !== s || d !== 0 && S.nodeType !== 3 || (h = y + d), S.nodeType === 3 && (y += S.nodeValue.length), (a = S.firstChild) !== null;)c = S, S = a;
                         for(;;){
                             if (S === o) break n;
-                            if (c === u && (++k) === i && (_4 = y), c === s && (++E) === d && (h = y), (a = S.nextSibling) !== null) break;
+                            if (c === u && ++k === i && (_4 = y), c === s && ++E === d && (h = y), (a = S.nextSibling) !== null) break;
                             S = c, c = S.parentNode;
                         }
                         S = a;

--- a/bundler/tests/fixture/deno-9212/case1/output/entry.ts
+++ b/bundler/tests/fixture/deno-9212/case1/output/entry.ts
@@ -5126,7 +5126,7 @@ Add a <Suspense fallback=...> component higher in the tree to provide a loading 
                         for(var a; S !== u || i !== 0 && S.nodeType !== 3 || (_4 = y + i), S !== s || d !== 0 && S.nodeType !== 3 || (h = y + d), S.nodeType === 3 && (y += S.nodeValue.length), (a = S.firstChild) !== null;)c = S, S = a;
                         for(;;){
                             if (S === o) break n;
-                            if (c === u && (++k) === i && (_4 = y), c === s && (++E) === d && (h = y), (a = S.nextSibling) !== null) break;
+                            if (c === u && ++k === i && (_4 = y), c === s && ++E === d && (h = y), (a = S.nextSibling) !== null) break;
                             S = c, c = S.parentNode;
                         }
                         S = a;

--- a/bundler/tests/fixture/deno-9591/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-9591/output/entry.inlined.ts
@@ -756,7 +756,7 @@ function basename(path, ext = "") {
                 }
                 if (extIdx >= 0) {
                     if (code === ext.charCodeAt(extIdx)) {
-                        if ((--extIdx) === -1) {
+                        if (--extIdx === -1) {
                             end = i;
                         }
                     } else {
@@ -1139,7 +1139,7 @@ function basename1(path, ext = "") {
                 }
                 if (extIdx >= 0) {
                     if (code === ext.charCodeAt(extIdx)) {
-                        if ((--extIdx) === -1) {
+                        if (--extIdx === -1) {
                             end = i;
                         }
                     } else {

--- a/bundler/tests/fixture/deno-9591/output/entry.ts
+++ b/bundler/tests/fixture/deno-9591/output/entry.ts
@@ -764,7 +764,7 @@ function basename(path, ext = "") {
                 }
                 if (extIdx >= 0) {
                     if (code === ext.charCodeAt(extIdx)) {
-                        if ((--extIdx) === -1) {
+                        if (--extIdx === -1) {
                             end = i;
                         }
                     } else {
@@ -1147,7 +1147,7 @@ function basename1(path, ext = "") {
                 }
                 if (extIdx >= 0) {
                     if (code === ext.charCodeAt(extIdx)) {
-                        if ((--extIdx) === -1) {
+                        if (--extIdx === -1) {
                             end = i;
                         }
                     } else {

--- a/bundler/tests/fixture/deno-9620/case1/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-9620/case1/output/entry.inlined.ts
@@ -668,7 +668,7 @@ function basename(path, ext = "") {
                 }
                 if (extIdx >= 0) {
                     if (code === ext.charCodeAt(extIdx)) {
-                        if ((--extIdx) === -1) {
+                        if (--extIdx === -1) {
                             end = i;
                         }
                     } else {
@@ -1051,7 +1051,7 @@ function basename1(path, ext = "") {
                 }
                 if (extIdx >= 0) {
                     if (code === ext.charCodeAt(extIdx)) {
-                        if ((--extIdx) === -1) {
+                        if (--extIdx === -1) {
                             end = i;
                         }
                     } else {

--- a/bundler/tests/fixture/deno-9620/case1/output/entry.ts
+++ b/bundler/tests/fixture/deno-9620/case1/output/entry.ts
@@ -676,7 +676,7 @@ function basename(path, ext = "") {
                 }
                 if (extIdx >= 0) {
                     if (code === ext.charCodeAt(extIdx)) {
-                        if ((--extIdx) === -1) {
+                        if (--extIdx === -1) {
                             end = i;
                         }
                     } else {
@@ -1059,7 +1059,7 @@ function basename1(path, ext = "") {
                 }
                 if (extIdx >= 0) {
                     if (code === ext.charCodeAt(extIdx)) {
-                        if ((--extIdx) === -1) {
+                        if (--extIdx === -1) {
                             end = i;
                         }
                     } else {

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.22.2"
+version = "0.22.3"
 
 [dependencies]
 fxhash = "0.2.1"

--- a/ecmascript/transforms/base/src/fixer.rs
+++ b/ecmascript/transforms/base/src/fixer.rs
@@ -243,7 +243,7 @@ impl VisitMut for Fixer<'_> {
                 || expr.op == op!("!==") => {}
 
             Expr::Seq(..)
-            | Expr::Update(..)
+            | Expr::Update(UpdateExpr { prefix: false, .. })
             | Expr::Unary(UnaryExpr {
                 op: op!("delete"), ..
             })
@@ -1340,6 +1340,8 @@ var store = global[SHARED] || (global[SHARED] = {});
         "(--remaining) || deferred.resolveWith()",
         "--remaining || deferred.resolveWith()"
     );
+
+    test_fixer!(minifier_010, "(--remaining) + ''", "--remaining + ''");
 
     identical!(
         if_stmt_001,

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.25.1"
+version = "0.25.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/ecmascript/transforms/compat/tests/es2015_classes.rs
+++ b/ecmascript/transforms/compat/tests/es2015_classes.rs
@@ -6444,3 +6444,26 @@ test!(
     }
     "
 );
+
+test!(
+    syntax(),
+    |t| tr(t),
+    issue_1869_1,
+    "
+    var _class;
+    let TestClass = _class = someClassDecorator((_class = function() {
+        class TestClass {
+        }
+        _defineProperty(TestClass, 'Something', 'hello');
+        _defineProperty(TestClass, 'SomeProperties', {
+            firstProp: TestClass.Something
+        });
+        return TestClass;
+    }()) || _class) || _class;
+    function someClassDecorator(c) {
+        return c;
+    }
+    ",
+    "
+    "
+);

--- a/ecmascript/transforms/compat/tests/es2015_classes.rs
+++ b/ecmascript/transforms/compat/tests/es2015_classes.rs
@@ -6444,26 +6444,3 @@ test!(
     }
     "
 );
-
-test!(
-    syntax(),
-    |t| tr(t),
-    issue_1869_1,
-    "
-    var _class;
-    let TestClass = _class = someClassDecorator((_class = function() {
-        class TestClass {
-        }
-        _defineProperty(TestClass, 'Something', 'hello');
-        _defineProperty(TestClass, 'SomeProperties', {
-            firstProp: TestClass.Something
-        });
-        return TestClass;
-    }()) || _class) || _class;
-    function someClassDecorator(c) {
-        return c;
-    }
-    ",
-    "
-    "
-);

--- a/ecmascript/transforms/compat/tests/es2020_class_properties.rs
+++ b/ecmascript/transforms/compat/tests/es2020_class_properties.rs
@@ -5509,23 +5509,3 @@ test!(
     }
     "
 );
-
-test!(
-    syntax(),
-    |_| class_properties(),
-    issue_1869_2,
-    "
-    var _class;
-    let TestClass = _class = someClassDecorator((_class = class TestClass {
-        static Something = 'hello';
-        static SomeProperties = {
-            firstProp: TestClass.Something
-        };
-    }) || _class) || _class;
-    function someClassDecorator(c) {
-        return c;
-    }
-    ",
-    "
-    "
-);

--- a/ecmascript/transforms/compat/tests/es2020_class_properties.rs
+++ b/ecmascript/transforms/compat/tests/es2020_class_properties.rs
@@ -5527,5 +5527,18 @@ test!(
     }
     ",
     "
+    var _class;
+    let TestClass = _class = someClassDecorator((_class = function() {
+        class TestClass {
+        }
+        _defineProperty(TestClass, 'Something', 'hello');
+        _defineProperty(TestClass, 'SomeProperties', {
+            firstProp: TestClass.Something
+        });
+        return TestClass;
+    }()) || _class) || _class;
+    function someClassDecorator(c) {
+        return c;
+    }
     "
 );

--- a/ecmascript/transforms/compat/tests/es2020_class_properties.rs
+++ b/ecmascript/transforms/compat/tests/es2020_class_properties.rs
@@ -5497,5 +5497,15 @@ test!(
         return c;
     }
     ",
-    ""
+    "
+    class TestClass {
+    }
+    _defineProperty(TestClass, 'Something', 'hello');
+    _defineProperty(TestClass, 'SomeProperties', {
+        firstProp: TestClass.Something
+    });
+    function someClassDecorator(c) {
+        return c;
+    }
+    "
 );

--- a/ecmascript/transforms/compat/tests/es2020_class_properties.rs
+++ b/ecmascript/transforms/compat/tests/es2020_class_properties.rs
@@ -5509,3 +5509,23 @@ test!(
     }
     "
 );
+
+test!(
+    syntax(),
+    |_| class_properties(),
+    issue_1869_2,
+    "
+    var _class;
+    let TestClass = _class = someClassDecorator((_class = class TestClass {
+        static Something = 'hello';
+        static SomeProperties = {
+            firstProp: TestClass.Something
+        };
+    }) || _class) || _class;
+    function someClassDecorator(c) {
+        return c;
+    }
+    ",
+    "
+    "
+);

--- a/ecmascript/transforms/compat/tests/es2020_class_properties.rs
+++ b/ecmascript/transforms/compat/tests/es2020_class_properties.rs
@@ -5479,3 +5479,23 @@ test!(
     new Foo();
     "
 );
+
+test!(
+    syntax(),
+    |_| class_properties(),
+    issue_1869_1,
+    "
+    class TestClass {
+        static Something = 'hello';
+
+        static SomeProperties = {
+            firstProp: TestClass.Something,
+        };
+    }
+
+    function someClassDecorator(c) {
+        return c;
+    }
+    ",
+    ""
+);

--- a/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
+++ b/ecmascript/transforms/optimization/src/simplify/expr/mod.rs
@@ -1316,13 +1316,13 @@ impl VisitMut for SimplifyExpr {
                                 if expr.is_object() =>
                             {
                                 let props = expr.object().unwrap().props;
-                                ps.extend(props)
+                                ps.extend(props);
+                                self.changed = true;
                             }
 
                             _ => ps.push(p),
                         }
                     }
-                    self.changed = true;
                     ObjectLit { span, props: ps }.into()
                 }
 

--- a/ecmascript/transforms/optimization/tests/expr-simplifier/issue-1846/fcase1/input.js
+++ b/ecmascript/transforms/optimization/tests/expr-simplifier/issue-1846/fcase1/input.js
@@ -1,0 +1,20 @@
+import "reflect-metadata";
+
+const Test = (target) => {
+    const metadata = Reflect.getMetadataKeys(target).reduce((metadata, key) => {
+        const { [key]: values = [] } = metadata;
+
+        const all = Reflect.getMetadata(key, target);
+        const own = Reflect.getOwnMetadata(key, target);
+
+        return {
+            ...metadata,
+            [key]: [{ all, own }, ...values],
+        };
+    }, {});
+
+    console.dir(metadata, { depth: 5 });
+};
+
+@Test
+export class Foo { }

--- a/ecmascript/transforms/optimization/tests/expr-simplifier/issue-1846/fcase1/input.js
+++ b/ecmascript/transforms/optimization/tests/expr-simplifier/issue-1846/fcase1/input.js
@@ -16,5 +16,4 @@ const Test = (target) => {
     console.dir(metadata, { depth: 5 });
 };
 
-@Test
 export class Foo { }

--- a/ecmascript/transforms/optimization/tests/expr-simplifier/issue-1846/fcase1/output.js
+++ b/ecmascript/transforms/optimization/tests/expr-simplifier/issue-1846/fcase1/output.js
@@ -1,0 +1,24 @@
+import   "reflect-metadata";
+const Test = (target)=>{
+    const metadata = Reflect.getMetadataKeys(target).reduce((metadata, key)=>{
+        const { [key]: values = []  } = metadata;
+        const all = Reflect.getMetadata(key, target);
+        const own = Reflect.getOwnMetadata(key, target);
+        return {
+            ...metadata,
+            [key]: [
+                {
+                    all,
+                    own
+                },
+                ...values
+            ]
+        };
+    }, {
+    });
+    console.dir(metadata, {
+        depth: 5
+    });
+};
+export class Foo {
+}

--- a/ecmascript/transforms/optimization/tests/expr-simplifier/issue-1901/case1/input.js
+++ b/ecmascript/transforms/optimization/tests/expr-simplifier/issue-1901/case1/input.js
@@ -1,0 +1,5 @@
+const object = { a: true }
+
+export const mapContextToProps = () => {
+    return { ...object }
+}

--- a/ecmascript/transforms/optimization/tests/expr-simplifier/issue-1901/case1/output.js
+++ b/ecmascript/transforms/optimization/tests/expr-simplifier/issue-1901/case1/output.js
@@ -1,0 +1,8 @@
+const object = {
+    a: true
+};
+export const mapContextToProps = ()=>{
+    return {
+        ...object
+    };
+};

--- a/ecmascript/transforms/optimization/tests/fixture.rs
+++ b/ecmascript/transforms/optimization/tests/fixture.rs
@@ -47,7 +47,7 @@ fn expr(input: PathBuf) {
             dynamic_import: true,
             ..Default::default()
         }),
-        &|_| expr_simplifier(),
+        &|_| Repeat::new(expr_simplifier()),
         &input,
         &output,
     );

--- a/ecmascript/transforms/proposal/Cargo.toml
+++ b/ecmascript/transforms/proposal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_proposal"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.26.0"
+version = "0.26.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ecmascript/transforms/proposal/src/decorators/legacy.rs
+++ b/ecmascript/transforms/proposal/src/decorators/legacy.rs
@@ -471,7 +471,7 @@ impl Legacy {
                 }))
             }
 
-            ClassMember::ClassProp(mut p) if !p.decorators.is_empty() => {
+            ClassMember::ClassProp(p) if !p.decorators.is_empty() => {
                 let prototype = if p.is_static {
                     cls_ident.clone().as_arg()
                 } else {

--- a/ecmascript/transforms/proposal/src/decorators/legacy.rs
+++ b/ecmascript/transforms/proposal/src/decorators/legacy.rs
@@ -310,6 +310,15 @@ impl Legacy {
             computed: false,
         };
 
+        c.class.body.iter_mut().for_each(|m| match m {
+            ClassMember::ClassProp(p) => {
+                if let Some(name) = &cls_name {
+                    replace_ident(&mut p.value, name.to_id(), &cls_ident);
+                }
+            }
+            _ => {}
+        });
+
         c.class.body = c.class.body.move_flat_map(|m| match m {
             ClassMember::Method(mut m)
                 if !m.function.decorators.is_empty()

--- a/ecmascript/transforms/proposal/src/decorators/legacy.rs
+++ b/ecmascript/transforms/proposal/src/decorators/legacy.rs
@@ -310,15 +310,6 @@ impl Legacy {
             computed: false,
         };
 
-        c.class.body.iter_mut().for_each(|m| match m {
-            ClassMember::ClassProp(p) => {
-                if let Some(name) = &cls_name {
-                    replace_ident(&mut p.value, name.to_id(), &cls_ident);
-                }
-            }
-            _ => {}
-        });
-
         c.class.body = c.class.body.move_flat_map(|m| match m {
             ClassMember::Method(mut m)
                 if !m.function.decorators.is_empty()
@@ -480,7 +471,7 @@ impl Legacy {
                 }))
             }
 
-            ClassMember::ClassProp(p) if !p.decorators.is_empty() => {
+            ClassMember::ClassProp(mut p) if !p.decorators.is_empty() => {
                 let prototype = if p.is_static {
                     cls_ident.clone().as_arg()
                 } else {

--- a/ecmascript/transforms/tests/decorators.rs
+++ b/ecmascript/transforms/tests/decorators.rs
@@ -5953,6 +5953,7 @@ let Store = ((_class = class Store extends BaseStore {
 test!(
     syntax(false),
     |_| decorators(Config {
+        legacy: true,
         ..Default::default()
     }),
     issue_1869_1,

--- a/ecmascript/transforms/tests/decorators.rs
+++ b/ecmascript/transforms/tests/decorators.rs
@@ -5976,7 +5976,7 @@ test!(
     let TestClass = _class = someClassDecorator((_class = class TestClass {
         static Something = 'hello';
         static SomeProperties = {
-            firstProp: TestClass.Something
+            firstProp: _class.Something
         };
     }) || _class) || _class;
     function someClassDecorator(c) {

--- a/ecmascript/transforms/tests/decorators.rs
+++ b/ecmascript/transforms/tests/decorators.rs
@@ -5949,3 +5949,26 @@ let Store = ((_class = class Store extends BaseStore {
 }), _class);
 "
 );
+
+test!(
+    syntax(false),
+    |_| decorators(Config {
+        ..Default::default()
+    }),
+    issue_1869_1,
+    "
+    @someClassDecorator
+    class TestClass {
+        static Something = 'hello';
+
+        static SomeProperties = {
+            firstProp: TestClass.Something,
+        };
+    }
+
+    function someClassDecorator(c) {
+        return c;
+    }
+    ",
+    ""
+);

--- a/ecmascript/transforms/tests/decorators.rs
+++ b/ecmascript/transforms/tests/decorators.rs
@@ -5971,5 +5971,16 @@ test!(
         return c;
     }
     ",
-    ""
+    "
+    var _class;
+    let TestClass = _class = someClassDecorator((_class = class TestClass {
+        static Something = 'hello';
+        static SomeProperties = {
+            firstProp: TestClass.Something
+        };
+    }) || _class) || _class;
+    function someClassDecorator(c) {
+        return c;
+    }
+    "
 );

--- a/ecmascript/transforms/tests/decorators.rs
+++ b/ecmascript/transforms/tests/decorators.rs
@@ -5976,7 +5976,7 @@ test!(
     let TestClass = _class = someClassDecorator((_class = class TestClass {
         static Something = 'hello';
         static SomeProperties = {
-            firstProp: _class.Something
+            firstProp: TestClass.Something
         };
     }) || _class) || _class;
     function someClassDecorator(c) {

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.28.1"
+version = "0.28.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/ecmascript/transforms/typescript/tests/strip.rs
+++ b/ecmascript/transforms/typescript/tests/strip.rs
@@ -4041,5 +4041,14 @@ to!(
     }
     ",
     "
+    var _class;
+    var _class1;
+    let TestClass = _class1 = someClassDecorator((_class1 = (_class = class TestClass {
+    }, _class.Something = 'hello', _class.SomeProperties = {
+        firstProp: _class.Something
+    }, _class)) || _class1) || _class1;
+    function someClassDecorator(c) {
+        return c;
+    }
     "
 );

--- a/ecmascript/transforms/typescript/tests/strip.rs
+++ b/ecmascript/transforms/typescript/tests/strip.rs
@@ -4025,3 +4025,21 @@ to!(
     console.log(b.Foo);
     "
 );
+
+to!(
+    issue_1869_3,
+    "
+    var _class;
+    let TestClass = _class = someClassDecorator((_class = class TestClass {
+        static Something = 'hello';
+        static SomeProperties = {
+            firstProp: TestClass.Something
+        };
+    }) || _class) || _class;
+    function someClassDecorator(c) {
+        return c;
+    }
+    ",
+    "
+    "
+);

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.40.0"
+version = "0.40.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ecmascript/utils/src/lib.rs
+++ b/ecmascript/utils/src/lib.rs
@@ -21,7 +21,9 @@ use std::{
 use swc_atoms::{js_word, JsWord};
 use swc_common::{errors::Handler, Mark, Span, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitMut, VisitMutWith, VisitWith};
+use swc_ecma_visit::{
+    noop_visit_mut_type, noop_visit_type, Node, Visit, VisitMut, VisitMutWith, VisitWith,
+};
 use unicode_xid::UnicodeXID;
 
 #[macro_use]
@@ -2016,5 +2018,36 @@ pub fn prop_name_eq(p: &PropName, key: &str) -> bool {
             Expr::Lit(Lit::Str(Str { value, .. })) => *value == *key,
             _ => false,
         },
+    }
+}
+
+pub fn replace_ident<T>(node: &mut T, from: Id, to: &Ident)
+where
+    T: for<'any> VisitMutWith<IdentReplacer<'any>>,
+{
+    node.visit_mut_with(&mut IdentReplacer { from, to })
+}
+
+pub struct IdentReplacer<'a> {
+    from: Id,
+    to: &'a Ident,
+}
+
+impl VisitMut for IdentReplacer<'_> {
+    noop_visit_mut_type!();
+
+    fn visit_mut_ident(&mut self, node: &mut Ident) {
+        if node.sym == self.from.0 && node.span.ctxt == self.from.1 {
+            *node = self.to.clone();
+            return;
+        }
+    }
+
+    fn visit_mut_member_expr(&mut self, node: &mut MemberExpr) {
+        node.obj.visit_mut_with(self);
+
+        if node.computed {
+            node.prop.visit_mut_with(self);
+        }
     }
 }

--- a/ecmascript/utils/src/lib.rs
+++ b/ecmascript/utils/src/lib.rs
@@ -2021,6 +2021,14 @@ pub fn prop_name_eq(p: &PropName, key: &str) -> bool {
     }
 }
 
+/// Replace all `from` in `expr` with `to`.
+///
+/// # Usage
+
+///
+/// ```ignore
+/// replace_ident(&mut dec.expr, cls_name.to_id(), alias);
+/// ```
 pub fn replace_ident<T>(node: &mut T, from: Id, to: &Ident)
 where
     T: for<'any> VisitMutWith<IdentReplacer<'any>>,

--- a/spack/tests/pass/issue-1328/case1/output/entry.js
+++ b/spack/tests/pass/issue-1328/case1/output/entry.js
@@ -436,7 +436,7 @@ var load = __spack_require__.bind(void 0, function(module, exports) {
                 if (typeof iterable.next === "function") return iterable;
                 if (!isNaN(iterable.length)) {
                     var i = -1, next = function next1() {
-                        while((++i) < iterable.length)if (hasOwn.call(iterable, i)) {
+                        while(++i < iterable.length)if (hasOwn.call(iterable, i)) {
                             next1.value = iterable[i];
                             next1.done = false;
                             return next1;

--- a/tests/fixture/issue-1333/case2/output/index.js
+++ b/tests/fixture/issue-1333/case2/output/index.js
@@ -63,7 +63,7 @@ class Shard extends _utils.Emitter {
         if (this.connected) {
             let _i = 0, _w = 1;
             const func = ()=>{
-                if ((++_i) < _w) {
+                if (++_i < _w) {
                     return;
                 }
                 const encoded = _classPrivateFieldGet(this, _serialization2).encode(data);

--- a/tests/fixture/issue-1869/decorator/.swcrc
+++ b/tests/fixture/issue-1869/decorator/.swcrc
@@ -1,0 +1,8 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "decorators": true
+        }
+    }
+}

--- a/tests/fixture/issue-1869/decorator/input/index.ts
+++ b/tests/fixture/issue-1869/decorator/input/index.ts
@@ -1,0 +1,12 @@
+@someClassDecorator
+class TestClass {
+    static Something = 'hello';
+
+    static SomeProperties = {
+        firstProp: TestClass.Something,
+    };
+}
+
+function someClassDecorator(c) {
+    return c;
+}

--- a/tests/fixture/issue-1869/decorator/output/index.ts
+++ b/tests/fixture/issue-1869/decorator/output/index.ts
@@ -1,0 +1,16 @@
+function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+        throw new TypeError("Cannot call a class as a function");
+    }
+}
+var _class;
+var _class1;
+var TestClass = _class1 = someClassDecorator((_class1 = (_class = function TestClass1() {
+    "use strict";
+    _classCallCheck(this, TestClass1);
+}, _class.Something = 'hello', _class.SomeProperties = {
+    firstProp: _class.Something
+}, _class)) || _class1) || _class1;
+function someClassDecorator(c) {
+    return c;
+}


### PR DESCRIPTION
swc_ecma_trasnsforms_base:
 - [x] `fixer`: Don't de-optimize `++foo || bar`.

swc_ecma_trasnsforms_typescript:
 - [x] Allow using properties from a decorated class. (Closes #1869)

swc_ecma_transforms_optimization:
 - [x] Fix infinite loop. (Closes #1901, Closes #1946)