### PR TITLE
fix(spack): prevent spreading string into return

### DIFF
--- a/node-swc/src/spack.ts
+++ b/node-swc/src/spack.ts
@@ -22,7 +22,11 @@ export async function compileBundleOptions(config: BundleInput | string | undefi
             }
             return configFromFile;
         }
-        return Object.assign({}, configFromFile, config);
+
+        return {
+            ...configFromFile,
+            ...(typeof config === 'string') ? {} : config
+        };
     } catch (e) {
         if (typeof f === 'string') {
             throw new Error(`Error occurred while loading config file at ${config}: ${e}`);


### PR DESCRIPTION
## Summary

This PR prevent spreading string typed `config` into the return of `compileBundleOptions`

## What happened?

In this syntax
```js
return Object.assign({}, configFromFile, config);
```
`config` can be of type string referencing the config's file path.

Example:
If `config` is a file path = `"/app/c.js"`, the function will do

```js
Object.assign({}, configFromFile, "/app/c.js");
```

and the resultant return becomes
```js
{
  "0": "/",
  "1": "a",
  "2": "p",
  "3": "p",
  "4": "/",
  "5": "c",
  "6": ".",
  "7": "j",
  "8": "s",
  ...configFromFile,
}
```