### PR TITLE
feat(css): Recover from invalid properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "swc_css_ast",
  "swc_css_codegen",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "is-macro",
  "serde",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "auto_impl",
  "bitflags",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitflags",
  "lexical",
@@ -2541,7 +2541,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "swc_atoms 0.2.7",
  "swc_common",
@@ -2551,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "swc_atoms 0.2.7",
  "swc_common",
@@ -3116,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "swc_stylis"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "swc_atoms 0.2.7",
  "swc_common",

--- a/css/Cargo.toml
+++ b/css/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies]
-swc_css_ast = {version = "0.6.0", path = "./ast"}
-swc_css_codegen = {version = "0.5.0", path = "./codegen"}
-swc_css_parser = {version = "0.7.0", path = "./parser"}
-swc_css_utils = {version = "0.3.0", path = "./utils/"}
-swc_css_visit = {version = "0.5.0", path = "./visit"}
+swc_css_ast = {version = "0.7.0", path = "./ast"}
+swc_css_codegen = {version = "0.6.0", path = "./codegen"}
+swc_css_parser = {version = "0.8.0", path = "./parser"}
+swc_css_utils = {version = "0.4.0", path = "./utils/"}
+swc_css_visit = {version = "0.6.0", path = "./visit"}

--- a/css/ast/Cargo.toml
+++ b/css/ast/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_ast"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.6.0"
+version = "0.7.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/css/ast/src/style_rule.rs
+++ b/css/ast/src/style_rule.rs
@@ -1,4 +1,4 @@
-use crate::{ComplexSelector, Property};
+use crate::{ComplexSelector, Property, Tokens};
 use swc_common::{ast_node, Span};
 
 #[ast_node("StyleRule")]
@@ -11,5 +11,19 @@ pub struct StyleRule {
 #[ast_node("DeclBlock")]
 pub struct DeclBlock {
     pub span: Span,
-    pub properties: Vec<Property>,
+    pub body: DeclBlockBody,
+}
+
+#[ast_node]
+pub enum DeclBlockBody {
+    #[tag("Tokens")]
+    Invalid(Tokens),
+    #[tag("Properties")]
+    Properties(Props),
+}
+
+#[ast_node("Properties")]
+pub struct Props {
+    pub span: Span,
+    pub props: Vec<Property>,
 }

--- a/css/ast/src/style_rule.rs
+++ b/css/ast/src/style_rule.rs
@@ -11,19 +11,13 @@ pub struct StyleRule {
 #[ast_node("DeclBlock")]
 pub struct DeclBlock {
     pub span: Span,
-    pub body: DeclBlockBody,
+    pub items: Vec<DeclBlockItem>,
 }
 
 #[ast_node]
-pub enum DeclBlockBody {
+pub enum DeclBlockItem {
     #[tag("Tokens")]
     Invalid(Tokens),
-    #[tag("Properties")]
-    Properties(Props),
-}
-
-#[ast_node("Properties")]
-pub struct Props {
-    pub span: Span,
-    pub props: Vec<Property>,
+    #[tag("Property")]
+    Property(Property),
 }

--- a/css/codegen/Cargo.toml
+++ b/css/codegen/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
 auto_impl = "0.4.1"
 bitflags = "1.3.2"
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
 swc_common = {version = "0.13.0", path = "../../common"}
-swc_css_ast = {version = "0.6.0", path = "../ast/"}
+swc_css_ast = {version = "0.7.0", path = "../ast/"}
 swc_css_codegen_macros = {version = "0.2.0", path = "macros/"}
 
 [dev-dependencies]
-swc_css_parser = {version = "0.7.0", path = "../parser"}
-swc_css_visit = {version = "0.5.0", path = "../visit"}
+swc_css_parser = {version = "0.8.0", path = "../parser"}
+swc_css_visit = {version = "0.6.0", path = "../visit"}
 testing = {version = "0.14.0", path = "../../testing"}

--- a/css/codegen/src/lib.rs
+++ b/css/codegen/src/lib.rs
@@ -320,12 +320,17 @@ where
     fn emit_decl_block(&mut self, n: &DeclBlock) -> Result {
         punct!(self, "{");
 
-        self.emit_list(
-            &n.properties,
-            ListFormat::SemiDelimited | ListFormat::MultiLine,
-        )?;
+        self.emit_list(&n.items, ListFormat::SemiDelimited | ListFormat::MultiLine)?;
 
         punct!(self, "}");
+    }
+
+    #[emitter]
+    fn emit_decl_block_item(&mut self, n: &DeclBlockItem) -> Result {
+        match n {
+            DeclBlockItem::Invalid(n) => emit!(self, n),
+            DeclBlockItem::Property(n) => emit!(self, n),
+        }
     }
 
     #[emitter]

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.7.0"
+version = "0.8.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -17,11 +17,11 @@ bitflags = "1.2.1"
 lexical = "5.2.2"
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
 swc_common = {version = "0.13.0", path = "../../common"}
-swc_css_ast = {version = "0.6.0", path = "../ast"}
+swc_css_ast = {version = "0.7.0", path = "../ast"}
 unicode-xid = "0.2.2"
 
 [dev-dependencies]
 serde = "1.0.127"
 serde_json = "1.0.66"
-swc_css_visit = {version = "0.5.0", path = "../visit"}
+swc_css_visit = {version = "0.6.0", path = "../visit"}
 testing = {version = "0.14.0", path = "../../testing"}

--- a/css/parser/src/lib.rs
+++ b/css/parser/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(unused_must_use)]
 
+use error::Error;
 use lexer::Lexer;
 use parser::{input::TokensInput, PResult, Parser, ParserConfig};
 use swc_common::{input::StringInput, BytePos, SourceFile};
@@ -27,11 +28,15 @@ where
 }
 
 /// Parse a given string as `T`.
+///
+/// If there are syntax errors but if it was recoverable, it will be appendend
+/// to `errors`.
 pub fn parse_str<'a, T>(
     src: &'a str,
     start_pos: BytePos,
     end_pos: BytePos,
     config: ParserConfig,
+    errors: &mut Vec<Error>,
 ) -> PResult<T>
 where
     Parser<Lexer<StringInput<'a>>>: Parse<T>,
@@ -43,7 +48,14 @@ where
 }
 
 /// Parse a given file as `T`.
-pub fn parse_file<'a, T>(fm: &'a SourceFile, config: ParserConfig) -> PResult<T>
+///
+/// If there are syntax errors but if it was recoverable, it will be appendend
+/// to `errors`.
+pub fn parse_file<'a, T>(
+    fm: &'a SourceFile,
+    config: ParserConfig,
+    errors: &mut Vec<Error>,
+) -> PResult<T>
 where
     Parser<Lexer<StringInput<'a>>>: Parse<T>,
 {
@@ -54,7 +66,14 @@ where
 }
 
 /// Parse a given file as `T`.
-pub fn parse_tokens<'a, T>(tokens: &'a Tokens, config: ParserConfig) -> PResult<T>
+///
+/// If there are syntax errors but if it was recoverable, it will be appendend
+/// to `errors`.
+pub fn parse_tokens<'a, T>(
+    tokens: &'a Tokens,
+    config: ParserConfig,
+    errors: &mut Vec<Error>,
+) -> PResult<T>
 where
     Parser<TokensInput<'a>>: Parse<T>,
 {

--- a/css/parser/src/lib.rs
+++ b/css/parser/src/lib.rs
@@ -46,7 +46,9 @@ where
     let lexer = Lexer::new(StringInput::new(src, start_pos, end_pos));
     let mut parser = Parser::new(lexer, config);
 
-    parser.parse()
+    let res = parser.parse();
+    errors.extend(parser.take_errors());
+    res
 }
 
 /// Parse a given file as `T`.
@@ -64,7 +66,9 @@ where
     let lexer = Lexer::new(StringInput::from(fm));
     let mut parser = Parser::new(lexer, config);
 
-    parser.parse()
+    let res = parser.parse();
+    errors.extend(parser.take_errors());
+    res
 }
 
 /// Parse a given file as `T`.
@@ -82,5 +86,7 @@ where
     let lexer = TokensInput::new(tokens);
     let mut parser = Parser::new(lexer, config);
 
-    parser.parse()
+    let res = parser.parse();
+    errors.extend(parser.take_errors());
+    res
 }

--- a/css/parser/src/lib.rs
+++ b/css/parser/src/lib.rs
@@ -1,8 +1,10 @@
 #![deny(unused_must_use)]
 
-use error::Error;
-use lexer::Lexer;
-use parser::{input::TokensInput, PResult, Parser, ParserConfig};
+use crate::{
+    error::Error,
+    lexer::Lexer,
+    parser::{input::TokensInput, PResult, Parser, ParserConfig},
+};
 use swc_common::{input::StringInput, BytePos, SourceFile};
 use swc_css_ast::Tokens;
 

--- a/css/parser/src/parser/mod.rs
+++ b/css/parser/src/parser/mod.rs
@@ -1,10 +1,9 @@
-use std::mem::take;
-
 use self::input::{Buffer, ParserInput};
 use crate::{
     error::{Error, ErrorKind},
     Parse,
 };
+use std::mem::take;
 use swc_atoms::js_word;
 use swc_common::Span;
 use swc_css_ast::*;

--- a/css/parser/src/parser/style_rule.rs
+++ b/css/parser/src/parser/style_rule.rs
@@ -157,6 +157,15 @@ where
     }
 }
 
+impl<I> Parse<Vec<DeclBlockItem>> for Parser<I>
+where
+    I: ParserInput,
+{
+    fn parse(&mut self) -> PResult<Vec<DeclBlockItem>> {
+        self.parse_decl_block_items()
+    }
+}
+
 impl<I> Parse<DeclBlockItem> for Parser<I>
 where
     I: ParserInput,

--- a/css/parser/src/parser/style_rule.rs
+++ b/css/parser/src/parser/style_rule.rs
@@ -34,14 +34,16 @@ where
 
         self.input.skip_ws()?;
 
-        let properties = self.parse_properties()?;
+        let items = self.parse_decl_block_items()?;
 
         expect!(self, "}");
 
         let span = span!(self, start);
 
-        Ok(DeclBlock { span, properties })
+        Ok(DeclBlock { span, items })
     }
+
+    fn parse_decl_block_items(&mut self) -> PResult<Vec<DeclBlockItem>> {}
 
     pub(crate) fn parse_properties(&mut self) -> PResult<Vec<Property>> {
         let mut props = vec![];
@@ -139,4 +141,11 @@ where
     fn parse(&mut self) -> PResult<Vec<Property>> {
         self.parse_properties()
     }
+}
+
+impl<I> Parse<DeclBlockItem> for Parser<I>
+where
+    I: ParserInput,
+{
+    fn parse(&mut self) -> PResult<DeclBlockItem> {}
 }

--- a/css/parser/tests/fixture/esbuild/misc/-4j83DwgJa0nPQIjlb0RIA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-4j83DwgJa0nPQIjlb0RIA/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/-8o_H6sq86TDAHqF7YO0hg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-8o_H6sq86TDAHqF7YO0hg/output.json
@@ -61,7 +61,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/-GZJfOA9TK6La2KGGNgCkg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-GZJfOA9TK6La2KGGNgCkg/output.json
@@ -197,7 +197,7 @@
           "end": 67,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/-JoxoRcnA-zaaEC7RjXKvQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-JoxoRcnA-zaaEC7RjXKvQ/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/-b4VODLSeaV93gwC2Ot2tw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-b4VODLSeaV93gwC2Ot2tw/output.json
@@ -62,7 +62,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/output.json
@@ -61,7 +61,7 @@
           "end": 45,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/-shTP60AAG6a4mCJUpV1cQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-shTP60AAG6a4mCJUpV1cQ/output.json
@@ -82,7 +82,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/07tvJxvZrgDeTmptOclErA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/07tvJxvZrgDeTmptOclErA/output.json
@@ -61,7 +61,7 @@
           "end": 21,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/0Zlgi2sdsFfTrdnWOHUqeg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/0Zlgi2sdsFfTrdnWOHUqeg/output.json
@@ -82,7 +82,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/0qqdP6EmNqzSa3h8c8lYUQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/0qqdP6EmNqzSa3h8c8lYUQ/output.json
@@ -62,7 +62,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/0yo6flt6jo-UA8rUEFjrWA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/0yo6flt6jo-UA8rUEFjrWA/output.json
@@ -61,7 +61,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/10VLLYwNo7xaTisP9r9Kfg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/10VLLYwNo7xaTisP9r9Kfg/output.json
@@ -79,7 +79,7 @@
           "end": 9,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/output.json
@@ -61,7 +61,7 @@
           "end": 59,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/1JQzQJ1QtQJ1onUzZx7BVg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/1JQzQJ1QtQJ1onUzZx7BVg/output.json
@@ -62,7 +62,7 @@
           "end": 8,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/1naykwaIKZc6zuHRNIccLQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/1naykwaIKZc6zuHRNIccLQ/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/2Z7MIIhOQ0mreKqEgkeZYQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/2Z7MIIhOQ0mreKqEgkeZYQ/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/2nNBhRWO2cNcBJf09zDxjw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/2nNBhRWO2cNcBJf09zDxjw/output.json
@@ -89,7 +89,7 @@
           "end": 27,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/36qnNuIUvbIrMnJKDxwE5A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/36qnNuIUvbIrMnJKDxwE5A/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/375WZQg3bngUbuoHsqEIcA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/375WZQg3bngUbuoHsqEIcA/output.json
@@ -47,7 +47,7 @@
               "end": 37,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {
@@ -104,7 +104,7 @@
               "end": 43,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         }
       ]

--- a/css/parser/tests/fixture/esbuild/misc/39pbt1sIeFh8WWhCalZS4g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/39pbt1sIeFh8WWhCalZS4g/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/3EgMpLwjJNG0ht4U_r6cnw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/3EgMpLwjJNG0ht4U_r6cnw/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/3JGye8AhworwNFoUL1gKbg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/3JGye8AhworwNFoUL1gKbg/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/3a1KXFwtncypOUCwQI7IAw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/3a1KXFwtncypOUCwQI7IAw/output.json
@@ -55,7 +55,7 @@
               "end": 37,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {

--- a/css/parser/tests/fixture/esbuild/misc/4-S1C8qZOZ6Mm7WdRUH72Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/4-S1C8qZOZ6Mm7WdRUH72Q/output.json
@@ -61,7 +61,7 @@
           "end": 24,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/485Ns9qQHa89OJU5Lhjx-Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/485Ns9qQHa89OJU5Lhjx-Q/output.json
@@ -61,7 +61,7 @@
           "end": 21,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/486QvEO8dmLFsXYp6xgKVw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/486QvEO8dmLFsXYp6xgKVw/output.json
@@ -61,7 +61,7 @@
           "end": 21,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/4Tjjgepnha63E4UiXXDNEA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/4Tjjgepnha63E4UiXXDNEA/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/4UaOTazLwrr9gd5xkBBlnw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/4UaOTazLwrr9gd5xkBBlnw/output.json
@@ -79,7 +79,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/output.json
@@ -61,7 +61,7 @@
           "end": 26,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/4_H2sj_CNmUQHGctk7geQQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/4_H2sj_CNmUQHGctk7geQQ/output.json
@@ -47,7 +47,7 @@
               "end": 26,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         }
       ]

--- a/css/parser/tests/fixture/esbuild/misc/52obp49U0CyYOskQAEoIJw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/52obp49U0CyYOskQAEoIJw/output.json
@@ -79,7 +79,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/54mhLGCwQMwsuiVkiTzAAQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/54mhLGCwQMwsuiVkiTzAAQ/output.json
@@ -82,7 +82,7 @@
           "end": 14,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/5al65IRQbw_x4yG3ke74fQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/5al65IRQbw_x4yG3ke74fQ/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/5cnGKjYPm1XBeqTmw3oCag/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/5cnGKjYPm1XBeqTmw3oCag/output.json
@@ -61,7 +61,7 @@
           "end": 16,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/5nNFwUYmVb5_MMMzIvIeQg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/5nNFwUYmVb5_MMMzIvIeQg/output.json
@@ -90,7 +90,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/5yer6GUWydidDHrfgacUkA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/5yer6GUWydidDHrfgacUkA/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/62BQJI-uDjHXNJ7kyL8HiA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/62BQJI-uDjHXNJ7kyL8HiA/output.json
@@ -82,7 +82,7 @@
           "end": 14,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/6IWHWiWjsuGkPiPAp2KmoA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6IWHWiWjsuGkPiPAp2KmoA/output.json
@@ -82,7 +82,7 @@
           "end": 13,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/6WYwXsqP1SJOa-6oDBobzQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6WYwXsqP1SJOa-6oDBobzQ/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/6fufNZ3PA6_-pNwY-IP61Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6fufNZ3PA6_-pNwY-IP61Q/output.json
@@ -90,7 +90,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/6kUhG0W7hwZxIuaCsZ7pHg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6kUhG0W7hwZxIuaCsZ7pHg/output.json
@@ -89,7 +89,7 @@
           "end": 29,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/6mrV_7sMC078PDku0AmwVw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6mrV_7sMC078PDku0AmwVw/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/6s_VBuRPHbPiUrh1fWCR_Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6s_VBuRPHbPiUrh1fWCR_Q/output.json
@@ -83,7 +83,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/7CK6ZYt4CWz7Ge5KWLKBYg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/7CK6ZYt4CWz7Ge5KWLKBYg/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/7S9dyZUmnJW4VKAa7gcKvw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/7S9dyZUmnJW4VKAa7gcKvw/output.json
@@ -62,7 +62,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/7Wto7epgdmJCos0XkrnMww/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/7Wto7epgdmJCos0XkrnMww/output.json
@@ -90,7 +90,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/output.json
@@ -61,7 +61,7 @@
           "end": 23,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/8R-UUShF-1EmQSj6_GQwrA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/8R-UUShF-1EmQSj6_GQwrA/output.json
@@ -62,7 +62,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/9IIa-42s3YQFw8ilk39GdQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/9IIa-42s3YQFw8ilk39GdQ/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/9aSeJQPn4WHMexejaMQQoQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/9aSeJQPn4WHMexejaMQQoQ/output.json
@@ -82,7 +82,7 @@
           "end": 13,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/ACQUsGVQAmGzhMqBRmS6Mw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ACQUsGVQAmGzhMqBRmS6Mw/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/AMheAL_TeyLZpn77YdNTZA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/AMheAL_TeyLZpn77YdNTZA/output.json
@@ -47,7 +47,7 @@
               "end": 26,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         }
       ]

--- a/css/parser/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/output.json
@@ -72,7 +72,7 @@
               "end": 40,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {
@@ -154,7 +154,7 @@
               "end": 65,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {

--- a/css/parser/tests/fixture/esbuild/misc/AVaQlt9z0lhJC6bHHDPVeA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/AVaQlt9z0lhJC6bHHDPVeA/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Aby-BQPnUhIoK9wn-kUcDQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Aby-BQPnUhIoK9wn-kUcDQ/output.json
@@ -62,7 +62,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/Ae5_auBp274oaSQ0kls9sw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Ae5_auBp274oaSQ0kls9sw/output.json
@@ -82,7 +82,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/Afm91-TMNbzd52HsPrCCNA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Afm91-TMNbzd52HsPrCCNA/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/AigZ338AGwCqF4M9a3Quqw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/AigZ338AGwCqF4M9a3Quqw/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/AocxkR5Gt30Hu6JV7J56Wg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/AocxkR5Gt30Hu6JV7J56Wg/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/AwZM5l5vBlyrbgG-Fk0_EQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/AwZM5l5vBlyrbgG-Fk0_EQ/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/BGEkoLaLFY8_QtKKVFDVhQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/BGEkoLaLFY8_QtKKVFDVhQ/output.json
@@ -47,7 +47,7 @@
               "end": 27,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         }
       ]

--- a/css/parser/tests/fixture/esbuild/misc/BKyQWW5j9vRP-kr41nqcjg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/BKyQWW5j9vRP-kr41nqcjg/output.json
@@ -61,7 +61,7 @@
           "end": 21,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/BltaGv1fY5VvJahyCRNxqQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/BltaGv1fY5VvJahyCRNxqQ/output.json
@@ -90,7 +90,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/BrJMdtdKJAuIZIG5MVWUYA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/BrJMdtdKJAuIZIG5MVWUYA/output.json
@@ -62,7 +62,7 @@
           "end": 32,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/C419dJQ48QjmgKufnQhNVw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/C419dJQ48QjmgKufnQhNVw/output.json
@@ -90,7 +90,7 @@
           "end": 8,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/C4I0cdQcSbpaGOS-V8fwew/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/C4I0cdQcSbpaGOS-V8fwew/output.json
@@ -61,7 +61,7 @@
           "end": 21,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/C6gS3Kl0KEwGsFaUUGXzFg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/C6gS3Kl0KEwGsFaUUGXzFg/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/C9nXM9jBTT9WvCQHrwH24Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/C9nXM9jBTT9WvCQHrwH24Q/output.json
@@ -74,7 +74,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/CQiowK9DjojqKtlpQifemA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/CQiowK9DjojqKtlpQifemA/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/CiejHTPFd8U5szvvY3uRjw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/CiejHTPFd8U5szvvY3uRjw/output.json
@@ -61,7 +61,7 @@
           "end": 23,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/CqrYlHva8qUNgSPb8EwWjg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/CqrYlHva8qUNgSPb8EwWjg/output.json
@@ -61,7 +61,7 @@
           "end": 21,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Cz4vXE_NaBs6qNXE1kUyqQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Cz4vXE_NaBs6qNXE1kUyqQ/output.json
@@ -61,7 +61,7 @@
           "end": 15,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/D5Oyf1ABeS8lie5Lg-5pqg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/D5Oyf1ABeS8lie5Lg-5pqg/output.json
@@ -61,7 +61,7 @@
           "end": 16,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Dl_KXhjnyR5RfRaNMKBEdw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Dl_KXhjnyR5RfRaNMKBEdw/output.json
@@ -72,7 +72,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/Drl1Excz8WEwlfIfA2oRQg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Drl1Excz8WEwlfIfA2oRQg/output.json
@@ -82,7 +82,7 @@
           "end": 14,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/DrlXteRB-ppLVxi4_N4dhA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/DrlXteRB-ppLVxi4_N4dhA/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/DstCRLR-k3tqe3B46li15Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/DstCRLR-k3tqe3B46li15Q/output.json
@@ -74,7 +74,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/EB1IJLfMRoP0XwlJOGLTPA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EB1IJLfMRoP0XwlJOGLTPA/output.json
@@ -61,7 +61,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/EC04FJYJG-jwsR3Sbo9Rfg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EC04FJYJG-jwsR3Sbo9Rfg/output.json
@@ -79,7 +79,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/EJ3xE2oHAiQiiAA6TOFfLA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EJ3xE2oHAiQiiAA6TOFfLA/output.json
@@ -74,7 +74,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/EJPa4WhTn_fRRrDiA2bczg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EJPa4WhTn_fRRrDiA2bczg/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/EX6W7U27ut-K7x8AfSlQSg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EX6W7U27ut-K7x8AfSlQSg/output.json
@@ -90,7 +90,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/EYFn-trzBus37dDEvK1jUQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EYFn-trzBus37dDEvK1jUQ/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/ElFW4lY06Cb-VFYtK0WX4A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ElFW4lY06Cb-VFYtK0WX4A/output.json
@@ -89,7 +89,7 @@
               "end": 49,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {

--- a/css/parser/tests/fixture/esbuild/misc/EmvZzoCy9JnSP70AqHmNNA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EmvZzoCy9JnSP70AqHmNNA/output.json
@@ -90,7 +90,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/F-AbRDwG_3dGLhE7pzr5aA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/F-AbRDwG_3dGLhE7pzr5aA/output.json
@@ -61,7 +61,7 @@
           "end": 16,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/FlqjDLebWxQvNIxKppBllw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/FlqjDLebWxQvNIxKppBllw/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Fm7gvlx7uRyvrfzUC7rJxg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Fm7gvlx7uRyvrfzUC7rJxg/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Ft7g4H2gHwlEjiFMDwEkYQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Ft7g4H2gHwlEjiFMDwEkYQ/output.json
@@ -72,7 +72,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/GC0pcFQY1xSlq9QsgSvEVg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GC0pcFQY1xSlq9QsgSvEVg/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/GI1rffTXev-78n9ei_53wQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GI1rffTXev-78n9ei_53wQ/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/GNiHtd4OPiZDQlN5KGAmRQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GNiHtd4OPiZDQlN5KGAmRQ/output.json
@@ -61,7 +61,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/GVqeF3thmlPBqLweHlqIJQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GVqeF3thmlPBqLweHlqIJQ/output.json
@@ -90,7 +90,7 @@
           "end": 9,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/GjvJfQVAaNQonYJwt8QRDQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GjvJfQVAaNQonYJwt8QRDQ/output.json
@@ -82,7 +82,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/GpePX8ZJM8IP14hXFTKKxQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GpePX8ZJM8IP14hXFTKKxQ/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Gt3Lw4L5Pe4aLLDPz9cxRg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Gt3Lw4L5Pe4aLLDPz9cxRg/output.json
@@ -62,7 +62,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/HBQJEriDrHgN_kXjKrVW9g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/HBQJEriDrHgN_kXjKrVW9g/output.json
@@ -82,7 +82,7 @@
           "end": 14,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/HDNE73X9waUrBkTAzz-20g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/HDNE73X9waUrBkTAzz-20g/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/HGH4crVp9Whp_G0PY6BaQA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/HGH4crVp9Whp_G0PY6BaQA/output.json
@@ -91,7 +91,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/I33LxmnLDtSRSbNrHmoNRA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/I33LxmnLDtSRSbNrHmoNRA/output.json
@@ -90,7 +90,7 @@
           "end": 8,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/ISvhgCbFuiTTWo41R3UVRA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ISvhgCbFuiTTWo41R3UVRA/output.json
@@ -62,7 +62,7 @@
           "end": 13,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/JRVJhNKhBZ5OsLVFkRfqxw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/JRVJhNKhBZ5OsLVFkRfqxw/output.json
@@ -47,7 +47,7 @@
               "end": 29,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         }
       ]

--- a/css/parser/tests/fixture/esbuild/misc/Jir2h5-Giw9AVhE3ep3_sg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Jir2h5-Giw9AVhE3ep3_sg/output.json
@@ -62,7 +62,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/Jmhb8p_Oc2-nzkcDSk0dww/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Jmhb8p_Oc2-nzkcDSk0dww/output.json
@@ -47,7 +47,7 @@
               "end": 37,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {

--- a/css/parser/tests/fixture/esbuild/misc/LoeMqdekBkn3XKYHQFHOZA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/LoeMqdekBkn3XKYHQFHOZA/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Loy9sX2qaylR2OySt7N-BQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Loy9sX2qaylR2OySt7N-BQ/output.json
@@ -69,7 +69,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/MCJc58-6bYzpgizSxt8jQg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MCJc58-6bYzpgizSxt8jQg/output.json
@@ -82,7 +82,7 @@
           "end": 15,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/MHzCL6d2nAk4bByQ_ja7xg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MHzCL6d2nAk4bByQ_ja7xg/output.json
@@ -61,7 +61,7 @@
           "end": 3,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/MK5PGiCFMf7RHDp05gnDCw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MK5PGiCFMf7RHDp05gnDCw/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/MU8JgGd_-h5ocqkfawNxeQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MU8JgGd_-h5ocqkfawNxeQ/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/MmOsa9XFdPMS9x4ITbWSzg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MmOsa9XFdPMS9x4ITbWSzg/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/MvD7ThpMVIxU3dzF71Gpcg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MvD7ThpMVIxU3dzF71Gpcg/output.json
@@ -83,7 +83,7 @@
           "end": 9,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/MxxFvoxSpp02tFmpbNdA8g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MxxFvoxSpp02tFmpbNdA8g/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/O2EvcnNp_CVyX3xq5-eM-g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/O2EvcnNp_CVyX3xq5-eM-g/output.json
@@ -89,7 +89,7 @@
           "end": 27,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/OFqVy3cBzYnrIy6uze5Nuw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/OFqVy3cBzYnrIy6uze5Nuw/output.json
@@ -47,7 +47,7 @@
               "end": 25,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         },
         {
@@ -74,7 +74,7 @@
               "end": 43,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {

--- a/css/parser/tests/fixture/esbuild/misc/OHdIPr6lNfq9lBs5RMtbrQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/OHdIPr6lNfq9lBs5RMtbrQ/output.json
@@ -47,7 +47,7 @@
               "end": 27,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         }
       ]

--- a/css/parser/tests/fixture/esbuild/misc/Oc6Obl7mbH-MlFllIoAbdg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Oc6Obl7mbH-MlFllIoAbdg/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/OjiW46YAJSt_cq_MHhs2Bw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/OjiW46YAJSt_cq_MHhs2Bw/output.json
@@ -61,7 +61,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/OtM9lGhbFLqI-r3dvNTUjQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/OtM9lGhbFLqI-r3dvNTUjQ/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/PRqD5VDViUThMCxIEmwIcg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/PRqD5VDViUThMCxIEmwIcg/output.json
@@ -61,7 +61,7 @@
           "end": 4,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/PSncmPJMuHC-CjpwiYtkDw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/PSncmPJMuHC-CjpwiYtkDw/output.json
@@ -61,7 +61,7 @@
           "end": 33,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/output.json
@@ -69,7 +69,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/PwUHqMTSmtZW7IYn9gsinQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/PwUHqMTSmtZW7IYn9gsinQ/output.json
@@ -62,7 +62,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/Q42FDvG6_mtoeI7PoHqgQw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Q42FDvG6_mtoeI7PoHqgQw/output.json
@@ -103,7 +103,7 @@
           "end": 8,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/QLHVnSGDdGN_iDeP3OAXfQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/QLHVnSGDdGN_iDeP3OAXfQ/output.json
@@ -82,7 +82,7 @@
           "end": 14,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/Q_wA-fPw3o2m3R7gyWNxbQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Q_wA-fPw3o2m3R7gyWNxbQ/output.json
@@ -89,7 +89,7 @@
           "end": 31,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/R6OYU1g_sB_euLV8Yzjw6w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/R6OYU1g_sB_euLV8Yzjw6w/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/RmGccmub1dooAN8WPKTwhQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/RmGccmub1dooAN8WPKTwhQ/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/output.json
@@ -61,7 +61,7 @@
           "end": 45,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/S2Mhk5rU2YxQPgm9rtF9WA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/S2Mhk5rU2YxQPgm9rtF9WA/output.json
@@ -99,7 +99,7 @@
               "end": 63,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {

--- a/css/parser/tests/fixture/esbuild/misc/SFBgyV9jnFbMzWZoo9VbSQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/SFBgyV9jnFbMzWZoo9VbSQ/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Ssg_Qhdw7h_c6ZtY52Qe4A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Ssg_Qhdw7h_c6ZtY52Qe4A/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Sy2aOxINv1bvZmbK_Pc5Mg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Sy2aOxINv1bvZmbK_Pc5Mg/output.json
@@ -69,7 +69,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/T1SOp4KXmIb1WNsyPFEKqg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/T1SOp4KXmIb1WNsyPFEKqg/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/TB0HbwEy-7bhtK7ck9tHKQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/TB0HbwEy-7bhtK7ck9tHKQ/output.json
@@ -47,7 +47,7 @@
               "end": 31,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {
@@ -104,7 +104,7 @@
               "end": 45,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {

--- a/css/parser/tests/fixture/esbuild/misc/TdBn3uBF54mw96CCUwpgew/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/TdBn3uBF54mw96CCUwpgew/output.json
@@ -82,7 +82,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/TyMkoZpPOEhvUBOmUhGOXQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/TyMkoZpPOEhvUBOmUhGOXQ/output.json
@@ -61,7 +61,7 @@
           "end": 16,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/U-MOOs2vmQ3m-i8XisYj8w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/U-MOOs2vmQ3m-i8XisYj8w/output.json
@@ -82,7 +82,7 @@
           "end": 13,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/U2nuhvtnEWZ_kMd6i7EDWA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/U2nuhvtnEWZ_kMd6i7EDWA/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/UeHn9b5w6R3dVjrtRCGxkA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/UeHn9b5w6R3dVjrtRCGxkA/output.json
@@ -69,7 +69,7 @@
           "end": 5,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/output.json
@@ -61,7 +61,7 @@
           "end": 24,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/V6ATfoZsbJDwKWSnlREl-w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/V6ATfoZsbJDwKWSnlREl-w/output.json
@@ -82,7 +82,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/Vx6S11kYP0h0sx1VehL-tw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Vx6S11kYP0h0sx1VehL-tw/output.json
@@ -47,7 +47,7 @@
               "end": 27,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         }
       ]

--- a/css/parser/tests/fixture/esbuild/misc/W3R-c5DPSkhG9QWYdcFdFg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/W3R-c5DPSkhG9QWYdcFdFg/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/WQWdwW4B4hm60AQgxTU08Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/WQWdwW4B4hm60AQgxTU08Q/output.json
@@ -100,7 +100,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/Wb-aVu7CEQfCy1QL2yUrEw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Wb-aVu7CEQfCy1QL2yUrEw/output.json
@@ -61,7 +61,7 @@
           "end": 57,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/WnrbfdZnESKVnJxygl6yYA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/WnrbfdZnESKVnJxygl6yYA/output.json
@@ -90,7 +90,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/Wplrqmb_IDjNC-o-eqLw4A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Wplrqmb_IDjNC-o-eqLw4A/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Wxf4N3jnpCG5lQzkYt7wog/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Wxf4N3jnpCG5lQzkYt7wog/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/X-yuwO0x1B-l1Js4JkKJZg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/X-yuwO0x1B-l1Js4JkKJZg/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/X0UTnZK8bQhMRs3DGoqFAw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/X0UTnZK8bQhMRs3DGoqFAw/output.json
@@ -47,7 +47,7 @@
               "end": 37,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {
@@ -104,7 +104,7 @@
               "end": 43,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         }
       ]

--- a/css/parser/tests/fixture/esbuild/misc/XVtQeQIEHAyQlpmKRigHcg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/XVtQeQIEHAyQlpmKRigHcg/output.json
@@ -90,7 +90,7 @@
           "end": 8,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/XetGJrWBJuC-NtgpX2eq1Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/XetGJrWBJuC-NtgpX2eq1Q/output.json
@@ -62,7 +62,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/YIW6UUMmxrTYJjJ3JSL3uQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/YIW6UUMmxrTYJjJ3JSL3uQ/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/YUPpw78_zYmKpAkI2SzNsg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/YUPpw78_zYmKpAkI2SzNsg/output.json
@@ -72,7 +72,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/Yc70giIIGDIddrjD858dDw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Yc70giIIGDIddrjD858dDw/output.json
@@ -61,7 +61,7 @@
           "end": 16,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Ys7z8C2qi5O_HM9ElZQrUQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Ys7z8C2qi5O_HM9ElZQrUQ/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Z4J4sVA4UnGhTMiN5tdMMQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Z4J4sVA4UnGhTMiN5tdMMQ/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/_APxY5Pe47Bb71-CwD1nhw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_APxY5Pe47Bb71-CwD1nhw/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/_U4zAUbS93Xo7_tJOolGuA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_U4zAUbS93Xo7_tJOolGuA/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/_XB1oeHz4bZ49LCE2cBI6g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_XB1oeHz4bZ49LCE2cBI6g/output.json
@@ -82,7 +82,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/_d22bZcPKDgNEKSyJ2NRsQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_d22bZcPKDgNEKSyJ2NRsQ/output.json
@@ -100,7 +100,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/_e6qpZBWfowEh1P3Wn3orA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_e6qpZBWfowEh1P3Wn3orA/output.json
@@ -83,7 +83,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/_qcmYeHAxw35hMnF2IST8A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_qcmYeHAxw35hMnF2IST8A/output.json
@@ -82,7 +82,7 @@
           "end": 12,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/a0Yurt7E7InOYieD7nMCXg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/a0Yurt7E7InOYieD7nMCXg/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/a7KElWOMF9ilrSsoliHkcg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/a7KElWOMF9ilrSsoliHkcg/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/aDkLP2LEPmyD_ImzrGw8SQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/aDkLP2LEPmyD_ImzrGw8SQ/output.json
@@ -47,7 +47,7 @@
               "end": 25,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         },
         {
@@ -74,7 +74,7 @@
               "end": 43,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {

--- a/css/parser/tests/fixture/esbuild/misc/aEF_NRb2u-g7UzHxaKpOfA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/aEF_NRb2u-g7UzHxaKpOfA/output.json
@@ -91,7 +91,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/aVG5R30iWKuuw8iOGrgVmw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/aVG5R30iWKuuw8iOGrgVmw/output.json
@@ -69,7 +69,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/aVoVLZHijXjMsJvx4rbJGQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/aVoVLZHijXjMsJvx4rbJGQ/output.json
@@ -20,7 +20,7 @@
           "end": 26,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/avMO0PRST3qaooxANKWiIw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/avMO0PRST3qaooxANKWiIw/output.json
@@ -62,7 +62,7 @@
           "end": 21,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/axTS8OYqxbJ3cRQm9h4ZYA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/axTS8OYqxbJ3cRQm9h4ZYA/output.json
@@ -61,7 +61,7 @@
           "end": 21,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/b102IE1MrM3aGTKCRrSU6Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/b102IE1MrM3aGTKCRrSU6Q/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/b2m1STf0F5CKity6Nd4vmQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/b2m1STf0F5CKity6Nd4vmQ/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/b6WBp-DsAKNB9xg6pcRTzQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/b6WBp-DsAKNB9xg6pcRTzQ/output.json
@@ -62,7 +62,7 @@
           "end": 15,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/bO5VdzMYGbUbK2CCYCMKTA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/bO5VdzMYGbUbK2CCYCMKTA/output.json
@@ -62,7 +62,7 @@
           "end": 14,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/bdiLSVQWZCfQNNwD_OM6qA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/bdiLSVQWZCfQNNwD_OM6qA/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/biImEvafuG5pEuEW8LgCCw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/biImEvafuG5pEuEW8LgCCw/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/btdQp-3m090Q73vMHSpKgw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/btdQp-3m090Q73vMHSpKgw/output.json
@@ -69,7 +69,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/c3bWgxp_3BNOH3BSgNg7-Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/c3bWgxp_3BNOH3BSgNg7-Q/output.json
@@ -89,7 +89,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/cFk0V1dktTRk2wWOux0Y9A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cFk0V1dktTRk2wWOux0Y9A/output.json
@@ -89,7 +89,7 @@
           "end": 31,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/cfNrGQbCQ18L8pQmD7lBZQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cfNrGQbCQ18L8pQmD7lBZQ/output.json
@@ -61,7 +61,7 @@
           "end": 42,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/coHEK8Dkb2Zflw3JwafU5Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/coHEK8Dkb2Zflw3JwafU5Q/output.json
@@ -82,7 +82,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/cpoL0JfVO7TLrlcAga939A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cpoL0JfVO7TLrlcAga939A/output.json
@@ -82,7 +82,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/cxYYDM0_rXbkvaqi8UPWOg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cxYYDM0_rXbkvaqi8UPWOg/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/d1BWbOHfSbCE8-_qEz-luA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/d1BWbOHfSbCE8-_qEz-luA/output.json
@@ -108,7 +108,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/d6iTYxGk5HHi4hIZcn73Bw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/d6iTYxGk5HHi4hIZcn73Bw/output.json
@@ -89,7 +89,7 @@
           "end": 27,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/d8Q6MceynW9-IQJ4l0OGzA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/d8Q6MceynW9-IQJ4l0OGzA/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/dVUzkh7NtbXySLzWGW0t9g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/dVUzkh7NtbXySLzWGW0t9g/output.json
@@ -61,7 +61,7 @@
           "end": 16,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {
@@ -149,7 +149,7 @@
           "end": 35,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {
@@ -237,7 +237,7 @@
           "end": 52,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/dnJiFdC_77rVfPM-yerzTQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/dnJiFdC_77rVfPM-yerzTQ/output.json
@@ -74,7 +74,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/dqE2h21N1vX-ivcowP16dQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/dqE2h21N1vX-ivcowP16dQ/output.json
@@ -62,7 +62,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/eBC_tv-_FNqjWVMq-no99A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eBC_tv-_FNqjWVMq-no99A/output.json
@@ -61,7 +61,7 @@
           "end": 4,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/eRzlGAuJZZYbPU6hnTADoA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eRzlGAuJZZYbPU6hnTADoA/output.json
@@ -62,7 +62,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/eVSpM_pYsIvyyewUkjTa2A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eVSpM_pYsIvyyewUkjTa2A/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/eWp7_8m3btY6p4erQ5c2JQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eWp7_8m3btY6p4erQ5c2JQ/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/e_FDMPgmGFzIY3W0EbjxHA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/e_FDMPgmGFzIY3W0EbjxHA/output.json
@@ -82,7 +82,7 @@
           "end": 14,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/egyt9Hk9xnn2Xfbi3Ckfrg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/egyt9Hk9xnn2Xfbi3Ckfrg/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/eivsIn6ub-xYiqErLqd8oA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eivsIn6ub-xYiqErLqd8oA/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/fT3vLBT7xnGwPlQ-kXdN1g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fT3vLBT7xnGwPlQ-kXdN1g/output.json
@@ -62,7 +62,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/fTZzFds73kLZoyY9Y2gZdQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fTZzFds73kLZoyY9Y2gZdQ/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/fYJdtIZOdQKTLI8JJC2b_g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fYJdtIZOdQKTLI8JJC2b_g/output.json
@@ -90,7 +90,7 @@
           "end": 12,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/fe2WQQLV9qt16pYQLzZrpw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fe2WQQLV9qt16pYQLzZrpw/output.json
@@ -82,7 +82,7 @@
           "end": 12,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/output.json
@@ -61,7 +61,7 @@
           "end": 21,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/fp9AcaoyGYHGTzXDXcy_ZQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fp9AcaoyGYHGTzXDXcy_ZQ/output.json
@@ -82,7 +82,7 @@
           "end": 13,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/ftc5-zf_sliOrFRRBGGS-g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ftc5-zf_sliOrFRRBGGS-g/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/fxosM7xcuYbDyErN-ODVbw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fxosM7xcuYbDyErN-ODVbw/output.json
@@ -82,7 +82,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/output.json
@@ -61,7 +61,7 @@
           "end": 24,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/output.json
@@ -61,7 +61,7 @@
           "end": 25,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/gxBoWO36fKxIuYwPzrWyKQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/gxBoWO36fKxIuYwPzrWyKQ/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/hYoP2sEvEyLualMll8L_RQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/hYoP2sEvEyLualMll8L_RQ/output.json
@@ -61,7 +61,7 @@
           "end": 5,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/hfb4Q3SC19oWsisaiRslOA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/hfb4Q3SC19oWsisaiRslOA/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/hfprsTDi2yEOOmPdjb8Cew/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/hfprsTDi2yEOOmPdjb8Cew/output.json
@@ -79,7 +79,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/i7oy_7cYzOxuhIPcZo1yow/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/i7oy_7cYzOxuhIPcZo1yow/output.json
@@ -82,7 +82,7 @@
           "end": 13,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/iY6z2A7vaO8bBm_U1Qrm8g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/iY6z2A7vaO8bBm_U1Qrm8g/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/inMW5rttJFPDfH0aKVFg_Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/inMW5rttJFPDfH0aKVFg_Q/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/isfWm5W8qb6_aJSz_bdwDw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/isfWm5W8qb6_aJSz_bdwDw/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/j9dr5-Ih68VDH1exMwsmZA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/j9dr5-Ih68VDH1exMwsmZA/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/jD_IvFQVk8LtCrictrWpxw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/jD_IvFQVk8LtCrictrWpxw/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/jbIIxHeXTPO0PtiubVziHQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/jbIIxHeXTPO0PtiubVziHQ/output.json
@@ -47,7 +47,7 @@
               "end": 37,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {
@@ -104,7 +104,7 @@
               "end": 56,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {

--- a/css/parser/tests/fixture/esbuild/misc/jdLujY0rTP02e0KuCnvbvg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/jdLujY0rTP02e0KuCnvbvg/output.json
@@ -89,7 +89,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/jzpj5gTOBgKB1ITBDfJiNA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/jzpj5gTOBgKB1ITBDfJiNA/output.json
@@ -69,7 +69,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/kVdd5WJZqKSou4cGvcL40g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/kVdd5WJZqKSou4cGvcL40g/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/kubgOdBUY3iT30KfPRcbsA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/kubgOdBUY3iT30KfPRcbsA/output.json
@@ -90,7 +90,7 @@
           "end": 14,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/lFIVvsKPgxD4lJlULqKluw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/lFIVvsKPgxD4lJlULqKluw/output.json
@@ -74,7 +74,7 @@
           "end": 11,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/lS8DPMFU-dQY4SnMMBW4Aw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/lS8DPMFU-dQY4SnMMBW4Aw/output.json
@@ -47,7 +47,7 @@
               "end": 25,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         },
         {
@@ -74,7 +74,7 @@
               "end": 31,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         }
       ]

--- a/css/parser/tests/fixture/esbuild/misc/mJEhy0k_dxoszsTVHb3x_Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mJEhy0k_dxoszsTVHb3x_Q/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/mTLdgh264Uoe84INHS3fAw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mTLdgh264Uoe84INHS3fAw/output.json
@@ -72,7 +72,7 @@
           "end": 6,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/mn3ADjaNJuY6IF0Nqms-VQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mn3ADjaNJuY6IF0Nqms-VQ/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/mnQPy45Xrp2Ze7IdrwV0Ow/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mnQPy45Xrp2Ze7IdrwV0Ow/output.json
@@ -89,7 +89,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/output.json
@@ -61,7 +61,7 @@
           "end": 23,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/nTOoTMumkTvMLx_Y_al5RQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/nTOoTMumkTvMLx_Y_al5RQ/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/niufyVEBI4s-ZqSXdfhptA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/niufyVEBI4s-ZqSXdfhptA/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/nlYSjWzJfpf38YhsJNbwmA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/nlYSjWzJfpf38YhsJNbwmA/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/oNUbYW5wdxqAQR8cAY1YBA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/oNUbYW5wdxqAQR8cAY1YBA/output.json
@@ -82,7 +82,7 @@
           "end": 13,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/octeetJYrV7Yu6rAS3AUFQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/octeetJYrV7Yu6rAS3AUFQ/output.json
@@ -62,7 +62,7 @@
           "end": 13,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/oj5Yn0RxnGFEbVphKqrL2Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/oj5Yn0RxnGFEbVphKqrL2Q/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/ottVCVON2IlQB3WCD-lu_A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ottVCVON2IlQB3WCD-lu_A/output.json
@@ -61,7 +61,7 @@
           "end": 16,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/p4k8Aj2Nw7Pd4QNaHfLCyg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/p4k8Aj2Nw7Pd4QNaHfLCyg/output.json
@@ -82,7 +82,7 @@
           "end": 13,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/pJGP-gxqsiFs_ruNrpY3bw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pJGP-gxqsiFs_ruNrpY3bw/output.json
@@ -116,7 +116,7 @@
           "end": 8,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/pLQn9swtbpZ-CVZMGw0EwA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pLQn9swtbpZ-CVZMGw0EwA/output.json
@@ -83,7 +83,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/pOZgFOB3GdVvQ0hiAsWfpQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pOZgFOB3GdVvQ0hiAsWfpQ/output.json
@@ -82,7 +82,7 @@
           "end": 14,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/pQWwEpWgxuUS6-uSAJR0nQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pQWwEpWgxuUS6-uSAJR0nQ/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/pRKMU9FUvZ77y9hGWxYQnw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pRKMU9FUvZ77y9hGWxYQnw/output.json
@@ -82,7 +82,7 @@
           "end": 12,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/pTW2Z7kJ0nR_yQzsOsjAwQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pTW2Z7kJ0nR_yQzsOsjAwQ/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/pUymwoCxUAxDqtaTC7CaOQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pUymwoCxUAxDqtaTC7CaOQ/output.json
@@ -69,7 +69,7 @@
           "end": 8,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/pqHD3F10M6OunHKOop7-lA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pqHD3F10M6OunHKOop7-lA/output.json
@@ -62,7 +62,7 @@
           "end": 8,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/prqRW0qUpem2SVAI9WN-5w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/prqRW0qUpem2SVAI9WN-5w/output.json
@@ -69,7 +69,7 @@
           "end": 5,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/puXMOLryMROitDKRX2oMmw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/puXMOLryMROitDKRX2oMmw/output.json
@@ -62,7 +62,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/qgkE_nOj4HtPukMzEjCY5w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/qgkE_nOj4HtPukMzEjCY5w/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/qmXSF9N8euK5gfPoFGmV_Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/qmXSF9N8euK5gfPoFGmV_Q/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/qsC9vwnhYfmqVreVrA1SEg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/qsC9vwnhYfmqVreVrA1SEg/output.json
@@ -82,7 +82,7 @@
           "end": 13,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/rAzJtA56igpCO-gN3gRrYw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/rAzJtA56igpCO-gN3gRrYw/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/rGv8hpoRRBbCTlyQ-70xVw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/rGv8hpoRRBbCTlyQ-70xVw/output.json
@@ -72,7 +72,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/rZIFO-RMBeLmmQK8U6nNmQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/rZIFO-RMBeLmmQK8U6nNmQ/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/s6SbuS-mSQuuf1eQzngAFw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/s6SbuS-mSQuuf1eQzngAFw/output.json
@@ -62,7 +62,7 @@
           "end": 8,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/sAlB53zm7iv9WuhRVKadHQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sAlB53zm7iv9WuhRVKadHQ/output.json
@@ -89,7 +89,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/sEqPCrxONsC0GxTLw0X7IA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sEqPCrxONsC0GxTLw0X7IA/output.json
@@ -82,7 +82,7 @@
           "end": 16,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/sI7kJsMAHm4ehV5Ec9i9hg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sI7kJsMAHm4ehV5Ec9i9hg/output.json
@@ -82,7 +82,7 @@
           "end": 13,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/sNuIucY7tsVtjkcMTIXaGw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sNuIucY7tsVtjkcMTIXaGw/output.json
@@ -74,7 +74,7 @@
           "end": 13,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/tJNGkqEMVKFfOWjyOm5TSg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/tJNGkqEMVKFfOWjyOm5TSg/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/thvW-_S_FCA5eKxKgRyxig/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/thvW-_S_FCA5eKxKgRyxig/output.json
@@ -61,7 +61,7 @@
           "end": 16,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/tr7rB0yt-SnlIRotrT7uFA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/tr7rB0yt-SnlIRotrT7uFA/output.json
@@ -61,7 +61,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/uUAQc0UQ6MBf-ScTmlXMow/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/uUAQc0UQ6MBf-ScTmlXMow/output.json
@@ -44,7 +44,7 @@
           "end": 4,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/output.json
@@ -72,7 +72,7 @@
               "end": 33,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {
@@ -154,7 +154,7 @@
               "end": 52,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {

--- a/css/parser/tests/fixture/esbuild/misc/ugX8SLCLRvWN-wDCK7ouyA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ugX8SLCLRvWN-wDCK7ouyA/output.json
@@ -20,7 +20,7 @@
           "end": 30,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/vCiwe_ipn8ReAa4wyU52Ng/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vCiwe_ipn8ReAa4wyU52Ng/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/vJrDZy-xgYNUTNK3uei3cg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vJrDZy-xgYNUTNK3uei3cg/output.json
@@ -74,7 +74,7 @@
           "end": 5,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/vK9rUBJhwa0FsjBe18lL0w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vK9rUBJhwa0FsjBe18lL0w/output.json
@@ -61,7 +61,7 @@
           "end": 23,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/vN7xRB9YekSqanW68eIoNA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vN7xRB9YekSqanW68eIoNA/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/wEB80kxMinK4EZaPb3My1A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/wEB80kxMinK4EZaPb3My1A/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/wIDDuubF_bj7wmG8T_koVw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/wIDDuubF_bj7wmG8T_koVw/output.json
@@ -62,7 +62,7 @@
           "end": 7,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/esbuild/misc/wwLEw52LUKMFH3Wp5CaBAQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/wwLEw52LUKMFH3Wp5CaBAQ/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/xVWGh0UpWtRUrgqbJEENWA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/xVWGh0UpWtRUrgqbJEENWA/output.json
@@ -61,7 +61,7 @@
           "end": 18,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/xVqT8wNU4CEhaDlbLxGyaw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/xVqT8wNU4CEhaDlbLxGyaw/output.json
@@ -61,7 +61,7 @@
           "end": 17,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/xc1mD3YfHByTKL-N-FL49A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/xc1mD3YfHByTKL-N-FL49A/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/xdJ7w6fdV3po3r2aWrgPdA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/xdJ7w6fdV3po3r2aWrgPdA/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/yOHW3TOE35U7DAf9Hn7-Ew/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/yOHW3TOE35U7DAf9Hn7-Ew/output.json
@@ -61,7 +61,7 @@
           "end": 19,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/yVqdwpiB7OK23Te5mXKdFw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/yVqdwpiB7OK23Te5mXKdFw/output.json
@@ -61,7 +61,7 @@
           "end": 16,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/yboE7Tr5zjKHy9-m10AZTg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/yboE7Tr5zjKHy9-m10AZTg/output.json
@@ -61,7 +61,7 @@
           "end": 22,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/zUuWz4A8Y6yZO8JMLAe2fQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/zUuWz4A8Y6yZO8JMLAe2fQ/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/output.json
@@ -61,7 +61,7 @@
           "end": 20,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/function/url/output.json
+++ b/css/parser/tests/fixture/function/url/output.json
@@ -61,7 +61,7 @@
           "end": 823,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/important/basic/output.json
+++ b/css/parser/tests/fixture/important/basic/output.json
@@ -62,7 +62,7 @@
           "end": 495,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/calc/output.json
+++ b/css/parser/tests/fixture/rome/calc/output.json
@@ -62,7 +62,7 @@
           "end": 238,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/comment/output.json
+++ b/css/parser/tests/fixture/rome/comment/output.json
@@ -61,7 +61,7 @@
           "end": 54,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {
@@ -149,7 +149,7 @@
           "end": 90,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {
@@ -237,7 +237,7 @@
           "end": 126,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/custom-properties/output.json
+++ b/css/parser/tests/fixture/rome/custom-properties/output.json
@@ -62,7 +62,7 @@
           "end": 540,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/fit-content/output.json
+++ b/css/parser/tests/fixture/rome/fit-content/output.json
@@ -62,7 +62,7 @@
           "end": 73,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/font/output.json
+++ b/css/parser/tests/fixture/rome/font/output.json
@@ -20,7 +20,7 @@
           "end": 29,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/functions/output.json
+++ b/css/parser/tests/fixture/rome/functions/output.json
@@ -62,7 +62,7 @@
           "end": 165,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/grid/minmax/output.json
+++ b/css/parser/tests/fixture/rome/grid/minmax/output.json
@@ -62,7 +62,7 @@
           "end": 114,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/grid/repeat/fit-content/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/fit-content/output.json
@@ -62,7 +62,7 @@
           "end": 65,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/grid/repeat/flex/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/flex/output.json
@@ -62,7 +62,7 @@
           "end": 50,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/grid/repeat/line-name/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/line-name/output.json
@@ -62,7 +62,7 @@
           "end": 58,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/grid/repeat/minmax/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/minmax/output.json
@@ -62,7 +62,7 @@
           "end": 73,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/grid/repeat/multi-values/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/multi-values/output.json
@@ -62,7 +62,7 @@
           "end": 105,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/keyframe/output.json
+++ b/css/parser/tests/fixture/rome/keyframe/output.json
@@ -47,7 +47,7 @@
               "end": 77,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {
@@ -124,7 +124,7 @@
               "end": 130,
               "ctxt": 0
             },
-            "properties": [
+            "items": [
               {
                 "type": "Property",
                 "span": {
@@ -220,7 +220,7 @@
               "end": 167,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         },
         {
@@ -247,7 +247,7 @@
               "end": 182,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         },
         {
@@ -282,7 +282,7 @@
               "end": 198,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         },
         {
@@ -317,7 +317,7 @@
               "end": 213,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         },
         {
@@ -352,7 +352,7 @@
               "end": 230,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         }
       ]

--- a/css/parser/tests/fixture/rome/media/condition/output.json
+++ b/css/parser/tests/fixture/rome/media/condition/output.json
@@ -869,7 +869,7 @@
               "end": 390,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         },
         {
@@ -928,7 +928,7 @@
               "end": 404,
               "ctxt": 0
             },
-            "properties": []
+            "items": []
           }
         }
       ]

--- a/css/parser/tests/fixture/rome/min-and-max/output.json
+++ b/css/parser/tests/fixture/rome/min-and-max/output.json
@@ -62,7 +62,7 @@
           "end": 390,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/selectors/output.json
+++ b/css/parser/tests/fixture/rome/selectors/output.json
@@ -268,7 +268,7 @@
           "end": 41,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -327,7 +327,7 @@
           "end": 69,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -415,7 +415,7 @@
           "end": 86,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -503,7 +503,7 @@
           "end": 117,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {
@@ -629,7 +629,7 @@
           "end": 158,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {
@@ -755,7 +755,7 @@
           "end": 200,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {
@@ -918,7 +918,7 @@
           "end": 259,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {
@@ -1047,7 +1047,7 @@
           "end": 286,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -1153,7 +1153,7 @@
           "end": 305,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -1222,7 +1222,7 @@
           "end": 326,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -1328,7 +1328,7 @@
           "end": 351,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/rome/smoke/output.json
+++ b/css/parser/tests/fixture/rome/smoke/output.json
@@ -61,7 +61,7 @@
           "end": 78,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/rome/values/output.json
+++ b/css/parser/tests/fixture/rome/values/output.json
@@ -89,7 +89,7 @@
           "end": 36,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {
@@ -178,7 +178,7 @@
           "end": 115,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {
@@ -385,7 +385,7 @@
           "end": 139,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {
@@ -473,7 +473,7 @@
           "end": 182,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/selector/attribute/output.json
+++ b/css/parser/tests/fixture/selector/attribute/output.json
@@ -74,7 +74,7 @@
           "end": 10,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -153,7 +153,7 @@
           "end": 25,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -232,7 +232,7 @@
           "end": 42,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -311,7 +311,7 @@
           "end": 61,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -390,7 +390,7 @@
           "end": 77,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -469,7 +469,7 @@
           "end": 92,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -548,7 +548,7 @@
           "end": 110,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -627,7 +627,7 @@
           "end": 131,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -706,7 +706,7 @@
           "end": 158,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -785,7 +785,7 @@
           "end": 185,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -864,7 +864,7 @@
           "end": 205,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -943,7 +943,7 @@
           "end": 225,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -1030,7 +1030,7 @@
           "end": 242,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -1109,7 +1109,7 @@
           "end": 253,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -1180,7 +1180,7 @@
           "end": 263,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -1251,7 +1251,7 @@
           "end": 272,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/selector/comments/output.json
+++ b/css/parser/tests/fixture/selector/comments/output.json
@@ -90,7 +90,7 @@
           "end": 15,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -177,7 +177,7 @@
           "end": 32,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -264,7 +264,7 @@
           "end": 49,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -351,7 +351,7 @@
           "end": 67,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -438,7 +438,7 @@
           "end": 82,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -525,7 +525,7 @@
           "end": 98,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -612,7 +612,7 @@
           "end": 115,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -699,7 +699,7 @@
           "end": 133,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -786,7 +786,7 @@
           "end": 149,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -873,7 +873,7 @@
           "end": 166,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -960,7 +960,7 @@
           "end": 183,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -1047,7 +1047,7 @@
           "end": 201,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -1134,7 +1134,7 @@
           "end": 216,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -1221,7 +1221,7 @@
           "end": 232,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -1318,7 +1318,7 @@
           "end": 258,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     },
     {
@@ -1415,7 +1415,7 @@
           "end": 289,
           "ctxt": 0
         },
-        "properties": []
+        "items": []
       }
     }
   ]

--- a/css/parser/tests/fixture/selector/universal/output.json
+++ b/css/parser/tests/fixture/selector/universal/output.json
@@ -61,7 +61,7 @@
           "end": 25,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/styled-jsx/selector/1/output.json
+++ b/css/parser/tests/fixture/styled-jsx/selector/1/output.json
@@ -125,7 +125,7 @@
           "end": 37,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/styled-jsx/selector/2/output.json
+++ b/css/parser/tests/fixture/styled-jsx/selector/2/output.json
@@ -164,7 +164,7 @@
           "end": 48,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/parser/tests/fixture/stylis/comma/01/output.json
+++ b/css/parser/tests/fixture/stylis/comma/01/output.json
@@ -61,7 +61,7 @@
           "end": 54,
           "ctxt": 0
         },
-        "properties": [
+        "items": [
           {
             "type": "Property",
             "span": {

--- a/css/stylis/Cargo.toml
+++ b/css/stylis/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_stylis"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.4.0"
+version = "0.5.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
 swc_common = {version = "0.13.0", path = "../../common"}
-swc_css_ast = {version = "0.6.0", path = "../ast"}
-swc_css_utils = {version = "0.3.0", path = "../utils/"}
-swc_css_visit = {version = "0.5.0", path = "../visit"}
+swc_css_ast = {version = "0.7.0", path = "../ast"}
+swc_css_utils = {version = "0.4.0", path = "../utils/"}
+swc_css_visit = {version = "0.6.0", path = "../visit"}
 
 [dev-dependencies]
-swc_css_codegen = {version = "0.5.0", path = "../codegen"}
-swc_css_parser = {version = "0.7.0", path = "../parser"}
+swc_css_codegen = {version = "0.6.0", path = "../codegen"}
+swc_css_parser = {version = "0.8.0", path = "../parser"}
 testing = {version = "0.14.0", path = "../../testing"}

--- a/css/stylis/src/prefixer.rs
+++ b/css/stylis/src/prefixer.rs
@@ -80,11 +80,11 @@ impl Prefixer {
 }
 
 impl VisitMut for Prefixer {
-    fn visit_mut_properties(&mut self, props: &mut Vec<Property>) {
+    fn visit_mut_decl_block_items(&mut self, props: &mut Vec<DeclBlockItem>) {
         let mut new = vec![];
         for mut n in take(props) {
             n.visit_mut_with(self);
-            new.extend(self.added.drain(..));
+            new.extend(self.added.drain(..).map(DeclBlockItem::Property));
             new.push(n);
         }
 

--- a/css/stylis/tests/prefixer.rs
+++ b/css/stylis/tests/prefixer.rs
@@ -451,26 +451,18 @@ fn appearance() {
 fn error_recovery_1() {
     // This behavior is wrong, but it's what `stylis@3` does.
     t(
-        "h3 {
-            __styled-jsx-placeholder__1
+        "__styled-jsx-placeholder__1
             animation: slide 3s ease infinite;
-        }",
-        "h3 {
-            __styled-jsx-placeholder__1
-            animation: slide 3s ease infinite;
-        }",
+        ",
+        "__styled-jsx-placeholder__1 animation: slide 3s ease infinite;",
     );
 
     t(
-        "h3 {
-            animation: slide 3s ease infinite;
+        "animation: slide 3s ease infinite;
             __styled-jsx-placeholder__1
-        }",
-        "h3 {
-            animation: slide 3s ease infinite;
-            -webkit-animation: slide 3s ease infinite;
-            __styled-jsx-placeholder__1
-        }",
+        ",
+        "-webkit-animation:slide 3s ease infinite;animation:slide 3s ease \
+         infinite;__styled-jsx-placeholder__1 ;",
     );
 }
 
@@ -491,10 +483,6 @@ fn t(src: &str, expected: &str) {
         .unwrap();
         for err in errors {
             err.to_diagnostics(&handler).emit();
-        }
-
-        if handler.has_errors() {
-            return Err(());
         }
 
         props.visit_mut_with(&mut prefixer());

--- a/css/stylis/tests/prefixer.rs
+++ b/css/stylis/tests/prefixer.rs
@@ -447,6 +447,33 @@ fn appearance() {
     );
 }
 
+#[test]
+fn error_recovery_1() {
+    // This behavior is wrong, but it's what `stylis@3` does.
+    t(
+        "h3 {
+            __styled-jsx-placeholder__1
+            animation: slide 3s ease infinite;
+        }",
+        "h3 {
+            __styled-jsx-placeholder__1
+            animation: slide 3s ease infinite;
+        }",
+    );
+
+    t(
+        "h3 {
+            animation: slide 3s ease infinite;
+            __styled-jsx-placeholder__1
+        }",
+        "h3 {
+            animation: slide 3s ease infinite;
+            -webkit-animation: slide 3s ease infinite;
+            __styled-jsx-placeholder__1
+        }",
+    );
+}
+
 /// Test
 fn t(src: &str, expected: &str) {
     testing::run_test2(false, |cm, handler| {

--- a/css/utils/Cargo.toml
+++ b/css/utils/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.3.0"
+version = "0.4.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
 swc_common = {version = "0.13.0", path = "../../common"}
-swc_css_ast = {version = "0.6.0", path = "../ast"}
-swc_css_visit = {version = "0.5.0", path = "../visit"}
+swc_css_ast = {version = "0.7.0", path = "../ast"}
+swc_css_visit = {version = "0.6.0", path = "../visit"}

--- a/css/visit/Cargo.toml
+++ b/css/visit/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_visit"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.5.0"
+version = "0.6.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
 swc_common = {version = "0.13.0", path = "../../common"}
-swc_css_ast = {version = "0.6.0", path = "../ast/"}
+swc_css_ast = {version = "0.7.0", path = "../ast/"}
 swc_visit = {version = "0.2.6", path = "../../visit"}

--- a/css/visit/src/lib.rs
+++ b/css/visit/src/lib.rs
@@ -39,17 +39,12 @@ define!({
 
     pub struct DeclBlock {
         pub span: Span,
-        pub body: DeclBlockBody,
+        pub items: Vec<DeclBlockItem>,
     }
 
-    pub enum DeclBlockBody {
+    pub enum DeclBlockItem {
         Invalid(Tokens),
-        Properties(Props),
-    }
-
-    pub struct Props {
-        pub span: Span,
-        pub props: Vec<Property>,
+        Property(Property),
     }
 
     pub struct Tokens {

--- a/css/visit/src/lib.rs
+++ b/css/visit/src/lib.rs
@@ -39,7 +39,17 @@ define!({
 
     pub struct DeclBlock {
         pub span: Span,
-        pub properties: Vec<Property>,
+        pub body: DeclBlockBody,
+    }
+
+    pub enum DeclBlockBody {
+        Invalid(Tokens),
+        Properties(Props),
+    }
+
+    pub struct Props {
+        pub span: Span,
+        pub props: Vec<Property>,
     }
 
     pub struct Tokens {


### PR DESCRIPTION
swc_css_ast:
 - Add `DeclBlockItem`.
 - Change `DeclBlock.properties` to `DeclBlock.items`.

swc_css_parser:
 - Add a way to recovered errors.