### PR TITLE
Better test fixture for absolute paths

### DIFF
--- a/tests/fixture/issue-2050/input/C.ts
+++ b/tests/fixture/issue-2050/input/C.ts
@@ -1,0 +1,1 @@
+export const C = 250;

--- a/tests/fixture/issue-2050/input/index.ts
+++ b/tests/fixture/issue-2050/input/index.ts
@@ -1,4 +1,8 @@
 import A from './subfolder/A'
+import D from '~/subfolder/subsubfolder/D'
+import E from './subfolder/subsubfolder/E'
 
 
 console.log(A);
+console.log(D);
+console.log(E);

--- a/tests/fixture/issue-2050/input/subfolder/A.ts
+++ b/tests/fixture/issue-2050/input/subfolder/A.ts
@@ -1,5 +1,7 @@
 import { B } from '~/subfolder/B';
+import { C } from '~/C';
 
 console.log(B);
+console.log(C);
 
 export const A = 400;

--- a/tests/fixture/issue-2050/input/subfolder/subsubfolder/D.ts
+++ b/tests/fixture/issue-2050/input/subfolder/subsubfolder/D.ts
@@ -1,0 +1,7 @@
+import { B } from '~/subfolder/B';
+import { C } from '~/C';
+
+console.log(B);
+console.log(C);
+
+export const D = 800;

--- a/tests/fixture/issue-2050/input/subfolder/subsubfolder/E.ts
+++ b/tests/fixture/issue-2050/input/subfolder/subsubfolder/E.ts
@@ -1,0 +1,7 @@
+import { B } from '~/subfolder/B';
+import { C } from '~/C';
+
+console.log(B);
+console.log(C);
+
+export const D = 800;

--- a/tests/fixture/issue-2050/output/C.ts
+++ b/tests/fixture/issue-2050/output/C.ts
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.C = void 0;
+const C = 250;
+exports.C = C;

--- a/tests/fixture/issue-2050/output/index.ts
+++ b/tests/fixture/issue-2050/output/index.ts
@@ -1,8 +1,12 @@
 "use strict";
 var _a = _interopRequireDefault(require("./subfolder/A"));
+var _d = _interopRequireDefault(require("./subfolder/subsubfolder/D"));
+var _e = _interopRequireDefault(require("./subfolder/subsubfolder/E"));
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : {
         default: obj
     };
 }
 console.log(_a.default);
+console.log(_d.default);
+console.log(_e.default);

--- a/tests/fixture/issue-2050/output/subfolder/A.ts
+++ b/tests/fixture/issue-2050/output/subfolder/A.ts
@@ -4,6 +4,8 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.A = void 0;
 var _b = require("./B");
+var _c = require("../C");
 console.log(_b.B);
+console.log(_c.C);
 const A = 400;
 exports.A = A;

--- a/tests/fixture/issue-2050/output/subfolder/subsubfolder/D.ts
+++ b/tests/fixture/issue-2050/output/subfolder/subsubfolder/D.ts
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.D = void 0;
+var _b = require("../B");
+var _c = require("../../C");
+console.log(_b.B);
+console.log(_c.C);
+const D = 400;
+exports.D = D;

--- a/tests/fixture/issue-2050/output/subfolder/subsubfolder/E.ts
+++ b/tests/fixture/issue-2050/output/subfolder/subsubfolder/E.ts
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.D = void 0;
+var _b = require("../B");
+var _c = require("../../C");
+console.log(_b.B);
+console.log(_c.C);
+const D = 400;
+exports.D = D;


### PR DESCRIPTION
My attempt at improving the test fixture for #2050 (originally introduced in #2227) to encompass pathing up to a module in parent directory.