### PR TITLE
Fix typo `ExportNamespaceSpecifier`

### DIFF
--- a/node-swc/src/Visitor.ts
+++ b/node-swc/src/Visitor.ts
@@ -37,7 +37,7 @@ import {
   ExportDefaultExpression,
   ExportDefaultSpecifier,
   ExportNamedDeclaration,
-  ExportNamespaceSpecifer,
+  ExportNamespaceSpecifier,
   ExportSpecifier,
   Expression,
   ExpressionStatement,
@@ -287,7 +287,7 @@ export default class Visitor {
     switch (n.type) {
       case "ExportDefaultSpecifier":
         return this.visitExportDefaultSpecifier(n);
-      case "ExportNamespaceSpecifer":
+      case "ExportNamespaceSpecifier":
         return this.visitExportNamespaceSpecifier(n);
       case "ExportSpecifier":
         return this.visitNamedExportSpecifier(n);
@@ -301,7 +301,7 @@ export default class Visitor {
     return n;
   }
 
-  visitExportNamespaceSpecifier(n: ExportNamespaceSpecifer): ExportSpecifier {
+  visitExportNamespaceSpecifier(n: ExportNamespaceSpecifier): ExportSpecifier {
     n.name = this.visitBindingIdentifier(n.name);
     return n;
   }

--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -1523,15 +1523,15 @@ export interface NamedImportSpecifier extends Node, HasSpan {
 }
 
 export type ExportSpecifier =
-  | ExportNamespaceSpecifer
+  | ExportNamespaceSpecifier
   | ExportDefaultSpecifier
   | NamedExportSpecifier;
 
 /**
  * `export * as foo from 'src';`
  */
-export interface ExportNamespaceSpecifer extends Node, HasSpan {
-  type: "ExportNamespaceSpecifer";
+export interface ExportNamespaceSpecifier extends Node, HasSpan {
+  type: "ExportNamespaceSpecifier";
 
   name: Identifier;
 }


### PR DESCRIPTION
There's a typo in the `ExportNamespaceSpecifier` which means TypeScript errors occur when spelling it correctly. 

This might be a breaking change.

