### PR TITLE
fix: do not mutate comment maps while transforming

### DIFF
--- a/bundler/examples/path.rs
+++ b/bundler/examples/path.rs
@@ -44,12 +44,12 @@ fn main() {
     );
 
     let wr = stdout();
-    let mut emitter = Emitter {
-        cfg: swc_ecma_codegen::Config { minify: false },
-        cm: cm.clone(),
-        comments: None,
-        wr: Box::new(JsWriter::new(cm.clone(), "\n", wr.lock(), None)),
-    };
+    let mut emitter = Emitter::new(
+        swc_ecma_codegen::Config { minify: false },
+        cm.clone(),
+        None,
+        Box::new(JsWriter::new(cm.clone(), "\n", wr.lock(), None)),
+    );
 
     emitter.emit_module(&bundle.module).unwrap();
 }

--- a/bundler/src/debug/mod.rs
+++ b/bundler/src/debug/mod.rs
@@ -17,12 +17,12 @@ pub(crate) fn print_hygiene(event: &str, cm: &Lrc<SourceMap>, t: &Module) {
     let mut w = stdout.lock();
 
     writeln!(w, "==================== @ {} ====================", event).unwrap();
-    Emitter {
-        cfg: swc_ecma_codegen::Config { minify: false },
-        cm: cm.clone(),
-        comments: None,
-        wr: Box::new(JsWriter::new(cm.clone(), "\n", &mut w, None)),
-    }
+    Emitter::new(
+        swc_ecma_codegen::Config { minify: false },
+        cm.clone(),
+        None,
+        Box::new(JsWriter::new(cm.clone(), "\n", &mut w, None)),
+    )
     .emit_module(&module)
     .unwrap();
     writeln!(w, "==================== @ ====================").unwrap();

--- a/bundler/src/hash.rs
+++ b/bundler/src/hash.rs
@@ -10,12 +10,12 @@ pub(crate) fn calc_hash(cm: Lrc<SourceMap>, m: &Module) -> Result<String, Error>
     let mut buf = Hasher { digest };
 
     {
-        let mut emitter = Emitter {
-            cfg: Default::default(),
+        let mut emitter = Emitter::new(
+            Default::default(),
             cm,
-            comments: None,
-            wr: Box::new(&mut buf) as Box<dyn WriteJs>,
-        };
+            None,
+            Box::new(&mut buf) as Box<dyn WriteJs>,
+        );
 
         emitter
             .emit_module(&m)

--- a/bundler/tests/deno.rs
+++ b/bundler/tests/deno.rs
@@ -1046,12 +1046,12 @@ fn bundle(url: &str) -> String {
 
             let mut buf = vec![];
             {
-                Emitter {
-                    cfg: swc_ecma_codegen::Config { minify: false },
-                    cm: cm.clone(),
-                    comments: None,
-                    wr: Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, None)),
-                }
+                Emitter::new(
+                    swc_ecma_codegen::Config { minify: false },
+                    cm.clone(),
+                    None,
+                    Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, None)),
+                )
                 .emit_module(&module)
                 .unwrap();
             }

--- a/bundler/tests/fixture.rs
+++ b/bundler/tests/fixture.rs
@@ -201,14 +201,14 @@ fn do_test(entry: &DirEntry, entries: HashMap<String, FileName>, inline: bool) {
                 let mut buf = vec![];
 
                 {
-                    let mut emitter = Emitter {
-                        cfg: swc_ecma_codegen::Config {
+                    let mut emitter = Emitter::new(
+                        swc_ecma_codegen::Config {
                             ..Default::default()
                         },
-                        cm: cm.clone(),
-                        comments: None,
-                        wr: Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, None)),
-                    };
+                        cm.clone(),
+                        None,
+                        Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, None)),
+                    );
 
                     emitter
                         .emit_module(&bundled.module.fold_with(&mut fixer(None)))

--- a/common/src/comments.rs
+++ b/common/src/comments.rs
@@ -1,6 +1,6 @@
 use crate::{
     pos::Spanned,
-    syntax_pos::{BytePos, Span},
+    syntax_pos::{BytePos, Span, DUMMY_SP},
 };
 use fxhash::FxHashMap;
 use std::{
@@ -219,7 +219,7 @@ impl Comments for SingleThreadedComments {
         let leading = leading_map.entry(pos).or_default();
         let pure_comment = Comment {
             kind: CommentKind::Block,
-            span: Span::new(pos, pos, Default::default()),
+            span: DUMMY_SP,
             text: "#__PURE__".into(),
         };
 

--- a/common/src/comments.rs
+++ b/common/src/comments.rs
@@ -292,10 +292,8 @@ pub trait CommentsExt: Comments {
     where
         F: FnOnce(&[Comment]) -> Ret,
     {
-        if let Some(comments) = self.take_leading(pos) {
-            let ret = op(&comments);
-            self.add_leading_comments(pos, comments);
-            ret
+        if let Some(comments) = self.get_leading(pos) {
+            op(&comments)
         } else {
             op(&[])
         }
@@ -305,10 +303,8 @@ pub trait CommentsExt: Comments {
     where
         F: FnOnce(&[Comment]) -> Ret,
     {
-        if let Some(comments) = self.take_trailing(pos) {
-            let ret = op(&comments);
-            self.add_trailing_comments(pos, comments);
-            ret
+        if let Some(comments) = self.get_trailing(pos) {
+            op(&comments)
         } else {
             op(&[])
         }

--- a/common/src/comments.rs
+++ b/common/src/comments.rs
@@ -1,6 +1,6 @@
 use crate::{
     pos::Spanned,
-    syntax_pos::{BytePos, Span, DUMMY_SP},
+    syntax_pos::{BytePos, Span},
 };
 use fxhash::FxHashMap;
 use std::{
@@ -219,7 +219,7 @@ impl Comments for SingleThreadedComments {
         let leading = leading_map.entry(pos).or_default();
         let pure_comment = Comment {
             kind: CommentKind::Block,
-            span: DUMMY_SP,
+            span: Span::new(pos, pos, Default::default()),
             text: "#__PURE__".into(),
         };
 

--- a/ecmascript/codegen/benches/bench.rs
+++ b/ecmascript/codegen/benches/bench.rs
@@ -102,19 +102,19 @@ fn bench_emitter(b: &mut Bencher, s: &str) {
         b.iter(|| {
             let mut buf = vec![];
             {
-                let mut emitter = Emitter {
-                    cfg: swc_ecma_codegen::Config {
+                let mut emitter = Emitter::new(
+                    swc_ecma_codegen::Config {
                         ..Default::default()
                     },
-                    comments: None,
-                    cm: cm.clone(),
-                    wr: Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
+                    None,
+                    cm.clone(),
+                    Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
                         cm.clone(),
                         "\n",
                         &mut buf,
                         Some(&mut src_map_buf),
                     )),
-                };
+                );
 
                 let _ = emitter.emit_module(&module);
             }

--- a/ecmascript/codegen/benches/bench.rs
+++ b/ecmascript/codegen/benches/bench.rs
@@ -106,8 +106,8 @@ fn bench_emitter(b: &mut Bencher, s: &str) {
                     swc_ecma_codegen::Config {
                         ..Default::default()
                     },
-                    None,
                     cm.clone(),
+                    None,
                     Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
                         cm.clone(),
                         "\n",

--- a/ecmascript/codegen/benches/with_parse.rs
+++ b/ecmascript/codegen/benches/with_parse.rs
@@ -105,8 +105,8 @@ fn bench_emitter(b: &mut Bencher, s: &str) {
                     swc_ecma_codegen::Config {
                         ..Default::default()
                     },
-                    None,
                     cm.clone(),
+                    None,
                     Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
                         cm.clone(),
                         "\n",

--- a/ecmascript/codegen/benches/with_parse.rs
+++ b/ecmascript/codegen/benches/with_parse.rs
@@ -101,19 +101,19 @@ fn bench_emitter(b: &mut Bencher, s: &str) {
 
             let mut buf = vec![];
             {
-                let mut emitter = Emitter {
-                    cfg: swc_ecma_codegen::Config {
+                let mut emitter = Emitter::new(
+                    swc_ecma_codegen::Config {
                         ..Default::default()
                     },
-                    comments: None,
-                    cm: cm.clone(),
-                    wr: Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
+                    None,
+                    cm.clone(),
+                    Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
                         cm.clone(),
                         "\n",
                         &mut buf,
                         Some(&mut src_map_buf),
                     )),
-                };
+                );
 
                 let _ = emitter.emit_module(&module);
             }

--- a/ecmascript/codegen/src/comments.rs
+++ b/ecmascript/codegen/src/comments.rs
@@ -50,7 +50,7 @@ impl<'a> Emitter<'a> {
             None => return Ok(()),
         };
 
-        let cmts = comments.take_trailing(pos);
+        let cmts = comments.get_trailing(pos);
 
         write_comments!(self, prefix_space, &cmts)
     }
@@ -65,7 +65,7 @@ impl<'a> Emitter<'a> {
             None => return Ok(()),
         };
 
-        write_comments!(self, false, comments.take_leading(pos))
+        write_comments!(self, false, comments.get_leading(pos))
     }
 
     pub(super) fn emit_leading_comments_of_span(&mut self, span: Span, is_hi: bool) -> Result {

--- a/ecmascript/codegen/src/comments.rs
+++ b/ecmascript/codegen/src/comments.rs
@@ -50,6 +50,10 @@ impl<'a> Emitter<'a> {
             None => return Ok(()),
         };
 
+        if !self.emitted_comment_positions.insert(pos) {
+            return Ok(());
+        }
+
         let cmts = comments.get_trailing(pos);
 
         write_comments!(self, prefix_space, &cmts)

--- a/ecmascript/codegen/src/comments.rs
+++ b/ecmascript/codegen/src/comments.rs
@@ -64,6 +64,10 @@ impl<'a> Emitter<'a> {
             pos = pos - BytePos(1)
         }
 
+        if !self.emitted_comment_positions.insert(pos) {
+            return Ok(());
+        }
+
         let comments = match self.comments {
             Some(ref comments) => comments,
             None => return Ok(()),

--- a/ecmascript/codegen/src/tests.rs
+++ b/ecmascript/codegen/src/tests.rs
@@ -31,12 +31,7 @@ impl Builder {
             Box::new(writer)
         };
 
-        let mut e = Emitter {
-            cfg: self.cfg,
-            cm: self.cm.clone(),
-            wr: writer,
-            comments: Some(&self.comments),
-        };
+        let mut e = Emitter::new(self.cfg, self.cm.clone(), Some(&self.comments), writer);
 
         let ret = op(&mut e);
 

--- a/ecmascript/codegen/tests/fixture.rs
+++ b/ecmascript/codegen/tests/fixture.rs
@@ -46,12 +46,8 @@ fn run(input: &Path, minify: bool) {
                 wr = Box::new(swc_ecma_codegen::text_writer::omit_trailing_semi(wr));
             }
 
-            let mut emitter = Emitter {
-                cfg: swc_ecma_codegen::Config { minify },
-                cm: cm.clone(),
-                comments: None,
-                wr,
-            };
+            let mut emitter =
+                Emitter::new(swc_ecma_codegen::Config { minify }, cm.clone(), None, wr);
 
             emitter.emit_module(&m).unwrap();
         }

--- a/ecmascript/codegen/tests/test262.rs
+++ b/ecmascript/codegen/tests/test262.rs
@@ -168,12 +168,12 @@ fn error_tests(tests: &mut Vec<TestDescAndFn>, minify: bool) -> Result<(), io::E
                         wr = Box::new(swc_ecma_codegen::text_writer::omit_trailing_semi(wr));
                     }
 
-                    let mut emitter = Emitter {
-                        cfg: swc_ecma_codegen::Config { minify },
-                        cm: cm.clone(),
+                    let mut emitter = Emitter::new(
+                        swc_ecma_codegen::Config { minify },
+                        cm.clone(),
+                        if minify { None } else { Some(&comments) },
                         wr,
-                        comments: if minify { None } else { Some(&comments) },
-                    };
+                    );
 
                     // Parse source
                     if module {

--- a/ecmascript/minifier/src/debug.rs
+++ b/ecmascript/minifier/src/debug.rs
@@ -52,12 +52,12 @@ where
     let cm = Lrc::new(SourceMap::default());
 
     {
-        let mut emitter = Emitter {
-            cfg: Default::default(),
-            cm: cm.clone(),
-            comments: None,
-            wr: Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, None)),
-        };
+        let mut emitter = Emitter::new(
+            Default::default(),
+            cm.clone(),
+            None,
+            Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, None)),
+        );
 
         node.emit_with(&mut emitter).unwrap();
     }
@@ -87,12 +87,12 @@ pub(crate) fn invoke(module: &Module) {
     let cm = Lrc::new(SourceMap::default());
 
     {
-        let mut emitter = Emitter {
-            cfg: Default::default(),
-            cm: cm.clone(),
-            comments: None,
-            wr: Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, None)),
-        };
+        let mut emitter = Emitter::new(
+            Default::default(),
+            cm.clone(),
+            None,
+            Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, None)),
+        );
 
         emitter.emit_module(&module).unwrap();
     }

--- a/ecmascript/minifier/tests/compress.rs
+++ b/ecmascript/minifier/tests/compress.rs
@@ -460,12 +460,12 @@ fn print<N: swc_ecma_codegen::Node>(cm: Lrc<SourceMap>, nodes: &[N], minify: boo
     let mut buf = vec![];
 
     {
-        let mut emitter = Emitter {
-            cfg: swc_ecma_codegen::Config { minify },
-            cm: cm.clone(),
-            comments: None,
-            wr: Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, None)),
-        };
+        let mut emitter = Emitter::new(
+            swc_ecma_codegen::Config { minify },
+            cm.clone(),
+            None,
+            Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, None)),
+        );
 
         for n in nodes {
             n.emit_with(&mut emitter).unwrap();

--- a/ecmascript/minifier/tests/hygiene.rs
+++ b/ecmascript/minifier/tests/hygiene.rs
@@ -57,12 +57,12 @@ fn print<N: swc_ecma_codegen::Node>(cm: Lrc<SourceMap>, nodes: &[N]) -> String {
     let mut buf = vec![];
 
     {
-        let mut emitter = Emitter {
-            cfg: Default::default(),
-            cm: cm.clone(),
-            comments: None,
-            wr: Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, None)),
-        };
+        let mut emitter = Emitter::new(
+            Default::default(),
+            cm.clone(),
+            None,
+            Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, None)),
+        );
 
         for n in nodes {
             n.emit_with(&mut emitter).unwrap();

--- a/ecmascript/preset-env/tests/test.rs
+++ b/ecmascript/preset-env/tests/test.rs
@@ -209,17 +209,17 @@ fn exec(c: PresetConfig, dir: PathBuf) -> Result<(), Error> {
             let print = |m: &Module| {
                 let mut buf = vec![];
                 {
-                    let mut emitter = Emitter {
-                        cfg: swc_ecma_codegen::Config { minify: false },
-                        comments: None,
-                        cm: cm.clone(),
-                        wr: Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
+                    let mut emitter = Emitter::new(
+                        swc_ecma_codegen::Config { minify: false },
+                        cm.clone(),
+                        None,
+                        Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
                             cm.clone(),
                             "\n",
                             &mut buf,
                             None,
                         )),
-                    };
+                    );
 
                     emitter.emit_module(m).expect("failed to emit module");
                 }

--- a/ecmascript/transforms/base/src/tests.rs
+++ b/ecmascript/transforms/base/src/tests.rs
@@ -119,17 +119,17 @@ impl<'a> Tester<'a> {
     pub fn print(&mut self, module: &Module) -> String {
         let mut buf = vec![];
         {
-            let mut emitter = Emitter {
-                cfg: Default::default(),
-                cm: self.cm.clone(),
-                wr: Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
+            let mut emitter = Emitter::new(
+                Default::default(),
+                self.cm.clone(),
+                None,
+                Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
                     self.cm.clone(),
                     "\n",
                     &mut buf,
                     None,
                 )),
-                comments: None,
-            };
+            );
 
             // println!("Emitting: {:?}", module);
             emitter.emit_module(&module).unwrap();

--- a/ecmascript/transforms/base/tests/fixer_test262.rs
+++ b/ecmascript/transforms/base/tests/fixer_test262.rs
@@ -168,25 +168,25 @@ fn identity_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                         Parser::new(Syntax::default(), (&*src).into(), None);
 
                     {
-                        let mut emitter = Emitter {
-                            cfg: swc_ecma_codegen::Config { minify: false },
-                            cm: cm.clone(),
-                            wr: Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
+                        let mut emitter = Emitter::new(
+                            swc_ecma_codegen::Config { minify: false },
+                            cm.clone(),
+                            None,
+                            Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
                                 cm.clone(),
                                 "\n",
                                 &mut wr,
                                 None,
                             )),
-                            comments: None,
-                        };
-                        let mut expected_emitter = Emitter {
-                            cfg: swc_ecma_codegen::Config { minify: false },
-                            cm: cm.clone(),
-                            wr: Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
+                        );
+                        let mut expected_emitter = Emitter::new(
+                            swc_ecma_codegen::Config { minify: false },
+                            cm.clone(),
+                            None,
+                            Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
                                 cm, "\n", &mut wr2, None,
                             )),
-                            comments: None,
-                        };
+                        );
 
                         // Parse source
 

--- a/ecmascript/transforms/base/tests/fixture.rs
+++ b/ecmascript/transforms/base/tests/fixture.rs
@@ -22,17 +22,17 @@ use testing::{fixture, run_test2};
 pub fn print(cm: Lrc<SourceMap>, module: &Module) -> String {
     let mut buf = vec![];
     {
-        let mut emitter = Emitter {
-            cfg: Default::default(),
-            cm: cm.clone(),
-            wr: Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
+        let mut emitter = Emitter::new(
+            Default::default(),
+            cm.clone(),
+            None,
+            Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
                 cm.clone(),
                 "\n",
                 &mut buf,
                 None,
             )),
-            comments: None,
-        };
+        );
 
         // println!("Emitting: {:?}", module);
         emitter.emit_module(&module).unwrap();

--- a/ecmascript/transforms/react/src/jsx/mod.rs
+++ b/ecmascript/transforms/react/src/jsx/mod.rs
@@ -719,8 +719,8 @@ where
     noop_visit_mut_type!();
 
     fn visit_mut_module(&mut self, module: &mut Module) {
-        let leading = if let Some(comments) = &self.comments {
-            let leading = comments.take_leading(module.span.lo);
+        if let Some(comments) = &self.comments {
+            let leading = comments.get_leading(module.span.lo);
 
             if let Some(leading) = &leading {
                 for leading in &**leading {
@@ -798,16 +798,6 @@ where
                         }
                     }
                 }
-            }
-
-            leading
-        } else {
-            None
-        };
-
-        if let Some(leading) = leading {
-            if let Some(comments) = &self.comments {
-                comments.add_leading_comments(module.span.lo, leading);
             }
         }
 

--- a/ecmascript/transforms/react/src/pure_annotations/tests.rs
+++ b/ecmascript/transforms/react/src/pure_annotations/tests.rs
@@ -49,12 +49,12 @@ fn emit(
             &mut buf,
             Some(&mut src_map_buf),
         ));
-        let mut emitter = Emitter {
-            cfg: Default::default(),
-            comments: Some(&comments),
-            cm: source_map.clone(),
-            wr: writer,
-        };
+        let mut emitter = Emitter::new(
+            Default::default(),
+            source_map.clone(),
+            Some(&comments),
+            writer,
+        );
         emitter.emit_module(&program).unwrap();
     }
 

--- a/ecmascript/transforms/testing/src/lib.rs
+++ b/ecmascript/transforms/testing/src/lib.rs
@@ -176,17 +176,17 @@ impl<'a> Tester<'a> {
     pub fn print(&mut self, module: &Module, comments: &Rc<SingleThreadedComments>) -> String {
         let mut wr = Buf(Arc::new(RwLock::new(vec![])));
         {
-            let mut emitter = Emitter {
-                cfg: Default::default(),
-                cm: self.cm.clone(),
-                wr: Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
+            let mut emitter = Emitter::new(
+                Default::default(),
+                self.cm.clone(),
+                Some(comments),
+                Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
                     self.cm.clone(),
                     "\n",
                     &mut wr,
                     None,
                 )),
-                comments: Some(comments),
-            };
+            );
 
             // println!("Emitting: {:?}", module);
             emitter.emit_module(&module).unwrap();

--- a/ecmascript/transforms/typescript/tests/strip_correctness.rs
+++ b/ecmascript/transforms/typescript/tests/strip_correctness.rs
@@ -164,17 +164,17 @@ fn correctness_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                     let mut wr = Buf(Arc::new(RwLock::new(vec![])));
 
                     {
-                        let mut emitter = Emitter {
-                            cfg: swc_ecma_codegen::Config { minify: false },
-                            cm: cm.clone(),
-                            wr: Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
+                        let mut emitter = Emitter::new(
+                            swc_ecma_codegen::Config { minify: false },
+                            cm.clone(),
+                            None,
+                            Box::new(swc_ecma_codegen::text_writer::JsWriter::new(
                                 cm.clone(),
                                 "\n",
                                 &mut wr,
                                 None,
                             )),
-                            comments: None,
-                        };
+                        );
 
                         // Parse source
                         let module = parser

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,12 +280,12 @@ impl Compiler {
                         wr = Box::new(swc_ecma_codegen::text_writer::omit_trailing_semi(wr));
                     }
 
-                    let mut emitter = Emitter {
-                        cfg: swc_ecma_codegen::Config { minify },
-                        comments: if minify { None } else { Some(&self.comments) },
-                        cm: self.cm.clone(),
+                    let mut emitter = Emitter::new(
+                        swc_ecma_codegen::Config { minify },
+                        self.cm.clone(),
+                        if minify { None } else { Some(&self.comments) },
                         wr,
-                    };
+                    );
 
                     node.emit_with(&mut emitter)
                         .context("failed to emit module")?;

--- a/tests/projects.rs
+++ b/tests/projects.rs
@@ -244,7 +244,7 @@ fn issue_406() {
     let s = file("tests/projects/issue-406/input.js").unwrap();
     println!("{}", s);
 
-    assert!(s.contains("return true"));
+    assert!(s.contains("return(true)"));
 }
 
 #[test]


### PR DESCRIPTION
This change does three things:

1. Does not mutate the comment maps in transforms. This allows for another thread to be safely doing stuff with the comment maps without having another thread mutating it in a transform. Edit: Actually, I'm not sure if this makes sense... instead should a cloned version of the comment map be worked on?
2. It does not remove comments and forget about them when emitting.
3. Removes race condition in `with_leading` and `with_trailing` until #1952 is implemented.