### PR TITLE
fix(transform): calculate class member fn args identifier collision

### DIFF
--- a/bundler/tests/fixture/deno-8211-3/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-8211-3/output/entry.inlined.ts
@@ -1,8 +1,8 @@
 class LuxonError extends Error {
 }
 class InvalidDateTimeError extends LuxonError {
-    constructor(reason4){
-        super(`Invalid DateTime: ${reason4.toMessage()}`);
+    constructor(reason){
+        super(`Invalid DateTime: ${reason.toMessage()}`);
     }
 }
 class InvalidIntervalError extends LuxonError {
@@ -18,8 +18,8 @@ class InvalidDurationError extends LuxonError {
 class ConflictingSpecificationError extends LuxonError {
 }
 class InvalidUnitError extends LuxonError {
-    constructor(unit1){
-        super(`Invalid unit ${unit1}`);
+    constructor(unit){
+        super(`Invalid unit ${unit}`);
     }
 }
 class InvalidArgumentError extends LuxonError {
@@ -244,152 +244,152 @@ function timeObject(obj) {
     ]);
 }
 const ianaRegex = /[A-Za-z_+-]{1,256}(:?\/[A-Za-z_+-]{1,256}(\/[A-Za-z_+-]{1,256})?)?/;
-const n1 = "numeric", s1 = "short", l = "long";
+const n = "numeric", s = "short", l = "long";
 const DATE_SHORT = {
-    year: n1,
-    month: n1,
-    day: n1
+    year: n,
+    month: n,
+    day: n
 };
 const DATE_MED = {
-    year: n1,
-    month: s1,
-    day: n1
+    year: n,
+    month: s,
+    day: n
 };
 const DATE_MED_WITH_WEEKDAY = {
-    year: n1,
-    month: s1,
-    day: n1,
-    weekday: s1
+    year: n,
+    month: s,
+    day: n,
+    weekday: s
 };
 const DATE_FULL = {
-    year: n1,
+    year: n,
     month: l,
-    day: n1
+    day: n
 };
 const DATE_HUGE = {
-    year: n1,
+    year: n,
     month: l,
-    day: n1,
+    day: n,
     weekday: l
 };
 const TIME_SIMPLE = {
-    hour: n1,
-    minute: n1
+    hour: n,
+    minute: n
 };
 const TIME_WITH_SECONDS = {
-    hour: n1,
-    minute: n1,
-    second: n1
+    hour: n,
+    minute: n,
+    second: n
 };
 const TIME_WITH_SHORT_OFFSET = {
-    hour: n1,
-    minute: n1,
-    second: n1,
-    timeZoneName: s1
+    hour: n,
+    minute: n,
+    second: n,
+    timeZoneName: s
 };
 const TIME_WITH_LONG_OFFSET = {
-    hour: n1,
-    minute: n1,
-    second: n1,
+    hour: n,
+    minute: n,
+    second: n,
     timeZoneName: l
 };
 const TIME_24_SIMPLE = {
-    hour: n1,
-    minute: n1,
+    hour: n,
+    minute: n,
     hour12: false
 };
 const TIME_24_WITH_SECONDS = {
-    hour: n1,
-    minute: n1,
-    second: n1,
+    hour: n,
+    minute: n,
+    second: n,
     hour12: false
 };
 const TIME_24_WITH_SHORT_OFFSET = {
-    hour: n1,
-    minute: n1,
-    second: n1,
+    hour: n,
+    minute: n,
+    second: n,
     hour12: false,
-    timeZoneName: s1
+    timeZoneName: s
 };
 const TIME_24_WITH_LONG_OFFSET = {
-    hour: n1,
-    minute: n1,
-    second: n1,
+    hour: n,
+    minute: n,
+    second: n,
     hour12: false,
     timeZoneName: l
 };
 const DATETIME_SHORT = {
-    year: n1,
-    month: n1,
-    day: n1,
-    hour: n1,
-    minute: n1
+    year: n,
+    month: n,
+    day: n,
+    hour: n,
+    minute: n
 };
 const DATETIME_SHORT_WITH_SECONDS = {
-    year: n1,
-    month: n1,
-    day: n1,
-    hour: n1,
-    minute: n1,
-    second: n1
+    year: n,
+    month: n,
+    day: n,
+    hour: n,
+    minute: n,
+    second: n
 };
 const DATETIME_MED = {
-    year: n1,
-    month: s1,
-    day: n1,
-    hour: n1,
-    minute: n1
+    year: n,
+    month: s,
+    day: n,
+    hour: n,
+    minute: n
 };
 const DATETIME_MED_WITH_SECONDS = {
-    year: n1,
-    month: s1,
-    day: n1,
-    hour: n1,
-    minute: n1,
-    second: n1
+    year: n,
+    month: s,
+    day: n,
+    hour: n,
+    minute: n,
+    second: n
 };
 const DATETIME_MED_WITH_WEEKDAY = {
-    year: n1,
-    month: s1,
-    day: n1,
-    weekday: s1,
-    hour: n1,
-    minute: n1
+    year: n,
+    month: s,
+    day: n,
+    weekday: s,
+    hour: n,
+    minute: n
 };
 const DATETIME_FULL = {
-    year: n1,
+    year: n,
     month: l,
-    day: n1,
-    hour: n1,
-    minute: n1,
-    timeZoneName: s1
+    day: n,
+    hour: n,
+    minute: n,
+    timeZoneName: s
 };
 const DATETIME_FULL_WITH_SECONDS = {
-    year: n1,
+    year: n,
     month: l,
-    day: n1,
-    hour: n1,
-    minute: n1,
-    second: n1,
-    timeZoneName: s1
+    day: n,
+    hour: n,
+    minute: n,
+    second: n,
+    timeZoneName: s
 };
 const DATETIME_HUGE = {
-    year: n1,
+    year: n,
     month: l,
-    day: n1,
+    day: n,
     weekday: l,
-    hour: n1,
-    minute: n1,
+    hour: n,
+    minute: n,
     timeZoneName: l
 };
 const DATETIME_HUGE_WITH_SECONDS = {
-    year: n1,
+    year: n,
     month: l,
-    day: n1,
+    day: n,
     weekday: l,
-    hour: n1,
-    minute: n1,
-    second: n1,
+    hour: n,
+    minute: n,
+    second: n,
     timeZoneName: l
 };
 function stringify(obj) {
@@ -770,100 +770,100 @@ class Formatter {
         this.loc = locale1;
         this.systemLoc = null;
     }
-    formatWithSystemDefault(dt, opts) {
+    formatWithSystemDefault(dt, opts1) {
         if (this.systemLoc === null) {
             this.systemLoc = this.loc.redefaultToSystem();
         }
         const df = this.systemLoc.dtFormatter(dt, Object.assign({
-        }, this.opts, opts));
+        }, this.opts, opts1));
         return df.format();
     }
-    formatDateTime(dt, opts = {
+    formatDateTime(dt1, opts2 = {
     }) {
-        const df = this.loc.dtFormatter(dt, Object.assign({
-        }, this.opts, opts));
+        const df = this.loc.dtFormatter(dt1, Object.assign({
+        }, this.opts, opts2));
         return df.format();
     }
-    formatDateTimeParts(dt, opts = {
+    formatDateTimeParts(dt2, opts3 = {
     }) {
-        const df = this.loc.dtFormatter(dt, Object.assign({
-        }, this.opts, opts));
+        const df = this.loc.dtFormatter(dt2, Object.assign({
+        }, this.opts, opts3));
         return df.formatToParts();
     }
-    resolvedOptions(dt, opts = {
+    resolvedOptions(dt3, opts4 = {
     }) {
-        const df = this.loc.dtFormatter(dt, Object.assign({
-        }, this.opts, opts));
+        const df = this.loc.dtFormatter(dt3, Object.assign({
+        }, this.opts, opts4));
         return df.resolvedOptions();
     }
-    num(n, p = 0) {
+    num(n1, p = 0) {
         if (this.opts.forceSimple) {
-            return padStart(n, p);
+            return padStart(n1, p);
         }
-        const opts = Object.assign({
+        const opts5 = Object.assign({
         }, this.opts);
         if (p > 0) {
-            opts.padTo = p;
+            opts5.padTo = p;
         }
-        return this.loc.numberFormatter(opts).format(n);
+        return this.loc.numberFormatter(opts5).format(n1);
     }
-    formatDateTimeFromString(dt, fmt) {
-        const knownEnglish = this.loc.listingMode() === "en", useDateTimeFormatter = this.loc.outputCalendar && this.loc.outputCalendar !== "gregory" && hasFormatToParts(), string = (opts, extract)=>this.loc.extract(dt, opts, extract)
-        , formatOffset1 = (opts)=>{
-            if (dt.isOffsetFixed && dt.offset === 0 && opts.allowZ) {
+    formatDateTimeFromString(dt4, fmt1) {
+        const knownEnglish = this.loc.listingMode() === "en", useDateTimeFormatter = this.loc.outputCalendar && this.loc.outputCalendar !== "gregory" && hasFormatToParts(), string = (opts5, extract)=>this.loc.extract(dt4, opts5, extract)
+        , formatOffset1 = (opts5)=>{
+            if (dt4.isOffsetFixed && dt4.offset === 0 && opts5.allowZ) {
                 return "Z";
             }
-            return dt.isValid ? dt.zone.formatOffset(dt.ts, opts.format) : "";
-        }, meridiem = ()=>knownEnglish ? meridiemForDateTime(dt) : string({
+            return dt4.isValid ? dt4.zone.formatOffset(dt4.ts, opts5.format) : "";
+        }, meridiem = ()=>knownEnglish ? meridiemForDateTime(dt4) : string({
                 hour: "numeric",
                 hour12: true
             }, "dayperiod")
-        , month = (length, standalone)=>knownEnglish ? monthForDateTime(dt, length) : string(standalone ? {
+        , month = (length, standalone)=>knownEnglish ? monthForDateTime(dt4, length) : string(standalone ? {
                 month: length
             } : {
                 month: length,
                 day: "numeric"
             }, "month")
-        , weekday = (length, standalone)=>knownEnglish ? weekdayForDateTime(dt, length) : string(standalone ? {
+        , weekday = (length, standalone)=>knownEnglish ? weekdayForDateTime(dt4, length) : string(standalone ? {
                 weekday: length
             } : {
                 weekday: length,
                 month: "long",
                 day: "numeric"
             }, "weekday")
-        , maybeMacro = (token)=>{
-            const formatOpts1 = Formatter.macroTokenToFormatOpts(token);
+        , maybeMacro = (token1)=>{
+            const formatOpts1 = Formatter.macroTokenToFormatOpts(token1);
             if (formatOpts1) {
-                return this.formatWithSystemDefault(dt, formatOpts1);
+                return this.formatWithSystemDefault(dt4, formatOpts1);
             } else {
-                return token;
+                return token1;
             }
-        }, era = (length)=>knownEnglish ? eraForDateTime(dt, length) : string({
+        }, era = (length)=>knownEnglish ? eraForDateTime(dt4, length) : string({
                 era: length
             }, "era")
-        , tokenToString = (token)=>{
-            switch(token){
+        , tokenToString = (token1)=>{
+            switch(token1){
                 case "S":
-                    return this.num(dt.millisecond);
+                    return this.num(dt4.millisecond);
                 case "u":
                 case "SSS":
-                    return this.num(dt.millisecond, 3);
+                    return this.num(dt4.millisecond, 3);
                 case "s":
-                    return this.num(dt.second);
+                    return this.num(dt4.second);
                 case "ss":
-                    return this.num(dt.second, 2);
+                    return this.num(dt4.second, 2);
                 case "m":
-                    return this.num(dt.minute);
+                    return this.num(dt4.minute);
                 case "mm":
-                    return this.num(dt.minute, 2);
+                    return this.num(dt4.minute, 2);
                 case "h":
-                    return this.num(dt.hour % 12 === 0 ? 12 : dt.hour % 12);
+                    return this.num(dt4.hour % 12 === 0 ? 12 : dt4.hour % 12);
                 case "hh":
-                    return this.num(dt.hour % 12 === 0 ? 12 : dt.hour % 12, 2);
+                    return this.num(dt4.hour % 12 === 0 ? 12 : dt4.hour % 12, 2);
                 case "H":
-                    return this.num(dt.hour);
+                    return this.num(dt4.hour);
                 case "HH":
-                    return this.num(dt.hour, 2);
+                    return this.num(dt4.hour, 2);
                 case "Z":
                     return formatOffset1({
                         format: "narrow",
@@ -880,29 +880,29 @@ class Formatter {
                         allowZ: this.opts.allowZ
                     });
                 case "ZZZZ":
-                    return dt.zone.offsetName(dt.ts, {
+                    return dt4.zone.offsetName(dt4.ts, {
                         format: "short",
                         locale: this.loc.locale
                     });
                 case "ZZZZZ":
-                    return dt.zone.offsetName(dt.ts, {
+                    return dt4.zone.offsetName(dt4.ts, {
                         format: "long",
                         locale: this.loc.locale
                     });
                 case "z":
-                    return dt.zoneName;
+                    return dt4.zoneName;
                 case "a":
                     return meridiem();
                 case "d":
                     return useDateTimeFormatter ? string({
                         day: "numeric"
-                    }, "day") : this.num(dt.day);
+                    }, "day") : this.num(dt4.day);
                 case "dd":
                     return useDateTimeFormatter ? string({
                         day: "2-digit"
-                    }, "day") : this.num(dt.day, 2);
+                    }, "day") : this.num(dt4.day, 2);
                 case "c":
-                    return this.num(dt.weekday);
+                    return this.num(dt4.weekday);
                 case "ccc":
                     return weekday("short", true);
                 case "cccc":
@@ -910,7 +910,7 @@ class Formatter {
                 case "ccccc":
                     return weekday("narrow", true);
                 case "E":
-                    return this.num(dt.weekday);
+                    return this.num(dt4.weekday);
                 case "EEE":
                     return weekday("short", false);
                 case "EEEE":
@@ -921,12 +921,12 @@ class Formatter {
                     return useDateTimeFormatter ? string({
                         month: "numeric",
                         day: "numeric"
-                    }, "month") : this.num(dt.month);
+                    }, "month") : this.num(dt4.month);
                 case "LL":
                     return useDateTimeFormatter ? string({
                         month: "2-digit",
                         day: "numeric"
-                    }, "month") : this.num(dt.month, 2);
+                    }, "month") : this.num(dt4.month, 2);
                 case "LLL":
                     return month("short", true);
                 case "LLLL":
@@ -936,11 +936,11 @@ class Formatter {
                 case "M":
                     return useDateTimeFormatter ? string({
                         month: "numeric"
-                    }, "month") : this.num(dt.month);
+                    }, "month") : this.num(dt4.month);
                 case "MM":
                     return useDateTimeFormatter ? string({
                         month: "2-digit"
-                    }, "month") : this.num(dt.month, 2);
+                    }, "month") : this.num(dt4.month, 2);
                 case "MMM":
                     return month("short", false);
                 case "MMMM":
@@ -950,19 +950,19 @@ class Formatter {
                 case "y":
                     return useDateTimeFormatter ? string({
                         year: "numeric"
-                    }, "year") : this.num(dt.year);
+                    }, "year") : this.num(dt4.year);
                 case "yy":
                     return useDateTimeFormatter ? string({
                         year: "2-digit"
-                    }, "year") : this.num(dt.year.toString().slice(-2), 2);
+                    }, "year") : this.num(dt4.year.toString().slice(-2), 2);
                 case "yyyy":
                     return useDateTimeFormatter ? string({
                         year: "numeric"
-                    }, "year") : this.num(dt.year, 4);
+                    }, "year") : this.num(dt4.year, 4);
                 case "yyyyyy":
                     return useDateTimeFormatter ? string({
                         year: "numeric"
-                    }, "year") : this.num(dt.year, 6);
+                    }, "year") : this.num(dt4.year, 6);
                 case "G":
                     return era("short");
                 case "GG":
@@ -970,34 +970,34 @@ class Formatter {
                 case "GGGGG":
                     return era("narrow");
                 case "kk":
-                    return this.num(dt.weekYear.toString().slice(-2), 2);
+                    return this.num(dt4.weekYear.toString().slice(-2), 2);
                 case "kkkk":
-                    return this.num(dt.weekYear, 4);
+                    return this.num(dt4.weekYear, 4);
                 case "W":
-                    return this.num(dt.weekNumber);
+                    return this.num(dt4.weekNumber);
                 case "WW":
-                    return this.num(dt.weekNumber, 2);
+                    return this.num(dt4.weekNumber, 2);
                 case "o":
-                    return this.num(dt.ordinal);
+                    return this.num(dt4.ordinal);
                 case "ooo":
-                    return this.num(dt.ordinal, 3);
+                    return this.num(dt4.ordinal, 3);
                 case "q":
-                    return this.num(dt.quarter);
+                    return this.num(dt4.quarter);
                 case "qq":
-                    return this.num(dt.quarter, 2);
+                    return this.num(dt4.quarter, 2);
                 case "X":
-                    return this.num(Math.floor(dt.ts / 1000));
+                    return this.num(Math.floor(dt4.ts / 1000));
                 case "x":
-                    return this.num(dt.ts);
+                    return this.num(dt4.ts);
                 default:
-                    return maybeMacro(token);
+                    return maybeMacro(token1);
             }
         };
-        return stringifyTokens(Formatter.parseFormat(fmt), tokenToString);
+        return stringifyTokens(Formatter.parseFormat(fmt1), tokenToString);
     }
-    formatDurationFromString(dur, fmt) {
-        const tokenToField = (token)=>{
-            switch(token[0]){
+    formatDurationFromString(dur, fmt2) {
+        const tokenToField = (token1)=>{
+            switch(token1[0]){
                 case "S":
                     return "millisecond";
                 case "s":
@@ -1015,15 +1015,15 @@ class Formatter {
                 default:
                     return null;
             }
-        }, tokenToString = (lildur)=>(token)=>{
-                const mapped = tokenToField(token);
+        }, tokenToString = (lildur)=>(token1)=>{
+                const mapped = tokenToField(token1);
                 if (mapped) {
-                    return this.num(lildur.get(mapped), token.length);
+                    return this.num(lildur.get(mapped), token1.length);
                 } else {
-                    return token;
+                    return token1;
                 }
             }
-        , tokens = Formatter.parseFormat(fmt), realTokens = tokens.reduce((found, { literal , val  })=>literal ? found : found.concat(val)
+        , tokens = Formatter.parseFormat(fmt2), realTokens = tokens.reduce((found, { literal , val  })=>literal ? found : found.concat(val)
         , []), collapsed = dur.shiftTo(...realTokens.map(tokenToField).filter((t)=>t
         ));
         return stringifyTokens(tokens, tokenToString(collapsed));
@@ -1039,13 +1039,13 @@ class Zone {
     get universal() {
         throw new ZoneIsAbstractError();
     }
-    offsetName(ts, opts) {
+    offsetName(ts, opts5) {
         throw new ZoneIsAbstractError();
     }
-    formatOffset(ts, format) {
+    formatOffset(ts1, format) {
         throw new ZoneIsAbstractError();
     }
-    offset(ts) {
+    offset(ts2) {
         throw new ZoneIsAbstractError();
     }
     equals(otherZone) {
@@ -1066,9 +1066,9 @@ class FixedOffsetZone extends Zone {
     static instance(offset) {
         return offset === 0 ? FixedOffsetZone.utcInstance : new FixedOffsetZone(offset);
     }
-    static parseSpecifier(s) {
-        if (s) {
-            const r = s.match(/^utc(?:([+-]\d{1,2})(?::(\d{2}))?)?$/i);
+    static parseSpecifier(s1) {
+        if (s1) {
+            const r = s1.match(/^utc(?:([+-]\d{1,2})(?::(\d{2}))?)?$/i);
             if (r) {
                 return new FixedOffsetZone(signedOffset(r[1], r[2]));
             }
@@ -1088,8 +1088,8 @@ class FixedOffsetZone extends Zone {
     offsetName() {
         return this.name;
     }
-    formatOffset(ts, format) {
-        return formatOffset(this.fixed, format);
+    formatOffset(ts3, format1) {
+        return formatOffset(this.fixed, format1);
     }
     get universal() {
         return true;
@@ -1097,8 +1097,8 @@ class FixedOffsetZone extends Zone {
     offset() {
         return this.fixed;
     }
-    equals(otherZone) {
-        return otherZone.type === "fixed" && otherZone.fixed === this.fixed;
+    equals(otherZone1) {
+        return otherZone1.type === "fixed" && otherZone1.fixed === this.fixed;
     }
     get isValid() {
         return true;
@@ -1166,8 +1166,8 @@ class IANAZone extends Zone {
         dtfCache = {
         };
     }
-    static isValidSpecifier(s) {
-        return !!(s && s.match(matchingRegex));
+    static isValidSpecifier(s2) {
+        return !!(s2 && s2.match(matchingRegex));
     }
     static isValidZone(zone) {
         try {
@@ -1188,10 +1188,10 @@ class IANAZone extends Zone {
         }
         return null;
     }
-    constructor(name){
+    constructor(name1){
         super();
-        this.zoneName = name;
-        this.valid = IANAZone.isValidZone(name);
+        this.zoneName = name1;
+        this.valid = IANAZone.isValidZone(name1);
     }
     get type() {
         return "iana";
@@ -1202,14 +1202,14 @@ class IANAZone extends Zone {
     get universal() {
         return false;
     }
-    offsetName(ts, { format , locale  }) {
-        return parseZoneInfo(ts, format, locale, this.name);
+    offsetName(ts4, { format: format2 , locale: locale2  }) {
+        return parseZoneInfo(ts4, format2, locale2, this.name);
     }
-    formatOffset(ts, format) {
-        return formatOffset(this.offset(ts), format);
+    formatOffset(ts5, format3) {
+        return formatOffset(this.offset(ts5), format3);
     }
-    offset(ts) {
-        const date = new Date(ts), dtf = makeDTF(this.name), [year, month, day, hour, minute, second] = dtf.formatToParts ? partsOffset(dtf, date) : hackyOffset(dtf, date), adjustedHour = hour === 24 ? 0 : hour;
+    offset(ts6) {
+        const date = new Date(ts6), dtf = makeDTF(this.name), [year, month, day, hour, minute, second] = dtf.formatToParts ? partsOffset(dtf, date) : hackyOffset(dtf, date), adjustedHour = hour === 24 ? 0 : hour;
         const asUTC = objToLocalTS({
             year,
             month,
@@ -1224,8 +1224,8 @@ class IANAZone extends Zone {
         asTS -= over >= 0 ? over : 1000 + over;
         return (asUTC - asTS) / (60 * 1000);
     }
-    equals(otherZone) {
-        return otherZone.type === "iana" && otherZone.name === this.name;
+    equals(otherZone2) {
+        return otherZone2.type === "iana" && otherZone2.name === this.name;
     }
     get isValid() {
         return this.valid;
@@ -1389,7 +1389,7 @@ class InvalidZone extends Zone {
     }
 }
 function normalizeZone(input, defaultZone) {
-    let offset1;
+    let offset2;
     if (isUndefined(input) || input === null) {
         return defaultZone;
     } else if (input instanceof Zone) {
@@ -1398,8 +1398,8 @@ function normalizeZone(input, defaultZone) {
         const lowered = input.toLowerCase();
         if (lowered === "local") return defaultZone;
         else if (lowered === "utc" || lowered === "gmt") return FixedOffsetZone.utcInstance;
-        else if ((offset1 = IANAZone.parseGMTOffset(input)) != null) {
-            return FixedOffsetZone.instance(offset1);
+        else if ((offset2 = IANAZone.parseGMTOffset(input)) != null) {
+            return FixedOffsetZone.instance(offset2);
         } else if (IANAZone.isValidSpecifier(lowered)) return IANAZone.create(input);
         else return FixedOffsetZone.parseSpecifier(lowered) || new InvalidZone(input);
     } else if (isNumber(input)) {
@@ -1411,9 +1411,9 @@ function normalizeZone(input, defaultZone) {
     }
 }
 class Invalid {
-    constructor(reason3, explanation1){
+    constructor(reason3, explanation){
         this.reason = reason3;
-        this.explanation = explanation1;
+        this.explanation = explanation;
     }
     toMessage() {
         if (this.explanation) {
@@ -1442,17 +1442,17 @@ class LocalZone extends Zone {
     get universal() {
         return false;
     }
-    offsetName(ts, { format , locale  }) {
-        return parseZoneInfo(ts, format, locale);
+    offsetName(ts7, { format: format4 , locale: locale3  }) {
+        return parseZoneInfo(ts7, format4, locale3);
     }
-    formatOffset(ts, format) {
-        return formatOffset(this.offset(ts), format);
+    formatOffset(ts8, format5) {
+        return formatOffset(this.offset(ts8), format5);
     }
-    offset(ts) {
-        return -new Date(ts).getTimezoneOffset();
+    offset(ts9) {
+        return -new Date(ts9).getTimezoneOffset();
     }
-    equals(otherZone) {
-        return otherZone.type === "local";
+    equals(otherZone3) {
+        return otherZone3.type === "local";
     }
     get isValid() {
         return true;
@@ -1465,10 +1465,10 @@ function combineRegexes(...regexes) {
 }
 function combineExtractors(...extractors) {
     return (m)=>extractors.reduce(([mergedVals, mergedZone, cursor], ex)=>{
-            const [val, zone, next] = ex(m, cursor);
+            const [val, zone1, next] = ex(m, cursor);
             return [
                 Object.assign(mergedVals, val),
-                mergedZone || zone,
+                mergedZone || zone1,
                 next
             ];
         }, [
@@ -1479,15 +1479,15 @@ function combineExtractors(...extractors) {
         ]).slice(0, 2)
     ;
 }
-function parse(s2, ...patterns) {
-    if (s2 == null) {
+function parse(s3, ...patterns) {
+    if (s3 == null) {
         return [
             null,
             null
         ];
     }
     for (const [regex, extractor] of patterns){
-        const m = regex.exec(s2);
+        const m = regex.exec(s3);
         if (m) {
             return extractor(m);
         }
@@ -1543,27 +1543,27 @@ function extractISOTime(match, cursor) {
     ];
 }
 function extractISOOffset(match, cursor) {
-    const local = !match[cursor] && !match[cursor + 1], fullOffset = signedOffset(match[cursor + 1], match[cursor + 2]), zone = local ? null : FixedOffsetZone.instance(fullOffset);
+    const local = !match[cursor] && !match[cursor + 1], fullOffset = signedOffset(match[cursor + 1], match[cursor + 2]), zone1 = local ? null : FixedOffsetZone.instance(fullOffset);
     return [
         {
         },
-        zone,
+        zone1,
         cursor + 3
     ];
 }
 function extractIANAZone(match, cursor) {
-    const zone = match[cursor] ? IANAZone.create(match[cursor]) : null;
+    const zone1 = match[cursor] ? IANAZone.create(match[cursor]) : null;
     return [
         {
         },
-        zone,
+        zone1,
         cursor + 1
     ];
 }
 const isoDuration = /^-?P(?:(?:(-?\d{1,9})Y)?(?:(-?\d{1,9})M)?(?:(-?\d{1,9})W)?(?:(-?\d{1,9})D)?(?:T(?:(-?\d{1,9})H)?(?:(-?\d{1,9})M)?(?:(-?\d{1,20})(?:[.,](-?\d{1,9}))?S)?)?)$/;
 function extractISODuration(match) {
-    const [s2, yearStr, monthStr, weekStr, dayStr, hourStr, minuteStr, secondStr, millisecondsStr] = match;
-    const hasNegativePrefix = s2[0] === "-";
+    const [s3, yearStr, monthStr, weekStr, dayStr, hourStr, minuteStr, secondStr, millisecondsStr] = match;
+    const hasNegativePrefix = s3[0] === "-";
     const maybeNegate = (num)=>num && hasNegativePrefix ? -num : num
     ;
     return [
@@ -1607,21 +1607,21 @@ function fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, 
 const rfc2822 = /^(?:(Mon|Tue|Wed|Thu|Fri|Sat|Sun),\s)?(\d{1,2})\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\d{2,4})\s(\d\d):(\d\d)(?::(\d\d))?\s(?:(UT|GMT|[ECMP][SD]T)|([Zz])|(?:([+-]\d\d)(\d\d)))$/;
 function extractRFC2822(match) {
     const [, weekdayStr, dayStr, monthStr, yearStr, hourStr, minuteStr, secondStr, obsOffset, milOffset, offHourStr, offMinuteStr] = match, result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
-    let offset1;
+    let offset2;
     if (obsOffset) {
-        offset1 = obsOffsets[obsOffset];
+        offset2 = obsOffsets[obsOffset];
     } else if (milOffset) {
-        offset1 = 0;
+        offset2 = 0;
     } else {
-        offset1 = signedOffset(offHourStr, offMinuteStr);
+        offset2 = signedOffset(offHourStr, offMinuteStr);
     }
     return [
         result,
-        new FixedOffsetZone(offset1)
+        new FixedOffsetZone(offset2)
     ];
 }
-function preprocessRFC2822(s2) {
-    return s2.replace(/\([^)]*\)|[\n\t]/g, " ").replace(/(\s\s+)/g, " ").trim();
+function preprocessRFC2822(s3) {
+    return s3.replace(/\([^)]*\)|[\n\t]/g, " ").replace(/(\s\s+)/g, " ").trim();
 }
 const rfc1123 = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d\d) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d\d):(\d\d):(\d\d) GMT$/, rfc850 = /^(Monday|Tuesday|Wedsday|Thursday|Friday|Saturday|Sunday), (\d\d)-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d\d) (\d\d):(\d\d):(\d\d) GMT$/, ascii = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ( \d|\d\d) (\d\d):(\d\d):(\d\d) (\d{4})$/;
 function extractRFC1123Or850(match) {
@@ -1646,8 +1646,8 @@ const extractISOYmdTimeAndOffset = combineExtractors(extractISOYmd, extractISOTi
 const extractISOWeekTimeAndOffset = combineExtractors(extractISOWeekData, extractISOTime, extractISOOffset);
 const extractISOOrdinalDataAndTime = combineExtractors(extractISOOrdinalData, extractISOTime);
 const extractISOTimeAndOffset = combineExtractors(extractISOTime, extractISOOffset);
-function parseISODate(s2) {
-    return parse(s2, [
+function parseISODate(s3) {
+    return parse(s3, [
         isoYmdWithTimeExtensionRegex,
         extractISOYmdTimeAndOffset
     ], [
@@ -1661,14 +1661,14 @@ function parseISODate(s2) {
         extractISOTimeAndOffset
     ]);
 }
-function parseRFC2822Date(s2) {
-    return parse(preprocessRFC2822(s2), [
+function parseRFC2822Date(s3) {
+    return parse(preprocessRFC2822(s3), [
         rfc2822,
         extractRFC2822
     ]);
 }
-function parseHTTPDate(s2) {
-    return parse(s2, [
+function parseHTTPDate(s3) {
+    return parse(s3, [
         rfc1123,
         extractRFC1123Or850
     ], [
@@ -1679,8 +1679,8 @@ function parseHTTPDate(s2) {
         extractASCII
     ]);
 }
-function parseISODuration(s2) {
-    return parse(s2, [
+function parseISODuration(s3) {
+    return parse(s3, [
         isoDuration,
         extractISODuration
     ]);
@@ -1689,8 +1689,8 @@ const sqlYmdWithTimeExtensionRegex = combineRegexes(sqlYmdRegex, sqlTimeExtensio
 const sqlTimeCombinedRegex = combineRegexes(sqlTimeRegex);
 const extractISOYmdTimeOffsetAndIANAZone = combineExtractors(extractISOYmd, extractISOTime, extractISOOffset, extractIANAZone);
 const extractISOTimeOffsetAndIANAZone = combineExtractors(extractISOTime, extractISOOffset, extractIANAZone);
-function parseSQL(s2) {
-    return parse(s2, [
+function parseSQL(s3) {
+    return parse(s3, [
         sqlYmdWithTimeExtensionRegex,
         extractISOYmdTimeOffsetAndIANAZone
     ], [
@@ -1844,43 +1844,43 @@ let now = ()=>Date.now()
 , defaultZone = null, defaultLocale = null, defaultNumberingSystem = null, defaultOutputCalendar = null, throwOnInvalid = false;
 const INVALID2 = "Invalid Interval";
 class Info {
-    static hasDST(zone = Settings.defaultZone) {
-        const proto = DateTime.local().setZone(zone).set({
+    static hasDST(zone1 = Settings.defaultZone) {
+        const proto = DateTime.local().setZone(zone1).set({
             month: 12
         });
-        return !zone.universal && proto.offset !== proto.set({
+        return !zone1.universal && proto.offset !== proto.set({
             month: 6
         }).offset;
     }
-    static isValidIANAZone(zone) {
-        return IANAZone.isValidSpecifier(zone) && IANAZone.isValidZone(zone);
+    static isValidIANAZone(zone2) {
+        return IANAZone.isValidSpecifier(zone2) && IANAZone.isValidZone(zone2);
     }
     static normalizeZone(input) {
         return normalizeZone(input, Settings.defaultZone);
     }
-    static months(length = "long", { locale =null , numberingSystem =null , outputCalendar ="gregory"  } = {
+    static months(length = "long", { locale: locale4 = null , numberingSystem =null , outputCalendar ="gregory"  } = {
     }) {
-        return Locale.create(locale, numberingSystem, outputCalendar).months(length);
+        return Locale.create(locale4, numberingSystem, outputCalendar).months(length);
     }
-    static monthsFormat(length = "long", { locale =null , numberingSystem =null , outputCalendar ="gregory"  } = {
+    static monthsFormat(length1 = "long", { locale: locale5 = null , numberingSystem: numberingSystem1 = null , outputCalendar: outputCalendar1 = "gregory"  } = {
     }) {
-        return Locale.create(locale, numberingSystem, outputCalendar).months(length, true);
+        return Locale.create(locale5, numberingSystem1, outputCalendar1).months(length1, true);
     }
-    static weekdays(length = "long", { locale =null , numberingSystem =null  } = {
+    static weekdays(length2 = "long", { locale: locale6 = null , numberingSystem: numberingSystem2 = null  } = {
     }) {
-        return Locale.create(locale, numberingSystem, null).weekdays(length);
+        return Locale.create(locale6, numberingSystem2, null).weekdays(length2);
     }
-    static weekdaysFormat(length = "long", { locale =null , numberingSystem =null  } = {
+    static weekdaysFormat(length3 = "long", { locale: locale7 = null , numberingSystem: numberingSystem3 = null  } = {
     }) {
-        return Locale.create(locale, numberingSystem, null).weekdays(length, true);
+        return Locale.create(locale7, numberingSystem3, null).weekdays(length3, true);
     }
-    static meridiems({ locale =null  } = {
+    static meridiems({ locale: locale8 = null  } = {
     }) {
-        return Locale.create(locale).meridiems();
+        return Locale.create(locale8).meridiems();
     }
-    static eras(length = "short", { locale =null  } = {
+    static eras(length4 = "short", { locale: locale9 = null  } = {
     }) {
-        return Locale.create(locale, null, "gregory").eras(length);
+        return Locale.create(locale9, null, "gregory").eras(length4);
     }
     static features() {
         let intl = false, intlTokens = false, zones = false, relative = false;
@@ -1999,13 +1999,13 @@ const orderedUnits = [
     "milliseconds"
 ];
 const reverseUnits = orderedUnits.slice(0).reverse();
-function clone(dur, alts, clear = false) {
+function clone(dur1, alts, clear = false) {
     const conf = {
         values: clear ? alts.values : Object.assign({
-        }, dur.values, alts.values || {
+        }, dur1.values, alts.values || {
         }),
-        loc: dur.loc.clone(alts.loc),
-        conversionAccuracy: alts.conversionAccuracy || dur.conversionAccuracy
+        loc: dur1.loc.clone(alts.loc),
+        conversionAccuracy: alts.conversionAccuracy || dur1.conversionAccuracy
     };
     return new Duration(conf);
 }
@@ -2039,10 +2039,10 @@ class Duration {
         this.matrix = accurate ? accurateMatrix : casualMatrix;
         this.isLuxonDuration = true;
     }
-    static fromMillis(count, opts) {
+    static fromMillis(count, opts6) {
         return Duration.fromObject(Object.assign({
             milliseconds: count
-        }, opts));
+        }, opts6));
     }
     static fromObject(obj) {
         if (obj == null || typeof obj !== "object") {
@@ -2059,20 +2059,20 @@ class Duration {
             conversionAccuracy: obj.conversionAccuracy
         });
     }
-    static fromISO(text, opts) {
+    static fromISO(text, opts7) {
         const [parsed] = parseISODuration(text);
         if (parsed) {
-            const obj = Object.assign(parsed, opts);
-            return Duration.fromObject(obj);
+            const obj1 = Object.assign(parsed, opts7);
+            return Duration.fromObject(obj1);
         } else {
             return Duration.invalid("unparsable", `the input "${text}" can't be parsed as ISO 8601`);
         }
     }
-    static invalid(reason, explanation = null) {
-        if (!reason) {
+    static invalid(reason4, explanation1 = null) {
+        if (!reason4) {
             throw new InvalidArgumentError("need to specify a reason the Duration is invalid");
         }
-        const invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
+        const invalid = reason4 instanceof Invalid ? reason4 : new Invalid(reason4, explanation1);
         if (Settings.throwOnInvalid) {
             throw new InvalidDurationError(invalid);
         } else {
@@ -2081,7 +2081,7 @@ class Duration {
             });
         }
     }
-    static normalizeUnit(unit) {
+    static normalizeUnit(unit1) {
         const normalized = {
             year: "years",
             years: "years",
@@ -2101,8 +2101,8 @@ class Duration {
             seconds: "seconds",
             millisecond: "milliseconds",
             milliseconds: "milliseconds"
-        }[unit ? unit.toLowerCase() : unit];
-        if (!normalized) throw new InvalidUnitError(unit);
+        }[unit1 ? unit1.toLowerCase() : unit1];
+        if (!normalized) throw new InvalidUnitError(unit1);
         return normalized;
     }
     static isDuration(o) {
@@ -2114,21 +2114,21 @@ class Duration {
     get numberingSystem() {
         return this.isValid ? this.loc.numberingSystem : null;
     }
-    toFormat(fmt, opts = {
+    toFormat(fmt3, opts8 = {
     }) {
         const fmtOpts = Object.assign({
-        }, opts, {
-            floor: opts.round !== false && opts.floor !== false
+        }, opts8, {
+            floor: opts8.round !== false && opts8.floor !== false
         });
-        return this.isValid ? Formatter.create(this.loc, fmtOpts).formatDurationFromString(this, fmt) : INVALID1;
+        return this.isValid ? Formatter.create(this.loc, fmtOpts).formatDurationFromString(this, fmt3) : INVALID1;
     }
-    toObject(opts = {
+    toObject(opts9 = {
     }) {
         if (!this.isValid) return {
         };
         const base = Object.assign({
         }, this.values);
-        if (opts.includeConfig) {
+        if (opts9.includeConfig) {
             base.conversionAccuracy = this.conversionAccuracy;
             base.numberingSystem = this.loc.numberingSystem;
             base.locale = this.loc.locale;
@@ -2137,17 +2137,17 @@ class Duration {
     }
     toISO() {
         if (!this.isValid) return null;
-        let s2 = "P";
-        if (this.years !== 0) s2 += this.years + "Y";
-        if (this.months !== 0 || this.quarters !== 0) s2 += this.months + this.quarters * 3 + "M";
-        if (this.weeks !== 0) s2 += this.weeks + "W";
-        if (this.days !== 0) s2 += this.days + "D";
-        if (this.hours !== 0 || this.minutes !== 0 || this.seconds !== 0 || this.milliseconds !== 0) s2 += "T";
-        if (this.hours !== 0) s2 += this.hours + "H";
-        if (this.minutes !== 0) s2 += this.minutes + "M";
-        if (this.seconds !== 0 || this.milliseconds !== 0) s2 += roundTo(this.seconds + this.milliseconds / 1000, 3) + "S";
-        if (s2 === "P") s2 += "T0S";
-        return s2;
+        let s3 = "P";
+        if (this.years !== 0) s3 += this.years + "Y";
+        if (this.months !== 0 || this.quarters !== 0) s3 += this.months + this.quarters * 3 + "M";
+        if (this.weeks !== 0) s3 += this.weeks + "W";
+        if (this.days !== 0) s3 += this.days + "D";
+        if (this.hours !== 0 || this.minutes !== 0 || this.seconds !== 0 || this.milliseconds !== 0) s3 += "T";
+        if (this.hours !== 0) s3 += this.hours + "H";
+        if (this.minutes !== 0) s3 += this.minutes + "M";
+        if (this.seconds !== 0 || this.milliseconds !== 0) s3 += roundTo(this.seconds + this.milliseconds / 1000, 3) + "S";
+        if (s3 === "P") s3 += "T0S";
+        return s3;
     }
     toJSON() {
         return this.toISO();
@@ -2160,21 +2160,21 @@ class Duration {
     }
     plus(duration) {
         if (!this.isValid) return this;
-        const dur = friendlyDuration(duration), result = {
+        const dur1 = friendlyDuration(duration), result = {
         };
         for (const k of orderedUnits){
-            if (hasOwnProperty(dur.values, k) || hasOwnProperty(this.values, k)) {
-                result[k] = dur.get(k) + this.get(k);
+            if (hasOwnProperty(dur1.values, k) || hasOwnProperty(this.values, k)) {
+                result[k] = dur1.get(k) + this.get(k);
             }
         }
         return clone(this, {
             values: result
         }, true);
     }
-    minus(duration) {
+    minus(duration1) {
         if (!this.isValid) return this;
-        const dur = friendlyDuration(duration);
-        return this.plus(dur.negate());
+        const dur1 = friendlyDuration(duration1);
+        return this.plus(dur1.negate());
     }
     mapUnits(fn) {
         if (!this.isValid) return this;
@@ -2187,8 +2187,8 @@ class Duration {
             values: result
         }, true);
     }
-    get(unit) {
-        return this[Duration.normalizeUnit(unit)];
+    get(unit2) {
+        return this[Duration.normalizeUnit(unit2)];
     }
     set(values) {
         if (!this.isValid) return this;
@@ -2197,21 +2197,21 @@ class Duration {
             values: mixed
         });
     }
-    reconfigure({ locale , numberingSystem , conversionAccuracy  } = {
+    reconfigure({ locale: locale10 , numberingSystem: numberingSystem4 , conversionAccuracy  } = {
     }) {
         const loc = this.loc.clone({
-            locale,
-            numberingSystem
-        }), opts = {
+            locale: locale10,
+            numberingSystem: numberingSystem4
+        }), opts10 = {
             loc
         };
         if (conversionAccuracy) {
-            opts.conversionAccuracy = conversionAccuracy;
+            opts10.conversionAccuracy = conversionAccuracy;
         }
-        return clone(this, opts);
+        return clone(this, opts10);
     }
-    as(unit) {
-        return this.isValid ? this.shiftTo(unit).get(unit) : NaN;
+    as(unit3) {
+        return this.isValid ? this.shiftTo(unit3).get(unit3) : NaN;
     }
     normalize() {
         if (!this.isValid) return this;
@@ -2327,21 +2327,21 @@ class Duration {
     }
 }
 function dayDiff(earlier, later) {
-    const utcDayStart = (dt)=>dt.toUTC(0, {
+    const utcDayStart = (dt5)=>dt5.toUTC(0, {
             keepLocalTime: true
         }).startOf("day").valueOf()
     , ms = utcDayStart(later) - utcDayStart(earlier);
     return Math.floor(Duration.fromMillis(ms).as("days"));
 }
 const MISSING_FTP = "missing Intl.DateTimeFormat.formatToParts support";
-function unsupportedZone(zone) {
-    return new Invalid("unsupported zone", `the zone "${zone.name}" is not supported`);
+function unsupportedZone(zone3) {
+    return new Invalid("unsupported zone", `the zone "${zone3.name}" is not supported`);
 }
-function possiblyCachedWeekData(dt) {
-    if (dt.weekData === null) {
-        dt.weekData = gregorianToWeek(dt.c);
+function possiblyCachedWeekData(dt5) {
+    if (dt5.weekData === null) {
+        dt5.weekData = gregorianToWeek(dt5.c);
     }
-    return dt.weekData;
+    return dt5.weekData;
 }
 function clone1(inst, alts) {
     const current = {
@@ -2357,16 +2357,16 @@ function clone1(inst, alts) {
         old: current
     }));
 }
-function fixOffset(localTS, o, tz) {
-    let utcGuess = localTS - o * 60 * 1000;
+function fixOffset(localTS, o1, tz) {
+    let utcGuess = localTS - o1 * 60 * 1000;
     const o2 = tz.offset(utcGuess);
-    if (o === o2) {
+    if (o1 === o2) {
         return [
             utcGuess,
-            o
+            o1
         ];
     }
-    utcGuess -= (o2 - o) * 60 * 1000;
+    utcGuess -= (o2 - o1) * 60 * 1000;
     const o3 = tz.offset(utcGuess);
     if (o2 === o3) {
         return [
@@ -2379,9 +2379,9 @@ function fixOffset(localTS, o, tz) {
         Math.max(o2, o3)
     ];
 }
-function tsToObj(ts, offset1) {
-    ts += offset1 * 60 * 1000;
-    const d = new Date(ts);
+function tsToObj(ts10, offset2) {
+    ts10 += offset2 * 60 * 1000;
+    const d = new Date(ts10);
     return {
         year: d.getUTCFullYear(),
         month: d.getUTCMonth() + 1,
@@ -2392,71 +2392,71 @@ function tsToObj(ts, offset1) {
         millisecond: d.getUTCMilliseconds()
     };
 }
-function objToTS(obj, offset1, zone) {
-    return fixOffset(objToLocalTS(obj), offset1, zone);
+function objToTS(obj1, offset2, zone3) {
+    return fixOffset(objToLocalTS(obj1), offset2, zone3);
 }
-function adjustTime(inst, dur) {
-    const oPre = inst.o, year = inst.c.year + Math.trunc(dur.years), month = inst.c.month + Math.trunc(dur.months) + Math.trunc(dur.quarters) * 3, c = Object.assign({
+function adjustTime(inst, dur1) {
+    const oPre = inst.o, year = inst.c.year + Math.trunc(dur1.years), month = inst.c.month + Math.trunc(dur1.months) + Math.trunc(dur1.quarters) * 3, c = Object.assign({
     }, inst.c, {
         year,
         month,
-        day: Math.min(inst.c.day, daysInMonth(year, month)) + Math.trunc(dur.days) + Math.trunc(dur.weeks) * 7
+        day: Math.min(inst.c.day, daysInMonth(year, month)) + Math.trunc(dur1.days) + Math.trunc(dur1.weeks) * 7
     }), millisToAdd = Duration.fromObject({
-        years: dur.years - Math.trunc(dur.years),
-        quarters: dur.quarters - Math.trunc(dur.quarters),
-        months: dur.months - Math.trunc(dur.months),
-        weeks: dur.weeks - Math.trunc(dur.weeks),
-        days: dur.days - Math.trunc(dur.days),
-        hours: dur.hours,
-        minutes: dur.minutes,
-        seconds: dur.seconds,
-        milliseconds: dur.milliseconds
+        years: dur1.years - Math.trunc(dur1.years),
+        quarters: dur1.quarters - Math.trunc(dur1.quarters),
+        months: dur1.months - Math.trunc(dur1.months),
+        weeks: dur1.weeks - Math.trunc(dur1.weeks),
+        days: dur1.days - Math.trunc(dur1.days),
+        hours: dur1.hours,
+        minutes: dur1.minutes,
+        seconds: dur1.seconds,
+        milliseconds: dur1.milliseconds
     }).as("milliseconds"), localTS = objToLocalTS(c);
-    let [ts, o] = fixOffset(localTS, oPre, inst.zone);
+    let [ts10, o1] = fixOffset(localTS, oPre, inst.zone);
     if (millisToAdd !== 0) {
-        ts += millisToAdd;
-        o = inst.zone.offset(ts);
+        ts10 += millisToAdd;
+        o1 = inst.zone.offset(ts10);
     }
     return {
-        ts,
-        o
+        ts: ts10,
+        o: o1
     };
 }
-function parseDataToDateTime(parsed, parsedZone, opts, format, text) {
-    const { setZone , zone  } = opts;
+function parseDataToDateTime(parsed, parsedZone, opts10, format6, text1) {
+    const { setZone , zone: zone3  } = opts10;
     if (parsed && Object.keys(parsed).length !== 0) {
-        const interpretationZone = parsedZone || zone, inst = DateTime.fromObject(Object.assign(parsed, opts, {
+        const interpretationZone = parsedZone || zone3, inst = DateTime.fromObject(Object.assign(parsed, opts10, {
             zone: interpretationZone,
             setZone: undefined
         }));
-        return setZone ? inst : inst.setZone(zone);
+        return setZone ? inst : inst.setZone(zone3);
     } else {
-        return DateTime.invalid(new Invalid("unparsable", `the input "${text}" can't be parsed as ${format}`));
+        return DateTime.invalid(new Invalid("unparsable", `the input "${text1}" can't be parsed as ${format6}`));
     }
 }
-function toTechFormat(dt, format, allowZ = true) {
-    return dt.isValid ? Formatter.create(Locale.create("en-US"), {
+function toTechFormat(dt5, format6, allowZ = true) {
+    return dt5.isValid ? Formatter.create(Locale.create("en-US"), {
         allowZ,
         forceSimple: true
-    }).formatDateTimeFromString(dt, format) : null;
+    }).formatDateTimeFromString(dt5, format6) : null;
 }
-function toTechTimeFormat(dt, { suppressSeconds =false , suppressMilliseconds =false , includeOffset , includeZone =false , spaceZone =false , format ="extended"  }) {
-    let fmt = format === "basic" ? "HHmm" : "HH:mm";
-    if (!suppressSeconds || dt.second !== 0 || dt.millisecond !== 0) {
-        fmt += format === "basic" ? "ss" : ":ss";
-        if (!suppressMilliseconds || dt.millisecond !== 0) {
-            fmt += ".SSS";
+function toTechTimeFormat(dt5, { suppressSeconds =false , suppressMilliseconds =false , includeOffset , includeZone =false , spaceZone =false , format: format6 = "extended"  }) {
+    let fmt4 = format6 === "basic" ? "HHmm" : "HH:mm";
+    if (!suppressSeconds || dt5.second !== 0 || dt5.millisecond !== 0) {
+        fmt4 += format6 === "basic" ? "ss" : ":ss";
+        if (!suppressMilliseconds || dt5.millisecond !== 0) {
+            fmt4 += ".SSS";
         }
     }
     if ((includeZone || includeOffset) && spaceZone) {
-        fmt += " ";
+        fmt4 += " ";
     }
     if (includeZone) {
-        fmt += "z";
+        fmt4 += "z";
     } else if (includeOffset) {
-        fmt += format === "basic" ? "ZZZ" : "ZZ";
+        fmt4 += format6 === "basic" ? "ZZZ" : "ZZ";
     }
-    return toTechFormat(dt, fmt);
+    return toTechFormat(dt5, fmt4);
 }
 const defaultUnitValues = {
     month: 1,
@@ -2503,7 +2503,7 @@ const orderedUnits1 = [
     "second",
     "millisecond"
 ];
-function normalizeUnit(unit2) {
+function normalizeUnit(unit4) {
     const normalized = {
         year: "year",
         years: "year",
@@ -2529,51 +2529,51 @@ function normalizeUnit(unit2) {
         weekyear: "weekYear",
         weekyears: "weekYear",
         ordinal: "ordinal"
-    }[unit2.toLowerCase()];
-    if (!normalized) throw new InvalidUnitError(unit2);
+    }[unit4.toLowerCase()];
+    if (!normalized) throw new InvalidUnitError(unit4);
     return normalized;
 }
-function quickDT(obj, zone) {
+function quickDT(obj1, zone3) {
     for (const u of orderedUnits1){
-        if (isUndefined(obj[u])) {
-            obj[u] = defaultUnitValues[u];
+        if (isUndefined(obj1[u])) {
+            obj1[u] = defaultUnitValues[u];
         }
     }
-    const invalid = hasInvalidGregorianData(obj) || hasInvalidTimeData(obj);
+    const invalid = hasInvalidGregorianData(obj1) || hasInvalidTimeData(obj1);
     if (invalid) {
         return DateTime.invalid(invalid);
     }
-    const tsNow = Settings.now(), offsetProvis = zone.offset(tsNow), [ts, o] = objToTS(obj, offsetProvis, zone);
+    const tsNow = Settings.now(), offsetProvis = zone3.offset(tsNow), [ts10, o1] = objToTS(obj1, offsetProvis, zone3);
     return new DateTime({
-        ts,
-        zone,
-        o
+        ts: ts10,
+        zone: zone3,
+        o: o1
     });
 }
-function diffRelative(start, end, opts) {
-    const round = isUndefined(opts.round) ? true : opts.round, format = (c, unit2)=>{
-        c = roundTo(c, round || opts.calendary ? 0 : 2, true);
-        const formatter = end.loc.clone(opts).relFormatter(opts);
-        return formatter.format(c, unit2);
-    }, differ = (unit2)=>{
-        if (opts.calendary) {
-            if (!end.hasSame(start, unit2)) {
-                return end.startOf(unit2).diff(start.startOf(unit2), unit2).get(unit2);
+function diffRelative(start, end, opts10) {
+    const round = isUndefined(opts10.round) ? true : opts10.round, format6 = (c, unit4)=>{
+        c = roundTo(c, round || opts10.calendary ? 0 : 2, true);
+        const formatter = end.loc.clone(opts10).relFormatter(opts10);
+        return formatter.format(c, unit4);
+    }, differ = (unit4)=>{
+        if (opts10.calendary) {
+            if (!end.hasSame(start, unit4)) {
+                return end.startOf(unit4).diff(start.startOf(unit4), unit4).get(unit4);
             } else return 0;
         } else {
-            return end.diff(start, unit2).get(unit2);
+            return end.diff(start, unit4).get(unit4);
         }
     };
-    if (opts.unit) {
-        return format(differ(opts.unit), opts.unit);
+    if (opts10.unit) {
+        return format6(differ(opts10.unit), opts10.unit);
     }
-    for (const unit2 of opts.units){
-        const count = differ(unit2);
-        if (Math.abs(count) >= 1) {
-            return format(count, unit2);
+    for (const unit4 of opts10.units){
+        const count1 = differ(unit4);
+        if (Math.abs(count1) >= 1) {
+            return format6(count1, unit4);
         }
     }
-    return format(0, opts.units[opts.units.length - 1]);
+    return format6(0, opts10.units[opts10.units.length - 1]);
 }
 function friendlyDuration(durationish) {
     if (isNumber(durationish)) {
@@ -2588,26 +2588,26 @@ function friendlyDuration(durationish) {
 }
 class DateTime {
     constructor(config1){
-        const zone1 = config1.zone || Settings.defaultZone;
-        let invalid = config1.invalid || (Number.isNaN(config1.ts) ? new Invalid("invalid input") : null) || (!zone1.isValid ? unsupportedZone(zone1) : null);
+        const zone3 = config1.zone || Settings.defaultZone;
+        let invalid = config1.invalid || (Number.isNaN(config1.ts) ? new Invalid("invalid input") : null) || (!zone3.isValid ? unsupportedZone(zone3) : null);
         this.ts = isUndefined(config1.ts) ? Settings.now() : config1.ts;
         let c = null, o1 = null;
         if (!invalid) {
-            const unchanged = config1.old && config1.old.ts === this.ts && config1.old.zone.equals(zone1);
+            const unchanged = config1.old && config1.old.ts === this.ts && config1.old.zone.equals(zone3);
             if (unchanged) {
                 [c, o1] = [
                     config1.old.c,
                     config1.old.o
                 ];
             } else {
-                const ot = zone1.offset(this.ts);
+                const ot = zone3.offset(this.ts);
                 c = tsToObj(this.ts, ot);
                 invalid = Number.isNaN(c.year) ? new Invalid("invalid input") : null;
                 c = invalid ? null : c;
                 o1 = invalid ? null : ot;
             }
         }
-        this._zone = zone1;
+        this._zone = zone3;
         this.loc = config1.loc || Locale.create();
         this.invalid = invalid;
         this.weekData = null;
@@ -2632,28 +2632,28 @@ class DateTime {
             }, Settings.defaultZone);
         }
     }
-    static utc(year, month, day, hour, minute, second, millisecond) {
-        if (isUndefined(year)) {
+    static utc(year1, month1, day1, hour1, minute1, second1, millisecond1) {
+        if (isUndefined(year1)) {
             return new DateTime({
                 ts: Settings.now(),
                 zone: FixedOffsetZone.utcInstance
             });
         } else {
             return quickDT({
-                year,
-                month,
-                day,
-                hour,
-                minute,
-                second,
-                millisecond
+                year: year1,
+                month: month1,
+                day: day1,
+                hour: hour1,
+                minute: minute1,
+                second: second1,
+                millisecond: millisecond1
             }, FixedOffsetZone.utcInstance);
         }
     }
     static fromJSDate(date, options = {
     }) {
-        const ts = isDate(date) ? date.valueOf() : NaN;
-        if (Number.isNaN(ts)) {
+        const ts10 = isDate(date) ? date.valueOf() : NaN;
+        if (Number.isNaN(ts10)) {
             return DateTime.invalid("invalid input");
         }
         const zoneToUse = normalizeZone(options.zone, Settings.defaultZone);
@@ -2661,12 +2661,12 @@ class DateTime {
             return DateTime.invalid(unsupportedZone(zoneToUse));
         }
         return new DateTime({
-            ts: ts,
+            ts: ts10,
             zone: zoneToUse,
             loc: Locale.fromObject(options)
         });
     }
-    static fromMillis(milliseconds, options = {
+    static fromMillis(milliseconds, options1 = {
     }) {
         if (!isNumber(milliseconds)) {
             throw new InvalidArgumentError(`fromMillis requires a numerical input, but received a ${typeof milliseconds} with value ${milliseconds}`);
@@ -2675,34 +2675,34 @@ class DateTime {
         } else {
             return new DateTime({
                 ts: milliseconds,
-                zone: normalizeZone(options.zone, Settings.defaultZone),
-                loc: Locale.fromObject(options)
+                zone: normalizeZone(options1.zone, Settings.defaultZone),
+                loc: Locale.fromObject(options1)
             });
         }
     }
-    static fromSeconds(seconds, options = {
+    static fromSeconds(seconds, options2 = {
     }) {
         if (!isNumber(seconds)) {
             throw new InvalidArgumentError("fromSeconds requires a numerical input");
         } else {
             return new DateTime({
                 ts: seconds * 1000,
-                zone: normalizeZone(options.zone, Settings.defaultZone),
-                loc: Locale.fromObject(options)
+                zone: normalizeZone(options2.zone, Settings.defaultZone),
+                loc: Locale.fromObject(options2)
             });
         }
     }
-    static fromObject(obj) {
-        const zoneToUse = normalizeZone(obj.zone, Settings.defaultZone);
+    static fromObject(obj1) {
+        const zoneToUse = normalizeZone(obj1.zone, Settings.defaultZone);
         if (!zoneToUse.isValid) {
             return DateTime.invalid(unsupportedZone(zoneToUse));
         }
-        const tsNow = Settings.now(), offsetProvis = zoneToUse.offset(tsNow), normalized = normalizeObject(obj, normalizeUnit, [
+        const tsNow = Settings.now(), offsetProvis = zoneToUse.offset(tsNow), normalized = normalizeObject(obj1, normalizeUnit, [
             "zone",
             "locale",
             "outputCalendar",
             "numberingSystem"
-        ]), containsOrdinal = !isUndefined(normalized.ordinal), containsGregorYear = !isUndefined(normalized.year), containsGregorMD = !isUndefined(normalized.month) || !isUndefined(normalized.day), containsGregor = containsGregorYear || containsGregorMD, definiteWeekDef = normalized.weekYear || normalized.weekNumber, loc = Locale.fromObject(obj);
+        ]), containsOrdinal = !isUndefined(normalized.ordinal), containsGregorYear = !isUndefined(normalized.year), containsGregorMD = !isUndefined(normalized.month) || !isUndefined(normalized.day), containsGregor = containsGregorYear || containsGregorMD, definiteWeekDef = normalized.weekYear || normalized.weekNumber, loc = Locale.fromObject(obj1);
         if ((containsGregor || containsOrdinal) && definiteWeekDef) {
             throw new ConflictingSpecificationError("Can't mix weekYear/weekNumber units with year/month/day or ordinals");
         }
@@ -2710,21 +2710,21 @@ class DateTime {
             throw new ConflictingSpecificationError("Can't mix ordinal dates with month/day");
         }
         const useWeekData = definiteWeekDef || normalized.weekday && !containsGregor;
-        let units, defaultValues, objNow = tsToObj(tsNow, offsetProvis);
+        let units1, defaultValues, objNow = tsToObj(tsNow, offsetProvis);
         if (useWeekData) {
-            units = orderedWeekUnits;
+            units1 = orderedWeekUnits;
             defaultValues = defaultWeekUnitValues;
             objNow = gregorianToWeek(objNow);
         } else if (containsOrdinal) {
-            units = orderedOrdinalUnits;
+            units1 = orderedOrdinalUnits;
             defaultValues = defaultOrdinalUnitValues;
             objNow = gregorianToOrdinal(objNow);
         } else {
-            units = orderedUnits1;
+            units1 = orderedUnits1;
             defaultValues = defaultUnitValues;
         }
         let foundFirst = false;
-        for (const u of units){
+        for (const u of units1){
             const v = normalized[u];
             if (!isUndefined(v)) {
                 foundFirst = true;
@@ -2744,56 +2744,56 @@ class DateTime {
             o: offsetFinal,
             loc
         });
-        if (normalized.weekday && containsGregor && obj.weekday !== inst.weekday) {
+        if (normalized.weekday && containsGregor && obj1.weekday !== inst.weekday) {
             return DateTime.invalid("mismatched weekday", `you can't specify both a weekday of ${normalized.weekday} and a date of ${inst.toISO()}`);
         }
         return inst;
     }
-    static fromISO(text, opts = {
+    static fromISO(text1, opts10 = {
     }) {
-        const [vals, parsedZone] = parseISODate(text);
-        return parseDataToDateTime(vals, parsedZone, opts, "ISO 8601", text);
+        const [vals, parsedZone] = parseISODate(text1);
+        return parseDataToDateTime(vals, parsedZone, opts10, "ISO 8601", text1);
     }
-    static fromRFC2822(text, opts = {
+    static fromRFC2822(text2, opts11 = {
     }) {
-        const [vals, parsedZone] = parseRFC2822Date(text);
-        return parseDataToDateTime(vals, parsedZone, opts, "RFC 2822", text);
+        const [vals, parsedZone] = parseRFC2822Date(text2);
+        return parseDataToDateTime(vals, parsedZone, opts11, "RFC 2822", text2);
     }
-    static fromHTTP(text, opts = {
+    static fromHTTP(text3, opts12 = {
     }) {
-        const [vals, parsedZone] = parseHTTPDate(text);
-        return parseDataToDateTime(vals, parsedZone, opts, "HTTP", opts);
+        const [vals, parsedZone] = parseHTTPDate(text3);
+        return parseDataToDateTime(vals, parsedZone, opts12, "HTTP", opts12);
     }
-    static fromFormat(text, fmt, opts = {
+    static fromFormat(text4, fmt4, opts13 = {
     }) {
-        if (isUndefined(text) || isUndefined(fmt)) {
+        if (isUndefined(text4) || isUndefined(fmt4)) {
             throw new InvalidArgumentError("fromFormat requires an input string and a format");
         }
-        const { locale: locale2 = null , numberingSystem =null  } = opts, localeToUse = Locale.fromOpts({
-            locale: locale2,
-            numberingSystem,
+        const { locale: locale11 = null , numberingSystem: numberingSystem5 = null  } = opts13, localeToUse = Locale.fromOpts({
+            locale: locale11,
+            numberingSystem: numberingSystem5,
             defaultToEN: true
-        }), [vals, parsedZone, invalid1] = parseFromTokens(localeToUse, text, fmt);
+        }), [vals, parsedZone, invalid1] = parseFromTokens(localeToUse, text4, fmt4);
         if (invalid1) {
             return DateTime.invalid(invalid1);
         } else {
-            return parseDataToDateTime(vals, parsedZone, opts, `format ${fmt}`, text);
+            return parseDataToDateTime(vals, parsedZone, opts13, `format ${fmt4}`, text4);
         }
     }
-    static fromString(text, fmt, opts = {
+    static fromString(text5, fmt5, opts14 = {
     }) {
-        return DateTime.fromFormat(text, fmt, opts);
+        return DateTime.fromFormat(text5, fmt5, opts14);
     }
-    static fromSQL(text, opts = {
+    static fromSQL(text6, opts15 = {
     }) {
-        const [vals, parsedZone] = parseSQL(text);
-        return parseDataToDateTime(vals, parsedZone, opts, "SQL", text);
+        const [vals, parsedZone] = parseSQL(text6);
+        return parseDataToDateTime(vals, parsedZone, opts15, "SQL", text6);
     }
-    static invalid(reason, explanation = null) {
-        if (!reason) {
+    static invalid(reason5, explanation2 = null) {
+        if (!reason5) {
             throw new InvalidArgumentError("need to specify a reason the DateTime is invalid");
         }
-        const invalid1 = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
+        const invalid1 = reason5 instanceof Invalid ? reason5 : new Invalid(reason5, explanation2);
         if (Settings.throwOnInvalid) {
             throw new InvalidDateTimeError(invalid1);
         } else {
@@ -2802,11 +2802,11 @@ class DateTime {
             });
         }
     }
-    static isDateTime(o) {
-        return o && o.isLuxonDateTime || false;
+    static isDateTime(o2) {
+        return o2 && o2.isLuxonDateTime || false;
     }
-    get(unit) {
-        return this[unit];
+    get(unit4) {
+        return this[unit4];
     }
     get isValid() {
         return this.invalid === null;
@@ -2937,61 +2937,61 @@ class DateTime {
     get weeksInWeekYear() {
         return this.isValid ? weeksInWeekYear(this.weekYear) : NaN;
     }
-    resolvedLocaleOpts(opts = {
+    resolvedLocaleOpts(opts16 = {
     }) {
-        const { locale: locale2 , numberingSystem , calendar  } = Formatter.create(this.loc.clone(opts), opts).resolvedOptions(this);
+        const { locale: locale11 , numberingSystem: numberingSystem5 , calendar  } = Formatter.create(this.loc.clone(opts16), opts16).resolvedOptions(this);
         return {
-            locale: locale2,
-            numberingSystem,
+            locale: locale11,
+            numberingSystem: numberingSystem5,
             outputCalendar: calendar
         };
     }
-    toUTC(offset = 0, opts = {
+    toUTC(offset2 = 0, opts17 = {
     }) {
-        return this.setZone(FixedOffsetZone.instance(offset), opts);
+        return this.setZone(FixedOffsetZone.instance(offset2), opts17);
     }
     toLocal() {
         return this.setZone(Settings.defaultZone);
     }
-    setZone(zone, { keepLocalTime =false , keepCalendarTime =false  } = {
+    setZone(zone4, { keepLocalTime =false , keepCalendarTime =false  } = {
     }) {
-        zone = normalizeZone(zone, Settings.defaultZone);
-        if (zone.equals(this.zone)) {
+        zone4 = normalizeZone(zone4, Settings.defaultZone);
+        if (zone4.equals(this.zone)) {
             return this;
-        } else if (!zone.isValid) {
-            return DateTime.invalid(unsupportedZone(zone));
+        } else if (!zone4.isValid) {
+            return DateTime.invalid(unsupportedZone(zone4));
         } else {
             let newTS = this.ts;
             if (keepLocalTime || keepCalendarTime) {
-                const offsetGuess = zone.offset(this.ts);
+                const offsetGuess = zone4.offset(this.ts);
                 const asObj = this.toObject();
-                [newTS] = objToTS(asObj, offsetGuess, zone);
+                [newTS] = objToTS(asObj, offsetGuess, zone4);
             }
             return clone1(this, {
                 ts: newTS,
-                zone
+                zone: zone4
             });
         }
     }
-    reconfigure({ locale , numberingSystem , outputCalendar  } = {
+    reconfigure({ locale: locale11 , numberingSystem: numberingSystem5 , outputCalendar: outputCalendar2  } = {
     }) {
         const loc = this.loc.clone({
-            locale,
-            numberingSystem,
-            outputCalendar
+            locale: locale11,
+            numberingSystem: numberingSystem5,
+            outputCalendar: outputCalendar2
         });
         return clone1(this, {
             loc
         });
     }
-    setLocale(locale) {
+    setLocale(locale12) {
         return this.reconfigure({
-            locale
+            locale: locale12
         });
     }
-    set(values) {
+    set(values1) {
         if (!this.isValid) return this;
-        const normalized = normalizeObject(values, normalizeUnit, []), settingWeekStuff = !isUndefined(normalized.weekYear) || !isUndefined(normalized.weekNumber) || !isUndefined(normalized.weekday);
+        const normalized = normalizeObject(values1, normalizeUnit, []), settingWeekStuff = !isUndefined(normalized.weekYear) || !isUndefined(normalized.weekNumber) || !isUndefined(normalized.weekday);
         let mixed;
         if (settingWeekStuff) {
             mixed = weekToGregorian(Object.assign(gregorianToWeek(this.c), normalized));
@@ -3003,94 +3003,94 @@ class DateTime {
                 mixed.day = Math.min(daysInMonth(mixed.year, mixed.month), mixed.day);
             }
         }
-        const [ts, o2] = objToTS(mixed, this.o, this.zone);
+        const [ts10, o3] = objToTS(mixed, this.o, this.zone);
         return clone1(this, {
-            ts,
-            o: o2
+            ts: ts10,
+            o: o3
         });
     }
-    plus(duration) {
+    plus(duration2) {
         if (!this.isValid) return this;
-        const dur = friendlyDuration(duration);
-        return clone1(this, adjustTime(this, dur));
+        const dur1 = friendlyDuration(duration2);
+        return clone1(this, adjustTime(this, dur1));
     }
-    minus(duration) {
+    minus(duration3) {
         if (!this.isValid) return this;
-        const dur = friendlyDuration(duration).negate();
-        return clone1(this, adjustTime(this, dur));
+        const dur1 = friendlyDuration(duration3).negate();
+        return clone1(this, adjustTime(this, dur1));
     }
-    startOf(unit) {
+    startOf(unit5) {
         if (!this.isValid) return this;
-        const o2 = {
-        }, normalizedUnit = Duration.normalizeUnit(unit);
+        const o3 = {
+        }, normalizedUnit = Duration.normalizeUnit(unit5);
         switch(normalizedUnit){
             case "years":
-                o2.month = 1;
+                o3.month = 1;
             case "quarters":
             case "months":
-                o2.day = 1;
+                o3.day = 1;
             case "weeks":
             case "days":
-                o2.hour = 0;
+                o3.hour = 0;
             case "hours":
-                o2.minute = 0;
+                o3.minute = 0;
             case "minutes":
-                o2.second = 0;
+                o3.second = 0;
             case "seconds":
-                o2.millisecond = 0;
+                o3.millisecond = 0;
                 break;
             case "milliseconds": break;
         }
         if (normalizedUnit === "weeks") {
-            o2.weekday = 1;
+            o3.weekday = 1;
         }
         if (normalizedUnit === "quarters") {
             const q = Math.ceil(this.month / 3);
-            o2.month = (q - 1) * 3 + 1;
+            o3.month = (q - 1) * 3 + 1;
         }
-        return this.set(o2);
+        return this.set(o3);
     }
-    endOf(unit) {
+    endOf(unit6) {
         return this.isValid ? this.plus({
-            [unit]: 1
-        }).startOf(unit).minus(1) : this;
+            [unit6]: 1
+        }).startOf(unit6).minus(1) : this;
     }
-    toFormat(fmt, opts = {
+    toFormat(fmt6, opts18 = {
     }) {
-        return this.isValid ? Formatter.create(this.loc.redefaultToEN(opts)).formatDateTimeFromString(this, fmt) : INVALID;
+        return this.isValid ? Formatter.create(this.loc.redefaultToEN(opts18)).formatDateTimeFromString(this, fmt6) : INVALID;
     }
-    toLocaleString(opts = DATE_SHORT) {
-        return this.isValid ? Formatter.create(this.loc.clone(opts), opts).formatDateTime(this) : INVALID;
+    toLocaleString(opts19 = DATE_SHORT) {
+        return this.isValid ? Formatter.create(this.loc.clone(opts19), opts19).formatDateTime(this) : INVALID;
     }
-    toLocaleParts(opts = {
+    toLocaleParts(opts20 = {
     }) {
-        return this.isValid ? Formatter.create(this.loc.clone(opts), opts).formatDateTimeParts(this) : [];
+        return this.isValid ? Formatter.create(this.loc.clone(opts20), opts20).formatDateTimeParts(this) : [];
     }
-    toISO(opts = {
+    toISO(opts21 = {
     }) {
         if (!this.isValid) {
             return null;
         }
-        return `${this.toISODate(opts)}T${this.toISOTime(opts)}`;
+        return `${this.toISODate(opts21)}T${this.toISOTime(opts21)}`;
     }
-    toISODate({ format ="extended"  } = {
+    toISODate({ format: format6 = "extended"  } = {
     }) {
-        let fmt = format === "basic" ? "yyyyMMdd" : "yyyy-MM-dd";
+        let fmt7 = format6 === "basic" ? "yyyyMMdd" : "yyyy-MM-dd";
         if (this.year > 9999) {
-            fmt = "+" + fmt;
+            fmt7 = "+" + fmt7;
         }
-        return toTechFormat(this, fmt);
+        return toTechFormat(this, fmt7);
     }
     toISOWeekDate() {
         return toTechFormat(this, "kkkk-'W'WW-c");
     }
-    toISOTime({ suppressMilliseconds =false , suppressSeconds =false , includeOffset =true , format ="extended"  } = {
+    toISOTime({ suppressMilliseconds =false , suppressSeconds =false , includeOffset =true , format: format7 = "extended"  } = {
     }) {
         return toTechTimeFormat(this, {
             suppressSeconds,
             suppressMilliseconds,
             includeOffset,
-            format
+            format: format7
         });
     }
     toRFC2822() {
@@ -3102,20 +3102,20 @@ class DateTime {
     toSQLDate() {
         return toTechFormat(this, "yyyy-MM-dd");
     }
-    toSQLTime({ includeOffset =true , includeZone =false  } = {
+    toSQLTime({ includeOffset: includeOffset1 = true , includeZone =false  } = {
     }) {
         return toTechTimeFormat(this, {
-            includeOffset,
+            includeOffset: includeOffset1,
             includeZone,
             spaceZone: true
         });
     }
-    toSQL(opts = {
+    toSQL(opts22 = {
     }) {
         if (!this.isValid) {
             return null;
         }
-        return `${this.toSQLDate()} ${this.toSQLTime(opts)}`;
+        return `${this.toSQLDate()} ${this.toSQLTime(opts22)}`;
     }
     toString() {
         return this.isValid ? this.toISO() : INVALID;
@@ -3135,13 +3135,13 @@ class DateTime {
     toBSON() {
         return this.toJSDate();
     }
-    toObject(opts = {
+    toObject(opts23 = {
     }) {
         if (!this.isValid) return {
         };
         const base = Object.assign({
         }, this.c);
-        if (opts.includeConfig) {
+        if (opts23.includeConfig) {
             base.outputCalendar = this.outputCalendar;
             base.numberingSystem = this.loc.numberingSystem;
             base.locale = this.loc.locale;
@@ -3151,7 +3151,7 @@ class DateTime {
     toJSDate() {
         return new Date(this.isValid ? this.ts : NaN);
     }
-    diff(otherDateTime, unit = "milliseconds", opts = {
+    diff(otherDateTime, unit7 = "milliseconds", opts24 = {
     }) {
         if (!this.isValid || !otherDateTime.isValid) {
             return Duration.invalid(this.invalid || otherDateTime.invalid, "created by diffing an invalid DateTime");
@@ -3159,36 +3159,36 @@ class DateTime {
         const durOpts = Object.assign({
             locale: this.locale,
             numberingSystem: this.numberingSystem
-        }, opts);
-        const units = maybeArray(unit).map(Duration.normalizeUnit), otherIsLater = otherDateTime.valueOf() > this.valueOf(), earlier = otherIsLater ? this : otherDateTime, later = otherIsLater ? otherDateTime : this, diffed = __default(earlier, later, units, durOpts);
+        }, opts24);
+        const units1 = maybeArray(unit7).map(Duration.normalizeUnit), otherIsLater = otherDateTime.valueOf() > this.valueOf(), earlier = otherIsLater ? this : otherDateTime, later = otherIsLater ? otherDateTime : this, diffed = __default(earlier, later, units1, durOpts);
         return otherIsLater ? diffed.negate() : diffed;
     }
-    diffNow(unit = "milliseconds", opts = {
+    diffNow(unit8 = "milliseconds", opts25 = {
     }) {
-        return this.diff(DateTime.local(), unit, opts);
+        return this.diff(DateTime.local(), unit8, opts25);
     }
-    until(otherDateTime) {
-        return this.isValid ? Interval.fromDateTimes(this, otherDateTime) : this;
+    until(otherDateTime1) {
+        return this.isValid ? Interval.fromDateTimes(this, otherDateTime1) : this;
     }
-    hasSame(otherDateTime, unit) {
+    hasSame(otherDateTime2, unit9) {
         if (!this.isValid) return false;
-        if (unit === "millisecond") {
-            return this.valueOf() === otherDateTime.valueOf();
+        if (unit9 === "millisecond") {
+            return this.valueOf() === otherDateTime2.valueOf();
         } else {
-            const inputMs = otherDateTime.valueOf();
-            return this.startOf(unit) <= inputMs && inputMs <= this.endOf(unit);
+            const inputMs = otherDateTime2.valueOf();
+            return this.startOf(unit9) <= inputMs && inputMs <= this.endOf(unit9);
         }
     }
-    equals(other) {
-        return this.isValid && other.isValid && this.valueOf() === other.valueOf() && this.zone.equals(other.zone) && this.loc.equals(other.loc);
+    equals(other1) {
+        return this.isValid && other1.isValid && this.valueOf() === other1.valueOf() && this.zone.equals(other1.zone) && this.loc.equals(other1.loc);
     }
-    toRelative(options = {
+    toRelative(options3 = {
     }) {
         if (!this.isValid) return null;
-        const base = options.base || DateTime.fromObject({
+        const base = options3.base || DateTime.fromObject({
             zone: this.zone
-        }), padding = options.padding ? this < base ? -options.padding : options.padding : 0;
-        return diffRelative(base, this.plus(padding), Object.assign(options, {
+        }), padding = options3.padding ? this < base ? -options3.padding : options3.padding : 0;
+        return diffRelative(base, this.plus(padding), Object.assign(options3, {
             numeric: "always",
             units: [
                 "years",
@@ -3200,12 +3200,12 @@ class DateTime {
             ]
         }));
     }
-    toRelativeCalendar(options = {
+    toRelativeCalendar(options4 = {
     }) {
         if (!this.isValid) return null;
-        return diffRelative(options.base || DateTime.fromObject({
+        return diffRelative(options4.base || DateTime.fromObject({
             zone: this.zone
-        }), this, Object.assign(options, {
+        }), this, Object.assign(options4, {
             numeric: "auto",
             units: [
                 "years",
@@ -3222,25 +3222,25 @@ class DateTime {
         return bestBy(dateTimes, (i)=>i.valueOf()
         , Math.min);
     }
-    static max(...dateTimes) {
-        if (!dateTimes.every(DateTime.isDateTime)) {
+    static max(...dateTimes1) {
+        if (!dateTimes1.every(DateTime.isDateTime)) {
             throw new InvalidArgumentError("max requires all arguments be DateTimes");
         }
-        return bestBy(dateTimes, (i)=>i.valueOf()
+        return bestBy(dateTimes1, (i)=>i.valueOf()
         , Math.max);
     }
-    static fromFormatExplain(text, fmt, options = {
+    static fromFormatExplain(text7, fmt7, options5 = {
     }) {
-        const { locale: locale2 = null , numberingSystem =null  } = options, localeToUse = Locale.fromOpts({
-            locale: locale2,
-            numberingSystem,
+        const { locale: locale13 = null , numberingSystem: numberingSystem6 = null  } = options5, localeToUse = Locale.fromOpts({
+            locale: locale13,
+            numberingSystem: numberingSystem6,
             defaultToEN: true
         });
-        return explainFromTokens(localeToUse, text, fmt);
+        return explainFromTokens(localeToUse, text7, fmt7);
     }
-    static fromStringExplain(text, fmt, options = {
+    static fromStringExplain(text8, fmt8, options6 = {
     }) {
-        return DateTime.fromFormatExplain(text, fmt, options);
+        return DateTime.fromFormatExplain(text8, fmt8, options6);
     }
     static get DATE_SHORT() {
         return DATE_SHORT;
@@ -3320,46 +3320,46 @@ function friendlyDateTime(dateTimeish) {
         throw new InvalidArgumentError(`Unknown datetime argument: ${dateTimeish}, of type ${typeof dateTimeish}`);
     }
 }
-function getCachedDTF(locString, opts = {
+function getCachedDTF(locString, opts26 = {
 }) {
     const key = JSON.stringify([
         locString,
-        opts
+        opts26
     ]);
     let dtf = intlDTCache[key];
     if (!dtf) {
-        dtf = new Intl.DateTimeFormat(locString, opts);
+        dtf = new Intl.DateTimeFormat(locString, opts26);
         intlDTCache[key] = dtf;
     }
     return dtf;
 }
 let intlNumCache = {
 };
-function getCachedINF(locString, opts = {
+function getCachedINF(locString, opts26 = {
 }) {
     const key = JSON.stringify([
         locString,
-        opts
+        opts26
     ]);
     let inf = intlNumCache[key];
     if (!inf) {
-        inf = new Intl.NumberFormat(locString, opts);
+        inf = new Intl.NumberFormat(locString, opts26);
         intlNumCache[key] = inf;
     }
     return inf;
 }
 let intlRelCache = {
 };
-function getCachedRTF(locString, opts = {
+function getCachedRTF(locString, opts26 = {
 }) {
-    const { base , ...cacheKeyOpts } = opts;
+    const { base , ...cacheKeyOpts } = opts26;
     const key = JSON.stringify([
         locString,
         cacheKeyOpts
     ]);
     let inf = intlRelCache[key];
     if (!inf) {
-        inf = new Intl.RelativeTimeFormat(locString, opts);
+        inf = new Intl.RelativeTimeFormat(locString, opts26);
         intlRelCache[key] = inf;
     }
     return inf;
@@ -3384,30 +3384,30 @@ function parseLocaleString(localeStr) {
             localeStr
         ];
     } else {
-        let options;
+        let options7;
         const smaller = localeStr.substring(0, uIndex);
         try {
-            options = getCachedDTF(localeStr).resolvedOptions();
+            options7 = getCachedDTF(localeStr).resolvedOptions();
         } catch (e) {
-            options = getCachedDTF(smaller).resolvedOptions();
+            options7 = getCachedDTF(smaller).resolvedOptions();
         }
-        const { numberingSystem , calendar  } = options;
+        const { numberingSystem: numberingSystem6 , calendar  } = options7;
         return [
             smaller,
-            numberingSystem,
+            numberingSystem6,
             calendar
         ];
     }
 }
-function intlConfigString(localeStr, numberingSystem, outputCalendar) {
+function intlConfigString(localeStr, numberingSystem6, outputCalendar3) {
     if (hasIntl()) {
-        if (outputCalendar || numberingSystem) {
+        if (outputCalendar3 || numberingSystem6) {
             localeStr += "-u";
-            if (outputCalendar) {
-                localeStr += `-ca-${outputCalendar}`;
+            if (outputCalendar3) {
+                localeStr += `-ca-${outputCalendar3}`;
             }
-            if (numberingSystem) {
-                localeStr += `-nu-${numberingSystem}`;
+            if (numberingSystem6) {
+                localeStr += `-nu-${numberingSystem6}`;
             }
             return localeStr;
         } else {
@@ -3420,27 +3420,27 @@ function intlConfigString(localeStr, numberingSystem, outputCalendar) {
 function mapMonths(f) {
     const ms = [];
     for(let i = 1; i <= 12; i++){
-        const dt = DateTime.utc(2016, i, 1);
-        ms.push(f(dt));
+        const dt5 = DateTime.utc(2016, i, 1);
+        ms.push(f(dt5));
     }
     return ms;
 }
 function mapWeekdays(f) {
     const ms = [];
     for(let i = 1; i <= 7; i++){
-        const dt = DateTime.utc(2016, 11, 13 + i);
-        ms.push(f(dt));
+        const dt5 = DateTime.utc(2016, 11, 13 + i);
+        ms.push(f(dt5));
     }
     return ms;
 }
-function listStuff(loc, length, defaultOK, englishFn, intlFn) {
+function listStuff(loc, length5, defaultOK, englishFn, intlFn) {
     const mode = loc.listingMode(defaultOK);
     if (mode === "error") {
         return null;
     } else if (mode === "en") {
-        return englishFn(length);
+        return englishFn(length5);
     } else {
-        return intlFn(length);
+        return intlFn(length5);
     }
 }
 function supportsFastNumbers(loc) {
@@ -3451,14 +3451,14 @@ function supportsFastNumbers(loc) {
     }
 }
 class PolyNumberFormatter {
-    constructor(intl, forceSimple, opts3){
-        this.padTo = opts3.padTo || 0;
-        this.floor = opts3.floor || false;
+    constructor(intl, forceSimple, opts26){
+        this.padTo = opts26.padTo || 0;
+        this.floor = opts26.floor || false;
         if (!forceSimple && hasIntl()) {
             const intlOpts = {
                 useGrouping: false
             };
-            if (opts3.padTo > 0) intlOpts.minimumIntegerDigits = opts3.padTo;
+            if (opts26.padTo > 0) intlOpts.minimumIntegerDigits = opts26.padTo;
             this.inf = getCachedINF(intl, intlOpts);
         }
     }
@@ -3473,28 +3473,28 @@ class PolyNumberFormatter {
     }
 }
 class PolyDateFormatter {
-    constructor(dt1, intl1, opts1){
-        this.opts = opts1;
+    constructor(dt5, intl1, opts27){
+        this.opts = opts27;
         this.hasIntl = hasIntl();
-        let z1;
-        if (dt1.zone.universal && this.hasIntl) {
-            z1 = "UTC";
-            if (opts1.timeZoneName) {
-                this.dt = dt1;
+        let z;
+        if (dt5.zone.universal && this.hasIntl) {
+            z = "UTC";
+            if (opts27.timeZoneName) {
+                this.dt = dt5;
             } else {
-                this.dt = dt1.offset === 0 ? dt1 : DateTime.fromMillis(dt1.ts + dt1.offset * 60 * 1000);
+                this.dt = dt5.offset === 0 ? dt5 : DateTime.fromMillis(dt5.ts + dt5.offset * 60 * 1000);
             }
-        } else if (dt1.zone.type === "local") {
-            this.dt = dt1;
+        } else if (dt5.zone.type === "local") {
+            this.dt = dt5;
         } else {
-            this.dt = dt1;
-            z1 = dt1.zone.name;
+            this.dt = dt5;
+            z = dt5.zone.name;
         }
         if (this.hasIntl) {
             const intlOpts = Object.assign({
             }, this.opts);
-            if (z1) {
-                intlOpts.timeZone = z1;
+            if (z) {
+                intlOpts.timeZone = z;
             }
             this.dtf = getCachedDTF(intl1, intlOpts);
         }
@@ -3527,35 +3527,35 @@ class PolyDateFormatter {
     }
 }
 class PolyRelFormatter {
-    constructor(intl2, isEnglish, opts2){
+    constructor(intl2, isEnglish, opts28){
         this.opts = Object.assign({
             style: "long"
-        }, opts2);
+        }, opts28);
         if (!isEnglish && hasRelative()) {
-            this.rtf = getCachedRTF(intl2, opts2);
+            this.rtf = getCachedRTF(intl2, opts28);
         }
     }
-    format(count, unit) {
+    format(count1, unit10) {
         if (this.rtf) {
-            return this.rtf.format(count, unit);
+            return this.rtf.format(count1, unit10);
         } else {
-            return formatRelativeTime(unit, count, this.opts.numeric, this.opts.style !== "long");
+            return formatRelativeTime(unit10, count1, this.opts.numeric, this.opts.style !== "long");
         }
     }
-    formatToParts(count, unit) {
+    formatToParts(count2, unit11) {
         if (this.rtf) {
-            return this.rtf.formatToParts(count, unit);
+            return this.rtf.formatToParts(count2, unit11);
         } else {
             return [];
         }
     }
 }
 class Locale {
-    static fromOpts(opts) {
-        return Locale.create(opts.locale, opts.numberingSystem, opts.outputCalendar, opts.defaultToEN);
+    static fromOpts(opts29) {
+        return Locale.create(opts29.locale, opts29.numberingSystem, opts29.outputCalendar, opts29.defaultToEN);
     }
-    static create(locale, numberingSystem, outputCalendar, defaultToEN = false) {
-        const specifiedLocale = locale || Settings.defaultLocale, localeR = specifiedLocale || (defaultToEN ? "en-US" : systemLocale()), numberingSystemR = numberingSystem || Settings.defaultNumberingSystem, outputCalendarR = outputCalendar || Settings.defaultOutputCalendar;
+    static create(locale13, numberingSystem6, outputCalendar3, defaultToEN = false) {
+        const specifiedLocale = locale13 || Settings.defaultLocale, localeR = specifiedLocale || (defaultToEN ? "en-US" : systemLocale()), numberingSystemR = numberingSystem6 || Settings.defaultNumberingSystem, outputCalendarR = outputCalendar3 || Settings.defaultOutputCalendar;
         return new Locale(localeR, numberingSystemR, outputCalendarR, specifiedLocale);
     }
     static resetCache() {
@@ -3567,15 +3567,15 @@ class Locale {
         intlRelCache = {
         };
     }
-    static fromObject({ locale , numberingSystem , outputCalendar  } = {
+    static fromObject({ locale: locale14 , numberingSystem: numberingSystem7 , outputCalendar: outputCalendar4  } = {
     }) {
-        return Locale.create(locale, numberingSystem, outputCalendar);
+        return Locale.create(locale14, numberingSystem7, outputCalendar4);
     }
-    constructor(locale2, numbering, outputCalendar1, specifiedLocale){
-        const [parsedLocale, parsedNumberingSystem, parsedOutputCalendar] = parseLocaleString(locale2);
+    constructor(locale15, numbering, outputCalendar5, specifiedLocale){
+        const [parsedLocale, parsedNumberingSystem, parsedOutputCalendar] = parseLocaleString(locale15);
         this.locale = parsedLocale;
         this.numberingSystem = numbering || parsedNumberingSystem || null;
-        this.outputCalendar = outputCalendar1 || parsedOutputCalendar || null;
+        this.outputCalendar = outputCalendar5 || parsedOutputCalendar || null;
         this.intl = intlConfigString(this.locale, this.numberingSystem, this.outputCalendar);
         this.weekdaysCache = {
             format: {
@@ -3618,54 +3618,54 @@ class Locale {
             return Locale.create(alts.locale || this.specifiedLocale, alts.numberingSystem || this.numberingSystem, alts.outputCalendar || this.outputCalendar, alts.defaultToEN || false);
         }
     }
-    redefaultToEN(alts = {
+    redefaultToEN(alts1 = {
     }) {
         return this.clone(Object.assign({
-        }, alts, {
+        }, alts1, {
             defaultToEN: true
         }));
     }
-    redefaultToSystem(alts = {
+    redefaultToSystem(alts2 = {
     }) {
         return this.clone(Object.assign({
-        }, alts, {
+        }, alts2, {
             defaultToEN: false
         }));
     }
-    months(length, format = false, defaultOK = true) {
-        return listStuff(this, length, defaultOK, months, ()=>{
-            const intl3 = format ? {
-                month: length,
+    months(length5, format8 = false, defaultOK1 = true) {
+        return listStuff(this, length5, defaultOK1, months, ()=>{
+            const intl3 = format8 ? {
+                month: length5,
                 day: "numeric"
             } : {
-                month: length
-            }, formatStr = format ? "format" : "standalone";
-            if (!this.monthsCache[formatStr][length]) {
-                this.monthsCache[formatStr][length] = mapMonths((dt1)=>this.extract(dt1, intl3, "month")
+                month: length5
+            }, formatStr = format8 ? "format" : "standalone";
+            if (!this.monthsCache[formatStr][length5]) {
+                this.monthsCache[formatStr][length5] = mapMonths((dt6)=>this.extract(dt6, intl3, "month")
                 );
             }
-            return this.monthsCache[formatStr][length];
+            return this.monthsCache[formatStr][length5];
         });
     }
-    weekdays(length, format = false, defaultOK = true) {
-        return listStuff(this, length, defaultOK, weekdays, ()=>{
-            const intl3 = format ? {
-                weekday: length,
+    weekdays(length6, format9 = false, defaultOK2 = true) {
+        return listStuff(this, length6, defaultOK2, weekdays, ()=>{
+            const intl3 = format9 ? {
+                weekday: length6,
                 year: "numeric",
                 month: "long",
                 day: "numeric"
             } : {
-                weekday: length
-            }, formatStr = format ? "format" : "standalone";
-            if (!this.weekdaysCache[formatStr][length]) {
-                this.weekdaysCache[formatStr][length] = mapWeekdays((dt1)=>this.extract(dt1, intl3, "weekday")
+                weekday: length6
+            }, formatStr = format9 ? "format" : "standalone";
+            if (!this.weekdaysCache[formatStr][length6]) {
+                this.weekdaysCache[formatStr][length6] = mapWeekdays((dt6)=>this.extract(dt6, intl3, "weekday")
                 );
             }
-            return this.weekdaysCache[formatStr][length];
+            return this.weekdaysCache[formatStr][length6];
         });
     }
-    meridiems(defaultOK = true) {
-        return listStuff(this, undefined, defaultOK, ()=>meridiems
+    meridiems(defaultOK3 = true) {
+        return listStuff(this, undefined, defaultOK3, ()=>meridiems
         , ()=>{
             if (!this.meridiemCache) {
                 const intl3 = {
@@ -3675,66 +3675,66 @@ class Locale {
                 this.meridiemCache = [
                     DateTime.utc(2016, 11, 13, 9),
                     DateTime.utc(2016, 11, 13, 19)
-                ].map((dt1)=>this.extract(dt1, intl3, "dayperiod")
+                ].map((dt6)=>this.extract(dt6, intl3, "dayperiod")
                 );
             }
             return this.meridiemCache;
         });
     }
-    eras(length, defaultOK = true) {
-        return listStuff(this, length, defaultOK, eras, ()=>{
+    eras(length7, defaultOK4 = true) {
+        return listStuff(this, length7, defaultOK4, eras, ()=>{
             const intl3 = {
-                era: length
+                era: length7
             };
-            if (!this.eraCache[length]) {
-                this.eraCache[length] = [
+            if (!this.eraCache[length7]) {
+                this.eraCache[length7] = [
                     DateTime.utc(-40, 1, 1),
                     DateTime.utc(2017, 1, 1)
-                ].map((dt1)=>this.extract(dt1, intl3, "era")
+                ].map((dt6)=>this.extract(dt6, intl3, "era")
                 );
             }
-            return this.eraCache[length];
+            return this.eraCache[length7];
         });
     }
-    extract(dt, intlOpts, field) {
-        const df = this.dtFormatter(dt, intlOpts), results = df.formatToParts(), matching = results.find((m)=>m.type.toLowerCase() === field
+    extract(dt6, intlOpts, field) {
+        const df = this.dtFormatter(dt6, intlOpts), results = df.formatToParts(), matching = results.find((m)=>m.type.toLowerCase() === field
         );
         return matching ? matching.value : null;
     }
-    numberFormatter(opts = {
+    numberFormatter(opts30 = {
     }) {
-        return new PolyNumberFormatter(this.intl, opts.forceSimple || this.fastNumbers, opts);
+        return new PolyNumberFormatter(this.intl, opts30.forceSimple || this.fastNumbers, opts30);
     }
-    dtFormatter(dt, intlOpts = {
+    dtFormatter(dt7, intlOpts1 = {
     }) {
-        return new PolyDateFormatter(dt, this.intl, intlOpts);
+        return new PolyDateFormatter(dt7, this.intl, intlOpts1);
     }
-    relFormatter(opts = {
+    relFormatter(opts31 = {
     }) {
-        return new PolyRelFormatter(this.intl, this.isEnglish(), opts);
+        return new PolyRelFormatter(this.intl, this.isEnglish(), opts31);
     }
     isEnglish() {
         return this.locale === "en" || this.locale.toLowerCase() === "en-us" || hasIntl() && new Intl.DateTimeFormat(this.intl).resolvedOptions().locale.startsWith("en-us");
     }
-    equals(other) {
-        return this.locale === other.locale && this.numberingSystem === other.numberingSystem && this.outputCalendar === other.outputCalendar;
+    equals(other2) {
+        return this.locale === other2.locale && this.numberingSystem === other2.numberingSystem && this.outputCalendar === other2.outputCalendar;
     }
 }
 class Settings {
     static get now() {
         return now;
     }
-    static set now(n) {
-        now = n;
+    static set now(n2) {
+        now = n2;
     }
     static get defaultZoneName() {
         return Settings.defaultZone.name;
     }
-    static set defaultZoneName(z) {
-        if (!z) {
+    static set defaultZoneName(z1) {
+        if (!z1) {
             defaultZone = null;
         } else {
-            defaultZone = normalizeZone(z);
+            defaultZone = normalizeZone(z1);
         }
     }
     static get defaultZone() {
@@ -3743,20 +3743,20 @@ class Settings {
     static get defaultLocale() {
         return defaultLocale;
     }
-    static set defaultLocale(locale) {
-        defaultLocale = locale;
+    static set defaultLocale(locale16) {
+        defaultLocale = locale16;
     }
     static get defaultNumberingSystem() {
         return defaultNumberingSystem;
     }
-    static set defaultNumberingSystem(numberingSystem) {
-        defaultNumberingSystem = numberingSystem;
+    static set defaultNumberingSystem(numberingSystem8) {
+        defaultNumberingSystem = numberingSystem8;
     }
     static get defaultOutputCalendar() {
         return defaultOutputCalendar;
     }
-    static set defaultOutputCalendar(outputCalendar) {
-        defaultOutputCalendar = outputCalendar;
+    static set defaultOutputCalendar(outputCalendar6) {
+        defaultOutputCalendar = outputCalendar6;
     }
     static get throwOnInvalid() {
         return throwOnInvalid;
@@ -3787,11 +3787,11 @@ class Interval {
         this.invalid = config2.invalid || null;
         this.isLuxonInterval = true;
     }
-    static invalid(reason, explanation = null) {
-        if (!reason) {
+    static invalid(reason6, explanation3 = null) {
+        if (!reason6) {
             throw new InvalidArgumentError("need to specify a reason the Interval is invalid");
         }
-        const invalid1 = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
+        const invalid1 = reason6 instanceof Invalid ? reason6 : new Invalid(reason6, explanation3);
         if (Settings.throwOnInvalid) {
             throw new InvalidIntervalError(invalid1);
         } else {
@@ -3812,50 +3812,50 @@ class Interval {
             return validateError;
         }
     }
-    static after(start, duration) {
-        const dur = friendlyDuration(duration), dt2 = friendlyDateTime(start);
-        return Interval.fromDateTimes(dt2, dt2.plus(dur));
+    static after(start1, duration4) {
+        const dur1 = friendlyDuration(duration4), dt8 = friendlyDateTime(start1);
+        return Interval.fromDateTimes(dt8, dt8.plus(dur1));
     }
-    static before(end, duration) {
-        const dur = friendlyDuration(duration), dt2 = friendlyDateTime(end);
-        return Interval.fromDateTimes(dt2.minus(dur), dt2);
+    static before(end1, duration5) {
+        const dur1 = friendlyDuration(duration5), dt8 = friendlyDateTime(end1);
+        return Interval.fromDateTimes(dt8.minus(dur1), dt8);
     }
-    static fromISO(text, opts) {
-        const [s2, e] = (text || "").split("/", 2);
-        if (s2 && e) {
-            let start, startIsValid;
+    static fromISO(text9, opts32) {
+        const [s3, e] = (text9 || "").split("/", 2);
+        if (s3 && e) {
+            let start2, startIsValid;
             try {
-                start = DateTime.fromISO(s2, opts);
-                startIsValid = start.isValid;
+                start2 = DateTime.fromISO(s3, opts32);
+                startIsValid = start2.isValid;
             } catch (e1) {
                 startIsValid = false;
             }
-            let end, endIsValid;
+            let end2, endIsValid;
             try {
-                end = DateTime.fromISO(e, opts);
-                endIsValid = end.isValid;
+                end2 = DateTime.fromISO(e, opts32);
+                endIsValid = end2.isValid;
             } catch (e1) {
                 endIsValid = false;
             }
             if (startIsValid && endIsValid) {
-                return Interval.fromDateTimes(start, end);
+                return Interval.fromDateTimes(start2, end2);
             }
             if (startIsValid) {
-                const dur = Duration.fromISO(e, opts);
-                if (dur.isValid) {
-                    return Interval.after(start, dur);
+                const dur1 = Duration.fromISO(e, opts32);
+                if (dur1.isValid) {
+                    return Interval.after(start2, dur1);
                 }
             } else if (endIsValid) {
-                const dur = Duration.fromISO(s2, opts);
-                if (dur.isValid) {
-                    return Interval.before(end, dur);
+                const dur1 = Duration.fromISO(s3, opts32);
+                if (dur1.isValid) {
+                    return Interval.before(end2, dur1);
                 }
             }
         }
-        return Interval.invalid("unparsable", `the input "${text}" can't be parsed as ISO 8601`);
+        return Interval.invalid("unparsable", `the input "${text9}" can't be parsed as ISO 8601`);
     }
-    static isInterval(o) {
-        return o && o.isLuxonInterval || false;
+    static isInterval(o3) {
+        return o3 && o3.isLuxonInterval || false;
     }
     get start() {
         return this.isValid ? this.s : null;
@@ -3872,18 +3872,18 @@ class Interval {
     get invalidExplanation() {
         return this.invalid ? this.invalid.explanation : null;
     }
-    length(unit = "milliseconds") {
+    length(unit12 = "milliseconds") {
         return this.isValid ? this.toDuration(...[
-            unit
-        ]).get(unit) : NaN;
+            unit12
+        ]).get(unit12) : NaN;
     }
-    count(unit = "milliseconds") {
+    count(unit13 = "milliseconds") {
         if (!this.isValid) return NaN;
-        const start = this.start.startOf(unit), end = this.end.startOf(unit);
-        return Math.floor(end.diff(start, unit).get(unit)) + 1;
+        const start2 = this.start.startOf(unit13), end2 = this.end.startOf(unit13);
+        return Math.floor(end2.diff(start2, unit13).get(unit13)) + 1;
     }
-    hasSame(unit) {
-        return this.isValid ? this.isEmpty() || this.e.minus(1).hasSame(this.s, unit) : false;
+    hasSame(unit14) {
+        return this.isValid ? this.isEmpty() || this.e.minus(1).hasSame(this.s, unit14) : false;
     }
     isEmpty() {
         return this.s.valueOf() === this.e.valueOf();
@@ -3892,44 +3892,44 @@ class Interval {
         if (!this.isValid) return false;
         return this.s > dateTime;
     }
-    isBefore(dateTime) {
+    isBefore(dateTime1) {
         if (!this.isValid) return false;
-        return this.e <= dateTime;
+        return this.e <= dateTime1;
     }
-    contains(dateTime) {
+    contains(dateTime2) {
         if (!this.isValid) return false;
-        return this.s <= dateTime && this.e > dateTime;
+        return this.s <= dateTime2 && this.e > dateTime2;
     }
-    set({ start , end  } = {
+    set({ start: start2 , end: end2  } = {
     }) {
         if (!this.isValid) return this;
-        return Interval.fromDateTimes(start || this.s, end || this.e);
+        return Interval.fromDateTimes(start2 || this.s, end2 || this.e);
     }
-    splitAt(...dateTimes) {
+    splitAt(...dateTimes2) {
         if (!this.isValid) return [];
-        const sorted = dateTimes.map(friendlyDateTime).filter((d)=>this.contains(d)
+        const sorted = dateTimes2.map(friendlyDateTime).filter((d)=>this.contains(d)
         ).sort(), results = [];
-        let { s: s2  } = this, i = 0;
-        while(s2 < this.e){
-            const added = sorted[i] || this.e, next = +added > +this.e ? this.e : added;
-            results.push(Interval.fromDateTimes(s2, next));
-            s2 = next;
-            i += 1;
+        let { s: s3  } = this, i1 = 0;
+        while(s3 < this.e){
+            const added = sorted[i1] || this.e, next = +added > +this.e ? this.e : added;
+            results.push(Interval.fromDateTimes(s3, next));
+            s3 = next;
+            i1 += 1;
         }
         return results;
     }
-    splitBy(duration) {
-        const dur = friendlyDuration(duration);
-        if (!this.isValid || !dur.isValid || dur.as("milliseconds") === 0) {
+    splitBy(duration6) {
+        const dur1 = friendlyDuration(duration6);
+        if (!this.isValid || !dur1.isValid || dur1.as("milliseconds") === 0) {
             return [];
         }
-        let { s: s2  } = this, added, next;
+        let { s: s3  } = this, added, next;
         const results = [];
-        while(s2 < this.e){
-            added = s2.plus(dur);
+        while(s3 < this.e){
+            added = s3.plus(dur1);
             next = +added > +this.e ? this.e : added;
-            results.push(Interval.fromDateTimes(s2, next));
-            s2 = next;
+            results.push(Interval.fromDateTimes(s3, next));
+            s3 = next;
         }
         return results;
     }
@@ -3937,40 +3937,40 @@ class Interval {
         if (!this.isValid) return [];
         return this.splitBy(this.length() / numberOfParts).slice(0, numberOfParts);
     }
-    overlaps(other) {
-        return this.e > other.s && this.s < other.e;
+    overlaps(other3) {
+        return this.e > other3.s && this.s < other3.e;
     }
-    abutsStart(other) {
+    abutsStart(other4) {
         if (!this.isValid) return false;
-        return +this.e === +other.s;
+        return +this.e === +other4.s;
     }
-    abutsEnd(other) {
+    abutsEnd(other5) {
         if (!this.isValid) return false;
-        return +other.e === +this.s;
+        return +other5.e === +this.s;
     }
-    engulfs(other) {
+    engulfs(other6) {
         if (!this.isValid) return false;
-        return this.s <= other.s && this.e >= other.e;
+        return this.s <= other6.s && this.e >= other6.e;
     }
-    equals(other) {
-        if (!this.isValid || !other.isValid) {
+    equals(other7) {
+        if (!this.isValid || !other7.isValid) {
             return false;
         }
-        return this.s.equals(other.s) && this.e.equals(other.e);
+        return this.s.equals(other7.s) && this.e.equals(other7.e);
     }
-    intersection(other) {
+    intersection(other8) {
         if (!this.isValid) return this;
-        const s2 = this.s > other.s ? this.s : other.s, e = this.e < other.e ? this.e : other.e;
-        if (s2 > e) {
+        const s3 = this.s > other8.s ? this.s : other8.s, e = this.e < other8.e ? this.e : other8.e;
+        if (s3 > e) {
             return null;
         } else {
-            return Interval.fromDateTimes(s2, e);
+            return Interval.fromDateTimes(s3, e);
         }
     }
-    union(other) {
+    union(other9) {
         if (!this.isValid) return this;
-        const s2 = this.s < other.s ? this.s : other.s, e = this.e > other.e ? this.e : other.e;
-        return Interval.fromDateTimes(s2, e);
+        const s3 = this.s < other9.s ? this.s : other9.s, e = this.e > other9.e ? this.e : other9.e;
+        return Interval.fromDateTimes(s3, e);
     }
     static merge(intervals) {
         const [found, __final] = intervals.sort((a, b)=>a.s - b.s
@@ -4002,72 +4002,72 @@ class Interval {
         }
         return found;
     }
-    static xor(intervals) {
-        let start = null, currentCount = 0;
-        const results = [], ends = intervals.map((i)=>[
+    static xor(intervals1) {
+        let start3 = null, currentCount = 0;
+        const results = [], ends = intervals1.map((i1)=>[
                 {
-                    time: i.s,
+                    time: i1.s,
                     type: "s"
                 },
                 {
-                    time: i.e,
+                    time: i1.e,
                     type: "e"
                 }
             ]
         ), flattened = Array.prototype.concat(...ends), arr = flattened.sort((a, b)=>a.time - b.time
         );
-        for (const i of arr){
-            currentCount += i.type === "s" ? 1 : -1;
+        for (const i1 of arr){
+            currentCount += i1.type === "s" ? 1 : -1;
             if (currentCount === 1) {
-                start = i.time;
+                start3 = i1.time;
             } else {
-                if (start && +start !== +i.time) {
-                    results.push(Interval.fromDateTimes(start, i.time));
+                if (start3 && +start3 !== +i1.time) {
+                    results.push(Interval.fromDateTimes(start3, i1.time));
                 }
-                start = null;
+                start3 = null;
             }
         }
         return Interval.merge(results);
     }
-    difference(...intervals) {
+    difference(...intervals2) {
         return Interval.xor([
             this
-        ].concat(intervals)).map((i)=>this.intersection(i)
-        ).filter((i)=>i && !i.isEmpty()
+        ].concat(intervals2)).map((i1)=>this.intersection(i1)
+        ).filter((i1)=>i1 && !i1.isEmpty()
         );
     }
     toString() {
         if (!this.isValid) return INVALID2;
         return `[${this.s.toISO()} – ${this.e.toISO()})`;
     }
-    toISO(opts) {
+    toISO(opts33) {
         if (!this.isValid) return INVALID2;
-        return `${this.s.toISO(opts)}/${this.e.toISO(opts)}`;
+        return `${this.s.toISO(opts33)}/${this.e.toISO(opts33)}`;
     }
     toISODate() {
         if (!this.isValid) return INVALID2;
         return `${this.s.toISODate()}/${this.e.toISODate()}`;
     }
-    toISOTime(opts) {
+    toISOTime(opts34) {
         if (!this.isValid) return INVALID2;
-        return `${this.s.toISOTime(opts)}/${this.e.toISOTime(opts)}`;
+        return `${this.s.toISOTime(opts34)}/${this.e.toISOTime(opts34)}`;
     }
     toFormat(dateFormat, { separator =" – "  } = {
     }) {
         if (!this.isValid) return INVALID2;
         return `${this.s.toFormat(dateFormat)}${separator}${this.e.toFormat(dateFormat)}`;
     }
-    toDuration(unit, opts) {
+    toDuration(unit15, opts35) {
         if (!this.isValid) {
             return Duration.invalid(this.invalidReason);
         }
-        return this.e.diff(this.s, unit, opts);
+        return this.e.diff(this.s, unit15, opts35);
     }
     mapEndpoints(mapFn) {
         return Interval.fromDateTimes(mapFn(this.s), mapFn(this.e));
     }
 }
-function highOrderDiffs(cursor, later, units) {
+function highOrderDiffs(cursor, later, units1) {
     const differs = [
         [
             "years",
@@ -4092,22 +4092,22 @@ function highOrderDiffs(cursor, later, units) {
     const results = {
     };
     let lowestOrder, highWater;
-    for (const [unit2, differ] of differs){
-        if (units.indexOf(unit2) >= 0) {
-            lowestOrder = unit2;
+    for (const [unit16, differ] of differs){
+        if (units1.indexOf(unit16) >= 0) {
+            lowestOrder = unit16;
             let delta = differ(cursor, later);
             highWater = cursor.plus({
-                [unit2]: delta
+                [unit16]: delta
             });
             if (highWater > later) {
                 cursor = cursor.plus({
-                    [unit2]: delta - 1
+                    [unit16]: delta - 1
                 });
                 delta -= 1;
             } else {
                 cursor = highWater;
             }
-            results[unit2] = delta;
+            results[unit16] = delta;
         }
     }
     return [
@@ -4117,10 +4117,10 @@ function highOrderDiffs(cursor, later, units) {
         lowestOrder
     ];
 }
-function __default(earlier, later, units, opts4) {
-    let [cursor, results, highWater, lowestOrder] = highOrderDiffs(earlier, later, units);
+function __default(earlier, later, units1, opts36) {
+    let [cursor, results, highWater, lowestOrder] = highOrderDiffs(earlier, later, units1);
     const remainingMillis = later - cursor;
-    const lowerOrderUnits = units.filter((u)=>[
+    const lowerOrderUnits = units1.filter((u)=>[
             "hours",
             "minutes",
             "seconds",
@@ -4137,28 +4137,28 @@ function __default(earlier, later, units, opts4) {
             results[lowestOrder] = (results[lowestOrder] || 0) + remainingMillis / (highWater - cursor);
         }
     }
-    const duration = Duration.fromObject(Object.assign(results, opts4));
+    const duration7 = Duration.fromObject(Object.assign(results, opts36));
     if (lowerOrderUnits.length > 0) {
-        return Duration.fromMillis(remainingMillis, opts4).shiftTo(...lowerOrderUnits).plus(duration);
+        return Duration.fromMillis(remainingMillis, opts36).shiftTo(...lowerOrderUnits).plus(duration7);
     } else {
-        return duration;
+        return duration7;
     }
 }
-function intUnit(regex, post = (i)=>i
+function intUnit(regex, post = (i1)=>i1
 ) {
     return {
         regex,
-        deser: ([s2])=>post(parseDigits(s2))
+        deser: ([s3])=>post(parseDigits(s3))
     };
 }
 const NBSP = String.fromCharCode(160);
 const spaceOrNBSP = `( |${NBSP})`;
 const spaceOrNBSPRegExp = new RegExp(spaceOrNBSP, "g");
-function fixListRegex(s2) {
-    return s2.replace(/\./g, "\\.?").replace(spaceOrNBSPRegExp, spaceOrNBSP);
+function fixListRegex(s3) {
+    return s3.replace(/\./g, "\\.?").replace(spaceOrNBSPRegExp, spaceOrNBSP);
 }
-function stripInsensitivities(s2) {
-    return s2.replace(/\./g, "").replace(spaceOrNBSPRegExp, " ").toLowerCase();
+function stripInsensitivities(s3) {
+    return s3.replace(/\./g, "").replace(spaceOrNBSPRegExp, " ").toLowerCase();
 }
 function oneOf(strings, startIndex) {
     if (strings === null) {
@@ -4166,12 +4166,12 @@ function oneOf(strings, startIndex) {
     } else {
         return {
             regex: RegExp(strings.map(fixListRegex).join("|")),
-            deser: ([s2])=>strings.findIndex((i)=>stripInsensitivities(s2) === stripInsensitivities(i)
+            deser: ([s3])=>strings.findIndex((i1)=>stripInsensitivities(s3) === stripInsensitivities(i1)
                 ) + startIndex
         };
     }
 }
-function offset2(regex, groups) {
+function offset3(regex, groups) {
     return {
         regex,
         deser: ([, h, m])=>signedOffset(h, m)
@@ -4182,24 +4182,24 @@ function offset2(regex, groups) {
 function simple(regex) {
     return {
         regex,
-        deser: ([s2])=>s2
+        deser: ([s3])=>s3
     };
 }
 function escapeToken(value) {
     return value.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&");
 }
-function unitForToken(token, loc) {
-    const one = digitRegex(loc), two = digitRegex(loc, "{2}"), three = digitRegex(loc, "{3}"), four = digitRegex(loc, "{4}"), six = digitRegex(loc, "{6}"), oneOrTwo = digitRegex(loc, "{1,2}"), oneToThree = digitRegex(loc, "{1,3}"), oneToSix = digitRegex(loc, "{1,6}"), oneToNine = digitRegex(loc, "{1,9}"), twoToFour = digitRegex(loc, "{2,4}"), fourToSix = digitRegex(loc, "{4,6}"), literal = (t)=>({
-            regex: RegExp(escapeToken(t.val)),
-            deser: ([s2])=>s2
+function unitForToken(token1, loc) {
+    const one = digitRegex(loc), two = digitRegex(loc, "{2}"), three = digitRegex(loc, "{3}"), four = digitRegex(loc, "{4}"), six = digitRegex(loc, "{6}"), oneOrTwo = digitRegex(loc, "{1,2}"), oneToThree = digitRegex(loc, "{1,3}"), oneToSix = digitRegex(loc, "{1,6}"), oneToNine = digitRegex(loc, "{1,9}"), twoToFour = digitRegex(loc, "{2,4}"), fourToSix = digitRegex(loc, "{4,6}"), literal = (t1)=>({
+            regex: RegExp(escapeToken(t1.val)),
+            deser: ([s3])=>s3
             ,
             literal: true
         })
-    , unitate = (t)=>{
-        if (token.literal) {
-            return literal(t);
+    , unitate = (t1)=>{
+        if (token1.literal) {
+            return literal(t1);
         }
-        switch(t.val){
+        switch(t1.val){
             case "G":
                 return oneOf(loc.eras("short", false), 0);
             case "GG":
@@ -4287,20 +4287,20 @@ function unitForToken(token, loc) {
                 return oneOf(loc.weekdays("long", true, false), 1);
             case "Z":
             case "ZZ":
-                return offset2(new RegExp(`([+-]${oneOrTwo.source})(?::(${two.source}))?`), 2);
+                return offset3(new RegExp(`([+-]${oneOrTwo.source})(?::(${two.source}))?`), 2);
             case "ZZZ":
-                return offset2(new RegExp(`([+-]${oneOrTwo.source})(${two.source})?`), 2);
+                return offset3(new RegExp(`([+-]${oneOrTwo.source})(${two.source})?`), 2);
             case "z":
                 return simple(/[a-z_+-/]{1,256}?/i);
             default:
-                return literal(t);
+                return literal(t1);
         }
     };
-    const unit2 = unitate(token) || {
+    const unit16 = unitate(token1) || {
         invalidReason: MISSING_FTP
     };
-    unit2.token = token;
-    return unit2;
+    unit16.token = token1;
+    return unit16;
 }
 const partTypeStyleToTokenVal = {
     year: {
@@ -4336,7 +4336,7 @@ const partTypeStyleToTokenVal = {
         "2-digit": "ss"
     }
 };
-function tokenForPart(part, locale3, formatOpts1) {
+function tokenForPart(part, locale17, formatOpts1) {
     const { type , value  } = part;
     if (type === "literal") {
         return {
@@ -4357,24 +4357,24 @@ function tokenForPart(part, locale3, formatOpts1) {
     }
     return undefined;
 }
-function buildRegex(units) {
-    const re = units.map((u)=>u.regex
+function buildRegex(units1) {
+    const re = units1.map((u)=>u.regex
     ).reduce((f, r)=>`${f}(${r.source})`
     , "");
     return [
         `^${re}$`,
-        units
+        units1
     ];
 }
-function match(input, regex, handlers) {
-    const matches = input.match(regex);
+function match(input1, regex, handlers) {
+    const matches = input1.match(regex);
     if (matches) {
         const all = {
         };
         let matchIndex = 1;
-        for(const i in handlers){
-            if (hasOwnProperty(handlers, i)) {
-                const h = handlers[i], groups = h.groups ? h.groups + 1 : 1;
+        for(const i1 in handlers){
+            if (hasOwnProperty(handlers, i1)) {
+                const h = handlers[i1], groups = h.groups ? h.groups + 1 : 1;
                 if (!h.literal && h.token) {
                     all[h.token.val[0]] = h.deser(matches.slice(matchIndex, matchIndex + groups));
                 }
@@ -4394,8 +4394,8 @@ function match(input, regex, handlers) {
     }
 }
 function dateTimeFromMatches(matches) {
-    const toField = (token)=>{
-        switch(token){
+    const toField = (token1)=>{
+        switch(token1){
             case "S":
                 return "millisecond";
             case "s":
@@ -4427,13 +4427,13 @@ function dateTimeFromMatches(matches) {
                 return null;
         }
     };
-    let zone2;
+    let zone5;
     if (!isUndefined(matches.Z)) {
-        zone2 = new FixedOffsetZone(matches.Z);
+        zone5 = new FixedOffsetZone(matches.Z);
     } else if (!isUndefined(matches.z)) {
-        zone2 = IANAZone.create(matches.z);
+        zone5 = IANAZone.create(matches.z);
     } else {
-        zone2 = null;
+        zone5 = null;
     }
     if (!isUndefined(matches.q)) {
         matches.M = (matches.q - 1) * 3 + 1;
@@ -4461,7 +4461,7 @@ function dateTimeFromMatches(matches) {
     });
     return [
         vals,
-        zone2
+        zone5
     ];
 }
 let dummyDateTimeCache = null;
@@ -4471,39 +4471,39 @@ function getDummyDateTime() {
     }
     return dummyDateTimeCache;
 }
-function maybeExpandMacroToken(token, locale3) {
-    if (token.literal) {
-        return token;
+function maybeExpandMacroToken(token1, locale17) {
+    if (token1.literal) {
+        return token1;
     }
-    const formatOpts1 = Formatter.macroTokenToFormatOpts(token.val);
+    const formatOpts1 = Formatter.macroTokenToFormatOpts(token1.val);
     if (!formatOpts1) {
-        return token;
+        return token1;
     }
-    const formatter = Formatter.create(locale3, formatOpts1);
+    const formatter = Formatter.create(locale17, formatOpts1);
     const parts = formatter.formatDateTimeParts(getDummyDateTime());
-    const tokens = parts.map((p)=>tokenForPart(p, locale3, formatOpts1)
+    const tokens = parts.map((p1)=>tokenForPart(p1, locale17, formatOpts1)
     );
     if (tokens.includes(undefined)) {
-        return token;
+        return token1;
     }
     return tokens;
 }
-function expandMacroTokens(tokens, locale3) {
-    return Array.prototype.concat(...tokens.map((t)=>maybeExpandMacroToken(t, locale3)
+function expandMacroTokens(tokens, locale17) {
+    return Array.prototype.concat(...tokens.map((t1)=>maybeExpandMacroToken(t1, locale17)
     ));
 }
-function explainFromTokens(locale3, input, format) {
-    const tokens = expandMacroTokens(Formatter.parseFormat(format), locale3), units = tokens.map((t)=>unitForToken(t, locale3)
-    ), disqualifyingUnit = units.find((t)=>t.invalidReason
+function explainFromTokens(locale17, input1, format10) {
+    const tokens = expandMacroTokens(Formatter.parseFormat(format10), locale17), units1 = tokens.map((t1)=>unitForToken(t1, locale17)
+    ), disqualifyingUnit = units1.find((t1)=>t1.invalidReason
     );
     if (disqualifyingUnit) {
         return {
-            input,
+            input: input1,
             tokens,
             invalidReason: disqualifyingUnit.invalidReason
         };
     } else {
-        const [regexString, handlers] = buildRegex(units), regex = RegExp(regexString, "i"), [rawMatches, matches] = match(input, regex, handlers), [result, zone2] = matches ? dateTimeFromMatches(matches) : [
+        const [regexString, handlers] = buildRegex(units1), regex = RegExp(regexString, "i"), [rawMatches, matches] = match(input1, regex, handlers), [result, zone5] = matches ? dateTimeFromMatches(matches) : [
             null,
             null
         ];
@@ -4511,21 +4511,21 @@ function explainFromTokens(locale3, input, format) {
             throw new ConflictingSpecificationError("Can't include meridiem when specifying 24-hour format");
         }
         return {
-            input,
+            input: input1,
             tokens,
             regex,
             rawMatches,
             matches,
             result,
-            zone: zone2
+            zone: zone5
         };
     }
 }
-function parseFromTokens(locale3, input, format) {
-    const { result , zone: zone2 , invalidReason  } = explainFromTokens(locale3, input, format);
+function parseFromTokens(locale17, input1, format10) {
+    const { result , zone: zone5 , invalidReason  } = explainFromTokens(locale17, input1, format10);
     return [
         result,
-        zone2,
+        zone5,
         invalidReason
     ];
 }
@@ -4543,6 +4543,6 @@ const mod = function() {
         Settings: Settings
     };
 }();
-const date = new Date();
-const dt2 = mod.DateTime.fromJSDate(date);
-console.log(dt2.toISO());
+const date1 = new Date();
+const dt8 = mod.DateTime.fromJSDate(date1);
+console.log(dt8.toISO());

--- a/bundler/tests/fixture/deno-8211-3/output/entry.ts
+++ b/bundler/tests/fixture/deno-8211-3/output/entry.ts
@@ -1,8 +1,8 @@
 class LuxonError extends Error {
 }
 class InvalidDateTimeError extends LuxonError {
-    constructor(reason4){
-        super(`Invalid DateTime: ${reason4.toMessage()}`);
+    constructor(reason){
+        super(`Invalid DateTime: ${reason.toMessage()}`);
     }
 }
 class InvalidIntervalError extends LuxonError {
@@ -18,8 +18,8 @@ class InvalidDurationError extends LuxonError {
 class ConflictingSpecificationError extends LuxonError {
 }
 class InvalidUnitError extends LuxonError {
-    constructor(unit1){
-        super(`Invalid unit ${unit1}`);
+    constructor(unit){
+        super(`Invalid unit ${unit}`);
     }
 }
 class InvalidArgumentError extends LuxonError {
@@ -244,152 +244,152 @@ function timeObject(obj) {
     ]);
 }
 const ianaRegex = /[A-Za-z_+-]{1,256}(:?\/[A-Za-z_+-]{1,256}(\/[A-Za-z_+-]{1,256})?)?/;
-const n1 = "numeric", s1 = "short", l = "long";
+const n = "numeric", s = "short", l = "long";
 const DATE_SHORT = {
-    year: n1,
-    month: n1,
-    day: n1
+    year: n,
+    month: n,
+    day: n
 };
 const DATE_MED = {
-    year: n1,
-    month: s1,
-    day: n1
+    year: n,
+    month: s,
+    day: n
 };
 const DATE_MED_WITH_WEEKDAY = {
-    year: n1,
-    month: s1,
-    day: n1,
-    weekday: s1
+    year: n,
+    month: s,
+    day: n,
+    weekday: s
 };
 const DATE_FULL = {
-    year: n1,
+    year: n,
     month: l,
-    day: n1
+    day: n
 };
 const DATE_HUGE = {
-    year: n1,
+    year: n,
     month: l,
-    day: n1,
+    day: n,
     weekday: l
 };
 const TIME_SIMPLE = {
-    hour: n1,
-    minute: n1
+    hour: n,
+    minute: n
 };
 const TIME_WITH_SECONDS = {
-    hour: n1,
-    minute: n1,
-    second: n1
+    hour: n,
+    minute: n,
+    second: n
 };
 const TIME_WITH_SHORT_OFFSET = {
-    hour: n1,
-    minute: n1,
-    second: n1,
-    timeZoneName: s1
+    hour: n,
+    minute: n,
+    second: n,
+    timeZoneName: s
 };
 const TIME_WITH_LONG_OFFSET = {
-    hour: n1,
-    minute: n1,
-    second: n1,
+    hour: n,
+    minute: n,
+    second: n,
     timeZoneName: l
 };
 const TIME_24_SIMPLE = {
-    hour: n1,
-    minute: n1,
+    hour: n,
+    minute: n,
     hour12: false
 };
 const TIME_24_WITH_SECONDS = {
-    hour: n1,
-    minute: n1,
-    second: n1,
+    hour: n,
+    minute: n,
+    second: n,
     hour12: false
 };
 const TIME_24_WITH_SHORT_OFFSET = {
-    hour: n1,
-    minute: n1,
-    second: n1,
+    hour: n,
+    minute: n,
+    second: n,
     hour12: false,
-    timeZoneName: s1
+    timeZoneName: s
 };
 const TIME_24_WITH_LONG_OFFSET = {
-    hour: n1,
-    minute: n1,
-    second: n1,
+    hour: n,
+    minute: n,
+    second: n,
     hour12: false,
     timeZoneName: l
 };
 const DATETIME_SHORT = {
-    year: n1,
-    month: n1,
-    day: n1,
-    hour: n1,
-    minute: n1
+    year: n,
+    month: n,
+    day: n,
+    hour: n,
+    minute: n
 };
 const DATETIME_SHORT_WITH_SECONDS = {
-    year: n1,
-    month: n1,
-    day: n1,
-    hour: n1,
-    minute: n1,
-    second: n1
+    year: n,
+    month: n,
+    day: n,
+    hour: n,
+    minute: n,
+    second: n
 };
 const DATETIME_MED = {
-    year: n1,
-    month: s1,
-    day: n1,
-    hour: n1,
-    minute: n1
+    year: n,
+    month: s,
+    day: n,
+    hour: n,
+    minute: n
 };
 const DATETIME_MED_WITH_SECONDS = {
-    year: n1,
-    month: s1,
-    day: n1,
-    hour: n1,
-    minute: n1,
-    second: n1
+    year: n,
+    month: s,
+    day: n,
+    hour: n,
+    minute: n,
+    second: n
 };
 const DATETIME_MED_WITH_WEEKDAY = {
-    year: n1,
-    month: s1,
-    day: n1,
-    weekday: s1,
-    hour: n1,
-    minute: n1
+    year: n,
+    month: s,
+    day: n,
+    weekday: s,
+    hour: n,
+    minute: n
 };
 const DATETIME_FULL = {
-    year: n1,
+    year: n,
     month: l,
-    day: n1,
-    hour: n1,
-    minute: n1,
-    timeZoneName: s1
+    day: n,
+    hour: n,
+    minute: n,
+    timeZoneName: s
 };
 const DATETIME_FULL_WITH_SECONDS = {
-    year: n1,
+    year: n,
     month: l,
-    day: n1,
-    hour: n1,
-    minute: n1,
-    second: n1,
-    timeZoneName: s1
+    day: n,
+    hour: n,
+    minute: n,
+    second: n,
+    timeZoneName: s
 };
 const DATETIME_HUGE = {
-    year: n1,
+    year: n,
     month: l,
-    day: n1,
+    day: n,
     weekday: l,
-    hour: n1,
-    minute: n1,
+    hour: n,
+    minute: n,
     timeZoneName: l
 };
 const DATETIME_HUGE_WITH_SECONDS = {
-    year: n1,
+    year: n,
     month: l,
-    day: n1,
+    day: n,
     weekday: l,
-    hour: n1,
-    minute: n1,
-    second: n1,
+    hour: n,
+    minute: n,
+    second: n,
     timeZoneName: l
 };
 function stringify(obj) {
@@ -770,100 +770,100 @@ class Formatter {
         this.loc = locale1;
         this.systemLoc = null;
     }
-    formatWithSystemDefault(dt, opts) {
+    formatWithSystemDefault(dt, opts1) {
         if (this.systemLoc === null) {
             this.systemLoc = this.loc.redefaultToSystem();
         }
         const df = this.systemLoc.dtFormatter(dt, Object.assign({
-        }, this.opts, opts));
+        }, this.opts, opts1));
         return df.format();
     }
-    formatDateTime(dt, opts = {
+    formatDateTime(dt1, opts2 = {
     }) {
-        const df = this.loc.dtFormatter(dt, Object.assign({
-        }, this.opts, opts));
+        const df = this.loc.dtFormatter(dt1, Object.assign({
+        }, this.opts, opts2));
         return df.format();
     }
-    formatDateTimeParts(dt, opts = {
+    formatDateTimeParts(dt2, opts3 = {
     }) {
-        const df = this.loc.dtFormatter(dt, Object.assign({
-        }, this.opts, opts));
+        const df = this.loc.dtFormatter(dt2, Object.assign({
+        }, this.opts, opts3));
         return df.formatToParts();
     }
-    resolvedOptions(dt, opts = {
+    resolvedOptions(dt3, opts4 = {
     }) {
-        const df = this.loc.dtFormatter(dt, Object.assign({
-        }, this.opts, opts));
+        const df = this.loc.dtFormatter(dt3, Object.assign({
+        }, this.opts, opts4));
         return df.resolvedOptions();
     }
-    num(n, p = 0) {
+    num(n1, p = 0) {
         if (this.opts.forceSimple) {
-            return padStart(n, p);
+            return padStart(n1, p);
         }
-        const opts = Object.assign({
+        const opts5 = Object.assign({
         }, this.opts);
         if (p > 0) {
-            opts.padTo = p;
+            opts5.padTo = p;
         }
-        return this.loc.numberFormatter(opts).format(n);
+        return this.loc.numberFormatter(opts5).format(n1);
     }
-    formatDateTimeFromString(dt, fmt) {
-        const knownEnglish = this.loc.listingMode() === "en", useDateTimeFormatter = this.loc.outputCalendar && this.loc.outputCalendar !== "gregory" && hasFormatToParts(), string = (opts, extract)=>this.loc.extract(dt, opts, extract)
-        , formatOffset1 = (opts)=>{
-            if (dt.isOffsetFixed && dt.offset === 0 && opts.allowZ) {
+    formatDateTimeFromString(dt4, fmt1) {
+        const knownEnglish = this.loc.listingMode() === "en", useDateTimeFormatter = this.loc.outputCalendar && this.loc.outputCalendar !== "gregory" && hasFormatToParts(), string = (opts5, extract)=>this.loc.extract(dt4, opts5, extract)
+        , formatOffset1 = (opts5)=>{
+            if (dt4.isOffsetFixed && dt4.offset === 0 && opts5.allowZ) {
                 return "Z";
             }
-            return dt.isValid ? dt.zone.formatOffset(dt.ts, opts.format) : "";
-        }, meridiem = ()=>knownEnglish ? meridiemForDateTime(dt) : string({
+            return dt4.isValid ? dt4.zone.formatOffset(dt4.ts, opts5.format) : "";
+        }, meridiem = ()=>knownEnglish ? meridiemForDateTime(dt4) : string({
                 hour: "numeric",
                 hour12: true
             }, "dayperiod")
-        , month = (length, standalone)=>knownEnglish ? monthForDateTime(dt, length) : string(standalone ? {
+        , month = (length, standalone)=>knownEnglish ? monthForDateTime(dt4, length) : string(standalone ? {
                 month: length
             } : {
                 month: length,
                 day: "numeric"
             }, "month")
-        , weekday = (length, standalone)=>knownEnglish ? weekdayForDateTime(dt, length) : string(standalone ? {
+        , weekday = (length, standalone)=>knownEnglish ? weekdayForDateTime(dt4, length) : string(standalone ? {
                 weekday: length
             } : {
                 weekday: length,
                 month: "long",
                 day: "numeric"
             }, "weekday")
-        , maybeMacro = (token)=>{
-            const formatOpts1 = Formatter.macroTokenToFormatOpts(token);
+        , maybeMacro = (token1)=>{
+            const formatOpts1 = Formatter.macroTokenToFormatOpts(token1);
             if (formatOpts1) {
-                return this.formatWithSystemDefault(dt, formatOpts1);
+                return this.formatWithSystemDefault(dt4, formatOpts1);
             } else {
-                return token;
+                return token1;
             }
-        }, era = (length)=>knownEnglish ? eraForDateTime(dt, length) : string({
+        }, era = (length)=>knownEnglish ? eraForDateTime(dt4, length) : string({
                 era: length
             }, "era")
-        , tokenToString = (token)=>{
-            switch(token){
+        , tokenToString = (token1)=>{
+            switch(token1){
                 case "S":
-                    return this.num(dt.millisecond);
+                    return this.num(dt4.millisecond);
                 case "u":
                 case "SSS":
-                    return this.num(dt.millisecond, 3);
+                    return this.num(dt4.millisecond, 3);
                 case "s":
-                    return this.num(dt.second);
+                    return this.num(dt4.second);
                 case "ss":
-                    return this.num(dt.second, 2);
+                    return this.num(dt4.second, 2);
                 case "m":
-                    return this.num(dt.minute);
+                    return this.num(dt4.minute);
                 case "mm":
-                    return this.num(dt.minute, 2);
+                    return this.num(dt4.minute, 2);
                 case "h":
-                    return this.num(dt.hour % 12 === 0 ? 12 : dt.hour % 12);
+                    return this.num(dt4.hour % 12 === 0 ? 12 : dt4.hour % 12);
                 case "hh":
-                    return this.num(dt.hour % 12 === 0 ? 12 : dt.hour % 12, 2);
+                    return this.num(dt4.hour % 12 === 0 ? 12 : dt4.hour % 12, 2);
                 case "H":
-                    return this.num(dt.hour);
+                    return this.num(dt4.hour);
                 case "HH":
-                    return this.num(dt.hour, 2);
+                    return this.num(dt4.hour, 2);
                 case "Z":
                     return formatOffset1({
                         format: "narrow",
@@ -880,29 +880,29 @@ class Formatter {
                         allowZ: this.opts.allowZ
                     });
                 case "ZZZZ":
-                    return dt.zone.offsetName(dt.ts, {
+                    return dt4.zone.offsetName(dt4.ts, {
                         format: "short",
                         locale: this.loc.locale
                     });
                 case "ZZZZZ":
-                    return dt.zone.offsetName(dt.ts, {
+                    return dt4.zone.offsetName(dt4.ts, {
                         format: "long",
                         locale: this.loc.locale
                     });
                 case "z":
-                    return dt.zoneName;
+                    return dt4.zoneName;
                 case "a":
                     return meridiem();
                 case "d":
                     return useDateTimeFormatter ? string({
                         day: "numeric"
-                    }, "day") : this.num(dt.day);
+                    }, "day") : this.num(dt4.day);
                 case "dd":
                     return useDateTimeFormatter ? string({
                         day: "2-digit"
-                    }, "day") : this.num(dt.day, 2);
+                    }, "day") : this.num(dt4.day, 2);
                 case "c":
-                    return this.num(dt.weekday);
+                    return this.num(dt4.weekday);
                 case "ccc":
                     return weekday("short", true);
                 case "cccc":
@@ -910,7 +910,7 @@ class Formatter {
                 case "ccccc":
                     return weekday("narrow", true);
                 case "E":
-                    return this.num(dt.weekday);
+                    return this.num(dt4.weekday);
                 case "EEE":
                     return weekday("short", false);
                 case "EEEE":
@@ -921,12 +921,12 @@ class Formatter {
                     return useDateTimeFormatter ? string({
                         month: "numeric",
                         day: "numeric"
-                    }, "month") : this.num(dt.month);
+                    }, "month") : this.num(dt4.month);
                 case "LL":
                     return useDateTimeFormatter ? string({
                         month: "2-digit",
                         day: "numeric"
-                    }, "month") : this.num(dt.month, 2);
+                    }, "month") : this.num(dt4.month, 2);
                 case "LLL":
                     return month("short", true);
                 case "LLLL":
@@ -936,11 +936,11 @@ class Formatter {
                 case "M":
                     return useDateTimeFormatter ? string({
                         month: "numeric"
-                    }, "month") : this.num(dt.month);
+                    }, "month") : this.num(dt4.month);
                 case "MM":
                     return useDateTimeFormatter ? string({
                         month: "2-digit"
-                    }, "month") : this.num(dt.month, 2);
+                    }, "month") : this.num(dt4.month, 2);
                 case "MMM":
                     return month("short", false);
                 case "MMMM":
@@ -950,19 +950,19 @@ class Formatter {
                 case "y":
                     return useDateTimeFormatter ? string({
                         year: "numeric"
-                    }, "year") : this.num(dt.year);
+                    }, "year") : this.num(dt4.year);
                 case "yy":
                     return useDateTimeFormatter ? string({
                         year: "2-digit"
-                    }, "year") : this.num(dt.year.toString().slice(-2), 2);
+                    }, "year") : this.num(dt4.year.toString().slice(-2), 2);
                 case "yyyy":
                     return useDateTimeFormatter ? string({
                         year: "numeric"
-                    }, "year") : this.num(dt.year, 4);
+                    }, "year") : this.num(dt4.year, 4);
                 case "yyyyyy":
                     return useDateTimeFormatter ? string({
                         year: "numeric"
-                    }, "year") : this.num(dt.year, 6);
+                    }, "year") : this.num(dt4.year, 6);
                 case "G":
                     return era("short");
                 case "GG":
@@ -970,34 +970,34 @@ class Formatter {
                 case "GGGGG":
                     return era("narrow");
                 case "kk":
-                    return this.num(dt.weekYear.toString().slice(-2), 2);
+                    return this.num(dt4.weekYear.toString().slice(-2), 2);
                 case "kkkk":
-                    return this.num(dt.weekYear, 4);
+                    return this.num(dt4.weekYear, 4);
                 case "W":
-                    return this.num(dt.weekNumber);
+                    return this.num(dt4.weekNumber);
                 case "WW":
-                    return this.num(dt.weekNumber, 2);
+                    return this.num(dt4.weekNumber, 2);
                 case "o":
-                    return this.num(dt.ordinal);
+                    return this.num(dt4.ordinal);
                 case "ooo":
-                    return this.num(dt.ordinal, 3);
+                    return this.num(dt4.ordinal, 3);
                 case "q":
-                    return this.num(dt.quarter);
+                    return this.num(dt4.quarter);
                 case "qq":
-                    return this.num(dt.quarter, 2);
+                    return this.num(dt4.quarter, 2);
                 case "X":
-                    return this.num(Math.floor(dt.ts / 1000));
+                    return this.num(Math.floor(dt4.ts / 1000));
                 case "x":
-                    return this.num(dt.ts);
+                    return this.num(dt4.ts);
                 default:
-                    return maybeMacro(token);
+                    return maybeMacro(token1);
             }
         };
-        return stringifyTokens(Formatter.parseFormat(fmt), tokenToString);
+        return stringifyTokens(Formatter.parseFormat(fmt1), tokenToString);
     }
-    formatDurationFromString(dur, fmt) {
-        const tokenToField = (token)=>{
-            switch(token[0]){
+    formatDurationFromString(dur, fmt2) {
+        const tokenToField = (token1)=>{
+            switch(token1[0]){
                 case "S":
                     return "millisecond";
                 case "s":
@@ -1015,15 +1015,15 @@ class Formatter {
                 default:
                     return null;
             }
-        }, tokenToString = (lildur)=>(token)=>{
-                const mapped = tokenToField(token);
+        }, tokenToString = (lildur)=>(token1)=>{
+                const mapped = tokenToField(token1);
                 if (mapped) {
-                    return this.num(lildur.get(mapped), token.length);
+                    return this.num(lildur.get(mapped), token1.length);
                 } else {
-                    return token;
+                    return token1;
                 }
             }
-        , tokens = Formatter.parseFormat(fmt), realTokens = tokens.reduce((found, { literal , val  })=>literal ? found : found.concat(val)
+        , tokens = Formatter.parseFormat(fmt2), realTokens = tokens.reduce((found, { literal , val  })=>literal ? found : found.concat(val)
         , []), collapsed = dur.shiftTo(...realTokens.map(tokenToField).filter((t)=>t
         ));
         return stringifyTokens(tokens, tokenToString(collapsed));
@@ -1039,13 +1039,13 @@ class Zone {
     get universal() {
         throw new ZoneIsAbstractError();
     }
-    offsetName(ts, opts) {
+    offsetName(ts, opts5) {
         throw new ZoneIsAbstractError();
     }
-    formatOffset(ts, format) {
+    formatOffset(ts1, format) {
         throw new ZoneIsAbstractError();
     }
-    offset(ts) {
+    offset(ts2) {
         throw new ZoneIsAbstractError();
     }
     equals(otherZone) {
@@ -1066,9 +1066,9 @@ class FixedOffsetZone extends Zone {
     static instance(offset) {
         return offset === 0 ? FixedOffsetZone.utcInstance : new FixedOffsetZone(offset);
     }
-    static parseSpecifier(s) {
-        if (s) {
-            const r = s.match(/^utc(?:([+-]\d{1,2})(?::(\d{2}))?)?$/i);
+    static parseSpecifier(s1) {
+        if (s1) {
+            const r = s1.match(/^utc(?:([+-]\d{1,2})(?::(\d{2}))?)?$/i);
             if (r) {
                 return new FixedOffsetZone(signedOffset(r[1], r[2]));
             }
@@ -1088,8 +1088,8 @@ class FixedOffsetZone extends Zone {
     offsetName() {
         return this.name;
     }
-    formatOffset(ts, format) {
-        return formatOffset(this.fixed, format);
+    formatOffset(ts3, format1) {
+        return formatOffset(this.fixed, format1);
     }
     get universal() {
         return true;
@@ -1097,8 +1097,8 @@ class FixedOffsetZone extends Zone {
     offset() {
         return this.fixed;
     }
-    equals(otherZone) {
-        return otherZone.type === "fixed" && otherZone.fixed === this.fixed;
+    equals(otherZone1) {
+        return otherZone1.type === "fixed" && otherZone1.fixed === this.fixed;
     }
     get isValid() {
         return true;
@@ -1166,8 +1166,8 @@ class IANAZone extends Zone {
         dtfCache = {
         };
     }
-    static isValidSpecifier(s) {
-        return !!(s && s.match(matchingRegex));
+    static isValidSpecifier(s2) {
+        return !!(s2 && s2.match(matchingRegex));
     }
     static isValidZone(zone) {
         try {
@@ -1188,10 +1188,10 @@ class IANAZone extends Zone {
         }
         return null;
     }
-    constructor(name){
+    constructor(name1){
         super();
-        this.zoneName = name;
-        this.valid = IANAZone.isValidZone(name);
+        this.zoneName = name1;
+        this.valid = IANAZone.isValidZone(name1);
     }
     get type() {
         return "iana";
@@ -1202,14 +1202,14 @@ class IANAZone extends Zone {
     get universal() {
         return false;
     }
-    offsetName(ts, { format , locale  }) {
-        return parseZoneInfo(ts, format, locale, this.name);
+    offsetName(ts4, { format: format2 , locale: locale2  }) {
+        return parseZoneInfo(ts4, format2, locale2, this.name);
     }
-    formatOffset(ts, format) {
-        return formatOffset(this.offset(ts), format);
+    formatOffset(ts5, format3) {
+        return formatOffset(this.offset(ts5), format3);
     }
-    offset(ts) {
-        const date = new Date(ts), dtf = makeDTF(this.name), [year, month, day, hour, minute, second] = dtf.formatToParts ? partsOffset(dtf, date) : hackyOffset(dtf, date), adjustedHour = hour === 24 ? 0 : hour;
+    offset(ts6) {
+        const date = new Date(ts6), dtf = makeDTF(this.name), [year, month, day, hour, minute, second] = dtf.formatToParts ? partsOffset(dtf, date) : hackyOffset(dtf, date), adjustedHour = hour === 24 ? 0 : hour;
         const asUTC = objToLocalTS({
             year,
             month,
@@ -1224,8 +1224,8 @@ class IANAZone extends Zone {
         asTS -= over >= 0 ? over : 1000 + over;
         return (asUTC - asTS) / (60 * 1000);
     }
-    equals(otherZone) {
-        return otherZone.type === "iana" && otherZone.name === this.name;
+    equals(otherZone2) {
+        return otherZone2.type === "iana" && otherZone2.name === this.name;
     }
     get isValid() {
         return this.valid;
@@ -1389,7 +1389,7 @@ class InvalidZone extends Zone {
     }
 }
 function normalizeZone(input, defaultZone) {
-    let offset1;
+    let offset2;
     if (isUndefined(input) || input === null) {
         return defaultZone;
     } else if (input instanceof Zone) {
@@ -1398,8 +1398,8 @@ function normalizeZone(input, defaultZone) {
         const lowered = input.toLowerCase();
         if (lowered === "local") return defaultZone;
         else if (lowered === "utc" || lowered === "gmt") return FixedOffsetZone.utcInstance;
-        else if ((offset1 = IANAZone.parseGMTOffset(input)) != null) {
-            return FixedOffsetZone.instance(offset1);
+        else if ((offset2 = IANAZone.parseGMTOffset(input)) != null) {
+            return FixedOffsetZone.instance(offset2);
         } else if (IANAZone.isValidSpecifier(lowered)) return IANAZone.create(input);
         else return FixedOffsetZone.parseSpecifier(lowered) || new InvalidZone(input);
     } else if (isNumber(input)) {
@@ -1411,9 +1411,9 @@ function normalizeZone(input, defaultZone) {
     }
 }
 class Invalid {
-    constructor(reason3, explanation1){
+    constructor(reason3, explanation){
         this.reason = reason3;
-        this.explanation = explanation1;
+        this.explanation = explanation;
     }
     toMessage() {
         if (this.explanation) {
@@ -1442,17 +1442,17 @@ class LocalZone extends Zone {
     get universal() {
         return false;
     }
-    offsetName(ts, { format , locale  }) {
-        return parseZoneInfo(ts, format, locale);
+    offsetName(ts7, { format: format4 , locale: locale3  }) {
+        return parseZoneInfo(ts7, format4, locale3);
     }
-    formatOffset(ts, format) {
-        return formatOffset(this.offset(ts), format);
+    formatOffset(ts8, format5) {
+        return formatOffset(this.offset(ts8), format5);
     }
-    offset(ts) {
-        return -new Date(ts).getTimezoneOffset();
+    offset(ts9) {
+        return -new Date(ts9).getTimezoneOffset();
     }
-    equals(otherZone) {
-        return otherZone.type === "local";
+    equals(otherZone3) {
+        return otherZone3.type === "local";
     }
     get isValid() {
         return true;
@@ -1465,10 +1465,10 @@ function combineRegexes(...regexes) {
 }
 function combineExtractors(...extractors) {
     return (m)=>extractors.reduce(([mergedVals, mergedZone, cursor], ex)=>{
-            const [val, zone, next] = ex(m, cursor);
+            const [val, zone1, next] = ex(m, cursor);
             return [
                 Object.assign(mergedVals, val),
-                mergedZone || zone,
+                mergedZone || zone1,
                 next
             ];
         }, [
@@ -1479,15 +1479,15 @@ function combineExtractors(...extractors) {
         ]).slice(0, 2)
     ;
 }
-function parse(s2, ...patterns) {
-    if (s2 == null) {
+function parse(s3, ...patterns) {
+    if (s3 == null) {
         return [
             null,
             null
         ];
     }
     for (const [regex, extractor] of patterns){
-        const m = regex.exec(s2);
+        const m = regex.exec(s3);
         if (m) {
             return extractor(m);
         }
@@ -1543,27 +1543,27 @@ function extractISOTime(match, cursor) {
     ];
 }
 function extractISOOffset(match, cursor) {
-    const local = !match[cursor] && !match[cursor + 1], fullOffset = signedOffset(match[cursor + 1], match[cursor + 2]), zone = local ? null : FixedOffsetZone.instance(fullOffset);
+    const local = !match[cursor] && !match[cursor + 1], fullOffset = signedOffset(match[cursor + 1], match[cursor + 2]), zone1 = local ? null : FixedOffsetZone.instance(fullOffset);
     return [
         {
         },
-        zone,
+        zone1,
         cursor + 3
     ];
 }
 function extractIANAZone(match, cursor) {
-    const zone = match[cursor] ? IANAZone.create(match[cursor]) : null;
+    const zone1 = match[cursor] ? IANAZone.create(match[cursor]) : null;
     return [
         {
         },
-        zone,
+        zone1,
         cursor + 1
     ];
 }
 const isoDuration = /^-?P(?:(?:(-?\d{1,9})Y)?(?:(-?\d{1,9})M)?(?:(-?\d{1,9})W)?(?:(-?\d{1,9})D)?(?:T(?:(-?\d{1,9})H)?(?:(-?\d{1,9})M)?(?:(-?\d{1,20})(?:[.,](-?\d{1,9}))?S)?)?)$/;
 function extractISODuration(match) {
-    const [s2, yearStr, monthStr, weekStr, dayStr, hourStr, minuteStr, secondStr, millisecondsStr] = match;
-    const hasNegativePrefix = s2[0] === "-";
+    const [s3, yearStr, monthStr, weekStr, dayStr, hourStr, minuteStr, secondStr, millisecondsStr] = match;
+    const hasNegativePrefix = s3[0] === "-";
     const maybeNegate = (num)=>num && hasNegativePrefix ? -num : num
     ;
     return [
@@ -1607,21 +1607,21 @@ function fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, 
 const rfc2822 = /^(?:(Mon|Tue|Wed|Thu|Fri|Sat|Sun),\s)?(\d{1,2})\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\d{2,4})\s(\d\d):(\d\d)(?::(\d\d))?\s(?:(UT|GMT|[ECMP][SD]T)|([Zz])|(?:([+-]\d\d)(\d\d)))$/;
 function extractRFC2822(match) {
     const [, weekdayStr, dayStr, monthStr, yearStr, hourStr, minuteStr, secondStr, obsOffset, milOffset, offHourStr, offMinuteStr] = match, result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
-    let offset1;
+    let offset2;
     if (obsOffset) {
-        offset1 = obsOffsets[obsOffset];
+        offset2 = obsOffsets[obsOffset];
     } else if (milOffset) {
-        offset1 = 0;
+        offset2 = 0;
     } else {
-        offset1 = signedOffset(offHourStr, offMinuteStr);
+        offset2 = signedOffset(offHourStr, offMinuteStr);
     }
     return [
         result,
-        new FixedOffsetZone(offset1)
+        new FixedOffsetZone(offset2)
     ];
 }
-function preprocessRFC2822(s2) {
-    return s2.replace(/\([^)]*\)|[\n\t]/g, " ").replace(/(\s\s+)/g, " ").trim();
+function preprocessRFC2822(s3) {
+    return s3.replace(/\([^)]*\)|[\n\t]/g, " ").replace(/(\s\s+)/g, " ").trim();
 }
 const rfc1123 = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d\d) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d\d):(\d\d):(\d\d) GMT$/, rfc850 = /^(Monday|Tuesday|Wedsday|Thursday|Friday|Saturday|Sunday), (\d\d)-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d\d) (\d\d):(\d\d):(\d\d) GMT$/, ascii = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ( \d|\d\d) (\d\d):(\d\d):(\d\d) (\d{4})$/;
 function extractRFC1123Or850(match) {
@@ -1646,8 +1646,8 @@ const extractISOYmdTimeAndOffset = combineExtractors(extractISOYmd, extractISOTi
 const extractISOWeekTimeAndOffset = combineExtractors(extractISOWeekData, extractISOTime, extractISOOffset);
 const extractISOOrdinalDataAndTime = combineExtractors(extractISOOrdinalData, extractISOTime);
 const extractISOTimeAndOffset = combineExtractors(extractISOTime, extractISOOffset);
-function parseISODate(s2) {
-    return parse(s2, [
+function parseISODate(s3) {
+    return parse(s3, [
         isoYmdWithTimeExtensionRegex,
         extractISOYmdTimeAndOffset
     ], [
@@ -1661,14 +1661,14 @@ function parseISODate(s2) {
         extractISOTimeAndOffset
     ]);
 }
-function parseRFC2822Date(s2) {
-    return parse(preprocessRFC2822(s2), [
+function parseRFC2822Date(s3) {
+    return parse(preprocessRFC2822(s3), [
         rfc2822,
         extractRFC2822
     ]);
 }
-function parseHTTPDate(s2) {
-    return parse(s2, [
+function parseHTTPDate(s3) {
+    return parse(s3, [
         rfc1123,
         extractRFC1123Or850
     ], [
@@ -1679,8 +1679,8 @@ function parseHTTPDate(s2) {
         extractASCII
     ]);
 }
-function parseISODuration(s2) {
-    return parse(s2, [
+function parseISODuration(s3) {
+    return parse(s3, [
         isoDuration,
         extractISODuration
     ]);
@@ -1689,8 +1689,8 @@ const sqlYmdWithTimeExtensionRegex = combineRegexes(sqlYmdRegex, sqlTimeExtensio
 const sqlTimeCombinedRegex = combineRegexes(sqlTimeRegex);
 const extractISOYmdTimeOffsetAndIANAZone = combineExtractors(extractISOYmd, extractISOTime, extractISOOffset, extractIANAZone);
 const extractISOTimeOffsetAndIANAZone = combineExtractors(extractISOTime, extractISOOffset, extractIANAZone);
-function parseSQL(s2) {
-    return parse(s2, [
+function parseSQL(s3) {
+    return parse(s3, [
         sqlYmdWithTimeExtensionRegex,
         extractISOYmdTimeOffsetAndIANAZone
     ], [
@@ -1844,43 +1844,43 @@ let now = ()=>Date.now()
 , defaultZone = null, defaultLocale = null, defaultNumberingSystem = null, defaultOutputCalendar = null, throwOnInvalid = false;
 const INVALID2 = "Invalid Interval";
 class Info {
-    static hasDST(zone = Settings.defaultZone) {
-        const proto = DateTime.local().setZone(zone).set({
+    static hasDST(zone1 = Settings.defaultZone) {
+        const proto = DateTime.local().setZone(zone1).set({
             month: 12
         });
-        return !zone.universal && proto.offset !== proto.set({
+        return !zone1.universal && proto.offset !== proto.set({
             month: 6
         }).offset;
     }
-    static isValidIANAZone(zone) {
-        return IANAZone.isValidSpecifier(zone) && IANAZone.isValidZone(zone);
+    static isValidIANAZone(zone2) {
+        return IANAZone.isValidSpecifier(zone2) && IANAZone.isValidZone(zone2);
     }
     static normalizeZone(input) {
         return normalizeZone(input, Settings.defaultZone);
     }
-    static months(length = "long", { locale =null , numberingSystem =null , outputCalendar ="gregory"  } = {
+    static months(length = "long", { locale: locale4 = null , numberingSystem =null , outputCalendar ="gregory"  } = {
     }) {
-        return Locale.create(locale, numberingSystem, outputCalendar).months(length);
+        return Locale.create(locale4, numberingSystem, outputCalendar).months(length);
     }
-    static monthsFormat(length = "long", { locale =null , numberingSystem =null , outputCalendar ="gregory"  } = {
+    static monthsFormat(length1 = "long", { locale: locale5 = null , numberingSystem: numberingSystem1 = null , outputCalendar: outputCalendar1 = "gregory"  } = {
     }) {
-        return Locale.create(locale, numberingSystem, outputCalendar).months(length, true);
+        return Locale.create(locale5, numberingSystem1, outputCalendar1).months(length1, true);
     }
-    static weekdays(length = "long", { locale =null , numberingSystem =null  } = {
+    static weekdays(length2 = "long", { locale: locale6 = null , numberingSystem: numberingSystem2 = null  } = {
     }) {
-        return Locale.create(locale, numberingSystem, null).weekdays(length);
+        return Locale.create(locale6, numberingSystem2, null).weekdays(length2);
     }
-    static weekdaysFormat(length = "long", { locale =null , numberingSystem =null  } = {
+    static weekdaysFormat(length3 = "long", { locale: locale7 = null , numberingSystem: numberingSystem3 = null  } = {
     }) {
-        return Locale.create(locale, numberingSystem, null).weekdays(length, true);
+        return Locale.create(locale7, numberingSystem3, null).weekdays(length3, true);
     }
-    static meridiems({ locale =null  } = {
+    static meridiems({ locale: locale8 = null  } = {
     }) {
-        return Locale.create(locale).meridiems();
+        return Locale.create(locale8).meridiems();
     }
-    static eras(length = "short", { locale =null  } = {
+    static eras(length4 = "short", { locale: locale9 = null  } = {
     }) {
-        return Locale.create(locale, null, "gregory").eras(length);
+        return Locale.create(locale9, null, "gregory").eras(length4);
     }
     static features() {
         let intl = false, intlTokens = false, zones = false, relative = false;
@@ -1999,13 +1999,13 @@ const orderedUnits = [
     "milliseconds"
 ];
 const reverseUnits = orderedUnits.slice(0).reverse();
-function clone(dur, alts, clear = false) {
+function clone(dur1, alts, clear = false) {
     const conf = {
         values: clear ? alts.values : Object.assign({
-        }, dur.values, alts.values || {
+        }, dur1.values, alts.values || {
         }),
-        loc: dur.loc.clone(alts.loc),
-        conversionAccuracy: alts.conversionAccuracy || dur.conversionAccuracy
+        loc: dur1.loc.clone(alts.loc),
+        conversionAccuracy: alts.conversionAccuracy || dur1.conversionAccuracy
     };
     return new Duration(conf);
 }
@@ -2039,10 +2039,10 @@ class Duration {
         this.matrix = accurate ? accurateMatrix : casualMatrix;
         this.isLuxonDuration = true;
     }
-    static fromMillis(count, opts) {
+    static fromMillis(count, opts6) {
         return Duration.fromObject(Object.assign({
             milliseconds: count
-        }, opts));
+        }, opts6));
     }
     static fromObject(obj) {
         if (obj == null || typeof obj !== "object") {
@@ -2059,20 +2059,20 @@ class Duration {
             conversionAccuracy: obj.conversionAccuracy
         });
     }
-    static fromISO(text, opts) {
+    static fromISO(text, opts7) {
         const [parsed] = parseISODuration(text);
         if (parsed) {
-            const obj = Object.assign(parsed, opts);
-            return Duration.fromObject(obj);
+            const obj1 = Object.assign(parsed, opts7);
+            return Duration.fromObject(obj1);
         } else {
             return Duration.invalid("unparsable", `the input "${text}" can't be parsed as ISO 8601`);
         }
     }
-    static invalid(reason, explanation = null) {
-        if (!reason) {
+    static invalid(reason4, explanation1 = null) {
+        if (!reason4) {
             throw new InvalidArgumentError("need to specify a reason the Duration is invalid");
         }
-        const invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
+        const invalid = reason4 instanceof Invalid ? reason4 : new Invalid(reason4, explanation1);
         if (Settings.throwOnInvalid) {
             throw new InvalidDurationError(invalid);
         } else {
@@ -2081,7 +2081,7 @@ class Duration {
             });
         }
     }
-    static normalizeUnit(unit) {
+    static normalizeUnit(unit1) {
         const normalized = {
             year: "years",
             years: "years",
@@ -2101,8 +2101,8 @@ class Duration {
             seconds: "seconds",
             millisecond: "milliseconds",
             milliseconds: "milliseconds"
-        }[unit ? unit.toLowerCase() : unit];
-        if (!normalized) throw new InvalidUnitError(unit);
+        }[unit1 ? unit1.toLowerCase() : unit1];
+        if (!normalized) throw new InvalidUnitError(unit1);
         return normalized;
     }
     static isDuration(o) {
@@ -2114,21 +2114,21 @@ class Duration {
     get numberingSystem() {
         return this.isValid ? this.loc.numberingSystem : null;
     }
-    toFormat(fmt, opts = {
+    toFormat(fmt3, opts8 = {
     }) {
         const fmtOpts = Object.assign({
-        }, opts, {
-            floor: opts.round !== false && opts.floor !== false
+        }, opts8, {
+            floor: opts8.round !== false && opts8.floor !== false
         });
-        return this.isValid ? Formatter.create(this.loc, fmtOpts).formatDurationFromString(this, fmt) : INVALID1;
+        return this.isValid ? Formatter.create(this.loc, fmtOpts).formatDurationFromString(this, fmt3) : INVALID1;
     }
-    toObject(opts = {
+    toObject(opts9 = {
     }) {
         if (!this.isValid) return {
         };
         const base = Object.assign({
         }, this.values);
-        if (opts.includeConfig) {
+        if (opts9.includeConfig) {
             base.conversionAccuracy = this.conversionAccuracy;
             base.numberingSystem = this.loc.numberingSystem;
             base.locale = this.loc.locale;
@@ -2137,17 +2137,17 @@ class Duration {
     }
     toISO() {
         if (!this.isValid) return null;
-        let s2 = "P";
-        if (this.years !== 0) s2 += this.years + "Y";
-        if (this.months !== 0 || this.quarters !== 0) s2 += this.months + this.quarters * 3 + "M";
-        if (this.weeks !== 0) s2 += this.weeks + "W";
-        if (this.days !== 0) s2 += this.days + "D";
-        if (this.hours !== 0 || this.minutes !== 0 || this.seconds !== 0 || this.milliseconds !== 0) s2 += "T";
-        if (this.hours !== 0) s2 += this.hours + "H";
-        if (this.minutes !== 0) s2 += this.minutes + "M";
-        if (this.seconds !== 0 || this.milliseconds !== 0) s2 += roundTo(this.seconds + this.milliseconds / 1000, 3) + "S";
-        if (s2 === "P") s2 += "T0S";
-        return s2;
+        let s3 = "P";
+        if (this.years !== 0) s3 += this.years + "Y";
+        if (this.months !== 0 || this.quarters !== 0) s3 += this.months + this.quarters * 3 + "M";
+        if (this.weeks !== 0) s3 += this.weeks + "W";
+        if (this.days !== 0) s3 += this.days + "D";
+        if (this.hours !== 0 || this.minutes !== 0 || this.seconds !== 0 || this.milliseconds !== 0) s3 += "T";
+        if (this.hours !== 0) s3 += this.hours + "H";
+        if (this.minutes !== 0) s3 += this.minutes + "M";
+        if (this.seconds !== 0 || this.milliseconds !== 0) s3 += roundTo(this.seconds + this.milliseconds / 1000, 3) + "S";
+        if (s3 === "P") s3 += "T0S";
+        return s3;
     }
     toJSON() {
         return this.toISO();
@@ -2160,21 +2160,21 @@ class Duration {
     }
     plus(duration) {
         if (!this.isValid) return this;
-        const dur = friendlyDuration(duration), result = {
+        const dur1 = friendlyDuration(duration), result = {
         };
         for (const k of orderedUnits){
-            if (hasOwnProperty(dur.values, k) || hasOwnProperty(this.values, k)) {
-                result[k] = dur.get(k) + this.get(k);
+            if (hasOwnProperty(dur1.values, k) || hasOwnProperty(this.values, k)) {
+                result[k] = dur1.get(k) + this.get(k);
             }
         }
         return clone(this, {
             values: result
         }, true);
     }
-    minus(duration) {
+    minus(duration1) {
         if (!this.isValid) return this;
-        const dur = friendlyDuration(duration);
-        return this.plus(dur.negate());
+        const dur1 = friendlyDuration(duration1);
+        return this.plus(dur1.negate());
     }
     mapUnits(fn) {
         if (!this.isValid) return this;
@@ -2187,8 +2187,8 @@ class Duration {
             values: result
         }, true);
     }
-    get(unit) {
-        return this[Duration.normalizeUnit(unit)];
+    get(unit2) {
+        return this[Duration.normalizeUnit(unit2)];
     }
     set(values) {
         if (!this.isValid) return this;
@@ -2197,21 +2197,21 @@ class Duration {
             values: mixed
         });
     }
-    reconfigure({ locale , numberingSystem , conversionAccuracy  } = {
+    reconfigure({ locale: locale10 , numberingSystem: numberingSystem4 , conversionAccuracy  } = {
     }) {
         const loc = this.loc.clone({
-            locale,
-            numberingSystem
-        }), opts = {
+            locale: locale10,
+            numberingSystem: numberingSystem4
+        }), opts10 = {
             loc
         };
         if (conversionAccuracy) {
-            opts.conversionAccuracy = conversionAccuracy;
+            opts10.conversionAccuracy = conversionAccuracy;
         }
-        return clone(this, opts);
+        return clone(this, opts10);
     }
-    as(unit) {
-        return this.isValid ? this.shiftTo(unit).get(unit) : NaN;
+    as(unit3) {
+        return this.isValid ? this.shiftTo(unit3).get(unit3) : NaN;
     }
     normalize() {
         if (!this.isValid) return this;
@@ -2327,7 +2327,7 @@ class Duration {
     }
 }
 function dayDiff(earlier, later) {
-    const utcDayStart = (dt)=>dt.toUTC(0, {
+    const utcDayStart = (dt5)=>dt5.toUTC(0, {
             keepLocalTime: true
         }).startOf("day").valueOf()
     , ms = utcDayStart(later) - utcDayStart(earlier);
@@ -2335,14 +2335,14 @@ function dayDiff(earlier, later) {
 }
 const MISSING_FTP = "missing Intl.DateTimeFormat.formatToParts support";
 const MAX_DATE = 8640000000000000;
-function unsupportedZone(zone) {
-    return new Invalid("unsupported zone", `the zone "${zone.name}" is not supported`);
+function unsupportedZone(zone3) {
+    return new Invalid("unsupported zone", `the zone "${zone3.name}" is not supported`);
 }
-function possiblyCachedWeekData(dt) {
-    if (dt.weekData === null) {
-        dt.weekData = gregorianToWeek(dt.c);
+function possiblyCachedWeekData(dt5) {
+    if (dt5.weekData === null) {
+        dt5.weekData = gregorianToWeek(dt5.c);
     }
-    return dt.weekData;
+    return dt5.weekData;
 }
 function clone1(inst, alts) {
     const current = {
@@ -2358,16 +2358,16 @@ function clone1(inst, alts) {
         old: current
     }));
 }
-function fixOffset(localTS, o, tz) {
-    let utcGuess = localTS - o * 60 * 1000;
+function fixOffset(localTS, o1, tz) {
+    let utcGuess = localTS - o1 * 60 * 1000;
     const o2 = tz.offset(utcGuess);
-    if (o === o2) {
+    if (o1 === o2) {
         return [
             utcGuess,
-            o
+            o1
         ];
     }
-    utcGuess -= (o2 - o) * 60 * 1000;
+    utcGuess -= (o2 - o1) * 60 * 1000;
     const o3 = tz.offset(utcGuess);
     if (o2 === o3) {
         return [
@@ -2380,9 +2380,9 @@ function fixOffset(localTS, o, tz) {
         Math.max(o2, o3)
     ];
 }
-function tsToObj(ts, offset1) {
-    ts += offset1 * 60 * 1000;
-    const d = new Date(ts);
+function tsToObj(ts10, offset2) {
+    ts10 += offset2 * 60 * 1000;
+    const d = new Date(ts10);
     return {
         year: d.getUTCFullYear(),
         month: d.getUTCMonth() + 1,
@@ -2393,71 +2393,71 @@ function tsToObj(ts, offset1) {
         millisecond: d.getUTCMilliseconds()
     };
 }
-function objToTS(obj, offset1, zone) {
-    return fixOffset(objToLocalTS(obj), offset1, zone);
+function objToTS(obj1, offset2, zone3) {
+    return fixOffset(objToLocalTS(obj1), offset2, zone3);
 }
-function adjustTime(inst, dur) {
-    const oPre = inst.o, year = inst.c.year + Math.trunc(dur.years), month = inst.c.month + Math.trunc(dur.months) + Math.trunc(dur.quarters) * 3, c = Object.assign({
+function adjustTime(inst, dur1) {
+    const oPre = inst.o, year = inst.c.year + Math.trunc(dur1.years), month = inst.c.month + Math.trunc(dur1.months) + Math.trunc(dur1.quarters) * 3, c = Object.assign({
     }, inst.c, {
         year,
         month,
-        day: Math.min(inst.c.day, daysInMonth(year, month)) + Math.trunc(dur.days) + Math.trunc(dur.weeks) * 7
+        day: Math.min(inst.c.day, daysInMonth(year, month)) + Math.trunc(dur1.days) + Math.trunc(dur1.weeks) * 7
     }), millisToAdd = Duration.fromObject({
-        years: dur.years - Math.trunc(dur.years),
-        quarters: dur.quarters - Math.trunc(dur.quarters),
-        months: dur.months - Math.trunc(dur.months),
-        weeks: dur.weeks - Math.trunc(dur.weeks),
-        days: dur.days - Math.trunc(dur.days),
-        hours: dur.hours,
-        minutes: dur.minutes,
-        seconds: dur.seconds,
-        milliseconds: dur.milliseconds
+        years: dur1.years - Math.trunc(dur1.years),
+        quarters: dur1.quarters - Math.trunc(dur1.quarters),
+        months: dur1.months - Math.trunc(dur1.months),
+        weeks: dur1.weeks - Math.trunc(dur1.weeks),
+        days: dur1.days - Math.trunc(dur1.days),
+        hours: dur1.hours,
+        minutes: dur1.minutes,
+        seconds: dur1.seconds,
+        milliseconds: dur1.milliseconds
     }).as("milliseconds"), localTS = objToLocalTS(c);
-    let [ts, o] = fixOffset(localTS, oPre, inst.zone);
+    let [ts10, o1] = fixOffset(localTS, oPre, inst.zone);
     if (millisToAdd !== 0) {
-        ts += millisToAdd;
-        o = inst.zone.offset(ts);
+        ts10 += millisToAdd;
+        o1 = inst.zone.offset(ts10);
     }
     return {
-        ts,
-        o
+        ts: ts10,
+        o: o1
     };
 }
-function parseDataToDateTime(parsed, parsedZone, opts, format, text) {
-    const { setZone , zone  } = opts;
+function parseDataToDateTime(parsed, parsedZone, opts10, format6, text1) {
+    const { setZone , zone: zone3  } = opts10;
     if (parsed && Object.keys(parsed).length !== 0) {
-        const interpretationZone = parsedZone || zone, inst = DateTime.fromObject(Object.assign(parsed, opts, {
+        const interpretationZone = parsedZone || zone3, inst = DateTime.fromObject(Object.assign(parsed, opts10, {
             zone: interpretationZone,
             setZone: undefined
         }));
-        return setZone ? inst : inst.setZone(zone);
+        return setZone ? inst : inst.setZone(zone3);
     } else {
-        return DateTime.invalid(new Invalid("unparsable", `the input "${text}" can't be parsed as ${format}`));
+        return DateTime.invalid(new Invalid("unparsable", `the input "${text1}" can't be parsed as ${format6}`));
     }
 }
-function toTechFormat(dt, format, allowZ = true) {
-    return dt.isValid ? Formatter.create(Locale.create("en-US"), {
+function toTechFormat(dt5, format6, allowZ = true) {
+    return dt5.isValid ? Formatter.create(Locale.create("en-US"), {
         allowZ,
         forceSimple: true
-    }).formatDateTimeFromString(dt, format) : null;
+    }).formatDateTimeFromString(dt5, format6) : null;
 }
-function toTechTimeFormat(dt, { suppressSeconds =false , suppressMilliseconds =false , includeOffset , includeZone =false , spaceZone =false , format ="extended"  }) {
-    let fmt = format === "basic" ? "HHmm" : "HH:mm";
-    if (!suppressSeconds || dt.second !== 0 || dt.millisecond !== 0) {
-        fmt += format === "basic" ? "ss" : ":ss";
-        if (!suppressMilliseconds || dt.millisecond !== 0) {
-            fmt += ".SSS";
+function toTechTimeFormat(dt5, { suppressSeconds =false , suppressMilliseconds =false , includeOffset , includeZone =false , spaceZone =false , format: format6 = "extended"  }) {
+    let fmt4 = format6 === "basic" ? "HHmm" : "HH:mm";
+    if (!suppressSeconds || dt5.second !== 0 || dt5.millisecond !== 0) {
+        fmt4 += format6 === "basic" ? "ss" : ":ss";
+        if (!suppressMilliseconds || dt5.millisecond !== 0) {
+            fmt4 += ".SSS";
         }
     }
     if ((includeZone || includeOffset) && spaceZone) {
-        fmt += " ";
+        fmt4 += " ";
     }
     if (includeZone) {
-        fmt += "z";
+        fmt4 += "z";
     } else if (includeOffset) {
-        fmt += format === "basic" ? "ZZZ" : "ZZ";
+        fmt4 += format6 === "basic" ? "ZZZ" : "ZZ";
     }
-    return toTechFormat(dt, fmt);
+    return toTechFormat(dt5, fmt4);
 }
 const defaultUnitValues = {
     month: 1,
@@ -2504,7 +2504,7 @@ const orderedUnits1 = [
     "second",
     "millisecond"
 ];
-function normalizeUnit(unit2) {
+function normalizeUnit(unit4) {
     const normalized = {
         year: "year",
         years: "year",
@@ -2530,51 +2530,51 @@ function normalizeUnit(unit2) {
         weekyear: "weekYear",
         weekyears: "weekYear",
         ordinal: "ordinal"
-    }[unit2.toLowerCase()];
-    if (!normalized) throw new InvalidUnitError(unit2);
+    }[unit4.toLowerCase()];
+    if (!normalized) throw new InvalidUnitError(unit4);
     return normalized;
 }
-function quickDT(obj, zone) {
+function quickDT(obj1, zone3) {
     for (const u of orderedUnits1){
-        if (isUndefined(obj[u])) {
-            obj[u] = defaultUnitValues[u];
+        if (isUndefined(obj1[u])) {
+            obj1[u] = defaultUnitValues[u];
         }
     }
-    const invalid = hasInvalidGregorianData(obj) || hasInvalidTimeData(obj);
+    const invalid = hasInvalidGregorianData(obj1) || hasInvalidTimeData(obj1);
     if (invalid) {
         return DateTime.invalid(invalid);
     }
-    const tsNow = Settings.now(), offsetProvis = zone.offset(tsNow), [ts, o] = objToTS(obj, offsetProvis, zone);
+    const tsNow = Settings.now(), offsetProvis = zone3.offset(tsNow), [ts10, o1] = objToTS(obj1, offsetProvis, zone3);
     return new DateTime({
-        ts,
-        zone,
-        o
+        ts: ts10,
+        zone: zone3,
+        o: o1
     });
 }
-function diffRelative(start, end, opts) {
-    const round = isUndefined(opts.round) ? true : opts.round, format = (c, unit2)=>{
-        c = roundTo(c, round || opts.calendary ? 0 : 2, true);
-        const formatter = end.loc.clone(opts).relFormatter(opts);
-        return formatter.format(c, unit2);
-    }, differ = (unit2)=>{
-        if (opts.calendary) {
-            if (!end.hasSame(start, unit2)) {
-                return end.startOf(unit2).diff(start.startOf(unit2), unit2).get(unit2);
+function diffRelative(start, end, opts10) {
+    const round = isUndefined(opts10.round) ? true : opts10.round, format6 = (c, unit4)=>{
+        c = roundTo(c, round || opts10.calendary ? 0 : 2, true);
+        const formatter = end.loc.clone(opts10).relFormatter(opts10);
+        return formatter.format(c, unit4);
+    }, differ = (unit4)=>{
+        if (opts10.calendary) {
+            if (!end.hasSame(start, unit4)) {
+                return end.startOf(unit4).diff(start.startOf(unit4), unit4).get(unit4);
             } else return 0;
         } else {
-            return end.diff(start, unit2).get(unit2);
+            return end.diff(start, unit4).get(unit4);
         }
     };
-    if (opts.unit) {
-        return format(differ(opts.unit), opts.unit);
+    if (opts10.unit) {
+        return format6(differ(opts10.unit), opts10.unit);
     }
-    for (const unit2 of opts.units){
-        const count = differ(unit2);
-        if (Math.abs(count) >= 1) {
-            return format(count, unit2);
+    for (const unit4 of opts10.units){
+        const count1 = differ(unit4);
+        if (Math.abs(count1) >= 1) {
+            return format6(count1, unit4);
         }
     }
-    return format(0, opts.units[opts.units.length - 1]);
+    return format6(0, opts10.units[opts10.units.length - 1]);
 }
 function friendlyDuration(durationish) {
     if (isNumber(durationish)) {
@@ -2589,26 +2589,26 @@ function friendlyDuration(durationish) {
 }
 class DateTime {
     constructor(config1){
-        const zone1 = config1.zone || Settings.defaultZone;
-        let invalid = config1.invalid || (Number.isNaN(config1.ts) ? new Invalid("invalid input") : null) || (!zone1.isValid ? unsupportedZone(zone1) : null);
+        const zone3 = config1.zone || Settings.defaultZone;
+        let invalid = config1.invalid || (Number.isNaN(config1.ts) ? new Invalid("invalid input") : null) || (!zone3.isValid ? unsupportedZone(zone3) : null);
         this.ts = isUndefined(config1.ts) ? Settings.now() : config1.ts;
         let c = null, o1 = null;
         if (!invalid) {
-            const unchanged = config1.old && config1.old.ts === this.ts && config1.old.zone.equals(zone1);
+            const unchanged = config1.old && config1.old.ts === this.ts && config1.old.zone.equals(zone3);
             if (unchanged) {
                 [c, o1] = [
                     config1.old.c,
                     config1.old.o
                 ];
             } else {
-                const ot = zone1.offset(this.ts);
+                const ot = zone3.offset(this.ts);
                 c = tsToObj(this.ts, ot);
                 invalid = Number.isNaN(c.year) ? new Invalid("invalid input") : null;
                 c = invalid ? null : c;
                 o1 = invalid ? null : ot;
             }
         }
-        this._zone = zone1;
+        this._zone = zone3;
         this.loc = config1.loc || Locale.create();
         this.invalid = invalid;
         this.weekData = null;
@@ -2633,28 +2633,28 @@ class DateTime {
             }, Settings.defaultZone);
         }
     }
-    static utc(year, month, day, hour, minute, second, millisecond) {
-        if (isUndefined(year)) {
+    static utc(year1, month1, day1, hour1, minute1, second1, millisecond1) {
+        if (isUndefined(year1)) {
             return new DateTime({
                 ts: Settings.now(),
                 zone: FixedOffsetZone.utcInstance
             });
         } else {
             return quickDT({
-                year,
-                month,
-                day,
-                hour,
-                minute,
-                second,
-                millisecond
+                year: year1,
+                month: month1,
+                day: day1,
+                hour: hour1,
+                minute: minute1,
+                second: second1,
+                millisecond: millisecond1
             }, FixedOffsetZone.utcInstance);
         }
     }
     static fromJSDate(date, options = {
     }) {
-        const ts = isDate(date) ? date.valueOf() : NaN;
-        if (Number.isNaN(ts)) {
+        const ts10 = isDate(date) ? date.valueOf() : NaN;
+        if (Number.isNaN(ts10)) {
             return DateTime.invalid("invalid input");
         }
         const zoneToUse = normalizeZone(options.zone, Settings.defaultZone);
@@ -2662,12 +2662,12 @@ class DateTime {
             return DateTime.invalid(unsupportedZone(zoneToUse));
         }
         return new DateTime({
-            ts: ts,
+            ts: ts10,
             zone: zoneToUse,
             loc: Locale.fromObject(options)
         });
     }
-    static fromMillis(milliseconds, options = {
+    static fromMillis(milliseconds, options1 = {
     }) {
         if (!isNumber(milliseconds)) {
             throw new InvalidArgumentError(`fromMillis requires a numerical input, but received a ${typeof milliseconds} with value ${milliseconds}`);
@@ -2676,34 +2676,34 @@ class DateTime {
         } else {
             return new DateTime({
                 ts: milliseconds,
-                zone: normalizeZone(options.zone, Settings.defaultZone),
-                loc: Locale.fromObject(options)
+                zone: normalizeZone(options1.zone, Settings.defaultZone),
+                loc: Locale.fromObject(options1)
             });
         }
     }
-    static fromSeconds(seconds, options = {
+    static fromSeconds(seconds, options2 = {
     }) {
         if (!isNumber(seconds)) {
             throw new InvalidArgumentError("fromSeconds requires a numerical input");
         } else {
             return new DateTime({
                 ts: seconds * 1000,
-                zone: normalizeZone(options.zone, Settings.defaultZone),
-                loc: Locale.fromObject(options)
+                zone: normalizeZone(options2.zone, Settings.defaultZone),
+                loc: Locale.fromObject(options2)
             });
         }
     }
-    static fromObject(obj) {
-        const zoneToUse = normalizeZone(obj.zone, Settings.defaultZone);
+    static fromObject(obj1) {
+        const zoneToUse = normalizeZone(obj1.zone, Settings.defaultZone);
         if (!zoneToUse.isValid) {
             return DateTime.invalid(unsupportedZone(zoneToUse));
         }
-        const tsNow = Settings.now(), offsetProvis = zoneToUse.offset(tsNow), normalized = normalizeObject(obj, normalizeUnit, [
+        const tsNow = Settings.now(), offsetProvis = zoneToUse.offset(tsNow), normalized = normalizeObject(obj1, normalizeUnit, [
             "zone",
             "locale",
             "outputCalendar",
             "numberingSystem"
-        ]), containsOrdinal = !isUndefined(normalized.ordinal), containsGregorYear = !isUndefined(normalized.year), containsGregorMD = !isUndefined(normalized.month) || !isUndefined(normalized.day), containsGregor = containsGregorYear || containsGregorMD, definiteWeekDef = normalized.weekYear || normalized.weekNumber, loc = Locale.fromObject(obj);
+        ]), containsOrdinal = !isUndefined(normalized.ordinal), containsGregorYear = !isUndefined(normalized.year), containsGregorMD = !isUndefined(normalized.month) || !isUndefined(normalized.day), containsGregor = containsGregorYear || containsGregorMD, definiteWeekDef = normalized.weekYear || normalized.weekNumber, loc = Locale.fromObject(obj1);
         if ((containsGregor || containsOrdinal) && definiteWeekDef) {
             throw new ConflictingSpecificationError("Can't mix weekYear/weekNumber units with year/month/day or ordinals");
         }
@@ -2711,21 +2711,21 @@ class DateTime {
             throw new ConflictingSpecificationError("Can't mix ordinal dates with month/day");
         }
         const useWeekData = definiteWeekDef || normalized.weekday && !containsGregor;
-        let units, defaultValues, objNow = tsToObj(tsNow, offsetProvis);
+        let units1, defaultValues, objNow = tsToObj(tsNow, offsetProvis);
         if (useWeekData) {
-            units = orderedWeekUnits;
+            units1 = orderedWeekUnits;
             defaultValues = defaultWeekUnitValues;
             objNow = gregorianToWeek(objNow);
         } else if (containsOrdinal) {
-            units = orderedOrdinalUnits;
+            units1 = orderedOrdinalUnits;
             defaultValues = defaultOrdinalUnitValues;
             objNow = gregorianToOrdinal(objNow);
         } else {
-            units = orderedUnits1;
+            units1 = orderedUnits1;
             defaultValues = defaultUnitValues;
         }
         let foundFirst = false;
-        for (const u of units){
+        for (const u of units1){
             const v = normalized[u];
             if (!isUndefined(v)) {
                 foundFirst = true;
@@ -2745,56 +2745,56 @@ class DateTime {
             o: offsetFinal,
             loc
         });
-        if (normalized.weekday && containsGregor && obj.weekday !== inst.weekday) {
+        if (normalized.weekday && containsGregor && obj1.weekday !== inst.weekday) {
             return DateTime.invalid("mismatched weekday", `you can't specify both a weekday of ${normalized.weekday} and a date of ${inst.toISO()}`);
         }
         return inst;
     }
-    static fromISO(text, opts = {
+    static fromISO(text1, opts10 = {
     }) {
-        const [vals, parsedZone] = parseISODate(text);
-        return parseDataToDateTime(vals, parsedZone, opts, "ISO 8601", text);
+        const [vals, parsedZone] = parseISODate(text1);
+        return parseDataToDateTime(vals, parsedZone, opts10, "ISO 8601", text1);
     }
-    static fromRFC2822(text, opts = {
+    static fromRFC2822(text2, opts11 = {
     }) {
-        const [vals, parsedZone] = parseRFC2822Date(text);
-        return parseDataToDateTime(vals, parsedZone, opts, "RFC 2822", text);
+        const [vals, parsedZone] = parseRFC2822Date(text2);
+        return parseDataToDateTime(vals, parsedZone, opts11, "RFC 2822", text2);
     }
-    static fromHTTP(text, opts = {
+    static fromHTTP(text3, opts12 = {
     }) {
-        const [vals, parsedZone] = parseHTTPDate(text);
-        return parseDataToDateTime(vals, parsedZone, opts, "HTTP", opts);
+        const [vals, parsedZone] = parseHTTPDate(text3);
+        return parseDataToDateTime(vals, parsedZone, opts12, "HTTP", opts12);
     }
-    static fromFormat(text, fmt, opts = {
+    static fromFormat(text4, fmt4, opts13 = {
     }) {
-        if (isUndefined(text) || isUndefined(fmt)) {
+        if (isUndefined(text4) || isUndefined(fmt4)) {
             throw new InvalidArgumentError("fromFormat requires an input string and a format");
         }
-        const { locale: locale2 = null , numberingSystem =null  } = opts, localeToUse = Locale.fromOpts({
-            locale: locale2,
-            numberingSystem,
+        const { locale: locale11 = null , numberingSystem: numberingSystem5 = null  } = opts13, localeToUse = Locale.fromOpts({
+            locale: locale11,
+            numberingSystem: numberingSystem5,
             defaultToEN: true
-        }), [vals, parsedZone, invalid1] = parseFromTokens(localeToUse, text, fmt);
+        }), [vals, parsedZone, invalid1] = parseFromTokens(localeToUse, text4, fmt4);
         if (invalid1) {
             return DateTime.invalid(invalid1);
         } else {
-            return parseDataToDateTime(vals, parsedZone, opts, `format ${fmt}`, text);
+            return parseDataToDateTime(vals, parsedZone, opts13, `format ${fmt4}`, text4);
         }
     }
-    static fromString(text, fmt, opts = {
+    static fromString(text5, fmt5, opts14 = {
     }) {
-        return DateTime.fromFormat(text, fmt, opts);
+        return DateTime.fromFormat(text5, fmt5, opts14);
     }
-    static fromSQL(text, opts = {
+    static fromSQL(text6, opts15 = {
     }) {
-        const [vals, parsedZone] = parseSQL(text);
-        return parseDataToDateTime(vals, parsedZone, opts, "SQL", text);
+        const [vals, parsedZone] = parseSQL(text6);
+        return parseDataToDateTime(vals, parsedZone, opts15, "SQL", text6);
     }
-    static invalid(reason, explanation = null) {
-        if (!reason) {
+    static invalid(reason5, explanation2 = null) {
+        if (!reason5) {
             throw new InvalidArgumentError("need to specify a reason the DateTime is invalid");
         }
-        const invalid1 = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
+        const invalid1 = reason5 instanceof Invalid ? reason5 : new Invalid(reason5, explanation2);
         if (Settings.throwOnInvalid) {
             throw new InvalidDateTimeError(invalid1);
         } else {
@@ -2803,11 +2803,11 @@ class DateTime {
             });
         }
     }
-    static isDateTime(o) {
-        return o && o.isLuxonDateTime || false;
+    static isDateTime(o2) {
+        return o2 && o2.isLuxonDateTime || false;
     }
-    get(unit) {
-        return this[unit];
+    get(unit4) {
+        return this[unit4];
     }
     get isValid() {
         return this.invalid === null;
@@ -2938,61 +2938,61 @@ class DateTime {
     get weeksInWeekYear() {
         return this.isValid ? weeksInWeekYear(this.weekYear) : NaN;
     }
-    resolvedLocaleOpts(opts = {
+    resolvedLocaleOpts(opts16 = {
     }) {
-        const { locale: locale2 , numberingSystem , calendar  } = Formatter.create(this.loc.clone(opts), opts).resolvedOptions(this);
+        const { locale: locale11 , numberingSystem: numberingSystem5 , calendar  } = Formatter.create(this.loc.clone(opts16), opts16).resolvedOptions(this);
         return {
-            locale: locale2,
-            numberingSystem,
+            locale: locale11,
+            numberingSystem: numberingSystem5,
             outputCalendar: calendar
         };
     }
-    toUTC(offset = 0, opts = {
+    toUTC(offset2 = 0, opts17 = {
     }) {
-        return this.setZone(FixedOffsetZone.instance(offset), opts);
+        return this.setZone(FixedOffsetZone.instance(offset2), opts17);
     }
     toLocal() {
         return this.setZone(Settings.defaultZone);
     }
-    setZone(zone, { keepLocalTime =false , keepCalendarTime =false  } = {
+    setZone(zone4, { keepLocalTime =false , keepCalendarTime =false  } = {
     }) {
-        zone = normalizeZone(zone, Settings.defaultZone);
-        if (zone.equals(this.zone)) {
+        zone4 = normalizeZone(zone4, Settings.defaultZone);
+        if (zone4.equals(this.zone)) {
             return this;
-        } else if (!zone.isValid) {
-            return DateTime.invalid(unsupportedZone(zone));
+        } else if (!zone4.isValid) {
+            return DateTime.invalid(unsupportedZone(zone4));
         } else {
             let newTS = this.ts;
             if (keepLocalTime || keepCalendarTime) {
-                const offsetGuess = zone.offset(this.ts);
+                const offsetGuess = zone4.offset(this.ts);
                 const asObj = this.toObject();
-                [newTS] = objToTS(asObj, offsetGuess, zone);
+                [newTS] = objToTS(asObj, offsetGuess, zone4);
             }
             return clone1(this, {
                 ts: newTS,
-                zone
+                zone: zone4
             });
         }
     }
-    reconfigure({ locale , numberingSystem , outputCalendar  } = {
+    reconfigure({ locale: locale11 , numberingSystem: numberingSystem5 , outputCalendar: outputCalendar2  } = {
     }) {
         const loc = this.loc.clone({
-            locale,
-            numberingSystem,
-            outputCalendar
+            locale: locale11,
+            numberingSystem: numberingSystem5,
+            outputCalendar: outputCalendar2
         });
         return clone1(this, {
             loc
         });
     }
-    setLocale(locale) {
+    setLocale(locale12) {
         return this.reconfigure({
-            locale
+            locale: locale12
         });
     }
-    set(values) {
+    set(values1) {
         if (!this.isValid) return this;
-        const normalized = normalizeObject(values, normalizeUnit, []), settingWeekStuff = !isUndefined(normalized.weekYear) || !isUndefined(normalized.weekNumber) || !isUndefined(normalized.weekday);
+        const normalized = normalizeObject(values1, normalizeUnit, []), settingWeekStuff = !isUndefined(normalized.weekYear) || !isUndefined(normalized.weekNumber) || !isUndefined(normalized.weekday);
         let mixed;
         if (settingWeekStuff) {
             mixed = weekToGregorian(Object.assign(gregorianToWeek(this.c), normalized));
@@ -3004,94 +3004,94 @@ class DateTime {
                 mixed.day = Math.min(daysInMonth(mixed.year, mixed.month), mixed.day);
             }
         }
-        const [ts, o2] = objToTS(mixed, this.o, this.zone);
+        const [ts10, o3] = objToTS(mixed, this.o, this.zone);
         return clone1(this, {
-            ts,
-            o: o2
+            ts: ts10,
+            o: o3
         });
     }
-    plus(duration) {
+    plus(duration2) {
         if (!this.isValid) return this;
-        const dur = friendlyDuration(duration);
-        return clone1(this, adjustTime(this, dur));
+        const dur1 = friendlyDuration(duration2);
+        return clone1(this, adjustTime(this, dur1));
     }
-    minus(duration) {
+    minus(duration3) {
         if (!this.isValid) return this;
-        const dur = friendlyDuration(duration).negate();
-        return clone1(this, adjustTime(this, dur));
+        const dur1 = friendlyDuration(duration3).negate();
+        return clone1(this, adjustTime(this, dur1));
     }
-    startOf(unit) {
+    startOf(unit5) {
         if (!this.isValid) return this;
-        const o2 = {
-        }, normalizedUnit = Duration.normalizeUnit(unit);
+        const o3 = {
+        }, normalizedUnit = Duration.normalizeUnit(unit5);
         switch(normalizedUnit){
             case "years":
-                o2.month = 1;
+                o3.month = 1;
             case "quarters":
             case "months":
-                o2.day = 1;
+                o3.day = 1;
             case "weeks":
             case "days":
-                o2.hour = 0;
+                o3.hour = 0;
             case "hours":
-                o2.minute = 0;
+                o3.minute = 0;
             case "minutes":
-                o2.second = 0;
+                o3.second = 0;
             case "seconds":
-                o2.millisecond = 0;
+                o3.millisecond = 0;
                 break;
             case "milliseconds": break;
         }
         if (normalizedUnit === "weeks") {
-            o2.weekday = 1;
+            o3.weekday = 1;
         }
         if (normalizedUnit === "quarters") {
             const q = Math.ceil(this.month / 3);
-            o2.month = (q - 1) * 3 + 1;
+            o3.month = (q - 1) * 3 + 1;
         }
-        return this.set(o2);
+        return this.set(o3);
     }
-    endOf(unit) {
+    endOf(unit6) {
         return this.isValid ? this.plus({
-            [unit]: 1
-        }).startOf(unit).minus(1) : this;
+            [unit6]: 1
+        }).startOf(unit6).minus(1) : this;
     }
-    toFormat(fmt, opts = {
+    toFormat(fmt6, opts18 = {
     }) {
-        return this.isValid ? Formatter.create(this.loc.redefaultToEN(opts)).formatDateTimeFromString(this, fmt) : INVALID;
+        return this.isValid ? Formatter.create(this.loc.redefaultToEN(opts18)).formatDateTimeFromString(this, fmt6) : INVALID;
     }
-    toLocaleString(opts = DATE_SHORT) {
-        return this.isValid ? Formatter.create(this.loc.clone(opts), opts).formatDateTime(this) : INVALID;
+    toLocaleString(opts19 = DATE_SHORT) {
+        return this.isValid ? Formatter.create(this.loc.clone(opts19), opts19).formatDateTime(this) : INVALID;
     }
-    toLocaleParts(opts = {
+    toLocaleParts(opts20 = {
     }) {
-        return this.isValid ? Formatter.create(this.loc.clone(opts), opts).formatDateTimeParts(this) : [];
+        return this.isValid ? Formatter.create(this.loc.clone(opts20), opts20).formatDateTimeParts(this) : [];
     }
-    toISO(opts = {
+    toISO(opts21 = {
     }) {
         if (!this.isValid) {
             return null;
         }
-        return `${this.toISODate(opts)}T${this.toISOTime(opts)}`;
+        return `${this.toISODate(opts21)}T${this.toISOTime(opts21)}`;
     }
-    toISODate({ format ="extended"  } = {
+    toISODate({ format: format6 = "extended"  } = {
     }) {
-        let fmt = format === "basic" ? "yyyyMMdd" : "yyyy-MM-dd";
+        let fmt7 = format6 === "basic" ? "yyyyMMdd" : "yyyy-MM-dd";
         if (this.year > 9999) {
-            fmt = "+" + fmt;
+            fmt7 = "+" + fmt7;
         }
-        return toTechFormat(this, fmt);
+        return toTechFormat(this, fmt7);
     }
     toISOWeekDate() {
         return toTechFormat(this, "kkkk-'W'WW-c");
     }
-    toISOTime({ suppressMilliseconds =false , suppressSeconds =false , includeOffset =true , format ="extended"  } = {
+    toISOTime({ suppressMilliseconds =false , suppressSeconds =false , includeOffset =true , format: format7 = "extended"  } = {
     }) {
         return toTechTimeFormat(this, {
             suppressSeconds,
             suppressMilliseconds,
             includeOffset,
-            format
+            format: format7
         });
     }
     toRFC2822() {
@@ -3103,20 +3103,20 @@ class DateTime {
     toSQLDate() {
         return toTechFormat(this, "yyyy-MM-dd");
     }
-    toSQLTime({ includeOffset =true , includeZone =false  } = {
+    toSQLTime({ includeOffset: includeOffset1 = true , includeZone =false  } = {
     }) {
         return toTechTimeFormat(this, {
-            includeOffset,
+            includeOffset: includeOffset1,
             includeZone,
             spaceZone: true
         });
     }
-    toSQL(opts = {
+    toSQL(opts22 = {
     }) {
         if (!this.isValid) {
             return null;
         }
-        return `${this.toSQLDate()} ${this.toSQLTime(opts)}`;
+        return `${this.toSQLDate()} ${this.toSQLTime(opts22)}`;
     }
     toString() {
         return this.isValid ? this.toISO() : INVALID;
@@ -3136,13 +3136,13 @@ class DateTime {
     toBSON() {
         return this.toJSDate();
     }
-    toObject(opts = {
+    toObject(opts23 = {
     }) {
         if (!this.isValid) return {
         };
         const base = Object.assign({
         }, this.c);
-        if (opts.includeConfig) {
+        if (opts23.includeConfig) {
             base.outputCalendar = this.outputCalendar;
             base.numberingSystem = this.loc.numberingSystem;
             base.locale = this.loc.locale;
@@ -3152,7 +3152,7 @@ class DateTime {
     toJSDate() {
         return new Date(this.isValid ? this.ts : NaN);
     }
-    diff(otherDateTime, unit = "milliseconds", opts = {
+    diff(otherDateTime, unit7 = "milliseconds", opts24 = {
     }) {
         if (!this.isValid || !otherDateTime.isValid) {
             return Duration.invalid(this.invalid || otherDateTime.invalid, "created by diffing an invalid DateTime");
@@ -3160,36 +3160,36 @@ class DateTime {
         const durOpts = Object.assign({
             locale: this.locale,
             numberingSystem: this.numberingSystem
-        }, opts);
-        const units = maybeArray(unit).map(Duration.normalizeUnit), otherIsLater = otherDateTime.valueOf() > this.valueOf(), earlier = otherIsLater ? this : otherDateTime, later = otherIsLater ? otherDateTime : this, diffed = __default(earlier, later, units, durOpts);
+        }, opts24);
+        const units1 = maybeArray(unit7).map(Duration.normalizeUnit), otherIsLater = otherDateTime.valueOf() > this.valueOf(), earlier = otherIsLater ? this : otherDateTime, later = otherIsLater ? otherDateTime : this, diffed = __default(earlier, later, units1, durOpts);
         return otherIsLater ? diffed.negate() : diffed;
     }
-    diffNow(unit = "milliseconds", opts = {
+    diffNow(unit8 = "milliseconds", opts25 = {
     }) {
-        return this.diff(DateTime.local(), unit, opts);
+        return this.diff(DateTime.local(), unit8, opts25);
     }
-    until(otherDateTime) {
-        return this.isValid ? Interval.fromDateTimes(this, otherDateTime) : this;
+    until(otherDateTime1) {
+        return this.isValid ? Interval.fromDateTimes(this, otherDateTime1) : this;
     }
-    hasSame(otherDateTime, unit) {
+    hasSame(otherDateTime2, unit9) {
         if (!this.isValid) return false;
-        if (unit === "millisecond") {
-            return this.valueOf() === otherDateTime.valueOf();
+        if (unit9 === "millisecond") {
+            return this.valueOf() === otherDateTime2.valueOf();
         } else {
-            const inputMs = otherDateTime.valueOf();
-            return this.startOf(unit) <= inputMs && inputMs <= this.endOf(unit);
+            const inputMs = otherDateTime2.valueOf();
+            return this.startOf(unit9) <= inputMs && inputMs <= this.endOf(unit9);
         }
     }
-    equals(other) {
-        return this.isValid && other.isValid && this.valueOf() === other.valueOf() && this.zone.equals(other.zone) && this.loc.equals(other.loc);
+    equals(other1) {
+        return this.isValid && other1.isValid && this.valueOf() === other1.valueOf() && this.zone.equals(other1.zone) && this.loc.equals(other1.loc);
     }
-    toRelative(options = {
+    toRelative(options3 = {
     }) {
         if (!this.isValid) return null;
-        const base = options.base || DateTime.fromObject({
+        const base = options3.base || DateTime.fromObject({
             zone: this.zone
-        }), padding = options.padding ? this < base ? -options.padding : options.padding : 0;
-        return diffRelative(base, this.plus(padding), Object.assign(options, {
+        }), padding = options3.padding ? this < base ? -options3.padding : options3.padding : 0;
+        return diffRelative(base, this.plus(padding), Object.assign(options3, {
             numeric: "always",
             units: [
                 "years",
@@ -3201,12 +3201,12 @@ class DateTime {
             ]
         }));
     }
-    toRelativeCalendar(options = {
+    toRelativeCalendar(options4 = {
     }) {
         if (!this.isValid) return null;
-        return diffRelative(options.base || DateTime.fromObject({
+        return diffRelative(options4.base || DateTime.fromObject({
             zone: this.zone
-        }), this, Object.assign(options, {
+        }), this, Object.assign(options4, {
             numeric: "auto",
             units: [
                 "years",
@@ -3223,25 +3223,25 @@ class DateTime {
         return bestBy(dateTimes, (i)=>i.valueOf()
         , Math.min);
     }
-    static max(...dateTimes) {
-        if (!dateTimes.every(DateTime.isDateTime)) {
+    static max(...dateTimes1) {
+        if (!dateTimes1.every(DateTime.isDateTime)) {
             throw new InvalidArgumentError("max requires all arguments be DateTimes");
         }
-        return bestBy(dateTimes, (i)=>i.valueOf()
+        return bestBy(dateTimes1, (i)=>i.valueOf()
         , Math.max);
     }
-    static fromFormatExplain(text, fmt, options = {
+    static fromFormatExplain(text7, fmt7, options5 = {
     }) {
-        const { locale: locale2 = null , numberingSystem =null  } = options, localeToUse = Locale.fromOpts({
-            locale: locale2,
-            numberingSystem,
+        const { locale: locale13 = null , numberingSystem: numberingSystem6 = null  } = options5, localeToUse = Locale.fromOpts({
+            locale: locale13,
+            numberingSystem: numberingSystem6,
             defaultToEN: true
         });
-        return explainFromTokens(localeToUse, text, fmt);
+        return explainFromTokens(localeToUse, text7, fmt7);
     }
-    static fromStringExplain(text, fmt, options = {
+    static fromStringExplain(text8, fmt8, options6 = {
     }) {
-        return DateTime.fromFormatExplain(text, fmt, options);
+        return DateTime.fromFormatExplain(text8, fmt8, options6);
     }
     static get DATE_SHORT() {
         return DATE_SHORT;
@@ -3321,46 +3321,46 @@ function friendlyDateTime(dateTimeish) {
         throw new InvalidArgumentError(`Unknown datetime argument: ${dateTimeish}, of type ${typeof dateTimeish}`);
     }
 }
-function getCachedDTF(locString, opts = {
+function getCachedDTF(locString, opts26 = {
 }) {
     const key = JSON.stringify([
         locString,
-        opts
+        opts26
     ]);
     let dtf = intlDTCache[key];
     if (!dtf) {
-        dtf = new Intl.DateTimeFormat(locString, opts);
+        dtf = new Intl.DateTimeFormat(locString, opts26);
         intlDTCache[key] = dtf;
     }
     return dtf;
 }
 let intlNumCache = {
 };
-function getCachedINF(locString, opts = {
+function getCachedINF(locString, opts26 = {
 }) {
     const key = JSON.stringify([
         locString,
-        opts
+        opts26
     ]);
     let inf = intlNumCache[key];
     if (!inf) {
-        inf = new Intl.NumberFormat(locString, opts);
+        inf = new Intl.NumberFormat(locString, opts26);
         intlNumCache[key] = inf;
     }
     return inf;
 }
 let intlRelCache = {
 };
-function getCachedRTF(locString, opts = {
+function getCachedRTF(locString, opts26 = {
 }) {
-    const { base , ...cacheKeyOpts } = opts;
+    const { base , ...cacheKeyOpts } = opts26;
     const key = JSON.stringify([
         locString,
         cacheKeyOpts
     ]);
     let inf = intlRelCache[key];
     if (!inf) {
-        inf = new Intl.RelativeTimeFormat(locString, opts);
+        inf = new Intl.RelativeTimeFormat(locString, opts26);
         intlRelCache[key] = inf;
     }
     return inf;
@@ -3385,30 +3385,30 @@ function parseLocaleString(localeStr) {
             localeStr
         ];
     } else {
-        let options;
+        let options7;
         const smaller = localeStr.substring(0, uIndex);
         try {
-            options = getCachedDTF(localeStr).resolvedOptions();
+            options7 = getCachedDTF(localeStr).resolvedOptions();
         } catch (e) {
-            options = getCachedDTF(smaller).resolvedOptions();
+            options7 = getCachedDTF(smaller).resolvedOptions();
         }
-        const { numberingSystem , calendar  } = options;
+        const { numberingSystem: numberingSystem6 , calendar  } = options7;
         return [
             smaller,
-            numberingSystem,
+            numberingSystem6,
             calendar
         ];
     }
 }
-function intlConfigString(localeStr, numberingSystem, outputCalendar) {
+function intlConfigString(localeStr, numberingSystem6, outputCalendar3) {
     if (hasIntl()) {
-        if (outputCalendar || numberingSystem) {
+        if (outputCalendar3 || numberingSystem6) {
             localeStr += "-u";
-            if (outputCalendar) {
-                localeStr += `-ca-${outputCalendar}`;
+            if (outputCalendar3) {
+                localeStr += `-ca-${outputCalendar3}`;
             }
-            if (numberingSystem) {
-                localeStr += `-nu-${numberingSystem}`;
+            if (numberingSystem6) {
+                localeStr += `-nu-${numberingSystem6}`;
             }
             return localeStr;
         } else {
@@ -3421,27 +3421,27 @@ function intlConfigString(localeStr, numberingSystem, outputCalendar) {
 function mapMonths(f) {
     const ms = [];
     for(let i = 1; i <= 12; i++){
-        const dt = DateTime.utc(2016, i, 1);
-        ms.push(f(dt));
+        const dt5 = DateTime.utc(2016, i, 1);
+        ms.push(f(dt5));
     }
     return ms;
 }
 function mapWeekdays(f) {
     const ms = [];
     for(let i = 1; i <= 7; i++){
-        const dt = DateTime.utc(2016, 11, 13 + i);
-        ms.push(f(dt));
+        const dt5 = DateTime.utc(2016, 11, 13 + i);
+        ms.push(f(dt5));
     }
     return ms;
 }
-function listStuff(loc, length, defaultOK, englishFn, intlFn) {
+function listStuff(loc, length5, defaultOK, englishFn, intlFn) {
     const mode = loc.listingMode(defaultOK);
     if (mode === "error") {
         return null;
     } else if (mode === "en") {
-        return englishFn(length);
+        return englishFn(length5);
     } else {
-        return intlFn(length);
+        return intlFn(length5);
     }
 }
 function supportsFastNumbers(loc) {
@@ -3452,14 +3452,14 @@ function supportsFastNumbers(loc) {
     }
 }
 class PolyNumberFormatter {
-    constructor(intl, forceSimple, opts3){
-        this.padTo = opts3.padTo || 0;
-        this.floor = opts3.floor || false;
+    constructor(intl, forceSimple, opts26){
+        this.padTo = opts26.padTo || 0;
+        this.floor = opts26.floor || false;
         if (!forceSimple && hasIntl()) {
             const intlOpts = {
                 useGrouping: false
             };
-            if (opts3.padTo > 0) intlOpts.minimumIntegerDigits = opts3.padTo;
+            if (opts26.padTo > 0) intlOpts.minimumIntegerDigits = opts26.padTo;
             this.inf = getCachedINF(intl, intlOpts);
         }
     }
@@ -3474,28 +3474,28 @@ class PolyNumberFormatter {
     }
 }
 class PolyDateFormatter {
-    constructor(dt1, intl1, opts1){
-        this.opts = opts1;
+    constructor(dt5, intl1, opts27){
+        this.opts = opts27;
         this.hasIntl = hasIntl();
-        let z1;
-        if (dt1.zone.universal && this.hasIntl) {
-            z1 = "UTC";
-            if (opts1.timeZoneName) {
-                this.dt = dt1;
+        let z;
+        if (dt5.zone.universal && this.hasIntl) {
+            z = "UTC";
+            if (opts27.timeZoneName) {
+                this.dt = dt5;
             } else {
-                this.dt = dt1.offset === 0 ? dt1 : DateTime.fromMillis(dt1.ts + dt1.offset * 60 * 1000);
+                this.dt = dt5.offset === 0 ? dt5 : DateTime.fromMillis(dt5.ts + dt5.offset * 60 * 1000);
             }
-        } else if (dt1.zone.type === "local") {
-            this.dt = dt1;
+        } else if (dt5.zone.type === "local") {
+            this.dt = dt5;
         } else {
-            this.dt = dt1;
-            z1 = dt1.zone.name;
+            this.dt = dt5;
+            z = dt5.zone.name;
         }
         if (this.hasIntl) {
             const intlOpts = Object.assign({
             }, this.opts);
-            if (z1) {
-                intlOpts.timeZone = z1;
+            if (z) {
+                intlOpts.timeZone = z;
             }
             this.dtf = getCachedDTF(intl1, intlOpts);
         }
@@ -3528,35 +3528,35 @@ class PolyDateFormatter {
     }
 }
 class PolyRelFormatter {
-    constructor(intl2, isEnglish, opts2){
+    constructor(intl2, isEnglish, opts28){
         this.opts = Object.assign({
             style: "long"
-        }, opts2);
+        }, opts28);
         if (!isEnglish && hasRelative()) {
-            this.rtf = getCachedRTF(intl2, opts2);
+            this.rtf = getCachedRTF(intl2, opts28);
         }
     }
-    format(count, unit) {
+    format(count1, unit10) {
         if (this.rtf) {
-            return this.rtf.format(count, unit);
+            return this.rtf.format(count1, unit10);
         } else {
-            return formatRelativeTime(unit, count, this.opts.numeric, this.opts.style !== "long");
+            return formatRelativeTime(unit10, count1, this.opts.numeric, this.opts.style !== "long");
         }
     }
-    formatToParts(count, unit) {
+    formatToParts(count2, unit11) {
         if (this.rtf) {
-            return this.rtf.formatToParts(count, unit);
+            return this.rtf.formatToParts(count2, unit11);
         } else {
             return [];
         }
     }
 }
 class Locale {
-    static fromOpts(opts) {
-        return Locale.create(opts.locale, opts.numberingSystem, opts.outputCalendar, opts.defaultToEN);
+    static fromOpts(opts29) {
+        return Locale.create(opts29.locale, opts29.numberingSystem, opts29.outputCalendar, opts29.defaultToEN);
     }
-    static create(locale, numberingSystem, outputCalendar, defaultToEN = false) {
-        const specifiedLocale = locale || Settings.defaultLocale, localeR = specifiedLocale || (defaultToEN ? "en-US" : systemLocale()), numberingSystemR = numberingSystem || Settings.defaultNumberingSystem, outputCalendarR = outputCalendar || Settings.defaultOutputCalendar;
+    static create(locale13, numberingSystem6, outputCalendar3, defaultToEN = false) {
+        const specifiedLocale = locale13 || Settings.defaultLocale, localeR = specifiedLocale || (defaultToEN ? "en-US" : systemLocale()), numberingSystemR = numberingSystem6 || Settings.defaultNumberingSystem, outputCalendarR = outputCalendar3 || Settings.defaultOutputCalendar;
         return new Locale(localeR, numberingSystemR, outputCalendarR, specifiedLocale);
     }
     static resetCache() {
@@ -3568,15 +3568,15 @@ class Locale {
         intlRelCache = {
         };
     }
-    static fromObject({ locale , numberingSystem , outputCalendar  } = {
+    static fromObject({ locale: locale14 , numberingSystem: numberingSystem7 , outputCalendar: outputCalendar4  } = {
     }) {
-        return Locale.create(locale, numberingSystem, outputCalendar);
+        return Locale.create(locale14, numberingSystem7, outputCalendar4);
     }
-    constructor(locale2, numbering, outputCalendar1, specifiedLocale){
-        const [parsedLocale, parsedNumberingSystem, parsedOutputCalendar] = parseLocaleString(locale2);
+    constructor(locale15, numbering, outputCalendar5, specifiedLocale){
+        const [parsedLocale, parsedNumberingSystem, parsedOutputCalendar] = parseLocaleString(locale15);
         this.locale = parsedLocale;
         this.numberingSystem = numbering || parsedNumberingSystem || null;
-        this.outputCalendar = outputCalendar1 || parsedOutputCalendar || null;
+        this.outputCalendar = outputCalendar5 || parsedOutputCalendar || null;
         this.intl = intlConfigString(this.locale, this.numberingSystem, this.outputCalendar);
         this.weekdaysCache = {
             format: {
@@ -3619,54 +3619,54 @@ class Locale {
             return Locale.create(alts.locale || this.specifiedLocale, alts.numberingSystem || this.numberingSystem, alts.outputCalendar || this.outputCalendar, alts.defaultToEN || false);
         }
     }
-    redefaultToEN(alts = {
+    redefaultToEN(alts1 = {
     }) {
         return this.clone(Object.assign({
-        }, alts, {
+        }, alts1, {
             defaultToEN: true
         }));
     }
-    redefaultToSystem(alts = {
+    redefaultToSystem(alts2 = {
     }) {
         return this.clone(Object.assign({
-        }, alts, {
+        }, alts2, {
             defaultToEN: false
         }));
     }
-    months(length, format = false, defaultOK = true) {
-        return listStuff(this, length, defaultOK, months, ()=>{
-            const intl3 = format ? {
-                month: length,
+    months(length5, format8 = false, defaultOK1 = true) {
+        return listStuff(this, length5, defaultOK1, months, ()=>{
+            const intl3 = format8 ? {
+                month: length5,
                 day: "numeric"
             } : {
-                month: length
-            }, formatStr = format ? "format" : "standalone";
-            if (!this.monthsCache[formatStr][length]) {
-                this.monthsCache[formatStr][length] = mapMonths((dt1)=>this.extract(dt1, intl3, "month")
+                month: length5
+            }, formatStr = format8 ? "format" : "standalone";
+            if (!this.monthsCache[formatStr][length5]) {
+                this.monthsCache[formatStr][length5] = mapMonths((dt6)=>this.extract(dt6, intl3, "month")
                 );
             }
-            return this.monthsCache[formatStr][length];
+            return this.monthsCache[formatStr][length5];
         });
     }
-    weekdays(length, format = false, defaultOK = true) {
-        return listStuff(this, length, defaultOK, weekdays, ()=>{
-            const intl3 = format ? {
-                weekday: length,
+    weekdays(length6, format9 = false, defaultOK2 = true) {
+        return listStuff(this, length6, defaultOK2, weekdays, ()=>{
+            const intl3 = format9 ? {
+                weekday: length6,
                 year: "numeric",
                 month: "long",
                 day: "numeric"
             } : {
-                weekday: length
-            }, formatStr = format ? "format" : "standalone";
-            if (!this.weekdaysCache[formatStr][length]) {
-                this.weekdaysCache[formatStr][length] = mapWeekdays((dt1)=>this.extract(dt1, intl3, "weekday")
+                weekday: length6
+            }, formatStr = format9 ? "format" : "standalone";
+            if (!this.weekdaysCache[formatStr][length6]) {
+                this.weekdaysCache[formatStr][length6] = mapWeekdays((dt6)=>this.extract(dt6, intl3, "weekday")
                 );
             }
-            return this.weekdaysCache[formatStr][length];
+            return this.weekdaysCache[formatStr][length6];
         });
     }
-    meridiems(defaultOK = true) {
-        return listStuff(this, undefined, defaultOK, ()=>meridiems
+    meridiems(defaultOK3 = true) {
+        return listStuff(this, undefined, defaultOK3, ()=>meridiems
         , ()=>{
             if (!this.meridiemCache) {
                 const intl3 = {
@@ -3676,66 +3676,66 @@ class Locale {
                 this.meridiemCache = [
                     DateTime.utc(2016, 11, 13, 9),
                     DateTime.utc(2016, 11, 13, 19)
-                ].map((dt1)=>this.extract(dt1, intl3, "dayperiod")
+                ].map((dt6)=>this.extract(dt6, intl3, "dayperiod")
                 );
             }
             return this.meridiemCache;
         });
     }
-    eras(length, defaultOK = true) {
-        return listStuff(this, length, defaultOK, eras, ()=>{
+    eras(length7, defaultOK4 = true) {
+        return listStuff(this, length7, defaultOK4, eras, ()=>{
             const intl3 = {
-                era: length
+                era: length7
             };
-            if (!this.eraCache[length]) {
-                this.eraCache[length] = [
+            if (!this.eraCache[length7]) {
+                this.eraCache[length7] = [
                     DateTime.utc(-40, 1, 1),
                     DateTime.utc(2017, 1, 1)
-                ].map((dt1)=>this.extract(dt1, intl3, "era")
+                ].map((dt6)=>this.extract(dt6, intl3, "era")
                 );
             }
-            return this.eraCache[length];
+            return this.eraCache[length7];
         });
     }
-    extract(dt, intlOpts, field) {
-        const df = this.dtFormatter(dt, intlOpts), results = df.formatToParts(), matching = results.find((m)=>m.type.toLowerCase() === field
+    extract(dt6, intlOpts, field) {
+        const df = this.dtFormatter(dt6, intlOpts), results = df.formatToParts(), matching = results.find((m)=>m.type.toLowerCase() === field
         );
         return matching ? matching.value : null;
     }
-    numberFormatter(opts = {
+    numberFormatter(opts30 = {
     }) {
-        return new PolyNumberFormatter(this.intl, opts.forceSimple || this.fastNumbers, opts);
+        return new PolyNumberFormatter(this.intl, opts30.forceSimple || this.fastNumbers, opts30);
     }
-    dtFormatter(dt, intlOpts = {
+    dtFormatter(dt7, intlOpts1 = {
     }) {
-        return new PolyDateFormatter(dt, this.intl, intlOpts);
+        return new PolyDateFormatter(dt7, this.intl, intlOpts1);
     }
-    relFormatter(opts = {
+    relFormatter(opts31 = {
     }) {
-        return new PolyRelFormatter(this.intl, this.isEnglish(), opts);
+        return new PolyRelFormatter(this.intl, this.isEnglish(), opts31);
     }
     isEnglish() {
         return this.locale === "en" || this.locale.toLowerCase() === "en-us" || hasIntl() && new Intl.DateTimeFormat(this.intl).resolvedOptions().locale.startsWith("en-us");
     }
-    equals(other) {
-        return this.locale === other.locale && this.numberingSystem === other.numberingSystem && this.outputCalendar === other.outputCalendar;
+    equals(other2) {
+        return this.locale === other2.locale && this.numberingSystem === other2.numberingSystem && this.outputCalendar === other2.outputCalendar;
     }
 }
 class Settings {
     static get now() {
         return now;
     }
-    static set now(n) {
-        now = n;
+    static set now(n2) {
+        now = n2;
     }
     static get defaultZoneName() {
         return Settings.defaultZone.name;
     }
-    static set defaultZoneName(z) {
-        if (!z) {
+    static set defaultZoneName(z1) {
+        if (!z1) {
             defaultZone = null;
         } else {
-            defaultZone = normalizeZone(z);
+            defaultZone = normalizeZone(z1);
         }
     }
     static get defaultZone() {
@@ -3744,20 +3744,20 @@ class Settings {
     static get defaultLocale() {
         return defaultLocale;
     }
-    static set defaultLocale(locale) {
-        defaultLocale = locale;
+    static set defaultLocale(locale16) {
+        defaultLocale = locale16;
     }
     static get defaultNumberingSystem() {
         return defaultNumberingSystem;
     }
-    static set defaultNumberingSystem(numberingSystem) {
-        defaultNumberingSystem = numberingSystem;
+    static set defaultNumberingSystem(numberingSystem8) {
+        defaultNumberingSystem = numberingSystem8;
     }
     static get defaultOutputCalendar() {
         return defaultOutputCalendar;
     }
-    static set defaultOutputCalendar(outputCalendar) {
-        defaultOutputCalendar = outputCalendar;
+    static set defaultOutputCalendar(outputCalendar6) {
+        defaultOutputCalendar = outputCalendar6;
     }
     static get throwOnInvalid() {
         return throwOnInvalid;
@@ -3788,11 +3788,11 @@ class Interval {
         this.invalid = config2.invalid || null;
         this.isLuxonInterval = true;
     }
-    static invalid(reason, explanation = null) {
-        if (!reason) {
+    static invalid(reason6, explanation3 = null) {
+        if (!reason6) {
             throw new InvalidArgumentError("need to specify a reason the Interval is invalid");
         }
-        const invalid1 = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
+        const invalid1 = reason6 instanceof Invalid ? reason6 : new Invalid(reason6, explanation3);
         if (Settings.throwOnInvalid) {
             throw new InvalidIntervalError(invalid1);
         } else {
@@ -3813,50 +3813,50 @@ class Interval {
             return validateError;
         }
     }
-    static after(start, duration) {
-        const dur = friendlyDuration(duration), dt2 = friendlyDateTime(start);
-        return Interval.fromDateTimes(dt2, dt2.plus(dur));
+    static after(start1, duration4) {
+        const dur1 = friendlyDuration(duration4), dt8 = friendlyDateTime(start1);
+        return Interval.fromDateTimes(dt8, dt8.plus(dur1));
     }
-    static before(end, duration) {
-        const dur = friendlyDuration(duration), dt2 = friendlyDateTime(end);
-        return Interval.fromDateTimes(dt2.minus(dur), dt2);
+    static before(end1, duration5) {
+        const dur1 = friendlyDuration(duration5), dt8 = friendlyDateTime(end1);
+        return Interval.fromDateTimes(dt8.minus(dur1), dt8);
     }
-    static fromISO(text, opts) {
-        const [s2, e] = (text || "").split("/", 2);
-        if (s2 && e) {
-            let start, startIsValid;
+    static fromISO(text9, opts32) {
+        const [s3, e] = (text9 || "").split("/", 2);
+        if (s3 && e) {
+            let start2, startIsValid;
             try {
-                start = DateTime.fromISO(s2, opts);
-                startIsValid = start.isValid;
+                start2 = DateTime.fromISO(s3, opts32);
+                startIsValid = start2.isValid;
             } catch (e1) {
                 startIsValid = false;
             }
-            let end, endIsValid;
+            let end2, endIsValid;
             try {
-                end = DateTime.fromISO(e, opts);
-                endIsValid = end.isValid;
+                end2 = DateTime.fromISO(e, opts32);
+                endIsValid = end2.isValid;
             } catch (e1) {
                 endIsValid = false;
             }
             if (startIsValid && endIsValid) {
-                return Interval.fromDateTimes(start, end);
+                return Interval.fromDateTimes(start2, end2);
             }
             if (startIsValid) {
-                const dur = Duration.fromISO(e, opts);
-                if (dur.isValid) {
-                    return Interval.after(start, dur);
+                const dur1 = Duration.fromISO(e, opts32);
+                if (dur1.isValid) {
+                    return Interval.after(start2, dur1);
                 }
             } else if (endIsValid) {
-                const dur = Duration.fromISO(s2, opts);
-                if (dur.isValid) {
-                    return Interval.before(end, dur);
+                const dur1 = Duration.fromISO(s3, opts32);
+                if (dur1.isValid) {
+                    return Interval.before(end2, dur1);
                 }
             }
         }
-        return Interval.invalid("unparsable", `the input "${text}" can't be parsed as ISO 8601`);
+        return Interval.invalid("unparsable", `the input "${text9}" can't be parsed as ISO 8601`);
     }
-    static isInterval(o) {
-        return o && o.isLuxonInterval || false;
+    static isInterval(o3) {
+        return o3 && o3.isLuxonInterval || false;
     }
     get start() {
         return this.isValid ? this.s : null;
@@ -3873,18 +3873,18 @@ class Interval {
     get invalidExplanation() {
         return this.invalid ? this.invalid.explanation : null;
     }
-    length(unit = "milliseconds") {
+    length(unit12 = "milliseconds") {
         return this.isValid ? this.toDuration(...[
-            unit
-        ]).get(unit) : NaN;
+            unit12
+        ]).get(unit12) : NaN;
     }
-    count(unit = "milliseconds") {
+    count(unit13 = "milliseconds") {
         if (!this.isValid) return NaN;
-        const start = this.start.startOf(unit), end = this.end.startOf(unit);
-        return Math.floor(end.diff(start, unit).get(unit)) + 1;
+        const start2 = this.start.startOf(unit13), end2 = this.end.startOf(unit13);
+        return Math.floor(end2.diff(start2, unit13).get(unit13)) + 1;
     }
-    hasSame(unit) {
-        return this.isValid ? this.isEmpty() || this.e.minus(1).hasSame(this.s, unit) : false;
+    hasSame(unit14) {
+        return this.isValid ? this.isEmpty() || this.e.minus(1).hasSame(this.s, unit14) : false;
     }
     isEmpty() {
         return this.s.valueOf() === this.e.valueOf();
@@ -3893,44 +3893,44 @@ class Interval {
         if (!this.isValid) return false;
         return this.s > dateTime;
     }
-    isBefore(dateTime) {
+    isBefore(dateTime1) {
         if (!this.isValid) return false;
-        return this.e <= dateTime;
+        return this.e <= dateTime1;
     }
-    contains(dateTime) {
+    contains(dateTime2) {
         if (!this.isValid) return false;
-        return this.s <= dateTime && this.e > dateTime;
+        return this.s <= dateTime2 && this.e > dateTime2;
     }
-    set({ start , end  } = {
+    set({ start: start2 , end: end2  } = {
     }) {
         if (!this.isValid) return this;
-        return Interval.fromDateTimes(start || this.s, end || this.e);
+        return Interval.fromDateTimes(start2 || this.s, end2 || this.e);
     }
-    splitAt(...dateTimes) {
+    splitAt(...dateTimes2) {
         if (!this.isValid) return [];
-        const sorted = dateTimes.map(friendlyDateTime).filter((d)=>this.contains(d)
+        const sorted = dateTimes2.map(friendlyDateTime).filter((d)=>this.contains(d)
         ).sort(), results = [];
-        let { s: s2  } = this, i = 0;
-        while(s2 < this.e){
-            const added = sorted[i] || this.e, next = +added > +this.e ? this.e : added;
-            results.push(Interval.fromDateTimes(s2, next));
-            s2 = next;
-            i += 1;
+        let { s: s3  } = this, i1 = 0;
+        while(s3 < this.e){
+            const added = sorted[i1] || this.e, next = +added > +this.e ? this.e : added;
+            results.push(Interval.fromDateTimes(s3, next));
+            s3 = next;
+            i1 += 1;
         }
         return results;
     }
-    splitBy(duration) {
-        const dur = friendlyDuration(duration);
-        if (!this.isValid || !dur.isValid || dur.as("milliseconds") === 0) {
+    splitBy(duration6) {
+        const dur1 = friendlyDuration(duration6);
+        if (!this.isValid || !dur1.isValid || dur1.as("milliseconds") === 0) {
             return [];
         }
-        let { s: s2  } = this, added, next;
+        let { s: s3  } = this, added, next;
         const results = [];
-        while(s2 < this.e){
-            added = s2.plus(dur);
+        while(s3 < this.e){
+            added = s3.plus(dur1);
             next = +added > +this.e ? this.e : added;
-            results.push(Interval.fromDateTimes(s2, next));
-            s2 = next;
+            results.push(Interval.fromDateTimes(s3, next));
+            s3 = next;
         }
         return results;
     }
@@ -3938,40 +3938,40 @@ class Interval {
         if (!this.isValid) return [];
         return this.splitBy(this.length() / numberOfParts).slice(0, numberOfParts);
     }
-    overlaps(other) {
-        return this.e > other.s && this.s < other.e;
+    overlaps(other3) {
+        return this.e > other3.s && this.s < other3.e;
     }
-    abutsStart(other) {
+    abutsStart(other4) {
         if (!this.isValid) return false;
-        return +this.e === +other.s;
+        return +this.e === +other4.s;
     }
-    abutsEnd(other) {
+    abutsEnd(other5) {
         if (!this.isValid) return false;
-        return +other.e === +this.s;
+        return +other5.e === +this.s;
     }
-    engulfs(other) {
+    engulfs(other6) {
         if (!this.isValid) return false;
-        return this.s <= other.s && this.e >= other.e;
+        return this.s <= other6.s && this.e >= other6.e;
     }
-    equals(other) {
-        if (!this.isValid || !other.isValid) {
+    equals(other7) {
+        if (!this.isValid || !other7.isValid) {
             return false;
         }
-        return this.s.equals(other.s) && this.e.equals(other.e);
+        return this.s.equals(other7.s) && this.e.equals(other7.e);
     }
-    intersection(other) {
+    intersection(other8) {
         if (!this.isValid) return this;
-        const s2 = this.s > other.s ? this.s : other.s, e = this.e < other.e ? this.e : other.e;
-        if (s2 > e) {
+        const s3 = this.s > other8.s ? this.s : other8.s, e = this.e < other8.e ? this.e : other8.e;
+        if (s3 > e) {
             return null;
         } else {
-            return Interval.fromDateTimes(s2, e);
+            return Interval.fromDateTimes(s3, e);
         }
     }
-    union(other) {
+    union(other9) {
         if (!this.isValid) return this;
-        const s2 = this.s < other.s ? this.s : other.s, e = this.e > other.e ? this.e : other.e;
-        return Interval.fromDateTimes(s2, e);
+        const s3 = this.s < other9.s ? this.s : other9.s, e = this.e > other9.e ? this.e : other9.e;
+        return Interval.fromDateTimes(s3, e);
     }
     static merge(intervals) {
         const [found, __final] = intervals.sort((a, b)=>a.s - b.s
@@ -4003,72 +4003,72 @@ class Interval {
         }
         return found;
     }
-    static xor(intervals) {
-        let start = null, currentCount = 0;
-        const results = [], ends = intervals.map((i)=>[
+    static xor(intervals1) {
+        let start3 = null, currentCount = 0;
+        const results = [], ends = intervals1.map((i1)=>[
                 {
-                    time: i.s,
+                    time: i1.s,
                     type: "s"
                 },
                 {
-                    time: i.e,
+                    time: i1.e,
                     type: "e"
                 }
             ]
         ), flattened = Array.prototype.concat(...ends), arr = flattened.sort((a, b)=>a.time - b.time
         );
-        for (const i of arr){
-            currentCount += i.type === "s" ? 1 : -1;
+        for (const i1 of arr){
+            currentCount += i1.type === "s" ? 1 : -1;
             if (currentCount === 1) {
-                start = i.time;
+                start3 = i1.time;
             } else {
-                if (start && +start !== +i.time) {
-                    results.push(Interval.fromDateTimes(start, i.time));
+                if (start3 && +start3 !== +i1.time) {
+                    results.push(Interval.fromDateTimes(start3, i1.time));
                 }
-                start = null;
+                start3 = null;
             }
         }
         return Interval.merge(results);
     }
-    difference(...intervals) {
+    difference(...intervals2) {
         return Interval.xor([
             this
-        ].concat(intervals)).map((i)=>this.intersection(i)
-        ).filter((i)=>i && !i.isEmpty()
+        ].concat(intervals2)).map((i1)=>this.intersection(i1)
+        ).filter((i1)=>i1 && !i1.isEmpty()
         );
     }
     toString() {
         if (!this.isValid) return INVALID2;
         return `[${this.s.toISO()} – ${this.e.toISO()})`;
     }
-    toISO(opts) {
+    toISO(opts33) {
         if (!this.isValid) return INVALID2;
-        return `${this.s.toISO(opts)}/${this.e.toISO(opts)}`;
+        return `${this.s.toISO(opts33)}/${this.e.toISO(opts33)}`;
     }
     toISODate() {
         if (!this.isValid) return INVALID2;
         return `${this.s.toISODate()}/${this.e.toISODate()}`;
     }
-    toISOTime(opts) {
+    toISOTime(opts34) {
         if (!this.isValid) return INVALID2;
-        return `${this.s.toISOTime(opts)}/${this.e.toISOTime(opts)}`;
+        return `${this.s.toISOTime(opts34)}/${this.e.toISOTime(opts34)}`;
     }
     toFormat(dateFormat, { separator =" – "  } = {
     }) {
         if (!this.isValid) return INVALID2;
         return `${this.s.toFormat(dateFormat)}${separator}${this.e.toFormat(dateFormat)}`;
     }
-    toDuration(unit, opts) {
+    toDuration(unit15, opts35) {
         if (!this.isValid) {
             return Duration.invalid(this.invalidReason);
         }
-        return this.e.diff(this.s, unit, opts);
+        return this.e.diff(this.s, unit15, opts35);
     }
     mapEndpoints(mapFn) {
         return Interval.fromDateTimes(mapFn(this.s), mapFn(this.e));
     }
 }
-function highOrderDiffs(cursor, later, units) {
+function highOrderDiffs(cursor, later, units1) {
     const differs = [
         [
             "years",
@@ -4093,22 +4093,22 @@ function highOrderDiffs(cursor, later, units) {
     const results = {
     };
     let lowestOrder, highWater;
-    for (const [unit2, differ] of differs){
-        if (units.indexOf(unit2) >= 0) {
-            lowestOrder = unit2;
+    for (const [unit16, differ] of differs){
+        if (units1.indexOf(unit16) >= 0) {
+            lowestOrder = unit16;
             let delta = differ(cursor, later);
             highWater = cursor.plus({
-                [unit2]: delta
+                [unit16]: delta
             });
             if (highWater > later) {
                 cursor = cursor.plus({
-                    [unit2]: delta - 1
+                    [unit16]: delta - 1
                 });
                 delta -= 1;
             } else {
                 cursor = highWater;
             }
-            results[unit2] = delta;
+            results[unit16] = delta;
         }
     }
     return [
@@ -4118,10 +4118,10 @@ function highOrderDiffs(cursor, later, units) {
         lowestOrder
     ];
 }
-function __default(earlier, later, units, opts4) {
-    let [cursor, results, highWater, lowestOrder] = highOrderDiffs(earlier, later, units);
+function __default(earlier, later, units1, opts36) {
+    let [cursor, results, highWater, lowestOrder] = highOrderDiffs(earlier, later, units1);
     const remainingMillis = later - cursor;
-    const lowerOrderUnits = units.filter((u)=>[
+    const lowerOrderUnits = units1.filter((u)=>[
             "hours",
             "minutes",
             "seconds",
@@ -4138,28 +4138,28 @@ function __default(earlier, later, units, opts4) {
             results[lowestOrder] = (results[lowestOrder] || 0) + remainingMillis / (highWater - cursor);
         }
     }
-    const duration = Duration.fromObject(Object.assign(results, opts4));
+    const duration7 = Duration.fromObject(Object.assign(results, opts36));
     if (lowerOrderUnits.length > 0) {
-        return Duration.fromMillis(remainingMillis, opts4).shiftTo(...lowerOrderUnits).plus(duration);
+        return Duration.fromMillis(remainingMillis, opts36).shiftTo(...lowerOrderUnits).plus(duration7);
     } else {
-        return duration;
+        return duration7;
     }
 }
-function intUnit(regex, post = (i)=>i
+function intUnit(regex, post = (i1)=>i1
 ) {
     return {
         regex,
-        deser: ([s2])=>post(parseDigits(s2))
+        deser: ([s3])=>post(parseDigits(s3))
     };
 }
 const NBSP = String.fromCharCode(160);
 const spaceOrNBSP = `( |${NBSP})`;
 const spaceOrNBSPRegExp = new RegExp(spaceOrNBSP, "g");
-function fixListRegex(s2) {
-    return s2.replace(/\./g, "\\.?").replace(spaceOrNBSPRegExp, spaceOrNBSP);
+function fixListRegex(s3) {
+    return s3.replace(/\./g, "\\.?").replace(spaceOrNBSPRegExp, spaceOrNBSP);
 }
-function stripInsensitivities(s2) {
-    return s2.replace(/\./g, "").replace(spaceOrNBSPRegExp, " ").toLowerCase();
+function stripInsensitivities(s3) {
+    return s3.replace(/\./g, "").replace(spaceOrNBSPRegExp, " ").toLowerCase();
 }
 function oneOf(strings, startIndex) {
     if (strings === null) {
@@ -4167,12 +4167,12 @@ function oneOf(strings, startIndex) {
     } else {
         return {
             regex: RegExp(strings.map(fixListRegex).join("|")),
-            deser: ([s2])=>strings.findIndex((i)=>stripInsensitivities(s2) === stripInsensitivities(i)
+            deser: ([s3])=>strings.findIndex((i1)=>stripInsensitivities(s3) === stripInsensitivities(i1)
                 ) + startIndex
         };
     }
 }
-function offset2(regex, groups) {
+function offset3(regex, groups) {
     return {
         regex,
         deser: ([, h, m])=>signedOffset(h, m)
@@ -4183,24 +4183,24 @@ function offset2(regex, groups) {
 function simple(regex) {
     return {
         regex,
-        deser: ([s2])=>s2
+        deser: ([s3])=>s3
     };
 }
 function escapeToken(value) {
     return value.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&");
 }
-function unitForToken(token, loc) {
-    const one = digitRegex(loc), two = digitRegex(loc, "{2}"), three = digitRegex(loc, "{3}"), four = digitRegex(loc, "{4}"), six = digitRegex(loc, "{6}"), oneOrTwo = digitRegex(loc, "{1,2}"), oneToThree = digitRegex(loc, "{1,3}"), oneToSix = digitRegex(loc, "{1,6}"), oneToNine = digitRegex(loc, "{1,9}"), twoToFour = digitRegex(loc, "{2,4}"), fourToSix = digitRegex(loc, "{4,6}"), literal = (t)=>({
-            regex: RegExp(escapeToken(t.val)),
-            deser: ([s2])=>s2
+function unitForToken(token1, loc) {
+    const one = digitRegex(loc), two = digitRegex(loc, "{2}"), three = digitRegex(loc, "{3}"), four = digitRegex(loc, "{4}"), six = digitRegex(loc, "{6}"), oneOrTwo = digitRegex(loc, "{1,2}"), oneToThree = digitRegex(loc, "{1,3}"), oneToSix = digitRegex(loc, "{1,6}"), oneToNine = digitRegex(loc, "{1,9}"), twoToFour = digitRegex(loc, "{2,4}"), fourToSix = digitRegex(loc, "{4,6}"), literal = (t1)=>({
+            regex: RegExp(escapeToken(t1.val)),
+            deser: ([s3])=>s3
             ,
             literal: true
         })
-    , unitate = (t)=>{
-        if (token.literal) {
-            return literal(t);
+    , unitate = (t1)=>{
+        if (token1.literal) {
+            return literal(t1);
         }
-        switch(t.val){
+        switch(t1.val){
             case "G":
                 return oneOf(loc.eras("short", false), 0);
             case "GG":
@@ -4288,20 +4288,20 @@ function unitForToken(token, loc) {
                 return oneOf(loc.weekdays("long", true, false), 1);
             case "Z":
             case "ZZ":
-                return offset2(new RegExp(`([+-]${oneOrTwo.source})(?::(${two.source}))?`), 2);
+                return offset3(new RegExp(`([+-]${oneOrTwo.source})(?::(${two.source}))?`), 2);
             case "ZZZ":
-                return offset2(new RegExp(`([+-]${oneOrTwo.source})(${two.source})?`), 2);
+                return offset3(new RegExp(`([+-]${oneOrTwo.source})(${two.source})?`), 2);
             case "z":
                 return simple(/[a-z_+-/]{1,256}?/i);
             default:
-                return literal(t);
+                return literal(t1);
         }
     };
-    const unit2 = unitate(token) || {
+    const unit16 = unitate(token1) || {
         invalidReason: MISSING_FTP
     };
-    unit2.token = token;
-    return unit2;
+    unit16.token = token1;
+    return unit16;
 }
 const partTypeStyleToTokenVal = {
     year: {
@@ -4337,7 +4337,7 @@ const partTypeStyleToTokenVal = {
         "2-digit": "ss"
     }
 };
-function tokenForPart(part, locale3, formatOpts1) {
+function tokenForPart(part, locale17, formatOpts1) {
     const { type , value  } = part;
     if (type === "literal") {
         return {
@@ -4358,24 +4358,24 @@ function tokenForPart(part, locale3, formatOpts1) {
     }
     return undefined;
 }
-function buildRegex(units) {
-    const re = units.map((u)=>u.regex
+function buildRegex(units1) {
+    const re = units1.map((u)=>u.regex
     ).reduce((f, r)=>`${f}(${r.source})`
     , "");
     return [
         `^${re}$`,
-        units
+        units1
     ];
 }
-function match(input, regex, handlers) {
-    const matches = input.match(regex);
+function match(input1, regex, handlers) {
+    const matches = input1.match(regex);
     if (matches) {
         const all = {
         };
         let matchIndex = 1;
-        for(const i in handlers){
-            if (hasOwnProperty(handlers, i)) {
-                const h = handlers[i], groups = h.groups ? h.groups + 1 : 1;
+        for(const i1 in handlers){
+            if (hasOwnProperty(handlers, i1)) {
+                const h = handlers[i1], groups = h.groups ? h.groups + 1 : 1;
                 if (!h.literal && h.token) {
                     all[h.token.val[0]] = h.deser(matches.slice(matchIndex, matchIndex + groups));
                 }
@@ -4395,8 +4395,8 @@ function match(input, regex, handlers) {
     }
 }
 function dateTimeFromMatches(matches) {
-    const toField = (token)=>{
-        switch(token){
+    const toField = (token1)=>{
+        switch(token1){
             case "S":
                 return "millisecond";
             case "s":
@@ -4428,13 +4428,13 @@ function dateTimeFromMatches(matches) {
                 return null;
         }
     };
-    let zone2;
+    let zone5;
     if (!isUndefined(matches.Z)) {
-        zone2 = new FixedOffsetZone(matches.Z);
+        zone5 = new FixedOffsetZone(matches.Z);
     } else if (!isUndefined(matches.z)) {
-        zone2 = IANAZone.create(matches.z);
+        zone5 = IANAZone.create(matches.z);
     } else {
-        zone2 = null;
+        zone5 = null;
     }
     if (!isUndefined(matches.q)) {
         matches.M = (matches.q - 1) * 3 + 1;
@@ -4462,7 +4462,7 @@ function dateTimeFromMatches(matches) {
     });
     return [
         vals,
-        zone2
+        zone5
     ];
 }
 let dummyDateTimeCache = null;
@@ -4472,39 +4472,39 @@ function getDummyDateTime() {
     }
     return dummyDateTimeCache;
 }
-function maybeExpandMacroToken(token, locale3) {
-    if (token.literal) {
-        return token;
+function maybeExpandMacroToken(token1, locale17) {
+    if (token1.literal) {
+        return token1;
     }
-    const formatOpts1 = Formatter.macroTokenToFormatOpts(token.val);
+    const formatOpts1 = Formatter.macroTokenToFormatOpts(token1.val);
     if (!formatOpts1) {
-        return token;
+        return token1;
     }
-    const formatter = Formatter.create(locale3, formatOpts1);
+    const formatter = Formatter.create(locale17, formatOpts1);
     const parts = formatter.formatDateTimeParts(getDummyDateTime());
-    const tokens = parts.map((p)=>tokenForPart(p, locale3, formatOpts1)
+    const tokens = parts.map((p1)=>tokenForPart(p1, locale17, formatOpts1)
     );
     if (tokens.includes(undefined)) {
-        return token;
+        return token1;
     }
     return tokens;
 }
-function expandMacroTokens(tokens, locale3) {
-    return Array.prototype.concat(...tokens.map((t)=>maybeExpandMacroToken(t, locale3)
+function expandMacroTokens(tokens, locale17) {
+    return Array.prototype.concat(...tokens.map((t1)=>maybeExpandMacroToken(t1, locale17)
     ));
 }
-function explainFromTokens(locale3, input, format) {
-    const tokens = expandMacroTokens(Formatter.parseFormat(format), locale3), units = tokens.map((t)=>unitForToken(t, locale3)
-    ), disqualifyingUnit = units.find((t)=>t.invalidReason
+function explainFromTokens(locale17, input1, format10) {
+    const tokens = expandMacroTokens(Formatter.parseFormat(format10), locale17), units1 = tokens.map((t1)=>unitForToken(t1, locale17)
+    ), disqualifyingUnit = units1.find((t1)=>t1.invalidReason
     );
     if (disqualifyingUnit) {
         return {
-            input,
+            input: input1,
             tokens,
             invalidReason: disqualifyingUnit.invalidReason
         };
     } else {
-        const [regexString, handlers] = buildRegex(units), regex = RegExp(regexString, "i"), [rawMatches, matches] = match(input, regex, handlers), [result, zone2] = matches ? dateTimeFromMatches(matches) : [
+        const [regexString, handlers] = buildRegex(units1), regex = RegExp(regexString, "i"), [rawMatches, matches] = match(input1, regex, handlers), [result, zone5] = matches ? dateTimeFromMatches(matches) : [
             null,
             null
         ];
@@ -4512,21 +4512,21 @@ function explainFromTokens(locale3, input, format) {
             throw new ConflictingSpecificationError("Can't include meridiem when specifying 24-hour format");
         }
         return {
-            input,
+            input: input1,
             tokens,
             regex,
             rawMatches,
             matches,
             result,
-            zone: zone2
+            zone: zone5
         };
     }
 }
-function parseFromTokens(locale3, input, format) {
-    const { result , zone: zone2 , invalidReason  } = explainFromTokens(locale3, input, format);
+function parseFromTokens(locale17, input1, format10) {
+    const { result , zone: zone5 , invalidReason  } = explainFromTokens(locale17, input1, format10);
     return [
         result,
-        zone2,
+        zone5,
         invalidReason
     ];
 }
@@ -4544,6 +4544,6 @@ const mod = function() {
         Settings: Settings
     };
 }();
-const date = new Date();
-const dt2 = mod.DateTime.fromJSDate(date);
-console.log(dt2.toISO());
+const date1 = new Date();
+const dt8 = mod.DateTime.fromJSDate(date1);
+console.log(dt8.toISO());

--- a/bundler/tests/fixture/deno-8734/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-8734/output/entry.inlined.ts
@@ -3,13 +3,13 @@ if (!m) {
     throw new Error('b');
 }
 class Comparator1 {
-    constructor(comp1, optionsOrLoose = {
+    constructor(comp, optionsOrLoose = {
     }){
     }
-    parse(comp) {
+    parse(comp1) {
         const m1 = "another";
         if (!m1) {
-            throw new TypeError("Invalid comparator: " + comp);
+            throw new TypeError("Invalid comparator: " + comp1);
         }
         const m11 = m1[1];
         console.log(m11);

--- a/bundler/tests/fixture/deno-8734/output/entry.ts
+++ b/bundler/tests/fixture/deno-8734/output/entry.ts
@@ -3,13 +3,13 @@ if (!m) {
     throw new Error('b');
 }
 class Comparator1 {
-    constructor(comp1, optionsOrLoose = {
+    constructor(comp, optionsOrLoose = {
     }){
     }
-    parse(comp) {
+    parse(comp1) {
         const m1 = "another";
         if (!m1) {
-            throw new TypeError("Invalid comparator: " + comp);
+            throw new TypeError("Invalid comparator: " + comp1);
         }
         const m11 = m1[1];
         console.log(m11);

--- a/bundler/tests/fixture/deno-9220/case1/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-9220/case1/output/entry.inlined.ts
@@ -9,8 +9,8 @@ class Image1 {
         };
         return rntVal;
     }
-    setPixel(x, y, pix) {
-        const index = x + y * this.width;
+    setPixel(x1, y1, pix) {
+        const index = x1 + y1 * this.width;
         this.data[index * 4] = pix.r;
         this.data[index * 4 + 1] = pix.g;
         this.data[index * 4 + 2] = pix.b;
@@ -780,7 +780,7 @@ const JpegImage = function jpegImage() {
             const scaleX = this.width / width, scaleY = this.height / height;
             let component1, component2, component3, component4;
             let component1Line, component2Line, component3Line, component4Line;
-            let x, y;
+            let x2, y2;
             let offset = 0;
             let Y, Cb, Cr, K, C, M, Ye, R, G, B;
             let colorTransform;
@@ -789,10 +789,10 @@ const JpegImage = function jpegImage() {
             switch(this.components.length){
                 case 1:
                     component1 = this.components[0];
-                    for(y = 0; y < height; y++){
-                        component1Line = component1.lines[0 | y * component1.scaleY * scaleY];
-                        for(x = 0; x < width; x++){
-                            Y = component1Line[0 | x * component1.scaleX * scaleX];
+                    for(y2 = 0; y2 < height; y2++){
+                        component1Line = component1.lines[0 | y2 * component1.scaleY * scaleY];
+                        for(x2 = 0; x2 < width; x2++){
+                            Y = component1Line[0 | x2 * component1.scaleX * scaleX];
                             data[offset++] = Y;
                         }
                     }
@@ -800,13 +800,13 @@ const JpegImage = function jpegImage() {
                 case 2:
                     component1 = this.components[0];
                     component2 = this.components[1];
-                    for(y = 0; y < height; y++){
-                        component1Line = component1.lines[0 | y * component1.scaleY * scaleY];
-                        component2Line = component2.lines[0 | y * component2.scaleY * scaleY];
-                        for(x = 0; x < width; x++){
-                            Y = component1Line[0 | x * component1.scaleX * scaleX];
+                    for(y2 = 0; y2 < height; y2++){
+                        component1Line = component1.lines[0 | y2 * component1.scaleY * scaleY];
+                        component2Line = component2.lines[0 | y2 * component2.scaleY * scaleY];
+                        for(x2 = 0; x2 < width; x2++){
+                            Y = component1Line[0 | x2 * component1.scaleX * scaleX];
                             data[offset++] = Y;
-                            Y = component2Line[0 | x * component2.scaleX * scaleX];
+                            Y = component2Line[0 | x2 * component2.scaleX * scaleX];
                             data[offset++] = Y;
                         }
                     }
@@ -821,19 +821,19 @@ const JpegImage = function jpegImage() {
                     component1 = this.components[0];
                     component2 = this.components[1];
                     component3 = this.components[2];
-                    for(y = 0; y < height; y++){
-                        component1Line = component1.lines[0 | y * component1.scaleY * scaleY];
-                        component2Line = component2.lines[0 | y * component2.scaleY * scaleY];
-                        component3Line = component3.lines[0 | y * component3.scaleY * scaleY];
-                        for(x = 0; x < width; x++){
+                    for(y2 = 0; y2 < height; y2++){
+                        component1Line = component1.lines[0 | y2 * component1.scaleY * scaleY];
+                        component2Line = component2.lines[0 | y2 * component2.scaleY * scaleY];
+                        component3Line = component3.lines[0 | y2 * component3.scaleY * scaleY];
+                        for(x2 = 0; x2 < width; x2++){
                             if (!colorTransform) {
-                                R = component1Line[0 | x * component1.scaleX * scaleX];
-                                G = component2Line[0 | x * component2.scaleX * scaleX];
-                                B = component3Line[0 | x * component3.scaleX * scaleX];
+                                R = component1Line[0 | x2 * component1.scaleX * scaleX];
+                                G = component2Line[0 | x2 * component2.scaleX * scaleX];
+                                B = component3Line[0 | x2 * component3.scaleX * scaleX];
                             } else {
-                                Y = component1Line[0 | x * component1.scaleX * scaleX];
-                                Cb = component2Line[0 | x * component2.scaleX * scaleX];
-                                Cr = component3Line[0 | x * component3.scaleX * scaleX];
+                                Y = component1Line[0 | x2 * component1.scaleX * scaleX];
+                                Cb = component2Line[0 | x2 * component2.scaleX * scaleX];
+                                Cr = component3Line[0 | x2 * component3.scaleX * scaleX];
                                 R = clampTo8bit(Y + 1.402 * (Cr - 128));
                                 G = clampTo8bit(Y - 0.3441363 * (Cb - 128) - 0.71413636 * (Cr - 128));
                                 B = clampTo8bit(Y + 1.772 * (Cb - 128));
@@ -858,22 +858,22 @@ const JpegImage = function jpegImage() {
                     component2 = this.components[1];
                     component3 = this.components[2];
                     component4 = this.components[3];
-                    for(y = 0; y < height; y++){
-                        component1Line = component1.lines[0 | y * component1.scaleY * scaleY];
-                        component2Line = component2.lines[0 | y * component2.scaleY * scaleY];
-                        component3Line = component3.lines[0 | y * component3.scaleY * scaleY];
-                        component4Line = component4.lines[0 | y * component4.scaleY * scaleY];
-                        for(x = 0; x < width; x++){
+                    for(y2 = 0; y2 < height; y2++){
+                        component1Line = component1.lines[0 | y2 * component1.scaleY * scaleY];
+                        component2Line = component2.lines[0 | y2 * component2.scaleY * scaleY];
+                        component3Line = component3.lines[0 | y2 * component3.scaleY * scaleY];
+                        component4Line = component4.lines[0 | y2 * component4.scaleY * scaleY];
+                        for(x2 = 0; x2 < width; x2++){
                             if (!colorTransform) {
-                                C = component1Line[0 | x * component1.scaleX * scaleX];
-                                M = component2Line[0 | x * component2.scaleX * scaleX];
-                                Ye = component3Line[0 | x * component3.scaleX * scaleX];
-                                K = component4Line[0 | x * component4.scaleX * scaleX];
+                                C = component1Line[0 | x2 * component1.scaleX * scaleX];
+                                M = component2Line[0 | x2 * component2.scaleX * scaleX];
+                                Ye = component3Line[0 | x2 * component3.scaleX * scaleX];
+                                K = component4Line[0 | x2 * component4.scaleX * scaleX];
                             } else {
-                                Y = component1Line[0 | x * component1.scaleX * scaleX];
-                                Cb = component2Line[0 | x * component2.scaleX * scaleX];
-                                Cr = component3Line[0 | x * component3.scaleX * scaleX];
-                                K = component4Line[0 | x * component4.scaleX * scaleX];
+                                Y = component1Line[0 | x2 * component1.scaleX * scaleX];
+                                Cb = component2Line[0 | x2 * component2.scaleX * scaleX];
+                                Cr = component3Line[0 | x2 * component3.scaleX * scaleX];
+                                K = component4Line[0 | x2 * component4.scaleX * scaleX];
                                 C = 255 - clampTo8bit(Y + 1.402 * (Cr - 128));
                                 M = 255 - clampTo8bit(Y - 0.3441363 * (Cb - 128) - 0.71413636 * (Cr - 128));
                                 Ye = 255 - clampTo8bit(Y + 1.772 * (Cb - 128));
@@ -894,12 +894,12 @@ const JpegImage = function jpegImage() {
             const width = imageData.width, height = imageData.height;
             const imageDataArray = imageData.data;
             const data = this.getData(width, height);
-            let i = 0, j = 0, x, y;
+            let i = 0, j = 0, x2, y2;
             let Y, K, C, M, R, G, B;
             switch(this.components.length){
                 case 1:
-                    for(y = 0; y < height; y++){
-                        for(x = 0; x < width; x++){
+                    for(y2 = 0; y2 < height; y2++){
+                        for(x2 = 0; x2 < width; x2++){
                             Y = data[i++];
                             imageDataArray[j++] = Y;
                             imageDataArray[j++] = Y;
@@ -909,8 +909,8 @@ const JpegImage = function jpegImage() {
                     }
                     break;
                 case 3:
-                    for(y = 0; y < height; y++){
-                        for(x = 0; x < width; x++){
+                    for(y2 = 0; y2 < height; y2++){
+                        for(x2 = 0; x2 < width; x2++){
                             R = data[i++];
                             G = data[i++];
                             B = data[i++];
@@ -922,8 +922,8 @@ const JpegImage = function jpegImage() {
                     }
                     break;
                 case 4:
-                    for(y = 0; y < height; y++){
-                        for(x = 0; x < width; x++){
+                    for(y2 = 0; y2 < height; y2++){
+                        for(x2 = 0; x2 < width; x2++){
                             C = data[i++];
                             M = data[i++];
                             Y = data[i++];

--- a/bundler/tests/fixture/deno-9220/case1/output/entry.ts
+++ b/bundler/tests/fixture/deno-9220/case1/output/entry.ts
@@ -9,8 +9,8 @@ class Image1 {
         };
         return rntVal;
     }
-    setPixel(x, y, pix) {
-        const index = x + y * this.width;
+    setPixel(x1, y1, pix) {
+        const index = x1 + y1 * this.width;
         this.data[index * 4] = pix.r;
         this.data[index * 4 + 1] = pix.g;
         this.data[index * 4 + 2] = pix.b;
@@ -780,7 +780,7 @@ const JpegImage = function jpegImage() {
             const scaleX = this.width / width, scaleY = this.height / height;
             let component1, component2, component3, component4;
             let component1Line, component2Line, component3Line, component4Line;
-            let x, y;
+            let x2, y2;
             let offset = 0;
             let Y, Cb, Cr, K, C, M, Ye, R, G, B;
             let colorTransform;
@@ -789,10 +789,10 @@ const JpegImage = function jpegImage() {
             switch(this.components.length){
                 case 1:
                     component1 = this.components[0];
-                    for(y = 0; y < height; y++){
-                        component1Line = component1.lines[0 | y * component1.scaleY * scaleY];
-                        for(x = 0; x < width; x++){
-                            Y = component1Line[0 | x * component1.scaleX * scaleX];
+                    for(y2 = 0; y2 < height; y2++){
+                        component1Line = component1.lines[0 | y2 * component1.scaleY * scaleY];
+                        for(x2 = 0; x2 < width; x2++){
+                            Y = component1Line[0 | x2 * component1.scaleX * scaleX];
                             data[offset++] = Y;
                         }
                     }
@@ -800,13 +800,13 @@ const JpegImage = function jpegImage() {
                 case 2:
                     component1 = this.components[0];
                     component2 = this.components[1];
-                    for(y = 0; y < height; y++){
-                        component1Line = component1.lines[0 | y * component1.scaleY * scaleY];
-                        component2Line = component2.lines[0 | y * component2.scaleY * scaleY];
-                        for(x = 0; x < width; x++){
-                            Y = component1Line[0 | x * component1.scaleX * scaleX];
+                    for(y2 = 0; y2 < height; y2++){
+                        component1Line = component1.lines[0 | y2 * component1.scaleY * scaleY];
+                        component2Line = component2.lines[0 | y2 * component2.scaleY * scaleY];
+                        for(x2 = 0; x2 < width; x2++){
+                            Y = component1Line[0 | x2 * component1.scaleX * scaleX];
                             data[offset++] = Y;
-                            Y = component2Line[0 | x * component2.scaleX * scaleX];
+                            Y = component2Line[0 | x2 * component2.scaleX * scaleX];
                             data[offset++] = Y;
                         }
                     }
@@ -821,19 +821,19 @@ const JpegImage = function jpegImage() {
                     component1 = this.components[0];
                     component2 = this.components[1];
                     component3 = this.components[2];
-                    for(y = 0; y < height; y++){
-                        component1Line = component1.lines[0 | y * component1.scaleY * scaleY];
-                        component2Line = component2.lines[0 | y * component2.scaleY * scaleY];
-                        component3Line = component3.lines[0 | y * component3.scaleY * scaleY];
-                        for(x = 0; x < width; x++){
+                    for(y2 = 0; y2 < height; y2++){
+                        component1Line = component1.lines[0 | y2 * component1.scaleY * scaleY];
+                        component2Line = component2.lines[0 | y2 * component2.scaleY * scaleY];
+                        component3Line = component3.lines[0 | y2 * component3.scaleY * scaleY];
+                        for(x2 = 0; x2 < width; x2++){
                             if (!colorTransform) {
-                                R = component1Line[0 | x * component1.scaleX * scaleX];
-                                G = component2Line[0 | x * component2.scaleX * scaleX];
-                                B = component3Line[0 | x * component3.scaleX * scaleX];
+                                R = component1Line[0 | x2 * component1.scaleX * scaleX];
+                                G = component2Line[0 | x2 * component2.scaleX * scaleX];
+                                B = component3Line[0 | x2 * component3.scaleX * scaleX];
                             } else {
-                                Y = component1Line[0 | x * component1.scaleX * scaleX];
-                                Cb = component2Line[0 | x * component2.scaleX * scaleX];
-                                Cr = component3Line[0 | x * component3.scaleX * scaleX];
+                                Y = component1Line[0 | x2 * component1.scaleX * scaleX];
+                                Cb = component2Line[0 | x2 * component2.scaleX * scaleX];
+                                Cr = component3Line[0 | x2 * component3.scaleX * scaleX];
                                 R = clampTo8bit(Y + 1.402 * (Cr - 128));
                                 G = clampTo8bit(Y - 0.3441363 * (Cb - 128) - 0.71413636 * (Cr - 128));
                                 B = clampTo8bit(Y + 1.772 * (Cb - 128));
@@ -858,22 +858,22 @@ const JpegImage = function jpegImage() {
                     component2 = this.components[1];
                     component3 = this.components[2];
                     component4 = this.components[3];
-                    for(y = 0; y < height; y++){
-                        component1Line = component1.lines[0 | y * component1.scaleY * scaleY];
-                        component2Line = component2.lines[0 | y * component2.scaleY * scaleY];
-                        component3Line = component3.lines[0 | y * component3.scaleY * scaleY];
-                        component4Line = component4.lines[0 | y * component4.scaleY * scaleY];
-                        for(x = 0; x < width; x++){
+                    for(y2 = 0; y2 < height; y2++){
+                        component1Line = component1.lines[0 | y2 * component1.scaleY * scaleY];
+                        component2Line = component2.lines[0 | y2 * component2.scaleY * scaleY];
+                        component3Line = component3.lines[0 | y2 * component3.scaleY * scaleY];
+                        component4Line = component4.lines[0 | y2 * component4.scaleY * scaleY];
+                        for(x2 = 0; x2 < width; x2++){
                             if (!colorTransform) {
-                                C = component1Line[0 | x * component1.scaleX * scaleX];
-                                M = component2Line[0 | x * component2.scaleX * scaleX];
-                                Ye = component3Line[0 | x * component3.scaleX * scaleX];
-                                K = component4Line[0 | x * component4.scaleX * scaleX];
+                                C = component1Line[0 | x2 * component1.scaleX * scaleX];
+                                M = component2Line[0 | x2 * component2.scaleX * scaleX];
+                                Ye = component3Line[0 | x2 * component3.scaleX * scaleX];
+                                K = component4Line[0 | x2 * component4.scaleX * scaleX];
                             } else {
-                                Y = component1Line[0 | x * component1.scaleX * scaleX];
-                                Cb = component2Line[0 | x * component2.scaleX * scaleX];
-                                Cr = component3Line[0 | x * component3.scaleX * scaleX];
-                                K = component4Line[0 | x * component4.scaleX * scaleX];
+                                Y = component1Line[0 | x2 * component1.scaleX * scaleX];
+                                Cb = component2Line[0 | x2 * component2.scaleX * scaleX];
+                                Cr = component3Line[0 | x2 * component3.scaleX * scaleX];
+                                K = component4Line[0 | x2 * component4.scaleX * scaleX];
                                 C = 255 - clampTo8bit(Y + 1.402 * (Cr - 128));
                                 M = 255 - clampTo8bit(Y - 0.3441363 * (Cb - 128) - 0.71413636 * (Cr - 128));
                                 Ye = 255 - clampTo8bit(Y + 1.772 * (Cb - 128));
@@ -894,12 +894,12 @@ const JpegImage = function jpegImage() {
             const width = imageData.width, height = imageData.height;
             const imageDataArray = imageData.data;
             const data = this.getData(width, height);
-            let i = 0, j = 0, x, y;
+            let i = 0, j = 0, x2, y2;
             let Y, K, C, M, R, G, B;
             switch(this.components.length){
                 case 1:
-                    for(y = 0; y < height; y++){
-                        for(x = 0; x < width; x++){
+                    for(y2 = 0; y2 < height; y2++){
+                        for(x2 = 0; x2 < width; x2++){
                             Y = data[i++];
                             imageDataArray[j++] = Y;
                             imageDataArray[j++] = Y;
@@ -909,8 +909,8 @@ const JpegImage = function jpegImage() {
                     }
                     break;
                 case 3:
-                    for(y = 0; y < height; y++){
-                        for(x = 0; x < width; x++){
+                    for(y2 = 0; y2 < height; y2++){
+                        for(x2 = 0; x2 < width; x2++){
                             R = data[i++];
                             G = data[i++];
                             B = data[i++];
@@ -922,8 +922,8 @@ const JpegImage = function jpegImage() {
                     }
                     break;
                 case 4:
-                    for(y = 0; y < height; y++){
-                        for(x = 0; x < width; x++){
+                    for(y2 = 0; y2 < height; y2++){
+                        for(x2 = 0; x2 < width; x2++){
                             C = data[i++];
                             M = data[i++];
                             Y = data[i++];

--- a/bundler/tests/fixture/deno-9591/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-9591/output/entry.inlined.ts
@@ -821,7 +821,7 @@ function extname(path) {
     }
     return path.slice(startDot, end);
 }
-function format4(pathObject) {
+function format(pathObject) {
     if (pathObject === null || typeof pathObject !== "object") {
         throw new TypeError(`The "pathObject" argument must be of type Object. Received type ${typeof pathObject}`);
     }
@@ -968,7 +968,7 @@ const mod1 = function() {
         dirname: dirname,
         basename: basename,
         extname: extname,
-        format: format4,
+        format: format,
         parse: parse1,
         fromFileUrl: fromFileUrl,
         toFileUrl: toFileUrl
@@ -1703,10 +1703,10 @@ class Logger {
     #level;
     #handlers;
     #loggerName;
-    constructor(loggerName, levelName1, options1 = {
+    constructor(loggerName, levelName, options1 = {
     }){
         this.#loggerName = loggerName;
-        this.#level = getLevelByName(levelName1);
+        this.#level = getLevelByName(levelName);
         this.#handlers = options1.handlers || [];
     }
     get level() {
@@ -1718,8 +1718,8 @@ class Logger {
     get levelName() {
         return getLevelName(this.#level);
     }
-    set levelName(levelName) {
-        this.#level = getLevelByName(levelName);
+    set levelName(levelName1) {
+        this.#level = getLevelByName(levelName1);
     }
     get loggerName() {
         return this.#loggerName;
@@ -1730,8 +1730,8 @@ class Logger {
     get handlers() {
         return this.#handlers;
     }
-    _log(level, msg, ...args) {
-        if (this.level > level) {
+    _log(level1, msg, ...args) {
+        if (this.level > level1) {
             return msg instanceof Function ? undefined : msg;
         }
         let fnResult;
@@ -1745,7 +1745,7 @@ class Logger {
         const record = new LogRecord({
             msg: logMessage,
             args: args,
-            level: level,
+            level: level1,
             loggerName: this.loggerName
         });
         this.#handlers.forEach((handler)=>{
@@ -1763,20 +1763,20 @@ class Logger {
         }
         return "undefined";
     }
-    debug(msg, ...args) {
-        return this._log(LogLevels.DEBUG, msg, ...args);
+    debug(msg1, ...args1) {
+        return this._log(LogLevels.DEBUG, msg1, ...args1);
     }
-    info(msg, ...args) {
-        return this._log(LogLevels.INFO, msg, ...args);
+    info(msg2, ...args2) {
+        return this._log(LogLevels.INFO, msg2, ...args2);
     }
-    warning(msg, ...args) {
-        return this._log(LogLevels.WARNING, msg, ...args);
+    warning(msg3, ...args3) {
+        return this._log(LogLevels.WARNING, msg3, ...args3);
     }
-    error(msg, ...args) {
-        return this._log(LogLevels.ERROR, msg, ...args);
+    error(msg4, ...args4) {
+        return this._log(LogLevels.ERROR, msg4, ...args4);
     }
-    critical(msg, ...args) {
-        return this._log(LogLevels.CRITICAL, msg, ...args);
+    critical(msg5, ...args5) {
+        return this._log(LogLevels.CRITICAL, msg5, ...args5);
     }
 }
 const noColor = globalThis.Deno?.noColor ?? true;
@@ -1867,14 +1867,14 @@ class BufReader {
     static create(r, size = 4096) {
         return r instanceof BufReader ? r : new BufReader(r, size);
     }
-    constructor(rd1, size1 = 4096){
+    constructor(rd, size1 = 4096){
         this.r = 0;
         this.w = 0;
         this.eof = false;
         if (size1 < 16) {
             size1 = MIN_BUF_SIZE;
         }
-        this._reset(new Uint8Array(size1), rd1);
+        this._reset(new Uint8Array(size1), rd);
     }
     size() {
         return this.buf.byteLength;
@@ -1905,12 +1905,12 @@ class BufReader {
         }
         throw new Error(`No progress after ${100} read() calls`);
     }
-    reset(r) {
-        this._reset(this.buf, r);
+    reset(r1) {
+        this._reset(this.buf, r1);
     }
-    _reset(buf, rd) {
+    _reset(buf, rd1) {
         this.buf = buf;
-        this.rd = rd;
+        this.rd = rd1;
         this.eof = false;
     }
     async read(p) {
@@ -1934,11 +1934,11 @@ class BufReader {
         this.r += copied;
         return copied;
     }
-    async readFull(p) {
+    async readFull(p1) {
         let bytesRead = 0;
-        while(bytesRead < p.length){
+        while(bytesRead < p1.length){
             try {
-                const rr = await this.read(p.subarray(bytesRead));
+                const rr = await this.read(p1.subarray(bytesRead));
                 if (rr === null) {
                     if (bytesRead === 0) {
                         return null;
@@ -1948,11 +1948,11 @@ class BufReader {
                 }
                 bytesRead += rr;
             } catch (err) {
-                err.partial = p.subarray(0, bytesRead);
+                err.partial = p1.subarray(0, bytesRead);
                 throw err;
             }
         }
-        return p;
+        return p1;
     }
     async readByte() {
         while(this.r === this.w){
@@ -2012,11 +2012,11 @@ class BufReader {
             more: false
         };
     }
-    async readSlice(delim) {
+    async readSlice(delim1) {
         let s = 0;
         let slice;
         while(true){
-            let i = this.buf.subarray(this.r + s, this.w).indexOf(delim);
+            let i = this.buf.subarray(this.r + s, this.w).indexOf(delim1);
             if (i >= 0) {
                 i += s;
                 slice = this.buf.subarray(this.r, this.r + i + 1);
@@ -2088,16 +2088,16 @@ class AbstractBufBase {
     }
 }
 class BufWriter extends AbstractBufBase {
-    static create(writer, size = 4096) {
-        return writer instanceof BufWriter ? writer : new BufWriter(writer, size);
+    static create(writer, size2 = 4096) {
+        return writer instanceof BufWriter ? writer : new BufWriter(writer, size2);
     }
-    constructor(writer1, size2 = 4096){
+    constructor(writer1, size3 = 4096){
         super();
         this.writer = writer1;
-        if (size2 <= 0) {
-            size2 = DEFAULT_BUF_SIZE;
+        if (size3 <= 0) {
+            size3 = DEFAULT_BUF_SIZE;
         }
-        this.buf = new Uint8Array(size2);
+        this.buf = new Uint8Array(size3);
     }
     reset(w) {
         this.err = null;
@@ -2116,49 +2116,49 @@ class BufWriter extends AbstractBufBase {
         this.buf = new Uint8Array(this.buf.length);
         this.usedBufferBytes = 0;
     }
-    async write(data) {
+    async write(data1) {
         if (this.err !== null) throw this.err;
-        if (data.length === 0) return 0;
+        if (data1.length === 0) return 0;
         let totalBytesWritten = 0;
         let numBytesWritten = 0;
-        while(data.byteLength > this.available()){
+        while(data1.byteLength > this.available()){
             if (this.buffered() === 0) {
                 try {
-                    numBytesWritten = await this.writer.write(data);
+                    numBytesWritten = await this.writer.write(data1);
                 } catch (e) {
                     this.err = e;
                     throw e;
                 }
             } else {
-                numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
+                numBytesWritten = copyBytes(data1, this.buf, this.usedBufferBytes);
                 this.usedBufferBytes += numBytesWritten;
                 await this.flush();
             }
             totalBytesWritten += numBytesWritten;
-            data = data.subarray(numBytesWritten);
+            data1 = data1.subarray(numBytesWritten);
         }
-        numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
+        numBytesWritten = copyBytes(data1, this.buf, this.usedBufferBytes);
         this.usedBufferBytes += numBytesWritten;
         totalBytesWritten += numBytesWritten;
         return totalBytesWritten;
     }
 }
 class BufWriterSync extends AbstractBufBase {
-    static create(writer, size = 4096) {
-        return writer instanceof BufWriterSync ? writer : new BufWriterSync(writer, size);
+    static create(writer2, size4 = 4096) {
+        return writer2 instanceof BufWriterSync ? writer2 : new BufWriterSync(writer2, size4);
     }
-    constructor(writer2, size3 = 4096){
+    constructor(writer3, size5 = 4096){
         super();
-        this.writer = writer2;
-        if (size3 <= 0) {
-            size3 = DEFAULT_BUF_SIZE;
+        this.writer = writer3;
+        if (size5 <= 0) {
+            size5 = DEFAULT_BUF_SIZE;
         }
-        this.buf = new Uint8Array(size3);
+        this.buf = new Uint8Array(size5);
     }
-    reset(w) {
+    reset(w1) {
         this.err = null;
         this.usedBufferBytes = 0;
-        this.writer = w;
+        this.writer = w1;
     }
     flush() {
         if (this.err !== null) throw this.err;
@@ -2172,28 +2172,28 @@ class BufWriterSync extends AbstractBufBase {
         this.buf = new Uint8Array(this.buf.length);
         this.usedBufferBytes = 0;
     }
-    writeSync(data) {
+    writeSync(data2) {
         if (this.err !== null) throw this.err;
-        if (data.length === 0) return 0;
+        if (data2.length === 0) return 0;
         let totalBytesWritten = 0;
         let numBytesWritten = 0;
-        while(data.byteLength > this.available()){
+        while(data2.byteLength > this.available()){
             if (this.buffered() === 0) {
                 try {
-                    numBytesWritten = this.writer.writeSync(data);
+                    numBytesWritten = this.writer.writeSync(data2);
                 } catch (e) {
                     this.err = e;
                     throw e;
                 }
             } else {
-                numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
+                numBytesWritten = copyBytes(data2, this.buf, this.usedBufferBytes);
                 this.usedBufferBytes += numBytesWritten;
                 this.flush();
             }
             totalBytesWritten += numBytesWritten;
-            data = data.subarray(numBytesWritten);
+            data2 = data2.subarray(numBytesWritten);
         }
-        numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
+        numBytesWritten = copyBytes(data2, this.buf, this.usedBufferBytes);
         this.usedBufferBytes += numBytesWritten;
         totalBytesWritten += numBytesWritten;
         return totalBytesWritten;
@@ -2209,15 +2209,15 @@ class BaseHandler {
     }
     handle(logRecord) {
         if (this.level > logRecord.level) return;
-        const msg = this.format(logRecord);
-        return this.log(msg);
+        const msg6 = this.format(logRecord);
+        return this.log(msg6);
     }
-    format(logRecord) {
+    format(logRecord1) {
         if (this.formatter instanceof Function) {
-            return this.formatter(logRecord);
+            return this.formatter(logRecord1);
         }
-        return this.formatter.replace(/{(\S+)}/g, (match, p1)=>{
-            const value = logRecord[p1];
+        return this.formatter.replace(/{(\S+)}/g, (match, p11)=>{
+            const value = logRecord1[p11];
             if (value == null) {
                 return match;
             }
@@ -2232,27 +2232,27 @@ class BaseHandler {
     }
 }
 class ConsoleHandler extends BaseHandler {
-    format(logRecord) {
-        let msg = super.format(logRecord);
-        switch(logRecord.level){
+    format(logRecord2) {
+        let msg6 = super.format(logRecord2);
+        switch(logRecord2.level){
             case LogLevels.INFO:
-                msg = blue(msg);
+                msg6 = blue(msg6);
                 break;
             case LogLevels.WARNING:
-                msg = yellow(msg);
+                msg6 = yellow(msg6);
                 break;
             case LogLevels.ERROR:
-                msg = red(msg);
+                msg6 = red(msg6);
                 break;
             case LogLevels.CRITICAL:
-                msg = bold(red(msg));
+                msg6 = bold(red(msg6));
                 break;
             default: break;
         }
-        return msg;
+        return msg6;
     }
-    log(msg) {
-        console.log(msg);
+    log(msg6) {
+        console.log(msg6);
     }
 }
 class WriterHandler extends BaseHandler {
@@ -2280,14 +2280,14 @@ class FileHandler extends WriterHandler {
         this._buf = new BufWriterSync(this._file);
         addEventListener("unload", this.#unloadCallback);
     }
-    handle(logRecord) {
-        super.handle(logRecord);
-        if (logRecord.level > LogLevels.ERROR) {
+    handle(logRecord3) {
+        super.handle(logRecord3);
+        if (logRecord3.level > LogLevels.ERROR) {
             this.flush();
         }
     }
-    log(msg) {
-        this._buf.writeSync(this._encoder.encode(msg + "\n"));
+    log(msg7) {
+        this._buf.writeSync(this._encoder.encode(msg7 + "\n"));
     }
     flush() {
         if (this._buf?.buffered() > 0) {
@@ -2338,13 +2338,13 @@ class RotatingFileHandler extends FileHandler {
             this.#currentFileSize = (await Deno.stat(this._filename)).size;
         }
     }
-    log(msg) {
-        const msgByteLength = this._encoder.encode(msg).byteLength + 1;
+    log(msg8) {
+        const msgByteLength = this._encoder.encode(msg8).byteLength + 1;
         if (this.#currentFileSize + msgByteLength > this.#maxBytes) {
             this.rotateLogFiles();
             this.#currentFileSize = 0;
         }
-        this._buf.writeSync(this._encoder.encode(msg + "\n"));
+        this._buf.writeSync(this._encoder.encode(msg8 + "\n"));
         this.#currentFileSize += msgByteLength;
     }
     rotateLogFiles() {
@@ -2406,35 +2406,35 @@ function getLogger(name) {
     }
     return result;
 }
-function debug(msg, ...args) {
-    if (msg instanceof Function) {
-        return getLogger("default").debug(msg, ...args);
+function debug(msg9, ...args6) {
+    if (msg9 instanceof Function) {
+        return getLogger("default").debug(msg9, ...args6);
     }
-    return getLogger("default").debug(msg, ...args);
+    return getLogger("default").debug(msg9, ...args6);
 }
-function info(msg, ...args) {
-    if (msg instanceof Function) {
-        return getLogger("default").info(msg, ...args);
+function info(msg9, ...args6) {
+    if (msg9 instanceof Function) {
+        return getLogger("default").info(msg9, ...args6);
     }
-    return getLogger("default").info(msg, ...args);
+    return getLogger("default").info(msg9, ...args6);
 }
-function warning(msg, ...args) {
-    if (msg instanceof Function) {
-        return getLogger("default").warning(msg, ...args);
+function warning(msg9, ...args6) {
+    if (msg9 instanceof Function) {
+        return getLogger("default").warning(msg9, ...args6);
     }
-    return getLogger("default").warning(msg, ...args);
+    return getLogger("default").warning(msg9, ...args6);
 }
-function error(msg, ...args) {
-    if (msg instanceof Function) {
-        return getLogger("default").error(msg, ...args);
+function error(msg9, ...args6) {
+    if (msg9 instanceof Function) {
+        return getLogger("default").error(msg9, ...args6);
     }
-    return getLogger("default").error(msg, ...args);
+    return getLogger("default").error(msg9, ...args6);
 }
-function critical(msg, ...args) {
-    if (msg instanceof Function) {
-        return getLogger("default").critical(msg, ...args);
+function critical(msg9, ...args6) {
+    if (msg9 instanceof Function) {
+        return getLogger("default").critical(msg9, ...args6);
     }
-    return getLogger("default").critical(msg, ...args);
+    return getLogger("default").critical(msg9, ...args6);
 }
 async function setup(config) {
     state.config = {
@@ -2840,7 +2840,7 @@ async function* expandGlob(glob, { root =Deno.cwd() , exclude =[] , includeDirs 
     ;
     const excludePatterns = exclude.map(resolveFromRoot).map((s)=>globToRegExp(s, globOptions)
     );
-    const shouldInclude = (path1)=>!excludePatterns.some((p)=>!!path1.match(p)
+    const shouldInclude = (path1)=>!excludePatterns.some((p2)=>!!path1.match(p2)
         )
     ;
     const { segments , hasTrailingSep , winRoot  } = split(resolveFromRoot(glob));
@@ -2933,7 +2933,7 @@ function* expandGlobSync(glob, { root =Deno.cwd() , exclude =[] , includeDirs =t
     ;
     const excludePatterns = exclude.map(resolveFromRoot).map((s)=>globToRegExp(s, globOptions)
     );
-    const shouldInclude = (path1)=>!excludePatterns.some((p)=>!!path1.match(p)
+    const shouldInclude = (path1)=>!excludePatterns.some((p2)=>!!path1.match(p2)
         )
     ;
     const { segments , hasTrailingSep , winRoot  } = split(resolveFromRoot(glob));
@@ -3346,8 +3346,8 @@ const base64abc = [
     "+",
     "/"
 ];
-function encode(data) {
-    const uint8 = typeof data === "string" ? new TextEncoder().encode(data) : data instanceof Uint8Array ? data : new Uint8Array(data);
+function encode(data3) {
+    const uint8 = typeof data3 === "string" ? new TextEncoder().encode(data3) : data3 instanceof Uint8Array ? data3 : new Uint8Array(data3);
     let result = "", i;
     const l = uint8.length;
     for(i = 2; i < l; i += 3){
@@ -3371,9 +3371,9 @@ function encode(data) {
 }
 function decode(b64) {
     const binString = atob(b64);
-    const size4 = binString.length;
-    const bytes = new Uint8Array(size4);
-    for(let i = 0; i < size4; i++){
+    const size6 = binString.length;
+    const bytes = new Uint8Array(size6);
+    for(let i = 0; i < size6; i++){
         bytes[i] = binString.charCodeAt(i);
     }
     return bytes;
@@ -3427,19 +3427,19 @@ let cachedTextEncoder = new TextEncoder('utf-8');
 const encodeString = typeof cachedTextEncoder.encodeInto === 'function' ? function(arg, view) {
     return cachedTextEncoder.encodeInto(arg, view);
 } : function(arg, view) {
-    const buf = cachedTextEncoder.encode(arg);
-    view.set(buf);
+    const buf1 = cachedTextEncoder.encode(arg);
+    view.set(buf1);
     return {
         read: arg.length,
-        written: buf.length
+        written: buf1.length
     };
 };
 function passStringToWasm0(arg, malloc, realloc) {
     if (realloc === undefined) {
-        const buf = cachedTextEncoder.encode(arg);
-        const ptr = malloc(buf.length);
-        getUint8Memory0().subarray(ptr, ptr + buf.length).set(buf);
-        WASM_VECTOR_LEN = buf.length;
+        const buf1 = cachedTextEncoder.encode(arg);
+        const ptr = malloc(buf1.length);
+        getUint8Memory0().subarray(ptr, ptr + buf1.length).set(buf1);
+        WASM_VECTOR_LEN = buf1.length;
         return ptr;
     }
     let len = arg.length;
@@ -3481,9 +3481,9 @@ function passArray8ToWasm0(arg, malloc) {
     WASM_VECTOR_LEN = arg.length;
     return ptr;
 }
-function update_hash(hash, data) {
+function update_hash(hash, data3) {
     _assertClass(hash, DenoHash);
-    var ptr0 = passArray8ToWasm0(data, wasm.__wbindgen_malloc);
+    var ptr0 = passArray8ToWasm0(data3, wasm.__wbindgen_malloc);
     var len0 = WASM_VECTOR_LEN;
     wasm.update_hash(hash.ptr, ptr0, len0);
 }
@@ -3504,9 +3504,9 @@ function digest_hash(hash) {
         _assertClass(hash, DenoHash);
         wasm.digest_hash(retptr, hash.ptr);
         var r0 = getInt32Memory0()[retptr / 4 + 0];
-        var r1 = getInt32Memory0()[retptr / 4 + 1];
-        var v0 = getArrayU8FromWasm0(r0, r1).slice();
-        wasm.__wbindgen_free(r0, r1 * 1);
+        var r11 = getInt32Memory0()[retptr / 4 + 1];
+        var v0 = getArrayU8FromWasm0(r0, r11).slice();
+        wasm.__wbindgen_free(r0, r11 * 1);
         return v0;
     } finally{
         wasm.__wbindgen_export_2.value += 16;
@@ -3519,9 +3519,9 @@ class DenoHash {
         return obj;
     }
     free() {
-        const ptr = this.ptr;
+        const ptr1 = this.ptr;
         this.ptr = 0;
-        wasm.__wbg_denohash_free(ptr);
+        wasm.__wbg_denohash_free(ptr1);
     }
 }
 async function load(module, imports) {
@@ -3578,8 +3578,8 @@ async function init(input) {
     return wasm;
 }
 const hextable = new TextEncoder().encode("0123456789abcdef");
-function encodedLen(n) {
-    return n * 2;
+function encodedLen(n1) {
+    return n1 * 2;
 }
 function encode1(src) {
     const dst = new Uint8Array(encodedLen(src.length));
@@ -3602,20 +3602,20 @@ class Hash {
         this.#hash = create_hash(algorithm);
         this.#digested = false;
     }
-    update(data) {
-        let msg;
-        if (typeof data === "string") {
-            msg = new TextEncoder().encode(data);
-        } else if (typeof data === "object") {
-            if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
-                msg = new Uint8Array(data);
+    update(data3) {
+        let msg9;
+        if (typeof data3 === "string") {
+            msg9 = new TextEncoder().encode(data3);
+        } else if (typeof data3 === "object") {
+            if (data3 instanceof ArrayBuffer || ArrayBuffer.isView(data3)) {
+                msg9 = new Uint8Array(data3);
             } else {
                 throw new Error(TYPE_ERROR_MSG);
             }
         } else {
             throw new Error(TYPE_ERROR_MSG);
         }
-        update_hash(this.#hash, msg);
+        update_hash(this.#hash, msg9);
         return this;
     }
     digest() {
@@ -3623,9 +3623,9 @@ class Hash {
         this.#digested = true;
         return digest_hash(this.#hash);
     }
-    toString(format = "hex") {
+    toString(format4 = "hex") {
         const finalized = new Uint8Array(this.digest());
-        switch(format){
+        switch(format4){
             case "hex":
                 return encodeToString(finalized);
             case "base64":
@@ -3749,8 +3749,8 @@ function parse4(version, optionsOrLoose) {
     if (version.length > 256) {
         return null;
     }
-    const r = optionsOrLoose.loose ? re[LOOSE] : re[FULL];
-    if (!r.test(version)) {
+    const r2 = optionsOrLoose.loose ? re[LOOSE] : re[FULL];
+    if (!r2.test(version)) {
         return null;
     }
     try {
@@ -3769,35 +3769,35 @@ function clean(version, optionsOrLoose) {
     return s ? s.version : null;
 }
 class SemVer {
-    constructor(version1, optionsOrLoose2){
-        if (!optionsOrLoose2 || typeof optionsOrLoose2 !== "object") {
-            optionsOrLoose2 = {
-                loose: !!optionsOrLoose2,
+    constructor(version, optionsOrLoose){
+        if (!optionsOrLoose || typeof optionsOrLoose !== "object") {
+            optionsOrLoose = {
+                loose: !!optionsOrLoose,
                 includePrerelease: false
             };
         }
-        if (version1 instanceof SemVer) {
-            if (version1.loose === optionsOrLoose2.loose) {
-                return version1;
+        if (version instanceof SemVer) {
+            if (version.loose === optionsOrLoose.loose) {
+                return version;
             } else {
-                version1 = version1.version;
+                version = version.version;
             }
-        } else if (typeof version1 !== "string") {
-            throw new TypeError("Invalid Version: " + version1);
+        } else if (typeof version !== "string") {
+            throw new TypeError("Invalid Version: " + version);
         }
-        if (version1.length > 256) {
+        if (version.length > 256) {
             throw new TypeError("version is longer than " + 256 + " characters");
         }
         if (!(this instanceof SemVer)) {
-            return new SemVer(version1, optionsOrLoose2);
+            return new SemVer(version, optionsOrLoose);
         }
-        this.options = optionsOrLoose2;
-        this.loose = !!optionsOrLoose2.loose;
-        const m = version1.trim().match(optionsOrLoose2.loose ? re[LOOSE] : re[FULL]);
+        this.options = optionsOrLoose;
+        this.loose = !!optionsOrLoose.loose;
+        const m = version.trim().match(optionsOrLoose.loose ? re[LOOSE] : re[FULL]);
         if (!m) {
-            throw new TypeError("Invalid Version: " + version1);
+            throw new TypeError("Invalid Version: " + version);
         }
-        this.raw = version1;
+        this.raw = version;
         this.major = +m[1];
         this.minor = +m[2];
         this.patch = +m[3];
@@ -3839,27 +3839,27 @@ class SemVer {
         }
         return this.compareMain(other) || this.comparePre(other);
     }
-    compareMain(other) {
-        if (!(other instanceof SemVer)) {
-            other = new SemVer(other, this.options);
+    compareMain(other1) {
+        if (!(other1 instanceof SemVer)) {
+            other1 = new SemVer(other1, this.options);
         }
-        return compareIdentifiers(this.major, other.major) || compareIdentifiers(this.minor, other.minor) || compareIdentifiers(this.patch, other.patch);
+        return compareIdentifiers(this.major, other1.major) || compareIdentifiers(this.minor, other1.minor) || compareIdentifiers(this.patch, other1.patch);
     }
-    comparePre(other) {
-        if (!(other instanceof SemVer)) {
-            other = new SemVer(other, this.options);
+    comparePre(other2) {
+        if (!(other2 instanceof SemVer)) {
+            other2 = new SemVer(other2, this.options);
         }
-        if (this.prerelease.length && !other.prerelease.length) {
+        if (this.prerelease.length && !other2.prerelease.length) {
             return -1;
-        } else if (!this.prerelease.length && other.prerelease.length) {
+        } else if (!this.prerelease.length && other2.prerelease.length) {
             return 1;
-        } else if (!this.prerelease.length && !other.prerelease.length) {
+        } else if (!this.prerelease.length && !other2.prerelease.length) {
             return 0;
         }
         let i1 = 0;
         do {
             const a = this.prerelease[i1];
-            const b = other.prerelease[i1];
+            const b = other2.prerelease[i1];
             if (a === undefined && b === undefined) {
                 return 0;
             } else if (b === undefined) {
@@ -3874,14 +3874,14 @@ class SemVer {
         }while (++i1)
         return 1;
     }
-    compareBuild(other) {
-        if (!(other instanceof SemVer)) {
-            other = new SemVer(other, this.options);
+    compareBuild(other3) {
+        if (!(other3 instanceof SemVer)) {
+            other3 = new SemVer(other3, this.options);
         }
         let i1 = 0;
         do {
             const a = this.build[i1];
-            const b = other.build[i1];
+            const b = other3.build[i1];
             if (a === undefined && b === undefined) {
                 return 0;
             } else if (b === undefined) {
@@ -3987,13 +3987,13 @@ class SemVer {
         return this.version;
     }
 }
-function inc(version1, release, optionsOrLoose1, identifier) {
+function inc(version1, release1, optionsOrLoose1, identifier1) {
     if (typeof optionsOrLoose1 === "string") {
-        identifier = optionsOrLoose1;
+        identifier1 = optionsOrLoose1;
         optionsOrLoose1 = undefined;
     }
     try {
-        return new SemVer(version1, optionsOrLoose1).inc(release, identifier).version;
+        return new SemVer(version1, optionsOrLoose1).inc(release1, identifier1).version;
     } catch (er) {
         return null;
     }
@@ -4118,37 +4118,37 @@ function cmp(v1, operator, v2, optionsOrLoose1) {
 const ANY = {
 };
 class Comparator {
-    constructor(comp1, optionsOrLoose1){
+    constructor(comp, optionsOrLoose1){
         if (!optionsOrLoose1 || typeof optionsOrLoose1 !== "object") {
             optionsOrLoose1 = {
                 loose: !!optionsOrLoose1,
                 includePrerelease: false
             };
         }
-        if (comp1 instanceof Comparator) {
-            if (comp1.loose === !!optionsOrLoose1.loose) {
-                return comp1;
+        if (comp instanceof Comparator) {
+            if (comp.loose === !!optionsOrLoose1.loose) {
+                return comp;
             } else {
-                comp1 = comp1.value;
+                comp = comp.value;
             }
         }
         if (!(this instanceof Comparator)) {
-            return new Comparator(comp1, optionsOrLoose1);
+            return new Comparator(comp, optionsOrLoose1);
         }
         this.options = optionsOrLoose1;
         this.loose = !!optionsOrLoose1.loose;
-        this.parse(comp1);
+        this.parse(comp);
         if (this.semver === ANY) {
             this.value = "";
         } else {
             this.value = this.operator + this.semver.version;
         }
     }
-    parse(comp) {
-        const r = this.options.loose ? re[COMPARATORLOOSE] : re[COMPARATOR];
-        const m1 = comp.match(r);
+    parse(comp1) {
+        const r2 = this.options.loose ? re[COMPARATORLOOSE] : re[COMPARATOR];
+        const m1 = comp1.match(r2);
         if (!m1) {
-            throw new TypeError("Invalid comparator: " + comp);
+            throw new TypeError("Invalid comparator: " + comp1);
         }
         const m11 = m1[1];
         this.operator = m11 !== undefined ? m11 : "";
@@ -4161,22 +4161,22 @@ class Comparator {
             this.semver = new SemVer(m1[2], this.options.loose);
         }
     }
-    test(version) {
-        if (this.semver === ANY || version === ANY) {
+    test(version1) {
+        if (this.semver === ANY || version1 === ANY) {
             return true;
         }
-        if (typeof version === "string") {
-            version = new SemVer(version, this.options);
+        if (typeof version1 === "string") {
+            version1 = new SemVer(version1, this.options);
         }
-        return cmp(version, this.operator, this.semver, this.options);
+        return cmp(version1, this.operator, this.semver, this.options);
     }
-    intersects(comp, optionsOrLoose) {
-        if (!(comp instanceof Comparator)) {
+    intersects(comp2, optionsOrLoose2) {
+        if (!(comp2 instanceof Comparator)) {
             throw new TypeError("a Comparator is required");
         }
-        if (!optionsOrLoose || typeof optionsOrLoose !== "object") {
-            optionsOrLoose = {
-                loose: !!optionsOrLoose,
+        if (!optionsOrLoose2 || typeof optionsOrLoose2 !== "object") {
+            optionsOrLoose2 = {
+                loose: !!optionsOrLoose2,
                 includePrerelease: false
             };
         }
@@ -4185,21 +4185,21 @@ class Comparator {
             if (this.value === "") {
                 return true;
             }
-            rangeTmp = new Range1(comp.value, optionsOrLoose);
-            return satisfies(this.value, rangeTmp, optionsOrLoose);
-        } else if (comp.operator === "") {
-            if (comp.value === "") {
+            rangeTmp = new Range1(comp2.value, optionsOrLoose2);
+            return satisfies(this.value, rangeTmp, optionsOrLoose2);
+        } else if (comp2.operator === "") {
+            if (comp2.value === "") {
                 return true;
             }
-            rangeTmp = new Range1(this.value, optionsOrLoose);
-            return satisfies(comp.semver, rangeTmp, optionsOrLoose);
+            rangeTmp = new Range1(this.value, optionsOrLoose2);
+            return satisfies(comp2.semver, rangeTmp, optionsOrLoose2);
         }
-        const sameDirectionIncreasing = (this.operator === ">=" || this.operator === ">") && (comp.operator === ">=" || comp.operator === ">");
-        const sameDirectionDecreasing = (this.operator === "<=" || this.operator === "<") && (comp.operator === "<=" || comp.operator === "<");
-        const sameSemVer = this.semver.version === comp.semver.version;
-        const differentDirectionsInclusive = (this.operator === ">=" || this.operator === "<=") && (comp.operator === ">=" || comp.operator === "<=");
-        const oppositeDirectionsLessThan = cmp(this.semver, "<", comp.semver, optionsOrLoose) && (this.operator === ">=" || this.operator === ">") && (comp.operator === "<=" || comp.operator === "<");
-        const oppositeDirectionsGreaterThan = cmp(this.semver, ">", comp.semver, optionsOrLoose) && (this.operator === "<=" || this.operator === "<") && (comp.operator === ">=" || comp.operator === ">");
+        const sameDirectionIncreasing = (this.operator === ">=" || this.operator === ">") && (comp2.operator === ">=" || comp2.operator === ">");
+        const sameDirectionDecreasing = (this.operator === "<=" || this.operator === "<") && (comp2.operator === "<=" || comp2.operator === "<");
+        const sameSemVer = this.semver.version === comp2.semver.version;
+        const differentDirectionsInclusive = (this.operator === ">=" || this.operator === "<=") && (comp2.operator === ">=" || comp2.operator === "<=");
+        const oppositeDirectionsLessThan = cmp(this.semver, "<", comp2.semver, optionsOrLoose2) && (this.operator === ">=" || this.operator === ">") && (comp2.operator === "<=" || comp2.operator === "<");
+        const oppositeDirectionsGreaterThan = cmp(this.semver, ">", comp2.semver, optionsOrLoose2) && (this.operator === "<=" || this.operator === "<") && (comp2.operator === ">=" || comp2.operator === ">");
         return sameDirectionIncreasing || sameDirectionDecreasing || sameSemVer && differentDirectionsInclusive || oppositeDirectionsLessThan || oppositeDirectionsGreaterThan;
     }
     toString() {
@@ -4207,36 +4207,36 @@ class Comparator {
     }
 }
 class Range1 {
-    constructor(range1, optionsOrLoose3){
+    constructor(range, optionsOrLoose3){
         if (!optionsOrLoose3 || typeof optionsOrLoose3 !== "object") {
             optionsOrLoose3 = {
                 loose: !!optionsOrLoose3,
                 includePrerelease: false
             };
         }
-        if (range1 instanceof Range1) {
-            if (range1.loose === !!optionsOrLoose3.loose && range1.includePrerelease === !!optionsOrLoose3.includePrerelease) {
-                return range1;
+        if (range instanceof Range1) {
+            if (range.loose === !!optionsOrLoose3.loose && range.includePrerelease === !!optionsOrLoose3.includePrerelease) {
+                return range;
             } else {
-                return new Range1(range1.raw, optionsOrLoose3);
+                return new Range1(range.raw, optionsOrLoose3);
             }
         }
-        if (range1 instanceof Comparator) {
-            return new Range1(range1.value, optionsOrLoose3);
+        if (range instanceof Comparator) {
+            return new Range1(range.value, optionsOrLoose3);
         }
         if (!(this instanceof Range1)) {
-            return new Range1(range1, optionsOrLoose3);
+            return new Range1(range, optionsOrLoose3);
         }
         this.options = optionsOrLoose3;
         this.loose = !!optionsOrLoose3.loose;
         this.includePrerelease = !!optionsOrLoose3.includePrerelease;
-        this.raw = range1;
-        this.set = range1.split(/\s*\|\|\s*/).map((range1)=>this.parseRange(range1.trim())
+        this.raw = range;
+        this.set = range.split(/\s*\|\|\s*/).map((range1)=>this.parseRange(range1.trim())
         ).filter((c)=>{
             return c.length;
         });
         if (!this.set.length) {
-            throw new TypeError("Invalid SemVer Range: " + range1);
+            throw new TypeError("Invalid SemVer Range: " + range);
         }
         this.format();
     }
@@ -4245,46 +4245,46 @@ class Range1 {
         ).join("||").trim();
         return this.range;
     }
-    parseRange(range) {
+    parseRange(range1) {
         const loose = this.options.loose;
-        range = range.trim();
+        range1 = range1.trim();
         const hr = loose ? re[HYPHENRANGELOOSE] : re[HYPHENRANGE];
-        range = range.replace(hr, hyphenReplace);
-        range = range.replace(re[COMPARATORTRIM], comparatorTrimReplace);
-        range = range.replace(re[TILDETRIM], tildeTrimReplace);
-        range = range.replace(re[CARETTRIM], caretTrimReplace);
-        range = range.split(/\s+/).join(" ");
+        range1 = range1.replace(hr, hyphenReplace);
+        range1 = range1.replace(re[COMPARATORTRIM], comparatorTrimReplace);
+        range1 = range1.replace(re[TILDETRIM], tildeTrimReplace);
+        range1 = range1.replace(re[CARETTRIM], caretTrimReplace);
+        range1 = range1.split(/\s+/).join(" ");
         const compRe = loose ? re[COMPARATORLOOSE] : re[COMPARATOR];
-        let set = range.split(" ").map((comp2)=>parseComparator(comp2, this.options)
+        let set = range1.split(" ").map((comp3)=>parseComparator(comp3, this.options)
         ).join(" ").split(/\s+/);
         if (this.options.loose) {
-            set = set.filter((comp2)=>{
-                return !!comp2.match(compRe);
+            set = set.filter((comp3)=>{
+                return !!comp3.match(compRe);
             });
         }
-        return set.map((comp2)=>new Comparator(comp2, this.options)
+        return set.map((comp3)=>new Comparator(comp3, this.options)
         );
     }
-    test(version) {
-        if (typeof version === "string") {
-            version = new SemVer(version, this.options);
+    test(version2) {
+        if (typeof version2 === "string") {
+            version2 = new SemVer(version2, this.options);
         }
         for(var i1 = 0; i1 < this.set.length; i1++){
-            if (testSet(this.set[i1], version, this.options)) {
+            if (testSet(this.set[i1], version2, this.options)) {
                 return true;
             }
         }
         return false;
     }
-    intersects(range, optionsOrLoose) {
-        if (!(range instanceof Range1)) {
+    intersects(range2, optionsOrLoose4) {
+        if (!(range2 instanceof Range1)) {
             throw new TypeError("a Range is required");
         }
         return this.set.some((thisComparators)=>{
-            return isSatisfiable(thisComparators, optionsOrLoose) && range.set.some((rangeComparators)=>{
-                return isSatisfiable(rangeComparators, optionsOrLoose) && thisComparators.every((thisComparator)=>{
+            return isSatisfiable(thisComparators, optionsOrLoose4) && range2.set.some((rangeComparators)=>{
+                return isSatisfiable(rangeComparators, optionsOrLoose4) && thisComparators.every((thisComparator)=>{
                     return rangeComparators.every((rangeComparator)=>{
-                        return thisComparator.intersects(rangeComparator, optionsOrLoose);
+                        return thisComparator.intersects(rangeComparator, optionsOrLoose4);
                     });
                 });
             });
@@ -4294,20 +4294,20 @@ class Range1 {
         return this.range;
     }
 }
-function testSet(set, version2, options5) {
+function testSet(set, version3, options5) {
     for(let i2 = 0; i2 < set.length; i2++){
-        if (!set[i2].test(version2)) {
+        if (!set[i2].test(version3)) {
             return false;
         }
     }
-    if (version2.prerelease.length && !options5.includePrerelease) {
+    if (version3.prerelease.length && !options5.includePrerelease) {
         for(let i3 = 0; i3 < set.length; i3++){
             if (set[i3].semver === ANY) {
                 continue;
             }
             if (set[i3].semver.prerelease.length > 0) {
                 const allowed = set[i3].semver;
-                if (allowed.major === version2.major && allowed.minor === version2.minor && allowed.patch === version2.patch) {
+                if (allowed.major === version3.major && allowed.minor === version3.minor && allowed.patch === version3.patch) {
                     return true;
                 }
             }
@@ -4328,57 +4328,57 @@ function isSatisfiable(comparators, options5) {
     }
     return result;
 }
-function toComparators(range2, optionsOrLoose4) {
-    return new Range1(range2, optionsOrLoose4).set.map((comp2)=>{
-        return comp2.map((c)=>c.value
+function toComparators(range3, optionsOrLoose5) {
+    return new Range1(range3, optionsOrLoose5).set.map((comp3)=>{
+        return comp3.map((c)=>c.value
         ).join(" ").trim().split(" ");
     });
 }
-function parseComparator(comp2, options5) {
-    comp2 = replaceCarets(comp2, options5);
-    comp2 = replaceTildes(comp2, options5);
-    comp2 = replaceXRanges(comp2, options5);
-    comp2 = replaceStars(comp2, options5);
-    return comp2;
+function parseComparator(comp3, options5) {
+    comp3 = replaceCarets(comp3, options5);
+    comp3 = replaceTildes(comp3, options5);
+    comp3 = replaceXRanges(comp3, options5);
+    comp3 = replaceStars(comp3, options5);
+    return comp3;
 }
 function isX(id) {
     return !id || id.toLowerCase() === "x" || id === "*";
 }
-function replaceTildes(comp2, options5) {
-    return comp2.trim().split(/\s+/).map((comp3)=>replaceTilde(comp3, options5)
+function replaceTildes(comp3, options5) {
+    return comp3.trim().split(/\s+/).map((comp4)=>replaceTilde(comp4, options5)
     ).join(" ");
 }
-function replaceTilde(comp2, options5) {
-    const r = options5.loose ? re[TILDELOOSE] : re[TILDE];
-    return comp2.replace(r, (_, M, m1, p, pr)=>{
+function replaceTilde(comp3, options5) {
+    const r2 = options5.loose ? re[TILDELOOSE] : re[TILDE];
+    return comp3.replace(r2, (_, M, m1, p2, pr)=>{
         let ret;
         if (isX(M)) {
             ret = "";
         } else if (isX(m1)) {
             ret = ">=" + M + ".0.0 <" + (+M + 1) + ".0.0";
-        } else if (isX(p)) {
+        } else if (isX(p2)) {
             ret = ">=" + M + "." + m1 + ".0 <" + M + "." + (+m1 + 1) + ".0";
         } else if (pr) {
-            ret = ">=" + M + "." + m1 + "." + p + "-" + pr + " <" + M + "." + (+m1 + 1) + ".0";
+            ret = ">=" + M + "." + m1 + "." + p2 + "-" + pr + " <" + M + "." + (+m1 + 1) + ".0";
         } else {
-            ret = ">=" + M + "." + m1 + "." + p + " <" + M + "." + (+m1 + 1) + ".0";
+            ret = ">=" + M + "." + m1 + "." + p2 + " <" + M + "." + (+m1 + 1) + ".0";
         }
         return ret;
     });
 }
-function replaceCarets(comp2, options5) {
-    return comp2.trim().split(/\s+/).map((comp3)=>replaceCaret(comp3, options5)
+function replaceCarets(comp3, options5) {
+    return comp3.trim().split(/\s+/).map((comp4)=>replaceCaret(comp4, options5)
     ).join(" ");
 }
-function replaceCaret(comp2, options5) {
-    const r = options5.loose ? re[CARETLOOSE] : re[CARET];
-    return comp2.replace(r, (_, M, m1, p, pr)=>{
+function replaceCaret(comp3, options5) {
+    const r2 = options5.loose ? re[CARETLOOSE] : re[CARET];
+    return comp3.replace(r2, (_, M, m1, p2, pr)=>{
         let ret;
         if (isX(M)) {
             ret = "";
         } else if (isX(m1)) {
             ret = ">=" + M + ".0.0 <" + (+M + 1) + ".0.0";
-        } else if (isX(p)) {
+        } else if (isX(p2)) {
             if (M === "0") {
                 ret = ">=" + M + "." + m1 + ".0 <" + M + "." + (+m1 + 1) + ".0";
             } else {
@@ -4387,38 +4387,38 @@ function replaceCaret(comp2, options5) {
         } else if (pr) {
             if (M === "0") {
                 if (m1 === "0") {
-                    ret = ">=" + M + "." + m1 + "." + p + "-" + pr + " <" + M + "." + m1 + "." + (+p + 1);
+                    ret = ">=" + M + "." + m1 + "." + p2 + "-" + pr + " <" + M + "." + m1 + "." + (+p2 + 1);
                 } else {
-                    ret = ">=" + M + "." + m1 + "." + p + "-" + pr + " <" + M + "." + (+m1 + 1) + ".0";
+                    ret = ">=" + M + "." + m1 + "." + p2 + "-" + pr + " <" + M + "." + (+m1 + 1) + ".0";
                 }
             } else {
-                ret = ">=" + M + "." + m1 + "." + p + "-" + pr + " <" + (+M + 1) + ".0.0";
+                ret = ">=" + M + "." + m1 + "." + p2 + "-" + pr + " <" + (+M + 1) + ".0.0";
             }
         } else {
             if (M === "0") {
                 if (m1 === "0") {
-                    ret = ">=" + M + "." + m1 + "." + p + " <" + M + "." + m1 + "." + (+p + 1);
+                    ret = ">=" + M + "." + m1 + "." + p2 + " <" + M + "." + m1 + "." + (+p2 + 1);
                 } else {
-                    ret = ">=" + M + "." + m1 + "." + p + " <" + M + "." + (+m1 + 1) + ".0";
+                    ret = ">=" + M + "." + m1 + "." + p2 + " <" + M + "." + (+m1 + 1) + ".0";
                 }
             } else {
-                ret = ">=" + M + "." + m1 + "." + p + " <" + (+M + 1) + ".0.0";
+                ret = ">=" + M + "." + m1 + "." + p2 + " <" + (+M + 1) + ".0.0";
             }
         }
         return ret;
     });
 }
-function replaceXRanges(comp2, options5) {
-    return comp2.split(/\s+/).map((comp3)=>replaceXRange(comp3, options5)
+function replaceXRanges(comp3, options5) {
+    return comp3.split(/\s+/).map((comp4)=>replaceXRange(comp4, options5)
     ).join(" ");
 }
-function replaceXRange(comp2, options5) {
-    comp2 = comp2.trim();
-    const r = options5.loose ? re[XRANGELOOSE] : re[XRANGE];
-    return comp2.replace(r, (ret, gtlt, M, m1, p, pr)=>{
+function replaceXRange(comp3, options5) {
+    comp3 = comp3.trim();
+    const r2 = options5.loose ? re[XRANGELOOSE] : re[XRANGE];
+    return comp3.replace(r2, (ret, gtlt, M, m1, p2, pr)=>{
         const xM = isX(M);
         const xm = xM || isX(m1);
-        const xp = xm || isX(p);
+        const xp = xm || isX(p2);
         const anyX = xp;
         if (gtlt === "=" && anyX) {
             gtlt = "";
@@ -4433,16 +4433,16 @@ function replaceXRange(comp2, options5) {
             if (xm) {
                 m1 = 0;
             }
-            p = 0;
+            p2 = 0;
             if (gtlt === ">") {
                 gtlt = ">=";
                 if (xm) {
                     M = +M + 1;
                     m1 = 0;
-                    p = 0;
+                    p2 = 0;
                 } else {
                     m1 = +m1 + 1;
-                    p = 0;
+                    p2 = 0;
                 }
             } else if (gtlt === "<=") {
                 gtlt = "<";
@@ -4452,7 +4452,7 @@ function replaceXRange(comp2, options5) {
                     m1 = +m1 + 1;
                 }
             }
-            ret = gtlt + M + "." + m1 + "." + p;
+            ret = gtlt + M + "." + m1 + "." + p2;
         } else if (xm) {
             ret = ">=" + M + ".0.0 <" + (+M + 1) + ".0.0";
         } else if (xp) {
@@ -4461,8 +4461,8 @@ function replaceXRange(comp2, options5) {
         return ret;
     });
 }
-function replaceStars(comp2, options5) {
-    return comp2.trim().replace(re[STAR], "");
+function replaceStars(comp3, options5) {
+    return comp3.trim().replace(re[STAR], "");
 }
 function hyphenReplace($0, from, fM, fm, fp, fpr, fb, to, tM, tm, tp, tpr, tb) {
     if (isX(fM)) {
@@ -4487,19 +4487,19 @@ function hyphenReplace($0, from, fM, fm, fp, fpr, fb, to, tM, tm, tp, tpr, tb) {
     }
     return (from + " " + to).trim();
 }
-function satisfies(version2, range2, optionsOrLoose4) {
+function satisfies(version3, range3, optionsOrLoose5) {
     try {
-        range2 = new Range1(range2, optionsOrLoose4);
+        range3 = new Range1(range3, optionsOrLoose5);
     } catch (er) {
         return false;
     }
-    return range2.test(version2);
+    return range3.test(version3);
 }
-function maxSatisfying(versions, range2, optionsOrLoose4) {
+function maxSatisfying(versions, range3, optionsOrLoose5) {
     var max = null;
     var maxSV = null;
     try {
-        var rangeObj = new Range1(range2, optionsOrLoose4);
+        var rangeObj = new Range1(range3, optionsOrLoose5);
     } catch (er) {
         return null;
     }
@@ -4507,17 +4507,17 @@ function maxSatisfying(versions, range2, optionsOrLoose4) {
         if (rangeObj.test(v)) {
             if (!max || maxSV && maxSV.compare(v) === -1) {
                 max = v;
-                maxSV = new SemVer(max, optionsOrLoose4);
+                maxSV = new SemVer(max, optionsOrLoose5);
             }
         }
     });
     return max;
 }
-function minSatisfying(versions, range2, optionsOrLoose4) {
+function minSatisfying(versions, range3, optionsOrLoose5) {
     var min = null;
     var minSV = null;
     try {
-        var rangeObj = new Range1(range2, optionsOrLoose4);
+        var rangeObj = new Range1(range3, optionsOrLoose5);
     } catch (er) {
         return null;
     }
@@ -4525,25 +4525,25 @@ function minSatisfying(versions, range2, optionsOrLoose4) {
         if (rangeObj.test(v)) {
             if (!min || minSV.compare(v) === 1) {
                 min = v;
-                minSV = new SemVer(min, optionsOrLoose4);
+                minSV = new SemVer(min, optionsOrLoose5);
             }
         }
     });
     return min;
 }
-function minVersion(range2, optionsOrLoose4) {
-    range2 = new Range1(range2, optionsOrLoose4);
+function minVersion(range3, optionsOrLoose5) {
+    range3 = new Range1(range3, optionsOrLoose5);
     var minver = new SemVer("0.0.0");
-    if (range2.test(minver)) {
+    if (range3.test(minver)) {
         return minver;
     }
     minver = new SemVer("0.0.0-0");
-    if (range2.test(minver)) {
+    if (range3.test(minver)) {
         return minver;
     }
     minver = null;
-    for(var i2 = 0; i2 < range2.set.length; ++i2){
-        var comparators = range2.set[i2];
+    for(var i2 = 0; i2 < range3.set.length; ++i2){
+        var comparators = range3.set[i2];
         comparators.forEach((comparator)=>{
             var compver = new SemVer(comparator.semver.version);
             switch(comparator.operator){
@@ -4567,56 +4567,56 @@ function minVersion(range2, optionsOrLoose4) {
             }
         });
     }
-    if (minver && range2.test(minver)) {
+    if (minver && range3.test(minver)) {
         return minver;
     }
     return null;
 }
-function validRange(range2, optionsOrLoose4) {
+function validRange(range3, optionsOrLoose5) {
     try {
-        if (range2 === null) return null;
-        return new Range1(range2, optionsOrLoose4).range || "*";
+        if (range3 === null) return null;
+        return new Range1(range3, optionsOrLoose5).range || "*";
     } catch (er) {
         return null;
     }
 }
-function ltr(version2, range2, optionsOrLoose4) {
-    return outside(version2, range2, "<", optionsOrLoose4);
+function ltr(version3, range3, optionsOrLoose5) {
+    return outside(version3, range3, "<", optionsOrLoose5);
 }
-function gtr(version2, range2, optionsOrLoose4) {
-    return outside(version2, range2, ">", optionsOrLoose4);
+function gtr(version3, range3, optionsOrLoose5) {
+    return outside(version3, range3, ">", optionsOrLoose5);
 }
-function outside(version2, range2, hilo, optionsOrLoose4) {
-    version2 = new SemVer(version2, optionsOrLoose4);
-    range2 = new Range1(range2, optionsOrLoose4);
+function outside(version3, range3, hilo, optionsOrLoose5) {
+    version3 = new SemVer(version3, optionsOrLoose5);
+    range3 = new Range1(range3, optionsOrLoose5);
     let gtfn;
     let ltefn;
     let ltfn;
-    let comp2;
+    let comp3;
     let ecomp;
     switch(hilo){
         case ">":
             gtfn = gt;
             ltefn = lte;
             ltfn = lt;
-            comp2 = ">";
+            comp3 = ">";
             ecomp = ">=";
             break;
         case "<":
             gtfn = lt;
             ltefn = gte;
             ltfn = gt;
-            comp2 = "<";
+            comp3 = "<";
             ecomp = "<=";
             break;
         default:
             throw new TypeError('Must provide a hilo val of "<" or ">"');
     }
-    if (satisfies(version2, range2, optionsOrLoose4)) {
+    if (satisfies(version3, range3, optionsOrLoose5)) {
         return false;
     }
-    for(let i2 = 0; i2 < range2.set.length; ++i2){
-        const comparators = range2.set[i2];
+    for(let i2 = 0; i2 < range3.set.length; ++i2){
+        const comparators = range3.set[i2];
         let high = null;
         let low = null;
         comparators.forEach((comparator)=>{
@@ -4625,45 +4625,45 @@ function outside(version2, range2, hilo, optionsOrLoose4) {
             }
             high = high || comparator;
             low = low || comparator;
-            if (gtfn(comparator.semver, high.semver, optionsOrLoose4)) {
+            if (gtfn(comparator.semver, high.semver, optionsOrLoose5)) {
                 high = comparator;
-            } else if (ltfn(comparator.semver, low.semver, optionsOrLoose4)) {
+            } else if (ltfn(comparator.semver, low.semver, optionsOrLoose5)) {
                 low = comparator;
             }
         });
         if (high === null || low === null) return true;
-        if (high.operator === comp2 || high.operator === ecomp) {
+        if (high.operator === comp3 || high.operator === ecomp) {
             return false;
         }
-        if ((!low.operator || low.operator === comp2) && ltefn(version2, low.semver)) {
+        if ((!low.operator || low.operator === comp3) && ltefn(version3, low.semver)) {
             return false;
-        } else if (low.operator === ecomp && ltfn(version2, low.semver)) {
+        } else if (low.operator === ecomp && ltfn(version3, low.semver)) {
             return false;
         }
     }
     return true;
 }
-function prerelease(version2, optionsOrLoose4) {
-    var parsed = parse4(version2, optionsOrLoose4);
+function prerelease(version3, optionsOrLoose5) {
+    var parsed = parse4(version3, optionsOrLoose5);
     return parsed && parsed.prerelease.length ? parsed.prerelease : null;
 }
-function intersects(range11, range2, optionsOrLoose4) {
-    range11 = new Range1(range11, optionsOrLoose4);
-    range2 = new Range1(range2, optionsOrLoose4);
-    return range11.intersects(range2);
+function intersects(range11, range21, optionsOrLoose5) {
+    range11 = new Range1(range11, optionsOrLoose5);
+    range21 = new Range1(range21, optionsOrLoose5);
+    return range11.intersects(range21);
 }
-function coerce(version2, optionsOrLoose4) {
-    if (version2 instanceof SemVer) {
-        return version2;
+function coerce(version3, optionsOrLoose5) {
+    if (version3 instanceof SemVer) {
+        return version3;
     }
-    if (typeof version2 !== "string") {
+    if (typeof version3 !== "string") {
         return null;
     }
-    const match = version2.match(re[COERCE]);
+    const match = version3.match(re[COERCE]);
     if (match == null) {
         return null;
     }
-    return parse4(match[1] + "." + (match[2] || "0") + "." + (match[3] || "0"), optionsOrLoose4);
+    return parse4(match[1] + "." + (match[2] || "0") + "." + (match[3] || "0"), optionsOrLoose5);
 }
 const mod7 = function() {
     return {
@@ -4709,7 +4709,7 @@ const mod7 = function() {
         default: SemVer
     };
 }();
-const version2 = "1.11.0";
+const version3 = "1.11.0";
 const TaskName_AST = {
     "moduleName": "dnit.manifest",
     "decl": {
@@ -5867,69 +5867,69 @@ const ADL = {
 };
 const RESOLVER = declResolver(ADL);
 class ADLMap {
-    constructor(data, isEqual){
-        this.data = data;
+    constructor(data4, isEqual){
+        this.data = data4;
         this.isEqual = isEqual;
     }
     has(k) {
         return this.findIndex(k) !== -1;
     }
-    get(k) {
-        const ind = this.findIndex(k);
+    get(k1) {
+        const ind = this.findIndex(k1);
         if (ind === -1) {
             return undefined;
         }
         return this.data[ind].v2;
     }
-    getOrInsert(k, v) {
-        const existing = this.get(k);
+    getOrInsert(k2, v) {
+        const existing = this.get(k2);
         if (existing === undefined) {
-            this.set(k, v);
+            this.set(k2, v);
             return v;
         }
         return existing;
     }
-    set(k, v) {
-        const ind = this.findIndex(k);
+    set(k3, v1) {
+        const ind = this.findIndex(k3);
         if (ind === -1) {
             this.data.push({
-                v1: k,
-                v2: v
+                v1: k3,
+                v2: v1
             });
         }
         this.data[ind] = {
-            v1: k,
-            v2: v
+            v1: k3,
+            v2: v1
         };
         return this;
     }
     keys() {
-        return this.data.map((p)=>p.v1
+        return this.data.map((p2)=>p2.v1
         );
     }
     values() {
-        return this.data.map((p)=>p.v2
+        return this.data.map((p2)=>p2.v2
         );
     }
     entries() {
-        return this.data.map((p)=>[
-                p.v1,
-                p.v2
+        return this.data.map((p2)=>[
+                p2.v1,
+                p2.v2
             ]
         );
     }
     toData() {
         return this.data;
     }
-    findIndex(k) {
-        return this.data.findIndex((p)=>this.isEqual(p.v1, k)
+    findIndex(k4) {
+        return this.data.findIndex((p2)=>this.isEqual(p2.v1, k4)
         );
     }
 }
 class Manifest {
     constructor(dir, filename = ".manifest.json"){
         this.jsonBinding = createJsonBinding(RESOLVER, texprManifest());
-        this.tasks = new ADLMap([], (k1, k2)=>k1 === k2
+        this.tasks = new ADLMap([], (k11, k21)=>k11 === k21
         );
         this.filename = mod3.join(dir, filename);
     }
@@ -5937,9 +5937,9 @@ class Manifest {
         if (await mod5.exists(this.filename)) {
             const json = JSON.parse(await Deno.readTextFile(this.filename));
             const mdata = this.jsonBinding.fromJson(json);
-            for (const p of mdata.tasks){
-                const taskName = p.v1;
-                const taskData = p.v2;
+            for (const p2 of mdata.tasks){
+                const taskName = p2.v1;
+                const taskData = p2.v2;
                 this.tasks.set(taskName, new TaskManifest(taskData));
             }
         }
@@ -5948,9 +5948,9 @@ class Manifest {
         if (!await mod5.exists(mod3.dirname(this.filename))) {
         }
         const mdata = {
-            tasks: this.tasks.entries().map((p)=>({
-                    v1: p[0],
-                    v2: p[1].toData()
+            tasks: this.tasks.entries().map((p2)=>({
+                    v1: p2[0],
+                    v2: p2[1].toData()
                 })
             )
         };
@@ -5959,19 +5959,19 @@ class Manifest {
     }
 }
 class TaskManifest {
-    constructor(data1){
+    constructor(data5){
         this.lastExecution = null;
-        this.trackedFiles = new ADLMap([], (k1, k2)=>k1 === k2
+        this.trackedFiles = new ADLMap([], (k11, k21)=>k11 === k21
         );
-        this.trackedFiles = new ADLMap(data1.trackedFiles, (k1, k2)=>k1 === k2
+        this.trackedFiles = new ADLMap(data5.trackedFiles, (k11, k21)=>k11 === k21
         );
-        this.lastExecution = data1.lastExecution;
+        this.lastExecution = data5.lastExecution;
     }
     getFileData(fn) {
         return this.trackedFiles.get(fn);
     }
-    setFileData(fn, d) {
-        this.trackedFiles.set(fn, d);
+    setFileData(fn1, d) {
+        this.trackedFiles.set(fn1, d);
     }
     setExecutionTimestamp() {
         this.lastExecution = new Date().toISOString();
@@ -6019,9 +6019,9 @@ class AsyncQueue {
     }
 }
 class ExecContext {
-    constructor(manifest, args){
+    constructor(manifest, args6){
         this.manifest = manifest;
-        this.args = args;
+        this.args = args6;
         this.taskRegister = new Map();
         this.targetRegister = new Map();
         this.doneTasks = new Set();
@@ -6029,12 +6029,12 @@ class ExecContext {
         this.internalLogger = mod4.getLogger("internal");
         this.taskLogger = mod4.getLogger("task");
         this.userLogger = mod4.getLogger("user");
-        if (args["verbose"] !== undefined) {
+        if (args6["verbose"] !== undefined) {
             this.internalLogger.levelName = "INFO";
         }
-        const concurrency1 = args["concurrency"] || 4;
+        const concurrency1 = args6["concurrency"] || 4;
         this.asyncQueue = new AsyncQueue(concurrency1);
-        this.internalLogger.info(`Starting ExecContext version: ${version2}`);
+        this.internalLogger.info(`Starting ExecContext version: ${version3}`);
     }
     getTaskByName(name) {
         return this.taskRegister.get(name);
@@ -6090,16 +6090,16 @@ class Task {
     getTaskDeps(deps) {
         return deps.filter(isTask);
     }
-    getTrackedFiles(deps) {
-        return deps.filter(isTrackedFile);
+    getTrackedFiles(deps1) {
+        return deps1.filter(isTrackedFile);
     }
-    getTrackedFilesAsync(deps) {
-        return deps.filter(isTrackedFileAsync);
+    getTrackedFilesAsync(deps2) {
+        return deps2.filter(isTrackedFileAsync);
     }
     async setup(ctx) {
         if (this.taskManifest === null) {
-            for (const t of this.targets){
-                ctx.targetRegister.set(t.path, this);
+            for (const t1 of this.targets){
+                ctx.targetRegister.set(t1.path, this);
             }
             this.taskManifest = ctx.manifest.tasks.getOrInsert(this.name, new TaskManifest({
                 lastExecution: null,
@@ -6116,14 +6116,14 @@ class Task {
             }
         }
     }
-    async exec(ctx) {
-        if (ctx.doneTasks.has(this)) {
+    async exec(ctx1) {
+        if (ctx1.doneTasks.has(this)) {
             return;
         }
-        if (ctx.inprogressTasks.has(this)) {
+        if (ctx1.inprogressTasks.has(this)) {
             return;
         }
-        ctx.inprogressTasks.add(this);
+        ctx1.inprogressTasks.add(this);
         for (const afd of this.async_files_deps){
             const file_deps = await afd.getTrackedFiles();
             for (const fd of file_deps){
@@ -6131,50 +6131,50 @@ class Task {
             }
         }
         for (const fd of this.file_deps){
-            const t = ctx.targetRegister.get(fd.path);
-            if (t !== undefined) {
-                this.task_deps.add(t);
+            const t1 = ctx1.targetRegister.get(fd.path);
+            if (t1 !== undefined) {
+                this.task_deps.add(t1);
             }
         }
-        await this.execDependencies(ctx);
+        await this.execDependencies(ctx1);
         let actualUpToDate = true;
-        actualUpToDate = actualUpToDate && await this.checkFileDeps(ctx);
-        ctx.internalLogger.info(`${this.name} checkFileDeps ${actualUpToDate}`);
-        actualUpToDate = actualUpToDate && await this.targetsExist(ctx);
-        ctx.internalLogger.info(`${this.name} targetsExist ${actualUpToDate}`);
+        actualUpToDate = actualUpToDate && await this.checkFileDeps(ctx1);
+        ctx1.internalLogger.info(`${this.name} checkFileDeps ${actualUpToDate}`);
+        actualUpToDate = actualUpToDate && await this.targetsExist(ctx1);
+        ctx1.internalLogger.info(`${this.name} targetsExist ${actualUpToDate}`);
         if (this.uptodate !== undefined) {
-            actualUpToDate = actualUpToDate && await this.uptodate(taskContext(ctx, this));
+            actualUpToDate = actualUpToDate && await this.uptodate(taskContext(ctx1, this));
         }
-        ctx.internalLogger.info(`${this.name} uptodate ${actualUpToDate}`);
+        ctx1.internalLogger.info(`${this.name} uptodate ${actualUpToDate}`);
         if (actualUpToDate) {
-            ctx.taskLogger.info(`--- ${this.name}`);
+            ctx1.taskLogger.info(`--- ${this.name}`);
         } else {
-            ctx.taskLogger.info(`... ${this.name}`);
-            await this.action(taskContext(ctx, this));
-            ctx.taskLogger.info(`=== ${this.name}`);
+            ctx1.taskLogger.info(`... ${this.name}`);
+            await this.action(taskContext(ctx1, this));
+            ctx1.taskLogger.info(`=== ${this.name}`);
             {
                 this.taskManifest?.setExecutionTimestamp();
                 let promisesInProgress = [];
                 for (const fdep of this.file_deps){
-                    promisesInProgress.push(ctx.asyncQueue.schedule(async ()=>{
-                        const trackedFileData = await fdep.getFileData(ctx);
+                    promisesInProgress.push(ctx1.asyncQueue.schedule(async ()=>{
+                        const trackedFileData = await fdep.getFileData(ctx1);
                         this.taskManifest?.setFileData(fdep.path, trackedFileData);
                     }));
                 }
                 await Promise.all(promisesInProgress);
             }
         }
-        ctx.doneTasks.add(this);
-        ctx.inprogressTasks.delete(this);
+        ctx1.doneTasks.add(this);
+        ctx1.inprogressTasks.delete(this);
     }
-    async targetsExist(ctx) {
-        const tex = await Promise.all(Array.from(this.targets).map(async (tf)=>ctx.asyncQueue.schedule(()=>tf.exists()
+    async targetsExist(ctx2) {
+        const tex = await Promise.all(Array.from(this.targets).map(async (tf)=>ctx2.asyncQueue.schedule(()=>tf.exists()
             )
         ));
-        return !tex.some((t)=>!t
+        return !tex.some((t1)=>!t1
         );
     }
-    async checkFileDeps(ctx) {
+    async checkFileDeps(ctx3) {
         let fileDepsUpToDate = true;
         let promisesInProgress = [];
         const taskManifest = this.taskManifest;
@@ -6182,20 +6182,20 @@ class Task {
             throw new Error(`Invalid null taskManifest on ${this.name}`);
         }
         for (const fdep of this.file_deps){
-            promisesInProgress.push(ctx.asyncQueue.schedule(async ()=>{
-                const r = await fdep.getFileDataOrCached(ctx, taskManifest.getFileData(fdep.path));
-                taskManifest.setFileData(fdep.path, r.tData);
-                fileDepsUpToDate = fileDepsUpToDate && r.upToDate;
+            promisesInProgress.push(ctx3.asyncQueue.schedule(async ()=>{
+                const r2 = await fdep.getFileDataOrCached(ctx3, taskManifest.getFileData(fdep.path));
+                taskManifest.setFileData(fdep.path, r2.tData);
+                fileDepsUpToDate = fileDepsUpToDate && r2.upToDate;
             }));
         }
         await Promise.all(promisesInProgress);
         promisesInProgress = [];
         return fileDepsUpToDate;
     }
-    async execDependencies(ctx) {
+    async execDependencies(ctx4) {
         for (const dep of this.task_deps){
-            if (!ctx.doneTasks.has(dep) && !ctx.inprogressTasks.has(dep)) {
-                await dep.exec(ctx);
+            if (!ctx4.doneTasks.has(dep) && !ctx4.inprogressTasks.has(dep)) {
+                await dep.exec(ctx4);
             }
         }
     }
@@ -6221,8 +6221,8 @@ class TrackedFile {
         }
         return statResult.kind === 'fileInfo';
     }
-    async getHash(statInput) {
-        let statResult = statInput;
+    async getHash(statInput1) {
+        let statResult = statInput1;
         if (statResult === undefined) {
             statResult = await this.stat();
         }
@@ -6232,8 +6232,8 @@ class TrackedFile {
         mod4.getLogger('internal').info(`checking hash on ${this.path}`);
         return this.#getHash(this.path, statResult.fileInfo);
     }
-    async getTimestamp(statInput) {
-        let statResult = statInput;
+    async getTimestamp(statInput2) {
+        let statResult = statInput2;
         if (statResult === undefined) {
             statResult = await this.stat();
         }
@@ -6242,11 +6242,11 @@ class TrackedFile {
         }
         return this.#getTimestamp(this.path, statResult.fileInfo);
     }
-    async isUpToDate(ctx, tData, statInput) {
+    async isUpToDate(ctx5, tData, statInput3) {
         if (tData === undefined) {
             return false;
         }
-        let statResult = statInput;
+        let statResult = statInput3;
         if (statResult === undefined) {
             statResult = await this.stat();
         }
@@ -6257,8 +6257,8 @@ class TrackedFile {
         const hash = await this.getHash(statResult);
         return hash === tData.hash;
     }
-    async getFileData(ctx, statInput) {
-        let statResult = statInput;
+    async getFileData(ctx6, statInput4) {
+        let statResult = statInput4;
         if (statResult === undefined) {
             statResult = await this.stat();
         }
@@ -6267,25 +6267,25 @@ class TrackedFile {
             timestamp: await this.getTimestamp(statResult)
         };
     }
-    async getFileDataOrCached(ctx, tData, statInput) {
-        let statResult = statInput;
+    async getFileDataOrCached(ctx7, tData1, statInput5) {
+        let statResult = statInput5;
         if (statResult === undefined) {
             statResult = await this.stat();
         }
-        if (tData !== undefined && await this.isUpToDate(ctx, tData, statResult)) {
+        if (tData1 !== undefined && await this.isUpToDate(ctx7, tData1, statResult)) {
             return {
-                tData,
+                tData: tData1,
                 upToDate: true
             };
         }
         return {
-            tData: await this.getFileData(ctx, statResult),
+            tData: await this.getFileData(ctx7, statResult),
             upToDate: false
         };
     }
-    setTask(t) {
+    setTask(t1) {
         if (this.fromTask === null) {
-            this.fromTask = t;
+            this.fromTask = t1;
         } else {
             throw new Error("Duplicate tasks generating TrackedFile as target - " + this.path);
         }
@@ -6304,9 +6304,9 @@ class TrackedFilesAsync {
     }
 }
 async function getFileSha1Sum(filename1) {
-    const data2 = await Deno.readFile(filename1);
+    const data6 = await Deno.readFile(filename1);
     const hashsha1 = mod6.createHash("sha1");
-    hashsha1.update(data2);
+    hashsha1.update(data6);
     const hashInHex = hashsha1.toString();
     return hashInHex;
 }
@@ -6320,13 +6320,13 @@ class StdErrPlainHandler extends mod4.handlers.BaseHandler {
             formatter: "{msg}"
         });
     }
-    log(msg) {
-        Deno.stderr.writeSync(new TextEncoder().encode(msg + "\n"));
+    log(msg9) {
+        Deno.stderr.writeSync(new TextEncoder().encode(msg9 + "\n"));
     }
 }
 class StdErrHandler extends mod4.handlers.ConsoleHandler {
-    log(msg) {
-        Deno.stderr.writeSync(new TextEncoder().encode(msg + "\n"));
+    log(msg10) {
+        Deno.stderr.writeSync(new TextEncoder().encode(msg10 + "\n"));
     }
 }
 async function setupLogging() {
@@ -6493,17 +6493,17 @@ async function launch(logger) {
     }
 }
 async function main1() {
-    const args1 = mod.parse(Deno.args);
-    if (args1["version"] === true) {
-        console.log(`dnit ${version2}`);
+    const args7 = mod.parse(Deno.args);
+    if (args7["version"] === true) {
+        console.log(`dnit ${version3}`);
         Deno.exit(0);
     }
     await setupLogging();
     const internalLogger = mod4.getLogger("internal");
-    if (args1["verbose"] !== undefined) {
+    if (args7["verbose"] !== undefined) {
         internalLogger.levelName = "INFO";
     }
-    internalLogger.info(`starting dnit launch using version: ${version2}`);
+    internalLogger.info(`starting dnit launch using version: ${version3}`);
     launch(internalLogger).then((st)=>{
         Deno.exit(st.code);
     });

--- a/bundler/tests/fixture/deno-9591/output/entry.ts
+++ b/bundler/tests/fixture/deno-9591/output/entry.ts
@@ -829,7 +829,7 @@ function extname(path) {
     }
     return path.slice(startDot, end);
 }
-function format4(pathObject) {
+function format(pathObject) {
     if (pathObject === null || typeof pathObject !== "object") {
         throw new TypeError(`The "pathObject" argument must be of type Object. Received type ${typeof pathObject}`);
     }
@@ -976,7 +976,7 @@ const mod1 = function() {
         dirname: dirname,
         basename: basename,
         extname: extname,
-        format: format4,
+        format: format,
         parse: parse1,
         fromFileUrl: fromFileUrl,
         toFileUrl: toFileUrl
@@ -1713,10 +1713,10 @@ class Logger {
     #level;
     #handlers;
     #loggerName;
-    constructor(loggerName, levelName1, options1 = {
+    constructor(loggerName, levelName, options1 = {
     }){
         this.#loggerName = loggerName;
-        this.#level = getLevelByName(levelName1);
+        this.#level = getLevelByName(levelName);
         this.#handlers = options1.handlers || [];
     }
     get level() {
@@ -1728,8 +1728,8 @@ class Logger {
     get levelName() {
         return getLevelName(this.#level);
     }
-    set levelName(levelName) {
-        this.#level = getLevelByName(levelName);
+    set levelName(levelName1) {
+        this.#level = getLevelByName(levelName1);
     }
     get loggerName() {
         return this.#loggerName;
@@ -1740,8 +1740,8 @@ class Logger {
     get handlers() {
         return this.#handlers;
     }
-    _log(level, msg, ...args) {
-        if (this.level > level) {
+    _log(level1, msg, ...args) {
+        if (this.level > level1) {
             return msg instanceof Function ? undefined : msg;
         }
         let fnResult;
@@ -1755,7 +1755,7 @@ class Logger {
         const record = new LogRecord({
             msg: logMessage,
             args: args,
-            level: level,
+            level: level1,
             loggerName: this.loggerName
         });
         this.#handlers.forEach((handler)=>{
@@ -1773,20 +1773,20 @@ class Logger {
         }
         return "undefined";
     }
-    debug(msg, ...args) {
-        return this._log(LogLevels.DEBUG, msg, ...args);
+    debug(msg1, ...args1) {
+        return this._log(LogLevels.DEBUG, msg1, ...args1);
     }
-    info(msg, ...args) {
-        return this._log(LogLevels.INFO, msg, ...args);
+    info(msg2, ...args2) {
+        return this._log(LogLevels.INFO, msg2, ...args2);
     }
-    warning(msg, ...args) {
-        return this._log(LogLevels.WARNING, msg, ...args);
+    warning(msg3, ...args3) {
+        return this._log(LogLevels.WARNING, msg3, ...args3);
     }
-    error(msg, ...args) {
-        return this._log(LogLevels.ERROR, msg, ...args);
+    error(msg4, ...args4) {
+        return this._log(LogLevels.ERROR, msg4, ...args4);
     }
-    critical(msg, ...args) {
-        return this._log(LogLevels.CRITICAL, msg, ...args);
+    critical(msg5, ...args5) {
+        return this._log(LogLevels.CRITICAL, msg5, ...args5);
     }
 }
 const noColor = globalThis.Deno?.noColor ?? true;
@@ -1878,14 +1878,14 @@ class BufReader {
     static create(r, size = DEFAULT_BUF_SIZE) {
         return r instanceof BufReader ? r : new BufReader(r, size);
     }
-    constructor(rd1, size1 = DEFAULT_BUF_SIZE){
+    constructor(rd, size1 = DEFAULT_BUF_SIZE){
         this.r = 0;
         this.w = 0;
         this.eof = false;
         if (size1 < MIN_BUF_SIZE) {
             size1 = MIN_BUF_SIZE;
         }
-        this._reset(new Uint8Array(size1), rd1);
+        this._reset(new Uint8Array(size1), rd);
     }
     size() {
         return this.buf.byteLength;
@@ -1916,12 +1916,12 @@ class BufReader {
         }
         throw new Error(`No progress after ${MAX_CONSECUTIVE_EMPTY_READS} read() calls`);
     }
-    reset(r) {
-        this._reset(this.buf, r);
+    reset(r1) {
+        this._reset(this.buf, r1);
     }
-    _reset(buf, rd) {
+    _reset(buf, rd1) {
         this.buf = buf;
-        this.rd = rd;
+        this.rd = rd1;
         this.eof = false;
     }
     async read(p) {
@@ -1945,11 +1945,11 @@ class BufReader {
         this.r += copied;
         return copied;
     }
-    async readFull(p) {
+    async readFull(p1) {
         let bytesRead = 0;
-        while(bytesRead < p.length){
+        while(bytesRead < p1.length){
             try {
-                const rr = await this.read(p.subarray(bytesRead));
+                const rr = await this.read(p1.subarray(bytesRead));
                 if (rr === null) {
                     if (bytesRead === 0) {
                         return null;
@@ -1959,11 +1959,11 @@ class BufReader {
                 }
                 bytesRead += rr;
             } catch (err) {
-                err.partial = p.subarray(0, bytesRead);
+                err.partial = p1.subarray(0, bytesRead);
                 throw err;
             }
         }
-        return p;
+        return p1;
     }
     async readByte() {
         while(this.r === this.w){
@@ -2023,11 +2023,11 @@ class BufReader {
             more: false
         };
     }
-    async readSlice(delim) {
+    async readSlice(delim1) {
         let s = 0;
         let slice;
         while(true){
-            let i = this.buf.subarray(this.r + s, this.w).indexOf(delim);
+            let i = this.buf.subarray(this.r + s, this.w).indexOf(delim1);
             if (i >= 0) {
                 i += s;
                 slice = this.buf.subarray(this.r, this.r + i + 1);
@@ -2099,16 +2099,16 @@ class AbstractBufBase {
     }
 }
 class BufWriter extends AbstractBufBase {
-    static create(writer, size = DEFAULT_BUF_SIZE) {
-        return writer instanceof BufWriter ? writer : new BufWriter(writer, size);
+    static create(writer, size2 = DEFAULT_BUF_SIZE) {
+        return writer instanceof BufWriter ? writer : new BufWriter(writer, size2);
     }
-    constructor(writer1, size2 = DEFAULT_BUF_SIZE){
+    constructor(writer1, size3 = DEFAULT_BUF_SIZE){
         super();
         this.writer = writer1;
-        if (size2 <= 0) {
-            size2 = DEFAULT_BUF_SIZE;
+        if (size3 <= 0) {
+            size3 = DEFAULT_BUF_SIZE;
         }
-        this.buf = new Uint8Array(size2);
+        this.buf = new Uint8Array(size3);
     }
     reset(w) {
         this.err = null;
@@ -2127,49 +2127,49 @@ class BufWriter extends AbstractBufBase {
         this.buf = new Uint8Array(this.buf.length);
         this.usedBufferBytes = 0;
     }
-    async write(data) {
+    async write(data1) {
         if (this.err !== null) throw this.err;
-        if (data.length === 0) return 0;
+        if (data1.length === 0) return 0;
         let totalBytesWritten = 0;
         let numBytesWritten = 0;
-        while(data.byteLength > this.available()){
+        while(data1.byteLength > this.available()){
             if (this.buffered() === 0) {
                 try {
-                    numBytesWritten = await this.writer.write(data);
+                    numBytesWritten = await this.writer.write(data1);
                 } catch (e) {
                     this.err = e;
                     throw e;
                 }
             } else {
-                numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
+                numBytesWritten = copyBytes(data1, this.buf, this.usedBufferBytes);
                 this.usedBufferBytes += numBytesWritten;
                 await this.flush();
             }
             totalBytesWritten += numBytesWritten;
-            data = data.subarray(numBytesWritten);
+            data1 = data1.subarray(numBytesWritten);
         }
-        numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
+        numBytesWritten = copyBytes(data1, this.buf, this.usedBufferBytes);
         this.usedBufferBytes += numBytesWritten;
         totalBytesWritten += numBytesWritten;
         return totalBytesWritten;
     }
 }
 class BufWriterSync extends AbstractBufBase {
-    static create(writer, size = DEFAULT_BUF_SIZE) {
-        return writer instanceof BufWriterSync ? writer : new BufWriterSync(writer, size);
+    static create(writer2, size4 = DEFAULT_BUF_SIZE) {
+        return writer2 instanceof BufWriterSync ? writer2 : new BufWriterSync(writer2, size4);
     }
-    constructor(writer2, size3 = DEFAULT_BUF_SIZE){
+    constructor(writer3, size5 = DEFAULT_BUF_SIZE){
         super();
-        this.writer = writer2;
-        if (size3 <= 0) {
-            size3 = DEFAULT_BUF_SIZE;
+        this.writer = writer3;
+        if (size5 <= 0) {
+            size5 = DEFAULT_BUF_SIZE;
         }
-        this.buf = new Uint8Array(size3);
+        this.buf = new Uint8Array(size5);
     }
-    reset(w) {
+    reset(w1) {
         this.err = null;
         this.usedBufferBytes = 0;
-        this.writer = w;
+        this.writer = w1;
     }
     flush() {
         if (this.err !== null) throw this.err;
@@ -2183,28 +2183,28 @@ class BufWriterSync extends AbstractBufBase {
         this.buf = new Uint8Array(this.buf.length);
         this.usedBufferBytes = 0;
     }
-    writeSync(data) {
+    writeSync(data2) {
         if (this.err !== null) throw this.err;
-        if (data.length === 0) return 0;
+        if (data2.length === 0) return 0;
         let totalBytesWritten = 0;
         let numBytesWritten = 0;
-        while(data.byteLength > this.available()){
+        while(data2.byteLength > this.available()){
             if (this.buffered() === 0) {
                 try {
-                    numBytesWritten = this.writer.writeSync(data);
+                    numBytesWritten = this.writer.writeSync(data2);
                 } catch (e) {
                     this.err = e;
                     throw e;
                 }
             } else {
-                numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
+                numBytesWritten = copyBytes(data2, this.buf, this.usedBufferBytes);
                 this.usedBufferBytes += numBytesWritten;
                 this.flush();
             }
             totalBytesWritten += numBytesWritten;
-            data = data.subarray(numBytesWritten);
+            data2 = data2.subarray(numBytesWritten);
         }
-        numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
+        numBytesWritten = copyBytes(data2, this.buf, this.usedBufferBytes);
         this.usedBufferBytes += numBytesWritten;
         totalBytesWritten += numBytesWritten;
         return totalBytesWritten;
@@ -2220,15 +2220,15 @@ class BaseHandler {
     }
     handle(logRecord) {
         if (this.level > logRecord.level) return;
-        const msg = this.format(logRecord);
-        return this.log(msg);
+        const msg6 = this.format(logRecord);
+        return this.log(msg6);
     }
-    format(logRecord) {
+    format(logRecord1) {
         if (this.formatter instanceof Function) {
-            return this.formatter(logRecord);
+            return this.formatter(logRecord1);
         }
-        return this.formatter.replace(/{(\S+)}/g, (match, p1)=>{
-            const value = logRecord[p1];
+        return this.formatter.replace(/{(\S+)}/g, (match, p11)=>{
+            const value = logRecord1[p11];
             if (value == null) {
                 return match;
             }
@@ -2243,27 +2243,27 @@ class BaseHandler {
     }
 }
 class ConsoleHandler extends BaseHandler {
-    format(logRecord) {
-        let msg = super.format(logRecord);
-        switch(logRecord.level){
+    format(logRecord2) {
+        let msg6 = super.format(logRecord2);
+        switch(logRecord2.level){
             case LogLevels.INFO:
-                msg = blue(msg);
+                msg6 = blue(msg6);
                 break;
             case LogLevels.WARNING:
-                msg = yellow(msg);
+                msg6 = yellow(msg6);
                 break;
             case LogLevels.ERROR:
-                msg = red(msg);
+                msg6 = red(msg6);
                 break;
             case LogLevels.CRITICAL:
-                msg = bold(red(msg));
+                msg6 = bold(red(msg6));
                 break;
             default: break;
         }
-        return msg;
+        return msg6;
     }
-    log(msg) {
-        console.log(msg);
+    log(msg6) {
+        console.log(msg6);
     }
 }
 class WriterHandler extends BaseHandler {
@@ -2291,14 +2291,14 @@ class FileHandler extends WriterHandler {
         this._buf = new BufWriterSync(this._file);
         addEventListener("unload", this.#unloadCallback);
     }
-    handle(logRecord) {
-        super.handle(logRecord);
-        if (logRecord.level > LogLevels.ERROR) {
+    handle(logRecord3) {
+        super.handle(logRecord3);
+        if (logRecord3.level > LogLevels.ERROR) {
             this.flush();
         }
     }
-    log(msg) {
-        this._buf.writeSync(this._encoder.encode(msg + "\n"));
+    log(msg7) {
+        this._buf.writeSync(this._encoder.encode(msg7 + "\n"));
     }
     flush() {
         if (this._buf?.buffered() > 0) {
@@ -2349,13 +2349,13 @@ class RotatingFileHandler extends FileHandler {
             this.#currentFileSize = (await Deno.stat(this._filename)).size;
         }
     }
-    log(msg) {
-        const msgByteLength = this._encoder.encode(msg).byteLength + 1;
+    log(msg8) {
+        const msgByteLength = this._encoder.encode(msg8).byteLength + 1;
         if (this.#currentFileSize + msgByteLength > this.#maxBytes) {
             this.rotateLogFiles();
             this.#currentFileSize = 0;
         }
-        this._buf.writeSync(this._encoder.encode(msg + "\n"));
+        this._buf.writeSync(this._encoder.encode(msg8 + "\n"));
         this.#currentFileSize += msgByteLength;
     }
     rotateLogFiles() {
@@ -2417,35 +2417,35 @@ function getLogger(name) {
     }
     return result;
 }
-function debug(msg, ...args) {
-    if (msg instanceof Function) {
-        return getLogger("default").debug(msg, ...args);
+function debug(msg9, ...args6) {
+    if (msg9 instanceof Function) {
+        return getLogger("default").debug(msg9, ...args6);
     }
-    return getLogger("default").debug(msg, ...args);
+    return getLogger("default").debug(msg9, ...args6);
 }
-function info(msg, ...args) {
-    if (msg instanceof Function) {
-        return getLogger("default").info(msg, ...args);
+function info(msg9, ...args6) {
+    if (msg9 instanceof Function) {
+        return getLogger("default").info(msg9, ...args6);
     }
-    return getLogger("default").info(msg, ...args);
+    return getLogger("default").info(msg9, ...args6);
 }
-function warning(msg, ...args) {
-    if (msg instanceof Function) {
-        return getLogger("default").warning(msg, ...args);
+function warning(msg9, ...args6) {
+    if (msg9 instanceof Function) {
+        return getLogger("default").warning(msg9, ...args6);
     }
-    return getLogger("default").warning(msg, ...args);
+    return getLogger("default").warning(msg9, ...args6);
 }
-function error(msg, ...args) {
-    if (msg instanceof Function) {
-        return getLogger("default").error(msg, ...args);
+function error(msg9, ...args6) {
+    if (msg9 instanceof Function) {
+        return getLogger("default").error(msg9, ...args6);
     }
-    return getLogger("default").error(msg, ...args);
+    return getLogger("default").error(msg9, ...args6);
 }
-function critical(msg, ...args) {
-    if (msg instanceof Function) {
-        return getLogger("default").critical(msg, ...args);
+function critical(msg9, ...args6) {
+    if (msg9 instanceof Function) {
+        return getLogger("default").critical(msg9, ...args6);
     }
-    return getLogger("default").critical(msg, ...args);
+    return getLogger("default").critical(msg9, ...args6);
 }
 async function setup(config) {
     state.config = {
@@ -2851,7 +2851,7 @@ async function* expandGlob(glob, { root =Deno.cwd() , exclude =[] , includeDirs 
     ;
     const excludePatterns = exclude.map(resolveFromRoot).map((s)=>globToRegExp(s, globOptions)
     );
-    const shouldInclude = (path1)=>!excludePatterns.some((p)=>!!path1.match(p)
+    const shouldInclude = (path1)=>!excludePatterns.some((p2)=>!!path1.match(p2)
         )
     ;
     const { segments , hasTrailingSep , winRoot  } = split(resolveFromRoot(glob));
@@ -2944,7 +2944,7 @@ function* expandGlobSync(glob, { root =Deno.cwd() , exclude =[] , includeDirs =t
     ;
     const excludePatterns = exclude.map(resolveFromRoot).map((s)=>globToRegExp(s, globOptions)
     );
-    const shouldInclude = (path1)=>!excludePatterns.some((p)=>!!path1.match(p)
+    const shouldInclude = (path1)=>!excludePatterns.some((p2)=>!!path1.match(p2)
         )
     ;
     const { segments , hasTrailingSep , winRoot  } = split(resolveFromRoot(glob));
@@ -3357,8 +3357,8 @@ const base64abc = [
     "+",
     "/"
 ];
-function encode(data) {
-    const uint8 = typeof data === "string" ? new TextEncoder().encode(data) : data instanceof Uint8Array ? data : new Uint8Array(data);
+function encode(data3) {
+    const uint8 = typeof data3 === "string" ? new TextEncoder().encode(data3) : data3 instanceof Uint8Array ? data3 : new Uint8Array(data3);
     let result = "", i;
     const l = uint8.length;
     for(i = 2; i < l; i += 3){
@@ -3382,9 +3382,9 @@ function encode(data) {
 }
 function decode(b64) {
     const binString = atob(b64);
-    const size4 = binString.length;
-    const bytes = new Uint8Array(size4);
-    for(let i = 0; i < size4; i++){
+    const size6 = binString.length;
+    const bytes = new Uint8Array(size6);
+    for(let i = 0; i < size6; i++){
         bytes[i] = binString.charCodeAt(i);
     }
     return bytes;
@@ -3438,19 +3438,19 @@ let cachedTextEncoder = new TextEncoder('utf-8');
 const encodeString = typeof cachedTextEncoder.encodeInto === 'function' ? function(arg, view) {
     return cachedTextEncoder.encodeInto(arg, view);
 } : function(arg, view) {
-    const buf = cachedTextEncoder.encode(arg);
-    view.set(buf);
+    const buf1 = cachedTextEncoder.encode(arg);
+    view.set(buf1);
     return {
         read: arg.length,
-        written: buf.length
+        written: buf1.length
     };
 };
 function passStringToWasm0(arg, malloc, realloc) {
     if (realloc === undefined) {
-        const buf = cachedTextEncoder.encode(arg);
-        const ptr = malloc(buf.length);
-        getUint8Memory0().subarray(ptr, ptr + buf.length).set(buf);
-        WASM_VECTOR_LEN = buf.length;
+        const buf1 = cachedTextEncoder.encode(arg);
+        const ptr = malloc(buf1.length);
+        getUint8Memory0().subarray(ptr, ptr + buf1.length).set(buf1);
+        WASM_VECTOR_LEN = buf1.length;
         return ptr;
     }
     let len = arg.length;
@@ -3492,9 +3492,9 @@ function passArray8ToWasm0(arg, malloc) {
     WASM_VECTOR_LEN = arg.length;
     return ptr;
 }
-function update_hash(hash, data) {
+function update_hash(hash, data3) {
     _assertClass(hash, DenoHash);
-    var ptr0 = passArray8ToWasm0(data, wasm.__wbindgen_malloc);
+    var ptr0 = passArray8ToWasm0(data3, wasm.__wbindgen_malloc);
     var len0 = WASM_VECTOR_LEN;
     wasm.update_hash(hash.ptr, ptr0, len0);
 }
@@ -3515,9 +3515,9 @@ function digest_hash(hash) {
         _assertClass(hash, DenoHash);
         wasm.digest_hash(retptr, hash.ptr);
         var r0 = getInt32Memory0()[retptr / 4 + 0];
-        var r1 = getInt32Memory0()[retptr / 4 + 1];
-        var v0 = getArrayU8FromWasm0(r0, r1).slice();
-        wasm.__wbindgen_free(r0, r1 * 1);
+        var r11 = getInt32Memory0()[retptr / 4 + 1];
+        var v0 = getArrayU8FromWasm0(r0, r11).slice();
+        wasm.__wbindgen_free(r0, r11 * 1);
         return v0;
     } finally{
         wasm.__wbindgen_export_2.value += 16;
@@ -3530,9 +3530,9 @@ class DenoHash {
         return obj;
     }
     free() {
-        const ptr = this.ptr;
+        const ptr1 = this.ptr;
         this.ptr = 0;
-        wasm.__wbg_denohash_free(ptr);
+        wasm.__wbg_denohash_free(ptr1);
     }
 }
 async function load(module, imports) {
@@ -3589,8 +3589,8 @@ async function init(input) {
     return wasm;
 }
 const hextable = new TextEncoder().encode("0123456789abcdef");
-function encodedLen(n) {
-    return n * 2;
+function encodedLen(n1) {
+    return n1 * 2;
 }
 function encode1(src) {
     const dst = new Uint8Array(encodedLen(src.length));
@@ -3613,20 +3613,20 @@ class Hash {
         this.#hash = create_hash(algorithm);
         this.#digested = false;
     }
-    update(data) {
-        let msg;
-        if (typeof data === "string") {
-            msg = new TextEncoder().encode(data);
-        } else if (typeof data === "object") {
-            if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
-                msg = new Uint8Array(data);
+    update(data3) {
+        let msg9;
+        if (typeof data3 === "string") {
+            msg9 = new TextEncoder().encode(data3);
+        } else if (typeof data3 === "object") {
+            if (data3 instanceof ArrayBuffer || ArrayBuffer.isView(data3)) {
+                msg9 = new Uint8Array(data3);
             } else {
                 throw new Error(TYPE_ERROR_MSG);
             }
         } else {
             throw new Error(TYPE_ERROR_MSG);
         }
-        update_hash(this.#hash, msg);
+        update_hash(this.#hash, msg9);
         return this;
     }
     digest() {
@@ -3634,9 +3634,9 @@ class Hash {
         this.#digested = true;
         return digest_hash(this.#hash);
     }
-    toString(format = "hex") {
+    toString(format4 = "hex") {
         const finalized = new Uint8Array(this.digest());
-        switch(format){
+        switch(format4){
             case "hex":
                 return encodeToString(finalized);
             case "base64":
@@ -3761,8 +3761,8 @@ function parse4(version, optionsOrLoose) {
     if (version.length > MAX_LENGTH) {
         return null;
     }
-    const r = optionsOrLoose.loose ? re[LOOSE] : re[FULL];
-    if (!r.test(version)) {
+    const r2 = optionsOrLoose.loose ? re[LOOSE] : re[FULL];
+    if (!r2.test(version)) {
         return null;
     }
     try {
@@ -3781,35 +3781,35 @@ function clean(version, optionsOrLoose) {
     return s ? s.version : null;
 }
 class SemVer {
-    constructor(version1, optionsOrLoose2){
-        if (!optionsOrLoose2 || typeof optionsOrLoose2 !== "object") {
-            optionsOrLoose2 = {
-                loose: !!optionsOrLoose2,
+    constructor(version, optionsOrLoose){
+        if (!optionsOrLoose || typeof optionsOrLoose !== "object") {
+            optionsOrLoose = {
+                loose: !!optionsOrLoose,
                 includePrerelease: false
             };
         }
-        if (version1 instanceof SemVer) {
-            if (version1.loose === optionsOrLoose2.loose) {
-                return version1;
+        if (version instanceof SemVer) {
+            if (version.loose === optionsOrLoose.loose) {
+                return version;
             } else {
-                version1 = version1.version;
+                version = version.version;
             }
-        } else if (typeof version1 !== "string") {
-            throw new TypeError("Invalid Version: " + version1);
+        } else if (typeof version !== "string") {
+            throw new TypeError("Invalid Version: " + version);
         }
-        if (version1.length > MAX_LENGTH) {
+        if (version.length > MAX_LENGTH) {
             throw new TypeError("version is longer than " + MAX_LENGTH + " characters");
         }
         if (!(this instanceof SemVer)) {
-            return new SemVer(version1, optionsOrLoose2);
+            return new SemVer(version, optionsOrLoose);
         }
-        this.options = optionsOrLoose2;
-        this.loose = !!optionsOrLoose2.loose;
-        const m = version1.trim().match(optionsOrLoose2.loose ? re[LOOSE] : re[FULL]);
+        this.options = optionsOrLoose;
+        this.loose = !!optionsOrLoose.loose;
+        const m = version.trim().match(optionsOrLoose.loose ? re[LOOSE] : re[FULL]);
         if (!m) {
-            throw new TypeError("Invalid Version: " + version1);
+            throw new TypeError("Invalid Version: " + version);
         }
-        this.raw = version1;
+        this.raw = version;
         this.major = +m[1];
         this.minor = +m[2];
         this.patch = +m[3];
@@ -3851,27 +3851,27 @@ class SemVer {
         }
         return this.compareMain(other) || this.comparePre(other);
     }
-    compareMain(other) {
-        if (!(other instanceof SemVer)) {
-            other = new SemVer(other, this.options);
+    compareMain(other1) {
+        if (!(other1 instanceof SemVer)) {
+            other1 = new SemVer(other1, this.options);
         }
-        return compareIdentifiers(this.major, other.major) || compareIdentifiers(this.minor, other.minor) || compareIdentifiers(this.patch, other.patch);
+        return compareIdentifiers(this.major, other1.major) || compareIdentifiers(this.minor, other1.minor) || compareIdentifiers(this.patch, other1.patch);
     }
-    comparePre(other) {
-        if (!(other instanceof SemVer)) {
-            other = new SemVer(other, this.options);
+    comparePre(other2) {
+        if (!(other2 instanceof SemVer)) {
+            other2 = new SemVer(other2, this.options);
         }
-        if (this.prerelease.length && !other.prerelease.length) {
+        if (this.prerelease.length && !other2.prerelease.length) {
             return -1;
-        } else if (!this.prerelease.length && other.prerelease.length) {
+        } else if (!this.prerelease.length && other2.prerelease.length) {
             return 1;
-        } else if (!this.prerelease.length && !other.prerelease.length) {
+        } else if (!this.prerelease.length && !other2.prerelease.length) {
             return 0;
         }
         let i1 = 0;
         do {
             const a = this.prerelease[i1];
-            const b = other.prerelease[i1];
+            const b = other2.prerelease[i1];
             if (a === undefined && b === undefined) {
                 return 0;
             } else if (b === undefined) {
@@ -3886,14 +3886,14 @@ class SemVer {
         }while (++i1)
         return 1;
     }
-    compareBuild(other) {
-        if (!(other instanceof SemVer)) {
-            other = new SemVer(other, this.options);
+    compareBuild(other3) {
+        if (!(other3 instanceof SemVer)) {
+            other3 = new SemVer(other3, this.options);
         }
         let i1 = 0;
         do {
             const a = this.build[i1];
-            const b = other.build[i1];
+            const b = other3.build[i1];
             if (a === undefined && b === undefined) {
                 return 0;
             } else if (b === undefined) {
@@ -3999,13 +3999,13 @@ class SemVer {
         return this.version;
     }
 }
-function inc(version1, release, optionsOrLoose1, identifier) {
+function inc(version1, release1, optionsOrLoose1, identifier1) {
     if (typeof optionsOrLoose1 === "string") {
-        identifier = optionsOrLoose1;
+        identifier1 = optionsOrLoose1;
         optionsOrLoose1 = undefined;
     }
     try {
-        return new SemVer(version1, optionsOrLoose1).inc(release, identifier).version;
+        return new SemVer(version1, optionsOrLoose1).inc(release1, identifier1).version;
     } catch (er) {
         return null;
     }
@@ -4130,37 +4130,37 @@ function cmp(v1, operator, v2, optionsOrLoose1) {
 const ANY = {
 };
 class Comparator {
-    constructor(comp1, optionsOrLoose1){
+    constructor(comp, optionsOrLoose1){
         if (!optionsOrLoose1 || typeof optionsOrLoose1 !== "object") {
             optionsOrLoose1 = {
                 loose: !!optionsOrLoose1,
                 includePrerelease: false
             };
         }
-        if (comp1 instanceof Comparator) {
-            if (comp1.loose === !!optionsOrLoose1.loose) {
-                return comp1;
+        if (comp instanceof Comparator) {
+            if (comp.loose === !!optionsOrLoose1.loose) {
+                return comp;
             } else {
-                comp1 = comp1.value;
+                comp = comp.value;
             }
         }
         if (!(this instanceof Comparator)) {
-            return new Comparator(comp1, optionsOrLoose1);
+            return new Comparator(comp, optionsOrLoose1);
         }
         this.options = optionsOrLoose1;
         this.loose = !!optionsOrLoose1.loose;
-        this.parse(comp1);
+        this.parse(comp);
         if (this.semver === ANY) {
             this.value = "";
         } else {
             this.value = this.operator + this.semver.version;
         }
     }
-    parse(comp) {
-        const r = this.options.loose ? re[COMPARATORLOOSE] : re[COMPARATOR];
-        const m1 = comp.match(r);
+    parse(comp1) {
+        const r2 = this.options.loose ? re[COMPARATORLOOSE] : re[COMPARATOR];
+        const m1 = comp1.match(r2);
         if (!m1) {
-            throw new TypeError("Invalid comparator: " + comp);
+            throw new TypeError("Invalid comparator: " + comp1);
         }
         const m11 = m1[1];
         this.operator = m11 !== undefined ? m11 : "";
@@ -4173,22 +4173,22 @@ class Comparator {
             this.semver = new SemVer(m1[2], this.options.loose);
         }
     }
-    test(version) {
-        if (this.semver === ANY || version === ANY) {
+    test(version1) {
+        if (this.semver === ANY || version1 === ANY) {
             return true;
         }
-        if (typeof version === "string") {
-            version = new SemVer(version, this.options);
+        if (typeof version1 === "string") {
+            version1 = new SemVer(version1, this.options);
         }
-        return cmp(version, this.operator, this.semver, this.options);
+        return cmp(version1, this.operator, this.semver, this.options);
     }
-    intersects(comp, optionsOrLoose) {
-        if (!(comp instanceof Comparator)) {
+    intersects(comp2, optionsOrLoose2) {
+        if (!(comp2 instanceof Comparator)) {
             throw new TypeError("a Comparator is required");
         }
-        if (!optionsOrLoose || typeof optionsOrLoose !== "object") {
-            optionsOrLoose = {
-                loose: !!optionsOrLoose,
+        if (!optionsOrLoose2 || typeof optionsOrLoose2 !== "object") {
+            optionsOrLoose2 = {
+                loose: !!optionsOrLoose2,
                 includePrerelease: false
             };
         }
@@ -4197,21 +4197,21 @@ class Comparator {
             if (this.value === "") {
                 return true;
             }
-            rangeTmp = new Range1(comp.value, optionsOrLoose);
-            return satisfies(this.value, rangeTmp, optionsOrLoose);
-        } else if (comp.operator === "") {
-            if (comp.value === "") {
+            rangeTmp = new Range1(comp2.value, optionsOrLoose2);
+            return satisfies(this.value, rangeTmp, optionsOrLoose2);
+        } else if (comp2.operator === "") {
+            if (comp2.value === "") {
                 return true;
             }
-            rangeTmp = new Range1(this.value, optionsOrLoose);
-            return satisfies(comp.semver, rangeTmp, optionsOrLoose);
+            rangeTmp = new Range1(this.value, optionsOrLoose2);
+            return satisfies(comp2.semver, rangeTmp, optionsOrLoose2);
         }
-        const sameDirectionIncreasing = (this.operator === ">=" || this.operator === ">") && (comp.operator === ">=" || comp.operator === ">");
-        const sameDirectionDecreasing = (this.operator === "<=" || this.operator === "<") && (comp.operator === "<=" || comp.operator === "<");
-        const sameSemVer = this.semver.version === comp.semver.version;
-        const differentDirectionsInclusive = (this.operator === ">=" || this.operator === "<=") && (comp.operator === ">=" || comp.operator === "<=");
-        const oppositeDirectionsLessThan = cmp(this.semver, "<", comp.semver, optionsOrLoose) && (this.operator === ">=" || this.operator === ">") && (comp.operator === "<=" || comp.operator === "<");
-        const oppositeDirectionsGreaterThan = cmp(this.semver, ">", comp.semver, optionsOrLoose) && (this.operator === "<=" || this.operator === "<") && (comp.operator === ">=" || comp.operator === ">");
+        const sameDirectionIncreasing = (this.operator === ">=" || this.operator === ">") && (comp2.operator === ">=" || comp2.operator === ">");
+        const sameDirectionDecreasing = (this.operator === "<=" || this.operator === "<") && (comp2.operator === "<=" || comp2.operator === "<");
+        const sameSemVer = this.semver.version === comp2.semver.version;
+        const differentDirectionsInclusive = (this.operator === ">=" || this.operator === "<=") && (comp2.operator === ">=" || comp2.operator === "<=");
+        const oppositeDirectionsLessThan = cmp(this.semver, "<", comp2.semver, optionsOrLoose2) && (this.operator === ">=" || this.operator === ">") && (comp2.operator === "<=" || comp2.operator === "<");
+        const oppositeDirectionsGreaterThan = cmp(this.semver, ">", comp2.semver, optionsOrLoose2) && (this.operator === "<=" || this.operator === "<") && (comp2.operator === ">=" || comp2.operator === ">");
         return sameDirectionIncreasing || sameDirectionDecreasing || sameSemVer && differentDirectionsInclusive || oppositeDirectionsLessThan || oppositeDirectionsGreaterThan;
     }
     toString() {
@@ -4219,36 +4219,36 @@ class Comparator {
     }
 }
 class Range1 {
-    constructor(range1, optionsOrLoose3){
+    constructor(range, optionsOrLoose3){
         if (!optionsOrLoose3 || typeof optionsOrLoose3 !== "object") {
             optionsOrLoose3 = {
                 loose: !!optionsOrLoose3,
                 includePrerelease: false
             };
         }
-        if (range1 instanceof Range1) {
-            if (range1.loose === !!optionsOrLoose3.loose && range1.includePrerelease === !!optionsOrLoose3.includePrerelease) {
-                return range1;
+        if (range instanceof Range1) {
+            if (range.loose === !!optionsOrLoose3.loose && range.includePrerelease === !!optionsOrLoose3.includePrerelease) {
+                return range;
             } else {
-                return new Range1(range1.raw, optionsOrLoose3);
+                return new Range1(range.raw, optionsOrLoose3);
             }
         }
-        if (range1 instanceof Comparator) {
-            return new Range1(range1.value, optionsOrLoose3);
+        if (range instanceof Comparator) {
+            return new Range1(range.value, optionsOrLoose3);
         }
         if (!(this instanceof Range1)) {
-            return new Range1(range1, optionsOrLoose3);
+            return new Range1(range, optionsOrLoose3);
         }
         this.options = optionsOrLoose3;
         this.loose = !!optionsOrLoose3.loose;
         this.includePrerelease = !!optionsOrLoose3.includePrerelease;
-        this.raw = range1;
-        this.set = range1.split(/\s*\|\|\s*/).map((range1)=>this.parseRange(range1.trim())
+        this.raw = range;
+        this.set = range.split(/\s*\|\|\s*/).map((range1)=>this.parseRange(range1.trim())
         ).filter((c)=>{
             return c.length;
         });
         if (!this.set.length) {
-            throw new TypeError("Invalid SemVer Range: " + range1);
+            throw new TypeError("Invalid SemVer Range: " + range);
         }
         this.format();
     }
@@ -4257,46 +4257,46 @@ class Range1 {
         ).join("||").trim();
         return this.range;
     }
-    parseRange(range) {
+    parseRange(range1) {
         const loose = this.options.loose;
-        range = range.trim();
+        range1 = range1.trim();
         const hr = loose ? re[HYPHENRANGELOOSE] : re[HYPHENRANGE];
-        range = range.replace(hr, hyphenReplace);
-        range = range.replace(re[COMPARATORTRIM], comparatorTrimReplace);
-        range = range.replace(re[TILDETRIM], tildeTrimReplace);
-        range = range.replace(re[CARETTRIM], caretTrimReplace);
-        range = range.split(/\s+/).join(" ");
+        range1 = range1.replace(hr, hyphenReplace);
+        range1 = range1.replace(re[COMPARATORTRIM], comparatorTrimReplace);
+        range1 = range1.replace(re[TILDETRIM], tildeTrimReplace);
+        range1 = range1.replace(re[CARETTRIM], caretTrimReplace);
+        range1 = range1.split(/\s+/).join(" ");
         const compRe = loose ? re[COMPARATORLOOSE] : re[COMPARATOR];
-        let set = range.split(" ").map((comp2)=>parseComparator(comp2, this.options)
+        let set = range1.split(" ").map((comp3)=>parseComparator(comp3, this.options)
         ).join(" ").split(/\s+/);
         if (this.options.loose) {
-            set = set.filter((comp2)=>{
-                return !!comp2.match(compRe);
+            set = set.filter((comp3)=>{
+                return !!comp3.match(compRe);
             });
         }
-        return set.map((comp2)=>new Comparator(comp2, this.options)
+        return set.map((comp3)=>new Comparator(comp3, this.options)
         );
     }
-    test(version) {
-        if (typeof version === "string") {
-            version = new SemVer(version, this.options);
+    test(version2) {
+        if (typeof version2 === "string") {
+            version2 = new SemVer(version2, this.options);
         }
         for(var i1 = 0; i1 < this.set.length; i1++){
-            if (testSet(this.set[i1], version, this.options)) {
+            if (testSet(this.set[i1], version2, this.options)) {
                 return true;
             }
         }
         return false;
     }
-    intersects(range, optionsOrLoose) {
-        if (!(range instanceof Range1)) {
+    intersects(range2, optionsOrLoose4) {
+        if (!(range2 instanceof Range1)) {
             throw new TypeError("a Range is required");
         }
         return this.set.some((thisComparators)=>{
-            return isSatisfiable(thisComparators, optionsOrLoose) && range.set.some((rangeComparators)=>{
-                return isSatisfiable(rangeComparators, optionsOrLoose) && thisComparators.every((thisComparator)=>{
+            return isSatisfiable(thisComparators, optionsOrLoose4) && range2.set.some((rangeComparators)=>{
+                return isSatisfiable(rangeComparators, optionsOrLoose4) && thisComparators.every((thisComparator)=>{
                     return rangeComparators.every((rangeComparator)=>{
-                        return thisComparator.intersects(rangeComparator, optionsOrLoose);
+                        return thisComparator.intersects(rangeComparator, optionsOrLoose4);
                     });
                 });
             });
@@ -4306,20 +4306,20 @@ class Range1 {
         return this.range;
     }
 }
-function testSet(set, version2, options5) {
+function testSet(set, version3, options5) {
     for(let i2 = 0; i2 < set.length; i2++){
-        if (!set[i2].test(version2)) {
+        if (!set[i2].test(version3)) {
             return false;
         }
     }
-    if (version2.prerelease.length && !options5.includePrerelease) {
+    if (version3.prerelease.length && !options5.includePrerelease) {
         for(let i3 = 0; i3 < set.length; i3++){
             if (set[i3].semver === ANY) {
                 continue;
             }
             if (set[i3].semver.prerelease.length > 0) {
                 const allowed = set[i3].semver;
-                if (allowed.major === version2.major && allowed.minor === version2.minor && allowed.patch === version2.patch) {
+                if (allowed.major === version3.major && allowed.minor === version3.minor && allowed.patch === version3.patch) {
                     return true;
                 }
             }
@@ -4340,57 +4340,57 @@ function isSatisfiable(comparators, options5) {
     }
     return result;
 }
-function toComparators(range2, optionsOrLoose4) {
-    return new Range1(range2, optionsOrLoose4).set.map((comp2)=>{
-        return comp2.map((c)=>c.value
+function toComparators(range3, optionsOrLoose5) {
+    return new Range1(range3, optionsOrLoose5).set.map((comp3)=>{
+        return comp3.map((c)=>c.value
         ).join(" ").trim().split(" ");
     });
 }
-function parseComparator(comp2, options5) {
-    comp2 = replaceCarets(comp2, options5);
-    comp2 = replaceTildes(comp2, options5);
-    comp2 = replaceXRanges(comp2, options5);
-    comp2 = replaceStars(comp2, options5);
-    return comp2;
+function parseComparator(comp3, options5) {
+    comp3 = replaceCarets(comp3, options5);
+    comp3 = replaceTildes(comp3, options5);
+    comp3 = replaceXRanges(comp3, options5);
+    comp3 = replaceStars(comp3, options5);
+    return comp3;
 }
 function isX(id) {
     return !id || id.toLowerCase() === "x" || id === "*";
 }
-function replaceTildes(comp2, options5) {
-    return comp2.trim().split(/\s+/).map((comp3)=>replaceTilde(comp3, options5)
+function replaceTildes(comp3, options5) {
+    return comp3.trim().split(/\s+/).map((comp4)=>replaceTilde(comp4, options5)
     ).join(" ");
 }
-function replaceTilde(comp2, options5) {
-    const r = options5.loose ? re[TILDELOOSE] : re[TILDE];
-    return comp2.replace(r, (_, M, m1, p, pr)=>{
+function replaceTilde(comp3, options5) {
+    const r2 = options5.loose ? re[TILDELOOSE] : re[TILDE];
+    return comp3.replace(r2, (_, M, m1, p2, pr)=>{
         let ret;
         if (isX(M)) {
             ret = "";
         } else if (isX(m1)) {
             ret = ">=" + M + ".0.0 <" + (+M + 1) + ".0.0";
-        } else if (isX(p)) {
+        } else if (isX(p2)) {
             ret = ">=" + M + "." + m1 + ".0 <" + M + "." + (+m1 + 1) + ".0";
         } else if (pr) {
-            ret = ">=" + M + "." + m1 + "." + p + "-" + pr + " <" + M + "." + (+m1 + 1) + ".0";
+            ret = ">=" + M + "." + m1 + "." + p2 + "-" + pr + " <" + M + "." + (+m1 + 1) + ".0";
         } else {
-            ret = ">=" + M + "." + m1 + "." + p + " <" + M + "." + (+m1 + 1) + ".0";
+            ret = ">=" + M + "." + m1 + "." + p2 + " <" + M + "." + (+m1 + 1) + ".0";
         }
         return ret;
     });
 }
-function replaceCarets(comp2, options5) {
-    return comp2.trim().split(/\s+/).map((comp3)=>replaceCaret(comp3, options5)
+function replaceCarets(comp3, options5) {
+    return comp3.trim().split(/\s+/).map((comp4)=>replaceCaret(comp4, options5)
     ).join(" ");
 }
-function replaceCaret(comp2, options5) {
-    const r = options5.loose ? re[CARETLOOSE] : re[CARET];
-    return comp2.replace(r, (_, M, m1, p, pr)=>{
+function replaceCaret(comp3, options5) {
+    const r2 = options5.loose ? re[CARETLOOSE] : re[CARET];
+    return comp3.replace(r2, (_, M, m1, p2, pr)=>{
         let ret;
         if (isX(M)) {
             ret = "";
         } else if (isX(m1)) {
             ret = ">=" + M + ".0.0 <" + (+M + 1) + ".0.0";
-        } else if (isX(p)) {
+        } else if (isX(p2)) {
             if (M === "0") {
                 ret = ">=" + M + "." + m1 + ".0 <" + M + "." + (+m1 + 1) + ".0";
             } else {
@@ -4399,38 +4399,38 @@ function replaceCaret(comp2, options5) {
         } else if (pr) {
             if (M === "0") {
                 if (m1 === "0") {
-                    ret = ">=" + M + "." + m1 + "." + p + "-" + pr + " <" + M + "." + m1 + "." + (+p + 1);
+                    ret = ">=" + M + "." + m1 + "." + p2 + "-" + pr + " <" + M + "." + m1 + "." + (+p2 + 1);
                 } else {
-                    ret = ">=" + M + "." + m1 + "." + p + "-" + pr + " <" + M + "." + (+m1 + 1) + ".0";
+                    ret = ">=" + M + "." + m1 + "." + p2 + "-" + pr + " <" + M + "." + (+m1 + 1) + ".0";
                 }
             } else {
-                ret = ">=" + M + "." + m1 + "." + p + "-" + pr + " <" + (+M + 1) + ".0.0";
+                ret = ">=" + M + "." + m1 + "." + p2 + "-" + pr + " <" + (+M + 1) + ".0.0";
             }
         } else {
             if (M === "0") {
                 if (m1 === "0") {
-                    ret = ">=" + M + "." + m1 + "." + p + " <" + M + "." + m1 + "." + (+p + 1);
+                    ret = ">=" + M + "." + m1 + "." + p2 + " <" + M + "." + m1 + "." + (+p2 + 1);
                 } else {
-                    ret = ">=" + M + "." + m1 + "." + p + " <" + M + "." + (+m1 + 1) + ".0";
+                    ret = ">=" + M + "." + m1 + "." + p2 + " <" + M + "." + (+m1 + 1) + ".0";
                 }
             } else {
-                ret = ">=" + M + "." + m1 + "." + p + " <" + (+M + 1) + ".0.0";
+                ret = ">=" + M + "." + m1 + "." + p2 + " <" + (+M + 1) + ".0.0";
             }
         }
         return ret;
     });
 }
-function replaceXRanges(comp2, options5) {
-    return comp2.split(/\s+/).map((comp3)=>replaceXRange(comp3, options5)
+function replaceXRanges(comp3, options5) {
+    return comp3.split(/\s+/).map((comp4)=>replaceXRange(comp4, options5)
     ).join(" ");
 }
-function replaceXRange(comp2, options5) {
-    comp2 = comp2.trim();
-    const r = options5.loose ? re[XRANGELOOSE] : re[XRANGE];
-    return comp2.replace(r, (ret, gtlt, M, m1, p, pr)=>{
+function replaceXRange(comp3, options5) {
+    comp3 = comp3.trim();
+    const r2 = options5.loose ? re[XRANGELOOSE] : re[XRANGE];
+    return comp3.replace(r2, (ret, gtlt, M, m1, p2, pr)=>{
         const xM = isX(M);
         const xm = xM || isX(m1);
-        const xp = xm || isX(p);
+        const xp = xm || isX(p2);
         const anyX = xp;
         if (gtlt === "=" && anyX) {
             gtlt = "";
@@ -4445,16 +4445,16 @@ function replaceXRange(comp2, options5) {
             if (xm) {
                 m1 = 0;
             }
-            p = 0;
+            p2 = 0;
             if (gtlt === ">") {
                 gtlt = ">=";
                 if (xm) {
                     M = +M + 1;
                     m1 = 0;
-                    p = 0;
+                    p2 = 0;
                 } else {
                     m1 = +m1 + 1;
-                    p = 0;
+                    p2 = 0;
                 }
             } else if (gtlt === "<=") {
                 gtlt = "<";
@@ -4464,7 +4464,7 @@ function replaceXRange(comp2, options5) {
                     m1 = +m1 + 1;
                 }
             }
-            ret = gtlt + M + "." + m1 + "." + p;
+            ret = gtlt + M + "." + m1 + "." + p2;
         } else if (xm) {
             ret = ">=" + M + ".0.0 <" + (+M + 1) + ".0.0";
         } else if (xp) {
@@ -4473,8 +4473,8 @@ function replaceXRange(comp2, options5) {
         return ret;
     });
 }
-function replaceStars(comp2, options5) {
-    return comp2.trim().replace(re[STAR], "");
+function replaceStars(comp3, options5) {
+    return comp3.trim().replace(re[STAR], "");
 }
 function hyphenReplace($0, from, fM, fm, fp, fpr, fb, to, tM, tm, tp, tpr, tb) {
     if (isX(fM)) {
@@ -4499,19 +4499,19 @@ function hyphenReplace($0, from, fM, fm, fp, fpr, fb, to, tM, tm, tp, tpr, tb) {
     }
     return (from + " " + to).trim();
 }
-function satisfies(version2, range2, optionsOrLoose4) {
+function satisfies(version3, range3, optionsOrLoose5) {
     try {
-        range2 = new Range1(range2, optionsOrLoose4);
+        range3 = new Range1(range3, optionsOrLoose5);
     } catch (er) {
         return false;
     }
-    return range2.test(version2);
+    return range3.test(version3);
 }
-function maxSatisfying(versions, range2, optionsOrLoose4) {
+function maxSatisfying(versions, range3, optionsOrLoose5) {
     var max = null;
     var maxSV = null;
     try {
-        var rangeObj = new Range1(range2, optionsOrLoose4);
+        var rangeObj = new Range1(range3, optionsOrLoose5);
     } catch (er) {
         return null;
     }
@@ -4519,17 +4519,17 @@ function maxSatisfying(versions, range2, optionsOrLoose4) {
         if (rangeObj.test(v)) {
             if (!max || maxSV && maxSV.compare(v) === -1) {
                 max = v;
-                maxSV = new SemVer(max, optionsOrLoose4);
+                maxSV = new SemVer(max, optionsOrLoose5);
             }
         }
     });
     return max;
 }
-function minSatisfying(versions, range2, optionsOrLoose4) {
+function minSatisfying(versions, range3, optionsOrLoose5) {
     var min = null;
     var minSV = null;
     try {
-        var rangeObj = new Range1(range2, optionsOrLoose4);
+        var rangeObj = new Range1(range3, optionsOrLoose5);
     } catch (er) {
         return null;
     }
@@ -4537,25 +4537,25 @@ function minSatisfying(versions, range2, optionsOrLoose4) {
         if (rangeObj.test(v)) {
             if (!min || minSV.compare(v) === 1) {
                 min = v;
-                minSV = new SemVer(min, optionsOrLoose4);
+                minSV = new SemVer(min, optionsOrLoose5);
             }
         }
     });
     return min;
 }
-function minVersion(range2, optionsOrLoose4) {
-    range2 = new Range1(range2, optionsOrLoose4);
+function minVersion(range3, optionsOrLoose5) {
+    range3 = new Range1(range3, optionsOrLoose5);
     var minver = new SemVer("0.0.0");
-    if (range2.test(minver)) {
+    if (range3.test(minver)) {
         return minver;
     }
     minver = new SemVer("0.0.0-0");
-    if (range2.test(minver)) {
+    if (range3.test(minver)) {
         return minver;
     }
     minver = null;
-    for(var i2 = 0; i2 < range2.set.length; ++i2){
-        var comparators = range2.set[i2];
+    for(var i2 = 0; i2 < range3.set.length; ++i2){
+        var comparators = range3.set[i2];
         comparators.forEach((comparator)=>{
             var compver = new SemVer(comparator.semver.version);
             switch(comparator.operator){
@@ -4579,56 +4579,56 @@ function minVersion(range2, optionsOrLoose4) {
             }
         });
     }
-    if (minver && range2.test(minver)) {
+    if (minver && range3.test(minver)) {
         return minver;
     }
     return null;
 }
-function validRange(range2, optionsOrLoose4) {
+function validRange(range3, optionsOrLoose5) {
     try {
-        if (range2 === null) return null;
-        return new Range1(range2, optionsOrLoose4).range || "*";
+        if (range3 === null) return null;
+        return new Range1(range3, optionsOrLoose5).range || "*";
     } catch (er) {
         return null;
     }
 }
-function ltr(version2, range2, optionsOrLoose4) {
-    return outside(version2, range2, "<", optionsOrLoose4);
+function ltr(version3, range3, optionsOrLoose5) {
+    return outside(version3, range3, "<", optionsOrLoose5);
 }
-function gtr(version2, range2, optionsOrLoose4) {
-    return outside(version2, range2, ">", optionsOrLoose4);
+function gtr(version3, range3, optionsOrLoose5) {
+    return outside(version3, range3, ">", optionsOrLoose5);
 }
-function outside(version2, range2, hilo, optionsOrLoose4) {
-    version2 = new SemVer(version2, optionsOrLoose4);
-    range2 = new Range1(range2, optionsOrLoose4);
+function outside(version3, range3, hilo, optionsOrLoose5) {
+    version3 = new SemVer(version3, optionsOrLoose5);
+    range3 = new Range1(range3, optionsOrLoose5);
     let gtfn;
     let ltefn;
     let ltfn;
-    let comp2;
+    let comp3;
     let ecomp;
     switch(hilo){
         case ">":
             gtfn = gt;
             ltefn = lte;
             ltfn = lt;
-            comp2 = ">";
+            comp3 = ">";
             ecomp = ">=";
             break;
         case "<":
             gtfn = lt;
             ltefn = gte;
             ltfn = gt;
-            comp2 = "<";
+            comp3 = "<";
             ecomp = "<=";
             break;
         default:
             throw new TypeError('Must provide a hilo val of "<" or ">"');
     }
-    if (satisfies(version2, range2, optionsOrLoose4)) {
+    if (satisfies(version3, range3, optionsOrLoose5)) {
         return false;
     }
-    for(let i2 = 0; i2 < range2.set.length; ++i2){
-        const comparators = range2.set[i2];
+    for(let i2 = 0; i2 < range3.set.length; ++i2){
+        const comparators = range3.set[i2];
         let high = null;
         let low = null;
         comparators.forEach((comparator)=>{
@@ -4637,45 +4637,45 @@ function outside(version2, range2, hilo, optionsOrLoose4) {
             }
             high = high || comparator;
             low = low || comparator;
-            if (gtfn(comparator.semver, high.semver, optionsOrLoose4)) {
+            if (gtfn(comparator.semver, high.semver, optionsOrLoose5)) {
                 high = comparator;
-            } else if (ltfn(comparator.semver, low.semver, optionsOrLoose4)) {
+            } else if (ltfn(comparator.semver, low.semver, optionsOrLoose5)) {
                 low = comparator;
             }
         });
         if (high === null || low === null) return true;
-        if (high.operator === comp2 || high.operator === ecomp) {
+        if (high.operator === comp3 || high.operator === ecomp) {
             return false;
         }
-        if ((!low.operator || low.operator === comp2) && ltefn(version2, low.semver)) {
+        if ((!low.operator || low.operator === comp3) && ltefn(version3, low.semver)) {
             return false;
-        } else if (low.operator === ecomp && ltfn(version2, low.semver)) {
+        } else if (low.operator === ecomp && ltfn(version3, low.semver)) {
             return false;
         }
     }
     return true;
 }
-function prerelease(version2, optionsOrLoose4) {
-    var parsed = parse4(version2, optionsOrLoose4);
+function prerelease(version3, optionsOrLoose5) {
+    var parsed = parse4(version3, optionsOrLoose5);
     return parsed && parsed.prerelease.length ? parsed.prerelease : null;
 }
-function intersects(range11, range2, optionsOrLoose4) {
-    range11 = new Range1(range11, optionsOrLoose4);
-    range2 = new Range1(range2, optionsOrLoose4);
-    return range11.intersects(range2);
+function intersects(range11, range21, optionsOrLoose5) {
+    range11 = new Range1(range11, optionsOrLoose5);
+    range21 = new Range1(range21, optionsOrLoose5);
+    return range11.intersects(range21);
 }
-function coerce(version2, optionsOrLoose4) {
-    if (version2 instanceof SemVer) {
-        return version2;
+function coerce(version3, optionsOrLoose5) {
+    if (version3 instanceof SemVer) {
+        return version3;
     }
-    if (typeof version2 !== "string") {
+    if (typeof version3 !== "string") {
         return null;
     }
-    const match = version2.match(re[COERCE]);
+    const match = version3.match(re[COERCE]);
     if (match == null) {
         return null;
     }
-    return parse4(match[1] + "." + (match[2] || "0") + "." + (match[3] || "0"), optionsOrLoose4);
+    return parse4(match[1] + "." + (match[2] || "0") + "." + (match[3] || "0"), optionsOrLoose5);
 }
 const mod7 = function() {
     return {
@@ -4721,7 +4721,7 @@ const mod7 = function() {
         default: SemVer
     };
 }();
-const version2 = "1.11.0";
+const version3 = "1.11.0";
 const TaskName_AST = {
     "moduleName": "dnit.manifest",
     "decl": {
@@ -5879,69 +5879,69 @@ const ADL = {
 };
 const RESOLVER = declResolver(ADL);
 class ADLMap {
-    constructor(data, isEqual){
-        this.data = data;
+    constructor(data4, isEqual){
+        this.data = data4;
         this.isEqual = isEqual;
     }
     has(k) {
         return this.findIndex(k) !== -1;
     }
-    get(k) {
-        const ind = this.findIndex(k);
+    get(k1) {
+        const ind = this.findIndex(k1);
         if (ind === -1) {
             return undefined;
         }
         return this.data[ind].v2;
     }
-    getOrInsert(k, v) {
-        const existing = this.get(k);
+    getOrInsert(k2, v) {
+        const existing = this.get(k2);
         if (existing === undefined) {
-            this.set(k, v);
+            this.set(k2, v);
             return v;
         }
         return existing;
     }
-    set(k, v) {
-        const ind = this.findIndex(k);
+    set(k3, v1) {
+        const ind = this.findIndex(k3);
         if (ind === -1) {
             this.data.push({
-                v1: k,
-                v2: v
+                v1: k3,
+                v2: v1
             });
         }
         this.data[ind] = {
-            v1: k,
-            v2: v
+            v1: k3,
+            v2: v1
         };
         return this;
     }
     keys() {
-        return this.data.map((p)=>p.v1
+        return this.data.map((p2)=>p2.v1
         );
     }
     values() {
-        return this.data.map((p)=>p.v2
+        return this.data.map((p2)=>p2.v2
         );
     }
     entries() {
-        return this.data.map((p)=>[
-                p.v1,
-                p.v2
+        return this.data.map((p2)=>[
+                p2.v1,
+                p2.v2
             ]
         );
     }
     toData() {
         return this.data;
     }
-    findIndex(k) {
-        return this.data.findIndex((p)=>this.isEqual(p.v1, k)
+    findIndex(k4) {
+        return this.data.findIndex((p2)=>this.isEqual(p2.v1, k4)
         );
     }
 }
 class Manifest {
     constructor(dir, filename = ".manifest.json"){
         this.jsonBinding = createJsonBinding(RESOLVER, texprManifest());
-        this.tasks = new ADLMap([], (k1, k2)=>k1 === k2
+        this.tasks = new ADLMap([], (k11, k21)=>k11 === k21
         );
         this.filename = mod3.join(dir, filename);
     }
@@ -5949,9 +5949,9 @@ class Manifest {
         if (await mod5.exists(this.filename)) {
             const json = JSON.parse(await Deno.readTextFile(this.filename));
             const mdata = this.jsonBinding.fromJson(json);
-            for (const p of mdata.tasks){
-                const taskName = p.v1;
-                const taskData = p.v2;
+            for (const p2 of mdata.tasks){
+                const taskName = p2.v1;
+                const taskData = p2.v2;
                 this.tasks.set(taskName, new TaskManifest(taskData));
             }
         }
@@ -5960,9 +5960,9 @@ class Manifest {
         if (!await mod5.exists(mod3.dirname(this.filename))) {
         }
         const mdata = {
-            tasks: this.tasks.entries().map((p)=>({
-                    v1: p[0],
-                    v2: p[1].toData()
+            tasks: this.tasks.entries().map((p2)=>({
+                    v1: p2[0],
+                    v2: p2[1].toData()
                 })
             )
         };
@@ -5971,19 +5971,19 @@ class Manifest {
     }
 }
 class TaskManifest {
-    constructor(data1){
+    constructor(data5){
         this.lastExecution = null;
-        this.trackedFiles = new ADLMap([], (k1, k2)=>k1 === k2
+        this.trackedFiles = new ADLMap([], (k11, k21)=>k11 === k21
         );
-        this.trackedFiles = new ADLMap(data1.trackedFiles, (k1, k2)=>k1 === k2
+        this.trackedFiles = new ADLMap(data5.trackedFiles, (k11, k21)=>k11 === k21
         );
-        this.lastExecution = data1.lastExecution;
+        this.lastExecution = data5.lastExecution;
     }
     getFileData(fn) {
         return this.trackedFiles.get(fn);
     }
-    setFileData(fn, d) {
-        this.trackedFiles.set(fn, d);
+    setFileData(fn1, d) {
+        this.trackedFiles.set(fn1, d);
     }
     setExecutionTimestamp() {
         this.lastExecution = new Date().toISOString();
@@ -6031,9 +6031,9 @@ class AsyncQueue {
     }
 }
 class ExecContext {
-    constructor(manifest, args){
+    constructor(manifest, args6){
         this.manifest = manifest;
-        this.args = args;
+        this.args = args6;
         this.taskRegister = new Map();
         this.targetRegister = new Map();
         this.doneTasks = new Set();
@@ -6041,12 +6041,12 @@ class ExecContext {
         this.internalLogger = mod4.getLogger("internal");
         this.taskLogger = mod4.getLogger("task");
         this.userLogger = mod4.getLogger("user");
-        if (args["verbose"] !== undefined) {
+        if (args6["verbose"] !== undefined) {
             this.internalLogger.levelName = "INFO";
         }
-        const concurrency1 = args["concurrency"] || 4;
+        const concurrency1 = args6["concurrency"] || 4;
         this.asyncQueue = new AsyncQueue(concurrency1);
-        this.internalLogger.info(`Starting ExecContext version: ${version2}`);
+        this.internalLogger.info(`Starting ExecContext version: ${version3}`);
     }
     getTaskByName(name) {
         return this.taskRegister.get(name);
@@ -6102,16 +6102,16 @@ class Task {
     getTaskDeps(deps) {
         return deps.filter(isTask);
     }
-    getTrackedFiles(deps) {
-        return deps.filter(isTrackedFile);
+    getTrackedFiles(deps1) {
+        return deps1.filter(isTrackedFile);
     }
-    getTrackedFilesAsync(deps) {
-        return deps.filter(isTrackedFileAsync);
+    getTrackedFilesAsync(deps2) {
+        return deps2.filter(isTrackedFileAsync);
     }
     async setup(ctx) {
         if (this.taskManifest === null) {
-            for (const t of this.targets){
-                ctx.targetRegister.set(t.path, this);
+            for (const t1 of this.targets){
+                ctx.targetRegister.set(t1.path, this);
             }
             this.taskManifest = ctx.manifest.tasks.getOrInsert(this.name, new TaskManifest({
                 lastExecution: null,
@@ -6128,14 +6128,14 @@ class Task {
             }
         }
     }
-    async exec(ctx) {
-        if (ctx.doneTasks.has(this)) {
+    async exec(ctx1) {
+        if (ctx1.doneTasks.has(this)) {
             return;
         }
-        if (ctx.inprogressTasks.has(this)) {
+        if (ctx1.inprogressTasks.has(this)) {
             return;
         }
-        ctx.inprogressTasks.add(this);
+        ctx1.inprogressTasks.add(this);
         for (const afd of this.async_files_deps){
             const file_deps = await afd.getTrackedFiles();
             for (const fd of file_deps){
@@ -6143,50 +6143,50 @@ class Task {
             }
         }
         for (const fd of this.file_deps){
-            const t = ctx.targetRegister.get(fd.path);
-            if (t !== undefined) {
-                this.task_deps.add(t);
+            const t1 = ctx1.targetRegister.get(fd.path);
+            if (t1 !== undefined) {
+                this.task_deps.add(t1);
             }
         }
-        await this.execDependencies(ctx);
+        await this.execDependencies(ctx1);
         let actualUpToDate = true;
-        actualUpToDate = actualUpToDate && await this.checkFileDeps(ctx);
-        ctx.internalLogger.info(`${this.name} checkFileDeps ${actualUpToDate}`);
-        actualUpToDate = actualUpToDate && await this.targetsExist(ctx);
-        ctx.internalLogger.info(`${this.name} targetsExist ${actualUpToDate}`);
+        actualUpToDate = actualUpToDate && await this.checkFileDeps(ctx1);
+        ctx1.internalLogger.info(`${this.name} checkFileDeps ${actualUpToDate}`);
+        actualUpToDate = actualUpToDate && await this.targetsExist(ctx1);
+        ctx1.internalLogger.info(`${this.name} targetsExist ${actualUpToDate}`);
         if (this.uptodate !== undefined) {
-            actualUpToDate = actualUpToDate && await this.uptodate(taskContext(ctx, this));
+            actualUpToDate = actualUpToDate && await this.uptodate(taskContext(ctx1, this));
         }
-        ctx.internalLogger.info(`${this.name} uptodate ${actualUpToDate}`);
+        ctx1.internalLogger.info(`${this.name} uptodate ${actualUpToDate}`);
         if (actualUpToDate) {
-            ctx.taskLogger.info(`--- ${this.name}`);
+            ctx1.taskLogger.info(`--- ${this.name}`);
         } else {
-            ctx.taskLogger.info(`... ${this.name}`);
-            await this.action(taskContext(ctx, this));
-            ctx.taskLogger.info(`=== ${this.name}`);
+            ctx1.taskLogger.info(`... ${this.name}`);
+            await this.action(taskContext(ctx1, this));
+            ctx1.taskLogger.info(`=== ${this.name}`);
             {
                 this.taskManifest?.setExecutionTimestamp();
                 let promisesInProgress = [];
                 for (const fdep of this.file_deps){
-                    promisesInProgress.push(ctx.asyncQueue.schedule(async ()=>{
-                        const trackedFileData = await fdep.getFileData(ctx);
+                    promisesInProgress.push(ctx1.asyncQueue.schedule(async ()=>{
+                        const trackedFileData = await fdep.getFileData(ctx1);
                         this.taskManifest?.setFileData(fdep.path, trackedFileData);
                     }));
                 }
                 await Promise.all(promisesInProgress);
             }
         }
-        ctx.doneTasks.add(this);
-        ctx.inprogressTasks.delete(this);
+        ctx1.doneTasks.add(this);
+        ctx1.inprogressTasks.delete(this);
     }
-    async targetsExist(ctx) {
-        const tex = await Promise.all(Array.from(this.targets).map(async (tf)=>ctx.asyncQueue.schedule(()=>tf.exists()
+    async targetsExist(ctx2) {
+        const tex = await Promise.all(Array.from(this.targets).map(async (tf)=>ctx2.asyncQueue.schedule(()=>tf.exists()
             )
         ));
-        return !tex.some((t)=>!t
+        return !tex.some((t1)=>!t1
         );
     }
-    async checkFileDeps(ctx) {
+    async checkFileDeps(ctx3) {
         let fileDepsUpToDate = true;
         let promisesInProgress = [];
         const taskManifest = this.taskManifest;
@@ -6194,20 +6194,20 @@ class Task {
             throw new Error(`Invalid null taskManifest on ${this.name}`);
         }
         for (const fdep of this.file_deps){
-            promisesInProgress.push(ctx.asyncQueue.schedule(async ()=>{
-                const r = await fdep.getFileDataOrCached(ctx, taskManifest.getFileData(fdep.path));
-                taskManifest.setFileData(fdep.path, r.tData);
-                fileDepsUpToDate = fileDepsUpToDate && r.upToDate;
+            promisesInProgress.push(ctx3.asyncQueue.schedule(async ()=>{
+                const r2 = await fdep.getFileDataOrCached(ctx3, taskManifest.getFileData(fdep.path));
+                taskManifest.setFileData(fdep.path, r2.tData);
+                fileDepsUpToDate = fileDepsUpToDate && r2.upToDate;
             }));
         }
         await Promise.all(promisesInProgress);
         promisesInProgress = [];
         return fileDepsUpToDate;
     }
-    async execDependencies(ctx) {
+    async execDependencies(ctx4) {
         for (const dep of this.task_deps){
-            if (!ctx.doneTasks.has(dep) && !ctx.inprogressTasks.has(dep)) {
-                await dep.exec(ctx);
+            if (!ctx4.doneTasks.has(dep) && !ctx4.inprogressTasks.has(dep)) {
+                await dep.exec(ctx4);
             }
         }
     }
@@ -6233,8 +6233,8 @@ class TrackedFile {
         }
         return statResult.kind === 'fileInfo';
     }
-    async getHash(statInput) {
-        let statResult = statInput;
+    async getHash(statInput1) {
+        let statResult = statInput1;
         if (statResult === undefined) {
             statResult = await this.stat();
         }
@@ -6244,8 +6244,8 @@ class TrackedFile {
         mod4.getLogger('internal').info(`checking hash on ${this.path}`);
         return this.#getHash(this.path, statResult.fileInfo);
     }
-    async getTimestamp(statInput) {
-        let statResult = statInput;
+    async getTimestamp(statInput2) {
+        let statResult = statInput2;
         if (statResult === undefined) {
             statResult = await this.stat();
         }
@@ -6254,11 +6254,11 @@ class TrackedFile {
         }
         return this.#getTimestamp(this.path, statResult.fileInfo);
     }
-    async isUpToDate(ctx, tData, statInput) {
+    async isUpToDate(ctx5, tData, statInput3) {
         if (tData === undefined) {
             return false;
         }
-        let statResult = statInput;
+        let statResult = statInput3;
         if (statResult === undefined) {
             statResult = await this.stat();
         }
@@ -6269,8 +6269,8 @@ class TrackedFile {
         const hash = await this.getHash(statResult);
         return hash === tData.hash;
     }
-    async getFileData(ctx, statInput) {
-        let statResult = statInput;
+    async getFileData(ctx6, statInput4) {
+        let statResult = statInput4;
         if (statResult === undefined) {
             statResult = await this.stat();
         }
@@ -6279,25 +6279,25 @@ class TrackedFile {
             timestamp: await this.getTimestamp(statResult)
         };
     }
-    async getFileDataOrCached(ctx, tData, statInput) {
-        let statResult = statInput;
+    async getFileDataOrCached(ctx7, tData1, statInput5) {
+        let statResult = statInput5;
         if (statResult === undefined) {
             statResult = await this.stat();
         }
-        if (tData !== undefined && await this.isUpToDate(ctx, tData, statResult)) {
+        if (tData1 !== undefined && await this.isUpToDate(ctx7, tData1, statResult)) {
             return {
-                tData,
+                tData: tData1,
                 upToDate: true
             };
         }
         return {
-            tData: await this.getFileData(ctx, statResult),
+            tData: await this.getFileData(ctx7, statResult),
             upToDate: false
         };
     }
-    setTask(t) {
+    setTask(t1) {
         if (this.fromTask === null) {
-            this.fromTask = t;
+            this.fromTask = t1;
         } else {
             throw new Error("Duplicate tasks generating TrackedFile as target - " + this.path);
         }
@@ -6316,9 +6316,9 @@ class TrackedFilesAsync {
     }
 }
 async function getFileSha1Sum(filename1) {
-    const data2 = await Deno.readFile(filename1);
+    const data6 = await Deno.readFile(filename1);
     const hashsha1 = mod6.createHash("sha1");
-    hashsha1.update(data2);
+    hashsha1.update(data6);
     const hashInHex = hashsha1.toString();
     return hashInHex;
 }
@@ -6332,13 +6332,13 @@ class StdErrPlainHandler extends mod4.handlers.BaseHandler {
             formatter: "{msg}"
         });
     }
-    log(msg) {
-        Deno.stderr.writeSync(new TextEncoder().encode(msg + "\n"));
+    log(msg9) {
+        Deno.stderr.writeSync(new TextEncoder().encode(msg9 + "\n"));
     }
 }
 class StdErrHandler extends mod4.handlers.ConsoleHandler {
-    log(msg) {
-        Deno.stderr.writeSync(new TextEncoder().encode(msg + "\n"));
+    log(msg10) {
+        Deno.stderr.writeSync(new TextEncoder().encode(msg10 + "\n"));
     }
 }
 async function setupLogging() {
@@ -6505,17 +6505,17 @@ async function launch(logger) {
     }
 }
 async function main1() {
-    const args1 = mod.parse(Deno.args);
-    if (args1["version"] === true) {
-        console.log(`dnit ${version2}`);
+    const args7 = mod.parse(Deno.args);
+    if (args7["version"] === true) {
+        console.log(`dnit ${version3}`);
         Deno.exit(0);
     }
     await setupLogging();
     const internalLogger = mod4.getLogger("internal");
-    if (args1["verbose"] !== undefined) {
+    if (args7["verbose"] !== undefined) {
         internalLogger.levelName = "INFO";
     }
-    internalLogger.info(`starting dnit launch using version: ${version2}`);
+    internalLogger.info(`starting dnit launch using version: ${version3}`);
     launch(internalLogger).then((st)=>{
         Deno.exit(st.code);
     });

--- a/bundler/tests/fixture/deno-9620/case1/output/entry.inlined.ts
+++ b/bundler/tests/fixture/deno-9620/case1/output/entry.inlined.ts
@@ -146,14 +146,14 @@ class LimitedReader {
         this.reader = reader;
         this.limit = limit;
     }
-    async read(p) {
+    async read(p1) {
         if (this.limit <= 0) {
             return null;
         }
-        if (p.length > this.limit) {
-            p = p.subarray(0, this.limit);
+        if (p1.length > this.limit) {
+            p1 = p1.subarray(0, this.limit);
         }
-        const n = await this.reader.read(p);
+        const n = await this.reader.read(p1);
         if (n == null) {
             return null;
         }
@@ -1241,14 +1241,14 @@ class BufReader {
     static create(r, size = 4096) {
         return r instanceof BufReader ? r : new BufReader(r, size);
     }
-    constructor(rd1, size1 = 4096){
+    constructor(rd, size1 = 4096){
         this.r = 0;
         this.w = 0;
         this.eof = false;
         if (size1 < 16) {
             size1 = MIN_BUF_SIZE;
         }
-        this._reset(new Uint8Array(size1), rd1);
+        this._reset(new Uint8Array(size1), rd);
     }
     size() {
         return this.buf.byteLength;
@@ -1279,20 +1279,20 @@ class BufReader {
         }
         throw new Error(`No progress after ${100} read() calls`);
     }
-    reset(r) {
-        this._reset(this.buf, r);
+    reset(r1) {
+        this._reset(this.buf, r1);
     }
-    _reset(buf, rd) {
+    _reset(buf, rd1) {
         this.buf = buf;
-        this.rd = rd;
+        this.rd = rd1;
         this.eof = false;
     }
-    async read(p) {
-        let rr = p.byteLength;
-        if (p.byteLength === 0) return rr;
+    async read(p2) {
+        let rr = p2.byteLength;
+        if (p2.byteLength === 0) return rr;
         if (this.r === this.w) {
-            if (p.byteLength >= this.buf.byteLength) {
-                const rr1 = await this.rd.read(p);
+            if (p2.byteLength >= this.buf.byteLength) {
+                const rr1 = await this.rd.read(p2);
                 const nread = rr1 ?? 0;
                 assert(nread >= 0, "negative read");
                 return rr1;
@@ -1304,15 +1304,15 @@ class BufReader {
             assert(rr >= 0, "negative read");
             this.w += rr;
         }
-        const copied = copy(this.buf.subarray(this.r, this.w), p, 0);
+        const copied = copy(this.buf.subarray(this.r, this.w), p2, 0);
         this.r += copied;
         return copied;
     }
-    async readFull(p) {
+    async readFull(p3) {
         let bytesRead = 0;
-        while(bytesRead < p.length){
+        while(bytesRead < p3.length){
             try {
-                const rr = await this.read(p.subarray(bytesRead));
+                const rr = await this.read(p3.subarray(bytesRead));
                 if (rr === null) {
                     if (bytesRead === 0) {
                         return null;
@@ -1322,11 +1322,11 @@ class BufReader {
                 }
                 bytesRead += rr;
             } catch (err) {
-                err.partial = p.subarray(0, bytesRead);
+                err.partial = p3.subarray(0, bytesRead);
                 throw err;
             }
         }
-        return p;
+        return p3;
     }
     async readByte() {
         while(this.r === this.w){
@@ -1386,11 +1386,11 @@ class BufReader {
             more: false
         };
     }
-    async readSlice(delim) {
+    async readSlice(delim1) {
         let s1 = 0;
         let slice;
         while(true){
-            let i = this.buf.subarray(this.r + s1, this.w).indexOf(delim);
+            let i = this.buf.subarray(this.r + s1, this.w).indexOf(delim1);
             if (i >= 0) {
                 i += s1;
                 slice = this.buf.subarray(this.r, this.r + i + 1);
@@ -1462,16 +1462,16 @@ class AbstractBufBase {
     }
 }
 class BufWriter extends AbstractBufBase {
-    static create(writer, size = 4096) {
-        return writer instanceof BufWriter ? writer : new BufWriter(writer, size);
+    static create(writer, size2 = 4096) {
+        return writer instanceof BufWriter ? writer : new BufWriter(writer, size2);
     }
-    constructor(writer1, size2 = 4096){
+    constructor(writer1, size3 = 4096){
         super();
         this.writer = writer1;
-        if (size2 <= 0) {
-            size2 = DEFAULT_BUF_SIZE;
+        if (size3 <= 0) {
+            size3 = DEFAULT_BUF_SIZE;
         }
-        this.buf = new Uint8Array(size2);
+        this.buf = new Uint8Array(size3);
     }
     reset(w) {
         this.err = null;
@@ -1518,21 +1518,21 @@ class BufWriter extends AbstractBufBase {
     }
 }
 class BufWriterSync extends AbstractBufBase {
-    static create(writer, size = 4096) {
-        return writer instanceof BufWriterSync ? writer : new BufWriterSync(writer, size);
+    static create(writer2, size4 = 4096) {
+        return writer2 instanceof BufWriterSync ? writer2 : new BufWriterSync(writer2, size4);
     }
-    constructor(writer2, size3 = 4096){
+    constructor(writer3, size5 = 4096){
         super();
-        this.writer = writer2;
-        if (size3 <= 0) {
-            size3 = DEFAULT_BUF_SIZE;
+        this.writer = writer3;
+        if (size5 <= 0) {
+            size5 = DEFAULT_BUF_SIZE;
         }
-        this.buf = new Uint8Array(size3);
+        this.buf = new Uint8Array(size5);
     }
-    reset(w) {
+    reset(w1) {
         this.err = null;
         this.usedBufferBytes = 0;
-        this.writer = w;
+        this.writer = w1;
     }
     flush() {
         if (this.err !== null) throw this.err;
@@ -1546,47 +1546,47 @@ class BufWriterSync extends AbstractBufBase {
         this.buf = new Uint8Array(this.buf.length);
         this.usedBufferBytes = 0;
     }
-    writeSync(data) {
+    writeSync(data1) {
         if (this.err !== null) throw this.err;
-        if (data.length === 0) return 0;
+        if (data1.length === 0) return 0;
         let totalBytesWritten = 0;
         let numBytesWritten = 0;
-        while(data.byteLength > this.available()){
+        while(data1.byteLength > this.available()){
             if (this.buffered() === 0) {
                 try {
-                    numBytesWritten = this.writer.writeSync(data);
+                    numBytesWritten = this.writer.writeSync(data1);
                 } catch (e) {
                     this.err = e;
                     throw e;
                 }
             } else {
-                numBytesWritten = copy(data, this.buf, this.usedBufferBytes);
+                numBytesWritten = copy(data1, this.buf, this.usedBufferBytes);
                 this.usedBufferBytes += numBytesWritten;
                 this.flush();
             }
             totalBytesWritten += numBytesWritten;
-            data = data.subarray(numBytesWritten);
+            data1 = data1.subarray(numBytesWritten);
         }
-        numBytesWritten = copy(data, this.buf, this.usedBufferBytes);
+        numBytesWritten = copy(data1, this.buf, this.usedBufferBytes);
         this.usedBufferBytes += numBytesWritten;
         totalBytesWritten += numBytesWritten;
         return totalBytesWritten;
     }
 }
 const invalidHeaderCharRegex = /[^\t\x20-\x7e\x80-\xff]/g;
-function str(buf) {
-    if (buf == null) {
+function str(buf1) {
+    if (buf1 == null) {
         return "";
     } else {
-        return new TextDecoder().decode(buf);
+        return new TextDecoder().decode(buf1);
     }
 }
 function charCode(s1) {
     return s1.charCodeAt(0);
 }
 class TextProtoReader {
-    constructor(r){
-        this.r = r;
+    constructor(r2){
+        this.r = r2;
     }
     async readLine() {
         const s1 = await this.readLineSlice();
@@ -1596,16 +1596,16 @@ class TextProtoReader {
     async readMIMEHeader() {
         const m = new Headers();
         let line;
-        let buf = await this.r.peek(1);
-        if (buf === null) {
+        let buf1 = await this.r.peek(1);
+        if (buf1 === null) {
             return null;
-        } else if (buf[0] == charCode(" ") || buf[0] == charCode("\t")) {
+        } else if (buf1[0] == charCode(" ") || buf1[0] == charCode("\t")) {
             line = await this.readLineSlice();
         }
-        buf = await this.r.peek(1);
-        if (buf === null) {
+        buf1 = await this.r.peek(1);
+        if (buf1 === null) {
             throw new Deno.errors.UnexpectedEof();
-        } else if (buf[0] == charCode(" ") || buf[0] == charCode("\t")) {
+        } else if (buf1[0] == charCode(" ") || buf1[0] == charCode("\t")) {
             throw new Deno.errors.InvalidData(`malformed MIME header initial line: ${str(line)}`);
         }
         while(true){
@@ -1634,9 +1634,9 @@ class TextProtoReader {
     async readLineSlice() {
         let line;
         while(true){
-            const r1 = await this.r.readLine();
-            if (r1 === null) return null;
-            const { line: l , more  } = r1;
+            const r3 = await this.r.readLine();
+            if (r3 === null) return null;
+            const { line: l , more  } = r3;
             if (!line && !more) {
                 if (this.skipSpace(l) === 0) {
                     return new Uint8Array(0);
@@ -1651,14 +1651,14 @@ class TextProtoReader {
         return line;
     }
     skipSpace(l) {
-        let n = 0;
+        let n1 = 0;
         for(let i = 0; i < l.length; i++){
             if (l[i] === charCode(" ") || l[i] === charCode("\t")) {
                 continue;
             }
-            n++;
+            n1++;
         }
-        return n;
+        return n1;
     }
 }
 function randomBoundary() {
@@ -1669,20 +1669,20 @@ function randomBoundary() {
     return boundary;
 }
 const encoder = new TextEncoder();
-function matchAfterPrefix(buf, prefix, eof) {
-    if (buf.length === prefix.length) {
+function matchAfterPrefix(buf1, prefix, eof) {
+    if (buf1.length === prefix.length) {
         return eof ? 1 : 0;
     }
-    const c = buf[prefix.length];
+    const c = buf1[prefix.length];
     if (c === " ".charCodeAt(0) || c === "\t".charCodeAt(0) || c === "\r".charCodeAt(0) || c === "\n".charCodeAt(0) || c === "-".charCodeAt(0)) {
         return 1;
     }
     return -1;
 }
-function scanUntilBoundary(buf, dashBoundary, newLineDashBoundary, total, eof) {
+function scanUntilBoundary(buf1, dashBoundary, newLineDashBoundary, total, eof) {
     if (total === 0) {
-        if (startsWith(buf, dashBoundary)) {
-            switch(matchAfterPrefix(buf, dashBoundary, eof)){
+        if (startsWith(buf1, dashBoundary)) {
+            switch(matchAfterPrefix(buf1, dashBoundary, eof)){
                 case -1:
                     return dashBoundary.length;
                 case 0:
@@ -1691,13 +1691,13 @@ function scanUntilBoundary(buf, dashBoundary, newLineDashBoundary, total, eof) {
                     return null;
             }
         }
-        if (startsWith(dashBoundary, buf)) {
+        if (startsWith(dashBoundary, buf1)) {
             return 0;
         }
     }
-    const i = indexOf(buf, newLineDashBoundary);
+    const i = indexOf(buf1, newLineDashBoundary);
     if (i >= 0) {
-        switch(matchAfterPrefix(buf.slice(i), newLineDashBoundary, eof)){
+        switch(matchAfterPrefix(buf1.slice(i), newLineDashBoundary, eof)){
             case -1:
                 return i + newLineDashBoundary.length;
             case 0:
@@ -1706,23 +1706,23 @@ function scanUntilBoundary(buf, dashBoundary, newLineDashBoundary, total, eof) {
                 return i > 0 ? i : null;
         }
     }
-    if (startsWith(newLineDashBoundary, buf)) {
+    if (startsWith(newLineDashBoundary, buf1)) {
         return 0;
     }
-    const j = lastIndexOf(buf, newLineDashBoundary.slice(0, 1));
-    if (j >= 0 && startsWith(newLineDashBoundary, buf.slice(j))) {
+    const j = lastIndexOf(buf1, newLineDashBoundary.slice(0, 1));
+    if (j >= 0 && startsWith(newLineDashBoundary, buf1.slice(j))) {
         return j;
     }
-    return buf.length;
+    return buf1.length;
 }
 class PartReader {
-    constructor(mr, headers2){
+    constructor(mr, headers){
         this.mr = mr;
-        this.headers = headers2;
+        this.headers = headers;
         this.n = 0;
         this.total = 0;
     }
-    async read(p) {
+    async read(p4) {
         const br = this.mr.bufReader;
         let peekLength = 1;
         while(this.n === 0){
@@ -1741,10 +1741,10 @@ class PartReader {
         if (this.n === null) {
             return null;
         }
-        const nread = Math.min(p.length, this.n);
-        const buf = p.subarray(0, nread);
-        const r1 = await br.readFull(buf);
-        assert(r1 === buf);
+        const nread = Math.min(p4.length, this.n);
+        const buf1 = p4.subarray(0, nread);
+        const r3 = await br.readFull(buf1);
+        assert(r3 === buf1);
         this.n -= nread;
         this.total += nread;
         return nread;
@@ -1778,9 +1778,9 @@ class PartReader {
         return this.getContentDispositionParams()["filename"];
     }
     get formName() {
-        const p = this.getContentDispositionParams();
+        const p5 = this.getContentDispositionParams();
         if (this.contentDisposition === "form-data") {
-            return p["name"];
+            return p5["name"];
         }
         return "";
     }
@@ -1810,32 +1810,32 @@ class MultipartReader {
         const fileMap = new Map();
         const valueMap = new Map();
         let maxValueBytes = maxMemory + (10 << 20);
-        const buf = new Deno.Buffer(new Uint8Array(maxValueBytes));
+        const buf1 = new Deno.Buffer(new Uint8Array(maxValueBytes));
         for(;;){
-            const p = await this.nextPart();
-            if (p === null) {
+            const p5 = await this.nextPart();
+            if (p5 === null) {
                 break;
             }
-            if (p.formName === "") {
+            if (p5.formName === "") {
                 continue;
             }
-            buf.reset();
-            if (!p.fileName) {
-                const n = await copyN(p, buf, maxValueBytes);
-                maxValueBytes -= n;
+            buf1.reset();
+            if (!p5.fileName) {
+                const n1 = await copyN(p5, buf1, maxValueBytes);
+                maxValueBytes -= n1;
                 if (maxValueBytes < 0) {
                     throw new RangeError("message too large");
                 }
-                const value = new TextDecoder().decode(buf.bytes());
-                valueMap.set(p.formName, value);
+                const value = new TextDecoder().decode(buf1.bytes());
+                valueMap.set(p5.formName, value);
                 continue;
             }
             let formFile;
-            const n = await copyN(p, buf, maxValueBytes);
-            const contentType = p.headers.get("content-type");
+            const n1 = await copyN(p5, buf1, maxValueBytes);
+            const contentType = p5.headers.get("content-type");
             assert(contentType != null, "content-type must be set");
-            if (n > maxMemory) {
-                const ext = extname2(p.fileName);
+            if (n1 > maxMemory) {
+                const ext = extname2(p5.fileName);
                 const filepath = await Deno.makeTempFile({
                     dir: ".",
                     prefix: "multipart-",
@@ -1845,13 +1845,13 @@ class MultipartReader {
                     write: true
                 });
                 try {
-                    const size4 = await Deno.copy(new MultiReader(buf, p), file);
+                    const size6 = await Deno.copy(new MultiReader(buf1, p5), file);
                     file.close();
                     formFile = {
-                        filename: p.fileName,
+                        filename: p5.fileName,
                         type: contentType,
                         tempfile: filepath,
-                        size: size4
+                        size: size6
                     };
                 } catch (e) {
                     await Deno.remove(filepath);
@@ -1859,27 +1859,27 @@ class MultipartReader {
                 }
             } else {
                 formFile = {
-                    filename: p.fileName,
+                    filename: p5.fileName,
                     type: contentType,
-                    content: buf.bytes(),
-                    size: buf.length
+                    content: buf1.bytes(),
+                    size: buf1.length
                 };
-                maxMemory -= n;
-                maxValueBytes -= n;
+                maxMemory -= n1;
+                maxValueBytes -= n1;
             }
             if (formFile) {
-                const mapVal = fileMap.get(p.formName);
+                const mapVal = fileMap.get(p5.formName);
                 if (mapVal !== undefined) {
                     if (Array.isArray(mapVal)) {
                         mapVal.push(formFile);
                     } else {
-                        fileMap.set(p.formName, [
+                        fileMap.set(p5.formName, [
                             mapVal,
                             formFile
                         ]);
                     }
                 } else {
-                    fileMap.set(p.formName, formFile);
+                    fileMap.set(p5.formName, formFile);
                 }
             }
         }
@@ -1900,8 +1900,8 @@ class MultipartReader {
             }
             if (this.isBoundaryDelimiterLine(line)) {
                 this.partsRead++;
-                const r1 = new TextProtoReader(this.bufReader);
-                const headers1 = await r1.readMIMEHeader();
+                const r3 = new TextProtoReader(this.bufReader);
+                const headers1 = await r3.readMIMEHeader();
                 if (headers1 === null) {
                     throw new Deno.errors.UnexpectedEof();
                 }
@@ -1932,11 +1932,11 @@ class MultipartReader {
         const rest = line.slice(this.dashBoundaryDash.length, line.length);
         return rest.length === 0 || equals(skipLWSPChar(rest), this.newLine);
     }
-    isBoundaryDelimiterLine(line) {
-        if (!startsWith(line, this.dashBoundary)) {
+    isBoundaryDelimiterLine(line1) {
+        if (!startsWith(line1, this.dashBoundary)) {
             return false;
         }
-        const rest = line.slice(this.dashBoundary.length);
+        const rest = line1.slice(this.dashBoundary.length);
         return equals(skipLWSPChar(rest), this.newLine);
     }
 }
@@ -1977,28 +1977,28 @@ function multipartFormData(fileMap, valueMap) {
     };
 }
 class PartWriter {
-    constructor(writer3, boundary1, headers1, isFirstBoundary){
-        this.writer = writer3;
+    constructor(writer4, boundary1, headers1, isFirstBoundary){
+        this.writer = writer4;
         this.boundary = boundary1;
         this.headers = headers1;
         this.closed = false;
         this.headersWritten = false;
-        let buf = "";
+        let buf1 = "";
         if (isFirstBoundary) {
-            buf += `--${boundary1}\r\n`;
+            buf1 += `--${boundary1}\r\n`;
         } else {
-            buf += `\r\n--${boundary1}\r\n`;
+            buf1 += `\r\n--${boundary1}\r\n`;
         }
-        for (const [key, value1] of headers1.entries()){
-            buf += `${key}: ${value1}\r\n`;
+        for (const [key, value] of headers1.entries()){
+            buf1 += `${key}: ${value}\r\n`;
         }
-        buf += `\r\n`;
-        this.partHeader = buf;
+        buf1 += `\r\n`;
+        this.partHeader = buf1;
     }
     close() {
         this.closed = true;
     }
-    async write(p) {
+    async write(p5) {
         if (this.closed) {
             throw new Error("part is closed");
         }
@@ -2006,7 +2006,7 @@ class PartWriter {
             await this.writer.write(encoder.encode(this.partHeader));
             this.headersWritten = true;
         }
-        return this.writer.write(p);
+        return this.writer.write(p5);
     }
 }
 function checkBoundary(b) {
@@ -2026,27 +2026,27 @@ class MultipartWriter {
     get boundary() {
         return this._boundary;
     }
-    constructor(writer4, boundary2){
-        this.writer = writer4;
+    constructor(writer5, boundary2){
+        this.writer = writer5;
         this.isClosed = false;
         if (boundary2 !== void 0) {
             this._boundary = checkBoundary(boundary2);
         } else {
             this._boundary = randomBoundary();
         }
-        this.bufWriter = new BufWriter(writer4);
+        this.bufWriter = new BufWriter(writer5);
     }
     formDataContentType() {
         return `multipart/form-data; boundary=${this.boundary}`;
     }
-    createPart(headers) {
+    createPart(headers2) {
         if (this.isClosed) {
             throw new Error("multipart: writer is closed");
         }
         if (this.lastPart) {
             this.lastPart.close();
         }
-        const part = new PartWriter(this.writer, this.boundary, headers, !this.lastPart);
+        const part = new PartWriter(this.writer, this.boundary, headers2, !this.lastPart);
         this.lastPart = part;
         return part;
     }
@@ -2056,18 +2056,18 @@ class MultipartWriter {
         h.set("Content-Type", "application/octet-stream");
         return this.createPart(h);
     }
-    createFormField(field) {
+    createFormField(field1) {
         const h = new Headers();
-        h.set("Content-Disposition", `form-data; name="${field}"`);
+        h.set("Content-Disposition", `form-data; name="${field1}"`);
         h.set("Content-Type", "application/octet-stream");
         return this.createPart(h);
     }
-    async writeField(field, value) {
-        const f = await this.createFormField(field);
-        await f.write(encoder.encode(value));
+    async writeField(field2, value1) {
+        const f = await this.createFormField(field2);
+        await f.write(encoder.encode(value1));
     }
-    async writeFile(field, filename, file) {
-        const f = await this.createFormFile(field, filename);
+    async writeFile(field3, filename1, file) {
+        const f = await this.createFormFile(field3, filename1);
         await Deno.copy(file, f);
     }
     flush() {

--- a/bundler/tests/fixture/deno-9620/case1/output/entry.ts
+++ b/bundler/tests/fixture/deno-9620/case1/output/entry.ts
@@ -146,14 +146,14 @@ class LimitedReader {
         this.reader = reader;
         this.limit = limit;
     }
-    async read(p) {
+    async read(p1) {
         if (this.limit <= 0) {
             return null;
         }
-        if (p.length > this.limit) {
-            p = p.subarray(0, this.limit);
+        if (p1.length > this.limit) {
+            p1 = p1.subarray(0, this.limit);
         }
-        const n = await this.reader.read(p);
+        const n = await this.reader.read(p1);
         if (n == null) {
             return null;
         }
@@ -1250,14 +1250,14 @@ class BufReader {
     static create(r, size = DEFAULT_BUF_SIZE) {
         return r instanceof BufReader ? r : new BufReader(r, size);
     }
-    constructor(rd1, size1 = DEFAULT_BUF_SIZE){
+    constructor(rd, size1 = DEFAULT_BUF_SIZE){
         this.r = 0;
         this.w = 0;
         this.eof = false;
         if (size1 < MIN_BUF_SIZE) {
             size1 = MIN_BUF_SIZE;
         }
-        this._reset(new Uint8Array(size1), rd1);
+        this._reset(new Uint8Array(size1), rd);
     }
     size() {
         return this.buf.byteLength;
@@ -1288,20 +1288,20 @@ class BufReader {
         }
         throw new Error(`No progress after ${MAX_CONSECUTIVE_EMPTY_READS} read() calls`);
     }
-    reset(r) {
-        this._reset(this.buf, r);
+    reset(r1) {
+        this._reset(this.buf, r1);
     }
-    _reset(buf, rd) {
+    _reset(buf, rd1) {
         this.buf = buf;
-        this.rd = rd;
+        this.rd = rd1;
         this.eof = false;
     }
-    async read(p) {
-        let rr = p.byteLength;
-        if (p.byteLength === 0) return rr;
+    async read(p2) {
+        let rr = p2.byteLength;
+        if (p2.byteLength === 0) return rr;
         if (this.r === this.w) {
-            if (p.byteLength >= this.buf.byteLength) {
-                const rr1 = await this.rd.read(p);
+            if (p2.byteLength >= this.buf.byteLength) {
+                const rr1 = await this.rd.read(p2);
                 const nread = rr1 ?? 0;
                 assert(nread >= 0, "negative read");
                 return rr1;
@@ -1313,15 +1313,15 @@ class BufReader {
             assert(rr >= 0, "negative read");
             this.w += rr;
         }
-        const copied = copy(this.buf.subarray(this.r, this.w), p, 0);
+        const copied = copy(this.buf.subarray(this.r, this.w), p2, 0);
         this.r += copied;
         return copied;
     }
-    async readFull(p) {
+    async readFull(p3) {
         let bytesRead = 0;
-        while(bytesRead < p.length){
+        while(bytesRead < p3.length){
             try {
-                const rr = await this.read(p.subarray(bytesRead));
+                const rr = await this.read(p3.subarray(bytesRead));
                 if (rr === null) {
                     if (bytesRead === 0) {
                         return null;
@@ -1331,11 +1331,11 @@ class BufReader {
                 }
                 bytesRead += rr;
             } catch (err) {
-                err.partial = p.subarray(0, bytesRead);
+                err.partial = p3.subarray(0, bytesRead);
                 throw err;
             }
         }
-        return p;
+        return p3;
     }
     async readByte() {
         while(this.r === this.w){
@@ -1395,11 +1395,11 @@ class BufReader {
             more: false
         };
     }
-    async readSlice(delim) {
+    async readSlice(delim1) {
         let s1 = 0;
         let slice;
         while(true){
-            let i = this.buf.subarray(this.r + s1, this.w).indexOf(delim);
+            let i = this.buf.subarray(this.r + s1, this.w).indexOf(delim1);
             if (i >= 0) {
                 i += s1;
                 slice = this.buf.subarray(this.r, this.r + i + 1);
@@ -1471,16 +1471,16 @@ class AbstractBufBase {
     }
 }
 class BufWriter extends AbstractBufBase {
-    static create(writer, size = DEFAULT_BUF_SIZE) {
-        return writer instanceof BufWriter ? writer : new BufWriter(writer, size);
+    static create(writer, size2 = DEFAULT_BUF_SIZE) {
+        return writer instanceof BufWriter ? writer : new BufWriter(writer, size2);
     }
-    constructor(writer1, size2 = DEFAULT_BUF_SIZE){
+    constructor(writer1, size3 = DEFAULT_BUF_SIZE){
         super();
         this.writer = writer1;
-        if (size2 <= 0) {
-            size2 = DEFAULT_BUF_SIZE;
+        if (size3 <= 0) {
+            size3 = DEFAULT_BUF_SIZE;
         }
-        this.buf = new Uint8Array(size2);
+        this.buf = new Uint8Array(size3);
     }
     reset(w) {
         this.err = null;
@@ -1527,21 +1527,21 @@ class BufWriter extends AbstractBufBase {
     }
 }
 class BufWriterSync extends AbstractBufBase {
-    static create(writer, size = DEFAULT_BUF_SIZE) {
-        return writer instanceof BufWriterSync ? writer : new BufWriterSync(writer, size);
+    static create(writer2, size4 = DEFAULT_BUF_SIZE) {
+        return writer2 instanceof BufWriterSync ? writer2 : new BufWriterSync(writer2, size4);
     }
-    constructor(writer2, size3 = DEFAULT_BUF_SIZE){
+    constructor(writer3, size5 = DEFAULT_BUF_SIZE){
         super();
-        this.writer = writer2;
-        if (size3 <= 0) {
-            size3 = DEFAULT_BUF_SIZE;
+        this.writer = writer3;
+        if (size5 <= 0) {
+            size5 = DEFAULT_BUF_SIZE;
         }
-        this.buf = new Uint8Array(size3);
+        this.buf = new Uint8Array(size5);
     }
-    reset(w) {
+    reset(w1) {
         this.err = null;
         this.usedBufferBytes = 0;
-        this.writer = w;
+        this.writer = w1;
     }
     flush() {
         if (this.err !== null) throw this.err;
@@ -1555,47 +1555,47 @@ class BufWriterSync extends AbstractBufBase {
         this.buf = new Uint8Array(this.buf.length);
         this.usedBufferBytes = 0;
     }
-    writeSync(data) {
+    writeSync(data1) {
         if (this.err !== null) throw this.err;
-        if (data.length === 0) return 0;
+        if (data1.length === 0) return 0;
         let totalBytesWritten = 0;
         let numBytesWritten = 0;
-        while(data.byteLength > this.available()){
+        while(data1.byteLength > this.available()){
             if (this.buffered() === 0) {
                 try {
-                    numBytesWritten = this.writer.writeSync(data);
+                    numBytesWritten = this.writer.writeSync(data1);
                 } catch (e) {
                     this.err = e;
                     throw e;
                 }
             } else {
-                numBytesWritten = copy(data, this.buf, this.usedBufferBytes);
+                numBytesWritten = copy(data1, this.buf, this.usedBufferBytes);
                 this.usedBufferBytes += numBytesWritten;
                 this.flush();
             }
             totalBytesWritten += numBytesWritten;
-            data = data.subarray(numBytesWritten);
+            data1 = data1.subarray(numBytesWritten);
         }
-        numBytesWritten = copy(data, this.buf, this.usedBufferBytes);
+        numBytesWritten = copy(data1, this.buf, this.usedBufferBytes);
         this.usedBufferBytes += numBytesWritten;
         totalBytesWritten += numBytesWritten;
         return totalBytesWritten;
     }
 }
 const invalidHeaderCharRegex = /[^\t\x20-\x7e\x80-\xff]/g;
-function str(buf) {
-    if (buf == null) {
+function str(buf1) {
+    if (buf1 == null) {
         return "";
     } else {
-        return new TextDecoder().decode(buf);
+        return new TextDecoder().decode(buf1);
     }
 }
 function charCode(s1) {
     return s1.charCodeAt(0);
 }
 class TextProtoReader {
-    constructor(r){
-        this.r = r;
+    constructor(r2){
+        this.r = r2;
     }
     async readLine() {
         const s1 = await this.readLineSlice();
@@ -1605,16 +1605,16 @@ class TextProtoReader {
     async readMIMEHeader() {
         const m = new Headers();
         let line;
-        let buf = await this.r.peek(1);
-        if (buf === null) {
+        let buf1 = await this.r.peek(1);
+        if (buf1 === null) {
             return null;
-        } else if (buf[0] == charCode(" ") || buf[0] == charCode("\t")) {
+        } else if (buf1[0] == charCode(" ") || buf1[0] == charCode("\t")) {
             line = await this.readLineSlice();
         }
-        buf = await this.r.peek(1);
-        if (buf === null) {
+        buf1 = await this.r.peek(1);
+        if (buf1 === null) {
             throw new Deno.errors.UnexpectedEof();
-        } else if (buf[0] == charCode(" ") || buf[0] == charCode("\t")) {
+        } else if (buf1[0] == charCode(" ") || buf1[0] == charCode("\t")) {
             throw new Deno.errors.InvalidData(`malformed MIME header initial line: ${str(line)}`);
         }
         while(true){
@@ -1643,9 +1643,9 @@ class TextProtoReader {
     async readLineSlice() {
         let line;
         while(true){
-            const r1 = await this.r.readLine();
-            if (r1 === null) return null;
-            const { line: l , more  } = r1;
+            const r3 = await this.r.readLine();
+            if (r3 === null) return null;
+            const { line: l , more  } = r3;
             if (!line && !more) {
                 if (this.skipSpace(l) === 0) {
                     return new Uint8Array(0);
@@ -1660,14 +1660,14 @@ class TextProtoReader {
         return line;
     }
     skipSpace(l) {
-        let n = 0;
+        let n1 = 0;
         for(let i = 0; i < l.length; i++){
             if (l[i] === charCode(" ") || l[i] === charCode("\t")) {
                 continue;
             }
-            n++;
+            n1++;
         }
-        return n;
+        return n1;
     }
 }
 function randomBoundary() {
@@ -1678,20 +1678,20 @@ function randomBoundary() {
     return boundary;
 }
 const encoder = new TextEncoder();
-function matchAfterPrefix(buf, prefix, eof) {
-    if (buf.length === prefix.length) {
+function matchAfterPrefix(buf1, prefix, eof) {
+    if (buf1.length === prefix.length) {
         return eof ? 1 : 0;
     }
-    const c = buf[prefix.length];
+    const c = buf1[prefix.length];
     if (c === " ".charCodeAt(0) || c === "\t".charCodeAt(0) || c === "\r".charCodeAt(0) || c === "\n".charCodeAt(0) || c === "-".charCodeAt(0)) {
         return 1;
     }
     return -1;
 }
-function scanUntilBoundary(buf, dashBoundary, newLineDashBoundary, total, eof) {
+function scanUntilBoundary(buf1, dashBoundary, newLineDashBoundary, total, eof) {
     if (total === 0) {
-        if (startsWith(buf, dashBoundary)) {
-            switch(matchAfterPrefix(buf, dashBoundary, eof)){
+        if (startsWith(buf1, dashBoundary)) {
+            switch(matchAfterPrefix(buf1, dashBoundary, eof)){
                 case -1:
                     return dashBoundary.length;
                 case 0:
@@ -1700,13 +1700,13 @@ function scanUntilBoundary(buf, dashBoundary, newLineDashBoundary, total, eof) {
                     return null;
             }
         }
-        if (startsWith(dashBoundary, buf)) {
+        if (startsWith(dashBoundary, buf1)) {
             return 0;
         }
     }
-    const i = indexOf(buf, newLineDashBoundary);
+    const i = indexOf(buf1, newLineDashBoundary);
     if (i >= 0) {
-        switch(matchAfterPrefix(buf.slice(i), newLineDashBoundary, eof)){
+        switch(matchAfterPrefix(buf1.slice(i), newLineDashBoundary, eof)){
             case -1:
                 return i + newLineDashBoundary.length;
             case 0:
@@ -1715,23 +1715,23 @@ function scanUntilBoundary(buf, dashBoundary, newLineDashBoundary, total, eof) {
                 return i > 0 ? i : null;
         }
     }
-    if (startsWith(newLineDashBoundary, buf)) {
+    if (startsWith(newLineDashBoundary, buf1)) {
         return 0;
     }
-    const j = lastIndexOf(buf, newLineDashBoundary.slice(0, 1));
-    if (j >= 0 && startsWith(newLineDashBoundary, buf.slice(j))) {
+    const j = lastIndexOf(buf1, newLineDashBoundary.slice(0, 1));
+    if (j >= 0 && startsWith(newLineDashBoundary, buf1.slice(j))) {
         return j;
     }
-    return buf.length;
+    return buf1.length;
 }
 class PartReader {
-    constructor(mr, headers2){
+    constructor(mr, headers){
         this.mr = mr;
-        this.headers = headers2;
+        this.headers = headers;
         this.n = 0;
         this.total = 0;
     }
-    async read(p) {
+    async read(p4) {
         const br = this.mr.bufReader;
         let peekLength = 1;
         while(this.n === 0){
@@ -1750,10 +1750,10 @@ class PartReader {
         if (this.n === null) {
             return null;
         }
-        const nread = Math.min(p.length, this.n);
-        const buf = p.subarray(0, nread);
-        const r1 = await br.readFull(buf);
-        assert(r1 === buf);
+        const nread = Math.min(p4.length, this.n);
+        const buf1 = p4.subarray(0, nread);
+        const r3 = await br.readFull(buf1);
+        assert(r3 === buf1);
         this.n -= nread;
         this.total += nread;
         return nread;
@@ -1787,9 +1787,9 @@ class PartReader {
         return this.getContentDispositionParams()["filename"];
     }
     get formName() {
-        const p = this.getContentDispositionParams();
+        const p5 = this.getContentDispositionParams();
         if (this.contentDisposition === "form-data") {
-            return p["name"];
+            return p5["name"];
         }
         return "";
     }
@@ -1819,32 +1819,32 @@ class MultipartReader {
         const fileMap = new Map();
         const valueMap = new Map();
         let maxValueBytes = maxMemory + (10 << 20);
-        const buf = new Deno.Buffer(new Uint8Array(maxValueBytes));
+        const buf1 = new Deno.Buffer(new Uint8Array(maxValueBytes));
         for(;;){
-            const p = await this.nextPart();
-            if (p === null) {
+            const p5 = await this.nextPart();
+            if (p5 === null) {
                 break;
             }
-            if (p.formName === "") {
+            if (p5.formName === "") {
                 continue;
             }
-            buf.reset();
-            if (!p.fileName) {
-                const n = await copyN(p, buf, maxValueBytes);
-                maxValueBytes -= n;
+            buf1.reset();
+            if (!p5.fileName) {
+                const n1 = await copyN(p5, buf1, maxValueBytes);
+                maxValueBytes -= n1;
                 if (maxValueBytes < 0) {
                     throw new RangeError("message too large");
                 }
-                const value = new TextDecoder().decode(buf.bytes());
-                valueMap.set(p.formName, value);
+                const value = new TextDecoder().decode(buf1.bytes());
+                valueMap.set(p5.formName, value);
                 continue;
             }
             let formFile;
-            const n = await copyN(p, buf, maxValueBytes);
-            const contentType = p.headers.get("content-type");
+            const n1 = await copyN(p5, buf1, maxValueBytes);
+            const contentType = p5.headers.get("content-type");
             assert(contentType != null, "content-type must be set");
-            if (n > maxMemory) {
-                const ext = extname2(p.fileName);
+            if (n1 > maxMemory) {
+                const ext = extname2(p5.fileName);
                 const filepath = await Deno.makeTempFile({
                     dir: ".",
                     prefix: "multipart-",
@@ -1854,13 +1854,13 @@ class MultipartReader {
                     write: true
                 });
                 try {
-                    const size4 = await Deno.copy(new MultiReader(buf, p), file);
+                    const size6 = await Deno.copy(new MultiReader(buf1, p5), file);
                     file.close();
                     formFile = {
-                        filename: p.fileName,
+                        filename: p5.fileName,
                         type: contentType,
                         tempfile: filepath,
-                        size: size4
+                        size: size6
                     };
                 } catch (e) {
                     await Deno.remove(filepath);
@@ -1868,27 +1868,27 @@ class MultipartReader {
                 }
             } else {
                 formFile = {
-                    filename: p.fileName,
+                    filename: p5.fileName,
                     type: contentType,
-                    content: buf.bytes(),
-                    size: buf.length
+                    content: buf1.bytes(),
+                    size: buf1.length
                 };
-                maxMemory -= n;
-                maxValueBytes -= n;
+                maxMemory -= n1;
+                maxValueBytes -= n1;
             }
             if (formFile) {
-                const mapVal = fileMap.get(p.formName);
+                const mapVal = fileMap.get(p5.formName);
                 if (mapVal !== undefined) {
                     if (Array.isArray(mapVal)) {
                         mapVal.push(formFile);
                     } else {
-                        fileMap.set(p.formName, [
+                        fileMap.set(p5.formName, [
                             mapVal,
                             formFile
                         ]);
                     }
                 } else {
-                    fileMap.set(p.formName, formFile);
+                    fileMap.set(p5.formName, formFile);
                 }
             }
         }
@@ -1909,8 +1909,8 @@ class MultipartReader {
             }
             if (this.isBoundaryDelimiterLine(line)) {
                 this.partsRead++;
-                const r1 = new TextProtoReader(this.bufReader);
-                const headers1 = await r1.readMIMEHeader();
+                const r3 = new TextProtoReader(this.bufReader);
+                const headers1 = await r3.readMIMEHeader();
                 if (headers1 === null) {
                     throw new Deno.errors.UnexpectedEof();
                 }
@@ -1941,11 +1941,11 @@ class MultipartReader {
         const rest = line.slice(this.dashBoundaryDash.length, line.length);
         return rest.length === 0 || equals(skipLWSPChar(rest), this.newLine);
     }
-    isBoundaryDelimiterLine(line) {
-        if (!startsWith(line, this.dashBoundary)) {
+    isBoundaryDelimiterLine(line1) {
+        if (!startsWith(line1, this.dashBoundary)) {
             return false;
         }
-        const rest = line.slice(this.dashBoundary.length);
+        const rest = line1.slice(this.dashBoundary.length);
         return equals(skipLWSPChar(rest), this.newLine);
     }
 }
@@ -1986,28 +1986,28 @@ function multipartFormData(fileMap, valueMap) {
     };
 }
 class PartWriter {
-    constructor(writer3, boundary1, headers1, isFirstBoundary){
-        this.writer = writer3;
+    constructor(writer4, boundary1, headers1, isFirstBoundary){
+        this.writer = writer4;
         this.boundary = boundary1;
         this.headers = headers1;
         this.closed = false;
         this.headersWritten = false;
-        let buf = "";
+        let buf1 = "";
         if (isFirstBoundary) {
-            buf += `--${boundary1}\r\n`;
+            buf1 += `--${boundary1}\r\n`;
         } else {
-            buf += `\r\n--${boundary1}\r\n`;
+            buf1 += `\r\n--${boundary1}\r\n`;
         }
-        for (const [key, value1] of headers1.entries()){
-            buf += `${key}: ${value1}\r\n`;
+        for (const [key, value] of headers1.entries()){
+            buf1 += `${key}: ${value}\r\n`;
         }
-        buf += `\r\n`;
-        this.partHeader = buf;
+        buf1 += `\r\n`;
+        this.partHeader = buf1;
     }
     close() {
         this.closed = true;
     }
-    async write(p) {
+    async write(p5) {
         if (this.closed) {
             throw new Error("part is closed");
         }
@@ -2015,7 +2015,7 @@ class PartWriter {
             await this.writer.write(encoder.encode(this.partHeader));
             this.headersWritten = true;
         }
-        return this.writer.write(p);
+        return this.writer.write(p5);
     }
 }
 function checkBoundary(b) {
@@ -2035,27 +2035,27 @@ class MultipartWriter {
     get boundary() {
         return this._boundary;
     }
-    constructor(writer4, boundary2){
-        this.writer = writer4;
+    constructor(writer5, boundary2){
+        this.writer = writer5;
         this.isClosed = false;
         if (boundary2 !== void 0) {
             this._boundary = checkBoundary(boundary2);
         } else {
             this._boundary = randomBoundary();
         }
-        this.bufWriter = new BufWriter(writer4);
+        this.bufWriter = new BufWriter(writer5);
     }
     formDataContentType() {
         return `multipart/form-data; boundary=${this.boundary}`;
     }
-    createPart(headers) {
+    createPart(headers2) {
         if (this.isClosed) {
             throw new Error("multipart: writer is closed");
         }
         if (this.lastPart) {
             this.lastPart.close();
         }
-        const part = new PartWriter(this.writer, this.boundary, headers, !this.lastPart);
+        const part = new PartWriter(this.writer, this.boundary, headers2, !this.lastPart);
         this.lastPart = part;
         return part;
     }
@@ -2065,18 +2065,18 @@ class MultipartWriter {
         h.set("Content-Type", "application/octet-stream");
         return this.createPart(h);
     }
-    createFormField(field) {
+    createFormField(field1) {
         const h = new Headers();
-        h.set("Content-Disposition", `form-data; name="${field}"`);
+        h.set("Content-Disposition", `form-data; name="${field1}"`);
         h.set("Content-Type", "application/octet-stream");
         return this.createPart(h);
     }
-    async writeField(field, value) {
-        const f = await this.createFormField(field);
-        await f.write(encoder.encode(value));
+    async writeField(field2, value1) {
+        const f = await this.createFormField(field2);
+        await f.write(encoder.encode(value1));
     }
-    async writeFile(field, filename, file) {
-        const f = await this.createFormFile(field, filename);
+    async writeFile(field3, filename1, file) {
+        const f = await this.createFormFile(field3, filename1);
         await Deno.copy(file, f);
     }
     flush() {

--- a/ecmascript/transforms/base/src/hygiene/mod.rs
+++ b/ecmascript/transforms/base/src/hygiene/mod.rs
@@ -586,9 +586,8 @@ impl<'a> VisitMut for Hygiene<'a> {
         let old = self.ident_type;
         self.ident_type = IdentType::Binding;
         n.ident.visit_mut_with(self);
-        self.ident_type = old;
-
         n.class.visit_mut_with(self);
+        self.ident_type = old;
     }
 
     fn visit_mut_setter_prop(&mut self, f: &mut SetterProp) {

--- a/ecmascript/transforms/compat/tests/es2015_destructuring.rs
+++ b/ecmascript/transforms/compat/tests/es2015_destructuring.rs
@@ -45,6 +45,70 @@ test!(
 
 test!(
     syntax(),
+    |_| chain!(
+        spread(spread::Config {
+            ..Default::default()
+        }),
+        parameters(),
+        destructuring(Default::default()),
+        block_scoping(),
+        object_rest_spread(),
+    ),
+    issue_1948,
+    "
+    const fn2 = (arg1, {opt1, opt2}, arg2, {opt3, opt4}, ...arg3) => {
+        console.log(arg1, opt1, opt2, arg2, opt3, opt4, arg3);
+    };
+
+    function fn3(arg1, {opt1, opt2}, arg2, {opt3, opt4}, ...arg3) {
+        console.log(arg1, opt1, opt2, arg2, opt3, opt4, arg3);
+    };
+
+    class cls {
+        fn4(arg1, {opt1, opt2}, arg2, {opt3, opt4}, ...arg3) {
+            console.log(arg1, opt1, opt2, arg2, opt3, opt4, arg3);
+        }
+
+        fn5(arg1, arg2) {
+            console.log(arg1, arg2);
+        }
+    }",
+    "
+    var fn2 = function(arg1, param, arg2, param1) {
+        var opt1 = param.opt1, opt2 = param.opt2, opt3 = param1.opt3, opt4 = param1.opt4;
+        for(var _len = arguments.length, arg3 = new Array(_len > 4 ? _len - 4 : 0), _key = 4; _key \
+     < _len; _key++){
+            arg3[_key - 4] = arguments[_key];
+        }
+        console.log(arg1, opt1, opt2, arg2, opt3, opt4, arg3);
+    };
+    function fn3(arg1, param, arg2, param1) {
+        var opt1 = param.opt1, opt2 = param.opt2, opt3 = param1.opt3, opt4 = param1.opt4;
+        for(var _len = arguments.length, arg3 = new Array(_len > 4 ? _len - 4 : 0), _key = 4; _key \
+     < _len; _key++){
+            arg3[_key - 4] = arguments[_key];
+        }
+        console.log(arg1, opt1, opt2, arg2, opt3, opt4, arg3);
+    }
+    ;
+    class cls {
+        fn4(arg1, param, arg2, param1) {
+            var opt1 = param.opt1, opt2 = param.opt2, opt3 = param1.opt3, opt4 = param1.opt4;
+            for(var _len = arguments.length, arg3 = new Array(_len > 4 ? _len - 4 : 0), _key = 4; \
+     _key < _len; _key++){
+                arg3[_key - 4] = arguments[_key];
+            }
+            console.log(arg1, opt1, opt2, arg2, opt3, opt4, arg3);
+        }
+        fn5(arg1, arg2) {
+            console.log(arg1, arg2);
+        }
+    }
+    "
+);
+
+test!(
+    syntax(),
     |_| tr(),
     issue_260_01,
     "[code = 1] = []",
@@ -334,7 +398,7 @@ test!(
     let w;
     let e;
     var ref;
-    if (true)  ref = [1, 2, 3].map(()=>123), q = ref[0], w = ref[1], e = ref[2], ref;    
+    if (true)  ref = [1, 2, 3].map(()=>123), q = ref[0], w = ref[1], e = ref[2], ref;
 })();"#
 );
 
@@ -993,7 +1057,7 @@ test!(
     var [[a, b]] = [[1, 2]];
     var [a, b, ...c] = [1, 2, 3, 4];
     var [[a, b, ...c]] = [[1, 2, 3, 4]];
-    
+
     var [a, b] = [1, 2, 3];
     var [[a, b]] = [[1, 2, 3]];
     var [a, b] = [a, b];
@@ -1006,7 +1070,7 @@ test!(
     [a, b] = [1, 2];
     [a, b] = [, 2];
     ; // Avoid completion record special case
-    
+
     "#,
     r#"
     var a = 1,
@@ -1030,8 +1094,8 @@ test!(
         b = ref2[1];
     var ref3;
     ref3 = [a[1], a[0]], a[0] = ref3[0], a[1] = ref3[1], ref3;
-    
-    
+
+
     var ref4 = _slicedToArray(_toConsumableArray(foo).concat([bar]), 2), a = ref4[0], b = ref4[1];
     // TODO: var ref4 = _toConsumableArray(foo).concat([bar]), a = ref4[0], b = ref4[1];
 

--- a/spack/tests/pass/deno-001/full/output/entry.js
+++ b/spack/tests/pass/deno-001/full/output/entry.js
@@ -44,14 +44,14 @@ class BufReader {
     /** return new BufReader unless r is BufReader */ static create(r, size = DEFAULT_BUF_SIZE) {
         return r instanceof BufReader ? r : new BufReader(r, size);
     }
-    constructor(rd1, size1 = DEFAULT_BUF_SIZE){
+    constructor(rd, size1 = DEFAULT_BUF_SIZE){
         this.r // buf read position.
          = 0;
         this.w // buf write position.
          = 0;
         this.eof = false;
         if (size1 < MIN_BUF_SIZE) size1 = MIN_BUF_SIZE;
-        this._reset(new Uint8Array(size1), rd1);
+        this._reset(new Uint8Array(size1), rd);
     }
     /** Returns the size of the underlying buffer in bytes. */ size() {
         return this.buf.byteLength;
@@ -83,12 +83,12 @@ class BufReader {
     }
     /** Discards any buffered data, resets all state, and switches
    * the buffered reader to read from r.
-   */ reset(r) {
-        this._reset(this.buf, r);
+   */ reset(r1) {
+        this._reset(this.buf, r1);
     }
-    _reset(buf, rd) {
+    _reset(buf, rd1) {
         this.buf = buf;
-        this.rd = rd;
+        this.rd = rd1;
         this.eof = false;
     // this.lastByte = -1;
     // this.lastCharSize = -1;
@@ -143,20 +143,20 @@ class BufReader {
    * buffer that has been successfully filled with data.
    *
    * Ported from https://golang.org/pkg/io/#ReadFull
-   */ async readFull(p) {
+   */ async readFull(p1) {
         let bytesRead = 0;
-        while(bytesRead < p.length)try {
-            const rr = await this.read(p.subarray(bytesRead));
+        while(bytesRead < p1.length)try {
+            const rr = await this.read(p1.subarray(bytesRead));
             if (rr === null) {
                 if (bytesRead === 0) return null;
                 else throw new PartialReadError();
             }
             bytesRead += rr;
         } catch (err) {
-            err.partial = p.subarray(0, bytesRead);
+            err.partial = p1.subarray(0, bytesRead);
             throw err;
         }
-        return p;
+        return p1;
     }
     /** Returns the next byte [0, 255] or `null`. */ async readByte() {
         while(this.r === this.w){
@@ -256,12 +256,12 @@ class BufReader {
    *
    * Because the data returned from `readSlice()` will be overwritten by the
    * next I/O operation, most clients should use `readString()` instead.
-   */ async readSlice(delim) {
+   */ async readSlice(delim1) {
         let s = 0; // search start index
         let slice;
         while(true){
             // Search buffer.
-            let i = this.buf.subarray(this.r + s, this.w).indexOf(delim);
+            let i = this.buf.subarray(this.r + s, this.w).indexOf(delim1);
             if (i >= 0) {
                 i += s;
                 slice = this.buf.subarray(this.r, this.r + i + 1);
@@ -347,14 +347,14 @@ class AbstractBufBase {
     }
 }
 class BufWriter extends AbstractBufBase {
-    /** return new BufWriter unless writer is BufWriter */ static create(writer, size = DEFAULT_BUF_SIZE) {
-        return writer instanceof BufWriter ? writer : new BufWriter(writer, size);
+    /** return new BufWriter unless writer is BufWriter */ static create(writer, size2 = DEFAULT_BUF_SIZE) {
+        return writer instanceof BufWriter ? writer : new BufWriter(writer, size2);
     }
-    constructor(writer1, size2 = DEFAULT_BUF_SIZE){
+    constructor(writer1, size3 = DEFAULT_BUF_SIZE){
         super();
         this.writer = writer1;
-        if (size2 <= 0) size2 = DEFAULT_BUF_SIZE;
-        this.buf = new Uint8Array(size2);
+        if (size3 <= 0) size3 = DEFAULT_BUF_SIZE;
+        this.buf = new Uint8Array(size3);
     }
     /** Discards any unflushed buffered data, clears any error, and
    * resets buffer to write its output to w.
@@ -410,21 +410,21 @@ class BufWriter extends AbstractBufBase {
     }
 }
 class BufWriterSync extends AbstractBufBase {
-    /** return new BufWriterSync unless writer is BufWriterSync */ static create(writer, size = DEFAULT_BUF_SIZE) {
-        return writer instanceof BufWriterSync ? writer : new BufWriterSync(writer, size);
+    /** return new BufWriterSync unless writer is BufWriterSync */ static create(writer2, size4 = DEFAULT_BUF_SIZE) {
+        return writer2 instanceof BufWriterSync ? writer2 : new BufWriterSync(writer2, size4);
     }
-    constructor(writer2, size3 = DEFAULT_BUF_SIZE){
+    constructor(writer3, size5 = DEFAULT_BUF_SIZE){
         super();
-        this.writer = writer2;
-        if (size3 <= 0) size3 = DEFAULT_BUF_SIZE;
-        this.buf = new Uint8Array(size3);
+        this.writer = writer3;
+        if (size5 <= 0) size5 = DEFAULT_BUF_SIZE;
+        this.buf = new Uint8Array(size5);
     }
     /** Discards any unflushed buffered data, clears any error, and
    * resets buffer to write its output to w.
-   */ reset(w) {
+   */ reset(w1) {
         this.err = null;
         this.usedBufferBytes = 0;
-        this.writer = w;
+        this.writer = w1;
     }
     /** Flush writes any buffered data to the underlying io.WriterSync. */ flush() {
         if (this.err !== null) throw this.err;
@@ -444,29 +444,29 @@ class BufWriterSync extends AbstractBufBase {
    * the now empty buffer.
    *
    * @return the number of bytes written to the buffer.
-   */ writeSync(data) {
+   */ writeSync(data1) {
         if (this.err !== null) throw this.err;
-        if (data.length === 0) return 0;
+        if (data1.length === 0) return 0;
         let totalBytesWritten = 0;
         let numBytesWritten = 0;
-        while(data.byteLength > this.available()){
+        while(data1.byteLength > this.available()){
             if (this.buffered() === 0) // Large write, empty buffer.
             // Write directly from data to avoid copy.
             try {
-                numBytesWritten = this.writer.writeSync(data);
+                numBytesWritten = this.writer.writeSync(data1);
             } catch (e) {
                 this.err = e;
                 throw e;
             }
             else {
-                numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
+                numBytesWritten = copyBytes(data1, this.buf, this.usedBufferBytes);
                 this.usedBufferBytes += numBytesWritten;
                 this.flush();
             }
             totalBytesWritten += numBytesWritten;
-            data = data.subarray(numBytesWritten);
+            data1 = data1.subarray(numBytesWritten);
         }
-        numBytesWritten = copyBytes(data, this.buf, this.usedBufferBytes);
+        numBytesWritten = copyBytes(data1, this.buf, this.usedBufferBytes);
         this.usedBufferBytes += numBytesWritten;
         totalBytesWritten += numBytesWritten;
         return totalBytesWritten;
@@ -482,9 +482,9 @@ function decode(input) {
 }
 // FROM https://github.com/denoland/deno/blob/b34628a26ab0187a827aa4ebe256e23178e25d39/cli/js/web/headers.ts#L9
 const invalidHeaderCharRegex = /[^\t\x20-\x7e\x80-\xff]/g;
-function str(buf) {
-    if (buf == null) return "";
-    else return decode(buf);
+function str(buf1) {
+    if (buf1 == null) return "";
+    else return decode(buf1);
 }
 function charCode(s) {
     return s.charCodeAt(0);
@@ -493,8 +493,8 @@ class TextProtoReader {
     constructor(r2){
         this.r = r2;
     }
-    constructor(r1){
-        this.r = r1;
+    constructor(r11){
+        this.r = r11;
     }
     /** readLine() reads a single line from the TextProtoReader,
    * eliding the final \n or \r\n from the returned string.
@@ -526,12 +526,12 @@ class TextProtoReader {
         const m = new Headers();
         let line;
         // The first line cannot start with a leading space.
-        let buf = await this.r.peek(1);
-        if (buf === null) return null;
-        else if (buf[0] == charCode(" ") || buf[0] == charCode("\t")) line = await this.readLineSlice();
-        buf = await this.r.peek(1);
-        if (buf === null) throw new Deno.errors.UnexpectedEof();
-        else if (buf[0] == charCode(" ") || buf[0] == charCode("\t")) throw new Deno.errors.InvalidData(`malformed MIME header initial line: ${str(line)}`);
+        let buf1 = await this.r.peek(1);
+        if (buf1 === null) return null;
+        else if (buf1[0] == charCode(" ") || buf1[0] == charCode("\t")) line = await this.readLineSlice();
+        buf1 = await this.r.peek(1);
+        if (buf1 === null) throw new Deno.errors.UnexpectedEof();
+        else if (buf1[0] == charCode(" ") || buf1[0] == charCode("\t")) throw new Deno.errors.InvalidData(`malformed MIME header initial line: ${str(line)}`);
         while(true){
             const kv = await this.readLineSlice(); // readContinuedLineSlice
             if (kv === null) throw new Deno.errors.UnexpectedEof();
@@ -564,9 +564,9 @@ class TextProtoReader {
         // this.closeDot();
         let line;
         while(true){
-            const r2 = await this.r.readLine();
-            if (r2 === null) return null;
-            const { line: l , more  } = r2;
+            const r21 = await this.r.readLine();
+            if (r21 === null) return null;
+            const { line: l , more  } = r21;
             // Avoid the copy if the first call produced a full line.
             if (!line && !more) {
                 // TODO(ry):
@@ -581,12 +581,12 @@ class TextProtoReader {
         return line;
     }
     skipSpace(l) {
-        let n = 0;
+        let n1 = 0;
         for(let i = 0; i < l.length; i++){
             if (l[i] === charCode(" ") || l[i] === charCode("\t")) continue;
-            n++;
+            n1++;
         }
-        return n;
+        return n1;
     }
 }
 const STATUS_TEXT = new Map([]);
@@ -605,12 +605,12 @@ class MuxAsyncIterator {
         ++this.iteratorCount;
         this.callIteratorNext(iterator);
     }
-    async callIteratorNext(iterator) {
+    async callIteratorNext(iterator1) {
         try {
-            const { value , done  } = await iterator.next();
+            const { value , done  } = await iterator1.next();
             if (done) --this.iteratorCount;
             else this.yields.push({
-                iterator,
+                iterator: iterator1,
                 value
             });
         } catch (e) {
@@ -624,9 +624,9 @@ class MuxAsyncIterator {
             await this.signal;
             // Note that while we're looping over `yields`, new items may be added.
             for(let i = 0; i < this.yields.length; i++){
-                const { iterator , value  } = this.yields[i];
+                const { iterator: iterator2 , value  } = this.yields[i];
                 yield value;
-                this.callIteratorNext(iterator);
+                this.callIteratorNext(iterator2);
             }
             if (this.throws.length) {
                 for (const e of this.throws)throw e;
@@ -655,17 +655,17 @@ function emptyReader() {
         }
     };
 }
-function bodyReader(contentLength, r2) {
+function bodyReader(contentLength, r3) {
     let totalRead = 0;
     let finished = false;
-    async function read(buf) {
+    async function read(buf1) {
         if (finished) return null;
         let result;
         const remaining = contentLength - totalRead;
-        if (remaining >= buf.byteLength) result = await r2.read(buf);
+        if (remaining >= buf1.byteLength) result = await r3.read(buf1);
         else {
-            const readBuf = buf.subarray(0, remaining);
-            result = await r2.read(readBuf);
+            const readBuf = buf1.subarray(0, remaining);
+            result = await r3.read(readBuf);
         }
         if (result !== null) totalRead += result;
         finished = totalRead === contentLength;
@@ -675,18 +675,18 @@ function bodyReader(contentLength, r2) {
         read
     };
 }
-function chunkedBodyReader(h, r2) {
+function chunkedBodyReader(h, r3) {
     // Based on https://tools.ietf.org/html/rfc2616#section-19.4.6
-    const tp = new TextProtoReader(r2);
+    const tp = new TextProtoReader(r3);
     let finished = false;
     const chunks = [];
-    async function read(buf) {
+    async function read(buf1) {
         if (finished) return null;
         const [chunk] = chunks;
         if (chunk) {
             const chunkRemaining = chunk.data.byteLength - chunk.offset;
-            const readLength = Math.min(chunkRemaining, buf.byteLength);
-            for(let i = 0; i < readLength; i++)buf[i] = chunk.data[chunk.offset + i];
+            const readLength = Math.min(chunkRemaining, buf1.byteLength);
+            for(let i = 0; i < readLength; i++)buf1[i] = chunk.data[chunk.offset + i];
             chunk.offset += readLength;
             if (chunk.offset === chunk.data.byteLength) {
                 chunks.shift();
@@ -702,20 +702,20 @@ function chunkedBodyReader(h, r2) {
         const chunkSize = parseInt(chunkSizeString, 16);
         if (Number.isNaN(chunkSize) || chunkSize < 0) throw new Error("Invalid chunk size");
         if (chunkSize > 0) {
-            if (chunkSize > buf.byteLength) {
-                let eof = await r2.readFull(buf);
+            if (chunkSize > buf1.byteLength) {
+                let eof = await r3.readFull(buf1);
                 if (eof === null) throw new Deno.errors.UnexpectedEof();
-                const restChunk = new Uint8Array(chunkSize - buf.byteLength);
-                eof = await r2.readFull(restChunk);
+                const restChunk = new Uint8Array(chunkSize - buf1.byteLength);
+                eof = await r3.readFull(restChunk);
                 if (eof === null) throw new Deno.errors.UnexpectedEof();
                 else chunks.push({
                     offset: 0,
                     data: restChunk
                 });
-                return buf.byteLength;
+                return buf1.byteLength;
             } else {
-                const bufToFill = buf.subarray(0, chunkSize);
-                const eof = await r2.readFull(bufToFill);
+                const bufToFill = buf1.subarray(0, chunkSize);
+                const eof = await r3.readFull(bufToFill);
                 if (eof === null) throw new Deno.errors.UnexpectedEof();
                 // Consume \r\n
                 if (await tp.readLine() === null) throw new Deno.errors.UnexpectedEof();
@@ -724,8 +724,8 @@ function chunkedBodyReader(h, r2) {
         } else {
             assert(chunkSize === 0);
             // Consume \r\n
-            if (await r2.readLine() === null) throw new Deno.errors.UnexpectedEof();
-            await readTrailers(h, r2);
+            if (await r3.readLine() === null) throw new Deno.errors.UnexpectedEof();
+            await readTrailers(h, r3);
             finished = true;
             return null;
         }
@@ -742,13 +742,13 @@ function isProhibidedForTrailer(key) {
     ]);
     return s.has(key.toLowerCase());
 }
-async function readTrailers(headers, r2) {
+async function readTrailers(headers, r3) {
     const trailers = parseTrailer(headers.get("trailer"));
     if (trailers == null) return;
     const trailerNames = [
         ...trailers.keys()
     ];
-    const tp = new TextProtoReader(r2);
+    const tp = new TextProtoReader(r3);
     const result = await tp.readMIMEHeader();
     if (result == null) throw new Deno.errors.InvalidData("Missing trailer header.");
     const undeclared = [
@@ -776,25 +776,25 @@ function parseTrailer(field) {
         ]
     ));
 }
-async function writeChunkedBody(w, r2) {
-    const writer = BufWriter.create(w);
-    for await (const chunk of Deno.iter(r2)){
+async function writeChunkedBody(w2, r3) {
+    const writer4 = BufWriter.create(w2);
+    for await (const chunk of Deno.iter(r3)){
         if (chunk.byteLength <= 0) continue;
         const start = encoder.encode(`${chunk.byteLength.toString(16)}\r\n`);
         const end = encoder.encode("\r\n");
-        await writer.write(start);
-        await writer.write(chunk);
-        await writer.write(end);
+        await writer4.write(start);
+        await writer4.write(chunk);
+        await writer4.write(end);
     }
     const endChunk = encoder.encode("0\r\n\r\n");
-    await writer.write(endChunk);
+    await writer4.write(endChunk);
 }
-async function writeTrailers(w, headers, trailers) {
+async function writeTrailers(w2, headers, trailers) {
     const trailer = headers.get("trailer");
     if (trailer === null) throw new TypeError("Missing trailer header.");
     const transferEncoding = headers.get("transfer-encoding");
     if (transferEncoding === null || !transferEncoding.match(/^chunked/)) throw new TypeError(`Trailers are only allowed for "transfer-encoding: chunked", got "transfer-encoding: ${transferEncoding}".`);
-    const writer = BufWriter.create(w);
+    const writer4 = BufWriter.create(w2);
     const trailerNames = trailer.split(",").map((s)=>s.trim().toLowerCase()
     );
     const prohibitedTrailers = trailerNames.filter((k)=>isProhibidedForTrailer(k)
@@ -805,45 +805,45 @@ async function writeTrailers(w, headers, trailers) {
     ].filter((k)=>!trailerNames.includes(k)
     );
     if (undeclared.length > 0) throw new TypeError(`Undeclared trailers: ${Deno.inspect(undeclared)}.`);
-    for (const [key, value] of trailers)await writer.write(encoder.encode(`${key}: ${value}\r\n`));
-    await writer.write(encoder.encode("\r\n"));
-    await writer.flush();
+    for (const [key, value] of trailers)await writer4.write(encoder.encode(`${key}: ${value}\r\n`));
+    await writer4.write(encoder.encode("\r\n"));
+    await writer4.flush();
 }
-async function writeResponse(w, r2) {
+async function writeResponse(w2, r3) {
     const protoMajor = 1;
     const protoMinor = 1;
-    const statusCode = r2.status || 200;
+    const statusCode = r3.status || 200;
     const statusText = STATUS_TEXT.get(statusCode);
-    const writer = BufWriter.create(w);
+    const writer4 = BufWriter.create(w2);
     if (!statusText) throw new Deno.errors.InvalidData("Bad status code");
-    if (!r2.body) r2.body = new Uint8Array();
-    if (typeof r2.body === "string") r2.body = encoder.encode(r2.body);
+    if (!r3.body) r3.body = new Uint8Array();
+    if (typeof r3.body === "string") r3.body = encoder.encode(r3.body);
     let out = `HTTP/${protoMajor}.${protoMinor} ${statusCode} ${statusText}\r\n`;
-    const headers = r2.headers ?? new Headers();
-    if (r2.body && !headers.get("content-length")) {
-        if (r2.body instanceof Uint8Array) out += `content-length: ${r2.body.byteLength}\r\n`;
+    const headers = r3.headers ?? new Headers();
+    if (r3.body && !headers.get("content-length")) {
+        if (r3.body instanceof Uint8Array) out += `content-length: ${r3.body.byteLength}\r\n`;
         else if (!headers.get("transfer-encoding")) out += "transfer-encoding: chunked\r\n";
     }
     for (const [key, value] of headers)out += `${key}: ${value}\r\n`;
     out += `\r\n`;
     const header = encoder.encode(out);
-    const n = await writer.write(header);
-    assert(n === header.byteLength);
-    if (r2.body instanceof Uint8Array) {
-        const n1 = await writer.write(r2.body);
-        assert(n1 === r2.body.byteLength);
+    const n1 = await writer4.write(header);
+    assert(n1 === header.byteLength);
+    if (r3.body instanceof Uint8Array) {
+        const n11 = await writer4.write(r3.body);
+        assert(n11 === r3.body.byteLength);
     } else if (headers.has("content-length")) {
         const contentLength = headers.get("content-length");
         assert(contentLength != null);
         const bodyLength = parseInt(contentLength);
-        const n1 = await Deno.copy(r2.body, writer);
-        assert(n1 === bodyLength);
-    } else await writeChunkedBody(writer, r2.body);
-    if (r2.trailers) {
-        const t = await r2.trailers();
-        await writeTrailers(writer, headers, t);
+        const n11 = await Deno.copy(r3.body, writer4);
+        assert(n11 === bodyLength);
+    } else await writeChunkedBody(writer4, r3.body);
+    if (r3.trailers) {
+        const t = await r3.trailers();
+        await writeTrailers(writer4, headers, t);
     }
-    await writer.flush();
+    await writer4.flush();
 }
 class ServerRequest {
     /**
@@ -882,11 +882,11 @@ class ServerRequest {
         }
         return this._body;
     }
-    async respond(r) {
+    async respond(r3) {
         let err;
         try {
             // Write our response!
-            await writeResponse(this.w, r);
+            await writeResponse(this.w, r3);
         } catch (e) {
             try {
                 // Eagerly close on error.
@@ -906,8 +906,8 @@ class ServerRequest {
         if (this.finalized) return;
         // Consume unread body
         const body = this.body;
-        const buf = new Uint8Array(1024);
-        while(await body.read(buf) !== null);
+        const buf1 = new Uint8Array(1024);
+        while(await body.read(buf1) !== null);
         this.finalized = true;
     }
     constructor(){
@@ -983,21 +983,21 @@ class Server {
     // Yields all HTTP requests on a single TCP connection.
     async *iterateHttpRequests(conn) {
         const reader = new BufReader(conn);
-        const writer = new BufWriter(conn);
+        const writer4 = new BufWriter(conn);
         while(!this.closing){
             let request;
             try {
                 request = await readRequest(conn, reader);
             } catch (error) {
                 if (error instanceof Deno.errors.InvalidData || error instanceof Deno.errors.UnexpectedEof) // An error was thrown while parsing request headers.
-                await writeResponse(writer, {
+                await writeResponse(writer4, {
                     status: 400,
                     body: encode(`${error.message}\r\n\r\n`)
                 });
                 break;
             }
             if (request === null) break;
-            request.w = writer;
+            request.w = writer4;
             yield request;
             // Wait for the request to be processed before we accept a new request on
             // this connection.
@@ -1019,11 +1019,11 @@ class Server {
         // might have been already closed
         }
     }
-    trackConnection(conn) {
-        this.connections.push(conn);
+    trackConnection(conn1) {
+        this.connections.push(conn1);
     }
-    untrackConnection(conn) {
-        const index = this.connections.indexOf(conn);
+    untrackConnection(conn2) {
+        const index = this.connections.indexOf(conn2);
         if (index !== -1) this.connections.splice(index, 1);
     }
     // Accepts a new TCP connection and yields all HTTP requests that arrive on
@@ -1033,23 +1033,23 @@ class Server {
     async *acceptConnAndIterateHttpRequests(mux) {
         if (this.closing) return;
         // Wait for a new connection.
-        let conn;
+        let conn3;
         try {
-            conn = await this.listener.accept();
+            conn3 = await this.listener.accept();
         } catch (error) {
             if (error instanceof Deno.errors.BadResource || error instanceof Deno.errors.InvalidData || error instanceof Deno.errors.UnexpectedEof) return mux.add(this.acceptConnAndIterateHttpRequests(mux));
             throw error;
         }
-        this.trackConnection(conn);
+        this.trackConnection(conn3);
         // Try to accept another connection and add it to the multiplexer.
         mux.add(this.acceptConnAndIterateHttpRequests(mux));
         // Yield the requests that arrive on the just-accepted connection.
-        yield* this.iterateHttpRequests(conn);
+        yield* this.iterateHttpRequests(conn3);
     }
     [Symbol.asyncIterator]() {
-        const mux = new MuxAsyncIterator();
-        mux.add(this.acceptConnAndIterateHttpRequests(mux));
-        return mux.iterate();
+        const mux1 = new MuxAsyncIterator();
+        mux1.add(this.acceptConnAndIterateHttpRequests(mux1));
+        return mux1.iterate();
     }
 }
 function _parseAddrFromStr(addr) {

--- a/spack/tests/pass/deno-001/simple-1/output/entry.js
+++ b/spack/tests/pass/deno-001/simple-1/output/entry.js
@@ -13,12 +13,12 @@ class MuxAsyncIterator {
         ++this.iteratorCount;
         this.callIteratorNext(iterator);
     }
-    async callIteratorNext(iterator) {
+    async callIteratorNext(iterator1) {
         try {
-            const { value , done  } = await iterator.next();
+            const { value , done  } = await iterator1.next();
             if (done) --this.iteratorCount;
             else this.yields.push({
-                iterator,
+                iterator: iterator1,
                 value
             });
         } catch (e) {
@@ -32,9 +32,9 @@ class MuxAsyncIterator {
             await this.signal;
             // Note that while we're looping over `yields`, new items may be added.
             for(let i = 0; i < this.yields.length; i++){
-                const { iterator , value  } = this.yields[i];
+                const { iterator: iterator2 , value  } = this.yields[i];
                 yield value;
-                this.callIteratorNext(iterator);
+                this.callIteratorNext(iterator2);
             }
             if (this.throws.length) {
                 for (const e of this.throws)throw e;
@@ -427,11 +427,11 @@ class Server {
         // might have been already closed
         }
     }
-    trackConnection(conn) {
-        this.connections.push(conn);
+    trackConnection(conn1) {
+        this.connections.push(conn1);
     }
-    untrackConnection(conn) {
-        const index = this.connections.indexOf(conn);
+    untrackConnection(conn2) {
+        const index = this.connections.indexOf(conn2);
         if (index !== -1) this.connections.splice(index, 1);
     }
     // Accepts a new TCP connection and yields all HTTP requests that arrive on
@@ -441,23 +441,23 @@ class Server {
     async *acceptConnAndIterateHttpRequests(mux) {
         if (this.closing) return;
         // Wait for a new connection.
-        let conn;
+        let conn3;
         try {
-            conn = await this.listener.accept();
+            conn3 = await this.listener.accept();
         } catch (error) {
             if (error instanceof Deno.errors.BadResource || error instanceof Deno.errors.InvalidData || error instanceof Deno.errors.UnexpectedEof) return mux.add(this.acceptConnAndIterateHttpRequests(mux));
             throw error;
         }
-        this.trackConnection(conn);
+        this.trackConnection(conn3);
         // Try to accept another connection and add it to the multiplexer.
         mux.add(this.acceptConnAndIterateHttpRequests(mux));
         // Yield the requests that arrive on the just-accepted connection.
-        yield* this.iterateHttpRequests(conn);
+        yield* this.iterateHttpRequests(conn3);
     }
     [Symbol.asyncIterator]() {
-        const mux = new MuxAsyncIterator();
-        mux.add(this.acceptConnAndIterateHttpRequests(mux));
-        return mux.iterate();
+        const mux1 = new MuxAsyncIterator();
+        mux1.add(this.acceptConnAndIterateHttpRequests(mux1));
+        return mux1.iterate();
     }
 }
 function _parseAddrFromStr(addr) {

--- a/spack/tests/pass/issue-1328/case1/output/entry.js
+++ b/spack/tests/pass/issue-1328/case1/output/entry.js
@@ -129,17 +129,18 @@ var load = __spack_require__.bind(void 0, function(module, exports) {
         // don't natively support it.
         var IteratorPrototype = {
         };
-        IteratorPrototype[iteratorSymbol] = function() {
+        define(IteratorPrototype, iteratorSymbol, function() {
             return this;
-        };
+        });
         var getProto = Object.getPrototypeOf;
         var NativeIteratorPrototype = getProto && getProto(getProto(values([])));
         if (NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol)) // This environment has a native %IteratorPrototype%; use it instead
         // of the polyfill.
         IteratorPrototype = NativeIteratorPrototype;
         var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype);
-        GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
-        GeneratorFunctionPrototype.constructor = GeneratorFunction;
+        GeneratorFunction.prototype = GeneratorFunctionPrototype;
+        define(Gp, "constructor", GeneratorFunctionPrototype);
+        define(GeneratorFunctionPrototype, "constructor", GeneratorFunction);
         GeneratorFunction.displayName = define(GeneratorFunctionPrototype, toStringTagSymbol, "GeneratorFunction");
         // Helper for defining the .next, .throw, and .return methods of the
         // Iterator interface in terms of a single ._invoke method.
@@ -231,9 +232,9 @@ var load = __spack_require__.bind(void 0, function(module, exports) {
             this._invoke = enqueue;
         }
         defineIteratorMethods(AsyncIterator.prototype);
-        AsyncIterator.prototype[asyncIteratorSymbol] = function() {
+        define(AsyncIterator.prototype, asyncIteratorSymbol, function() {
             return this;
-        };
+        });
         exports1.AsyncIterator = AsyncIterator;
         // Note that simple async functions are implemented on top of
         // AsyncIterator objects; they just return a Promise for the value of
@@ -371,12 +372,12 @@ var load = __spack_require__.bind(void 0, function(module, exports) {
         // iterator prototype chain incorrectly implement this, causing the Generator
         // object to not be returned from this call. This ensures that doesn't happen.
         // See https://github.com/facebook/regenerator/issues/274 for more details.
-        Gp[iteratorSymbol] = function() {
+        define(Gp, iteratorSymbol, function() {
             return this;
-        };
-        Gp.toString = function() {
+        });
+        define(Gp, "toString", function() {
             return "[object Generator]";
-        };
+        });
         function pushTryEntry(locs) {
             var entry = {
                 tryLoc: locs[0]
@@ -607,14 +608,16 @@ var load = __spack_require__.bind(void 0, function(module, exports) {
     } catch (accidentalStrictMode) {
         // This module should not be running in strict mode, so the above
         // assignment should always work unless something is misconfigured. Just
-        // in case runtime.js accidentally runs in strict mode, we can escape
+        // in case runtime.js accidentally runs in strict mode, in modern engines
+        // we can explicitly access globalThis. In older engines we can escape
         // strict mode using a global Function call. This could conceivably fail
         // if a Content Security Policy forbids using Function, but in that case
         // the proper solution is to fix the accidental strict mode problem. If
         // you've misconfigured your bundler to force strict mode and applied a
         // CSP to forbid Function, and you're not willing to fix either of those
         // problems, please detail your unique predicament in a GitHub issue.
-        Function("r", "regeneratorRuntime = r")(runtime);
+        if (typeof globalThis === "object") globalThis.regeneratorRuntime = runtime;
+        else Function("r", "regeneratorRuntime = r")(runtime);
     }
 });
 var { default: regeneratorRuntime  } = load();

--- a/tests/fixture/issue-1333/case2/output/index.js
+++ b/tests/fixture/issue-1333/case2/output/index.js
@@ -313,8 +313,8 @@ class Shard extends _utils.Emitter {
      * Called whenever the websocket receives a message.
      * @param {WebSocket.MessageEvent} evt
      * @private
-     */ _message(evt) {
-        return _classPrivateFieldGet(this, _compression2) ? _classPrivateFieldGet(this, _compression2).add(evt.data) : this._packet(evt.data);
+     */ _message(evt1) {
+        return _classPrivateFieldGet(this, _compression2) ? _classPrivateFieldGet(this, _compression2).add(evt1.data) : this._packet(evt1.data);
     }
     /**
      * Cleans up the WebSocket connection listeners.


### PR DESCRIPTION
- closes #1948

This PR is an attempt to close #1948 - class identifier is considered as ref which skips collision / conflict calculation for the renaming. PR changes behavior to declare identifiers then calculate collisions.

In result, this requires to change existing test fixtures having classes inside of it to amend generated member fn param names. I've peeked manually and for me it looks ok, but this change may not be desired still - would like to update PR if that's the case.