### PR TITLE
feat(common/syntax_pos): FileName supports URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "jsdoc"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2287,7 +2287,7 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "swc"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.11.9"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "arbitrary",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "swc_css_ast",
  "swc_css_codegen",
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "is-macro",
  "serde",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "auto_impl",
  "bitflags",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "bitflags",
  "lexical",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "swc_atoms 0.2.7",
  "swc_common",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "swc_atoms 0.2.7",
  "swc_common",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.51.1"
+version = "0.52.0"
 dependencies = [
  "arbitrary",
  "is-macro",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.69.1"
+version = "0.70.0"
 dependencies = [
  "bitflags",
  "num-bigint",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_dep_graph"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "swc_atoms 0.2.7",
  "swc_common",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.27.1"
+version = "0.28.0"
 dependencies = [
  "phf",
  "swc_atoms 0.2.7",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.69.1"
+version = "0.70.0"
 dependencies = [
  "either",
  "enum_kind",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "dashmap",
  "fxhash",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "pretty_assertions 0.6.1",
  "sourcemap",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "fxhash",
  "once_cell",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "swc_atoms 0.2.7",
  "swc_common",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "arrayvec",
  "fxhash",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "dashmap",
  "fxhash",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "either",
  "fxhash",
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "base64 0.13.0",
  "dashmap",
@@ -2903,7 +2903,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "fxhash",
  "serde",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.43.1"
+version = "0.44.0"
 dependencies = [
  "once_cell",
  "scoped-tls",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "num-bigint",
  "swc_atoms 0.2.7",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "swc_node_base"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "dashmap",
  "mimalloc-rust",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "abi_stable",
  "anyhow",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "abi_stable",
  "anyhow",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_testing"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "swc_atoms 0.2.7",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "swc_stylis"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "swc_atoms 0.2.7",
  "swc_common",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "ansi_term 0.12.1",
  "difference",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,6 +2454,7 @@ dependencies = [
  "swc_visit",
  "termcolor",
  "unicode-width",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.50.0"
+version = "0.51.0"
 
 [lib]
 name = "swc"
@@ -46,16 +46,16 @@ serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "./atoms"}
-swc_bundler = {version = "0.57.0", path = "./bundler"}
-swc_common = {version = "0.11.9", path = "./common", features = ["sourcemap", "concurrent"]}
-swc_ecma_ast = {version = "0.51.1", path = "./ecmascript/ast"}
-swc_ecma_codegen = {version = "0.69.1", path = "./ecmascript/codegen"}
-swc_ecma_ext_transforms = {version = "0.27.1", path = "./ecmascript/ext-transforms"}
-swc_ecma_loader = {version = "0.17.1", path = "./ecmascript/loader", features = ["lru", "node", "tsc"]}
-swc_ecma_minifier = {version = "0.26.0", path = "./ecmascript/minifier"}
-swc_ecma_parser = {version = "0.69.1", path = "./ecmascript/parser"}
-swc_ecma_preset_env = {version = "0.41.0", path = "./ecmascript/preset-env"}
-swc_ecma_transforms = {version = "0.70.0", path = "./ecmascript/transforms", features = [
+swc_bundler = {version = "0.58.0", path = "./bundler"}
+swc_common = {version = "0.12.0", path = "./common", features = ["sourcemap", "concurrent"]}
+swc_ecma_ast = {version = "0.52.0", path = "./ecmascript/ast"}
+swc_ecma_codegen = {version = "0.70.0", path = "./ecmascript/codegen"}
+swc_ecma_ext_transforms = {version = "0.28.0", path = "./ecmascript/ext-transforms"}
+swc_ecma_loader = {version = "0.18.0", path = "./ecmascript/loader", features = ["lru", "node", "tsc"]}
+swc_ecma_minifier = {version = "0.27.0", path = "./ecmascript/minifier"}
+swc_ecma_parser = {version = "0.70.0", path = "./ecmascript/parser"}
+swc_ecma_preset_env = {version = "0.42.0", path = "./ecmascript/preset-env"}
+swc_ecma_transforms = {version = "0.71.0", path = "./ecmascript/transforms", features = [
   "compat",
   "module",
   "optimization",
@@ -63,16 +63,16 @@ swc_ecma_transforms = {version = "0.70.0", path = "./ecmascript/transforms", fea
   "react",
   "typescript",
 ]}
-swc_ecma_transforms_base = {version = "0.30.0", path = "./ecmascript/transforms/base"}
-swc_ecma_utils = {version = "0.43.1", path = "./ecmascript/utils"}
-swc_ecma_visit = {version = "0.37.1", path = "./ecmascript/visit"}
-swc_ecmascript = {version = "0.62.0", path = "./ecmascript"}
-swc_node_base = {version = "0.2.3", path = "./node/base"}
+swc_ecma_transforms_base = {version = "0.31.0", path = "./ecmascript/transforms/base"}
+swc_ecma_utils = {version = "0.44.0", path = "./ecmascript/utils"}
+swc_ecma_visit = {version = "0.38.0", path = "./ecmascript/visit"}
+swc_ecmascript = {version = "0.63.0", path = "./ecmascript"}
+swc_node_base = {version = "0.3.0", path = "./node/base"}
 swc_visit = {version = "0.2.3", path = "./visit"}
 
 [dev-dependencies]
 rayon = "1"
-testing = {version = "0.12.3", path = "./testing"}
+testing = {version = "0.13.0", path = "./testing"}
 walkdir = "2"
 
 [[example]]

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -9,7 +9,7 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/**/*.js"]
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.57.0"
+version = "0.58.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -32,22 +32,22 @@ rayon = {version = "1", optional = true}
 relative-path = "1.2"
 retain_mut = "0.1.2"
 swc_atoms = {version = "0.2.4", path = "../atoms"}
-swc_common = {version = "0.11.9", path = "../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../ecmascript/ast"}
-swc_ecma_codegen = {version = "0.69.1", path = "../ecmascript/codegen"}
-swc_ecma_loader = {version = "0.17.1", path = "../ecmascript/loader"}
-swc_ecma_parser = {version = "0.69.1", path = "../ecmascript/parser"}
-swc_ecma_transforms = {version = "0.70.0", path = "../ecmascript/transforms", features = ["optimization"]}
-swc_ecma_utils = {version = "0.43.1", path = "../ecmascript/utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../ecmascript/visit"}
+swc_common = {version = "0.12.0", path = "../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../ecmascript/ast"}
+swc_ecma_codegen = {version = "0.70.0", path = "../ecmascript/codegen"}
+swc_ecma_loader = {version = "0.18.0", path = "../ecmascript/loader"}
+swc_ecma_parser = {version = "0.70.0", path = "../ecmascript/parser"}
+swc_ecma_transforms = {version = "0.71.0", path = "../ecmascript/transforms", features = ["optimization"]}
+swc_ecma_utils = {version = "0.44.0", path = "../ecmascript/utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../ecmascript/visit"}
 
 [dev-dependencies]
 hex = "0.4"
 ntest = "0.7.2"
 reqwest = {version = "0.11.4", features = ["blocking"]}
 sha-1 = "0.9"
-swc_ecma_transforms = {version = "0.70.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
+swc_ecma_transforms = {version = "0.71.0", path = "../ecmascript/transforms", features = ["react", "typescript"]}
 tempfile = "3.1.0"
-testing = {version = "0.12.3", path = "../testing"}
+testing = {version = "0.13.0", path = "../testing"}
 url = "2.1.1"
 walkdir = "2"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -35,6 +35,7 @@ swc_eq_ignore_macros = {version = "0.1", path = "../macros/eq_ignore"}
 swc_visit = {version = "0.2.4", path = "../visit"}
 termcolor = {version = "1.0", optional = true}
 unicode-width = "0.1.4"
+url = "2.2.2"
 
 [dev-dependencies]
 rayon = "1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_common"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.11.9"
+version = "0.12.0"
 
 [features]
 concurrent = ["parking_lot"]

--- a/common/src/source_map.rs
+++ b/common/src/source_map.rs
@@ -1112,7 +1112,7 @@ impl SourceMap {
                     src_id = builder.add_source(&config.file_name_to_source(&f.name));
 
                     match f.name {
-                        FileName::Real(..) | FileName::Custom(..) => {}
+                        FileName::Real(..) | FileName::Custom(..) | FileName::Url(..) => {}
                         _ => {
                             builder.set_source_contents(src_id, Some(&f.src));
                         }

--- a/common/src/syntax_pos.rs
+++ b/common/src/syntax_pos.rs
@@ -104,6 +104,7 @@ pub enum FileName {
     MacroExpansion,
     ProcMacroSourceCode,
     Url(Url),
+    Internal(String),
     /// Custom sources for explicit parser calls from plugins and drivers
     Custom(String),
 }
@@ -118,7 +119,7 @@ impl std::fmt::Display for FileName {
             FileName::Anon => write!(fmt, "<anon>"),
             FileName::ProcMacroSourceCode => write!(fmt, "<proc-macro source code>"),
             FileName::Url(ref u) => write!(fmt, "{}", u),
-            FileName::Custom(ref s) => write!(fmt, "<{}>", s),
+            FileName::Custom(ref s) | FileName::Internal(ref s) => write!(fmt, "<{}>", s),
         }
     }
 }
@@ -146,6 +147,7 @@ impl FileName {
             | FileName::ProcMacroSourceCode
             | FileName::Custom(_)
             | FileName::QuoteExpansion
+            | FileName::Internal(_)
             | FileName::Url(_) => false,
         }
     }
@@ -158,6 +160,7 @@ impl FileName {
             | FileName::ProcMacroSourceCode
             | FileName::Custom(_)
             | FileName::QuoteExpansion
+            | FileName::Internal(_)
             | FileName::Url(_) => false,
             FileName::Macros(_) => true,
         }

--- a/common/src/syntax_pos.rs
+++ b/common/src/syntax_pos.rs
@@ -9,6 +9,7 @@ use std::{
     path::PathBuf,
     sync::Mutex,
 };
+use url::Url;
 
 mod analyze_source_file;
 pub mod hygiene;
@@ -102,6 +103,7 @@ pub enum FileName {
     /// FIXME(jseyfried)
     MacroExpansion,
     ProcMacroSourceCode,
+    Url(Url),
     /// Custom sources for explicit parser calls from plugins and drivers
     Custom(String),
 }
@@ -115,6 +117,7 @@ impl std::fmt::Display for FileName {
             FileName::MacroExpansion => write!(fmt, "<macro expansion>"),
             FileName::Anon => write!(fmt, "<anon>"),
             FileName::ProcMacroSourceCode => write!(fmt, "<proc-macro source code>"),
+            FileName::Url(ref u) => write!(fmt, "{}", u),
             FileName::Custom(ref s) => write!(fmt, "<{}>", s),
         }
     }
@@ -127,6 +130,12 @@ impl From<PathBuf> for FileName {
     }
 }
 
+impl From<Url> for FileName {
+    fn from(url: Url) -> Self {
+        FileName::Url(url)
+    }
+}
+
 impl FileName {
     pub fn is_real(&self) -> bool {
         match *self {
@@ -136,7 +145,8 @@ impl FileName {
             | FileName::MacroExpansion
             | FileName::ProcMacroSourceCode
             | FileName::Custom(_)
-            | FileName::QuoteExpansion => false,
+            | FileName::QuoteExpansion
+            | FileName::Url(_) => false,
         }
     }
 
@@ -147,7 +157,8 @@ impl FileName {
             | FileName::MacroExpansion
             | FileName::ProcMacroSourceCode
             | FileName::Custom(_)
-            | FileName::QuoteExpansion => false,
+            | FileName::QuoteExpansion
+            | FileName::Url(_) => false,
             FileName::Macros(_) => true,
         }
     }

--- a/css/Cargo.toml
+++ b/css/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.4.1"
+version = "0.5.0"
 
 [dependencies]
-swc_css_ast = {version = "0.4.1", path = "./ast"}
-swc_css_codegen = {version = "0.2.1", path = "./codegen"}
-swc_css_parser = {version = "0.4.2", path = "./parser"}
-swc_css_utils = {version = "0.1.1", path = "./utils/"}
-swc_css_visit = {version = "0.3.1", path = "./visit"}
+swc_css_ast = {version = "0.5.0", path = "./ast"}
+swc_css_codegen = {version = "0.3.0", path = "./codegen"}
+swc_css_parser = {version = "0.5.0", path = "./parser"}
+swc_css_utils = {version = "0.2.0", path = "./utils/"}
+swc_css_visit = {version = "0.4.0", path = "./visit"}

--- a/css/ast/Cargo.toml
+++ b/css/ast/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_ast"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.4.1"
+version = "0.5.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,4 +15,4 @@ is-macro = "0.1.9"
 serde = {version = "1.0.127", features = ["derive"]}
 string_enum = {version = "0.3.1", path = "../../macros/string_enum/"}
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
+swc_common = {version = "0.12.0", path = "../../common"}

--- a/css/codegen/Cargo.toml
+++ b/css/codegen/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.2.1"
+version = "0.3.0"
 
 [dependencies]
 auto_impl = "0.4.1"
 bitflags = "1.3.2"
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_css_ast = {version = "0.4.1", path = "../ast/"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_css_ast = {version = "0.5.0", path = "../ast/"}
 swc_css_codegen_macros = {version = "0.2.0", path = "macros/"}
 
 [dev-dependencies]
-swc_css_parser = {version = "0.4.2", path = "../parser"}
-swc_css_visit = {version = "0.3.1", path = "../visit"}
-testing = {version = "0.12.3", path = "../../testing"}
+swc_css_parser = {version = "0.5.0", path = "../parser"}
+swc_css_visit = {version = "0.4.0", path = "../visit"}
+testing = {version = "0.13.0", path = "../../testing"}

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.4.2"
+version = "0.5.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -16,12 +16,12 @@ debug = []
 bitflags = "1.2.1"
 lexical = "5.2.2"
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_css_ast = {version = "0.4.1", path = "../ast"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_css_ast = {version = "0.5.0", path = "../ast"}
 unicode-xid = "0.2.2"
 
 [dev-dependencies]
 serde = "1.0.127"
 serde_json = "1.0.66"
-swc_css_visit = {version = "0.3.1", path = "../visit"}
-testing = {version = "0.12.3", path = "../../testing"}
+swc_css_visit = {version = "0.4.0", path = "../visit"}
+testing = {version = "0.13.0", path = "../../testing"}

--- a/css/stylis/Cargo.toml
+++ b/css/stylis/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_stylis"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.1.1"
+version = "0.2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_css_ast = {version = "0.4.1", path = "../ast"}
-swc_css_utils = {version = "0.1.1", path = "../utils/"}
-swc_css_visit = {version = "0.3.1", path = "../visit"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_css_ast = {version = "0.5.0", path = "../ast"}
+swc_css_utils = {version = "0.2.0", path = "../utils/"}
+swc_css_visit = {version = "0.4.0", path = "../visit"}
 
 [dev-dependencies]
-swc_css_codegen = {version = "0.2.1", path = "../codegen"}
-swc_css_parser = {version = "0.4.2", path = "../parser"}
-testing = {version = "0.12.3", path = "../../testing"}
+swc_css_codegen = {version = "0.3.0", path = "../codegen"}
+swc_css_parser = {version = "0.5.0", path = "../parser"}
+testing = {version = "0.13.0", path = "../../testing"}

--- a/css/utils/Cargo.toml
+++ b/css/utils/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.1.1"
+version = "0.2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_css_ast = {version = "0.4.1", path = "../ast"}
-swc_css_visit = {version = "0.3.1", path = "../visit"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_css_ast = {version = "0.5.0", path = "../ast"}
+swc_css_visit = {version = "0.4.0", path = "../visit"}

--- a/css/visit/Cargo.toml
+++ b/css/visit/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_visit"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.3.1"
+version = "0.4.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_css_ast = {version = "0.4.1", path = "../ast/"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_css_ast = {version = "0.5.0", path = "../ast/"}
 swc_visit = {version = "0.2.6", path = "../../visit"}

--- a/ecmascript/Cargo.toml
+++ b/ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.62.0"
+version = "0.63.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -32,14 +32,14 @@ react = ["swc_ecma_transforms/react"]
 typescript = ["typescript-parser", "swc_ecma_transforms/typescript"]
 
 [dependencies]
-swc_ecma_ast = {version = "0.51.1", path = "./ast"}
-swc_ecma_codegen = {version = "0.69.1", path = "./codegen", optional = true}
-swc_ecma_dep_graph = {version = "0.38.1", path = "./dep-graph", optional = true}
-swc_ecma_minifier = {version = "0.26.0", path = "./minifier", optional = true}
-swc_ecma_parser = {version = "0.69.1", path = "./parser", optional = true, default-features = false}
-swc_ecma_preset_env = {version = "0.41.0", path = "./preset-env", optional = true}
-swc_ecma_transforms = {version = "0.70.0", path = "./transforms", optional = true}
-swc_ecma_utils = {version = "0.43.1", path = "./utils", optional = true}
-swc_ecma_visit = {version = "0.37.1", path = "./visit", optional = true}
+swc_ecma_ast = {version = "0.52.0", path = "./ast"}
+swc_ecma_codegen = {version = "0.70.0", path = "./codegen", optional = true}
+swc_ecma_dep_graph = {version = "0.39.0", path = "./dep-graph", optional = true}
+swc_ecma_minifier = {version = "0.27.0", path = "./minifier", optional = true}
+swc_ecma_parser = {version = "0.70.0", path = "./parser", optional = true, default-features = false}
+swc_ecma_preset_env = {version = "0.42.0", path = "./preset-env", optional = true}
+swc_ecma_transforms = {version = "0.71.0", path = "./transforms", optional = true}
+swc_ecma_utils = {version = "0.44.0", path = "./utils", optional = true}
+swc_ecma_visit = {version = "0.38.0", path = "./visit", optional = true}
 
 [dev-dependencies]

--- a/ecmascript/ast/Cargo.toml
+++ b/ecmascript/ast/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ast"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.51.1"
+version = "0.52.0"
 
 [features]
 default = []
@@ -19,7 +19,7 @@ num-bigint = {version = "0.2", features = ["serde"]}
 serde = {version = "1.0.88", features = ["derive"]}
 string_enum = {version = "0.3.1", path = "../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
+swc_common = {version = "0.12.0", path = "../../common"}
 
 [dev-dependencies]
 serde_json = "1"

--- a/ecmascript/codegen/Cargo.toml
+++ b/ecmascript/codegen/Cargo.toml
@@ -7,18 +7,18 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.69.1"
+version = "0.70.0"
 
 [dependencies]
 bitflags = "1"
 num-bigint = {version = "0.2", features = ["serde"]}
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../ast"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../ast"}
 swc_ecma_codegen_macros = {version = "0.5.2", path = "./macros"}
-swc_ecma_parser = {version = "0.69.1", path = "../parser"}
+swc_ecma_parser = {version = "0.70.0", path = "../parser"}
 
 [dev-dependencies]
-swc_common = {version = "0.11.9", path = "../../common", features = ["sourcemap"]}
-testing = {version = "0.12.3", path = "../../testing"}
+swc_common = {version = "0.12.0", path = "../../common", features = ["sourcemap"]}
+testing = {version = "0.13.0", path = "../../testing"}

--- a/ecmascript/dep-graph/Cargo.toml
+++ b/ecmascript/dep-graph/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_dep_graph"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.38.1"
+version = "0.39.0"
 
 [dependencies]
 swc_atoms = {version = "0.2", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../ast"}
-swc_ecma_visit = {version = "0.37.1", path = "../visit"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../ast"}
+swc_ecma_visit = {version = "0.38.0", path = "../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.69.1", path = "../parser"}
-testing = {version = "0.12.3", path = "../../testing"}
+swc_ecma_parser = {version = "0.70.0", path = "../parser"}
+testing = {version = "0.13.0", path = "../../testing"}

--- a/ecmascript/ext-transforms/Cargo.toml
+++ b/ecmascript/ext-transforms/Cargo.toml
@@ -5,15 +5,15 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_ext_transforms/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ext_transforms"
-version = "0.27.1"
+version = "0.28.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 phf = {version = "0.8.0", features = ["macros"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../ast"}
-swc_ecma_parser = {version = "0.69.1", path = "../parser"}
-swc_ecma_utils = {version = "0.43.1", path = "../utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../visit"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../ast"}
+swc_ecma_parser = {version = "0.70.0", path = "../parser"}
+swc_ecma_utils = {version = "0.44.0", path = "../utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../visit"}

--- a/ecmascript/jsdoc/Cargo.toml
+++ b/ecmascript/jsdoc/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/jsdoc/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "jsdoc"
-version = "0.37.1"
+version = "0.38.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,12 +13,12 @@ version = "0.37.1"
 nom = "5.1.2"
 serde = {version = "1", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
+swc_common = {version = "0.12.0", path = "../../common"}
 
 [dev-dependencies]
 anyhow = "1"
 dashmap = "4.0.2"
-swc_ecma_ast = {version = "0.51.1", path = "../ast"}
-swc_ecma_parser = {version = "0.69.1", path = "../parser"}
-testing = {version = "0.12.3", path = "../../testing"}
+swc_ecma_ast = {version = "0.52.0", path = "../ast"}
+swc_ecma_parser = {version = "0.70.0", path = "../parser"}
+testing = {version = "0.13.0", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/loader/Cargo.toml
+++ b/ecmascript/loader/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_loader"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.17.1"
+version = "0.18.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -30,12 +30,12 @@ regex = {version = "1", optional = true}
 serde = {version = "1.0.126", optional = true}
 serde_json = {version = "1.0.64", optional = true}
 swc_atoms = {version = "0.2.3", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../ast"}
-swc_ecma_visit = {version = "0.37.1", path = "../visit"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../ast"}
+swc_ecma_visit = {version = "0.38.0", path = "../visit"}
 
 [dev-dependencies]
-testing = {version = "0.12.3", path = "../../testing"}
+testing = {version = "0.13.0", path = "../../testing"}
 
 [target.'cfg(windows)'.dependencies]
 normpath = {version = "0.2", optional = true}

--- a/ecmascript/minifier/Cargo.toml
+++ b/ecmascript/minifier/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "src/lists/*.json"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_minifier"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.26.0"
+version = "0.27.0"
 
 [features]
 debug = []
@@ -25,20 +25,20 @@ serde = {version = "1.0.118", features = ["derive"]}
 serde_json = "1.0.61"
 serde_regex = "1.1.0"
 swc_atoms = {version = "0.2", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../ast"}
-swc_ecma_codegen = {version = "0.69.1", path = "../codegen"}
-swc_ecma_parser = {version = "0.69.1", path = "../parser"}
-swc_ecma_transforms = {version = "0.70.0", path = "../transforms/", features = ["optimization"]}
-swc_ecma_transforms_base = {version = "0.30.0", path = "../transforms/base"}
-swc_ecma_utils = {version = "0.43.1", path = "../utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../visit"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../ast"}
+swc_ecma_codegen = {version = "0.70.0", path = "../codegen"}
+swc_ecma_parser = {version = "0.70.0", path = "../parser"}
+swc_ecma_transforms = {version = "0.71.0", path = "../transforms/", features = ["optimization"]}
+swc_ecma_transforms_base = {version = "0.31.0", path = "../transforms/base"}
+swc_ecma_utils = {version = "0.44.0", path = "../utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../visit"}
 unicode-xid = "0.2.2"
 
 [dev-dependencies]
 ansi_term = "0.12.1"
 anyhow = "1"
 pretty_assertions = "0.6.1"
-swc_node_base = {version = "0.2.3", path = "../../node/base"}
-testing = {version = "0.12.3", path = "../../testing"}
+swc_node_base = {version = "0.3.0", path = "../../node/base"}
+testing = {version = "0.13.0", path = "../../testing"}
 walkdir = "2.3.1"

--- a/ecmascript/parser/Cargo.toml
+++ b/ecmascript/parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.69.1"
+version = "0.70.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -26,16 +26,16 @@ num-bigint = "0.2"
 serde = {version = "1", features = ["derive"]}
 smallvec = "1"
 swc_atoms = {version = "0.2.3", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../ast"}
-swc_ecma_visit = {version = "0.37.1", path = "../visit"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../ast"}
+swc_ecma_visit = {version = "0.38.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]
 env_logger = "0.7"
 pretty_assertions = "0.6"
 serde_json = "1"
-testing = {version = "0.12.3", path = "../../testing"}
+testing = {version = "0.13.0", path = "../../testing"}
 walkdir = "2"
 
 [[example]]

--- a/ecmascript/preset-env/Cargo.toml
+++ b/ecmascript/preset-env/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_preset_env/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_preset_env"
-version = "0.41.0"
+version = "0.42.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,15 +20,15 @@ serde_json = "1"
 st-map = "0.1.2"
 string_enum = {version = "0.3.1", path = "../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../ast"}
-swc_ecma_transforms = {version = "0.70.0", path = "../transforms", features = ["compat", "proposal"]}
-swc_ecma_utils = {version = "0.43.1", path = "../utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../visit"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../ast"}
+swc_ecma_transforms = {version = "0.71.0", path = "../transforms", features = ["compat", "proposal"]}
+swc_ecma_utils = {version = "0.44.0", path = "../utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../visit"}
 walkdir = "2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
-swc_ecma_codegen = {version = "0.69.1", path = "../codegen"}
-swc_ecma_parser = {version = "0.69.1", path = "../parser"}
-testing = {version = "0.12.3", path = "../../testing"}
+swc_ecma_codegen = {version = "0.70.0", path = "../codegen"}
+swc_ecma_parser = {version = "0.70.0", path = "../parser"}
+testing = {version = "0.13.0", path = "../../testing"}

--- a/ecmascript/transforms/Cargo.toml
+++ b/ecmascript/transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.70.0"
+version = "0.71.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -22,25 +22,25 @@ typescript = ["swc_ecma_transforms_typescript"]
 
 [dependencies]
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../ast"}
-swc_ecma_parser = {version = "0.69.1", path = "../parser"}
-swc_ecma_transforms_base = {version = "0.30.0", path = "./base"}
-swc_ecma_transforms_compat = {version = "0.33.0", path = "./compat", optional = true}
-swc_ecma_transforms_module = {version = "0.37.0", path = "./module", optional = true}
-swc_ecma_transforms_optimization = {version = "0.40.0", path = "./optimization", optional = true}
-swc_ecma_transforms_proposal = {version = "0.37.0", path = "./proposal", optional = true}
-swc_ecma_transforms_react = {version = "0.38.0", path = "./react", optional = true}
-swc_ecma_transforms_typescript = {version = "0.39.0", path = "./typescript", optional = true}
-swc_ecma_utils = {version = "0.43.1", path = "../utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../visit"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../ast"}
+swc_ecma_parser = {version = "0.70.0", path = "../parser"}
+swc_ecma_transforms_base = {version = "0.31.0", path = "./base"}
+swc_ecma_transforms_compat = {version = "0.34.0", path = "./compat", optional = true}
+swc_ecma_transforms_module = {version = "0.38.0", path = "./module", optional = true}
+swc_ecma_transforms_optimization = {version = "0.41.0", path = "./optimization", optional = true}
+swc_ecma_transforms_proposal = {version = "0.38.0", path = "./proposal", optional = true}
+swc_ecma_transforms_react = {version = "0.39.0", path = "./react", optional = true}
+swc_ecma_transforms_typescript = {version = "0.40.0", path = "./typescript", optional = true}
+swc_ecma_utils = {version = "0.44.0", path = "../utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
 sourcemap = "6"
-swc_ecma_codegen = {version = "0.69.1", path = "../codegen"}
-swc_ecma_transforms_testing = {version = "0.31.0", path = "./testing"}
+swc_ecma_codegen = {version = "0.70.0", path = "../codegen"}
+swc_ecma_transforms_testing = {version = "0.32.0", path = "./testing"}
 tempfile = "3"
-testing = {version = "0.12.3", path = "../../testing"}
+testing = {version = "0.13.0", path = "../../testing"}
 walkdir = "2"

--- a/ecmascript/transforms/base/Cargo.toml
+++ b/ecmascript/transforms/base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.30.1"
+version = "0.31.0"
 
 [dependencies]
 fxhash = "0.2.1"
@@ -15,12 +15,12 @@ phf = {version = "0.8.0", features = ["macros"]}
 scoped-tls = "1.0.0"
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
-swc_common = {version = "0.11.9", path = "../../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.69.1", path = "../../parser"}
-swc_ecma_utils = {version = "0.43.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../../visit"}
+swc_common = {version = "0.12.0", path = "../../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.70.0", path = "../../parser"}
+swc_ecma_utils = {version = "0.44.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.69.1", path = "../../codegen"}
-testing = {version = "0.12.3", path = "../../../testing"}
+swc_ecma_codegen = {version = "0.70.0", path = "../../codegen"}
+testing = {version = "0.13.0", path = "../../../testing"}

--- a/ecmascript/transforms/classes/Cargo.toml
+++ b/ecmascript/transforms/classes/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_classes"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.16.0"
+version = "0.17.0"
 
 [dependencies]
 swc_atoms = {version = "0.2.6", path = "../../../atoms"}
-swc_common = {version = "0.11.9", path = "../../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.30.0", path = "../base"}
-swc_ecma_utils = {version = "0.43.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../../visit"}
+swc_common = {version = "0.12.0", path = "../../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../../ast"}
+swc_ecma_transforms_base = {version = "0.31.0", path = "../base"}
+swc_ecma_utils = {version = "0.44.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../../visit"}

--- a/ecmascript/transforms/compat/Cargo.toml
+++ b/ecmascript/transforms/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.33.0"
+version = "0.34.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -19,15 +19,15 @@ ordered-float = "2.0.1"
 serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2.5", path = "../../../atoms"}
-swc_common = {version = "0.11.9", path = "../../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../../ast"}
-swc_ecma_transforms_base = {version = "0.30.0", path = "../base"}
-swc_ecma_transforms_classes = {version = "0.16.0", path = "../classes"}
+swc_common = {version = "0.12.0", path = "../../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../../ast"}
+swc_ecma_transforms_base = {version = "0.31.0", path = "../base"}
+swc_ecma_transforms_classes = {version = "0.17.0", path = "../classes"}
 swc_ecma_transforms_macros = {version = "0.2.1", path = "../macros"}
-swc_ecma_utils = {version = "0.43.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../../visit"}
+swc_ecma_utils = {version = "0.44.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.69.1", path = "../../parser"}
-swc_ecma_transforms_testing = {version = "0.31.0", path = "../testing"}
-testing = {version = "0.12.3", path = "../../../testing"}
+swc_ecma_parser = {version = "0.70.0", path = "../../parser"}
+swc_ecma_transforms_testing = {version = "0.32.0", path = "../testing"}
+testing = {version = "0.13.0", path = "../../../testing"}

--- a/ecmascript/transforms/module/Cargo.toml
+++ b/ecmascript/transforms/module/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.37.0"
+version = "0.38.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -17,15 +17,15 @@ indexmap = "1.6.1"
 pathdiff = "0.2.0"
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
-swc_common = {version = "0.11.9", path = "../../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../../ast"}
-swc_ecma_loader = {version = "0.17.1", path = "../../loader", features = ["node"]}
-swc_ecma_parser = {version = "0.69.1", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.30.0", path = "../base"}
-swc_ecma_utils = {version = "0.43.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../../visit"}
+swc_common = {version = "0.12.0", path = "../../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../../ast"}
+swc_ecma_loader = {version = "0.18.0", path = "../../loader", features = ["node"]}
+swc_ecma_parser = {version = "0.70.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.31.0", path = "../base"}
+swc_ecma_utils = {version = "0.44.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.33.0", path = "../compat"}
-swc_ecma_transforms_testing = {version = "0.31.0", path = "../testing/"}
-testing = {version = "0.12.3", path = "../../../testing/"}
+swc_ecma_transforms_compat = {version = "0.34.0", path = "../compat"}
+swc_ecma_transforms_testing = {version = "0.32.0", path = "../testing/"}
+testing = {version = "0.13.0", path = "../../../testing/"}

--- a/ecmascript/transforms/optimization/Cargo.toml
+++ b/ecmascript/transforms/optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.40.0"
+version = "0.41.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -18,18 +18,18 @@ once_cell = "1.5.2"
 retain_mut = "0.1.2"
 serde_json = "1.0.61"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
-swc_common = {version = "0.11.9", path = "../../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.69.1", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.30.0", path = "../base"}
-swc_ecma_utils = {version = "0.43.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../../visit"}
+swc_common = {version = "0.12.0", path = "../../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.70.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.31.0", path = "../base"}
+swc_ecma_utils = {version = "0.44.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.33.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.37.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.37.0", path = "../proposal"}
-swc_ecma_transforms_react = {version = "0.38.0", path = "../react"}
-swc_ecma_transforms_testing = {version = "0.31.0", path = "../testing"}
-swc_ecma_transforms_typescript = {version = "0.39.0", path = "../typescript"}
-testing = {version = "0.12.3", path = "../../../testing"}
+swc_ecma_transforms_compat = {version = "0.34.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.38.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.38.0", path = "../proposal"}
+swc_ecma_transforms_react = {version = "0.39.0", path = "../react"}
+swc_ecma_transforms_testing = {version = "0.32.0", path = "../testing"}
+swc_ecma_transforms_typescript = {version = "0.40.0", path = "../typescript"}
+testing = {version = "0.13.0", path = "../../../testing"}

--- a/ecmascript/transforms/proposal/Cargo.toml
+++ b/ecmascript/transforms/proposal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_proposal"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.37.0"
+version = "0.38.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,16 +20,16 @@ fxhash = "0.2.1"
 serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../../../atoms"}
-swc_common = {version = "0.11.9", path = "../../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../../ast"}
-swc_ecma_loader = {version = "0.17.1", path = "../../loader", optional = true}
-swc_ecma_parser = {version = "0.69.1", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.30.0", path = "../base"}
-swc_ecma_transforms_classes = {version = "0.16.0", path = "../classes"}
-swc_ecma_utils = {version = "0.43.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../../visit"}
+swc_common = {version = "0.12.0", path = "../../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../../ast"}
+swc_ecma_loader = {version = "0.18.0", path = "../../loader", optional = true}
+swc_ecma_parser = {version = "0.70.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.31.0", path = "../base"}
+swc_ecma_transforms_classes = {version = "0.17.0", path = "../classes"}
+swc_ecma_utils = {version = "0.44.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.33.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.37.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.31.0", path = "../testing"}
+swc_ecma_transforms_compat = {version = "0.34.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.38.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.32.0", path = "../testing"}

--- a/ecmascript/transforms/react/Cargo.toml
+++ b/ecmascript/transforms/react/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_react"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.38.0"
+version = "0.39.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -20,16 +20,16 @@ serde = {version = "1.0.118", features = ["derive"]}
 sha-1 = "0.9.4"
 string_enum = {version = "0.3.1", path = "../../../macros/string_enum"}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
-swc_common = {version = "0.11.9", path = "../../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.69.1", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.30.0", path = "../base"}
-swc_ecma_utils = {version = "0.43.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../../visit"}
+swc_common = {version = "0.12.0", path = "../../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.70.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.31.0", path = "../base"}
+swc_ecma_utils = {version = "0.44.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.69.1", path = "../../codegen/"}
-swc_ecma_transforms_compat = {version = "0.33.0", path = "../compat/"}
-swc_ecma_transforms_module = {version = "0.37.0", path = "../module"}
-swc_ecma_transforms_testing = {version = "0.31.0", path = "../testing/"}
-testing = {version = "0.12.3", path = "../../../testing"}
+swc_ecma_codegen = {version = "0.70.0", path = "../../codegen/"}
+swc_ecma_transforms_compat = {version = "0.34.0", path = "../compat/"}
+swc_ecma_transforms_module = {version = "0.38.0", path = "../module"}
+swc_ecma_transforms_testing = {version = "0.32.0", path = "../testing/"}
+testing = {version = "0.13.0", path = "../../../testing"}

--- a/ecmascript/transforms/testing/Cargo.toml
+++ b/ecmascript/transforms/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.31.0"
+version = "0.32.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,12 +15,12 @@ ansi_term = "0.12.1"
 anyhow = "1"
 serde = "1"
 serde_json = "1"
-swc_common = {version = "0.11.9", path = "../../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../../ast"}
-swc_ecma_codegen = {version = "0.69.1", path = "../../codegen"}
-swc_ecma_parser = {version = "0.69.1", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.30.0", path = "../base"}
-swc_ecma_utils = {version = "0.43.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../../visit"}
+swc_common = {version = "0.12.0", path = "../../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../../ast"}
+swc_ecma_codegen = {version = "0.70.0", path = "../../codegen"}
+swc_ecma_parser = {version = "0.70.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.31.0", path = "../base"}
+swc_ecma_utils = {version = "0.44.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../../visit"}
 tempfile = "3.1.0"
-testing = {version = "0.12.3", path = "../../../testing"}
+testing = {version = "0.13.0", path = "../../../testing"}

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,25 +6,25 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.39.0"
+version = "0.40.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 fxhash = "0.2.1"
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../../../atoms"}
-swc_common = {version = "0.11.9", path = "../../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../../ast"}
-swc_ecma_parser = {version = "0.69.1", path = "../../parser"}
-swc_ecma_transforms_base = {version = "0.30.0", path = "../base"}
-swc_ecma_utils = {version = "0.43.1", path = "../../utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../../visit"}
+swc_common = {version = "0.12.0", path = "../../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../../ast"}
+swc_ecma_parser = {version = "0.70.0", path = "../../parser"}
+swc_ecma_transforms_base = {version = "0.31.0", path = "../base"}
+swc_ecma_utils = {version = "0.44.0", path = "../../utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../../visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.69.1", path = "../../codegen"}
-swc_ecma_transforms_compat = {version = "0.33.0", path = "../compat"}
-swc_ecma_transforms_module = {version = "0.37.0", path = "../module"}
-swc_ecma_transforms_proposal = {version = "0.37.0", path = "../proposal/"}
-swc_ecma_transforms_testing = {version = "0.31.0", path = "../testing"}
-testing = {version = "0.12.3", path = "../../../testing"}
+swc_ecma_codegen = {version = "0.70.0", path = "../../codegen"}
+swc_ecma_transforms_compat = {version = "0.34.0", path = "../compat"}
+swc_ecma_transforms_module = {version = "0.38.0", path = "../module"}
+swc_ecma_transforms_proposal = {version = "0.38.0", path = "../proposal/"}
+swc_ecma_transforms_testing = {version = "0.32.0", path = "../testing"}
+testing = {version = "0.13.0", path = "../../../testing"}
 walkdir = "2.3.1"

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.43.1"
+version = "0.44.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,10 +14,10 @@ version = "0.43.1"
 once_cell = "1"
 scoped-tls = "1"
 swc_atoms = {version = "0.2.0", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../ast"}
-swc_ecma_visit = {version = "0.37.1", path = "../visit"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../ast"}
+swc_ecma_visit = {version = "0.38.0", path = "../visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]
-testing = {version = "0.12.3", path = "../../testing"}
+testing = {version = "0.13.0", path = "../../testing"}

--- a/ecmascript/visit/Cargo.toml
+++ b/ecmascript/visit/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_visit"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.37.1"
+version = "0.38.0"
 
 [dependencies]
 num-bigint = {version = "0.2", features = ["serde"]}
 swc_atoms = {version = "0.2", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../ast"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../ast"}
 swc_visit = {version = "0.2.3", path = "../../visit"}

--- a/node/base/Cargo.toml
+++ b/node/base/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_node_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.2.3"
+version = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 dashmap = "4.0.2"
-swc_common = {version = "0.11.9", path = "../../common"}
+swc_common = {version = "0.12.0", path = "../../common"}
 
 [target.'cfg(all(target_arch = "x86_64", not(target_env = "musl")))'.dependencies]
 mimalloc-rust = "=0.1.1"

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_plugin"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.3.1"
+version = "0.4.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,7 +16,7 @@ anyhow = "1.0.41"
 serde = "1.0.126"
 serde_json = "1.0.64"
 swc_atoms = {version = "0.2.7", path = "../atoms"}
-swc_common = {version = "0.11.9", path = "../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../ecmascript/ast"}
-swc_ecma_utils = {version = "0.43.1", path = "../ecmascript/utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../ecmascript/visit"}
+swc_common = {version = "0.12.0", path = "../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../ecmascript/ast"}
+swc_ecma_utils = {version = "0.44.0", path = "../ecmascript/utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../ecmascript/visit"}

--- a/plugin/runner/Cargo.toml
+++ b/plugin/runner/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_plugin_runner"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.3.1"
+version = "0.4.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -16,11 +16,11 @@ libloading = "0.7.0"
 serde = {version = "1.0.126", features = ["derive"]}
 serde_json = "1.0.64"
 swc_atoms = "0.2.7"
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../../ecmascript/ast"}
-swc_ecma_parser = {version = "0.69.1", path = "../../ecmascript/parser"}
-swc_plugin = {version = "0.3.1", path = "../"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../../ecmascript/ast"}
+swc_ecma_parser = {version = "0.70.0", path = "../../ecmascript/parser"}
+swc_plugin = {version = "0.4.0", path = "../"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.69.1", path = "../../ecmascript/codegen"}
-testing = {version = "0.12.3", path = "../../testing"}
+swc_ecma_codegen = {version = "0.70.0", path = "../../ecmascript/codegen"}
+testing = {version = "0.13.0", path = "../../testing"}

--- a/plugin/testing/Cargo.toml
+++ b/plugin/testing/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_plugin_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.3.1"
+version = "0.4.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0.41"
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
-swc_common = {version = "0.11.9", path = "../../common"}
-swc_ecma_ast = {version = "0.51.1", path = "../../ecmascript/ast"}
-swc_ecma_codegen = {version = "0.69.1", path = "../../ecmascript/codegen"}
-swc_ecma_utils = {version = "0.43.1", path = "../../ecmascript/utils"}
-swc_ecma_visit = {version = "0.37.1", path = "../../ecmascript/visit"}
-swc_plugin = {version = "0.3.1", path = "../"}
+swc_common = {version = "0.12.0", path = "../../common"}
+swc_ecma_ast = {version = "0.52.0", path = "../../ecmascript/ast"}
+swc_ecma_codegen = {version = "0.70.0", path = "../../ecmascript/codegen"}
+swc_ecma_utils = {version = "0.44.0", path = "../../ecmascript/utils"}
+swc_ecma_visit = {version = "0.38.0", path = "../../ecmascript/visit"}
+swc_plugin = {version = "0.4.0", path = "../"}

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.12.3"
+version = "0.13.0"
 
 [dependencies]
 ansi_term = "0.12.1"
@@ -16,5 +16,5 @@ log = "0.4"
 once_cell = "1"
 pretty_assertions = "0.7.2"
 regex = "1"
-swc_common = {version = "0.11.9", path = "../common", features = ["tty-emitter"]}
+swc_common = {version = "0.12.0", path = "../common", features = ["tty-emitter"]}
 testing_macros = {version = "0.2.0", path = "./macros"}


### PR DESCRIPTION
This allows URLs to be represented as file names without being modified.  For platforms, like Deno, that handle sources a "native" URLs this is better than converting the URL to a `FileName::Custom`.

Closes: #2201 