### PR TITLE
Fix typo ~~`extenalModules`~~ to `externalModules`

### DIFF
--- a/node-swc/src/spack.ts
+++ b/node-swc/src/spack.ts
@@ -75,7 +75,7 @@ export interface SpackConfig {
     /**
      * Modules to exclude from bundle.
      */
-    extenalModules?: string[]
+    externalModules?: string[]
 }
 
 export interface OutputConfig {


### PR DESCRIPTION
### Description

Typo when using TypeScript for the `SpackConfig`.