### PR TITLE
fix(es/parser): Recover from `import.meta` in scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,7 +2440,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.66.1"
+version = "0.66.2"
 dependencies = [
  "either",
  "enum_kind",

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.66.1"
+version = "0.66.2"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ecmascript/parser/src/lib.rs
+++ b/ecmascript/parser/src/lib.rs
@@ -160,11 +160,11 @@ impl Syntax {
         }
     }
 
-    pub fn optional_chaining(self) -> bool {
+    pub const fn optional_chaining(self) -> bool {
         true
     }
 
-    pub fn dynamic_import(self) -> bool {
+    pub const fn dynamic_import(self) -> bool {
         true
     }
 
@@ -175,7 +175,7 @@ impl Syntax {
         }
     }
 
-    pub fn num_sep(self) -> bool {
+    pub const fn num_sep(self) -> bool {
         true
     }
 
@@ -191,15 +191,15 @@ impl Syntax {
         }
     }
 
-    pub fn class_private_methods(self) -> bool {
+    pub const fn class_private_methods(self) -> bool {
         true
     }
 
-    pub fn class_private_props(self) -> bool {
+    pub const fn class_private_props(self) -> bool {
         true
     }
 
-    pub fn class_props(self) -> bool {
+    pub const fn class_props(self) -> bool {
         true
     }
 
@@ -240,20 +240,20 @@ impl Syntax {
     }
 
     /// `true`
-    pub fn export_namespace_from(self) -> bool {
+    pub const fn export_namespace_from(self) -> bool {
         true
     }
 
     /// `true`
-    pub fn nullish_coalescing(self) -> bool {
+    pub const fn nullish_coalescing(self) -> bool {
         true
     }
 
-    pub fn import_meta(self) -> bool {
+    pub const fn import_meta(self) -> bool {
         true
     }
 
-    pub fn top_level_await(self) -> bool {
+    pub const fn top_level_await(self) -> bool {
         true
     }
 

--- a/ecmascript/parser/src/lib.rs
+++ b/ecmascript/parser/src/lib.rs
@@ -369,6 +369,7 @@ pub struct EsConfig {
 pub struct Context {
     /// Is in module code?
     module: bool,
+    can_be_module: bool,
     strict: bool,
     include_in_expr: bool,
     /// If true, await expression is parsed, and "await" is treated as a

--- a/ecmascript/parser/src/parser/expr.rs
+++ b/ecmascript/parser/src/parser/expr.rs
@@ -232,7 +232,8 @@ impl<'a, I: Tokens> Parser<I> {
                 tok!("import") => {
                     let import = self.parse_ident_name()?;
                     if self.input.syntax().import_meta() && is!(self, '.') {
-                        if !self.ctx().module {
+                        self.state.found_module_item = true;
+                        if !self.ctx().can_be_module {
                             syntax_error!(self, SyntaxError::ImportMetaInScript);
                         }
                         return self

--- a/ecmascript/parser/src/parser/expr.rs
+++ b/ecmascript/parser/src/parser/expr.rs
@@ -234,7 +234,8 @@ impl<'a, I: Tokens> Parser<I> {
                     if self.input.syntax().import_meta() && is!(self, '.') {
                         self.state.found_module_item = true;
                         if !self.ctx().can_be_module {
-                            syntax_error!(self, SyntaxError::ImportMetaInScript);
+                            let span = span!(self, start);
+                            self.emit_err(span, SyntaxError::ImportMetaInScript);
                         }
                         return self
                             .parse_import_meta_prop(import)

--- a/ecmascript/parser/src/parser/mod.rs
+++ b/ecmascript/parser/src/parser/mod.rs
@@ -248,12 +248,20 @@ where
         let lexer = Lexer::new(syntax, JscTarget::Es2019, input, None);
         let mut p = Parser::new_from(lexer);
         let ret = f(&mut p);
+        let mut error = false;
 
         for err in p.take_errors() {
+            error = true;
             err.into_diagnostic(handler).emit();
         }
 
-        ret.map_err(|err| err.into_diagnostic(handler).emit())
+        let res = ret.map_err(|err| err.into_diagnostic(handler).emit())?;
+
+        if error {
+            return Err(());
+        }
+
+        Ok(res)
     })
     .unwrap_or_else(|output| panic!("test_parser(): failed to parse \n{}\n{}", s, output))
 }

--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -1806,6 +1806,19 @@ export default function waitUntil(callback, options = {}) {
     }
 
     #[test]
+    fn import_meta_in_program() {
+        let src = "const foo = import.meta.url;";
+        test_parser(
+            src,
+            Syntax::Es(EsConfig {
+                import_meta: true,
+                ..Default::default()
+            }),
+            |p| p.parse_program(),
+        );
+    }
+
+    #[test]
     #[should_panic(expected = "'import', and 'export' cannot be used outside of module code")]
     fn import_statement_in_script() {
         let src = "import 'foo';";


### PR DESCRIPTION
swc_ecma_parser:
 - Recover from `import.meta` in scripts. (Closes #2041)
 - Allow `import.meta` when using `parse_program`.