### PR TITLE
fix(es/utils): Fix macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.46.1"
+version = "0.46.2"
 dependencies = [
  "once_cell",
  "scoped-tls",

--- a/ecmascript/utils/Cargo.toml
+++ b/ecmascript/utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.46.1"
+version = "0.46.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ecmascript/utils/src/lib.rs
+++ b/ecmascript/utils/src/lib.rs
@@ -1,3 +1,6 @@
+#[doc(hidden)]
+pub extern crate swc_ecma_ast;
+
 pub use self::{
     factory::ExprFactory,
     ident::{id, Id},

--- a/ecmascript/utils/src/macros.rs
+++ b/ecmascript/utils/src/macros.rs
@@ -8,7 +8,7 @@ macro_rules! private_ident {
         use swc_common::Mark;
         let mark = Mark::fresh(Mark::root());
         let span = $span.apply_mark(mark);
-        ::swc_ecma_ast::Ident::new($s.into(), span)
+        $crate::swc_ecma_ast::Ident::new($s.into(), span)
     }};
 }
 
@@ -18,7 +18,7 @@ macro_rules! quote_ident {
         quote_ident!(::swc_common::DUMMY_SP, $s)
     };
     ($span:expr, $s:expr) => {{
-        ::swc_ecma_ast::Ident::new($s.into(), $span)
+        $crate::swc_ecma_ast::Ident::new($s.into(), $span)
     }};
 }
 
@@ -28,7 +28,7 @@ macro_rules! quote_str {
         quote_str!(::swc_common::DUMMY_SP, $s)
     };
     ($span:expr, $s:expr) => {{
-        ::swc_ecma_ast::Str {
+        $crate::swc_ecma_ast::Str {
             span: $span,
             value: $s.into(),
             has_escape: false,
@@ -40,7 +40,7 @@ macro_rules! quote_str {
 #[macro_export]
 macro_rules! quote_expr {
     ($span:expr, null) => {{
-        use swc_ecma_ast::*;
+        use $crate::swc_ecma_ast::*;
         Expr::Lit(Lit::Null(Null { span: $span }))
     }};
 
@@ -60,7 +60,7 @@ macro_rules! quote_expr {
 #[macro_export]
 macro_rules! member_expr {
     ($span:expr, $first:ident) => {{
-        use swc_ecma_ast::Expr;
+        use $crate::swc_ecma_ast::Expr;
         Box::new(Expr::Ident($crate::quote_ident!($span, stringify!($first))))
     }};
 
@@ -75,14 +75,14 @@ macro_rules! member_expr {
 
         member_expr!(@EXT, $span, Box::new(Expr::Member(MemberExpr{
             span: ::swc_common::DUMMY_SP,
-            obj: ExprOrSuper::Expr($obj),
+            obj: $crate::swc_ecma_ast::ExprOrSuper::Expr($obj),
             computed: false,
             prop,
         })), $($rest)*)
     }};
 
     (@EXT, $span:expr, $obj:expr,  $first:ident) => {{
-        use swc_ecma_ast::*;
+        use $crate::swc_ecma_ast::*;
         let prop = member_expr!($span, $first);
 
         Box::new(Expr::Member(MemberExpr{


### PR DESCRIPTION
swc_ecma_utils:
 - Allow using macros from crates using `swc_ecmascript`.