### PR TITLE
Node base directory handling

### DIFF
--- a/ecmascript/loader/src/resolvers/node.rs
+++ b/ecmascript/loader/src/resolvers/node.rs
@@ -278,8 +278,12 @@ impl Resolve for NodeModulesResolver {
             _ => bail!("node-resolver supports only files"),
         };
 
-        let cwd = &Path::new(".");
-        let base_dir = base.parent().unwrap_or(&cwd);
+        let base_dir = if base.is_file() {
+            let cwd = &Path::new(".");
+            base.parent().unwrap_or(&cwd)
+        } else {
+            base
+        };
 
         // Handle module references for the `browser` package config
         // before we map aliases.
@@ -339,7 +343,7 @@ impl Resolve for NodeModulesResolver {
                         .or_else(|_| self.resolve_as_directory(&path))
                         .and_then(|p| self.wrap(p))
                 } else {
-                    self.resolve_node_modules(base, target)
+                    self.resolve_node_modules(base_dir, target)
                         .and_then(|p| self.wrap(p))
                 }
             }


### PR DESCRIPTION
This allows passing `base_dir` as either a directory or a file and the behavior should be correct either way.

Typically when walking the module graph we have a *calling file* that performs the `import` (or `require`) so it makes sense to pass the file and automatically use the parent however there are times when it is convenient to resolve packages outside of the module graph and then it is more appropriate to use `std::env::current_dir()` for `base_dir`.