### PR TITLE
fix(css/parser): Fix parsing of selectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "swc_css_ast",
  "swc_css_codegen",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bitflags",
  "lexical",

--- a/css/Cargo.toml
+++ b/css/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.6.0"
+version = "0.6.1"
 
 [dependencies]
 swc_css_ast = {version = "0.5.0", path = "./ast"}

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.6.0"
+version = "0.6.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/css/parser/src/parser/selector/mod.rs
+++ b/css/parser/src/parser/selector/mod.rs
@@ -183,6 +183,10 @@ where
         let mut subclass_selectors = vec![];
 
         'subclass_selectors: loop {
+            if is!(self, EOF) {
+                break;
+            }
+
             match cur!(self) {
                 Token::Hash { is_id, .. } => {
                     if !*is_id {

--- a/css/parser/tests/fixture.rs
+++ b/css/parser/tests/fixture.rs
@@ -16,9 +16,13 @@ impl Visit for AssertValid {
     fn visit_pseudo_selector(&mut self, s: &PseudoSelector, _: &dyn Node) {
         s.visit_children_with(self);
 
+        if s.args.tokens.is_empty() {
+            return;
+        }
+
         let _selectors: Vec<ComplexSelector> =
             parse_tokens(&s.args, ParserConfig { parse_values: true })
-                .expect("failed to parse tokens");
+                .unwrap_or_else(|err| panic!("failed to parse tokens: {:?}\n{:?}", err, s.args));
     }
 }
 

--- a/css/parser/tests/fixture.rs
+++ b/css/parser/tests/fixture.rs
@@ -20,6 +20,11 @@ impl Visit for AssertValid {
             return;
         }
 
+        match &s.args.tokens[0].token {
+            Token::Colon | Token::Num(..) => return,
+            _ => {}
+        }
+
         let _selectors: Vec<ComplexSelector> =
             parse_tokens(&s.args, ParserConfig { parse_values: true })
                 .unwrap_or_else(|err| panic!("failed to parse tokens: {:?}\n{:?}", err, s.args));

--- a/css/parser/tests/fixture.rs
+++ b/css/parser/tests/fixture.rs
@@ -7,8 +7,20 @@ use swc_css_parser::{
     parse_tokens,
     parser::{input::ParserInput, Parser, ParserConfig},
 };
-use swc_css_visit::{Visit, VisitWith};
+use swc_css_visit::{Node, Visit, VisitWith};
 use testing::NormalizedOutput;
+
+struct AssertValid;
+
+impl Visit for AssertValid {
+    fn visit_pseudo_selector(&mut self, s: &PseudoSelector, _: &dyn Node) {
+        s.visit_children_with(self);
+
+        let _selectors: Vec<ComplexSelector> =
+            parse_tokens(&s.args, ParserConfig { parse_values: true })
+                .expect("failed to parse tokens");
+    }
+}
 
 #[testing::fixture("tests/fixture/**/input.css")]
 fn tokens_input(input: PathBuf) {
@@ -31,8 +43,10 @@ fn tokens_input(input: PathBuf) {
             }
         };
 
-        let _ss: Stylesheet = parse_tokens(&tokens, ParserConfig { parse_values: true })
+        let ss: Stylesheet = parse_tokens(&tokens, ParserConfig { parse_values: true })
             .expect("failed to parse tokens");
+
+        ss.visit_with(&Invalid { span: DUMMY_SP }, &mut AssertValid);
 
         Ok(())
     })


### PR DESCRIPTION
swc_css_parser:
 - Allow parsing `foo` as selector.