### PR TITLE
fix: Fix simple bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "fxhash",
  "serde",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "once_cell",
  "scoped-tls",

--- a/ecmascript/transforms/typescript/Cargo.toml
+++ b/ecmascript/transforms/typescript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.40.0"
+version = "0.40.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/ecmascript/transforms/typescript/src/strip.rs
+++ b/ecmascript/transforms/typescript/src/strip.rs
@@ -1223,6 +1223,9 @@ impl Visit for Strip {
                     .referenced_idents
                     .entry(($i.sym.clone(), $i.span.ctxt()))
                     .or_default();
+                if n.type_only {
+                    self.scope.decls.entry($i.to_id()).or_default().has_type = true;
+                }
             }};
         }
         for s in &n.specifiers {

--- a/ecmascript/transforms/typescript/src/strip.rs
+++ b/ecmascript/transforms/typescript/src/strip.rs
@@ -1925,9 +1925,7 @@ impl VisitMut for Strip {
                     }
                     export.specifiers.retain(|s| match *s {
                         ExportSpecifier::Named(ExportNamedSpecifier { ref orig, .. }) => {
-                            if let Some(e) =
-                                self.scope.decls.get(&(orig.sym.clone(), orig.span.ctxt()))
-                            {
+                            if let Some(e) = self.scope.decls.get(&orig.to_id()) {
                                 e.has_concrete
                             } else {
                                 true

--- a/ecmascript/transforms/typescript/src/strip.rs
+++ b/ecmascript/transforms/typescript/src/strip.rs
@@ -1210,11 +1210,7 @@ impl Visit for Strip {
 
     fn visit_ident(&mut self, n: &Ident, _: &dyn Node) {
         let is_type_only_export = self.is_type_only_export;
-        let entry = self
-            .scope
-            .referenced_idents
-            .entry((n.sym.clone(), n.span.ctxt()))
-            .or_default();
+        let entry = self.scope.referenced_idents.entry(n.to_id()).or_default();
         entry.has_concrete |= !is_type_only_export;
 
         n.visit_children_with(self);
@@ -1249,13 +1245,16 @@ impl Visit for Strip {
         let old = self.non_top_level;
         self.non_top_level = false;
         n.iter().for_each(|n| {
-            if let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(export)) = n {
-                self.is_type_only_export = export.type_only;
-            }
             n.visit_with(&Invalid { span: DUMMY_SP }, self);
-            self.is_type_only_export = false;
         });
         self.non_top_level = old;
+    }
+
+    fn visit_named_export(&mut self, export: &NamedExport, _: &dyn Node) {
+        let old = self.is_type_only_export;
+        self.is_type_only_export = export.type_only;
+        export.visit_children_with(self);
+        self.is_type_only_export = old;
     }
 
     fn visit_prop_name(&mut self, n: &PropName, _: &dyn Node) {

--- a/ecmascript/transforms/typescript/tests/strip.rs
+++ b/ecmascript/transforms/typescript/tests/strip.rs
@@ -4065,3 +4065,15 @@ to!(
     }
     "
 );
+
+to!(
+    issue_2219,
+    "
+    import type { TestInfo } from './config'
+
+    export { TestInfo }
+    ",
+    "
+    
+    "
+);

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.44.0"
+version = "0.44.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ecmascript/utils/src/lib.rs
+++ b/ecmascript/utils/src/lib.rs
@@ -1149,7 +1149,7 @@ pub trait ExprExt {
             | Expr::JSXNamespacedName(..)
             | Expr::JSXEmpty(..)
             | Expr::JSXElement(..)
-            | Expr::JSXFragment(..) => unreachable!("simplifying jsx"),
+            | Expr::JSXFragment(..) => true,
 
             Expr::TsAs(TsAsExpr { ref expr, .. })
             | Expr::TsNonNull(TsNonNullExpr { ref expr, .. })
@@ -2005,7 +2005,7 @@ pub fn extract_side_effects_to(to: &mut Vec<Box<Expr>>, expr: Box<Expr>) {
         | Expr::JSXNamespacedName(..)
         | Expr::JSXEmpty(..)
         | Expr::JSXElement(..)
-        | Expr::JSXFragment(..) => unreachable!("simplifying jsx"),
+        | Expr::JSXFragment(..) => to.push(Box::new(expr)),
 
         Expr::TsTypeAssertion(TsTypeAssertion { expr, .. })
         | Expr::TsNonNull(TsNonNullExpr { expr, .. })


### PR DESCRIPTION
swc_ecma_utils:
 - Don't panic on jsx.

swc_ecma_transforms_typescript:
 - Drop type-only reexports. (Closes #2219)