### PR TITLE
fix(swc): Fix bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "arrayvec",
  "fxhash",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "ansi_term 0.12.1",
  "difference",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "testing_macros"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "glob",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,6 +2625,7 @@ name = "swc_ecma_transforms_testing"
 version = "0.26.1"
 dependencies = [
  "ansi_term 0.12.1",
+ "anyhow",
  "serde",
  "serde_json",
  "swc_common",

--- a/ecmascript/ast/src/module_decl.rs
+++ b/ecmascript/ast/src/module_decl.rs
@@ -73,7 +73,7 @@ pub struct ImportDecl {
     #[serde(rename = "source")]
     pub src: Str,
 
-    #[serde(rename = "typeOnly")]
+    #[serde(default, rename = "typeOnly")]
     pub type_only: bool,
 
     #[serde(default)]

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.29.2"
+version = "0.29.3"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/ecmascript/transforms/compat/src/es2020/opt_chaining.rs
+++ b/ecmascript/transforms/compat/src/es2020/opt_chaining.rs
@@ -467,6 +467,14 @@ impl OptChaining {
                             obj
                         };
                         let i = private_ident!(obj_span, "ref");
+                        let tmp = private_ident!(obj_span, "ref$t");
+
+                        self.vars_without_init.push(VarDeclarator {
+                            span: obj_span,
+                            definite: false,
+                            name: Pat::Ident(tmp.clone().into()),
+                            init: None,
+                        });
                         self.vars_without_init.push(VarDeclarator {
                             span: obj_span,
                             definite: false,

--- a/ecmascript/transforms/compat/src/es2020/opt_chaining.rs
+++ b/ecmascript/transforms/compat/src/es2020/opt_chaining.rs
@@ -497,7 +497,7 @@ impl OptChaining {
                             obj
                         };
 
-                        let tmp = private_ident!(obj_span, "tmp");
+                        let tmp = private_ident!(obj_span, "ref");
 
                         self.vars_without_init.push(VarDeclarator {
                             span: obj_span,

--- a/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
+++ b/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
@@ -1,10 +1,10 @@
 use std::fs::read_to_string;
 use std::path::PathBuf;
-
 use swc_ecma_parser::{Syntax, TsConfig};
 use swc_ecma_transforms_compat::es2020::optional_chaining;
 use swc_ecma_transforms_testing::{test, test_exec};
 use swc_ecma_transforms_testing::exec_tr;
+use swc_ecma_transforms_testing::compare_stdout;
 use swc_ecma_transforms_testing::test;
 use swc_ecma_transforms_testing::test_exec;
 use swc_ecma_visit::Fold;
@@ -737,7 +737,7 @@ test!(
 fn exec(input: PathBuf) {
     let src = read_to_string(&input).unwrap();
 
-    exec_tr(
+    compare_stdout(
         "opt_chain_fixture",
         Default::default(),
         |_| optional_chaining(),

--- a/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
+++ b/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
@@ -737,10 +737,5 @@ test!(
 fn exec(input: PathBuf) {
     let src = read_to_string(&input).unwrap();
 
-    compare_stdout(
-        "opt_chain_fixture",
-        Default::default(),
-        |_| optional_chaining(),
-        &src,
-    );
+    compare_stdout(Default::default(), |_| optional_chaining(), &src);
 }

--- a/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
+++ b/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
@@ -1,12 +1,7 @@
-use std::fs::read_to_string;
-use std::path::PathBuf;
+use std::{fs::read_to_string, path::PathBuf};
 use swc_ecma_parser::{Syntax, TsConfig};
 use swc_ecma_transforms_compat::es2020::optional_chaining;
-use swc_ecma_transforms_testing::{test, test_exec};
-use swc_ecma_transforms_testing::exec_tr;
-use swc_ecma_transforms_testing::compare_stdout;
-use swc_ecma_transforms_testing::test;
-use swc_ecma_transforms_testing::test_exec;
+use swc_ecma_transforms_testing::{compare_stdout, test, test_exec};
 use swc_ecma_visit::Fold;
 
 fn tr(_: ()) -> impl Fold {

--- a/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
+++ b/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
@@ -702,11 +702,11 @@ test!(
     const patch = PATCHES.get(ident)?.();
     ",
     "
-    var ref;
+    var _obj, ref;
     const PATCHES = new Map();
     const ident = \"foo\";
-    var _obj = PATCHES.get(ident);
-    const patch = (ref = _obj) === null || ref === void 0 ? void 0 : ref.call(_obj);
+    const patch = (ref = _obj = PATCHES.get(ident)) === null || ref === void 0 ? void 0 : \
+     ref.call(_obj);
     "
 );
 

--- a/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
+++ b/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
@@ -724,9 +724,9 @@ test!(
     "
     function bug() {
         const arrowFn = (arg)=>{
-            var ref;
-            var _object = this.object[arg];
-            return (ref = _object) === null || ref === void 0 ? void 0 : ref.call(_object);
+            var _object, ref;
+            return (ref = (_object = this.object)[arg]) === null || ref === void 0 ? void 0 : \
+     ref.call(_object);
         };
     }
     bug();

--- a/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
+++ b/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
@@ -304,7 +304,7 @@ foo?.bar()?.()
 
 "#,
     r#"
-var ref, ref1, ref2, ref3, ref4, ref5, ref6, ref7, ref8, ref9;
+var ref, ref1, ref2, ref3, ref4, ref5, ref6, ref7, ref8, _obj, ref9;
 foo === null || foo === void 0 ? void 0 : foo(foo);
 foo === null || foo === void 0 ? void 0 : foo.bar();
 (ref = foo.bar) === null || ref === void 0 ? void 0 : ref.call(foo, foo.bar, false);
@@ -315,8 +315,7 @@ foo === null || foo === void 0 ? void 0 : (ref2 = foo()) === null || ref2 === vo
 (ref4 = foo.bar) === null || ref4 === void 0 ? void 0 : (ref5 = ref4.call(foo)) === null || ref5 === void 0 ? void 0 : ref5.baz;
 foo === null || foo === void 0 ? void 0 : (ref6 = foo.bar) === null || ref6 === void 0 ? void 0 : ref6.call(foo).baz;
 foo === null || foo === void 0 ? void 0 : (ref7 = foo.bar) === null || ref7 === void 0 ? void 0 : (ref8 = ref7.call(foo)) === null || ref8 === void 0 ? void 0 : ref8.baz;
-var _obj = foo === null || foo === void 0 ? void 0 : foo.bar();
-(ref9 = _obj) === null || ref9 === void 0 ? void 0 : ref9.call(_obj);"#
+(ref9 = _obj = foo === null || foo === void 0 ? void 0 : foo.bar()) === null || ref9 === void 0 ? void 0 : ref9.call(_obj);"#
 );
 
 // general_unary_exec

--- a/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
+++ b/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
@@ -1,6 +1,12 @@
+use std::fs::read_to_string;
+use std::path::PathBuf;
+
 use swc_ecma_parser::{Syntax, TsConfig};
 use swc_ecma_transforms_compat::es2020::optional_chaining;
 use swc_ecma_transforms_testing::{test, test_exec};
+use swc_ecma_transforms_testing::exec_tr;
+use swc_ecma_transforms_testing::test;
+use swc_ecma_transforms_testing::test_exec;
 use swc_ecma_visit::Fold;
 
 fn tr(_: ()) -> impl Fold {
@@ -726,3 +732,15 @@ test!(
     bug();
     "
 );
+
+#[testing::fixture("tests/fixture/opt-chain/**/exec.js")]
+fn exec(input: PathBuf) {
+    let src = read_to_string(&input).unwrap();
+
+    exec_tr(
+        "opt_chain_fixture",
+        Default::default(),
+        |_| optional_chaining(),
+        &src,
+    );
+}

--- a/ecmascript/transforms/compat/tests/fixture/opt-chain/issue-2063/1/exec.js
+++ b/ecmascript/transforms/compat/tests/fixture/opt-chain/issue-2063/1/exec.js
@@ -4,4 +4,4 @@ const myVar = {
     }
 }
 
-expect(myVar.target.value.toLowerCase?.()).toEqual("abc")
+console.log(myVar.target.value.toLowerCase?.())

--- a/ecmascript/transforms/compat/tests/fixture/opt-chain/issue-2063/1/exec.js
+++ b/ecmascript/transforms/compat/tests/fixture/opt-chain/issue-2063/1/exec.js
@@ -1,0 +1,7 @@
+const myVar = {
+    target: {
+        value: "ABC"
+    }
+}
+
+expect(myVar.target.value.toLowerCase?.()).toEqual("abc")

--- a/ecmascript/transforms/compat/tests/fixture/opt-chain/issue-2063/2/exec.js
+++ b/ecmascript/transforms/compat/tests/fixture/opt-chain/issue-2063/2/exec.js
@@ -1,0 +1,5 @@
+const myVar = {
+    value: "ABC"
+}
+
+console.log(myVar.value.toLowerCase?.())

--- a/ecmascript/transforms/testing/Cargo.toml
+++ b/ecmascript/transforms/testing/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.26.1"
 
 [dependencies]
 ansi_term = "0.12.1"
+anyhow = "1"
 serde = "1"
 serde_json = "1"
 swc_common = {version = "0.11.0", path = "../../../common"}

--- a/ecmascript/transforms/testing/Cargo.toml
+++ b/ecmascript/transforms/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.26.1"
+version = "0.26.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ecmascript/transforms/testing/src/lib.rs
+++ b/ecmascript/transforms/testing/src/lib.rs
@@ -374,17 +374,7 @@ where
     Tester::run(|tester| {
         let tr = make_tr(test_name, tr, tester);
 
-        let module = tester.apply_transform(
-            tr,
-            "input.js",
-            syntax,
-            &format!(
-                "it('should work', async function () {{
-                    {}
-                }})",
-                input
-            ),
-        )?;
+        let module = tester.apply_transform(tr, "input.js", syntax, input)?;
 
         let mut module = module
             .fold_with(&mut hygiene::hygiene())

--- a/ecmascript/transforms/testing/src/lib.rs
+++ b/ecmascript/transforms/testing/src/lib.rs
@@ -1,7 +1,5 @@
 use ansi_term::Color;
-use anyhow::bail;
-use anyhow::Context;
-use anyhow::Error;
+use anyhow::{bail, Context, Error};
 use serde::de::DeserializeOwned;
 use std::{
     env,
@@ -19,7 +17,7 @@ use swc_common::{
 };
 use swc_ecma_ast::{Pat, *};
 use swc_ecma_codegen::Emitter;
-use swc_ecma_parser::{error::Error, lexer::Lexer, Parser, StringInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax};
 use swc_ecma_transforms_base::{
     fixer,
     helpers::{inject_helpers, HELPERS},
@@ -27,19 +25,6 @@ use swc_ecma_transforms_base::{
 };
 use swc_ecma_utils::{quote_ident, quote_str, DropSpan, ExprFactory, HANDLER};
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, FoldWith, VisitMut, VisitMutWith};
-use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax};
-use swc_ecma_transforms_base::fixer;
-use swc_ecma_transforms_base::helpers::{inject_helpers, HELPERS};
-use swc_ecma_transforms_base::hygiene;
-use swc_ecma_utils::quote_ident;
-use swc_ecma_utils::quote_str;
-use swc_ecma_utils::DropSpan;
-use swc_ecma_utils::ExprFactory;
-use swc_ecma_utils::HANDLER;
-use swc_ecma_visit::noop_visit_mut_type;
-use swc_ecma_visit::VisitMut;
-use swc_ecma_visit::VisitMutWith;
-use swc_ecma_visit::{as_folder, Fold, FoldWith};
 use tempfile::tempdir_in;
 use testing::{assert_eq, find_executable, DebugUsingDisplay, NormalizedOutput};
 

--- a/ecmascript/transforms/testing/src/lib.rs
+++ b/ecmascript/transforms/testing/src/lib.rs
@@ -250,7 +250,7 @@ impl VisitMut for RegeneratorHandler {
     }
 }
 
-fn make_tr<F, P>(_: &str, op: F, tester: &mut Tester<'_>) -> impl Fold
+fn make_tr<F, P>(op: F, tester: &mut Tester<'_>) -> impl Fold
 where
     F: FnOnce(&mut Tester<'_>) -> P,
     P: Fold,
@@ -282,7 +282,7 @@ pub fn test_transform<F, P>(
 
         println!("----- Actual -----");
 
-        let tr = make_tr("actual", tr, tester);
+        let tr = make_tr(tr, tester);
         let actual = tester.apply_transform(tr, "input.js", syntax, input)?;
 
         match ::std::env::var("PRINT_HYGIENE") {
@@ -366,13 +366,13 @@ macro_rules! test {
 
 /// Execute `node` for `input` and ensure that it prints same output after
 /// transformation.
-pub fn compare_stdout<F, P>(test_name: &str, syntax: Syntax, tr: F, input: &str)
+pub fn compare_stdout<F, P>(syntax: Syntax, tr: F, input: &str)
 where
     F: FnOnce(&mut Tester<'_>) -> P,
     P: Fold,
 {
     Tester::run(|tester| {
-        let tr = make_tr(test_name, tr, tester);
+        let tr = make_tr(tr, tester);
 
         let module = tester.apply_transform(tr, "input.js", syntax, input)?;
 
@@ -406,7 +406,7 @@ where
     P: Fold,
 {
     Tester::run(|tester| {
-        let tr = make_tr(test_name, tr, tester);
+        let tr = make_tr(tr, tester);
 
         let module = tester.apply_transform(
             tr,

--- a/ecmascript/transforms/testing/src/lib.rs
+++ b/ecmascript/transforms/testing/src/lib.rs
@@ -250,7 +250,7 @@ impl VisitMut for RegeneratorHandler {
     }
 }
 
-fn make_tr<F, P>(_: &'static str, op: F, tester: &mut Tester<'_>) -> impl Fold
+fn make_tr<F, P>(_: &str, op: F, tester: &mut Tester<'_>) -> impl Fold
 where
     F: FnOnce(&mut Tester<'_>) -> P,
     P: Fold,
@@ -366,7 +366,7 @@ macro_rules! test {
 
 /// Execute `node` for `input` and ensure that it prints same output after
 /// transformation.
-pub fn compare_stdout<F, P>(test_name: &'static str, syntax: Syntax, tr: F, input: &str)
+pub fn compare_stdout<F, P>(test_name: &str, syntax: Syntax, tr: F, input: &str)
 where
     F: FnOnce(&mut Tester<'_>) -> P,
     P: Fold,
@@ -400,7 +400,7 @@ where
 }
 
 /// Execute `jest` after transpiling `input` using `tr`.
-pub fn exec_tr<F, P>(test_name: &'static str, syntax: Syntax, tr: F, input: &str)
+pub fn exec_tr<F, P>(test_name: &str, syntax: Syntax, tr: F, input: &str)
 where
     F: FnOnce(&mut Tester<'_>) -> P,
     P: Fold,

--- a/ecmascript/transforms/testing/src/lib.rs
+++ b/ecmascript/transforms/testing/src/lib.rs
@@ -348,6 +348,7 @@ macro_rules! test {
     };
 }
 
+/// Execute `jest` after transpiling `input` using `tr`.
 pub fn exec_tr<F, P>(test_name: &'static str, syntax: Syntax, tr: F, input: &str)
 where
     F: FnOnce(&mut Tester<'_>) -> P,

--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -1449,6 +1449,8 @@ export interface ExportDeclaration extends Node, HasSpan {
 export interface ImportDeclaration extends Node, HasSpan {
   type: "ImportDeclaration";
 
+  typeOnly?: boolean;
+
   specifiers: ImportSpecifier[];
 
   source: StringLiteral;

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.12.0"
+version = "0.12.1"
 
 [dependencies]
 ansi_term = "0.12.1"

--- a/testing/macros/Cargo.toml
+++ b/testing/macros/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "testing_macros"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.2.1"
+version = "0.2.2"
 
 [lib]
 proc-macro = true

--- a/testing/macros/src/fixture.rs
+++ b/testing/macros/src/fixture.rs
@@ -159,6 +159,7 @@ pub fn expand(callee: &Ident, attr: Config) -> Result<Vec<ItemFn>, Error> {
             },
             {
                 #[test]
+                #[inline(never)]
                 #[ignore]
                 fn test_ident() {
                     callee(::std::path::PathBuf::from(path_str));

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(test)]
-
 pub use self::output::{NormalizedOutput, StdErr, StdOut, TestOutput};
 use difference::Changeset;
 use once_cell::sync::Lazy;

--- a/tests/fixture/issue-2063/input/index.js
+++ b/tests/fixture/issue-2063/input/index.js
@@ -1,0 +1,7 @@
+const myVar = {
+    target: {
+        value: "ABC"
+    }
+}
+
+console.log(myVar.target.value.toLowerCase?.());

--- a/tests/fixture/issue-2063/output/index.js
+++ b/tests/fixture/issue-2063/output/index.js
@@ -1,0 +1,7 @@
+var _value, ref;
+var myVar = {
+    target: {
+        value: "ABC"
+    }
+};
+console.log((ref = (_value = myVar.target.value).toLowerCase) === null || ref === void 0 ? void 0 : ref.call(_value));


### PR DESCRIPTION
swc_ecma_transforms_compat:
 - Fix optional chaining. (Closes #2063)

node/swc:
 - Fix definition of `ImportDeclaration`. (Closes #2059)

testing:
 - Allow using `testing` with stable `rustc`.

testing_macros:
 - Add `#[inline(never)]`.