### PR TITLE
feat(transform): allow to specify filename when parse module

### DIFF
--- a/node-swc/__tests__/transform/sourcemap_test.js
+++ b/node-swc/__tests__/transform/sourcemap_test.js
@@ -15,7 +15,7 @@ console.log('foo')
 
 
     expect(out.map).toBeTruthy();
-    validate(out.code, out.map, {'input.js': raw});
+    validate(out.code, out.map, { 'input.js': raw });
 
     // await sourceMap.SourceMapConsumer.with(JSON.parse(out.map), null, async (consumer) => {
     //     consumer.eachMapping((mapping) => {
@@ -33,6 +33,33 @@ console.log('foo')
 
 })
 
+it('should handle sourcemap correctly when parse module', async () => {
+    const raw = `
+class Foo extends Array {
+}
+console.log('foo')
+    `;
+    const out1 = swc.transformSync(raw, {
+        filename: 'input.js',
+        sourceMaps: true,
+        plugin: swc.plugins([m => m])
+    });
+
+
+    expect(out1.map).toBeTruthy();
+    expect(JSON.parse(out1.map).sources).toEqual(['input.js']);
+    validate(out1.code, out1.map, { 'input.js': raw });
+
+    const out2 = swc.transformSync(raw, {
+        sourceMaps: true,
+        plugin: swc.plugins([m => m])
+    });
+
+    expect(out2.map).toBeTruthy();
+    expect(JSON.parse(out2.map).sources).toEqual(['<anon>']);
+    validate(out2.code, out2.map, { 'input.js': raw });
+})
+
 it('should handle input sourcemap correctly', async () => {
     const raw = `class Foo extends Array {}`;
     const out1 = swc.transformSync(raw, {
@@ -48,7 +75,7 @@ it('should handle input sourcemap correctly', async () => {
     });
 
     expect(out1.map).toBeTruthy();
-    validate(out1.code, out1.map, {'input.js': raw});
+    validate(out1.code, out1.map, { 'input.js': raw });
     console.log(out1.code);
 
     const out2 = swc.transformSync(out1.code, {
@@ -65,8 +92,8 @@ it('should handle input sourcemap correctly', async () => {
 
     console.log(out2.code);
     expect(out2.map).toBeTruthy();
-    validate(out2.code, out2.map, {'input2.js': out1.code});
-    validate(out2.code, out2.map, {'input.js': raw});
+    validate(out2.code, out2.map, { 'input2.js': out1.code });
+    validate(out2.code, out2.map, { 'input.js': raw });
 
     await sourceMap.SourceMapConsumer.with(JSON.parse(out1.map), null, async (consumer1) => {
         await sourceMap.SourceMapConsumer.with(JSON.parse(out2.map), null, async (consumer2) => {

--- a/node-swc/src/index.ts
+++ b/node-swc/src/index.ts
@@ -43,22 +43,22 @@ export class Compiler {
     src: string,
     options: ParseOptions & { isModule: false }
   ): Promise<Script>;
-  parse(src: string, options?: ParseOptions): Promise<Module>;
-  async parse(src: string, options?: ParseOptions): Promise<Program> {
+  parse(src: string, options?: ParseOptions, filename?: string): Promise<Module>;
+  async parse(src: string, options?: ParseOptions, filename?: string): Promise<Program> {
     options = options || { syntax: "ecmascript" };
     options.syntax = options.syntax || "ecmascript";
 
-    const res = await bindings.parse(src, toBuffer(options));
+    const res = await bindings.parse(src, toBuffer(options), filename);
     return JSON.parse(res);
   }
 
   parseSync(src: string, options: ParseOptions & { isModule: false }): Script;
-  parseSync(src: string, options?: ParseOptions): Module;
-  parseSync(src: string, options?: ParseOptions): Program {
+  parseSync(src: string, options?: ParseOptions, filename?: string): Module;
+  parseSync(src: string, options?: ParseOptions, filename?: string): Program {
     options = options || { syntax: "ecmascript" };
     options.syntax = options.syntax || "ecmascript";
 
-    return JSON.parse(bindings.parseSync(src, toBuffer(options)));
+    return JSON.parse(bindings.parseSync(src, toBuffer(options), filename));
   }
 
   parseFile(
@@ -121,7 +121,7 @@ export class Compiler {
     if (plugin) {
       const m =
         typeof src === "string"
-          ? await this.parse(src, options?.jsc?.parser)
+          ? await this.parse(src, options?.jsc?.parser, options.filename)
           : src;
       return this.transform(plugin(m), newOptions);
     }
@@ -142,7 +142,7 @@ export class Compiler {
 
     if (plugin) {
       const m =
-        typeof src === "string" ? this.parseSync(src, options?.jsc?.parser) : src;
+        typeof src === "string" ? this.parseSync(src, options?.jsc?.parser, options.filename) : src;
       return this.transformSync(plugin(m), newOptions);
     }
 


### PR DESCRIPTION
- closes #2023 

This PR attempts to support sourcemapped stack with provided filename for `transform*` interfaces. When there are plguins specified, it goes through path to parse into module / program first to pass into plugin. When those occur, it always assigns filename to `FileName::Anon` even though transform option specifies it.

PR pass through `filename` as optional param to compiler's `parse*` and use it if it's specified, otherwise falls back to default behavior. Note PR did not make any public interface exposure to exported `pasre*` in node-swc, instead just passes down to compiler's fn via transform. This is mostly I am not sure if it's desired usecases to parse* allows to specify by default.