### PR TITLE
fix(es/parser): Fix class getter/setter ASI problem

### DIFF
--- a/ecmascript/parser/tests/typescript-errors/class/get-set-asi-issue-1/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/class/get-set-asi-issue-1/input.ts
@@ -1,0 +1,4 @@
+class C {
+  get
+  async x() { return 0 }
+}

--- a/ecmascript/parser/tests/typescript-errors/class/get-set-asi-issue-1/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/class/get-set-asi-issue-1/input.ts.stderr
@@ -1,0 +1,6 @@
+error: Expected '(', got 'x'
+ --> $DIR/tests/typescript-errors/class/get-set-asi-issue-1/input.ts:3:9
+  |
+3 |   async x() { return 0 }
+  |         ^
+

--- a/ecmascript/parser/tests/typescript-errors/class/get-set-asi-issue-2/input.ts
+++ b/ecmascript/parser/tests/typescript-errors/class/get-set-asi-issue-2/input.ts
@@ -1,0 +1,4 @@
+class C {
+  get
+  static x() { return 0 }
+}

--- a/ecmascript/parser/tests/typescript-errors/class/get-set-asi-issue-2/input.ts.stderr
+++ b/ecmascript/parser/tests/typescript-errors/class/get-set-asi-issue-2/input.ts.stderr
@@ -1,0 +1,6 @@
+error: Expected '(', got 'x'
+ --> $DIR/tests/typescript-errors/class/get-set-asi-issue-2/input.ts:3:10
+  |
+3 |   static x() { return 0 }
+  |          ^
+

--- a/ecmascript/parser/tests/typescript/class/get-set-asi-issue/input.ts
+++ b/ecmascript/parser/tests/typescript/class/get-set-asi-issue/input.ts
@@ -1,0 +1,7 @@
+class C {
+  get
+  x() { return 0 }
+
+  set
+  x(value) {}
+}

--- a/ecmascript/parser/tests/typescript/class/get-set-asi-issue/input.ts.json
+++ b/ecmascript/parser/tests/typescript/class/get-set-asi-issue/input.ts.json
@@ -1,0 +1,169 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 0,
+    "end": 57,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ClassDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 6,
+          "end": 7,
+          "ctxt": 0
+        },
+        "value": "C",
+        "optional": false
+      },
+      "declare": false,
+      "span": {
+        "start": 0,
+        "end": 57,
+        "ctxt": 0
+      },
+      "decorators": [],
+      "body": [
+        {
+          "type": "ClassMethod",
+          "span": {
+            "start": 12,
+            "end": 34,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 18,
+              "end": 19,
+              "ctxt": 0
+            },
+            "value": "x",
+            "optional": false
+          },
+          "function": {
+            "params": [],
+            "decorators": [],
+            "span": {
+              "start": 12,
+              "end": 34,
+              "ctxt": 0
+            },
+            "body": {
+              "type": "BlockStatement",
+              "span": {
+                "start": 22,
+                "end": 34,
+                "ctxt": 0
+              },
+              "stmts": [
+                {
+                  "type": "ReturnStatement",
+                  "span": {
+                    "start": 24,
+                    "end": 32,
+                    "ctxt": 0
+                  },
+                  "argument": {
+                    "type": "NumericLiteral",
+                    "span": {
+                      "start": 31,
+                      "end": 32,
+                      "ctxt": 0
+                    },
+                    "value": 0.0
+                  }
+                }
+              ]
+            },
+            "generator": false,
+            "async": false,
+            "typeParameters": null,
+            "returnType": null
+          },
+          "kind": "getter",
+          "isStatic": false,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": false
+        },
+        {
+          "type": "ClassMethod",
+          "span": {
+            "start": 38,
+            "end": 55,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 44,
+              "end": 45,
+              "ctxt": 0
+            },
+            "value": "x",
+            "optional": false
+          },
+          "function": {
+            "params": [
+              {
+                "type": "Parameter",
+                "span": {
+                  "start": 46,
+                  "end": 51,
+                  "ctxt": 0
+                },
+                "decorators": [],
+                "pat": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 46,
+                    "end": 51,
+                    "ctxt": 0
+                  },
+                  "value": "value",
+                  "optional": false,
+                  "typeAnnotation": null
+                }
+              }
+            ],
+            "decorators": [],
+            "span": {
+              "start": 38,
+              "end": 55,
+              "ctxt": 0
+            },
+            "body": {
+              "type": "BlockStatement",
+              "span": {
+                "start": 53,
+                "end": 55,
+                "ctxt": 0
+              },
+              "stmts": []
+            },
+            "generator": false,
+            "async": false,
+            "typeParameters": null,
+            "returnType": null
+          },
+          "kind": "setter",
+          "isStatic": false,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": false
+        }
+      ],
+      "superClass": null,
+      "isAbstract": false,
+      "typeParams": null,
+      "superTypeParams": null,
+      "implements": []
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
This affects:

```js
class C {
  get
  x() { return 0 }

  set
  x(value) {}
}
```

Previously, the example will be parsed as two class properties and two class methods. This PR let it be parsed as one getter and one setter.

Comparison:

- [Babel](https://astexplorer.net/#/gist/c0ea098c1ad6214773feb870c7be61cf/88cb83fedb6fd825e6350ab9605bd510010c9e1d)
- [TypeScript](https://www.typescriptlang.org/play?#code/MYGwhgzhAEDC0G8BQ1oHMCmAXF0AeAFAJSLQBO2ArmQHbQAM0AvkrhNroQG5giUYkELJkA)