### PR TITLE
Support Wallaby AST ranges

### DIFF
--- a/benches/typescript.rs
+++ b/benches/typescript.rs
@@ -133,6 +133,7 @@ fn bench_codegen(b: &mut Bencher, _target: JscTarget) {
                 None,
                 false,
                 None,
+                None,
             )
             .unwrap(),
         );

--- a/common/src/source_map.rs
+++ b/common/src/source_map.rs
@@ -193,6 +193,7 @@ impl SourceMap {
             .cloned()
     }
 
+    #[allow(unused)]
     fn next_start_pos(&self, len: usize) -> usize {
         // Add one so there is some space between files. This lets us distinguish
         // positions in the source_map, even in the presence of zero-length files.
@@ -222,6 +223,7 @@ impl SourceMap {
         let mut files = self.files.borrow_mut();
 
         let start_pos = self.next_start_pos(src.len());
+        //let start_pos = usize::MIN;
 
         let source_file = Lrc::new(SourceFile::new(
             filename,

--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -808,6 +808,10 @@ export interface Output {
    * Sourcemap (**not** base64 encoded)
    */
   map?: string;
+  /**
+   * Ranges for wallaby.js
+   */
+  ranges?: number[][];
 }
 
 export interface MatchPattern { }

--- a/node/binding/src/bundle.rs
+++ b/node/binding/src/bundle.rs
@@ -127,6 +127,7 @@ impl Task for BundleTask {
                             None,
                             minify,
                             None,
+                            None,
                         )?;
 
                         Ok((k, output))

--- a/node/binding/src/print.rs
+++ b/node/binding/src/print.rs
@@ -39,6 +39,7 @@ impl Task for PrintTask {
                 None,
                 self.options.config.clone().minify,
                 None,
+                None,
             )
             .convert_err()
     }
@@ -97,6 +98,7 @@ pub fn print_sync(cx: CallContext) -> napi::Result<JsObject> {
             &[],
             None,
             options.config.minify,
+            None,
             None,
         )
     }

--- a/node/bundler/tests/fixture.rs
+++ b/node/bundler/tests/fixture.rs
@@ -101,6 +101,7 @@ fn pass(input_dir: PathBuf) {
                         None,
                         false,
                         Some(true.into()),
+                        None,
                     )
                     .expect("failed to print?")
                     .code;

--- a/tests/projects.rs
+++ b/tests/projects.rs
@@ -777,6 +777,7 @@ fn should_visit() {
                 // TODO: figure out sourcemaps
                 config.minify,
                 config.preserve_comments,
+                None,
             )
             .unwrap()
             .code)
@@ -896,4 +897,24 @@ fn opt_source_file_name_1() {
     println!("{}", map);
 
     assert!(map.contains("entry-foo"));
+}
+
+#[test]
+fn ranges() {
+    let ranges = compile_str(
+        FileName::Real(PathBuf::from("not-unique.js")),
+        "var a = b ? c() : d();",
+        Options {
+            filename: "unique.js".into(),
+            source_maps: Some(SourceMapsConfig::Bool(true)),
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    .ranges
+    .unwrap();
+
+    println!("{}", ranges);
+
+    //assert!(map.contains("entry-foo"));
 }

--- a/tests/projects.rs
+++ b/tests/projects.rs
@@ -918,3 +918,25 @@ fn ranges() {
 
     //assert!(map.contains("entry-foo"));
 }
+
+#[test]
+fn ranges_multiple() {
+    testing::run_test2(false, |cm, handler| {
+        let c = Compiler::new(cm.clone());
+        let fm = c.cm.new_source_file(
+            FileName::Anon,
+            "var a = b ? c() : d();"
+            .into(),
+        );
+
+        let out1 = c.process_js_file(fm.clone(), &handler, &serde_json::from_str("{}").unwrap()).unwrap();
+
+        let out2 = c.process_js_file(fm.clone(), &handler, &serde_json::from_str("{}").unwrap()).unwrap();
+
+        println!("{}", out1.ranges.unwrap());
+        println!("{}", out2.ranges.unwrap());
+
+        Ok(())
+    })
+    .unwrap()
+}

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -83,6 +83,7 @@ pub fn print_sync(s: JsValue, opts: JsValue) -> Result<JsValue, JsValue> {
                 None,
                 opts.config.minify,
                 None,
+                None,
             )
             .context("failed to print code")?;
 


### PR DESCRIPTION
Wallaby requires information about the original source AST - as do several other tools.

E.g. For the following statement `var a = b ? c() : d();`

It needs this 2D array of ranges:

`[start-line, start-column, end-line, end-column]`

```
 * ranges = [
 *   [ 1, 0, 1, 22 ],   // whole statement
 *   [ 1, 12, 1, 15 ],  // c() execution path
 *   [ 1, 18, 1, 21 ]   // d() execution path
 * ];
```

See: https://wallabyjs.com/docs/config/compilers.html#writing-a-custom-compiler

I have modified the `Output` type to also return `ranges`.

To generate it, I just traverse the AST using a visitor.

For now, I am just returning the byte offsets, and then in my JS code I map the offsets to line/col. I think this is what you do in `SourceMap#span_to_line`.

Here is the JS code where I am using SWC as a Wallaby "compiler".

```ts
function compile(filename, code, opts) {
  const defaultSourceMap = true
  //const defaultSourceMap = 'inline' // originally
  const finalOpts = {
    ...opts,
    sourceMaps:
      opts.sourceMaps === undefined ? defaultSourceMap : opts.sourceMaps,
  }

  const output: swc.Output = swc.transformSync(code, finalOpts)

  //console.log('sourcemap', output.map)
  //const ranges = await sourceMapToWallabyRanges(output.map)
  let ranges = JSON.parse(output.ranges)

  // Spans to lines.
  const lines = code.split('\n')
  ranges = ranges.map(range => {
    const [x, startByte, y, endByte] = range
    const [startLine, startCol] = findLineColForByte(lines, startByte)
    const [endLine, endCol] = findLineColForByte(lines, endByte)
    const out = [startLine, startCol, endLine, endCol]
    return out
  })

  console.log('ranges', ranges)

  return {
    map: output.map,
    code: output.code,
    ranges,
  }
}

////////////////////////////////////////////////////////////////////////////////

function findLineColForByte(lines, index) {
  let totalLength = 0
  let lineStartPos = 0
  for (let lineNo = 0; lineNo < lines.length; lineNo++) {
    totalLength += lines[lineNo].length + 1 // Because we removed the '\n' during split.
    if (index < totalLength) {
      const colNo = index - lineStartPos
      return [lineNo + 1, colNo]
    }
    lineStartPos = totalLength
  }
  console.warn('WARN:', {totalLength, index})
  return []
}
```

I am new to Rust, so probably haven't done things in the best way.

Looking for feedback on the best way to get this access to the AST.

## Related

- https://github.com/swc-project/swc/issues/1366
- https://github.com/wallabyjs/public/issues/2818#issuecomment-929757665

