### PR TITLE
chore: ignore linguist detection for fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,6 @@
 *.js    text eol=lf merge=union 
 *.json  text eol=lf merge=union 
 *.debug text eol=lf merge=union 
+
+**/tests/**/*.js linguist-detectable=false
+**/tests/**/*.ts linguist-detectable=false


### PR DESCRIPTION
swc is a Rust project, but fixtures are written in JS or TS, so GitHub Linguist detected them as source files (as the screenshot below). This PR let it be ignored.

![image](https://user-images.githubusercontent.com/17216317/134317138-9c505841-b089-4c9a-90f3-451154810930.png)
