### PR TITLE
fix(css/parser): Fix parsing of selectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bitflags",
  "lexical",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "swc_css_ast",
  "swc_css_codegen",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "auto_impl",
  "bitflags",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "bitflags",
  "lexical",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "swc_stylis"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "swc_atoms 0.2.7",
  "swc_common",

--- a/css/Cargo.toml
+++ b/css/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
 swc_css_ast = {version = "0.5.0", path = "./ast"}
-swc_css_codegen = {version = "0.3.0", path = "./codegen"}
-swc_css_parser = {version = "0.5.0", path = "./parser"}
+swc_css_codegen = {version = "0.4.0", path = "./codegen"}
+swc_css_parser = {version = "0.6.0", path = "./parser"}
 swc_css_utils = {version = "0.2.0", path = "./utils/"}
 swc_css_visit = {version = "0.4.0", path = "./visit"}

--- a/css/codegen/Cargo.toml
+++ b/css/codegen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 auto_impl = "0.4.1"
@@ -17,6 +17,6 @@ swc_css_ast = {version = "0.5.0", path = "../ast/"}
 swc_css_codegen_macros = {version = "0.2.0", path = "macros/"}
 
 [dev-dependencies]
-swc_css_parser = {version = "0.5.0", path = "../parser"}
+swc_css_parser = {version = "0.6.0", path = "../parser"}
 swc_css_visit = {version = "0.4.0", path = "../visit"}
 testing = {version = "0.13.0", path = "../../testing"}

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.5.0"
+version = "0.5.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.5.1"
+version = "0.6.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/css/parser/src/parser/selector/mod.rs
+++ b/css/parser/src/parser/selector/mod.rs
@@ -501,11 +501,20 @@ where
     }
 }
 
-impl<I> Parse<CompoundSelector> for Parser<I>
+impl<I> Parse<Vec<ComplexSelector>> for Parser<I>
 where
     I: ParserInput,
 {
-    fn parse(&mut self) -> PResult<CompoundSelector> {
-        self.parse_compound_selector()
+    fn parse(&mut self) -> PResult<Vec<ComplexSelector>> {
+        self.parse_selectors()
+    }
+}
+
+impl<I> Parse<ComplexSelector> for Parser<I>
+where
+    I: ParserInput,
+{
+    fn parse(&mut self) -> PResult<ComplexSelector> {
+        self.parse_complex_selector()
     }
 }

--- a/css/parser/tests/fixture.rs
+++ b/css/parser/tests/fixture.rs
@@ -11,6 +11,35 @@ use swc_css_visit::{Visit, VisitWith};
 use testing::NormalizedOutput;
 
 #[testing::fixture("tests/fixture/**/input.css")]
+fn tokens_input(input: PathBuf) {
+    eprintln!("Input: {}", input.display());
+
+    testing::run_test2(false, |cm, _handler| {
+        let fm = cm.load_file(&input).unwrap();
+
+        let tokens = {
+            let mut lexer = Lexer::new(SourceFileInput::from(&*fm));
+
+            let mut tokens = vec![];
+
+            while let Ok(t) = lexer.next() {
+                tokens.push(t);
+            }
+            Tokens {
+                span: Span::new(fm.start_pos, fm.end_pos, Default::default()),
+                tokens,
+            }
+        };
+
+        let _ss: Stylesheet = parse_tokens(&tokens, ParserConfig { parse_values: true })
+            .expect("failed to parse tokens");
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[testing::fixture("tests/fixture/**/input.css")]
 fn pass(input: PathBuf) {
     eprintln!("Input: {}", input.display());
 

--- a/css/parser/tests/fixture/styled-jsx/selector/1/input.css
+++ b/css/parser/tests/fixture/styled-jsx/selector/1/input.css
@@ -1,0 +1,3 @@
+:global(.foo + a) {
+    color: red;
+}

--- a/css/parser/tests/fixture/styled-jsx/selector/1/output.json
+++ b/css/parser/tests/fixture/styled-jsx/selector/1/output.json
@@ -1,0 +1,162 @@
+{
+  "type": "Stylesheet",
+  "span": {
+    "start": 0,
+    "end": 38,
+    "ctxt": 0
+  },
+  "rules": [
+    {
+      "type": "StyleRule",
+      "span": {
+        "start": 0,
+        "end": 37,
+        "ctxt": 0
+      },
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 17,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 17,
+                "ctxt": 0
+              },
+              "hasNestPrefix": false,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 17,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
+                    "span": {
+                      "start": 1,
+                      "end": 7,
+                      "ctxt": 0
+                    },
+                    "value": "global"
+                  },
+                  "args": {
+                    "type": "Tokens",
+                    "span": {
+                      "start": 8,
+                      "end": 16,
+                      "ctxt": 0
+                    },
+                    "tokens": [
+                      {
+                        "span": {
+                          "start": 8,
+                          "end": 9,
+                          "ctxt": 0
+                        },
+                        "token": "Dot"
+                      },
+                      {
+                        "span": {
+                          "start": 9,
+                          "end": 12,
+                          "ctxt": 0
+                        },
+                        "token": {
+                          "Ident": "foo"
+                        }
+                      },
+                      {
+                        "span": {
+                          "start": 12,
+                          "end": 13,
+                          "ctxt": 0
+                        },
+                        "token": "WhiteSpace"
+                      },
+                      {
+                        "span": {
+                          "start": 13,
+                          "end": 14,
+                          "ctxt": 0
+                        },
+                        "token": "Plus"
+                      },
+                      {
+                        "span": {
+                          "start": 14,
+                          "end": 15,
+                          "ctxt": 0
+                        },
+                        "token": "WhiteSpace"
+                      },
+                      {
+                        "span": {
+                          "start": 15,
+                          "end": 16,
+                          "ctxt": 0
+                        },
+                        "token": {
+                          "Ident": "a"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "block": {
+        "type": "DeclBlock",
+        "span": {
+          "start": 18,
+          "end": 37,
+          "ctxt": 0
+        },
+        "properties": [
+          {
+            "type": "Property",
+            "span": {
+              "start": 24,
+              "end": 34,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 24,
+                "end": 29,
+                "ctxt": 0
+              },
+              "value": "color"
+            },
+            "values": [
+              {
+                "type": "Text",
+                "span": {
+                  "start": 31,
+                  "end": 34,
+                  "ctxt": 0
+                },
+                "value": "red"
+              }
+            ],
+            "important": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/css/parser/tests/fixture/styled-jsx/selector/1/span.rust-debug
+++ b/css/parser/tests/fixture/styled-jsx/selector/1/span.rust-debug
@@ -1,0 +1,129 @@
+error: Stylesheet
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:1
+  |
+1 | / :global(.foo + a) {
+2 | |     color: red;
+3 | | }
+  | |__^
+
+error: Rule
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:1
+  |
+1 | / :global(.foo + a) {
+2 | |     color: red;
+3 | | }
+  | |_^
+
+error: StyleRule
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:1
+  |
+1 | / :global(.foo + a) {
+2 | |     color: red;
+3 | | }
+  | |_^
+
+error: ComplexSelector
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:1
+  |
+1 | :global(.foo + a) {
+  | ^^^^^^^^^^^^^^^^^
+
+error: CompoundSelector
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:1
+  |
+1 | :global(.foo + a) {
+  | ^^^^^^^^^^^^^^^^^
+
+error: SubclassSelector
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:1
+  |
+1 | :global(.foo + a) {
+  | ^^^^^^^^^^^^^^^^^
+
+error: PseudoSelector
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:1
+  |
+1 | :global(.foo + a) {
+  | ^^^^^^^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:2
+  |
+1 | :global(.foo + a) {
+  |  ^^^^^^
+
+error: Tokens
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:9
+  |
+1 | :global(.foo + a) {
+  |         ^^^^^^^^
+
+error: Dot
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:9
+  |
+1 | :global(.foo + a) {
+  |         ^
+
+error: Ident(Atom('foo' type=inline))
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:10
+  |
+1 | :global(.foo + a) {
+  |          ^^^
+
+error: WhiteSpace
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:13
+  |
+1 | :global(.foo + a) {
+  |             ^
+
+error: Plus
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:14
+  |
+1 | :global(.foo + a) {
+  |              ^
+
+error: WhiteSpace
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:15
+  |
+1 | :global(.foo + a) {
+  |               ^
+
+error: Ident(Atom('a' type=inline))
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:16
+  |
+1 | :global(.foo + a) {
+  |                ^
+
+error: DeclBlock
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:1:19
+  |
+1 |   :global(.foo + a) {
+  |  ___________________^
+2 | |     color: red;
+3 | | }
+  | |_^
+
+error: Property
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:2:5
+  |
+2 |     color: red;
+  |     ^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:2:5
+  |
+2 |     color: red;
+  |     ^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:2:12
+  |
+2 |     color: red;
+  |            ^^^
+
+error: Text
+ --> $DIR/tests/fixture/styled-jsx/selector/1/input.css:2:12
+  |
+2 |     color: red;
+  |            ^^^
+

--- a/css/parser/tests/fixture/styled-jsx/selector/2/input.css
+++ b/css/parser/tests/fixture/styled-jsx/selector/2/input.css
@@ -1,0 +1,3 @@
+p :global(span:not(.test)) {
+    color: green;
+}

--- a/css/parser/tests/fixture/styled-jsx/selector/2/output.json
+++ b/css/parser/tests/fixture/styled-jsx/selector/2/output.json
@@ -1,0 +1,201 @@
+{
+  "type": "Stylesheet",
+  "span": {
+    "start": 0,
+    "end": 49,
+    "ctxt": 0
+  },
+  "rules": [
+    {
+      "type": "StyleRule",
+      "span": {
+        "start": 0,
+        "end": 48,
+        "ctxt": 0
+      },
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 26,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "hasNestPrefix": false,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
+                "span": {
+                  "start": 0,
+                  "end": 1,
+                  "ctxt": 0
+                },
+                "prefix": null,
+                "name": {
+                  "type": "Text",
+                  "span": {
+                    "start": 0,
+                    "end": 1,
+                    "ctxt": 0
+                  },
+                  "value": "p"
+                }
+              },
+              "subclassSelectors": []
+            },
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 2,
+                "end": 26,
+                "ctxt": 0
+              },
+              "hasNestPrefix": false,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 2,
+                    "end": 26,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
+                    "span": {
+                      "start": 3,
+                      "end": 9,
+                      "ctxt": 0
+                    },
+                    "value": "global"
+                  },
+                  "args": {
+                    "type": "Tokens",
+                    "span": {
+                      "start": 10,
+                      "end": 25,
+                      "ctxt": 0
+                    },
+                    "tokens": [
+                      {
+                        "span": {
+                          "start": 10,
+                          "end": 14,
+                          "ctxt": 0
+                        },
+                        "token": {
+                          "Ident": "span"
+                        }
+                      },
+                      {
+                        "span": {
+                          "start": 14,
+                          "end": 15,
+                          "ctxt": 0
+                        },
+                        "token": "Colon"
+                      },
+                      {
+                        "span": {
+                          "start": 15,
+                          "end": 18,
+                          "ctxt": 0
+                        },
+                        "token": {
+                          "Ident": "not"
+                        }
+                      },
+                      {
+                        "span": {
+                          "start": 18,
+                          "end": 19,
+                          "ctxt": 0
+                        },
+                        "token": "LParen"
+                      },
+                      {
+                        "span": {
+                          "start": 19,
+                          "end": 20,
+                          "ctxt": 0
+                        },
+                        "token": "Dot"
+                      },
+                      {
+                        "span": {
+                          "start": 20,
+                          "end": 24,
+                          "ctxt": 0
+                        },
+                        "token": {
+                          "Ident": "test"
+                        }
+                      },
+                      {
+                        "span": {
+                          "start": 18,
+                          "end": 19,
+                          "ctxt": 0
+                        },
+                        "token": "RParen"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "block": {
+        "type": "DeclBlock",
+        "span": {
+          "start": 27,
+          "end": 48,
+          "ctxt": 0
+        },
+        "properties": [
+          {
+            "type": "Property",
+            "span": {
+              "start": 33,
+              "end": 45,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 33,
+                "end": 38,
+                "ctxt": 0
+              },
+              "value": "color"
+            },
+            "values": [
+              {
+                "type": "Text",
+                "span": {
+                  "start": 40,
+                  "end": 45,
+                  "ctxt": 0
+                },
+                "value": "green"
+              }
+            ],
+            "important": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/css/parser/tests/fixture/styled-jsx/selector/2/span.rust-debug
+++ b/css/parser/tests/fixture/styled-jsx/selector/2/span.rust-debug
@@ -1,0 +1,153 @@
+error: Stylesheet
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:1
+  |
+1 | / p :global(span:not(.test)) {
+2 | |     color: green;
+3 | | }
+  | |__^
+
+error: Rule
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:1
+  |
+1 | / p :global(span:not(.test)) {
+2 | |     color: green;
+3 | | }
+  | |_^
+
+error: StyleRule
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:1
+  |
+1 | / p :global(span:not(.test)) {
+2 | |     color: green;
+3 | | }
+  | |_^
+
+error: ComplexSelector
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:1
+  |
+1 | p :global(span:not(.test)) {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: CompoundSelector
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:1
+  |
+1 | p :global(span:not(.test)) {
+  | ^
+
+error: NamespacedName
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:1
+  |
+1 | p :global(span:not(.test)) {
+  | ^
+
+error: Text
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:1
+  |
+1 | p :global(span:not(.test)) {
+  | ^
+
+error: CompoundSelector
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:3
+  |
+1 | p :global(span:not(.test)) {
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: SubclassSelector
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:3
+  |
+1 | p :global(span:not(.test)) {
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: PseudoSelector
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:3
+  |
+1 | p :global(span:not(.test)) {
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:4
+  |
+1 | p :global(span:not(.test)) {
+  |    ^^^^^^
+
+error: Tokens
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:11
+  |
+1 | p :global(span:not(.test)) {
+  |           ^^^^^^^^^^^^^^^
+
+error: Ident(Atom('span' type=inline))
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:11
+  |
+1 | p :global(span:not(.test)) {
+  |           ^^^^
+
+error: Colon
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:15
+  |
+1 | p :global(span:not(.test)) {
+  |               ^
+
+error: Ident(Atom('not' type=static))
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:16
+  |
+1 | p :global(span:not(.test)) {
+  |                ^^^
+
+error: LParen
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:19
+  |
+1 | p :global(span:not(.test)) {
+  |                   ^
+
+error: Dot
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:20
+  |
+1 | p :global(span:not(.test)) {
+  |                    ^
+
+error: Ident(Atom('test' type=inline))
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:21
+  |
+1 | p :global(span:not(.test)) {
+  |                     ^^^^
+
+error: RParen
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:19
+  |
+1 | p :global(span:not(.test)) {
+  |                   ^
+
+error: DeclBlock
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:1:28
+  |
+1 |   p :global(span:not(.test)) {
+  |  ____________________________^
+2 | |     color: green;
+3 | | }
+  | |_^
+
+error: Property
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:2:5
+  |
+2 |     color: green;
+  |     ^^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:2:5
+  |
+2 |     color: green;
+  |     ^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:2:12
+  |
+2 |     color: green;
+  |            ^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/styled-jsx/selector/2/input.css:2:12
+  |
+2 |     color: green;
+  |            ^^^^^
+

--- a/css/stylis/Cargo.toml
+++ b/css/stylis/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_stylis"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.2.0"
+version = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,6 +18,6 @@ swc_css_utils = {version = "0.2.0", path = "../utils/"}
 swc_css_visit = {version = "0.4.0", path = "../visit"}
 
 [dev-dependencies]
-swc_css_codegen = {version = "0.3.0", path = "../codegen"}
-swc_css_parser = {version = "0.5.0", path = "../parser"}
+swc_css_codegen = {version = "0.4.0", path = "../codegen"}
+swc_css_parser = {version = "0.6.0", path = "../parser"}
 testing = {version = "0.13.0", path = "../../testing"}


### PR DESCRIPTION
swc_css_parser:
 - Remove `Parse<CompoundSelector>` implementation.
 - Add `Parse<ComplexSelector>` implementation.
 - Add `Parse<Vec<ComplexSelector>>` implementation.
 - Verify tokens input.