### PR TITLE
fix(es/parser): syntax error for await in function

### DIFF
--- a/ecmascript/parser/src/error.rs
+++ b/ecmascript/parser/src/error.rs
@@ -140,6 +140,8 @@ pub enum SyntaxError {
 
     AwaitForStmt,
 
+    AwaitInFunction,
+
     UnterminatedJSXContents,
     EmptyJSXAttr,
     InvalidJSXValue,
@@ -362,6 +364,8 @@ impl SyntaxError {
             SyntaxError::AwaitForStmt => {
                 "for await syntax is valid only for for-of statement".into()
             }
+
+            SyntaxError::AwaitInFunction => "await isn't allowed in function".into(),
 
             SyntaxError::UnterminatedJSXContents => "Unterminated JSX contents".into(),
             SyntaxError::EmptyJSXAttr => {

--- a/ecmascript/parser/src/error.rs
+++ b/ecmascript/parser/src/error.rs
@@ -365,7 +365,7 @@ impl SyntaxError {
                 "for await syntax is valid only for for-of statement".into()
             }
 
-            SyntaxError::AwaitInFunction => "await isn't allowed in function".into(),
+            SyntaxError::AwaitInFunction => "await isn't allowed in non-async function".into(),
 
             SyntaxError::UnterminatedJSXContents => "Unterminated JSX contents".into(),
             SyntaxError::EmptyJSXAttr => {

--- a/ecmascript/parser/src/parser/expr/ops.rs
+++ b/ecmascript/parser/src/parser/expr/ops.rs
@@ -324,11 +324,10 @@ impl<'a, I: Tokens> Parser<I> {
 
         if is!(self, "await") {
             let ctx = self.ctx();
-            if ctx.in_async {
-                return self.parse_await_expr();
-            } else if ctx.in_function {
+            if ctx.in_function && !ctx.in_async {
                 syntax_error!(self, SyntaxError::AwaitInFunction);
             }
+            return self.parse_await_expr();
         }
 
         // UpdateExpression

--- a/ecmascript/parser/src/parser/expr/ops.rs
+++ b/ecmascript/parser/src/parser/expr/ops.rs
@@ -322,8 +322,13 @@ impl<'a, I: Tokens> Parser<I> {
             })));
         }
 
-        if (self.ctx().in_async || self.syntax().top_level_await()) && is!(self, "await") {
-            return self.parse_await_expr();
+        if is!(self, "await") {
+            let ctx = self.ctx();
+            if ctx.in_async {
+                return self.parse_await_expr();
+            } else if ctx.in_function {
+                syntax_error!(self, SyntaxError::AwaitInFunction);
+            }
         }
 
         // UpdateExpression

--- a/ecmascript/parser/src/parser/expr/ops.rs
+++ b/ecmascript/parser/src/parser/expr/ops.rs
@@ -325,7 +325,7 @@ impl<'a, I: Tokens> Parser<I> {
         if is!(self, "await") {
             let ctx = self.ctx();
             if ctx.in_function && !ctx.in_async {
-                syntax_error!(self, SyntaxError::AwaitInFunction);
+                self.emit_err(self.input.cur_span(), SyntaxError::AwaitInFunction);
             }
             return self.parse_await_expr();
         }

--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -1863,4 +1863,25 @@ export default function waitUntil(callback, options = {}) {
             |p| p.parse_program(),
         );
     }
+
+    #[test]
+    #[should_panic(expected = "await isn't allowed in function")]
+    fn await_in_function_in_module() {
+        let src = "function foo (p) { await p; }";
+        test_parser(src, Syntax::Es(Default::default()), |p| p.parse_module());
+    }
+
+    #[test]
+    #[should_panic(expected = "await isn't allowed in function")]
+    fn await_in_function_in_script() {
+        let src = "function foo (p) { await p; }";
+        test_parser(src, Syntax::Es(Default::default()), |p| p.parse_script());
+    }
+
+    #[test]
+    #[should_panic(expected = "await isn't allowed in function")]
+    fn await_in_function_in_program() {
+        let src = "function foo (p) { await p; }";
+        test_parser(src, Syntax::Es(Default::default()), |p| p.parse_program());
+    }
 }

--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -1865,21 +1865,21 @@ export default function waitUntil(callback, options = {}) {
     }
 
     #[test]
-    #[should_panic(expected = "await isn't allowed in function")]
+    #[should_panic(expected = "await isn't allowed in non-async function")]
     fn await_in_function_in_module() {
         let src = "function foo (p) { await p; }";
         test_parser(src, Syntax::Es(Default::default()), |p| p.parse_module());
     }
 
     #[test]
-    #[should_panic(expected = "await isn't allowed in function")]
+    #[should_panic(expected = "await isn't allowed in non-async function")]
     fn await_in_function_in_script() {
         let src = "function foo (p) { await p; }";
         test_parser(src, Syntax::Es(Default::default()), |p| p.parse_script());
     }
 
     #[test]
-    #[should_panic(expected = "await isn't allowed in function")]
+    #[should_panic(expected = "await isn't allowed in non-async function")]
     fn await_in_function_in_program() {
         let src = "function foo (p) { await p; }";
         test_parser(src, Syntax::Es(Default::default()), |p| p.parse_program());

--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -1884,4 +1884,10 @@ export default function waitUntil(callback, options = {}) {
         let src = "function foo (p) { await p; }";
         test_parser(src, Syntax::Es(Default::default()), |p| p.parse_program());
     }
+
+    #[test]
+    fn top_level_await_in_block() {
+        let src = "if (true) { await promise; }";
+        test_parser(src, Syntax::Es(Default::default()), |p| p.parse_module());
+    }
 }

--- a/ecmascript/transforms/tests/decorators.rs
+++ b/ecmascript/transforms/tests/decorators.rs
@@ -4749,7 +4749,7 @@ test!(
       }
 
       @Get('/callback')
-      callback(@Res() res: express.Response, @Session() session: express.Express.Session) {
+      async callback(@Res() res: express.Response, @Session() session: express.Express.Session) {
         const token = await this.getToken(code)
         const user = await this.getUserInfo(token.access_token)
 
@@ -4774,7 +4774,7 @@ export let AppController = _class = _dec14(_class = _dec13(_class = _dec12(((_cl
     getHello(): string {
         return this.appService.getHello();
     }
-    callback(res: express.Response, session: express.Express.Session) {
+    async callback(res: express.Response, session: express.Express.Session) {
         const token = await this.getToken(code);
         const user = await this.getUserInfo(token.access_token);
         session.oauth2Token = token;


### PR DESCRIPTION
`await` isn't allowed in `function`