### PR TITLE
fix(es/parser): error for `import.meta` in script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "jsdoc"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "ahash 0.7.4",
  "anyhow",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.11.2"
+version = "0.11.4"
 dependencies = [
  "arbitrary",
  "ast_node",
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.65.1"
+version = "0.66.0"
 dependencies = [
  "bitflags",
  "num-bigint",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_dep_graph"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "either",
  "enum_kind",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "dashmap",
  "fxhash",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "pretty_assertions 0.6.1",
  "sourcemap",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "fxhash",
  "once_cell",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "arrayvec",
  "fxhash",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "dashmap",
  "fxhash",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "either",
  "fxhash",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "base64 0.13.0",
  "dashmap",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "ansi_term 0.12.1",
  "serde",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "fxhash",
  "serde",
@@ -2835,7 +2835,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,16 +29,16 @@ serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "./atoms"}
-swc_bundler = {version = "0.49.0", path = "./bundler"}
+swc_bundler = {version = "0.50.0", path = "./bundler"}
 swc_common = {version = "0.11.0", path = "./common", features = ["sourcemap", "concurrent"]}
 swc_ecma_ast = {version = "0.49.0", path = "./ecmascript/ast"}
-swc_ecma_codegen = {version = "0.65.0", path = "./ecmascript/codegen"}
-swc_ecma_ext_transforms = {version = "0.23.0", path = "./ecmascript/ext-transforms"}
+swc_ecma_codegen = {version = "0.66.0", path = "./ecmascript/codegen"}
+swc_ecma_ext_transforms = {version = "0.24.0", path = "./ecmascript/ext-transforms"}
 swc_ecma_loader = {version = "0.12.0", path = "./ecmascript/loader", features = ["lru", "node", "tsc"]}
-swc_ecma_minifier = {version = "0.17.0", path = "./ecmascript/minifier"}
-swc_ecma_parser = {version = "0.65.0", path = "./ecmascript/parser"}
-swc_ecma_preset_env = {version = "0.32.0", path = "./ecmascript/preset-env"}
-swc_ecma_transforms = {version = "0.62.0", path = "./ecmascript/transforms", features = [
+swc_ecma_minifier = {version = "0.18.0", path = "./ecmascript/minifier"}
+swc_ecma_parser = {version = "0.66.0", path = "./ecmascript/parser"}
+swc_ecma_preset_env = {version = "0.33.0", path = "./ecmascript/preset-env"}
+swc_ecma_transforms = {version = "0.63.0", path = "./ecmascript/transforms", features = [
   "compat",
   "module",
   "optimization",
@@ -46,7 +46,7 @@ swc_ecma_transforms = {version = "0.62.0", path = "./ecmascript/transforms", fea
   "react",
   "typescript",
 ]}
-swc_ecma_transforms_base = {version = "0.25.0", path = "./ecmascript/transforms/base"}
+swc_ecma_transforms_base = {version = "0.26.0", path = "./ecmascript/transforms/base"}
 swc_ecma_utils = {version = "0.41.0", path = "./ecmascript/utils"}
 swc_ecma_visit = {version = "0.35.0", path = "./ecmascript/visit"}
 swc_node_base = {version = "0.2.0", path = "./node/base"}

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -9,7 +9,7 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/**/*.js"]
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.49.0"
+version = "0.50.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -34,10 +34,10 @@ retain_mut = "0.1.2"
 swc_atoms = {version = "0.2.4", path = "../atoms"}
 swc_common = {version = "0.11.0", path = "../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../ecmascript/ast"}
-swc_ecma_codegen = {version = "0.65.0", path = "../ecmascript/codegen"}
+swc_ecma_codegen = {version = "0.66.0", path = "../ecmascript/codegen"}
 swc_ecma_loader = {version = "0.12.0", path = "../ecmascript/loader"}
-swc_ecma_parser = {version = "0.65.0", path = "../ecmascript/parser"}
-swc_ecma_transforms = {version = "0.62.0", path = "../ecmascript/transforms", features = ["optimization"]}
+swc_ecma_parser = {version = "0.66.0", path = "../ecmascript/parser"}
+swc_ecma_transforms = {version = "0.63.0", path = "../ecmascript/transforms", features = ["optimization"]}
 swc_ecma_utils = {version = "0.41.0", path = "../ecmascript/utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../ecmascript/visit"}
 
@@ -46,7 +46,7 @@ hex = "0.4"
 ntest = "0.7.2"
 reqwest = {version = "0.10.8", features = ["blocking"]}
 sha-1 = "0.9"
-swc_ecma_transforms = {version = "0.62.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
+swc_ecma_transforms = {version = "0.63.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
 tempfile = "3.1.0"
 testing = {version = "0.12.0", path = "../testing"}
 url = "2.1.1"

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.51.0"
+version = "0.52.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -32,11 +32,11 @@ typescript = ["typescript-parser", "swc_ecma_transforms/typescript"]
 
 [dependencies]
 swc_ecma_ast = {version = "0.49.0", path = "./ast"}
-swc_ecma_codegen = {version = "0.65.0", path = "./codegen", optional = true}
-swc_ecma_dep_graph = {version = "0.33.0", path = "./dep-graph", optional = true}
-swc_ecma_minifier = {version = "0.17.0", path = "./minifier", optional = true}
-swc_ecma_parser = {version = "0.65.0", path = "./parser", optional = true, default-features = false}
-swc_ecma_transforms = {version = "0.62.0", path = "./transforms", optional = true}
+swc_ecma_codegen = {version = "0.66.0", path = "./codegen", optional = true}
+swc_ecma_dep_graph = {version = "0.34.0", path = "./dep-graph", optional = true}
+swc_ecma_minifier = {version = "0.18.0", path = "./minifier", optional = true}
+swc_ecma_parser = {version = "0.66.0", path = "./parser", optional = true, default-features = false}
+swc_ecma_transforms = {version = "0.63.0", path = "./transforms", optional = true}
 swc_ecma_utils = {version = "0.41.0", path = "./utils", optional = true}
 swc_ecma_visit = {version = "0.35.0", path = "./visit", optional = true}
 

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.65.1"
+version = "0.66.0"
 
 [dependencies]
 bitflags = "1"
@@ -17,7 +17,7 @@ swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.11.0", path = "../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../ast"}
 swc_ecma_codegen_macros = {version = "0.5.2", path = "./macros"}
-swc_ecma_parser = {version = "0.65.0", path = "../parser"}
+swc_ecma_parser = {version = "0.66.0", path = "../parser"}
 
 [dev-dependencies]
 swc_common = {version = "0.11.0", path = "../../common", features = ["sourcemap"]}

--- a/ecmascript/dep-graph/Cargo.toml
+++ b/ecmascript/dep-graph/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_dep_graph"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.33.0"
+version = "0.34.0"
 
 [dependencies]
 swc_atoms = {version = "0.2", path = "../../atoms"}
@@ -15,5 +15,5 @@ swc_ecma_ast = {version = "0.49.0", path = "../ast"}
 swc_ecma_visit = {version = "0.35.0", path = "../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.65.0", path = "../parser"}
+swc_ecma_parser = {version = "0.66.0", path = "../parser"}
 testing = {version = "0.12.0", path = "../../testing"}

--- a/ecmascript/ext-transforms/Cargo.toml
+++ b/ecmascript/ext-transforms/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_ext_transforms/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ext_transforms"
-version = "0.23.0"
+version = "0.24.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,6 +14,6 @@ phf = {version = "0.8.0", features = ["macros"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.11.0", path = "../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../ast"}
-swc_ecma_parser = {version = "0.65.0", path = "../parser"}
+swc_ecma_parser = {version = "0.66.0", path = "../parser"}
 swc_ecma_utils = {version = "0.41.0", path = "../utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../visit"}

--- a/ecmascript/jsdoc/Cargo.toml
+++ b/ecmascript/jsdoc/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/jsdoc/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "jsdoc"
-version = "0.33.0"
+version = "0.34.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -19,6 +19,6 @@ swc_common = {version = "0.11.0", path = "../../common"}
 anyhow = "1"
 dashmap = "4.0.2"
 swc_ecma_ast = {version = "0.49.0", path = "../ast"}
-swc_ecma_parser = {version = "0.65.0", path = "../parser"}
+swc_ecma_parser = {version = "0.66.0", path = "../parser"}
 testing = {version = "0.12.0", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/minifier/Cargo.toml
+++ b/ecmascript/minifier/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "src/lists/*.json"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_minifier"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.17.0"
+version = "0.18.0"
 
 [features]
 debug = []
@@ -26,10 +26,10 @@ serde_regex = "1.1.0"
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.11.2", path = "../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../ast"}
-swc_ecma_codegen = {version = "0.65.0", path = "../codegen"}
-swc_ecma_parser = {version = "0.65.0", path = "../parser"}
-swc_ecma_transforms = {version = "0.62.0", path = "../transforms/", features = ["optimization"]}
-swc_ecma_transforms_base = {version = "0.25.0", path = "../transforms/base"}
+swc_ecma_codegen = {version = "0.66.0", path = "../codegen"}
+swc_ecma_parser = {version = "0.66.0", path = "../parser"}
+swc_ecma_transforms = {version = "0.63.0", path = "../transforms/", features = ["optimization"]}
+swc_ecma_transforms_base = {version = "0.26.0", path = "../transforms/base"}
 swc_ecma_utils = {version = "0.41.0", path = "../utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../visit"}
 unicode-xid = "0.2.2"

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.65.0"
+version = "0.66.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ecmascript/parser/src/error.rs
+++ b/ecmascript/parser/src/error.rs
@@ -340,7 +340,9 @@ impl SyntaxError {
             SyntaxError::ImportExportInScript => {
                 "'import', and 'export' cannot be used outside of module code".into()
             }
-            SyntaxError::ImportMetaInScript => "'import.meta' cannot be used outside of module code.".into(),
+            SyntaxError::ImportMetaInScript => {
+                "'import.meta' cannot be used outside of module code.".into()
+            }
 
             SyntaxError::PatVarWithoutInit => "Destructuring bindings require initializers".into(),
             SyntaxError::WithInStrict => "With statement are not allowed in strict mode".into(),

--- a/ecmascript/parser/src/error.rs
+++ b/ecmascript/parser/src/error.rs
@@ -128,6 +128,7 @@ pub enum SyntaxError {
     AsyncGenerator,
     NonTopLevelImportExport,
     ImportExportInScript,
+    ImportMetaInScript,
     PatVarWithoutInit,
     WithInStrict,
     ReturnNotAllowed,
@@ -339,6 +340,7 @@ impl SyntaxError {
             SyntaxError::ImportExportInScript => {
                 "'import', and 'export' cannot be used outside of module code".into()
             }
+            SyntaxError::ImportMetaInScript => "'import.meta' cannot be used outside of module code.".into(),
 
             SyntaxError::PatVarWithoutInit => "Destructuring bindings require initializers".into(),
             SyntaxError::WithInStrict => "With statement are not allowed in strict mode".into(),

--- a/ecmascript/preset-env/Cargo.toml
+++ b/ecmascript/preset-env/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_preset_env/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_preset_env"
-version = "0.32.0"
+version = "0.33.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,13 +22,13 @@ string_enum = {version = "0.3.1", path = "../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.11.0", path = "../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../ast"}
-swc_ecma_transforms = {version = "0.62.0", path = "../transforms", features = ["compat", "proposal"]}
+swc_ecma_transforms = {version = "0.63.0", path = "../transforms", features = ["compat", "proposal"]}
 swc_ecma_utils = {version = "0.41.0", path = "../utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../visit"}
 walkdir = "2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
-swc_ecma_codegen = {version = "0.65.0", path = "../codegen"}
-swc_ecma_parser = {version = "0.65.0", path = "../parser"}
+swc_ecma_codegen = {version = "0.66.0", path = "../codegen"}
+swc_ecma_parser = {version = "0.66.0", path = "../parser"}
 testing = {version = "0.12.0", path = "../../testing"}

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.62.0"
+version = "0.63.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -24,14 +24,14 @@ typescript = ["swc_ecma_transforms_typescript"]
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.11.0", path = "../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../ast"}
-swc_ecma_parser = {version = "0.65.0", path = "../parser"}
-swc_ecma_transforms_base = {version = "0.25.0", path = "./base"}
-swc_ecma_transforms_compat = {version = "0.28.0", path = "./compat", optional = true}
-swc_ecma_transforms_module = {version = "0.29.0", path = "./module", optional = true}
-swc_ecma_transforms_optimization = {version = "0.32.0", path = "./optimization", optional = true}
-swc_ecma_transforms_proposal = {version = "0.29.0", path = "./proposal", optional = true}
-swc_ecma_transforms_react = {version = "0.30.0", path = "./react", optional = true}
-swc_ecma_transforms_typescript = {version = "0.31.0", path = "./typescript", optional = true}
+swc_ecma_parser = {version = "0.66.0", path = "../parser"}
+swc_ecma_transforms_base = {version = "0.26.0", path = "./base"}
+swc_ecma_transforms_compat = {version = "0.29.0", path = "./compat", optional = true}
+swc_ecma_transforms_module = {version = "0.30.0", path = "./module", optional = true}
+swc_ecma_transforms_optimization = {version = "0.33.0", path = "./optimization", optional = true}
+swc_ecma_transforms_proposal = {version = "0.30.0", path = "./proposal", optional = true}
+swc_ecma_transforms_react = {version = "0.31.0", path = "./react", optional = true}
+swc_ecma_transforms_typescript = {version = "0.32.0", path = "./typescript", optional = true}
 swc_ecma_utils = {version = "0.41.0", path = "../utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../visit"}
 unicode-xid = "0.2"
@@ -39,8 +39,8 @@ unicode-xid = "0.2"
 [dev-dependencies]
 pretty_assertions = "0.6"
 sourcemap = "6"
-swc_ecma_codegen = {version = "0.65.0", path = "../codegen"}
-swc_ecma_transforms_testing = {version = "0.25.0", path = "./testing"}
+swc_ecma_codegen = {version = "0.66.0", path = "../codegen"}
+swc_ecma_transforms_testing = {version = "0.26.0", path = "./testing"}
 tempfile = "3"
 testing = {version = "0.12.0", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.25.0"
+version = "0.26.0"
 
 [dependencies]
 fxhash = "0.2.1"
@@ -17,10 +17,10 @@ smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.11.0", path = "../../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.65.0", path = "../../parser"}
+swc_ecma_parser = {version = "0.66.0", path = "../../parser"}
 swc_ecma_utils = {version = "0.41.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.65.0", path = "../../codegen"}
+swc_ecma_codegen = {version = "0.66.0", path = "../../codegen"}
 testing = {version = "0.12.0", path = "../../../testing"}

--- a/ecmascript/transforms/classes/Cargo.toml
+++ b/ecmascript/transforms/classes/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_classes"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.11.0"
+version = "0.12.0"
 
 [dependencies]
 swc_atoms = {version = "0.2.6", path = "../../../atoms"}
 swc_common = {version = "0.11.0", path = "../../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.25.0", path = "../base"}
+swc_ecma_transforms_base = {version = "0.26.0", path = "../base"}
 swc_ecma_utils = {version = "0.41.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../../visit"}

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.28.0"
+version = "0.29.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -21,13 +21,13 @@ smallvec = "1.6.0"
 swc_atoms = {version = "0.2.5", path = "../../../atoms"}
 swc_common = {version = "0.11.0", path = "../../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.25.0", path = "../base"}
-swc_ecma_transforms_classes = {version = "0.11.0", path = "../classes"}
+swc_ecma_transforms_base = {version = "0.26.0", path = "../base"}
+swc_ecma_transforms_classes = {version = "0.12.0", path = "../classes"}
 swc_ecma_transforms_macros = {version = "0.2.1", path = "../macros"}
 swc_ecma_utils = {version = "0.41.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.65.0", path = "../../parser"}
-swc_ecma_transforms_testing = {version = "0.25.0", path = "../testing"}
+swc_ecma_parser = {version = "0.66.0", path = "../../parser"}
+swc_ecma_transforms_testing = {version = "0.26.0", path = "../testing"}
 testing = {version = "0.12.0", path = "../../../testing"}

--- a/ecmascript/transforms/module/Cargo.toml
+++ b/ecmascript/transforms/module/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.29.0"
+version = "0.30.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -20,12 +20,12 @@ swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.11.0", path = "../../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../../ast"}
 swc_ecma_loader = {version = "0.12.0", path = "../../loader", features = ["node"]}
-swc_ecma_parser = {version = "0.65.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.25.0", path = "../base"}
+swc_ecma_parser = {version = "0.66.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.26.0", path = "../base"}
 swc_ecma_utils = {version = "0.41.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.28.0", path = "../compat"}
-swc_ecma_transforms_testing = {version = "0.25.0", path = "../testing/"}
+swc_ecma_transforms_compat = {version = "0.29.0", path = "../compat"}
+swc_ecma_transforms_testing = {version = "0.26.0", path = "../testing/"}
 testing = {version = "0.12.0", path = "../../../testing/"}

--- a/ecmascript/transforms/optimization/Cargo.toml
+++ b/ecmascript/transforms/optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.32.0"
+version = "0.33.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -20,16 +20,16 @@ serde_json = "1.0.61"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.11.0", path = "../../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.65.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.25.0", path = "../base"}
+swc_ecma_parser = {version = "0.66.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.26.0", path = "../base"}
 swc_ecma_utils = {version = "0.41.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.28.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.29.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.29.0", path = "../proposal"}
-swc_ecma_transforms_react = {version = "0.30.0", path = "../react"}
-swc_ecma_transforms_testing = {version = "0.25.0", path = "../testing"}
-swc_ecma_transforms_typescript = {version = "0.31.0", path = "../typescript"}
+swc_ecma_transforms_compat = {version = "0.29.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.30.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.30.0", path = "../proposal"}
+swc_ecma_transforms_react = {version = "0.31.0", path = "../react"}
+swc_ecma_transforms_testing = {version = "0.26.0", path = "../testing"}
+swc_ecma_transforms_typescript = {version = "0.32.0", path = "../typescript"}
 testing = {version = "0.12.0", path = "../../../testing"}

--- a/ecmascript/transforms/proposal/Cargo.toml
+++ b/ecmascript/transforms/proposal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_proposal"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.29.0"
+version = "0.30.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -23,13 +23,13 @@ swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.11.0", path = "../../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../../ast"}
 swc_ecma_loader = {version = "0.12.0", path = "../../loader", optional = true}
-swc_ecma_parser = {version = "0.65.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.25.0", path = "../base"}
-swc_ecma_transforms_classes = {version = "0.11.0", path = "../classes"}
+swc_ecma_parser = {version = "0.66.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.26.0", path = "../base"}
+swc_ecma_transforms_classes = {version = "0.12.0", path = "../classes"}
 swc_ecma_utils = {version = "0.41.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.28.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.29.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.25.0", path = "../testing"}
+swc_ecma_transforms_compat = {version = "0.29.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.30.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.26.0", path = "../testing"}

--- a/ecmascript/transforms/react/Cargo.toml
+++ b/ecmascript/transforms/react/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_react"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.30.1"
+version = "0.31.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -22,14 +22,14 @@ string_enum = {version = "0.3.1", path = "../../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.11.0", path = "../../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.65.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.25.0", path = "../base"}
+swc_ecma_parser = {version = "0.66.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.26.0", path = "../base"}
 swc_ecma_utils = {version = "0.41.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.65.0", path = "../../codegen/"}
-swc_ecma_transforms_compat = {version = "0.28.0", path = "../compat/"}
-swc_ecma_transforms_module = {version = "0.29.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.25.0", path = "../testing/"}
+swc_ecma_codegen = {version = "0.66.0", path = "../../codegen/"}
+swc_ecma_transforms_compat = {version = "0.29.0", path = "../compat/"}
+swc_ecma_transforms_module = {version = "0.30.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.26.0", path = "../testing/"}
 testing = {version = "0.12.0", path = "../../../testing"}

--- a/ecmascript/transforms/testing/Cargo.toml
+++ b/ecmascript/transforms/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.25.0"
+version = "0.26.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,9 +16,9 @@ serde = "1"
 serde_json = "1"
 swc_common = {version = "0.11.0", path = "../../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../../ast"}
-swc_ecma_codegen = {version = "0.65.0", path = "../../codegen"}
-swc_ecma_parser = {version = "0.65.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.25.0", path = "../base"}
+swc_ecma_codegen = {version = "0.66.0", path = "../../codegen"}
+swc_ecma_parser = {version = "0.66.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.26.0", path = "../base"}
 swc_ecma_utils = {version = "0.41.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../../visit"}
 tempfile = "3.1.0"

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.31.0"
+version = "0.32.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -15,16 +15,16 @@ serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.11.0", path = "../../../common"}
 swc_ecma_ast = {version = "0.49.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.65.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.25.0", path = "../base"}
+swc_ecma_parser = {version = "0.66.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.26.0", path = "../base"}
 swc_ecma_utils = {version = "0.41.0", path = "../../utils"}
 swc_ecma_visit = {version = "0.35.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.65.0", path = "../../codegen"}
-swc_ecma_transforms_compat = {version = "0.28.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.29.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.29.0", path = "../proposal/"}
-swc_ecma_transforms_testing = {version = "0.25.0", path = "../testing"}
+swc_ecma_codegen = {version = "0.66.0", path = "../../codegen"}
+swc_ecma_transforms_compat = {version = "0.29.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.30.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.30.0", path = "../proposal/"}
+swc_ecma_transforms_testing = {version = "0.26.0", path = "../testing"}
 testing = {version = "0.12.0", path = "../../../testing"}
 walkdir = "2.3.1"


### PR DESCRIPTION
With the current parser, parsing `import.meta` in script mode does not generate an error. In ECMAScript, `import.meta` cannot be used in scripts. So this PR occurs a syntax error when parsing `import.meta` in script mode.