### PR TITLE
perf(ecmascript/parser): avoid string re-allocation

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_common"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.13.1"
+version = "0.13.2"
 
 [features]
 concurrent = ["parking_lot"]

--- a/common/src/source_map.rs
+++ b/common/src/source_map.rs
@@ -23,6 +23,7 @@ use crate::{
     rustc_data_structures::stable_hasher::StableHasher,
     sync::{Lock, LockGuard, Lrc, MappedLockGuard},
 };
+use once_cell::sync::Lazy;
 #[cfg(feature = "sourcemap")]
 use sourcemap::SourceMapBuilder;
 use std::{
@@ -35,6 +36,8 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering::SeqCst},
 };
 use tracing::debug;
+
+static CURRENT_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| env::current_dir().ok());
 
 // _____________________________________________________________________________
 // SourceFile, MultiByteChar, FileName, FileLines
@@ -64,7 +67,7 @@ impl FileLoader for RealFileLoader {
         if path.is_absolute() {
             Some(path.to_path_buf())
         } else {
-            env::current_dir().ok().map(|cwd| cwd.join(path))
+            CURRENT_DIR.as_ref().map(|cwd| cwd.join(path))
         }
     }
 

--- a/common/src/source_map.rs
+++ b/common/src/source_map.rs
@@ -30,7 +30,7 @@ use std::{
     cmp::{max, min},
     env, fs,
     hash::Hash,
-    io::{self, Read},
+    io,
     path::{Path, PathBuf},
     sync::atomic::{AtomicUsize, Ordering::SeqCst},
 };
@@ -69,9 +69,7 @@ impl FileLoader for RealFileLoader {
     }
 
     fn read_file(&self, path: &Path) -> io::Result<String> {
-        let mut src = String::new();
-        fs::File::open(path)?.read_to_string(&mut src)?;
-        Ok(src)
+        fs::read_to_string(path)
     }
 }
 


### PR DESCRIPTION
From the doc for `fs::read_to_string`:

> It pre-allocates a buffer based on the file size when available, so it is generally faster than reading into a string created with String::new()