### PR TITLE
fix(es/minifier): Don't drop used variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.27.3"
+version = "0.27.4"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/ecmascript/minifier/Cargo.toml
+++ b/ecmascript/minifier/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "src/lists/*.json"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_minifier"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.27.3"
+version = "0.27.4"
 
 [[bin]]
 name = "cli"

--- a/ecmascript/minifier/src/compress/optimize/mod.rs
+++ b/ecmascript/minifier/src/compress/optimize/mod.rs
@@ -1267,7 +1267,17 @@ where
             _ => false,
         }) {
             self.changed = true;
-            log::debug!("Merging variable declarations");
+
+            if cfg!(feature = "debug") {
+                log::debug!("Merging variable declarations");
+                log::trace!(
+                    "[Before]: {}",
+                    dump(&BlockStmt {
+                        span: DUMMY_SP,
+                        stmts: stmts.clone()
+                    })
+                )
+            }
 
             let orig = take(stmts);
             let mut new = Vec::with_capacity(orig.len());
@@ -1300,6 +1310,15 @@ where
 
             new.extend(var_decl.take().map(Decl::Var).map(Stmt::Decl));
 
+            if cfg!(feature = "debug") {
+                log::trace!(
+                    "[Change] merged: {}",
+                    dump(&BlockStmt {
+                        span: DUMMY_SP,
+                        stmts: new.clone()
+                    })
+                )
+            }
             *stmts = new
         }
     }

--- a/ecmascript/minifier/src/compress/optimize/mod.rs
+++ b/ecmascript/minifier/src/compress/optimize/mod.rs
@@ -1293,8 +1293,8 @@ where
                                 upper.decls.extend(below.decls);
                                 var_decl = Some(upper);
                             }
-                            _ => {
-                                new.extend(var_decl.take().map(Decl::Var).map(Stmt::Decl));
+                            d => {
+                                new.extend(d.map(Decl::Var).map(Stmt::Decl));
                                 var_decl = Some(below);
                             }
                         }

--- a/ecmascript/minifier/tests/compress/fixture/issues/2262/1/input.js
+++ b/ecmascript/minifier/tests/compress/fixture/issues/2262/1/input.js
@@ -10,11 +10,6 @@
 
     const esm = index;
 
-    var createNamedContext = function createNamedContext() {
-        esm();
-    };
-
-    createNamedContext();
-    createNamedContext();
+    esm();
 })()
 

--- a/ecmascript/minifier/tests/compress/fixture/issues/2262/1/input.js
+++ b/ecmascript/minifier/tests/compress/fixture/issues/2262/1/input.js
@@ -1,0 +1,17 @@
+(() => {
+    "use strict";
+
+    var commonjsGlobal = globalThis
+
+    var index = somethingGlobal;
+
+    const esm = index;
+
+    var createNamedContext = function createNamedContext() {
+        esm();
+    };
+
+    createNamedContext();
+    createNamedContext();
+})()
+

--- a/ecmascript/minifier/tests/compress/fixture/issues/2262/1/input.js
+++ b/ecmascript/minifier/tests/compress/fixture/issues/2262/1/input.js
@@ -3,6 +3,9 @@
 
     var commonjsGlobal = globalThis
 
+    function createEventEmitter(value) {
+    }
+
     var index = somethingGlobal;
 
     const esm = index;

--- a/ecmascript/minifier/tests/compress/fixture/issues/2262/1/output.js
+++ b/ecmascript/minifier/tests/compress/fixture/issues/2262/1/output.js
@@ -1,0 +1,1 @@
+somethingGlobal();

--- a/ecmascript/minifier/tests/terser/compress/block-scope/do_not_hoist_let/output.js
+++ b/ecmascript/minifier/tests/terser/compress/block-scope/do_not_hoist_let/output.js
@@ -1,5 +1,6 @@
 function x() {
     if (FOO) {
+        var var1, var2;
         let let1, let2;
     }
 }


### PR DESCRIPTION
This reproduces #2262, though I'm not sure how to fix

---

Closes #2262