### PR TITLE
fix(transform): calculate class member fn args identifier collision

### DIFF
--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.23.0"
+version = "0.23.1"
 
 [dependencies]
 fxhash = "0.2.1"

--- a/ecmascript/transforms/base/src/hygiene/mod.rs
+++ b/ecmascript/transforms/base/src/hygiene/mod.rs
@@ -665,6 +665,27 @@ impl<'a> VisitMut for Hygiene<'a> {
         n.class.visit_mut_with(self);
     }
 
+    fn visit_mut_class_method(&mut self, n: &mut ClassMethod) {
+        n.function.decorators.visit_mut_with(self);
+
+        let mut folder = Hygiene {
+            config: self.config.clone(),
+            current: Scope::new(ScopeKind::Fn, None),
+            ident_type: IdentType::Ref,
+            var_kind: None,
+        };
+
+        folder.ident_type = IdentType::Binding;
+        n.function.params.visit_mut_children_with(&mut folder);
+
+        folder.ident_type = IdentType::Ref;
+
+        n.function.body.visit_mut_with(self);
+        n.key.visit_mut_with(self);
+
+        folder.apply_ops(&mut n.function);
+    }
+
     fn visit_mut_constructor(&mut self, c: &mut Constructor) {
         let old = self.ident_type;
         self.ident_type = IdentType::Binding;

--- a/ecmascript/transforms/compat/tests/es2015_destructuring.rs
+++ b/ecmascript/transforms/compat/tests/es2015_destructuring.rs
@@ -45,6 +45,70 @@ test!(
 
 test!(
     syntax(),
+    |_| chain!(
+        spread(spread::Config {
+            ..Default::default()
+        }),
+        parameters(),
+        destructuring(Default::default()),
+        block_scoping(),
+        object_rest_spread(),
+    ),
+    issue_1948,
+    "
+    const fn2 = (arg1, {opt1, opt2}, arg2, {opt3, opt4}, ...arg3) => {
+        console.log(arg1, opt1, opt2, arg2, opt3, opt4, arg3);
+    };
+
+    function fn3(arg1, {opt1, opt2}, arg2, {opt3, opt4}, ...arg3) {
+        console.log(arg1, opt1, opt2, arg2, opt3, opt4, arg3);
+    };
+
+    class cls {
+        fn4(arg1, {opt1, opt2}, arg2, {opt3, opt4}, ...arg3) {
+            console.log(arg1, opt1, opt2, arg2, opt3, opt4, arg3);
+        }
+
+        fn5(arg1, arg2) {
+            console.log(arg1, arg2);
+        }
+    }",
+    "
+    var fn2 = function(arg1, param, arg2, param1) {
+        var opt1 = param.opt1, opt2 = param.opt2, opt3 = param1.opt3, opt4 = param1.opt4;
+        for(var _len = arguments.length, arg3 = new Array(_len > 4 ? _len - 4 : 0), _key = 4; _key \
+     < _len; _key++){
+            arg3[_key - 4] = arguments[_key];
+        }
+        console.log(arg1, opt1, opt2, arg2, opt3, opt4, arg3);
+    };
+    function fn3(arg1, param, arg2, param1) {
+        var opt1 = param.opt1, opt2 = param.opt2, opt3 = param1.opt3, opt4 = param1.opt4;
+        for(var _len = arguments.length, arg3 = new Array(_len > 4 ? _len - 4 : 0), _key = 4; _key \
+     < _len; _key++){
+            arg3[_key - 4] = arguments[_key];
+        }
+        console.log(arg1, opt1, opt2, arg2, opt3, opt4, arg3);
+    }
+    ;
+    class cls {
+        fn4(arg1, param, arg2, param1) {
+            var opt1 = param.opt1, opt2 = param.opt2, opt3 = param1.opt3, opt4 = param1.opt4;
+            for(var _len = arguments.length, arg3 = new Array(_len > 4 ? _len - 4 : 0), _key = 4; \
+     _key < _len; _key++){
+                arg3[_key - 4] = arguments[_key];
+            }
+            console.log(arg1, opt1, opt2, arg2, opt3, opt4, arg3);
+        }
+        fn5(arg1, arg2) {
+            console.log(arg1, arg2);
+        }
+    }
+    "
+);
+
+test!(
+    syntax(),
     |_| tr(),
     issue_260_01,
     "[code = 1] = []",
@@ -334,7 +398,7 @@ test!(
     let w;
     let e;
     var ref;
-    if (true)  ref = [1, 2, 3].map(()=>123), q = ref[0], w = ref[1], e = ref[2], ref;    
+    if (true)  ref = [1, 2, 3].map(()=>123), q = ref[0], w = ref[1], e = ref[2], ref;
 })();"#
 );
 
@@ -993,7 +1057,7 @@ test!(
     var [[a, b]] = [[1, 2]];
     var [a, b, ...c] = [1, 2, 3, 4];
     var [[a, b, ...c]] = [[1, 2, 3, 4]];
-    
+
     var [a, b] = [1, 2, 3];
     var [[a, b]] = [[1, 2, 3]];
     var [a, b] = [a, b];
@@ -1006,7 +1070,7 @@ test!(
     [a, b] = [1, 2];
     [a, b] = [, 2];
     ; // Avoid completion record special case
-    
+
     "#,
     r#"
     var a = 1,
@@ -1030,8 +1094,8 @@ test!(
         b = ref2[1];
     var ref3;
     ref3 = [a[1], a[0]], a[0] = ref3[0], a[1] = ref3[1], ref3;
-    
-    
+
+
     var ref4 = _slicedToArray(_toConsumableArray(foo).concat([bar]), 2), a = ref4[0], b = ref4[1];
     // TODO: var ref4 = _toConsumableArray(foo).concat([bar]), a = ref4[0], b = ref4[1];
 


### PR DESCRIPTION
Another attempt to close #1948 

Originate from PR https://github.com/swc-project/swc/pull/1961, this PR attempt to apply same changes partially for the class method params by creating separate scope since param identifier does not collide to other method / prop declarations. 

This _seems_ working, new test case passes without changing existing fixture update. But suggested recommendation (https://github.com/swc-project/swc/pull/1961#issuecomment-886156602) is updating `_mut_class_method` and `_mut_class_prop` both, while this one only touches class_method this may not be still legit approach. Also bit unsure using new folder is right approach to consider.