### PR TITLE
fix: Make crate features with global effects optional.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,7 +2287,7 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "swc"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ base64 = "0.13.0"
 dashmap = "4.0.2"
 either = "1"
 fxhash = "0.2.1"
-log = {version = "0.4", features = ["release_max_level_info"]}
+log = "0.4"
 lru = "0.6.1"
 once_cell = "1"
 pathdiff = "0.2.0"
@@ -74,13 +74,13 @@ swc_ecma_transforms_base = {version = "0.31.1", path = "./ecmascript/transforms/
 swc_ecma_utils = {version = "0.44.2", path = "./ecmascript/utils"}
 swc_ecma_visit = {version = "0.38.1", path = "./ecmascript/visit"}
 swc_ecmascript = {version = "0.63.1", path = "./ecmascript"}
-swc_node_base = {version = "0.3.0", path = "./node/base"}
 swc_visit = {version = "0.2.3", path = "./visit"}
 
 [dev-dependencies]
 rayon = "1"
 testing = {version = "0.13.0", path = "./testing"}
 walkdir = "2"
+swc_node_base = {version = "0.3.0", path = "./node/base"}
 
 [[example]]
 name = "usage"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.54.0"
+version = "0.55.0"
 
 [lib]
 name = "swc"


### PR DESCRIPTION
The `swc` crate currently has two features that cause issues when used as a library:

- `log/release_max_level_info`. This feature silences `debug` and `trace` logs globally in *all* crates that depend on the `log` crate.
- `swc_node_base` which depends on the `mimalloc-rust` crate and sets a custom allocator. Users of the `swc` crate may want to provide their own allocator, and the global allocator feature requires a nightly compiler.

This pull request makes these two features optional, while leaving them enabled by default to preserve the current behavior.