### PR TITLE
fix(swc): Report error correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3089,6 +3089,7 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 name = "wasm"
 version = "1.2.77"
 dependencies = [
+ "anyhow",
  "console_error_panic_hook",
  "once_cell",
  "path-clean",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,7 +2167,7 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "swc"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "ahash 0.7.4",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "arbitrary",
  "ast_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.39.0"
+version = "0.40.0"
 
 [lib]
 name = "swc"

--- a/babel/compat/Cargo.toml
+++ b/babel/compat/Cargo.toml
@@ -22,7 +22,7 @@ swc = {path = "../.."}
 swc_atoms = {path = "../../atoms"}
 swc_babel_ast = {path = "../ast"}
 swc_babel_visit = {path = "../visit"}
-swc_common = {path = "../../common", features = ["tty-emitter", "sourcemap"]}
+swc_common = {path = "../../common", features = ["sourcemap"]}
 swc_ecma_ast = {path = "../../ecmascript/ast"}
 swc_ecma_parser = {path = "../../ecmascript/parser"}
 swc_ecma_utils = {path = "../../ecmascript/utils"}

--- a/babel/compat/benches/babelify.rs
+++ b/babel/compat/benches/babelify.rs
@@ -2,14 +2,12 @@
 
 extern crate test;
 
+use std::io::stderr;
 use std::{hint::black_box, sync::Arc};
 use swc_babel_compat::babelify::Babelify;
 use swc_babel_compat::babelify::Context;
 use swc_common::SourceFile;
-use swc_common::{
-    errors::{ColorConfig, Handler},
-    FileName, FilePathMapping, SourceMap,
-};
+use swc_common::{errors::Handler, FileName, FilePathMapping, SourceMap};
 use swc_ecma_ast::Program;
 use swc_ecma_parser::{JscTarget, Syntax};
 use swc_ecma_transforms::compat::es2020;
@@ -21,14 +19,8 @@ static SOURCE: &str = include_str!("assets/AjaxObservable.ts");
 
 fn mk() -> swc::Compiler {
     let cm = Arc::new(SourceMap::new(FilePathMapping::empty()));
-    let handler = Arc::new(Handler::with_tty_emitter(
-        ColorConfig::Always,
-        true,
-        false,
-        Some(cm.clone()),
-    ));
 
-    let c = swc::Compiler::new(cm.clone(), handler);
+    let c = swc::Compiler::new(cm.clone());
 
     c
 }
@@ -38,9 +30,13 @@ fn parse(c: &swc::Compiler, src: &str) -> (Arc<SourceFile>, Program) {
         FileName::Real("rxjs/src/internal/observable/dom/AjaxObservable.ts".into()),
         src.to_string(),
     );
+
+    let handler = Handler::with_emitter_writer(Box::new(stderr()), Some(c.cm.clone()));
+
     let module = c
         .parse_js(
             fm.clone(),
+            &handler,
             JscTarget::Es5,
             Syntax::Typescript(Default::default()),
             true,
@@ -57,7 +53,9 @@ fn babelify_only(b: &mut Bencher) {
 
     let c = mk();
     let (fm, module) = parse(&c, SOURCE);
-    let module = c.run_transform(false, || {
+    let handler = Handler::with_emitter_writer(Box::new(stderr()), Some(c.cm.clone()));
+
+    let module = c.run_transform(&handler, false, || {
         module
             .fold_with(&mut typescript::strip())
             .fold_with(&mut es2020())

--- a/babel/compat/tests/convert.rs
+++ b/babel/compat/tests/convert.rs
@@ -126,12 +126,13 @@ fn run_test(src: String, expected: String, syntax: Syntax, is_module: bool) {
         false,
         Some(cm.clone()),
     ));
-    let compiler = Compiler::new(cm.clone(), handler);
+    let compiler = Compiler::new(cm.clone());
     let fm = compiler.cm.new_source_file(FileName::Anon, src);
 
     let swc_ast = compiler
         .parse_js(
             fm.clone(),
+            &handler,
             Default::default(), // JscTarget (ES version)
             syntax,
             is_module,

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_common"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.11.4"
+version = "0.11.5"
 
 [features]
 concurrent = ["parking_lot"]

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -20,6 +20,7 @@ use crate::{
     sync::{Lock, LockCell},
     syntax_pos::{BytePos, FileLinesResult, FileName, Loc, MultiSpan, Span, NO_EXPANSION},
 };
+use std::sync::Arc;
 use std::{
     borrow::Cow,
     cell::RefCell,
@@ -379,7 +380,7 @@ impl Handler {
     /// Calls [Self::with_emitter] with [EmitterWriter].
     pub fn with_emitter_writer(
         dst: Box<dyn Write + Send>,
-        cm: Option<Lrc<SourceMapperDyn>>,
+        cm: Option<Arc<SourceMapperDyn>>,
     ) -> Handler {
         Handler::with_emitter(
             true,

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -25,7 +25,9 @@ use std::{
     borrow::Cow,
     cell::RefCell,
     collections::HashSet,
-    error, fmt, panic,
+    error, fmt,
+    io::Write,
+    panic,
     sync::atomic::{AtomicUsize, Ordering::SeqCst},
 };
 #[cfg(feature = "tty-emitter")]
@@ -372,6 +374,18 @@ impl Handler {
                 treat_err_as_bug,
                 ..Default::default()
             },
+        )
+    }
+
+    /// Calls [Self::with_emitter] with [EmitterWriter].
+    pub fn with_emitter_writer(
+        dst: Box<dyn Write + Send>,
+        cm: Option<Lrc<SourceMapperDyn>>,
+    ) -> Handler {
+        Handler::with_emitter(
+            true,
+            false,
+            Box::new(EmitterWriter::new(dst, cm, false, true)),
         )
     }
 

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -359,13 +359,14 @@ impl Handler {
         Handler::with_emitter_and_flags(emitter, flags)
     }
 
+    /// Example implementation of [Emitter] is [EmitterWriter]
     pub fn with_emitter(
         can_emit_warnings: bool,
         treat_err_as_bug: bool,
-        e: Box<dyn Emitter + Send>,
+        emitter: Box<dyn Emitter + Send>,
     ) -> Handler {
         Handler::with_emitter_and_flags(
-            e,
+            emitter,
             HandlerFlags {
                 can_emit_warnings,
                 treat_err_as_bug,

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -15,12 +15,12 @@ pub use self::{
     emitter::{ColorConfig, Emitter, EmitterWriter},
 };
 use crate::sync::Lrc;
+use crate::sync::Send;
 use crate::{
     rustc_data_structures::stable_hasher::StableHasher,
     sync::{Lock, LockCell},
     syntax_pos::{BytePos, FileLinesResult, FileName, Loc, MultiSpan, Span, NO_EXPANSION},
 };
-use std::sync::Arc;
 use std::{
     borrow::Cow,
     cell::RefCell,
@@ -380,7 +380,7 @@ impl Handler {
     /// Calls [Self::with_emitter] with [EmitterWriter].
     pub fn with_emitter_writer(
         dst: Box<dyn Write + Send>,
-        cm: Option<Arc<SourceMapperDyn>>,
+        cm: Option<Lrc<SourceMapperDyn>>,
     ) -> Handler {
         Handler::with_emitter(
             true,

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -15,7 +15,6 @@ pub use self::{
     emitter::{ColorConfig, Emitter, EmitterWriter},
 };
 use crate::sync::Lrc;
-use crate::sync::Send;
 use crate::{
     rustc_data_structures::stable_hasher::StableHasher,
     sync::{Lock, LockCell},
@@ -365,7 +364,7 @@ impl Handler {
     pub fn with_emitter(
         can_emit_warnings: bool,
         treat_err_as_bug: bool,
-        emitter: Box<dyn Emitter + Send>,
+        emitter: Box<dyn Emitter>,
     ) -> Handler {
         Handler::with_emitter_and_flags(
             emitter,

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -14,7 +14,6 @@ pub use self::{
     diagnostic_builder::DiagnosticBuilder,
     emitter::{ColorConfig, Emitter, EmitterWriter},
 };
-#[cfg(feature = "tty-emitter")]
 use crate::sync::Lrc;
 use crate::{
     rustc_data_structures::stable_hasher::StableHasher,

--- a/common/src/errors/emitter.rs
+++ b/common/src/errors/emitter.rs
@@ -132,6 +132,7 @@ impl ColorConfig {
     }
 }
 
+/// Implementation of [Emitter] which pretty-prints the errors.
 pub struct EmitterWriter {
     dst: Destination,
     sm: Option<Lrc<SourceMapperDyn>>,

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -13,7 +13,7 @@ fn main() {
         false,
         Some(cm.clone()),
     ));
-    let c = swc::Compiler::new(cm.clone(), handler.clone());
+    let c = swc::Compiler::new(cm.clone());
 
     let fm = cm
         .load_file(Path::new("foo.js"))
@@ -21,6 +21,7 @@ fn main() {
 
     c.process_js_file(
         fm,
+        &handler,
         &Options {
             ..Default::default()
         },

--- a/node/binding/Cargo.toml
+++ b/node/binding/Cargo.toml
@@ -29,7 +29,7 @@ swc = {path = "../../"}
 swc_atoms = {version = "0.2.4", path = "../../atoms"}
 swc_babel_compat = {path = "../../babel/compat"}
 swc_bundler = {path = "../../bundler"}
-swc_common = {path = "../../common", features = ["tty-emitter", "sourcemap"]}
+swc_common = {path = "../../common", features = ["sourcemap"]}
 swc_ecma_ast = {path = "../../ecmascript/ast"}
 swc_ecma_parser = {path = "../../ecmascript/parser"}
 swc_node_base = {path = "../base"}

--- a/node/binding/src/lib.rs
+++ b/node/binding/src/lib.rs
@@ -9,12 +9,7 @@ use backtrace::Backtrace;
 use napi::{CallContext, Env, JsFunction, JsObject, JsUndefined};
 use std::{env, panic::set_hook, sync::Arc};
 use swc::{Compiler, TransformOutput};
-use swc_common::{
-    self,
-    errors::{ColorConfig, Handler},
-    sync::Lazy,
-    FilePathMapping, SourceMap,
-};
+use swc_common::{self, sync::Lazy, FilePathMapping, SourceMap};
 
 mod bundle;
 mod minify;
@@ -25,14 +20,8 @@ mod util;
 
 static COMPILER: Lazy<Arc<Compiler>> = Lazy::new(|| {
     let cm = Arc::new(SourceMap::new(FilePathMapping::empty()));
-    let handler = Arc::new(Handler::with_tty_emitter(
-        ColorConfig::Always,
-        true,
-        false,
-        Some(cm.clone()),
-    ));
 
-    Arc::new(Compiler::new(cm.clone(), handler))
+    Arc::new(Compiler::new(cm.clone()))
 });
 
 #[module_exports]

--- a/spack/src/loaders/swc.rs
+++ b/spack/src/loaders/swc.rs
@@ -3,8 +3,10 @@ use anyhow::{bail, Context, Error};
 use helpers::Helpers;
 use std::{collections::HashMap, env, sync::Arc};
 use swc::config::{InputSourceMap, JscConfig, TransformConfig};
+use swc::try_with_handler;
 use swc_atoms::JsWord;
 use swc_bundler::{Load, ModuleData};
+use swc_common::errors::Handler;
 use swc_common::{FileName, DUMMY_SP};
 use swc_ecma_ast::Module;
 use swc_ecma_ast::{Expr, Lit, Program, Str};
@@ -28,10 +30,8 @@ impl SwcLoader {
     pub fn new(compiler: Arc<swc::Compiler>, options: swc::config::Options) -> Self {
         SwcLoader { compiler, options }
     }
-}
 
-impl Load for SwcLoader {
-    fn load(&self, name: &FileName) -> Result<ModuleData, Error> {
+    fn load_with_handler(&self, handler: &Handler, name: &FileName) -> Result<ModuleData, Error> {
         log::debug!("JsLoader.load({})", name);
         let helpers = Helpers::new(false);
 
@@ -86,13 +86,14 @@ impl Load for SwcLoader {
         let program = if fm.name.to_string().contains("node_modules") {
             let program = self.compiler.parse_js(
                 fm.clone(),
+                &handler,
                 JscTarget::Es2020,
                 Default::default(),
                 true,
                 true,
             )?;
             let program = helpers::HELPERS.set(&helpers, || {
-                swc_ecma_utils::HANDLER.set(&self.compiler.handler, || {
+                swc_ecma_utils::HANDLER.set(&handler, || {
                     let program =
                         program.fold_with(&mut inline_globals(env_map(), Default::default()));
                     let program = program.fold_with(&mut expr_simplifier());
@@ -105,6 +106,7 @@ impl Load for SwcLoader {
             program
         } else {
             let config = self.compiler.config_for_file(
+                handler,
                 &swc::config::Options {
                     config: {
                         let c = &self.options.config;
@@ -165,6 +167,7 @@ impl Load for SwcLoader {
             // Note that we don't apply compat transform at loading phase.
             let program = self.compiler.parse_js(
                 fm.clone(),
+                handler,
                 JscTarget::Es2020,
                 config.as_ref().map(|v| v.syntax).unwrap_or_default(),
                 true,
@@ -181,7 +184,7 @@ impl Load for SwcLoader {
             // Fold module
             let program = if let Some(mut config) = config {
                 helpers::HELPERS.set(&helpers, || {
-                    swc_ecma_utils::HANDLER.set(&self.compiler.handler, || {
+                    swc_ecma_utils::HANDLER.set(handler, || {
                         let program =
                             program.fold_with(&mut inline_globals(env_map(), Default::default()));
                         let program = program.fold_with(&mut expr_simplifier());
@@ -209,6 +212,14 @@ impl Load for SwcLoader {
             }),
             _ => unreachable!(),
         }
+    }
+}
+
+impl Load for SwcLoader {
+    fn load(&self, name: &FileName) -> Result<ModuleData, Error> {
+        try_with_handler(self.compiler.cm.clone(), |handler| {
+            self.load_with_handler(&handler, name)
+        })
     }
 }
 

--- a/spack/tests/fixture.rs
+++ b/spack/tests/fixture.rs
@@ -125,8 +125,8 @@ fn reference_tests(tests: &mut Vec<TestDescAndFn>, errors: bool) -> Result<(), i
         add_test(tests, name, ignore, move || {
             eprintln!("\n\n========== Running reference test {}\n", dir_name);
 
-            testing::run_test2(false, |cm, handler| {
-                let compiler = Arc::new(swc::Compiler::new(cm.clone(), Arc::new(handler)));
+            testing::run_test2(false, |cm, _handler| {
+                let compiler = Arc::new(swc::Compiler::new(cm.clone()));
 
                 GLOBALS.set(compiler.globals(), || {
                     let loader = SwcLoader::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ where
 
     let handler = Handler::with_emitter_writer(wr.clone(), Some(cm.clone()));
 
-    let ret = op(&handler)?;
+    let ret = swc_ecma_utils::HANDLER.set(&handler, || op(&handler));
 
     if handler.has_errors() {
         let mut lock =
@@ -122,9 +122,9 @@ where
 
         let msg = String::from_utf8(error).expect("error string should be utf8");
 
-        Err(Error::msg(msg))
+        ret.context(msg)
     } else {
-        Ok(ret)
+        ret
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,10 @@ pub mod resolver {
 type SwcImportResolver =
     Arc<NodeImportResolver<CachingResolver<TsConfigResolver<NodeModulesResolver>>>>;
 
+/// All methods accept [Handler], which is a storage for errors.
+///
+/// The caller should check if the handler contains any errors after calling
+/// method.
 pub struct Compiler {
     /// swc uses rustc's span interning.
     ///

--- a/tests/error_msg.rs
+++ b/tests/error_msg.rs
@@ -1,15 +1,16 @@
-use std::{path::Path, sync::Arc};
+use std::path::Path;
 use swc::{config::Options, Compiler};
 use testing::{NormalizedOutput, Tester};
 
 fn file(f: &str) -> NormalizedOutput {
     Tester::new()
         .print_errors(|cm, handler| -> Result<NormalizedOutput, _> {
-            let c = Compiler::new(cm.clone(), Arc::new(handler));
+            let c = Compiler::new(cm.clone());
 
             let fm = cm.load_file(Path::new(f)).expect("failed to load file");
             let s = c.process_js_file(
                 fm,
+                &handler,
                 &Options {
                     swcrc: true,
                     is_module: true,

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use swc::{
     config::{Config, JscConfig, Options},
     Compiler,
@@ -12,11 +11,12 @@ use testing::Tester;
 fn compile(src: &str, options: Options) -> String {
     Tester::new()
         .print_errors(|cm, handler| {
-            let c = Compiler::new(cm.clone(), Arc::new(handler));
+            let c = Compiler::new(cm.clone());
 
             let fm = cm.new_source_file(FileName::Real("input.js".into()), src.into());
             let s = c.process_js_file(
                 fm,
+                &handler,
                 &Options {
                     is_module: true,
                     ..options
@@ -25,7 +25,7 @@ fn compile(src: &str, options: Options) -> String {
 
             match s {
                 Ok(v) => {
-                    if c.handler.has_errors() {
+                    if handler.has_errors() {
                         Err(())
                     } else {
                         Ok(v.code.into())

--- a/tests/source_map.rs
+++ b/tests/source_map.rs
@@ -22,12 +22,13 @@ fn file(f: &str) -> Result<(), StdErr> {
     Tester::new().print_errors(|cm, handler| {
         let path = canonicalize(f).expect("failed to canonicalize");
 
-        let c = Compiler::new(cm.clone(), Arc::new(handler));
+        let c = Compiler::new(cm.clone());
 
         let fm = cm.load_file(&path).expect("failed to load file");
         let s = c
             .process_js_file(
                 fm,
+                &handler,
                 &Options {
                     swcrc: true,
                     is_module: true,
@@ -72,12 +73,13 @@ fn inline(f: &str) -> Result<(), StdErr> {
     Tester::new().print_errors(|cm, handler| {
         let path = canonicalize(f).expect("failed to canonicalize");
 
-        let c = Compiler::new(cm.clone(), Arc::new(handler));
+        let c = Compiler::new(cm.clone());
 
         let fm = cm.load_file(&path).expect("failed to load file");
         let s = c
             .process_js_file(
                 fm,
+                &handler,
                 &Options {
                     swcrc: true,
                     is_module: true,

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -12,6 +12,7 @@ version = "1.2.77"
 crate-type = ["cdylib"]
 
 [dependencies]
+anyhow = "1.0.42"
 console_error_panic_hook = "0.1.6"
 once_cell = "1.3.1"
 path-clean = "0.1"

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,163 +1,119 @@
+use anyhow::{Context, Error};
 use once_cell::sync::Lazy;
-use std::{
-    fmt::{self, Display, Formatter},
-    io::{self, Write},
-    sync::{Arc, RwLock},
-};
+use std::sync::Arc;
 use swc::{
     config::{JsMinifyOptions, JscTarget, Options, ParseOptions, SourceMapsConfig},
-    Compiler,
+    try_with_handler, Compiler,
 };
-use swc_common::{
-    errors::{DiagnosticBuilder, Emitter, Handler, SourceMapperDyn},
-    FileName, FilePathMapping, SourceMap,
-};
+use swc_common::{FileName, FilePathMapping, SourceMap};
 use swc_ecmascript::ast::Program;
 use wasm_bindgen::prelude::*;
+
+fn convert_err(err: Error) -> JsValue {
+    format!("{:?}", err).into()
+}
 
 #[wasm_bindgen(js_name = "minifySync")]
 pub fn minify_sync(s: &str, opts: JsValue) -> Result<JsValue, JsValue> {
     console_error_panic_hook::set_once();
 
-    let opts: JsMinifyOptions = opts
-        .into_serde()
-        .map_err(|err| format!("failed to parse options: {}", err))?;
+    let c = compiler();
 
-    let (c, errors) = compiler();
+    try_with_handler(c.cm.clone(), |handler| {
+        let opts: JsMinifyOptions = opts.into_serde().context("failed to parse options")?;
 
-    let fm = c.cm.new_source_file(FileName::Anon, s.into());
-    let program = c
-        .minify(fm, &opts)
-        .map_err(|err| format!("failed to minify: {}\n{}", err, errors))?;
+        let fm = c.cm.new_source_file(FileName::Anon, s.into());
+        let program = c
+            .minify(fm, &handler, &opts)
+            .context("failed to minify file")?;
 
-    Ok(JsValue::from_serde(&program).map_err(|err| format!("failed to return value: {}", err))?)
+        Ok(JsValue::from_serde(&program).context("failed to serialize json")?)
+    })
+    .map_err(convert_err)
 }
 
 #[wasm_bindgen(js_name = "parseSync")]
 pub fn parse_sync(s: &str, opts: JsValue) -> Result<JsValue, JsValue> {
     console_error_panic_hook::set_once();
 
-    let opts: ParseOptions = opts
-        .into_serde()
-        .map_err(|err| format!("failed to parse options: {}", err))?;
+    let c = compiler();
 
-    let (c, errors) = compiler();
+    try_with_handler(c.cm.clone(), |handler| {
+        let opts: ParseOptions = opts.into_serde().context("failed to parse options")?;
 
-    let fm = c.cm.new_source_file(FileName::Anon, s.into());
-    let program = c
-        .parse_js(fm, opts.target, opts.syntax, opts.is_module, opts.comments)
-        .map_err(|err| format!("failed to parse: {}\n{}", err, errors))?;
+        let fm = c.cm.new_source_file(FileName::Anon, s.into());
+        let program = c
+            .parse_js(
+                fm,
+                &handler,
+                opts.target,
+                opts.syntax,
+                opts.is_module,
+                opts.comments,
+            )
+            .context("failed to parse code")?;
 
-    Ok(JsValue::from_serde(&program).map_err(|err| format!("failed to return value: {}", err))?)
+        Ok(JsValue::from_serde(&program).context("failed to serialize json")?)
+    })
+    .map_err(convert_err)
 }
 
 #[wasm_bindgen(js_name = "printSync")]
 pub fn print_sync(s: JsValue, opts: JsValue) -> Result<JsValue, JsValue> {
     console_error_panic_hook::set_once();
 
-    let program: Program = s
-        .into_serde()
-        .map_err(|err| format!("not a program: {}", err))?;
+    let c = compiler();
 
-    let opts: Options = opts
-        .into_serde()
-        .map_err(|err| format!("failed to parse options: {}", err))?;
+    try_with_handler(c.cm.clone(), |_handler| {
+        let opts: Options = opts.into_serde().context("failed to parse options")?;
 
-    let (c, errors) = compiler();
+        let program: Program = s.into_serde().context("failed to deserialize program")?;
 
-    let s = c
-        .print(
-            &program,
-            None,
-            None,
-            opts.codegen_target().unwrap_or(JscTarget::Es2020),
-            opts.source_maps
-                .clone()
-                .unwrap_or(SourceMapsConfig::Bool(false)),
-            None,
-            opts.config.minify,
-        )
-        .map_err(|err| format!("failed to print: {}\n{}", err, errors))?;
+        let s = c
+            .print(
+                &program,
+                None,
+                None,
+                opts.codegen_target().unwrap_or(JscTarget::Es2020),
+                opts.source_maps
+                    .clone()
+                    .unwrap_or(SourceMapsConfig::Bool(false)),
+                None,
+                opts.config.minify,
+            )
+            .context("failed to print code")?;
 
-    Ok(JsValue::from_serde(&s).map_err(|err| format!("failed to print: {}\n{}", err, errors))?)
+        Ok(JsValue::from_serde(&s).context("failed to serialize json")?)
+    })
+    .map_err(convert_err)
 }
 
 #[wasm_bindgen(js_name = "transformSync")]
 pub fn transform_sync(s: &str, opts: JsValue) -> Result<JsValue, JsValue> {
     console_error_panic_hook::set_once();
 
-    let opts: Options = opts
-        .into_serde()
-        .map_err(|err| format!("failed to parse options: {}", err))?;
+    let c = compiler();
 
-    let (c, errors) = compiler();
+    try_with_handler(c.cm.clone(), |handler| {
+        let opts: Options = opts.into_serde().context("failed to parse options")?;
 
-    let fm = c.cm.new_source_file(FileName::Anon, s.into());
-    let out = c
-        .process_js_file(fm, &opts)
-        .map_err(|err| format!("failed to process code: {}\n{}", err, errors))?;
+        let fm = c.cm.new_source_file(FileName::Anon, s.into());
+        let out = c
+            .process_js_file(fm, &handler, &opts)
+            .context("failed to process js file")?;
 
-    Ok(JsValue::from_serde(&out).unwrap())
-}
-
-fn compiler() -> (Compiler, BufferedError) {
-    let cm = codemap();
-
-    let (handler, errors) = new_handler(cm.clone());
-
-    let c = Compiler::new(cm.clone(), handler);
-
-    (c, errors)
+        Ok(JsValue::from_serde(&out).context("failed to serialize json")?)
+    })
+    .map_err(convert_err)
 }
 
 /// Get global sourcemap
-fn codemap() -> Arc<SourceMap> {
-    static CM: Lazy<Arc<SourceMap>> =
-        Lazy::new(|| Arc::new(SourceMap::new(FilePathMapping::empty())));
+fn compiler() -> Arc<Compiler> {
+    static C: Lazy<Arc<Compiler>> = Lazy::new(|| {
+        let cm = Arc::new(SourceMap::new(FilePathMapping::empty()));
 
-    CM.clone()
-}
+        Arc::new(Compiler::new(cm))
+    });
 
-/// Creates a new handler which emits to returned buffer.
-fn new_handler(_cm: Arc<SourceMapperDyn>) -> (Arc<Handler>, BufferedError) {
-    let e = BufferedError::default();
-
-    let handler = Handler::with_emitter(true, false, Box::new(MyEmitter::default()));
-
-    (Arc::new(handler), e)
-}
-
-#[derive(Clone, Default)]
-struct MyEmitter(BufferedError);
-
-impl Emitter for MyEmitter {
-    fn emit(&mut self, db: &DiagnosticBuilder<'_>) {
-        let z = &(self.0).0;
-        for msg in &db.message {
-            z.write().unwrap().push_str(&msg.0);
-        }
-    }
-}
-
-#[derive(Clone, Default)]
-pub(crate) struct BufferedError(Arc<RwLock<String>>);
-
-impl Write for BufferedError {
-    fn write(&mut self, d: &[u8]) -> io::Result<usize> {
-        self.0
-            .write()
-            .unwrap()
-            .push_str(&String::from_utf8_lossy(d));
-
-        Ok(d.len())
-    }
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-impl Display for BufferedError {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        Display::fmt(&self.0.read().unwrap(), f)
-    }
+    C.clone()
 }


### PR DESCRIPTION
swc_common:
  - Add some utilities for `Handler`.

swc:
 - Remove `Compiler.handler`.
 - Accept `handler` for each operations. (Closes #2035)
