### PR TITLE
Test number

### DIFF
--- a/css/ast/src/token.rs
+++ b/css/ast/src/token.rs
@@ -36,32 +36,6 @@ pub enum Token {
     /// `#`
     Hash {
         is_id: bool,
-    /// `(`
-    LParen,
-
-    /// `)`
-    RParen,
-
-    /// `[`
-    LBracket,
-
-    /// `]`
-    RBracket,
-
-    Percent {
-        value: f64,
-    },
-
-    Dimension {
-        value: f64,
-        unit: JsWord
-    },
-
-    Number {
-        value: f64,
-    },
-
-    Ident {
         value: JsWord,
         raw: JsWord,
     },
@@ -106,6 +80,7 @@ pub enum Token {
         raw_value: JsWord,
         unit: JsWord,
         raw_unit: JsWord,
+        unit: JsWord
     },
 
     /// One or more whitespace.

--- a/css/ast/src/token.rs
+++ b/css/ast/src/token.rs
@@ -36,6 +36,33 @@ pub enum Token {
     /// `#`
     Hash {
         is_id: bool,
+    /// `(`
+    LParen,
+
+    /// `)`
+    RParen,
+
+    /// `[`
+    LBracket,
+
+    /// `]`
+    RBracket,
+
+    Percent {
+        value: f64,
+    },
+
+    Dimension {
+        value: f64,
+        unit: JsWord
+    },
+
+    // TODO name to `Number`
+    Num {
+        value: f64,
+    },
+
+    Ident {
         value: JsWord,
         raw: JsWord,
     },

--- a/css/ast/src/token.rs
+++ b/css/ast/src/token.rs
@@ -81,6 +81,8 @@ pub enum Token {
         unit: JsWord,
         raw_unit: JsWord,
         unit: JsWord
+        unit: JsWord,
+        raw_unit: JsWord,
     },
 
     /// One or more whitespace.

--- a/css/ast/src/token.rs
+++ b/css/ast/src/token.rs
@@ -57,8 +57,7 @@ pub enum Token {
         unit: JsWord
     },
 
-    // TODO name to `Number`
-    Num {
+    Number {
         value: f64,
     },
 

--- a/css/parser/src/lexer/mod.rs
+++ b/css/parser/src/lexer/mod.rs
@@ -638,11 +638,11 @@ where
 
         if self.would_start_ident()? {
             let name = self.read_name()?;
-            let unit = name.0;
 
             return Ok(Token::Dimension {
                 value: number,
-                unit,
+                unit: name.0,
+                raw_unit: name.1
             });
         } else if self.input.cur().unwrap() == '%' {
             self.input.bump();

--- a/css/parser/src/lexer/mod.rs
+++ b/css/parser/src/lexer/mod.rs
@@ -634,7 +634,7 @@ where
             return Ok(Token::Percent { value: number });
         }
 
-        Ok(Token::Num { value: number })
+        Ok(Token::Number { value: number })
     }
 
     /// Ported from `isValidEscape` of `esbuild`

--- a/css/parser/src/parser/at_rule.rs
+++ b/css/parser/src/parser/at_rule.rs
@@ -719,7 +719,6 @@ where
                     self.input.skip_ws()?;
 
                     let ctx = Ctx {
-                        allow_operation_in_value: true,
                         ..self.ctx
                     };
                     let value = self.with_ctx(ctx).parse_property_values()?.0;

--- a/css/parser/src/parser/macros.rs
+++ b/css/parser/src/parser/macros.rs
@@ -30,8 +30,8 @@ macro_rules! tok_pat {
         swc_css_ast::Token::Str { .. }
     };
 
-    (Num) => {
-        swc_css_ast::Token::Num { .. }
+    (Number) => {
+        swc_css_ast::Token::Number { .. }
     };
 
     (Url) => {

--- a/css/parser/src/parser/macros.rs
+++ b/css/parser/src/parser/macros.rs
@@ -30,8 +30,8 @@ macro_rules! tok_pat {
         swc_css_ast::Token::Str { .. }
     };
 
-    (Number) => {
-        swc_css_ast::Token::Number { .. }
+    (Num) => {
+        swc_css_ast::Token::Num { .. }
     };
 
     (Url) => {

--- a/css/parser/src/parser/mod.rs
+++ b/css/parser/src/parser/mod.rs
@@ -35,7 +35,6 @@ pub struct ParserConfig {
 
 #[derive(Debug, Default, Clone, Copy)]
 struct Ctx {
-    allow_operation_in_value: bool,
     allow_separating_value_with_space: bool,
     allow_separating_value_with_comma: bool,
 

--- a/css/parser/src/parser/style_rule.rs
+++ b/css/parser/src/parser/style_rule.rs
@@ -168,7 +168,6 @@ where
 
         if !self.input.is_eof()? {
             let ctx = Ctx {
-                allow_operation_in_value: false,
                 recover_from_property_value: true,
                 ..self.ctx
             };

--- a/css/parser/src/parser/value/mod.rs
+++ b/css/parser/src/parser/value/mod.rs
@@ -86,6 +86,7 @@ where
 
             loop {
                 if !is_one_of!(self, Str, Num, Ident, Function, Dimension, "[", "(") {
+                if !is_one_of!(self, Str, Number, Ident, "[", "(") {
                     break;
                 }
 
@@ -203,18 +204,18 @@ where
                 }
             }
 
-            Token::Num { value } => {
+            Token::Number { .. } => {
                 let token = bump!(self);
 
                 match token {
-                    Token::Num { value } => return Ok(Value::Number(Num { span, value })),
+                    Token::Number { value } => return Ok(Value::Number(Num { span, value })),
                     _ => {
                         unreachable!()
                     }
                 }
             }
 
-            Token::Percent { value } => {
+            Token::Percent { .. } => {
                 let token = bump!(self);
 
                 match token {
@@ -233,7 +234,7 @@ where
                 }
             }
 
-            Token::Dimension { value, unit } => {
+            Token::Dimension { .. } => {
                 let token = bump!(self);
 
                 match token {
@@ -625,7 +626,7 @@ where
     fn parse(&mut self) -> PResult<Num> {
         let span = self.input.cur_span()?;
 
-        if !is!(self, Num) {
+        if !is!(self, Number) {
             return Err(Error::new(span, ErrorKind::ExpectedNumber));
         }
 
@@ -634,6 +635,7 @@ where
         match value {
             Token::Num { value, raw, .. } => Ok(Num { span, value, raw }),
             Token::Num { value } => Ok(Num { span, value }),
+            Token::Number { value } => Ok(Num { span, value }),
             _ => {
                 unreachable!()
             }

--- a/css/parser/tests/fixture.rs
+++ b/css/parser/tests/fixture.rs
@@ -22,6 +22,7 @@ impl Visit for AssertValid {
 
         match &s.args.tokens[0].token {
             Token::Colon | Token::Num { .. } => return,
+            Token::Colon => return,
             _ => {}
         }
 

--- a/css/parser/tests/fixture/value/number/input.css
+++ b/css/parser/tests/fixture/value/number/input.css
@@ -6,6 +6,8 @@ div {
     property: 0.1;
     property: 1.0;
     property: 0.0;
+    property: +0.0;
+    property: -0.0;
     property: .0;
     property: 1.200000;
     property: 1.2e2;
@@ -23,5 +25,4 @@ div {
     property: 1.75;
     property: +1.75;
     property: 1e;
-    property: 1e+;
 }

--- a/css/parser/tests/fixture/value/number/input.css
+++ b/css/parser/tests/fixture/value/number/input.css
@@ -1,0 +1,25 @@
+div {
+    property: 0;
+    property: 10;
+    property: .10;
+    property: 12.34;
+    property: 0.1;
+    property: 1.0;
+    property: 0.0;
+    property: .0;
+    property: 1.200000;
+    property: 1.2e2;
+    property: 1e2;
+    property: .2e2;
+    property: 1.2E2;
+    property: 1.2e+2;
+    property: 1.2e-2;
+    property: -1;
+    property: -1.2;
+    property: -.2;
+    property: -.2;
+    property: +.2;
+    property: -1.2e3;
+    property: 1.75;
+    property: +1.75;
+}

--- a/css/parser/tests/fixture/value/number/input.css
+++ b/css/parser/tests/fixture/value/number/input.css
@@ -22,4 +22,6 @@ div {
     property: -1.2e3;
     property: 1.75;
     property: +1.75;
+    property: 1e;
+    property: 1e+;
 }

--- a/css/parser/tests/fixture/value/number/output.json
+++ b/css/parser/tests/fixture/value/number/output.json
@@ -2,7 +2,7 @@
   "type": "Stylesheet",
   "span": {
     "start": 0,
-    "end": 464,
+    "end": 502,
     "ctxt": 0
   },
   "rules": [
@@ -10,7 +10,7 @@
       "type": "StyleRule",
       "span": {
         "start": 0,
-        "end": 464,
+        "end": 501,
         "ctxt": 0
       },
       "selectors": [
@@ -59,7 +59,7 @@
         "type": "DeclBlock",
         "span": {
           "start": 4,
-          "end": 464,
+          "end": 501,
           "ctxt": 0
         },
         "items": [
@@ -891,6 +891,124 @@
                   "ctxt": 0
                 },
                 "value": 1.75
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 467,
+              "end": 479,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 467,
+                "end": 475,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "UnitValue",
+                "span": {
+                  "start": 477,
+                  "end": 479,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 477,
+                    "end": 478,
+                    "ctxt": 0
+                  },
+                  "value": 1.0
+                },
+                "unit": {
+                  "span": {
+                    "start": 478,
+                    "end": 479,
+                    "ctxt": 0
+                  },
+                  "kind": "e"
+                }
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 485,
+              "end": 497,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 485,
+                "end": 493,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Tokens",
+                "span": {
+                  "start": 494,
+                  "end": 498,
+                  "ctxt": 0
+                },
+                "tokens": [
+                  {
+                    "span": {
+                      "start": 494,
+                      "end": 495,
+                      "ctxt": 0
+                    },
+                    "token": "WhiteSpace"
+                  },
+                  {
+                    "span": {
+                      "start": 495,
+                      "end": 496,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "Num": {
+                        "value": 1.0
+                      }
+                    }
+                  },
+                  {
+                    "span": {
+                      "start": 496,
+                      "end": 497,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "Ident": {
+                        "value": "e",
+                        "raw": "e"
+                      }
+                    }
+                  },
+                  {
+                    "span": {
+                      "start": 497,
+                      "end": 498,
+                      "ctxt": 0
+                    },
+                    "token": "Plus"
+                  }
+                ]
               }
             ],
             "important": null

--- a/css/parser/tests/fixture/value/number/output.json
+++ b/css/parser/tests/fixture/value/number/output.json
@@ -1,0 +1,902 @@
+{
+  "type": "Stylesheet",
+  "span": {
+    "start": 0,
+    "end": 464,
+    "ctxt": 0
+  },
+  "rules": [
+    {
+      "type": "StyleRule",
+      "span": {
+        "start": 0,
+        "end": 464,
+        "ctxt": 0
+      },
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "hasNestPrefix": false,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
+                "span": {
+                  "start": 0,
+                  "end": 3,
+                  "ctxt": 0
+                },
+                "prefix": null,
+                "name": {
+                  "type": "Text",
+                  "span": {
+                    "start": 0,
+                    "end": 3,
+                    "ctxt": 0
+                  },
+                  "value": "div",
+                  "raw": "div"
+                }
+              },
+              "subclassSelectors": []
+            }
+          ]
+        }
+      ],
+      "block": {
+        "type": "DeclBlock",
+        "span": {
+          "start": 4,
+          "end": 464,
+          "ctxt": 0
+        },
+        "items": [
+          {
+            "type": "Property",
+            "span": {
+              "start": 10,
+              "end": 21,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 10,
+                "end": 18,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 20,
+                  "end": 21,
+                  "ctxt": 0
+                },
+                "value": 0.0
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 27,
+              "end": 39,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 27,
+                "end": 35,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 37,
+                  "end": 39,
+                  "ctxt": 0
+                },
+                "value": 10.0
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 45,
+              "end": 58,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 45,
+                "end": 53,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 55,
+                  "end": 58,
+                  "ctxt": 0
+                },
+                "value": 0.1
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 64,
+              "end": 79,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 64,
+                "end": 72,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 74,
+                  "end": 79,
+                  "ctxt": 0
+                },
+                "value": 12.34
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 85,
+              "end": 98,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 85,
+                "end": 93,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 95,
+                  "end": 98,
+                  "ctxt": 0
+                },
+                "value": 0.1
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 104,
+              "end": 117,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 104,
+                "end": 112,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 114,
+                  "end": 117,
+                  "ctxt": 0
+                },
+                "value": 1.0
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 123,
+              "end": 136,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 123,
+                "end": 131,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 133,
+                  "end": 136,
+                  "ctxt": 0
+                },
+                "value": 0.0
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 142,
+              "end": 154,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 142,
+                "end": 150,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 152,
+                  "end": 154,
+                  "ctxt": 0
+                },
+                "value": 0.0
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 160,
+              "end": 178,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 160,
+                "end": 168,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 170,
+                  "end": 178,
+                  "ctxt": 0
+                },
+                "value": 1.2
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 184,
+              "end": 199,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 184,
+                "end": 192,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "UnitValue",
+                "span": {
+                  "start": 194,
+                  "end": 199,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 194,
+                    "end": 197,
+                    "ctxt": 0
+                  },
+                  "value": 1.2
+                },
+                "unit": {
+                  "span": {
+                    "start": 197,
+                    "end": 199,
+                    "ctxt": 0
+                  },
+                  "kind": "e2"
+                }
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 205,
+              "end": 218,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 205,
+                "end": 213,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "UnitValue",
+                "span": {
+                  "start": 215,
+                  "end": 218,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 215,
+                    "end": 216,
+                    "ctxt": 0
+                  },
+                  "value": 1.0
+                },
+                "unit": {
+                  "span": {
+                    "start": 216,
+                    "end": 218,
+                    "ctxt": 0
+                  },
+                  "kind": "e2"
+                }
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 224,
+              "end": 238,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 224,
+                "end": 232,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "UnitValue",
+                "span": {
+                  "start": 234,
+                  "end": 238,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 234,
+                    "end": 236,
+                    "ctxt": 0
+                  },
+                  "value": 0.2
+                },
+                "unit": {
+                  "span": {
+                    "start": 236,
+                    "end": 238,
+                    "ctxt": 0
+                  },
+                  "kind": "e2"
+                }
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 244,
+              "end": 259,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 244,
+                "end": 252,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "UnitValue",
+                "span": {
+                  "start": 254,
+                  "end": 259,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 254,
+                    "end": 257,
+                    "ctxt": 0
+                  },
+                  "value": 1.2
+                },
+                "unit": {
+                  "span": {
+                    "start": 257,
+                    "end": 259,
+                    "ctxt": 0
+                  },
+                  "kind": "E2"
+                }
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 265,
+              "end": 279,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 265,
+                "end": 273,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Tokens",
+                "span": {
+                  "start": 274,
+                  "end": 281,
+                  "ctxt": 0
+                },
+                "tokens": [
+                  {
+                    "span": {
+                      "start": 274,
+                      "end": 275,
+                      "ctxt": 0
+                    },
+                    "token": "WhiteSpace"
+                  },
+                  {
+                    "span": {
+                      "start": 275,
+                      "end": 278,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "Num": {
+                        "value": 1.2
+                      }
+                    }
+                  },
+                  {
+                    "span": {
+                      "start": 278,
+                      "end": 279,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "Ident": {
+                        "value": "e",
+                        "raw": "e"
+                      }
+                    }
+                  },
+                  {
+                    "span": {
+                      "start": 279,
+                      "end": 281,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "Num": {
+                        "value": 2.0
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 287,
+              "end": 303,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 287,
+                "end": 295,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "UnitValue",
+                "span": {
+                  "start": 297,
+                  "end": 303,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 297,
+                    "end": 300,
+                    "ctxt": 0
+                  },
+                  "value": 1.2
+                },
+                "unit": {
+                  "span": {
+                    "start": 300,
+                    "end": 303,
+                    "ctxt": 0
+                  },
+                  "kind": "e-2"
+                }
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 309,
+              "end": 321,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 309,
+                "end": 317,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 319,
+                  "end": 321,
+                  "ctxt": 0
+                },
+                "value": -1.0
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 327,
+              "end": 341,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 327,
+                "end": 335,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 337,
+                  "end": 341,
+                  "ctxt": 0
+                },
+                "value": -1.2
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 347,
+              "end": 360,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 347,
+                "end": 355,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 357,
+                  "end": 360,
+                  "ctxt": 0
+                },
+                "value": -0.2
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 366,
+              "end": 379,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 366,
+                "end": 374,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 376,
+                  "end": 379,
+                  "ctxt": 0
+                },
+                "value": -0.2
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 385,
+              "end": 398,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 385,
+                "end": 393,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 395,
+                  "end": 398,
+                  "ctxt": 0
+                },
+                "value": 0.2
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 404,
+              "end": 420,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 404,
+                "end": 412,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "UnitValue",
+                "span": {
+                  "start": 414,
+                  "end": 420,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 414,
+                    "end": 418,
+                    "ctxt": 0
+                  },
+                  "value": -1.2
+                },
+                "unit": {
+                  "span": {
+                    "start": 418,
+                    "end": 420,
+                    "ctxt": 0
+                  },
+                  "kind": "e3"
+                }
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 426,
+              "end": 440,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 426,
+                "end": 434,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 436,
+                  "end": 440,
+                  "ctxt": 0
+                },
+                "value": 1.75
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 446,
+              "end": 461,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 446,
+                "end": 454,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 456,
+                  "end": 461,
+                  "ctxt": 0
+                },
+                "value": 1.75
+              }
+            ],
+            "important": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/css/parser/tests/fixture/value/number/output.json
+++ b/css/parser/tests/fixture/value/number/output.json
@@ -2,7 +2,7 @@
   "type": "Stylesheet",
   "span": {
     "start": 0,
-    "end": 502,
+    "end": 523,
     "ctxt": 0
   },
   "rules": [
@@ -10,7 +10,7 @@
       "type": "StyleRule",
       "span": {
         "start": 0,
-        "end": 501,
+        "end": 522,
         "ctxt": 0
       },
       "selectors": [
@@ -59,7 +59,7 @@
         "type": "DeclBlock",
         "span": {
           "start": 4,
-          "end": 501,
+          "end": 522,
           "ctxt": 0
         },
         "items": [
@@ -277,7 +277,7 @@
             "type": "Property",
             "span": {
               "start": 142,
-              "end": 154,
+              "end": 156,
               "ctxt": 0
             },
             "name": {
@@ -295,7 +295,7 @@
                 "type": "Number",
                 "span": {
                   "start": 152,
-                  "end": 154,
+                  "end": 156,
                   "ctxt": 0
                 },
                 "value": 0.0
@@ -306,15 +306,15 @@
           {
             "type": "Property",
             "span": {
-              "start": 160,
-              "end": 178,
+              "start": 162,
+              "end": 176,
               "ctxt": 0
             },
             "name": {
               "type": "Text",
               "span": {
-                "start": 160,
-                "end": 168,
+                "start": 162,
+                "end": 170,
                 "ctxt": 0
               },
               "value": "property",
@@ -324,8 +324,68 @@
               {
                 "type": "Number",
                 "span": {
-                  "start": 170,
-                  "end": 178,
+                  "start": 172,
+                  "end": 176,
+                  "ctxt": 0
+                },
+                "value": -0.0
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 182,
+              "end": 194,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 182,
+                "end": 190,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 192,
+                  "end": 194,
+                  "ctxt": 0
+                },
+                "value": 0.0
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 200,
+              "end": 218,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 200,
+                "end": 208,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 210,
+                  "end": 218,
                   "ctxt": 0
                 },
                 "value": 1.2
@@ -336,100 +396,8 @@
           {
             "type": "Property",
             "span": {
-              "start": 184,
-              "end": 199,
-              "ctxt": 0
-            },
-            "name": {
-              "type": "Text",
-              "span": {
-                "start": 184,
-                "end": 192,
-                "ctxt": 0
-              },
-              "value": "property",
-              "raw": "property"
-            },
-            "values": [
-              {
-                "type": "UnitValue",
-                "span": {
-                  "start": 194,
-                  "end": 199,
-                  "ctxt": 0
-                },
-                "value": {
-                  "type": "Number",
-                  "span": {
-                    "start": 194,
-                    "end": 197,
-                    "ctxt": 0
-                  },
-                  "value": 1.2
-                },
-                "unit": {
-                  "span": {
-                    "start": 197,
-                    "end": 199,
-                    "ctxt": 0
-                  },
-                  "kind": "e2"
-                }
-              }
-            ],
-            "important": null
-          },
-          {
-            "type": "Property",
-            "span": {
-              "start": 205,
-              "end": 218,
-              "ctxt": 0
-            },
-            "name": {
-              "type": "Text",
-              "span": {
-                "start": 205,
-                "end": 213,
-                "ctxt": 0
-              },
-              "value": "property",
-              "raw": "property"
-            },
-            "values": [
-              {
-                "type": "UnitValue",
-                "span": {
-                  "start": 215,
-                  "end": 218,
-                  "ctxt": 0
-                },
-                "value": {
-                  "type": "Number",
-                  "span": {
-                    "start": 215,
-                    "end": 216,
-                    "ctxt": 0
-                  },
-                  "value": 1.0
-                },
-                "unit": {
-                  "span": {
-                    "start": 216,
-                    "end": 218,
-                    "ctxt": 0
-                  },
-                  "kind": "e2"
-                }
-              }
-            ],
-            "important": null
-          },
-          {
-            "type": "Property",
-            "span": {
               "start": 224,
-              "end": 238,
+              "end": 239,
               "ctxt": 0
             },
             "name": {
@@ -447,22 +415,22 @@
                 "type": "UnitValue",
                 "span": {
                   "start": 234,
-                  "end": 238,
+                  "end": 239,
                   "ctxt": 0
                 },
                 "value": {
                   "type": "Number",
                   "span": {
                     "start": 234,
-                    "end": 236,
+                    "end": 237,
                     "ctxt": 0
                   },
-                  "value": 0.2
+                  "value": 1.2
                 },
                 "unit": {
                   "span": {
-                    "start": 236,
-                    "end": 238,
+                    "start": 237,
+                    "end": 239,
                     "ctxt": 0
                   },
                   "kind": "e2"
@@ -474,15 +442,15 @@
           {
             "type": "Property",
             "span": {
-              "start": 244,
-              "end": 259,
+              "start": 245,
+              "end": 258,
               "ctxt": 0
             },
             "name": {
               "type": "Text",
               "span": {
-                "start": 244,
-                "end": 252,
+                "start": 245,
+                "end": 253,
                 "ctxt": 0
               },
               "value": "property",
@@ -492,23 +460,115 @@
               {
                 "type": "UnitValue",
                 "span": {
-                  "start": 254,
-                  "end": 259,
+                  "start": 255,
+                  "end": 258,
                   "ctxt": 0
                 },
                 "value": {
                   "type": "Number",
                   "span": {
-                    "start": 254,
-                    "end": 257,
+                    "start": 255,
+                    "end": 256,
+                    "ctxt": 0
+                  },
+                  "value": 1.0
+                },
+                "unit": {
+                  "span": {
+                    "start": 256,
+                    "end": 258,
+                    "ctxt": 0
+                  },
+                  "kind": "e2"
+                }
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 264,
+              "end": 278,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 264,
+                "end": 272,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "UnitValue",
+                "span": {
+                  "start": 274,
+                  "end": 278,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 274,
+                    "end": 276,
+                    "ctxt": 0
+                  },
+                  "value": 0.2
+                },
+                "unit": {
+                  "span": {
+                    "start": 276,
+                    "end": 278,
+                    "ctxt": 0
+                  },
+                  "kind": "e2"
+                }
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 284,
+              "end": 299,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 284,
+                "end": 292,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "UnitValue",
+                "span": {
+                  "start": 294,
+                  "end": 299,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 294,
+                    "end": 297,
                     "ctxt": 0
                   },
                   "value": 1.2
                 },
                 "unit": {
                   "span": {
-                    "start": 257,
-                    "end": 259,
+                    "start": 297,
+                    "end": 299,
                     "ctxt": 0
                   },
                   "kind": "E2"
@@ -520,15 +580,15 @@
           {
             "type": "Property",
             "span": {
-              "start": 265,
-              "end": 279,
+              "start": 305,
+              "end": 319,
               "ctxt": 0
             },
             "name": {
               "type": "Text",
               "span": {
-                "start": 265,
-                "end": 273,
+                "start": 305,
+                "end": 313,
                 "ctxt": 0
               },
               "value": "property",
@@ -538,23 +598,23 @@
               {
                 "type": "Tokens",
                 "span": {
-                  "start": 274,
-                  "end": 281,
+                  "start": 314,
+                  "end": 321,
                   "ctxt": 0
                 },
                 "tokens": [
                   {
                     "span": {
-                      "start": 274,
-                      "end": 275,
+                      "start": 314,
+                      "end": 315,
                       "ctxt": 0
                     },
                     "token": "WhiteSpace"
                   },
                   {
                     "span": {
-                      "start": 275,
-                      "end": 278,
+                      "start": 315,
+                      "end": 318,
                       "ctxt": 0
                     },
                     "token": {
@@ -565,8 +625,8 @@
                   },
                   {
                     "span": {
-                      "start": 278,
-                      "end": 279,
+                      "start": 318,
+                      "end": 319,
                       "ctxt": 0
                     },
                     "token": {
@@ -578,8 +638,8 @@
                   },
                   {
                     "span": {
-                      "start": 279,
-                      "end": 281,
+                      "start": 319,
+                      "end": 321,
                       "ctxt": 0
                     },
                     "token": {
@@ -596,84 +656,8 @@
           {
             "type": "Property",
             "span": {
-              "start": 287,
-              "end": 303,
-              "ctxt": 0
-            },
-            "name": {
-              "type": "Text",
-              "span": {
-                "start": 287,
-                "end": 295,
-                "ctxt": 0
-              },
-              "value": "property",
-              "raw": "property"
-            },
-            "values": [
-              {
-                "type": "UnitValue",
-                "span": {
-                  "start": 297,
-                  "end": 303,
-                  "ctxt": 0
-                },
-                "value": {
-                  "type": "Number",
-                  "span": {
-                    "start": 297,
-                    "end": 300,
-                    "ctxt": 0
-                  },
-                  "value": 1.2
-                },
-                "unit": {
-                  "span": {
-                    "start": 300,
-                    "end": 303,
-                    "ctxt": 0
-                  },
-                  "kind": "e-2"
-                }
-              }
-            ],
-            "important": null
-          },
-          {
-            "type": "Property",
-            "span": {
-              "start": 309,
-              "end": 321,
-              "ctxt": 0
-            },
-            "name": {
-              "type": "Text",
-              "span": {
-                "start": 309,
-                "end": 317,
-                "ctxt": 0
-              },
-              "value": "property",
-              "raw": "property"
-            },
-            "values": [
-              {
-                "type": "Number",
-                "span": {
-                  "start": 319,
-                  "end": 321,
-                  "ctxt": 0
-                },
-                "value": -1.0
-              }
-            ],
-            "important": null
-          },
-          {
-            "type": "Property",
-            "span": {
               "start": 327,
-              "end": 341,
+              "end": 343,
               "ctxt": 0
             },
             "name": {
@@ -688,10 +672,86 @@
             },
             "values": [
               {
-                "type": "Number",
+                "type": "UnitValue",
                 "span": {
                   "start": 337,
-                  "end": 341,
+                  "end": 343,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 337,
+                    "end": 340,
+                    "ctxt": 0
+                  },
+                  "value": 1.2
+                },
+                "unit": {
+                  "span": {
+                    "start": 340,
+                    "end": 343,
+                    "ctxt": 0
+                  },
+                  "kind": "e-2"
+                }
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 349,
+              "end": 361,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 349,
+                "end": 357,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 359,
+                  "end": 361,
+                  "ctxt": 0
+                },
+                "value": -1.0
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Property",
+            "span": {
+              "start": 367,
+              "end": 381,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Text",
+              "span": {
+                "start": 367,
+                "end": 375,
+                "ctxt": 0
+              },
+              "value": "property",
+              "raw": "property"
+            },
+            "values": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 377,
+                  "end": 381,
                   "ctxt": 0
                 },
                 "value": -1.2
@@ -702,15 +762,15 @@
           {
             "type": "Property",
             "span": {
-              "start": 347,
-              "end": 360,
+              "start": 387,
+              "end": 400,
               "ctxt": 0
             },
             "name": {
               "type": "Text",
               "span": {
-                "start": 347,
-                "end": 355,
+                "start": 387,
+                "end": 395,
                 "ctxt": 0
               },
               "value": "property",
@@ -720,8 +780,8 @@
               {
                 "type": "Number",
                 "span": {
-                  "start": 357,
-                  "end": 360,
+                  "start": 397,
+                  "end": 400,
                   "ctxt": 0
                 },
                 "value": -0.2
@@ -732,15 +792,15 @@
           {
             "type": "Property",
             "span": {
-              "start": 366,
-              "end": 379,
+              "start": 406,
+              "end": 419,
               "ctxt": 0
             },
             "name": {
               "type": "Text",
               "span": {
-                "start": 366,
-                "end": 374,
+                "start": 406,
+                "end": 414,
                 "ctxt": 0
               },
               "value": "property",
@@ -750,8 +810,8 @@
               {
                 "type": "Number",
                 "span": {
-                  "start": 376,
-                  "end": 379,
+                  "start": 416,
+                  "end": 419,
                   "ctxt": 0
                 },
                 "value": -0.2
@@ -762,15 +822,15 @@
           {
             "type": "Property",
             "span": {
-              "start": 385,
-              "end": 398,
+              "start": 425,
+              "end": 438,
               "ctxt": 0
             },
             "name": {
               "type": "Text",
               "span": {
-                "start": 385,
-                "end": 393,
+                "start": 425,
+                "end": 433,
                 "ctxt": 0
               },
               "value": "property",
@@ -780,8 +840,8 @@
               {
                 "type": "Number",
                 "span": {
-                  "start": 395,
-                  "end": 398,
+                  "start": 435,
+                  "end": 438,
                   "ctxt": 0
                 },
                 "value": 0.2
@@ -792,15 +852,15 @@
           {
             "type": "Property",
             "span": {
-              "start": 404,
-              "end": 420,
+              "start": 444,
+              "end": 460,
               "ctxt": 0
             },
             "name": {
               "type": "Text",
               "span": {
-                "start": 404,
-                "end": 412,
+                "start": 444,
+                "end": 452,
                 "ctxt": 0
               },
               "value": "property",
@@ -810,23 +870,23 @@
               {
                 "type": "UnitValue",
                 "span": {
-                  "start": 414,
-                  "end": 420,
+                  "start": 454,
+                  "end": 460,
                   "ctxt": 0
                 },
                 "value": {
                   "type": "Number",
                   "span": {
-                    "start": 414,
-                    "end": 418,
+                    "start": 454,
+                    "end": 458,
                     "ctxt": 0
                   },
                   "value": -1.2
                 },
                 "unit": {
                   "span": {
-                    "start": 418,
-                    "end": 420,
+                    "start": 458,
+                    "end": 460,
                     "ctxt": 0
                   },
                   "kind": "e3"
@@ -838,15 +898,15 @@
           {
             "type": "Property",
             "span": {
-              "start": 426,
-              "end": 440,
+              "start": 466,
+              "end": 480,
               "ctxt": 0
             },
             "name": {
               "type": "Text",
               "span": {
-                "start": 426,
-                "end": 434,
+                "start": 466,
+                "end": 474,
                 "ctxt": 0
               },
               "value": "property",
@@ -856,8 +916,8 @@
               {
                 "type": "Number",
                 "span": {
-                  "start": 436,
-                  "end": 440,
+                  "start": 476,
+                  "end": 480,
                   "ctxt": 0
                 },
                 "value": 1.75
@@ -868,15 +928,15 @@
           {
             "type": "Property",
             "span": {
-              "start": 446,
-              "end": 461,
+              "start": 486,
+              "end": 501,
               "ctxt": 0
             },
             "name": {
               "type": "Text",
               "span": {
-                "start": 446,
-                "end": 454,
+                "start": 486,
+                "end": 494,
                 "ctxt": 0
               },
               "value": "property",
@@ -886,8 +946,8 @@
               {
                 "type": "Number",
                 "span": {
-                  "start": 456,
-                  "end": 461,
+                  "start": 496,
+                  "end": 501,
                   "ctxt": 0
                 },
                 "value": 1.75
@@ -898,15 +958,15 @@
           {
             "type": "Property",
             "span": {
-              "start": 467,
-              "end": 479,
+              "start": 507,
+              "end": 519,
               "ctxt": 0
             },
             "name": {
               "type": "Text",
               "span": {
-                "start": 467,
-                "end": 475,
+                "start": 507,
+                "end": 515,
                 "ctxt": 0
               },
               "value": "property",
@@ -916,99 +976,27 @@
               {
                 "type": "UnitValue",
                 "span": {
-                  "start": 477,
-                  "end": 479,
+                  "start": 517,
+                  "end": 519,
                   "ctxt": 0
                 },
                 "value": {
                   "type": "Number",
                   "span": {
-                    "start": 477,
-                    "end": 478,
+                    "start": 517,
+                    "end": 518,
                     "ctxt": 0
                   },
                   "value": 1.0
                 },
                 "unit": {
                   "span": {
-                    "start": 478,
-                    "end": 479,
+                    "start": 518,
+                    "end": 519,
                     "ctxt": 0
                   },
                   "kind": "e"
                 }
-              }
-            ],
-            "important": null
-          },
-          {
-            "type": "Property",
-            "span": {
-              "start": 485,
-              "end": 497,
-              "ctxt": 0
-            },
-            "name": {
-              "type": "Text",
-              "span": {
-                "start": 485,
-                "end": 493,
-                "ctxt": 0
-              },
-              "value": "property",
-              "raw": "property"
-            },
-            "values": [
-              {
-                "type": "Tokens",
-                "span": {
-                  "start": 494,
-                  "end": 498,
-                  "ctxt": 0
-                },
-                "tokens": [
-                  {
-                    "span": {
-                      "start": 494,
-                      "end": 495,
-                      "ctxt": 0
-                    },
-                    "token": "WhiteSpace"
-                  },
-                  {
-                    "span": {
-                      "start": 495,
-                      "end": 496,
-                      "ctxt": 0
-                    },
-                    "token": {
-                      "Num": {
-                        "value": 1.0
-                      }
-                    }
-                  },
-                  {
-                    "span": {
-                      "start": 496,
-                      "end": 497,
-                      "ctxt": 0
-                    },
-                    "token": {
-                      "Ident": {
-                        "value": "e",
-                        "raw": "e"
-                      }
-                    }
-                  },
-                  {
-                    "span": {
-                      "start": 497,
-                      "end": 498,
-                      "ctxt": 0
-                    },
-                    "token": "Plus"
-                  }
-                ]
               }
             ],
             "important": null

--- a/css/parser/tests/fixture/value/number/span.rust-debug
+++ b/css/parser/tests/fixture/value/number/span.rust-debug
@@ -1,0 +1,721 @@
+error: Stylesheet
+  --> $DIR/tests/fixture/value/number/input.css:1:1
+   |
+1  | / div {
+2  | |     property: 0;
+3  | |     property: 10;
+4  | |     property: .10;
+...  |
+24 | |     property: +1.75;
+25 | | }
+   | |_^
+
+error: Rule
+  --> $DIR/tests/fixture/value/number/input.css:1:1
+   |
+1  | / div {
+2  | |     property: 0;
+3  | |     property: 10;
+4  | |     property: .10;
+...  |
+24 | |     property: +1.75;
+25 | | }
+   | |_^
+
+error: StyleRule
+  --> $DIR/tests/fixture/value/number/input.css:1:1
+   |
+1  | / div {
+2  | |     property: 0;
+3  | |     property: 10;
+4  | |     property: .10;
+...  |
+24 | |     property: +1.75;
+25 | | }
+   | |_^
+
+error: ComplexSelector
+ --> $DIR/tests/fixture/value/number/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: CompoundSelector
+ --> $DIR/tests/fixture/value/number/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: NamespacedName
+ --> $DIR/tests/fixture/value/number/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/number/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: DeclBlock
+  --> $DIR/tests/fixture/value/number/input.css:1:5
+   |
+1  |   div {
+   |  _____^
+2  | |     property: 0;
+3  | |     property: 10;
+4  | |     property: .10;
+...  |
+24 | |     property: +1.75;
+25 | | }
+   | |_^
+
+error: Property
+ --> $DIR/tests/fixture/value/number/input.css:2:5
+  |
+2 |     property: 0;
+  |     ^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/number/input.css:2:5
+  |
+2 |     property: 0;
+  |     ^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/number/input.css:2:15
+  |
+2 |     property: 0;
+  |               ^
+
+error: Num
+ --> $DIR/tests/fixture/value/number/input.css:2:15
+  |
+2 |     property: 0;
+  |               ^
+
+error: Property
+ --> $DIR/tests/fixture/value/number/input.css:3:5
+  |
+3 |     property: 10;
+  |     ^^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/number/input.css:3:5
+  |
+3 |     property: 10;
+  |     ^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/number/input.css:3:15
+  |
+3 |     property: 10;
+  |               ^^
+
+error: Num
+ --> $DIR/tests/fixture/value/number/input.css:3:15
+  |
+3 |     property: 10;
+  |               ^^
+
+error: Property
+ --> $DIR/tests/fixture/value/number/input.css:4:5
+  |
+4 |     property: .10;
+  |     ^^^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/number/input.css:4:5
+  |
+4 |     property: .10;
+  |     ^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/number/input.css:4:15
+  |
+4 |     property: .10;
+  |               ^^^
+
+error: Num
+ --> $DIR/tests/fixture/value/number/input.css:4:15
+  |
+4 |     property: .10;
+  |               ^^^
+
+error: Property
+ --> $DIR/tests/fixture/value/number/input.css:5:5
+  |
+5 |     property: 12.34;
+  |     ^^^^^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/number/input.css:5:5
+  |
+5 |     property: 12.34;
+  |     ^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/number/input.css:5:15
+  |
+5 |     property: 12.34;
+  |               ^^^^^
+
+error: Num
+ --> $DIR/tests/fixture/value/number/input.css:5:15
+  |
+5 |     property: 12.34;
+  |               ^^^^^
+
+error: Property
+ --> $DIR/tests/fixture/value/number/input.css:6:5
+  |
+6 |     property: 0.1;
+  |     ^^^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/number/input.css:6:5
+  |
+6 |     property: 0.1;
+  |     ^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/number/input.css:6:15
+  |
+6 |     property: 0.1;
+  |               ^^^
+
+error: Num
+ --> $DIR/tests/fixture/value/number/input.css:6:15
+  |
+6 |     property: 0.1;
+  |               ^^^
+
+error: Property
+ --> $DIR/tests/fixture/value/number/input.css:7:5
+  |
+7 |     property: 1.0;
+  |     ^^^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/number/input.css:7:5
+  |
+7 |     property: 1.0;
+  |     ^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/number/input.css:7:15
+  |
+7 |     property: 1.0;
+  |               ^^^
+
+error: Num
+ --> $DIR/tests/fixture/value/number/input.css:7:15
+  |
+7 |     property: 1.0;
+  |               ^^^
+
+error: Property
+ --> $DIR/tests/fixture/value/number/input.css:8:5
+  |
+8 |     property: 0.0;
+  |     ^^^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/number/input.css:8:5
+  |
+8 |     property: 0.0;
+  |     ^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/number/input.css:8:15
+  |
+8 |     property: 0.0;
+  |               ^^^
+
+error: Num
+ --> $DIR/tests/fixture/value/number/input.css:8:15
+  |
+8 |     property: 0.0;
+  |               ^^^
+
+error: Property
+ --> $DIR/tests/fixture/value/number/input.css:9:5
+  |
+9 |     property: .0;
+  |     ^^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/number/input.css:9:5
+  |
+9 |     property: .0;
+  |     ^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/number/input.css:9:15
+  |
+9 |     property: .0;
+  |               ^^
+
+error: Num
+ --> $DIR/tests/fixture/value/number/input.css:9:15
+  |
+9 |     property: .0;
+  |               ^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:10:5
+   |
+10 |     property: 1.200000;
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:10:5
+   |
+10 |     property: 1.200000;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:10:15
+   |
+10 |     property: 1.200000;
+   |               ^^^^^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:10:15
+   |
+10 |     property: 1.200000;
+   |               ^^^^^^^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:11:5
+   |
+11 |     property: 1.2e2;
+   |     ^^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:11:5
+   |
+11 |     property: 1.2e2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:11:15
+   |
+11 |     property: 1.2e2;
+   |               ^^^^^
+
+error: UnitValue
+  --> $DIR/tests/fixture/value/number/input.css:11:15
+   |
+11 |     property: 1.2e2;
+   |               ^^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:11:15
+   |
+11 |     property: 1.2e2;
+   |               ^^^
+
+error: Unit
+  --> $DIR/tests/fixture/value/number/input.css:11:18
+   |
+11 |     property: 1.2e2;
+   |                  ^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:12:5
+   |
+12 |     property: 1e2;
+   |     ^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:12:5
+   |
+12 |     property: 1e2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:12:15
+   |
+12 |     property: 1e2;
+   |               ^^^
+
+error: UnitValue
+  --> $DIR/tests/fixture/value/number/input.css:12:15
+   |
+12 |     property: 1e2;
+   |               ^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:12:15
+   |
+12 |     property: 1e2;
+   |               ^
+
+error: Unit
+  --> $DIR/tests/fixture/value/number/input.css:12:16
+   |
+12 |     property: 1e2;
+   |                ^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:13:5
+   |
+13 |     property: .2e2;
+   |     ^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:13:5
+   |
+13 |     property: .2e2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:13:15
+   |
+13 |     property: .2e2;
+   |               ^^^^
+
+error: UnitValue
+  --> $DIR/tests/fixture/value/number/input.css:13:15
+   |
+13 |     property: .2e2;
+   |               ^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:13:15
+   |
+13 |     property: .2e2;
+   |               ^^
+
+error: Unit
+  --> $DIR/tests/fixture/value/number/input.css:13:17
+   |
+13 |     property: .2e2;
+   |                 ^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:14:5
+   |
+14 |     property: 1.2E2;
+   |     ^^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:14:5
+   |
+14 |     property: 1.2E2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:14:15
+   |
+14 |     property: 1.2E2;
+   |               ^^^^^
+
+error: UnitValue
+  --> $DIR/tests/fixture/value/number/input.css:14:15
+   |
+14 |     property: 1.2E2;
+   |               ^^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:14:15
+   |
+14 |     property: 1.2E2;
+   |               ^^^
+
+error: Unit
+  --> $DIR/tests/fixture/value/number/input.css:14:18
+   |
+14 |     property: 1.2E2;
+   |                  ^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:15:5
+   |
+15 |     property: 1.2e+2;
+   |     ^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:15:5
+   |
+15 |     property: 1.2e+2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:15:14
+   |
+15 |     property: 1.2e+2;
+   |              ^^^^^^^
+
+error: Tokens
+  --> $DIR/tests/fixture/value/number/input.css:15:14
+   |
+15 |     property: 1.2e+2;
+   |              ^^^^^^^
+
+error: WhiteSpace
+  --> $DIR/tests/fixture/value/number/input.css:15:14
+   |
+15 |     property: 1.2e+2;
+   |              ^
+
+error: Num(NumToken { value: 1.2 })
+  --> $DIR/tests/fixture/value/number/input.css:15:15
+   |
+15 |     property: 1.2e+2;
+   |               ^^^
+
+error: Ident { value: Atom('e' type=inline), raw: Atom('e' type=inline) }
+  --> $DIR/tests/fixture/value/number/input.css:15:18
+   |
+15 |     property: 1.2e+2;
+   |                  ^
+
+error: Num(NumToken { value: 2.0 })
+  --> $DIR/tests/fixture/value/number/input.css:15:19
+   |
+15 |     property: 1.2e+2;
+   |                   ^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:16:5
+   |
+16 |     property: 1.2e-2;
+   |     ^^^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:16:5
+   |
+16 |     property: 1.2e-2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:16:15
+   |
+16 |     property: 1.2e-2;
+   |               ^^^^^^
+
+error: UnitValue
+  --> $DIR/tests/fixture/value/number/input.css:16:15
+   |
+16 |     property: 1.2e-2;
+   |               ^^^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:16:15
+   |
+16 |     property: 1.2e-2;
+   |               ^^^
+
+error: Unit
+  --> $DIR/tests/fixture/value/number/input.css:16:18
+   |
+16 |     property: 1.2e-2;
+   |                  ^^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:17:5
+   |
+17 |     property: -1;
+   |     ^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:17:5
+   |
+17 |     property: -1;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:17:15
+   |
+17 |     property: -1;
+   |               ^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:17:15
+   |
+17 |     property: -1;
+   |               ^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:18:5
+   |
+18 |     property: -1.2;
+   |     ^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:18:5
+   |
+18 |     property: -1.2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:18:15
+   |
+18 |     property: -1.2;
+   |               ^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:18:15
+   |
+18 |     property: -1.2;
+   |               ^^^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:19:5
+   |
+19 |     property: -.2;
+   |     ^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:19:5
+   |
+19 |     property: -.2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:19:15
+   |
+19 |     property: -.2;
+   |               ^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:19:15
+   |
+19 |     property: -.2;
+   |               ^^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:20:5
+   |
+20 |     property: -.2;
+   |     ^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:20:5
+   |
+20 |     property: -.2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:20:15
+   |
+20 |     property: -.2;
+   |               ^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:20:15
+   |
+20 |     property: -.2;
+   |               ^^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:21:5
+   |
+21 |     property: +.2;
+   |     ^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:21:5
+   |
+21 |     property: +.2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:21:15
+   |
+21 |     property: +.2;
+   |               ^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:21:15
+   |
+21 |     property: +.2;
+   |               ^^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:22:5
+   |
+22 |     property: -1.2e3;
+   |     ^^^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:22:5
+   |
+22 |     property: -1.2e3;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:22:15
+   |
+22 |     property: -1.2e3;
+   |               ^^^^^^
+
+error: UnitValue
+  --> $DIR/tests/fixture/value/number/input.css:22:15
+   |
+22 |     property: -1.2e3;
+   |               ^^^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:22:15
+   |
+22 |     property: -1.2e3;
+   |               ^^^^
+
+error: Unit
+  --> $DIR/tests/fixture/value/number/input.css:22:19
+   |
+22 |     property: -1.2e3;
+   |                   ^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:23:5
+   |
+23 |     property: 1.75;
+   |     ^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:23:5
+   |
+23 |     property: 1.75;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:23:15
+   |
+23 |     property: 1.75;
+   |               ^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:23:15
+   |
+23 |     property: 1.75;
+   |               ^^^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:24:5
+   |
+24 |     property: +1.75;
+   |     ^^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:24:5
+   |
+24 |     property: +1.75;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:24:15
+   |
+24 |     property: +1.75;
+   |               ^^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:24:15
+   |
+24 |     property: +1.75;
+   |               ^^^^^
+

--- a/css/parser/tests/fixture/value/number/span.rust-debug
+++ b/css/parser/tests/fixture/value/number/span.rust-debug
@@ -6,8 +6,8 @@ error: Stylesheet
 3  | |     property: 10;
 4  | |     property: .10;
 ...  |
-26 | |     property: 1e+;
-27 | | }
+27 | |     property: 1e;
+28 | | }
    | |__^
 
 error: Rule
@@ -18,8 +18,8 @@ error: Rule
 3  | |     property: 10;
 4  | |     property: .10;
 ...  |
-26 | |     property: 1e+;
-27 | | }
+27 | |     property: 1e;
+28 | | }
    | |_^
 
 error: StyleRule
@@ -30,8 +30,8 @@ error: StyleRule
 3  | |     property: 10;
 4  | |     property: .10;
 ...  |
-26 | |     property: 1e+;
-27 | | }
+27 | |     property: 1e;
+28 | | }
    | |_^
 
 error: ComplexSelector
@@ -67,8 +67,8 @@ error: DeclBlock
 3  | |     property: 10;
 4  | |     property: .10;
 ...  |
-26 | |     property: 1e+;
-27 | | }
+27 | |     property: 1e;
+28 | | }
    | |_^
 
 error: Property
@@ -242,564 +242,564 @@ error: Num
 error: Property
  --> $DIR/tests/fixture/value/number/input.css:9:5
   |
-9 |     property: .0;
-  |     ^^^^^^^^^^^^
+9 |     property: +0.0;
+  |     ^^^^^^^^^^^^^^
 
 error: Text
  --> $DIR/tests/fixture/value/number/input.css:9:5
   |
-9 |     property: .0;
+9 |     property: +0.0;
   |     ^^^^^^^^
 
 error: Value
  --> $DIR/tests/fixture/value/number/input.css:9:15
   |
-9 |     property: .0;
-  |               ^^
+9 |     property: +0.0;
+  |               ^^^^
 
 error: Num
  --> $DIR/tests/fixture/value/number/input.css:9:15
   |
-9 |     property: .0;
-  |               ^^
+9 |     property: +0.0;
+  |               ^^^^
 
 error: Property
   --> $DIR/tests/fixture/value/number/input.css:10:5
    |
-10 |     property: 1.200000;
+10 |     property: -0.0;
+   |     ^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:10:5
+   |
+10 |     property: -0.0;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:10:15
+   |
+10 |     property: -0.0;
+   |               ^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:10:15
+   |
+10 |     property: -0.0;
+   |               ^^^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:11:5
+   |
+11 |     property: .0;
+   |     ^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:11:5
+   |
+11 |     property: .0;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:11:15
+   |
+11 |     property: .0;
+   |               ^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:11:15
+   |
+11 |     property: .0;
+   |               ^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:12:5
+   |
+12 |     property: 1.200000;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: Text
-  --> $DIR/tests/fixture/value/number/input.css:10:5
+  --> $DIR/tests/fixture/value/number/input.css:12:5
    |
-10 |     property: 1.200000;
+12 |     property: 1.200000;
    |     ^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/number/input.css:10:15
+  --> $DIR/tests/fixture/value/number/input.css:12:15
    |
-10 |     property: 1.200000;
+12 |     property: 1.200000;
    |               ^^^^^^^^
 
 error: Num
-  --> $DIR/tests/fixture/value/number/input.css:10:15
+  --> $DIR/tests/fixture/value/number/input.css:12:15
    |
-10 |     property: 1.200000;
+12 |     property: 1.200000;
    |               ^^^^^^^^
 
 error: Property
-  --> $DIR/tests/fixture/value/number/input.css:11:5
+  --> $DIR/tests/fixture/value/number/input.css:13:5
    |
-11 |     property: 1.2e2;
+13 |     property: 1.2e2;
    |     ^^^^^^^^^^^^^^^
 
 error: Text
-  --> $DIR/tests/fixture/value/number/input.css:11:5
+  --> $DIR/tests/fixture/value/number/input.css:13:5
    |
-11 |     property: 1.2e2;
+13 |     property: 1.2e2;
    |     ^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/number/input.css:11:15
+  --> $DIR/tests/fixture/value/number/input.css:13:15
    |
-11 |     property: 1.2e2;
+13 |     property: 1.2e2;
    |               ^^^^^
 
 error: UnitValue
-  --> $DIR/tests/fixture/value/number/input.css:11:15
+  --> $DIR/tests/fixture/value/number/input.css:13:15
    |
-11 |     property: 1.2e2;
+13 |     property: 1.2e2;
    |               ^^^^^
 
 error: Num
-  --> $DIR/tests/fixture/value/number/input.css:11:15
+  --> $DIR/tests/fixture/value/number/input.css:13:15
    |
-11 |     property: 1.2e2;
+13 |     property: 1.2e2;
    |               ^^^
 
 error: Unit
-  --> $DIR/tests/fixture/value/number/input.css:11:18
+  --> $DIR/tests/fixture/value/number/input.css:13:18
    |
-11 |     property: 1.2e2;
+13 |     property: 1.2e2;
    |                  ^^
 
 error: Property
-  --> $DIR/tests/fixture/value/number/input.css:12:5
+  --> $DIR/tests/fixture/value/number/input.css:14:5
    |
-12 |     property: 1e2;
+14 |     property: 1e2;
    |     ^^^^^^^^^^^^^
 
 error: Text
-  --> $DIR/tests/fixture/value/number/input.css:12:5
+  --> $DIR/tests/fixture/value/number/input.css:14:5
    |
-12 |     property: 1e2;
+14 |     property: 1e2;
    |     ^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/number/input.css:12:15
+  --> $DIR/tests/fixture/value/number/input.css:14:15
    |
-12 |     property: 1e2;
+14 |     property: 1e2;
    |               ^^^
 
 error: UnitValue
-  --> $DIR/tests/fixture/value/number/input.css:12:15
+  --> $DIR/tests/fixture/value/number/input.css:14:15
    |
-12 |     property: 1e2;
+14 |     property: 1e2;
    |               ^^^
 
 error: Num
-  --> $DIR/tests/fixture/value/number/input.css:12:15
+  --> $DIR/tests/fixture/value/number/input.css:14:15
    |
-12 |     property: 1e2;
+14 |     property: 1e2;
    |               ^
 
 error: Unit
-  --> $DIR/tests/fixture/value/number/input.css:12:16
+  --> $DIR/tests/fixture/value/number/input.css:14:16
    |
-12 |     property: 1e2;
+14 |     property: 1e2;
    |                ^^
 
 error: Property
-  --> $DIR/tests/fixture/value/number/input.css:13:5
+  --> $DIR/tests/fixture/value/number/input.css:15:5
    |
-13 |     property: .2e2;
+15 |     property: .2e2;
    |     ^^^^^^^^^^^^^^
 
 error: Text
-  --> $DIR/tests/fixture/value/number/input.css:13:5
+  --> $DIR/tests/fixture/value/number/input.css:15:5
    |
-13 |     property: .2e2;
+15 |     property: .2e2;
    |     ^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/number/input.css:13:15
+  --> $DIR/tests/fixture/value/number/input.css:15:15
    |
-13 |     property: .2e2;
+15 |     property: .2e2;
    |               ^^^^
 
 error: UnitValue
-  --> $DIR/tests/fixture/value/number/input.css:13:15
+  --> $DIR/tests/fixture/value/number/input.css:15:15
    |
-13 |     property: .2e2;
+15 |     property: .2e2;
    |               ^^^^
 
 error: Num
-  --> $DIR/tests/fixture/value/number/input.css:13:15
+  --> $DIR/tests/fixture/value/number/input.css:15:15
    |
-13 |     property: .2e2;
+15 |     property: .2e2;
    |               ^^
 
 error: Unit
-  --> $DIR/tests/fixture/value/number/input.css:13:17
+  --> $DIR/tests/fixture/value/number/input.css:15:17
    |
-13 |     property: .2e2;
+15 |     property: .2e2;
    |                 ^^
 
 error: Property
-  --> $DIR/tests/fixture/value/number/input.css:14:5
+  --> $DIR/tests/fixture/value/number/input.css:16:5
    |
-14 |     property: 1.2E2;
+16 |     property: 1.2E2;
    |     ^^^^^^^^^^^^^^^
 
 error: Text
-  --> $DIR/tests/fixture/value/number/input.css:14:5
-   |
-14 |     property: 1.2E2;
-   |     ^^^^^^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/number/input.css:14:15
-   |
-14 |     property: 1.2E2;
-   |               ^^^^^
-
-error: UnitValue
-  --> $DIR/tests/fixture/value/number/input.css:14:15
-   |
-14 |     property: 1.2E2;
-   |               ^^^^^
-
-error: Num
-  --> $DIR/tests/fixture/value/number/input.css:14:15
-   |
-14 |     property: 1.2E2;
-   |               ^^^
-
-error: Unit
-  --> $DIR/tests/fixture/value/number/input.css:14:18
-   |
-14 |     property: 1.2E2;
-   |                  ^^
-
-error: Property
-  --> $DIR/tests/fixture/value/number/input.css:15:5
-   |
-15 |     property: 1.2e+2;
-   |     ^^^^^^^^^^^^^^
-
-error: Text
-  --> $DIR/tests/fixture/value/number/input.css:15:5
-   |
-15 |     property: 1.2e+2;
-   |     ^^^^^^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/number/input.css:15:14
-   |
-15 |     property: 1.2e+2;
-   |              ^^^^^^^
-
-error: Tokens
-  --> $DIR/tests/fixture/value/number/input.css:15:14
-   |
-15 |     property: 1.2e+2;
-   |              ^^^^^^^
-
-error: WhiteSpace
-  --> $DIR/tests/fixture/value/number/input.css:15:14
-   |
-15 |     property: 1.2e+2;
-   |              ^
-
-error: Num(NumToken { value: 1.2 })
-  --> $DIR/tests/fixture/value/number/input.css:15:15
-   |
-15 |     property: 1.2e+2;
-   |               ^^^
-
-error: Ident { value: Atom('e' type=inline), raw: Atom('e' type=inline) }
-  --> $DIR/tests/fixture/value/number/input.css:15:18
-   |
-15 |     property: 1.2e+2;
-   |                  ^
-
-error: Num(NumToken { value: 2.0 })
-  --> $DIR/tests/fixture/value/number/input.css:15:19
-   |
-15 |     property: 1.2e+2;
-   |                   ^^
-
-error: Property
   --> $DIR/tests/fixture/value/number/input.css:16:5
    |
-16 |     property: 1.2e-2;
-   |     ^^^^^^^^^^^^^^^^
-
-error: Text
-  --> $DIR/tests/fixture/value/number/input.css:16:5
-   |
-16 |     property: 1.2e-2;
+16 |     property: 1.2E2;
    |     ^^^^^^^^
 
 error: Value
   --> $DIR/tests/fixture/value/number/input.css:16:15
    |
-16 |     property: 1.2e-2;
-   |               ^^^^^^
+16 |     property: 1.2E2;
+   |               ^^^^^
 
 error: UnitValue
   --> $DIR/tests/fixture/value/number/input.css:16:15
    |
-16 |     property: 1.2e-2;
-   |               ^^^^^^
+16 |     property: 1.2E2;
+   |               ^^^^^
 
 error: Num
   --> $DIR/tests/fixture/value/number/input.css:16:15
    |
-16 |     property: 1.2e-2;
+16 |     property: 1.2E2;
    |               ^^^
 
 error: Unit
   --> $DIR/tests/fixture/value/number/input.css:16:18
    |
-16 |     property: 1.2e-2;
-   |                  ^^^
+16 |     property: 1.2E2;
+   |                  ^^
 
 error: Property
   --> $DIR/tests/fixture/value/number/input.css:17:5
    |
-17 |     property: -1;
-   |     ^^^^^^^^^^^^
-
-error: Text
-  --> $DIR/tests/fixture/value/number/input.css:17:5
-   |
-17 |     property: -1;
-   |     ^^^^^^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/number/input.css:17:15
-   |
-17 |     property: -1;
-   |               ^^
-
-error: Num
-  --> $DIR/tests/fixture/value/number/input.css:17:15
-   |
-17 |     property: -1;
-   |               ^^
-
-error: Property
-  --> $DIR/tests/fixture/value/number/input.css:18:5
-   |
-18 |     property: -1.2;
+17 |     property: 1.2e+2;
    |     ^^^^^^^^^^^^^^
 
 error: Text
-  --> $DIR/tests/fixture/value/number/input.css:18:5
+  --> $DIR/tests/fixture/value/number/input.css:17:5
    |
-18 |     property: -1.2;
+17 |     property: 1.2e+2;
    |     ^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/number/input.css:18:15
+  --> $DIR/tests/fixture/value/number/input.css:17:14
    |
-18 |     property: -1.2;
-   |               ^^^^
+17 |     property: 1.2e+2;
+   |              ^^^^^^^
 
-error: Num
-  --> $DIR/tests/fixture/value/number/input.css:18:15
+error: Tokens
+  --> $DIR/tests/fixture/value/number/input.css:17:14
    |
-18 |     property: -1.2;
-   |               ^^^^
+17 |     property: 1.2e+2;
+   |              ^^^^^^^
 
-error: Property
-  --> $DIR/tests/fixture/value/number/input.css:19:5
+error: WhiteSpace
+  --> $DIR/tests/fixture/value/number/input.css:17:14
    |
-19 |     property: -.2;
-   |     ^^^^^^^^^^^^^
+17 |     property: 1.2e+2;
+   |              ^
 
-error: Text
-  --> $DIR/tests/fixture/value/number/input.css:19:5
+error: Num(NumToken { value: 1.2 })
+  --> $DIR/tests/fixture/value/number/input.css:17:15
    |
-19 |     property: -.2;
-   |     ^^^^^^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/number/input.css:19:15
-   |
-19 |     property: -.2;
+17 |     property: 1.2e+2;
    |               ^^^
 
-error: Num
-  --> $DIR/tests/fixture/value/number/input.css:19:15
+error: Ident { value: Atom('e' type=inline), raw: Atom('e' type=inline) }
+  --> $DIR/tests/fixture/value/number/input.css:17:18
    |
-19 |     property: -.2;
-   |               ^^^
+17 |     property: 1.2e+2;
+   |                  ^
 
-error: Property
-  --> $DIR/tests/fixture/value/number/input.css:20:5
+error: Num(NumToken { value: 2.0 })
+  --> $DIR/tests/fixture/value/number/input.css:17:19
    |
-20 |     property: -.2;
-   |     ^^^^^^^^^^^^^
-
-error: Text
-  --> $DIR/tests/fixture/value/number/input.css:20:5
-   |
-20 |     property: -.2;
-   |     ^^^^^^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/number/input.css:20:15
-   |
-20 |     property: -.2;
-   |               ^^^
-
-error: Num
-  --> $DIR/tests/fixture/value/number/input.css:20:15
-   |
-20 |     property: -.2;
-   |               ^^^
-
-error: Property
-  --> $DIR/tests/fixture/value/number/input.css:21:5
-   |
-21 |     property: +.2;
-   |     ^^^^^^^^^^^^^
-
-error: Text
-  --> $DIR/tests/fixture/value/number/input.css:21:5
-   |
-21 |     property: +.2;
-   |     ^^^^^^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/number/input.css:21:15
-   |
-21 |     property: +.2;
-   |               ^^^
-
-error: Num
-  --> $DIR/tests/fixture/value/number/input.css:21:15
-   |
-21 |     property: +.2;
-   |               ^^^
-
-error: Property
-  --> $DIR/tests/fixture/value/number/input.css:22:5
-   |
-22 |     property: -1.2e3;
-   |     ^^^^^^^^^^^^^^^^
-
-error: Text
-  --> $DIR/tests/fixture/value/number/input.css:22:5
-   |
-22 |     property: -1.2e3;
-   |     ^^^^^^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/number/input.css:22:15
-   |
-22 |     property: -1.2e3;
-   |               ^^^^^^
-
-error: UnitValue
-  --> $DIR/tests/fixture/value/number/input.css:22:15
-   |
-22 |     property: -1.2e3;
-   |               ^^^^^^
-
-error: Num
-  --> $DIR/tests/fixture/value/number/input.css:22:15
-   |
-22 |     property: -1.2e3;
-   |               ^^^^
-
-error: Unit
-  --> $DIR/tests/fixture/value/number/input.css:22:19
-   |
-22 |     property: -1.2e3;
+17 |     property: 1.2e+2;
    |                   ^^
 
 error: Property
-  --> $DIR/tests/fixture/value/number/input.css:23:5
+  --> $DIR/tests/fixture/value/number/input.css:18:5
    |
-23 |     property: 1.75;
+18 |     property: 1.2e-2;
+   |     ^^^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:18:5
+   |
+18 |     property: 1.2e-2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:18:15
+   |
+18 |     property: 1.2e-2;
+   |               ^^^^^^
+
+error: UnitValue
+  --> $DIR/tests/fixture/value/number/input.css:18:15
+   |
+18 |     property: 1.2e-2;
+   |               ^^^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:18:15
+   |
+18 |     property: 1.2e-2;
+   |               ^^^
+
+error: Unit
+  --> $DIR/tests/fixture/value/number/input.css:18:18
+   |
+18 |     property: 1.2e-2;
+   |                  ^^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:19:5
+   |
+19 |     property: -1;
+   |     ^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:19:5
+   |
+19 |     property: -1;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:19:15
+   |
+19 |     property: -1;
+   |               ^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:19:15
+   |
+19 |     property: -1;
+   |               ^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:20:5
+   |
+20 |     property: -1.2;
    |     ^^^^^^^^^^^^^^
 
 error: Text
+  --> $DIR/tests/fixture/value/number/input.css:20:5
+   |
+20 |     property: -1.2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:20:15
+   |
+20 |     property: -1.2;
+   |               ^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:20:15
+   |
+20 |     property: -1.2;
+   |               ^^^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:21:5
+   |
+21 |     property: -.2;
+   |     ^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:21:5
+   |
+21 |     property: -.2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:21:15
+   |
+21 |     property: -.2;
+   |               ^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:21:15
+   |
+21 |     property: -.2;
+   |               ^^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:22:5
+   |
+22 |     property: -.2;
+   |     ^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:22:5
+   |
+22 |     property: -.2;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:22:15
+   |
+22 |     property: -.2;
+   |               ^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:22:15
+   |
+22 |     property: -.2;
+   |               ^^^
+
+error: Property
   --> $DIR/tests/fixture/value/number/input.css:23:5
    |
-23 |     property: 1.75;
+23 |     property: +.2;
+   |     ^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:23:5
+   |
+23 |     property: +.2;
    |     ^^^^^^^^
 
 error: Value
   --> $DIR/tests/fixture/value/number/input.css:23:15
    |
-23 |     property: 1.75;
-   |               ^^^^
+23 |     property: +.2;
+   |               ^^^
 
 error: Num
   --> $DIR/tests/fixture/value/number/input.css:23:15
    |
-23 |     property: 1.75;
-   |               ^^^^
+23 |     property: +.2;
+   |               ^^^
 
 error: Property
   --> $DIR/tests/fixture/value/number/input.css:24:5
    |
-24 |     property: +1.75;
+24 |     property: -1.2e3;
+   |     ^^^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:24:5
+   |
+24 |     property: -1.2e3;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:24:15
+   |
+24 |     property: -1.2e3;
+   |               ^^^^^^
+
+error: UnitValue
+  --> $DIR/tests/fixture/value/number/input.css:24:15
+   |
+24 |     property: -1.2e3;
+   |               ^^^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:24:15
+   |
+24 |     property: -1.2e3;
+   |               ^^^^
+
+error: Unit
+  --> $DIR/tests/fixture/value/number/input.css:24:19
+   |
+24 |     property: -1.2e3;
+   |                   ^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:25:5
+   |
+25 |     property: 1.75;
+   |     ^^^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:25:5
+   |
+25 |     property: 1.75;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:25:15
+   |
+25 |     property: 1.75;
+   |               ^^^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:25:15
+   |
+25 |     property: 1.75;
+   |               ^^^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:26:5
+   |
+26 |     property: +1.75;
    |     ^^^^^^^^^^^^^^^
 
 error: Text
-  --> $DIR/tests/fixture/value/number/input.css:24:5
+  --> $DIR/tests/fixture/value/number/input.css:26:5
    |
-24 |     property: +1.75;
+26 |     property: +1.75;
    |     ^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/number/input.css:24:15
+  --> $DIR/tests/fixture/value/number/input.css:26:15
    |
-24 |     property: +1.75;
+26 |     property: +1.75;
    |               ^^^^^
 
 error: Num
-  --> $DIR/tests/fixture/value/number/input.css:24:15
+  --> $DIR/tests/fixture/value/number/input.css:26:15
    |
-24 |     property: +1.75;
+26 |     property: +1.75;
    |               ^^^^^
 
 error: Property
-  --> $DIR/tests/fixture/value/number/input.css:25:5
+  --> $DIR/tests/fixture/value/number/input.css:27:5
    |
-25 |     property: 1e;
+27 |     property: 1e;
    |     ^^^^^^^^^^^^
 
 error: Text
-  --> $DIR/tests/fixture/value/number/input.css:25:5
+  --> $DIR/tests/fixture/value/number/input.css:27:5
    |
-25 |     property: 1e;
+27 |     property: 1e;
    |     ^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/number/input.css:25:15
+  --> $DIR/tests/fixture/value/number/input.css:27:15
    |
-25 |     property: 1e;
+27 |     property: 1e;
    |               ^^
 
 error: UnitValue
-  --> $DIR/tests/fixture/value/number/input.css:25:15
+  --> $DIR/tests/fixture/value/number/input.css:27:15
    |
-25 |     property: 1e;
+27 |     property: 1e;
    |               ^^
 
 error: Num
-  --> $DIR/tests/fixture/value/number/input.css:25:15
+  --> $DIR/tests/fixture/value/number/input.css:27:15
    |
-25 |     property: 1e;
+27 |     property: 1e;
    |               ^
 
 error: Unit
-  --> $DIR/tests/fixture/value/number/input.css:25:16
+  --> $DIR/tests/fixture/value/number/input.css:27:16
    |
-25 |     property: 1e;
+27 |     property: 1e;
    |                ^
-
-error: Property
-  --> $DIR/tests/fixture/value/number/input.css:26:5
-   |
-26 |     property: 1e+;
-   |     ^^^^^^^^^^^^
-
-error: Text
-  --> $DIR/tests/fixture/value/number/input.css:26:5
-   |
-26 |     property: 1e+;
-   |     ^^^^^^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/number/input.css:26:14
-   |
-26 |     property: 1e+;
-   |              ^^^^
-
-error: Tokens
-  --> $DIR/tests/fixture/value/number/input.css:26:14
-   |
-26 |     property: 1e+;
-   |              ^^^^
-
-error: WhiteSpace
-  --> $DIR/tests/fixture/value/number/input.css:26:14
-   |
-26 |     property: 1e+;
-   |              ^
-
-error: Num(NumToken { value: 1.0 })
-  --> $DIR/tests/fixture/value/number/input.css:26:15
-   |
-26 |     property: 1e+;
-   |               ^
-
-error: Ident { value: Atom('e' type=inline), raw: Atom('e' type=inline) }
-  --> $DIR/tests/fixture/value/number/input.css:26:16
-   |
-26 |     property: 1e+;
-   |                ^
-
-error: Plus
-  --> $DIR/tests/fixture/value/number/input.css:26:17
-   |
-26 |     property: 1e+;
-   |                 ^
 

--- a/css/parser/tests/fixture/value/number/span.rust-debug
+++ b/css/parser/tests/fixture/value/number/span.rust-debug
@@ -6,9 +6,9 @@ error: Stylesheet
 3  | |     property: 10;
 4  | |     property: .10;
 ...  |
-24 | |     property: +1.75;
-25 | | }
-   | |_^
+26 | |     property: 1e+;
+27 | | }
+   | |__^
 
 error: Rule
   --> $DIR/tests/fixture/value/number/input.css:1:1
@@ -18,8 +18,8 @@ error: Rule
 3  | |     property: 10;
 4  | |     property: .10;
 ...  |
-24 | |     property: +1.75;
-25 | | }
+26 | |     property: 1e+;
+27 | | }
    | |_^
 
 error: StyleRule
@@ -30,8 +30,8 @@ error: StyleRule
 3  | |     property: 10;
 4  | |     property: .10;
 ...  |
-24 | |     property: +1.75;
-25 | | }
+26 | |     property: 1e+;
+27 | | }
    | |_^
 
 error: ComplexSelector
@@ -67,8 +67,8 @@ error: DeclBlock
 3  | |     property: 10;
 4  | |     property: .10;
 ...  |
-24 | |     property: +1.75;
-25 | | }
+26 | |     property: 1e+;
+27 | | }
    | |_^
 
 error: Property
@@ -718,4 +718,88 @@ error: Num
    |
 24 |     property: +1.75;
    |               ^^^^^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:25:5
+   |
+25 |     property: 1e;
+   |     ^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:25:5
+   |
+25 |     property: 1e;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:25:15
+   |
+25 |     property: 1e;
+   |               ^^
+
+error: UnitValue
+  --> $DIR/tests/fixture/value/number/input.css:25:15
+   |
+25 |     property: 1e;
+   |               ^^
+
+error: Num
+  --> $DIR/tests/fixture/value/number/input.css:25:15
+   |
+25 |     property: 1e;
+   |               ^
+
+error: Unit
+  --> $DIR/tests/fixture/value/number/input.css:25:16
+   |
+25 |     property: 1e;
+   |                ^
+
+error: Property
+  --> $DIR/tests/fixture/value/number/input.css:26:5
+   |
+26 |     property: 1e+;
+   |     ^^^^^^^^^^^^
+
+error: Text
+  --> $DIR/tests/fixture/value/number/input.css:26:5
+   |
+26 |     property: 1e+;
+   |     ^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/number/input.css:26:14
+   |
+26 |     property: 1e+;
+   |              ^^^^
+
+error: Tokens
+  --> $DIR/tests/fixture/value/number/input.css:26:14
+   |
+26 |     property: 1e+;
+   |              ^^^^
+
+error: WhiteSpace
+  --> $DIR/tests/fixture/value/number/input.css:26:14
+   |
+26 |     property: 1e+;
+   |              ^
+
+error: Num(NumToken { value: 1.0 })
+  --> $DIR/tests/fixture/value/number/input.css:26:15
+   |
+26 |     property: 1e+;
+   |               ^
+
+error: Ident { value: Atom('e' type=inline), raw: Atom('e' type=inline) }
+  --> $DIR/tests/fixture/value/number/input.css:26:16
+   |
+26 |     property: 1e+;
+   |                ^
+
+error: Plus
+  --> $DIR/tests/fixture/value/number/input.css:26:17
+   |
+26 |     property: 1e+;
+   |                 ^
 


### PR DESCRIPTION
@kdy1 We have a lot of bug in lexer for `number`/`dimension`/`percent` tokens, also bugs in parser, here interesting case, I think we should not try to interested `+`/`-`/`*`/`/` for all values, because it is syntax only for `calc()`/`min()`/`max()`/`clamp()`.

I think we should stay out of the special syntax (for special syntax in values) for now, also we still do it invalid (and have invalid ast), in theory I can keep old behavior for math operations and covert them to `delim` token, I think we will improve AST for `calc`/etc in future because they are math operators and we should parser them as mathematical (left/right and operation regarding spec).

What do you think?