### PR TITLE
Fix bug resolving node modules.

### DIFF
--- a/ecmascript/loader/src/resolvers/node.rs
+++ b/ecmascript/loader/src/resolvers/node.rs
@@ -339,7 +339,7 @@ impl Resolve for NodeModulesResolver {
                         .or_else(|_| self.resolve_as_directory(&path))
                         .and_then(|p| self.wrap(p))
                 } else {
-                    self.resolve_node_modules(base_dir, target)
+                    self.resolve_node_modules(base, target)
                         .and_then(|p| self.wrap(p))
                 }
             }


### PR DESCRIPTION
Incorrectly passing the parent of the base directory would cause
some modules not to be found.