### PR TITLE
feat(node/swc): support for named export `Visitor`

### DIFF
--- a/node-swc/src/Visitor.ts
+++ b/node-swc/src/Visitor.ts
@@ -160,7 +160,7 @@ import {
   TsConstAssertion,
 } from "./types";
 
-export default class Visitor {
+export class Visitor {
   visitProgram(n: Program): Program {
     switch (n.type) {
       case "Module":
@@ -1723,3 +1723,5 @@ export default class Visitor {
     return n;
   }
 }
+
+export default Visitor;


### PR DESCRIPTION
In some environment, default exporting can be problematic.