### PR TITLE
fix(es/parser): multiple import/export specifiers without comma

### DIFF
--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -1838,6 +1838,24 @@ export default function waitUntil(callback, options = {}) {
     }
 
     #[test]
+    #[should_panic(expected = "Expected ,, got b")]
+    fn import_specifiers_without_comma() {
+        test_parser(
+            "import { a b c } from 'mod'",
+            Syntax::Es(EsConfig::default()),
+            |p| p.parse_module(),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected ,, got b")]
+    fn export_specifiers_without_comma() {
+        test_parser("export { a b c }", Syntax::Es(EsConfig::default()), |p| {
+            p.parse_module()
+        });
+    }
+
+    #[test]
     #[should_panic(expected = "top level await is only allowed in module")]
     fn top_level_await_in_script() {
         let src = "await promise";

--- a/ecmascript/parser/src/parser/stmt.rs
+++ b/ecmascript/parser/src/parser/stmt.rs
@@ -1838,24 +1838,6 @@ export default function waitUntil(callback, options = {}) {
     }
 
     #[test]
-    #[should_panic(expected = "Expected ,, got b")]
-    fn import_specifiers_without_comma() {
-        test_parser(
-            "import { a b c } from 'mod'",
-            Syntax::Es(EsConfig::default()),
-            |p| p.parse_module(),
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "Expected ,, got b")]
-    fn export_specifiers_without_comma() {
-        test_parser("export { a b c }", Syntax::Es(EsConfig::default()), |p| {
-            p.parse_module()
-        });
-    }
-
-    #[test]
     #[should_panic(expected = "top level await is only allowed in module")]
     fn top_level_await_in_script() {
         let src = "await promise";

--- a/ecmascript/parser/src/parser/stmt/module_item.rs
+++ b/ecmascript/parser/src/parser/stmt/module_item.rs
@@ -118,15 +118,14 @@ impl<'a, I: Tokens> Parser<I> {
                     local,
                 }));
             } else if eat!(self, '{') {
-                let mut first = true;
                 while !eof!(self) && !is!(self, '}') {
-                    if first {
-                        first = false;
-                    } else if eat!(self, ',') && is!(self, '}') {
-                        break;
-                    }
-
                     specifiers.push(self.parse_import_specifier()?);
+
+                    if is!(self, '}') {
+                        break;
+                    } else {
+                        expect!(self, ',');
+                    }
                 }
                 expect!(self, '}');
             }
@@ -513,18 +512,17 @@ impl<'a, I: Tokens> Parser<I> {
                     exported: default,
                 }))
             }
-            let mut first = true;
-            while is_one_of!(self, ',', IdentName) {
-                if first {
-                    first = false;
-                } else if eat!(self, ',') && is!(self, '}') {
-                    break;
-                }
-
+            while !eof!(self) && !is!(self, '}') {
                 specifiers.push(
                     self.parse_named_export_specifier()
                         .map(ExportSpecifier::Named)?,
                 );
+
+                if is!(self, '}') {
+                    break;
+                } else {
+                    expect!(self, ',');
+                }
             }
             expect!(self, '}');
 

--- a/ecmascript/parser/tests/test262-error-references/fail/26c0710a6449872a.module.js.stderr
+++ b/ecmascript/parser/tests/test262-error-references/fail/26c0710a6449872a.module.js.stderr
@@ -1,6 +1,6 @@
-error: Unexpected token `a`. Expected a string literal
- --> $DIR/tests/test262-parser/fail/26c0710a6449872a.module.js:1:20
+error: Expected ,, got b
+ --> $DIR/tests/test262-parser/fail/26c0710a6449872a.module.js:1:12
   |
 1 | export {as b} from a
-  |                    ^
+  |            ^
 

--- a/ecmascript/parser/tests/typescript-errors/multiple-specifiers/export/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/multiple-specifiers/export/input.ts
@@ -1,0 +1,1 @@
+export { a b c }

--- a/ecmascript/parser/tests/typescript-errors/multiple-specifiers/export/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/multiple-specifiers/export/input.ts.stderr
@@ -1,0 +1,6 @@
+error: Expected ,, got b
+ --> $DIR/tests/typescript-errors/multiple-specifiers/export/input.ts:1:12
+  |
+1 | export { a b c }
+  |            ^
+

--- a/ecmascript/parser/tests/typescript-errors/multiple-specifiers/import/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/multiple-specifiers/import/input.ts
@@ -1,0 +1,1 @@
+import { a b c } from 'mod'

--- a/ecmascript/parser/tests/typescript-errors/multiple-specifiers/import/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/multiple-specifiers/import/input.ts.stderr
@@ -1,0 +1,6 @@
+error: Expected ,, got b
+ --> $DIR/tests/typescript-errors/multiple-specifiers/import/input.ts:1:12
+  |
+1 | import { a b c } from 'mod'
+  |            ^
+


### PR DESCRIPTION
Before this PR, the code below should be invalid:

```js
import { a b c } from 'mod'

export { a b c }
```

but swc didn't report. This PR fixes it.