### PR TITLE
feat(css/parser): Improve parser api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bitflags",
  "lexical",

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.4.0"
+version = "0.4.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/css/parser/src/lib.rs
+++ b/css/parser/src/lib.rs
@@ -1,8 +1,9 @@
 #![deny(unused_must_use)]
 
 use lexer::Lexer;
-use parser::{PResult, Parser, ParserConfig};
+use parser::{input::TokensInput, PResult, Parser, ParserConfig};
 use swc_common::{input::StringInput, BytePos, SourceFile};
+use swc_css_ast::Tokens;
 
 #[macro_use]
 mod macros;
@@ -47,6 +48,17 @@ where
     Parser<Lexer<StringInput<'a>>>: Parse<T>,
 {
     let lexer = Lexer::new(StringInput::from(fm));
+    let mut parser = Parser::new(lexer, config);
+
+    parser.parse()
+}
+
+/// Parse a given file as `T`.
+pub fn parse_tokens<'a, T>(tokens: &'a Tokens, config: ParserConfig) -> PResult<T>
+where
+    Parser<TokensInput<'a>>: Parse<T>,
+{
+    let lexer = TokensInput::new(tokens);
     let mut parser = Parser::new(lexer, config);
 
     parser.parse()

--- a/css/parser/src/parser/input.rs
+++ b/css/parser/src/parser/input.rs
@@ -2,7 +2,7 @@ use super::PResult;
 use crate::error::ErrorKind;
 use std::fmt::Debug;
 use swc_common::{BytePos, Span};
-use swc_css_ast::{Token, TokenAndSpan};
+use swc_css_ast::{Token, TokenAndSpan, Tokens};
 
 pub trait ParserInput {
     type State: Debug;
@@ -182,4 +182,34 @@ where
 pub(super) struct WrappedState<S> {
     cur: Option<TokenAndSpan>,
     inner: S,
+}
+
+#[derive(Debug)]
+pub struct TokensState {}
+
+pub struct TokensInput<'a> {
+    tokens: &'a Tokens,
+    idx: usize,
+}
+
+impl<'a> TokensInput<'a> {
+    pub fn new(tokens: &'a Tokens) -> Self {
+        TokensInput { tokens, idx: 0 }
+    }
+}
+
+impl ParserInput for TokensInput<'_> {
+    type State = TokensState;
+
+    fn next(&mut self) -> PResult<TokenAndSpan> {}
+
+    fn skip_whitespaces(&mut self) -> PResult<()> {}
+
+    fn start_pos(&mut self) -> BytePos {
+        self.tokens.span.lo
+    }
+
+    fn state(&mut self) -> Self::State {}
+
+    fn reset(&mut self, state: &Self::State) {}
 }

--- a/css/parser/src/parser/input.rs
+++ b/css/parser/src/parser/input.rs
@@ -225,7 +225,12 @@ impl ParserInput for TokensInput<'_> {
     }
 
     fn skip_whitespaces(&mut self) -> PResult<()> {
-        let cur = self.cur()?;
+        let cur = self.tokens.tokens.get(self.idx);
+        let cur = match cur {
+            Some(cur) => cur,
+            None => return Ok(()),
+        };
+
         match cur.token {
             tok!(" ") => {
                 self.idx += 1;

--- a/css/parser/src/parser/selector/mod.rs
+++ b/css/parser/src/parser/selector/mod.rs
@@ -1,5 +1,8 @@
 use super::{input::ParserInput, PResult, Parser};
-use crate::error::{Error, ErrorKind};
+use crate::{
+    error::{Error, ErrorKind},
+    Parse,
+};
 use swc_atoms::js_word;
 use swc_common::Span;
 use swc_css_ast::*;
@@ -495,5 +498,14 @@ where
                 ErrorKind::ExpectedIdentOrStrForAttrSelectorOp,
             ))?,
         }
+    }
+}
+
+impl<I> Parse<CompoundSelector> for Parser<I>
+where
+    I: ParserInput,
+{
+    fn parse(&mut self) -> PResult<CompoundSelector> {
+        self.parse_compound_selector()
     }
 }

--- a/css/parser/tests/fixture.rs
+++ b/css/parser/tests/fixture.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use swc_common::{errors::Handler, input::SourceFileInput, Span, Spanned, DUMMY_SP};
 use swc_css_ast::*;
 use swc_css_parser::{
+    error::ErrorKind,
     lexer::Lexer,
     parse_tokens,
     parser::{input::ParserInput, Parser, ParserConfig},
@@ -37,8 +38,20 @@ fn pass(input: PathBuf) {
                         tokens: vec![],
                     };
 
-                    while let Ok(t) = lexer.next() {
-                        tokens.tokens.push(t);
+                    loop {
+                        let res = lexer.next();
+                        match res {
+                            Ok(t) => {
+                                tokens.tokens.push(t);
+                            }
+
+                            Err(e) => {
+                                if matches!(e.kind(), ErrorKind::Eof) {
+                                    break;
+                                }
+                                panic!("failed to lex tokens: {:?}", e)
+                            }
+                        }
                     }
 
                     let ss_tok: Stylesheet =


### PR DESCRIPTION
swc_css_parser:
 - Add `parse_tokens`.
 - Implement `Parse<CompoundSelector>` for the parser.