### PR TITLE
Fix tests failing due to CRLF on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ansi_term 0.12.1",
  "difference",

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.14.0"
+version = "0.14.1"
 
 [dependencies]
 ansi_term = "0.12.1"


### PR DESCRIPTION
A few tests were failing when the repository is checked out with native windows line endings (so the expected content actually has CRLF in it)

I could have changed my git setup but might as well fix it for everyone a the change is simple and seems harmless.