### PR TITLE
fix(swc): fix incorrect types path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "dependencies": {
         "@node-rs/helper": "^1.0.0"
     },
-    "types": "./lib/index.d.ts",
+    "types": "./index.d.ts",
     "scripts": {
         "artifacts": "napi artifacts --dist scripts/npm",
         "prepublishOnly": "tsc -d && napi prepublish -p scripts/npm --tagstyle npm",


### PR DESCRIPTION
In @swc/core package, types path in package.json is `./lib/index.d.ts`, but it should be` ./index.d.ts`