### PR TITLE
Chore: update TS1031 error message

### DIFF
--- a/ecmascript/parser/src/error.rs
+++ b/ecmascript/parser/src/error.rs
@@ -472,7 +472,9 @@ impl SyntaxError {
                 format!("'{}' modifier must precede '{}' modifier.", left, right).into()
             }
             SyntaxError::TS1030(word) => format!("'{}' modifier already seen.", word).into(),
-            SyntaxError::TS1031 => "`declare` modifier cannot appear on class elements of this kind".into(),
+            SyntaxError::TS1031 => {
+                "`declare` modifier cannot appear on class elements of this kind".into()
+            }
             SyntaxError::TS1038 => {
                 "`declare` modifier not allowed for code already in an ambient context".into()
             }

--- a/ecmascript/parser/src/error.rs
+++ b/ecmascript/parser/src/error.rs
@@ -472,7 +472,7 @@ impl SyntaxError {
                 format!("'{}' modifier must precede '{}' modifier.", left, right).into()
             }
             SyntaxError::TS1030(word) => format!("'{}' modifier already seen.", word).into(),
-            SyntaxError::TS1031 => "`declare` modifier cannot appear on a class element".into(),
+            SyntaxError::TS1031 => "`declare` modifier cannot appear on class elements of this kind".into(),
             SyntaxError::TS1038 => {
                 "`declare` modifier not allowed for code already in an ambient context".into()
             }

--- a/ecmascript/parser/tests/typescript-errors/class/declare-class-method/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/class/declare-class-method/input.ts.stderr
@@ -1,4 +1,4 @@
-error: `declare` modifier cannot appear on a class element
+error: `declare` modifier cannot appear on class elements of this kind
  --> $DIR/tests/typescript-errors/class/declare-class-method/input.ts:2:5
   |
 2 |     declare m1(): string;

--- a/ecmascript/parser/tests/typescript-errors/class/override-with-declare/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/class/override-with-declare/input.ts.stderr
@@ -4,7 +4,7 @@ error: 'override' modifier cannot be used with 'declare' modifier.
 2 |   declare override m1(): any
   |           ^^^^^^^^
 
-error: `declare` modifier cannot appear on a class element
+error: `declare` modifier cannot appear on class elements of this kind
  --> $DIR/tests/typescript-errors/class/override-with-declare/input.ts:2:3
   |
 2 |   declare override m1(): any


### PR DESCRIPTION
## Motivation

tsc's TS1031 error message was updated in https://github.com/microsoft/TypeScript/pull/40889, but TS1031 error message in swc still be an old version. 

I update and fix it.

## Note

TypeScript Playground URL: https://www.typescriptlang.org/play?#code/MYGwhgzhAEASD2BzAptA3gKGt6ATZoYATqmGQBQCUAXNBAC5ECWAdogNwYC+GQA