### PR TITLE
refactor: static blocks - use a block stmt instead of stmts vector and fix span

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "jsdoc"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2287,7 +2287,7 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "swc"
-version = "0.46.1"
+version = "0.48.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "arbitrary",
  "is-macro",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "bitflags",
  "num-bigint",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_dep_graph"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "swc_atoms 0.2.7",
  "swc_common",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "phf",
  "swc_atoms 0.2.7",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.68.1"
+version = "0.69.0"
 dependencies = [
  "either",
  "enum_kind",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "dashmap",
  "fxhash",
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "pretty_assertions 0.6.1",
  "sourcemap",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "fxhash",
  "once_cell",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "swc_atoms 0.2.7",
  "swc_common",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "arrayvec",
  "fxhash",
@@ -2804,7 +2804,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "dashmap",
  "fxhash",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "either",
  "fxhash",
@@ -2876,7 +2876,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "base64 0.13.0",
  "dashmap",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -2921,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "fxhash",
  "serde",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "once_cell",
  "scoped-tls",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "num-bigint",
  "swc_atoms 0.2.7",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "abi_stable",
  "anyhow",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "abi_stable",
  "anyhow",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_testing"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "swc_atoms 0.2.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.46.1"
+version = "0.48.0"
 
 [lib]
 name = "swc"
@@ -46,16 +46,16 @@ serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "./atoms"}
-swc_bundler = {version = "0.55.0", path = "./bundler"}
+swc_bundler = {version = "0.56.0", path = "./bundler"}
 swc_common = {version = "0.11.6", path = "./common", features = ["sourcemap", "concurrent"]}
-swc_ecma_ast = {version = "0.50.0", path = "./ecmascript/ast"}
-swc_ecma_codegen = {version = "0.68.0", path = "./ecmascript/codegen"}
-swc_ecma_ext_transforms = {version = "0.26.0", path = "./ecmascript/ext-transforms"}
-swc_ecma_loader = {version = "0.16.0", path = "./ecmascript/loader", features = ["lru", "node", "tsc"]}
-swc_ecma_minifier = {version = "0.23.0", path = "./ecmascript/minifier"}
-swc_ecma_parser = {version = "0.68.0", path = "./ecmascript/parser"}
-swc_ecma_preset_env = {version = "0.39.0", path = "./ecmascript/preset-env"}
-swc_ecma_transforms = {version = "0.68.0", path = "./ecmascript/transforms", features = [
+swc_ecma_ast = {version = "0.51.0", path = "./ecmascript/ast"}
+swc_ecma_codegen = {version = "0.69.0", path = "./ecmascript/codegen"}
+swc_ecma_ext_transforms = {version = "0.27.0", path = "./ecmascript/ext-transforms"}
+swc_ecma_loader = {version = "0.17.0", path = "./ecmascript/loader", features = ["lru", "node", "tsc"]}
+swc_ecma_minifier = {version = "0.24.0", path = "./ecmascript/minifier"}
+swc_ecma_parser = {version = "0.69.0", path = "./ecmascript/parser"}
+swc_ecma_preset_env = {version = "0.40.0", path = "./ecmascript/preset-env"}
+swc_ecma_transforms = {version = "0.69.0", path = "./ecmascript/transforms", features = [
   "compat",
   "module",
   "optimization",
@@ -63,10 +63,10 @@ swc_ecma_transforms = {version = "0.68.0", path = "./ecmascript/transforms", fea
   "react",
   "typescript",
 ]}
-swc_ecma_transforms_base = {version = "0.28.0", path = "./ecmascript/transforms/base"}
-swc_ecma_utils = {version = "0.42.0", path = "./ecmascript/utils"}
-swc_ecma_visit = {version = "0.36.0", path = "./ecmascript/visit"}
-swc_ecmascript = {version = "0.59.0", path = "./ecmascript"}
+swc_ecma_transforms_base = {version = "0.29.0", path = "./ecmascript/transforms/base"}
+swc_ecma_utils = {version = "0.43.0", path = "./ecmascript/utils"}
+swc_ecma_visit = {version = "0.37.0", path = "./ecmascript/visit"}
+swc_ecmascript = {version = "0.60.0", path = "./ecmascript"}
 swc_node_base = {version = "0.2.2", path = "./node/base"}
 swc_visit = {version = "0.2.3", path = "./visit"}
 

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -9,7 +9,7 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/**/*.js"]
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.55.0"
+version = "0.56.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -33,20 +33,20 @@ relative-path = "1.2"
 retain_mut = "0.1.2"
 swc_atoms = {version = "0.2.4", path = "../atoms"}
 swc_common = {version = "0.11.6", path = "../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../ecmascript/ast"}
-swc_ecma_codegen = {version = "0.68.0", path = "../ecmascript/codegen"}
-swc_ecma_loader = {version = "0.16.0", path = "../ecmascript/loader"}
-swc_ecma_parser = {version = "0.68.0", path = "../ecmascript/parser"}
-swc_ecma_transforms = {version = "0.68.0", path = "../ecmascript/transforms", features = ["optimization"]}
-swc_ecma_utils = {version = "0.42.0", path = "../ecmascript/utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../ecmascript/visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../ecmascript/ast"}
+swc_ecma_codegen = {version = "0.69.0", path = "../ecmascript/codegen"}
+swc_ecma_loader = {version = "0.17.0", path = "../ecmascript/loader"}
+swc_ecma_parser = {version = "0.69.0", path = "../ecmascript/parser"}
+swc_ecma_transforms = {version = "0.69.0", path = "../ecmascript/transforms", features = ["optimization"]}
+swc_ecma_utils = {version = "0.43.0", path = "../ecmascript/utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../ecmascript/visit"}
 
 [dev-dependencies]
 hex = "0.4"
 ntest = "0.7.2"
 reqwest = {version = "0.11.4", features = ["blocking"]}
 sha-1 = "0.9"
-swc_ecma_transforms = {version = "0.68.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
+swc_ecma_transforms = {version = "0.69.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
 tempfile = "3.1.0"
 testing = {version = "0.12.2", path = "../testing"}
 url = "2.1.1"

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.59.0"
+version = "0.60.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -32,14 +32,14 @@ react = ["swc_ecma_transforms/react"]
 typescript = ["typescript-parser", "swc_ecma_transforms/typescript"]
 
 [dependencies]
-swc_ecma_ast = {version = "0.50.0", path = "./ast"}
-swc_ecma_codegen = {version = "0.68.0", path = "./codegen", optional = true}
-swc_ecma_dep_graph = {version = "0.37.0", path = "./dep-graph", optional = true}
-swc_ecma_minifier = {version = "0.23.0", path = "./minifier", optional = true}
-swc_ecma_parser = {version = "0.68.0", path = "./parser", optional = true, default-features = false}
-swc_ecma_preset_env = {version = "0.39.0", path = "./preset-env", optional = true}
-swc_ecma_transforms = {version = "0.68.0", path = "./transforms", optional = true}
-swc_ecma_utils = {version = "0.42.0", path = "./utils", optional = true}
-swc_ecma_visit = {version = "0.36.0", path = "./visit", optional = true}
+swc_ecma_ast = {version = "0.51.0", path = "./ast"}
+swc_ecma_codegen = {version = "0.69.0", path = "./codegen", optional = true}
+swc_ecma_dep_graph = {version = "0.38.0", path = "./dep-graph", optional = true}
+swc_ecma_minifier = {version = "0.24.0", path = "./minifier", optional = true}
+swc_ecma_parser = {version = "0.69.0", path = "./parser", optional = true, default-features = false}
+swc_ecma_preset_env = {version = "0.40.0", path = "./preset-env", optional = true}
+swc_ecma_transforms = {version = "0.69.0", path = "./transforms", optional = true}
+swc_ecma_utils = {version = "0.43.0", path = "./utils", optional = true}
+swc_ecma_visit = {version = "0.37.0", path = "./visit", optional = true}
 
 [dev-dependencies]

--- a/ecmascript/ast/Cargo.toml
+++ b/ecmascript/ast/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ast"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.50.0"
+version = "0.51.0"
 
 [features]
 default = []

--- a/ecmascript/ast/src/class.rs
+++ b/ecmascript/ast/src/class.rs
@@ -8,7 +8,7 @@ use crate::{
         Accessibility, TsExprWithTypeArgs, TsIndexSignature, TsTypeAnn, TsTypeParamDecl,
         TsTypeParamInstantiation,
     },
-    EmptyStmt, Stmt,
+    EmptyStmt,
 };
 use is_macro::Is;
 use serde::{Deserialize, Serialize};
@@ -246,5 +246,5 @@ pub enum MethodKind {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct StaticBlock {
     pub span: Span,
-    pub body: Vec<Stmt>,
+    pub body: BlockStmt,
 }

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.68.0"
+version = "0.69.0"
 
 [dependencies]
 bitflags = "1"
@@ -15,9 +15,9 @@ num-bigint = {version = "0.2", features = ["serde"]}
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.11.6", path = "../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../ast"}
+swc_ecma_ast = {version = "0.51.0", path = "../ast"}
 swc_ecma_codegen_macros = {version = "0.5.2", path = "./macros"}
-swc_ecma_parser = {version = "0.68.0", path = "../parser"}
+swc_ecma_parser = {version = "0.69.0", path = "../parser"}
 
 [dev-dependencies]
 swc_common = {version = "0.11.6", path = "../../common", features = ["sourcemap"]}

--- a/ecmascript/codegen/src/lib.rs
+++ b/ecmascript/codegen/src/lib.rs
@@ -1221,15 +1221,7 @@ impl<'a> Emitter<'a> {
     fn emit_static_block(&mut self, n: &StaticBlock) -> Result {
         self.emit_leading_comments_of_span(n.span(), false)?;
         keyword!("static");
-        formatting_space!();
-        punct!("{");
-        self.emit_list(
-            n.span(),
-            Some(&n.body),
-            ListFormat::MultiLineBlockStatements,
-        )?;
-        self.emit_leading_comments_of_span(n.span(), true)?;
-        punct!("}");
+        emit!(n.body);
     }
 
     #[emitter]

--- a/ecmascript/dep-graph/Cargo.toml
+++ b/ecmascript/dep-graph/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_dep_graph"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.37.0"
+version = "0.38.0"
 
 [dependencies]
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.11.6", path = "../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../ast"}
-swc_ecma_visit = {version = "0.36.0", path = "../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../ast"}
+swc_ecma_visit = {version = "0.37.0", path = "../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.68.0", path = "../parser"}
+swc_ecma_parser = {version = "0.69.0", path = "../parser"}
 testing = {version = "0.12.2", path = "../../testing"}

--- a/ecmascript/ext-transforms/Cargo.toml
+++ b/ecmascript/ext-transforms/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_ext_transforms/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ext_transforms"
-version = "0.26.0"
+version = "0.27.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,7 +13,7 @@ version = "0.26.0"
 phf = {version = "0.8.0", features = ["macros"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.11.6", path = "../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../ast"}
-swc_ecma_parser = {version = "0.68.0", path = "../parser"}
-swc_ecma_utils = {version = "0.42.0", path = "../utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../ast"}
+swc_ecma_parser = {version = "0.69.0", path = "../parser"}
+swc_ecma_utils = {version = "0.43.0", path = "../utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../visit"}

--- a/ecmascript/jsdoc/Cargo.toml
+++ b/ecmascript/jsdoc/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/jsdoc/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "jsdoc"
-version = "0.36.0"
+version = "0.37.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,7 +18,7 @@ swc_common = {version = "0.11.6", path = "../../common"}
 [dev-dependencies]
 anyhow = "1"
 dashmap = "4.0.2"
-swc_ecma_ast = {version = "0.50.0", path = "../ast"}
-swc_ecma_parser = {version = "0.68.0", path = "../parser"}
+swc_ecma_ast = {version = "0.51.0", path = "../ast"}
+swc_ecma_parser = {version = "0.69.0", path = "../parser"}
 testing = {version = "0.12.2", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/loader/Cargo.toml
+++ b/ecmascript/loader/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_loader"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.16.0"
+version = "0.17.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -31,8 +31,8 @@ serde = {version = "1.0.126", optional = true}
 serde_json = {version = "1.0.64", optional = true}
 swc_atoms = {version = "0.2.3", path = "../../atoms"}
 swc_common = {version = "0.11.6", path = "../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../ast"}
-swc_ecma_visit = {version = "0.36.0", path = "../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../ast"}
+swc_ecma_visit = {version = "0.37.0", path = "../visit"}
 
 [dev-dependencies]
 testing = {version = "0.12.2", path = "../../testing"}

--- a/ecmascript/minifier/Cargo.toml
+++ b/ecmascript/minifier/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "src/lists/*.json"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_minifier"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.23.1"
+version = "0.24.0"
 
 [features]
 debug = []
@@ -26,13 +26,13 @@ serde_json = "1.0.61"
 serde_regex = "1.1.0"
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.11.6", path = "../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../ast"}
-swc_ecma_codegen = {version = "0.68.0", path = "../codegen"}
-swc_ecma_parser = {version = "0.68.0", path = "../parser"}
-swc_ecma_transforms = {version = "0.68.0", path = "../transforms/", features = ["optimization"]}
-swc_ecma_transforms_base = {version = "0.28.0", path = "../transforms/base"}
-swc_ecma_utils = {version = "0.42.0", path = "../utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../ast"}
+swc_ecma_codegen = {version = "0.69.0", path = "../codegen"}
+swc_ecma_parser = {version = "0.69.0", path = "../parser"}
+swc_ecma_transforms = {version = "0.69.0", path = "../transforms/", features = ["optimization"]}
+swc_ecma_transforms_base = {version = "0.29.0", path = "../transforms/base"}
+swc_ecma_utils = {version = "0.43.0", path = "../utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../visit"}
 unicode-xid = "0.2.2"
 
 [dev-dependencies]

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.68.1"
+version = "0.69.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -27,8 +27,8 @@ serde = {version = "1", features = ["derive"]}
 smallvec = "1"
 swc_atoms = {version = "0.2.3", path = "../../atoms"}
 swc_common = {version = "0.11.6", path = "../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../ast"}
-swc_ecma_visit = {version = "0.36.0", path = "../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../ast"}
+swc_ecma_visit = {version = "0.37.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]

--- a/ecmascript/parser/src/parser/class_and_fn.rs
+++ b/ecmascript/parser/src/parser/class_and_fn.rs
@@ -435,14 +435,11 @@ impl<'a, I: Tokens> Parser<I> {
         )
     }
 
-    fn parse_static_block(&mut self) -> PResult<ClassMember> {
-        let start = cur_pos!(self);
-        expect!(self, '{');
-
-        let stmts = self.parse_block_body(false, false, Some(&tok!('}')))?;
+    fn parse_static_block(&mut self, start: BytePos) -> PResult<ClassMember> {
+        let body = self.parse_block(false)?;
 
         let span = span!(self, start);
-        Ok(StaticBlock { span, body: stmts }.into())
+        Ok(StaticBlock { span, body }.into())
     }
 
     #[allow(clippy::cognitive_complexity)]
@@ -533,7 +530,7 @@ impl<'a, I: Tokens> Parser<I> {
                 if accessibility.is_some() {
                     self.emit_err(self.input.cur_span(), SyntaxError::TS1184);
                 }
-                return self.parse_static_block();
+                return self.parse_static_block(start);
             }
             if is!(self, "static") && peeked_is!(self, '{') {
                 // For "readonly", "abstract" and "override"
@@ -544,7 +541,7 @@ impl<'a, I: Tokens> Parser<I> {
                     self.emit_err(span, SyntaxError::TS1184);
                 }
                 bump!(self); // consume "static"
-                return self.parse_static_block();
+                return self.parse_static_block(start);
             }
         }
 

--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -1919,7 +1919,10 @@ export default function waitUntil(callback, options = {}) {
                     implements: Vec::new(),
                     body: vec!(ClassMember::StaticBlock(StaticBlock {
                         span,
-                        body: vec!(stmt("1 + 1;"))
+                        body: BlockStmt {
+                            span,
+                            stmts: vec!(stmt("1 + 1;")),
+                        }
                     }))
                 }
             }))
@@ -1955,11 +1958,17 @@ export default function waitUntil(callback, options = {}) {
                     body: vec!(
                         ClassMember::StaticBlock(StaticBlock {
                             span,
-                            body: vec!(stmt("1 + 1;"))
+                            body: BlockStmt {
+                                span,
+                                stmts: vec!(stmt("1 + 1;")),
+                            },
                         }),
                         ClassMember::StaticBlock(StaticBlock {
                             span,
-                            body: vec!(stmt("1 + 1;"))
+                            body: BlockStmt {
+                                span,
+                                stmts: vec!(stmt("1 + 1;")),
+                            },
                         })
                     )
                 }

--- a/ecmascript/parser/tests/span/js/decl/class.js
+++ b/ecmascript/parser/tests/span/js/decl/class.js
@@ -2,6 +2,7 @@ class Foo extends A {
     foo = '1';
     static bar = 2;
 
+    static { }
     method() { }
     async asyncMethod() { }
 }

--- a/ecmascript/parser/tests/span/js/decl/class.js.spans
+++ b/ecmascript/parser/tests/span/js/decl/class.js.spans
@@ -5,9 +5,9 @@ warning: Module
 2 | |     foo = '1';
 3 | |     static bar = 2;
 4 | |
-5 | |     method() { }
-6 | |     async asyncMethod() { }
-7 | | }
+... |
+7 | |     async asyncMethod() { }
+8 | | }
   | |_^
 
 warning: ModuleItem
@@ -17,9 +17,9 @@ warning: ModuleItem
 2 | |     foo = '1';
 3 | |     static bar = 2;
 4 | |
-5 | |     method() { }
-6 | |     async asyncMethod() { }
-7 | | }
+... |
+7 | |     async asyncMethod() { }
+8 | | }
   | |_^
 
 warning: Stmt
@@ -29,9 +29,9 @@ warning: Stmt
 2 | |     foo = '1';
 3 | |     static bar = 2;
 4 | |
-5 | |     method() { }
-6 | |     async asyncMethod() { }
-7 | | }
+... |
+7 | |     async asyncMethod() { }
+8 | | }
   | |_^
 
 warning: Decl
@@ -41,9 +41,9 @@ warning: Decl
 2 | |     foo = '1';
 3 | |     static bar = 2;
 4 | |
-5 | |     method() { }
-6 | |     async asyncMethod() { }
-7 | | }
+... |
+7 | |     async asyncMethod() { }
+8 | | }
   | |_^
 
 warning: ClassDecl
@@ -53,9 +53,9 @@ warning: ClassDecl
 2 | |     foo = '1';
 3 | |     static bar = 2;
 4 | |
-5 | |     method() { }
-6 | |     async asyncMethod() { }
-7 | | }
+... |
+7 | |     async asyncMethod() { }
+8 | | }
   | |_^
 
 warning: Ident
@@ -71,9 +71,9 @@ warning: Class
 2 | |     foo = '1';
 3 | |     static bar = 2;
 4 | |
-5 | |     method() { }
-6 | |     async asyncMethod() { }
-7 | | }
+... |
+7 | |     async asyncMethod() { }
+8 | | }
   | |_^
 
 warning: ClassMember
@@ -163,73 +163,85 @@ warning: Number
 warning: ClassMember
  --> $DIR/tests/span/js/decl/class.js:5:5
   |
-5 |     method() { }
-  |     ^^^^^^^^^^^^
-
-warning: ClassMethod
- --> $DIR/tests/span/js/decl/class.js:5:5
-  |
-5 |     method() { }
-  |     ^^^^^^^^^^^^
-
-warning: PropName
- --> $DIR/tests/span/js/decl/class.js:5:5
-  |
-5 |     method() { }
-  |     ^^^^^^
-
-warning: Ident
- --> $DIR/tests/span/js/decl/class.js:5:5
-  |
-5 |     method() { }
-  |     ^^^^^^
-
-warning: Function
- --> $DIR/tests/span/js/decl/class.js:5:5
-  |
-5 |     method() { }
-  |     ^^^^^^^^^^^^
+5 |     static { }
+  |     ^^^^^^^^^^
 
 warning: BlockStmt
- --> $DIR/tests/span/js/decl/class.js:5:14
+ --> $DIR/tests/span/js/decl/class.js:5:12
   |
-5 |     method() { }
-  |              ^^^
+5 |     static { }
+  |            ^^^
 
 warning: ClassMember
  --> $DIR/tests/span/js/decl/class.js:6:5
   |
-6 |     async asyncMethod() { }
-  |     ^^^^^^^^^^^^^^^^^^^^^^^
+6 |     method() { }
+  |     ^^^^^^^^^^^^
 
 warning: ClassMethod
  --> $DIR/tests/span/js/decl/class.js:6:5
   |
-6 |     async asyncMethod() { }
-  |     ^^^^^^^^^^^^^^^^^^^^^^^
+6 |     method() { }
+  |     ^^^^^^^^^^^^
 
 warning: PropName
- --> $DIR/tests/span/js/decl/class.js:6:11
+ --> $DIR/tests/span/js/decl/class.js:6:5
   |
-6 |     async asyncMethod() { }
-  |           ^^^^^^^^^^^
+6 |     method() { }
+  |     ^^^^^^
 
 warning: Ident
- --> $DIR/tests/span/js/decl/class.js:6:11
+ --> $DIR/tests/span/js/decl/class.js:6:5
   |
-6 |     async asyncMethod() { }
-  |           ^^^^^^^^^^^
+6 |     method() { }
+  |     ^^^^^^
 
 warning: Function
  --> $DIR/tests/span/js/decl/class.js:6:5
   |
-6 |     async asyncMethod() { }
+6 |     method() { }
+  |     ^^^^^^^^^^^^
+
+warning: BlockStmt
+ --> $DIR/tests/span/js/decl/class.js:6:14
+  |
+6 |     method() { }
+  |              ^^^
+
+warning: ClassMember
+ --> $DIR/tests/span/js/decl/class.js:7:5
+  |
+7 |     async asyncMethod() { }
+  |     ^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: ClassMethod
+ --> $DIR/tests/span/js/decl/class.js:7:5
+  |
+7 |     async asyncMethod() { }
+  |     ^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: PropName
+ --> $DIR/tests/span/js/decl/class.js:7:11
+  |
+7 |     async asyncMethod() { }
+  |           ^^^^^^^^^^^
+
+warning: Ident
+ --> $DIR/tests/span/js/decl/class.js:7:11
+  |
+7 |     async asyncMethod() { }
+  |           ^^^^^^^^^^^
+
+warning: Function
+ --> $DIR/tests/span/js/decl/class.js:7:5
+  |
+7 |     async asyncMethod() { }
   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: BlockStmt
- --> $DIR/tests/span/js/decl/class.js:6:25
+ --> $DIR/tests/span/js/decl/class.js:7:25
   |
-6 |     async asyncMethod() { }
+7 |     async asyncMethod() { }
   |                         ^^^
 
 warning: Expr

--- a/ecmascript/preset-env/Cargo.toml
+++ b/ecmascript/preset-env/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_preset_env/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_preset_env"
-version = "0.39.0"
+version = "0.40.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,14 +21,14 @@ st-map = "0.1.2"
 string_enum = {version = "0.3.1", path = "../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.11.6", path = "../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../ast"}
-swc_ecma_transforms = {version = "0.68.0", path = "../transforms", features = ["compat", "proposal"]}
-swc_ecma_utils = {version = "0.42.0", path = "../utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../ast"}
+swc_ecma_transforms = {version = "0.69.0", path = "../transforms", features = ["compat", "proposal"]}
+swc_ecma_utils = {version = "0.43.0", path = "../utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../visit"}
 walkdir = "2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
-swc_ecma_codegen = {version = "0.68.0", path = "../codegen"}
-swc_ecma_parser = {version = "0.68.0", path = "../parser"}
+swc_ecma_codegen = {version = "0.69.0", path = "../codegen"}
+swc_ecma_parser = {version = "0.69.0", path = "../parser"}
 testing = {version = "0.12.2", path = "../../testing"}

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.68.0"
+version = "0.69.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -23,24 +23,24 @@ typescript = ["swc_ecma_transforms_typescript"]
 [dependencies]
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.11.6", path = "../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../ast"}
-swc_ecma_parser = {version = "0.68.0", path = "../parser"}
-swc_ecma_transforms_base = {version = "0.28.0", path = "./base"}
-swc_ecma_transforms_compat = {version = "0.31.0", path = "./compat", optional = true}
-swc_ecma_transforms_module = {version = "0.35.0", path = "./module", optional = true}
-swc_ecma_transforms_optimization = {version = "0.38.0", path = "./optimization", optional = true}
-swc_ecma_transforms_proposal = {version = "0.35.0", path = "./proposal", optional = true}
-swc_ecma_transforms_react = {version = "0.36.0", path = "./react", optional = true}
-swc_ecma_transforms_typescript = {version = "0.37.0", path = "./typescript", optional = true}
-swc_ecma_utils = {version = "0.42.0", path = "../utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../ast"}
+swc_ecma_parser = {version = "0.69.0", path = "../parser"}
+swc_ecma_transforms_base = {version = "0.29.0", path = "./base"}
+swc_ecma_transforms_compat = {version = "0.32.0", path = "./compat", optional = true}
+swc_ecma_transforms_module = {version = "0.36.0", path = "./module", optional = true}
+swc_ecma_transforms_optimization = {version = "0.39.0", path = "./optimization", optional = true}
+swc_ecma_transforms_proposal = {version = "0.36.0", path = "./proposal", optional = true}
+swc_ecma_transforms_react = {version = "0.37.0", path = "./react", optional = true}
+swc_ecma_transforms_typescript = {version = "0.38.0", path = "./typescript", optional = true}
+swc_ecma_utils = {version = "0.43.0", path = "../utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
 sourcemap = "6"
-swc_ecma_codegen = {version = "0.68.0", path = "../codegen"}
-swc_ecma_transforms_testing = {version = "0.28.0", path = "./testing"}
+swc_ecma_codegen = {version = "0.69.0", path = "../codegen"}
+swc_ecma_transforms_testing = {version = "0.29.0", path = "./testing"}
 tempfile = "3"
 testing = {version = "0.12.2", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.28.0"
+version = "0.29.0"
 
 [dependencies]
 fxhash = "0.2.1"
@@ -16,11 +16,11 @@ scoped-tls = "1.0.0"
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.11.6", path = "../../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.68.0", path = "../../parser"}
-swc_ecma_utils = {version = "0.42.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.69.0", path = "../../parser"}
+swc_ecma_utils = {version = "0.43.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.68.0", path = "../../codegen"}
+swc_ecma_codegen = {version = "0.69.0", path = "../../codegen"}
 testing = {version = "0.12.2", path = "../../../testing"}

--- a/ecmascript/transforms/classes/Cargo.toml
+++ b/ecmascript/transforms/classes/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_classes"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.14.0"
+version = "0.15.0"
 
 [dependencies]
 swc_atoms = {version = "0.2.6", path = "../../../atoms"}
 swc_common = {version = "0.11.6", path = "../../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.28.0", path = "../base"}
-swc_ecma_utils = {version = "0.42.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../../ast"}
+swc_ecma_transforms_base = {version = "0.29.0", path = "../base"}
+swc_ecma_utils = {version = "0.43.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../../visit"}

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.31.0"
+version = "0.32.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -20,14 +20,14 @@ serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2.5", path = "../../../atoms"}
 swc_common = {version = "0.11.6", path = "../../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.28.0", path = "../base"}
-swc_ecma_transforms_classes = {version = "0.14.0", path = "../classes"}
+swc_ecma_ast = {version = "0.51.0", path = "../../ast"}
+swc_ecma_transforms_base = {version = "0.29.0", path = "../base"}
+swc_ecma_transforms_classes = {version = "0.15.0", path = "../classes"}
 swc_ecma_transforms_macros = {version = "0.2.1", path = "../macros"}
-swc_ecma_utils = {version = "0.42.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../../visit"}
+swc_ecma_utils = {version = "0.43.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.68.0", path = "../../parser"}
-swc_ecma_transforms_testing = {version = "0.28.0", path = "../testing"}
+swc_ecma_parser = {version = "0.69.0", path = "../../parser"}
+swc_ecma_transforms_testing = {version = "0.29.0", path = "../testing"}
 testing = {version = "0.12.2", path = "../../../testing"}

--- a/ecmascript/transforms/module/Cargo.toml
+++ b/ecmascript/transforms/module/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.35.0"
+version = "0.36.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -18,14 +18,14 @@ pathdiff = "0.2.0"
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.11.6", path = "../../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../../ast"}
-swc_ecma_loader = {version = "0.16.0", path = "../../loader", features = ["node"]}
-swc_ecma_parser = {version = "0.68.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.28.0", path = "../base"}
-swc_ecma_utils = {version = "0.42.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../../ast"}
+swc_ecma_loader = {version = "0.17.0", path = "../../loader", features = ["node"]}
+swc_ecma_parser = {version = "0.69.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.29.0", path = "../base"}
+swc_ecma_utils = {version = "0.43.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.31.0", path = "../compat"}
-swc_ecma_transforms_testing = {version = "0.28.0", path = "../testing/"}
+swc_ecma_transforms_compat = {version = "0.32.0", path = "../compat"}
+swc_ecma_transforms_testing = {version = "0.29.0", path = "../testing/"}
 testing = {version = "0.12.2", path = "../../../testing/"}

--- a/ecmascript/transforms/optimization/Cargo.toml
+++ b/ecmascript/transforms/optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.38.0"
+version = "0.39.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -19,17 +19,17 @@ retain_mut = "0.1.2"
 serde_json = "1.0.61"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.11.6", path = "../../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.68.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.28.0", path = "../base"}
-swc_ecma_utils = {version = "0.42.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.69.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.29.0", path = "../base"}
+swc_ecma_utils = {version = "0.43.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.31.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.35.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.35.0", path = "../proposal"}
-swc_ecma_transforms_react = {version = "0.36.0", path = "../react"}
-swc_ecma_transforms_testing = {version = "0.28.0", path = "../testing"}
-swc_ecma_transforms_typescript = {version = "0.37.0", path = "../typescript"}
+swc_ecma_transforms_compat = {version = "0.32.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.36.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.36.0", path = "../proposal"}
+swc_ecma_transforms_react = {version = "0.37.0", path = "../react"}
+swc_ecma_transforms_testing = {version = "0.29.0", path = "../testing"}
+swc_ecma_transforms_typescript = {version = "0.38.0", path = "../typescript"}
 testing = {version = "0.12.2", path = "../../../testing"}

--- a/ecmascript/transforms/proposal/Cargo.toml
+++ b/ecmascript/transforms/proposal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_proposal"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.35.0"
+version = "0.36.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,15 +21,15 @@ serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.11.6", path = "../../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../../ast"}
-swc_ecma_loader = {version = "0.16.0", path = "../../loader", optional = true}
-swc_ecma_parser = {version = "0.68.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.28.0", path = "../base"}
-swc_ecma_transforms_classes = {version = "0.14.0", path = "../classes"}
-swc_ecma_utils = {version = "0.42.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../../ast"}
+swc_ecma_loader = {version = "0.17.0", path = "../../loader", optional = true}
+swc_ecma_parser = {version = "0.69.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.29.0", path = "../base"}
+swc_ecma_transforms_classes = {version = "0.15.0", path = "../classes"}
+swc_ecma_utils = {version = "0.43.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.31.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.35.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.28.0", path = "../testing"}
+swc_ecma_transforms_compat = {version = "0.32.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.36.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.29.0", path = "../testing"}

--- a/ecmascript/transforms/react/Cargo.toml
+++ b/ecmascript/transforms/react/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_react"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.36.1"
+version = "0.37.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -21,15 +21,15 @@ sha-1 = "0.9.4"
 string_enum = {version = "0.3.1", path = "../../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.11.6", path = "../../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.68.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.28.0", path = "../base"}
-swc_ecma_utils = {version = "0.42.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.69.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.29.0", path = "../base"}
+swc_ecma_utils = {version = "0.43.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.68.0", path = "../../codegen/"}
-swc_ecma_transforms_compat = {version = "0.31.0", path = "../compat/"}
-swc_ecma_transforms_module = {version = "0.35.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.28.0", path = "../testing/"}
+swc_ecma_codegen = {version = "0.69.0", path = "../../codegen/"}
+swc_ecma_transforms_compat = {version = "0.32.0", path = "../compat/"}
+swc_ecma_transforms_module = {version = "0.36.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.29.0", path = "../testing/"}
 testing = {version = "0.12.2", path = "../../../testing"}

--- a/ecmascript/transforms/testing/Cargo.toml
+++ b/ecmascript/transforms/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.28.0"
+version = "0.29.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,11 +16,11 @@ anyhow = "1"
 serde = "1"
 serde_json = "1"
 swc_common = {version = "0.11.6", path = "../../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../../ast"}
-swc_ecma_codegen = {version = "0.68.0", path = "../../codegen"}
-swc_ecma_parser = {version = "0.68.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.28.0", path = "../base"}
-swc_ecma_utils = {version = "0.42.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../../ast"}
+swc_ecma_codegen = {version = "0.69.0", path = "../../codegen"}
+swc_ecma_parser = {version = "0.69.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.29.0", path = "../base"}
+swc_ecma_utils = {version = "0.43.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../../visit"}
 tempfile = "3.1.0"
 testing = {version = "0.12.2", path = "../../../testing"}

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.37.0"
+version = "0.38.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -14,17 +14,17 @@ fxhash = "0.2.1"
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
 swc_common = {version = "0.11.6", path = "../../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../../ast"}
-swc_ecma_parser = {version = "0.68.0", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.28.0", path = "../base"}
-swc_ecma_utils = {version = "0.42.0", path = "../../utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.69.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.29.0", path = "../base"}
+swc_ecma_utils = {version = "0.43.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.68.0", path = "../../codegen"}
-swc_ecma_transforms_compat = {version = "0.31.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.35.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.35.0", path = "../proposal/"}
-swc_ecma_transforms_testing = {version = "0.28.0", path = "../testing"}
+swc_ecma_codegen = {version = "0.69.0", path = "../../codegen"}
+swc_ecma_transforms_compat = {version = "0.32.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.36.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.36.0", path = "../proposal/"}
+swc_ecma_transforms_testing = {version = "0.29.0", path = "../testing"}
 testing = {version = "0.12.2", path = "../../../testing"}
 walkdir = "2.3.1"

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.42.0"
+version = "0.43.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,8 +15,8 @@ once_cell = "1"
 scoped-tls = "1"
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
 swc_common = {version = "0.11.6", path = "../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../ast"}
-swc_ecma_visit = {version = "0.36.0", path = "../visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../ast"}
+swc_ecma_visit = {version = "0.37.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]

--- a/ecmascript/visit/Cargo.toml
+++ b/ecmascript/visit/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_visit"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.36.0"
+version = "0.37.0"
 
 [dependencies]
 num-bigint = {version = "0.2", features = ["serde"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
 swc_common = {version = "0.11.6", path = "../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../ast"}
+swc_ecma_ast = {version = "0.51.0", path = "../ast"}
 swc_visit = {version = "0.2.3", path = "../../visit"}

--- a/ecmascript/visit/src/lib.rs
+++ b/ecmascript/visit/src/lib.rs
@@ -546,7 +546,7 @@ define!({
     }
     pub struct StaticBlock {
         pub span: Span,
-        pub body: Vec<Stmt>,
+        pub body: BlockStmt,
     }
     pub enum MethodKind {
         Method,

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_plugin"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.2.0"
+version = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -17,6 +17,6 @@ serde = "1.0.126"
 serde_json = "1.0.64"
 swc_atoms = {version = "0.2.7", path = "../atoms"}
 swc_common = {version = "0.11.6", path = "../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../ecmascript/ast"}
-swc_ecma_utils = {version = "0.42.0", path = "../ecmascript/utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../ecmascript/visit"}
+swc_ecma_ast = {version = "0.51.0", path = "../ecmascript/ast"}
+swc_ecma_utils = {version = "0.43.0", path = "../ecmascript/utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../ecmascript/visit"}

--- a/plugin/runner/Cargo.toml
+++ b/plugin/runner/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_plugin_runner"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.2.0"
+version = "0.3.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -17,10 +17,10 @@ serde = {version = "1.0.126", features = ["derive"]}
 serde_json = "1.0.64"
 swc_atoms = "0.2.7"
 swc_common = {version = "0.11.6", path = "../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../../ecmascript/ast"}
-swc_ecma_parser = {version = "0.68.0", path = "../../ecmascript/parser"}
-swc_plugin = {version = "0.2.0", path = "../"}
+swc_ecma_ast = {version = "0.51.0", path = "../../ecmascript/ast"}
+swc_ecma_parser = {version = "0.69.0", path = "../../ecmascript/parser"}
+swc_plugin = {version = "0.3.0", path = "../"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.68.0", path = "../../ecmascript/codegen"}
+swc_ecma_codegen = {version = "0.69.0", path = "../../ecmascript/codegen"}
 testing = {version = "0.12.2", path = "../../testing"}

--- a/plugin/testing/Cargo.toml
+++ b/plugin/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_plugin_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.2.0"
+version = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,8 +14,8 @@ version = "0.2.0"
 anyhow = "1.0.41"
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
 swc_common = {version = "0.11.6", path = "../../common"}
-swc_ecma_ast = {version = "0.50.0", path = "../../ecmascript/ast"}
-swc_ecma_codegen = {version = "0.68.0", path = "../../ecmascript/codegen"}
-swc_ecma_utils = {version = "0.42.0", path = "../../ecmascript/utils"}
-swc_ecma_visit = {version = "0.36.0", path = "../../ecmascript/visit"}
-swc_plugin = {version = "0.2.0", path = "../"}
+swc_ecma_ast = {version = "0.51.0", path = "../../ecmascript/ast"}
+swc_ecma_codegen = {version = "0.69.0", path = "../../ecmascript/codegen"}
+swc_ecma_utils = {version = "0.43.0", path = "../../ecmascript/utils"}
+swc_ecma_visit = {version = "0.37.0", path = "../../ecmascript/visit"}
+swc_plugin = {version = "0.3.0", path = "../"}


### PR DESCRIPTION
This change makes the `StaticBlock` node use a `BlockStmt` instead of `Vec<Stmt>` for the statements. This is more in line with the other class nodes (ex. `Constructor`) and aligns with what is done in the TypeScript compiler:

![image](https://user-images.githubusercontent.com/1609021/131406089-326d7681-89d7-4764-9006-899b091505db.png)

It will also make it easier for code formatting purposes to be able to get the span/range of the block.

Additionally, this fixes the span of `StaticBlock`.