### PR TITLE
feat: add `SingleThreadedComments::from_leading_and_trailing`

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_common"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.11.3"
+version = "0.11.4"
 
 [features]
 concurrent = ["parking_lot"]

--- a/common/src/comments.rs
+++ b/common/src/comments.rs
@@ -230,6 +230,14 @@ impl Comments for SingleThreadedComments {
 }
 
 impl SingleThreadedComments {
+    /// Creates a new `SingleThreadedComments` from the provided leading and trailing.
+    pub fn from_leading_and_trailing(leading: SingleThreadedCommentsMap, trailing: SingleThreadedCommentsMap) -> Self {
+        SingleThreadedComments {
+            leading,
+            trailing,
+        }
+    }
+
     /// Takes all the comments as (leading, trailing).
     pub fn take_all(self) -> (SingleThreadedCommentsMap, SingleThreadedCommentsMap) {
         (self.leading, self.trailing)

--- a/common/src/comments.rs
+++ b/common/src/comments.rs
@@ -230,12 +230,13 @@ impl Comments for SingleThreadedComments {
 }
 
 impl SingleThreadedComments {
-    /// Creates a new `SingleThreadedComments` from the provided leading and trailing.
-    pub fn from_leading_and_trailing(leading: SingleThreadedCommentsMap, trailing: SingleThreadedCommentsMap) -> Self {
-        SingleThreadedComments {
-            leading,
-            trailing,
-        }
+    /// Creates a new `SingleThreadedComments` from the provided leading and
+    /// trailing.
+    pub fn from_leading_and_trailing(
+        leading: SingleThreadedCommentsMap,
+        trailing: SingleThreadedCommentsMap,
+    ) -> Self {
+        SingleThreadedComments { leading, trailing }
     }
 
     /// Takes all the comments as (leading, trailing).


### PR DESCRIPTION
This is instead of my change in #1996.

Basically what I'm doing is using `single_threaded_comments.take_all()` to get the comment maps, then pulling the maps out of the `Rc` and `RefCell`. I'm then using these maps in my own implementation of `Comments` that's multi-threaded and immutable for analysis purposes. Then for transforming, I'm going to take these maps, clone them, then provide them them to this new method to create a `SingleThreadedComments` for transforming in which case it's ok for the emitting code to mutate the comment maps. Does that make sense?