### PR TITLE
fix(swc): Fix order of custom passes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,11 +15,6 @@
   "[typescript]": {
     "editor.formatOnSave": true
   },
-  "rust.rustflags": "--cfg procmacro2_semver_exempt",
-  // Important
-  "rust.cfg_test": false,
-  "rust-client.revealOutputChannelOn": "warn",
-  "rust-client.logToFile": true,
   "editor.formatOnSave": true,
   "git.ignoreLimitWarning": true
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2305,7 +2305,7 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "swc"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.62.0"
+version = "0.63.0"
 
 [lib]
 name = "swc"

--- a/benches/typescript.rs
+++ b/benches/typescript.rs
@@ -13,7 +13,7 @@ use swc::config::{Config, JscConfig, Options, SourceMapsConfig};
 use swc_common::{errors::Handler, FileName, FilePathMapping, SourceMap};
 use swc_ecma_ast::Program;
 use swc_ecma_parser::{JscTarget, Syntax, TsConfig};
-use swc_ecma_transforms::{fixer, hygiene, resolver, typescript};
+use swc_ecma_transforms::{fixer, hygiene, pass::noop, resolver, typescript};
 use swc_ecma_visit::FoldWith;
 use test::Bencher;
 
@@ -109,6 +109,7 @@ fn config_for_file(b: &mut Bencher) {
                 ..Default::default()
             },
             &FileName::Real("rxjs/src/internal/observable/dom/AjaxObservable.ts".into()),
+            noop(),
         ))
     });
 }
@@ -243,6 +244,7 @@ macro_rules! tr_only {
                         &FileName::Real(
                             "rxjs/src/internal/observable/dom/AjaxObservable.ts".into(),
                         ),
+                        noop(),
                     )
                     .unwrap()
                     .unwrap();

--- a/node/bundler/src/loaders/swc.rs
+++ b/node/bundler/src/loaders/swc.rs
@@ -18,6 +18,7 @@ use swc_ecma_transforms::{
         inline_globals,
         simplify::{dead_branch_remover, expr_simplifier},
     },
+    pass::noop,
 };
 use swc_ecma_visit::FoldWith;
 
@@ -221,6 +222,7 @@ impl SwcLoader {
                     ..Default::default()
                 },
                 &fm.name,
+                noop(),
             )?;
 
             tracing::trace!("JsLoader.load: loaded config");

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -154,6 +154,7 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
         syntax: Syntax,
         module: Option<ModuleConfig>,
         comments: Option<&'cmt SwcComments>,
+        custom_before_pass: impl 'cmt + swc_ecma_visit::Fold,
     ) -> impl 'cmt + swc_ecma_visit::Fold
     where
         P: 'cmt,
@@ -170,12 +171,14 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
             Either::Left(chain!(
                 import_assertions(),
                 Optional::new(typescript::strip(), syntax.typescript()),
+                custom_before_pass,
                 swc_ecma_preset_env::preset_env(self.global_mark, comments.clone(), env)
             ))
         } else {
             Either::Right(chain!(
                 import_assertions(),
                 Optional::new(typescript::strip(), syntax.typescript()),
+                custom_before_pass,
                 Optional::new(
                     compat::es2021::es2021(),
                     should_enable(self.target, JscTarget::Es2021)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -183,6 +183,7 @@ impl Options {
         is_module: bool,
         config: Option<Config>,
         comments: Option<&'a SwcComments>,
+        custom_before_pass: impl 'a + swc_ecma_visit::Fold,
     ) -> BuiltConfig<impl 'a + swc_ecma_visit::Fold> {
         let mut config = config.unwrap_or_else(Default::default);
         config.merge(&self.config);
@@ -288,6 +289,7 @@ impl Options {
                 syntax,
                 config.module,
                 comments,
+                custom_before_pass,
             );
 
         let pass = chain!(pass, Optional::new(jest::jest(), transform.hidden.jest));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 //! ## Custom javascript transforms
 //!
 //!
+//!
 //! ### What is [JsWord](swc_atoms::JsWord)?
 //!
 //! It's basically an interned string. See [swc_atoms].
@@ -29,10 +30,15 @@
 //!
 //! See [swc_atoms] for detailed description.
 //!
-//! ### [Fold](swc_ecma_visit::Fold) vs [VisitMut](swc_ecma_visit::VisitMut) vs
-//! [Visit](swc_ecma_visit::Visit)
+//! ### Fold vs VisitMut vs Visit
 //!
 //! See [swc_visit] for detailed description.
+//!
+//!
+//!  - [Fold](swc_ecma_visit::Fold)
+//!  - [VisitMut](swc_ecma_visit::VisitMut)
+//!  - [Visit](swc_ecma_visit::Visit)
+//!
 //!
 //! ### Variable management (Scoping)
 //!
@@ -76,6 +82,15 @@
 //!
 //!  - If you want to create [swc_ecma_ast::MemberExpr], you can use
 //!    [swc_ecma_utils::ExprFactory::as_obj] to create object field.
+//!
+//!
+//! ### Reducing binary size
+//!
+//! The visitor expands to a lot of code. You can reduce it by using macros like
+//!
+//!  - [noop_fold_type](swc_ecma_visit::noop_fold_type)
+//!  - [noop_visit_mut_type](swc_ecma_visit::noop_visit_mut_type)
+//!  - [noop_visit_type](swc_ecma_visit::noop_visit_type)
 #![deny(unused)]
 
 pub extern crate swc_atoms as atoms;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,10 @@
 //!  - [noop_fold_type](swc_ecma_visit::noop_fold_type)
 //!  - [noop_visit_mut_type](swc_ecma_visit::noop_visit_mut_type)
 //!  - [noop_visit_type](swc_ecma_visit::noop_visit_type)
+//!
+//! Note that this will make typescript-related nodes not processed, but it's
+//! typically fine as `typescript::strip` is invoked at the start and it removes
+//! typescript-specific nodes.
 #![deny(unused)]
 
 pub extern crate swc_atoms as atoms;

--- a/tests/projects.rs
+++ b/tests/projects.rs
@@ -12,7 +12,10 @@ use swc::{
 use swc_common::{chain, comments::Comment, BytePos, FileName};
 use swc_ecma_ast::{EsVersion, *};
 use swc_ecma_parser::{EsConfig, Syntax, TsConfig};
-use swc_ecma_transforms::helpers::{self, Helpers};
+use swc_ecma_transforms::{
+    helpers::{self, Helpers},
+    pass::noop,
+};
 use swc_ecma_utils::HANDLER;
 use swc_ecma_visit::{Fold, FoldWith};
 use testing::{NormalizedOutput, StdErr, Tester};
@@ -122,6 +125,7 @@ fn project(dir: &str) {
                         ..Default::default()
                     },
                     &fm.name,
+                    noop(),
                 )
                 .expect("failed to read config")
                 .is_none()
@@ -718,6 +722,7 @@ fn should_visit() {
                         ..Default::default()
                     },
                     &fm.name,
+                    noop(),
                 )
                 .unwrap()
                 .unwrap();

--- a/tests/rust-users.rs
+++ b/tests/rust-users.rs
@@ -1,0 +1,58 @@
+use swc::{
+    config::{Config, JscConfig, Options},
+    Compiler,
+};
+use swc_common::FileName;
+use swc_ecma_ast::*;
+use swc_ecma_parser::Syntax;
+use swc_ecma_transforms::pass::noop;
+use swc_ecma_visit::{as_folder, noop_visit_mut_type, VisitMut};
+
+struct NoopType;
+
+impl VisitMut for NoopType {
+    noop_visit_mut_type!();
+
+    fn visit_mut_number(&mut self, n: &mut Number) {
+        panic!("Expected {:?}", n.value)
+    }
+}
+
+#[test]
+#[should_panic(expected = "Expected 5.0")]
+fn test_visit_mut() {
+    testing::run_test2(false, |cm, handler| {
+        let c = Compiler::new(cm.clone());
+
+        let fm = cm.new_source_file(
+            FileName::Anon,
+            "
+                console.log(5 as const)
+            "
+            .into(),
+        );
+
+        let res = c.process_js_with_custom_pass(
+            fm,
+            &handler,
+            &Options {
+                config: Config {
+                    jsc: JscConfig {
+                        syntax: Some(Syntax::Typescript(Default::default())),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+
+                ..Default::default()
+            },
+            as_folder(NoopType),
+            noop(),
+        );
+
+        assert_ne!(res.unwrap().code, "console.log(5 as const)");
+
+        Ok(())
+    })
+    .unwrap()
+}


### PR DESCRIPTION
swc:
 - Invoke `resolver` and `typescript::strip` before applying user passes.