### PR TITLE
fix(node/swc): Allow `JsMinifyOptions` type for `JscConfig.minify`

### DIFF
--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -497,6 +497,8 @@ export interface JscConfig {
   paths?: {
     [from: string]: [string]
   }
+
+  minify?: JsMinifyOptions;
 }
 
 export type JscTarget =


### PR DESCRIPTION
Following the documentation ["Configuring js minifier"](https://swc.rs/docs/config-js-minify/), seems some minifier options can be put into `jsc.minify`, but type signature isn't.

Note: I'm not sure this is the only thing I have to fix.