### PR TITLE
fix(es/parser): Allow using parser with stable rustc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.66.5"
+version = "0.66.6"
 dependencies = [
  "either",
  "enum_kind",

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.66.5"
+version = "0.66.6"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ecmascript/parser/src/lib.rs
+++ b/ecmascript/parser/src/lib.rs
@@ -103,9 +103,9 @@
 //!
 //! [tc39/test262]:https://github.com/tc39/test262
 
+#![cfg_attr(test, feature(bench_black_box))]
 #![cfg_attr(test, feature(test))]
 #![deny(unused)]
-#![feature(bench_black_box)]
 
 pub use self::{
     lexer::input::{Input, StringInput},


### PR DESCRIPTION
swc_ecma_parser:
 - Don't use `#![feature]` for non-test builds. (Closes #2083)