### PR TITLE
docs: improve react transform docs related to the resolver

### DIFF
--- a/ecmascript/transforms/react/src/lib.rs
+++ b/ecmascript/transforms/react/src/lib.rs
@@ -23,7 +23,8 @@ mod refresh;
 ///
 ///
 /// `top_level_mark` should be [Mark] passed to
-/// [swc_ecma_transforms_base::resolver::resolver_with_mark].
+/// [swc_ecma_transforms_base::resolver::resolver_with_mark] or
+/// [[swc_ecma_transforms_base::resolver::ts_resolver]] when using TypeScript.
 pub fn react<C>(
     cm: Lrc<SourceMap>,
     comments: Option<C>,


### PR DESCRIPTION
I believe this should say to use `ts_resolver` when using TypeScript.