### PR TITLE
feat(css/ast): Add `SquareBracketBlock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "swc_css_ast",
  "swc_css_codegen",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "is-macro",
  "serde",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "auto_impl",
  "bitflags",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "bitflags",
  "lexical",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "swc_atoms 0.2.9",
  "swc_common",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "swc_atoms 0.2.9",
  "swc_common",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "swc_stylis"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "swc_atoms 0.2.9",
  "swc_common",

--- a/css/Cargo.toml
+++ b/css/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.25.0"
+version = "0.26.0"
 
 [dependencies]
-swc_css_ast = {version = "0.23.0", path = "./ast"}
-swc_css_codegen = {version = "0.23.0", path = "./codegen"}
-swc_css_parser = {version = "0.25.0", path = "./parser"}
-swc_css_utils = {version = "0.20.0", path = "./utils/"}
-swc_css_visit = {version = "0.22.0", path = "./visit"}
+swc_css_ast = {version = "0.24.0", path = "./ast"}
+swc_css_codegen = {version = "0.24.0", path = "./codegen"}
+swc_css_parser = {version = "0.26.0", path = "./parser"}
+swc_css_utils = {version = "0.21.0", path = "./utils/"}
+swc_css_visit = {version = "0.23.0", path = "./visit"}

--- a/css/ast/Cargo.toml
+++ b/css/ast/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_ast"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.23.0"
+version = "0.24.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/css/ast/src/value.rs
+++ b/css/ast/src/value.rs
@@ -5,6 +5,9 @@ use swc_common::{ast_node, EqIgnoreSpan, Span};
 
 #[ast_node]
 pub enum Value {
+    #[tag("SquareBracketBlock")]
+    SquareBracketBlock(SquareBracketBlock),
+
     #[tag("ParenValue")]
     Paren(ParenValue),
 
@@ -31,9 +34,6 @@ pub enum Value {
 
     #[tag("BinValue")]
     Bin(BinValue),
-
-    #[tag("ArrayValue")]
-    Array(ArrayValue),
 
     #[tag("SpaceValues")]
     Space(SpaceValues),
@@ -99,13 +99,11 @@ pub struct ParenValue {
     pub value: Option<Box<Value>>,
 }
 
-#[ast_node("ArrayValue")]
-pub struct ArrayValue {
+#[ast_node("SquareBracketBlock")]
+pub struct SquareBracketBlock {
     /// Includes `[` and `]`.
     pub span: Span,
-
-    /// Comma separated list of values.
-    pub values: Vec<Value>,
+    pub children: Option<Vec<Value>>,
 }
 
 #[ast_node("HashValue")]

--- a/css/codegen/Cargo.toml
+++ b/css/codegen/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.23.0"
+version = "0.24.0"
 
 [dependencies]
 auto_impl = "0.4.1"
 bitflags = "1.3.2"
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
 swc_common = {version = "0.14.0", path = "../../common"}
-swc_css_ast = {version = "0.23.0", path = "../ast/"}
+swc_css_ast = {version = "0.24.0", path = "../ast/"}
 swc_css_codegen_macros = {version = "0.2.0", path = "macros/"}
 
 [dev-dependencies]
-swc_css_parser = {version = "0.25.0", path = "../parser"}
-swc_css_visit = {version = "0.22.0", path = "../visit"}
+swc_css_parser = {version = "0.26.0", path = "../parser"}
+swc_css_visit = {version = "0.23.0", path = "../visit"}
 testing = {version = "0.15.0", path = "../../testing"}

--- a/css/codegen/src/lib.rs
+++ b/css/codegen/src/lib.rs
@@ -273,7 +273,7 @@ where
             Value::Str(n) => emit!(self, n),
             Value::Fn(n) => emit!(self, n),
             Value::Bin(n) => emit!(self, n),
-            Value::Array(n) => emit!(self, n),
+            Value::SquareBracketBlock(n) => emit!(self, n),
             Value::Space(n) => emit!(self, n),
             Value::Brace(n) => emit!(self, n),
             Value::Lazy(n) => emit!(self, n),
@@ -452,10 +452,12 @@ where
     }
 
     #[emitter]
-    fn emit_array_value(&mut self, n: &ArrayValue) -> Result {
+    fn emit_square_bracket_block(&mut self, n: &SquareBracketBlock) -> Result {
         punct!(self, "[");
 
-        self.emit_list(&n.values, ListFormat::CommaDelimited)?;
+        if let Some(values) = &n.children {
+            self.emit_list(&values, ListFormat::SpaceDelimited)?;
+        }
 
         punct!(self, "]");
     }

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.25.2"
+version = "0.26.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -17,11 +17,11 @@ bitflags = "1.2.1"
 lexical = "5.2.2"
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
 swc_common = {version = "0.14.0", path = "../../common"}
-swc_css_ast = {version = "0.23.0", path = "../ast"}
+swc_css_ast = {version = "0.24.0", path = "../ast"}
 unicode-xid = "0.2.2"
 
 [dev-dependencies]
 serde = "1.0.127"
 serde_json = "1.0.66"
-swc_css_visit = {version = "0.22.0", path = "../visit"}
+swc_css_visit = {version = "0.23.0", path = "../visit"}
 testing = {version = "0.15.0", path = "../../testing"}

--- a/css/parser/src/parser/value/mod.rs
+++ b/css/parser/src/parser/value/mod.rs
@@ -506,7 +506,7 @@ where
         expect!(self, "[");
 
         self.input.skip_ws()?;
-        
+
         let ctx = Ctx {
             is_in_delimited_value: true,
             allow_separating_value_with_space: true,
@@ -514,7 +514,7 @@ where
         };
 
         let children = Some(self.with_ctx(ctx).parse_property_values()?.0);
-        
+
         self.input.skip_ws()?;
 
         expect!(self, "]");

--- a/css/parser/src/parser/value/mod.rs
+++ b/css/parser/src/parser/value/mod.rs
@@ -26,10 +26,10 @@ where
         let mut values = vec![];
         let mut state = self.input.state();
         let start_pos = self.input.cur_span()?.lo;
-
         let mut hi = self.input.last_pos()?;
+
         loop {
-            if is_one_of!(self, EOF, ";", "}", "!", ")") {
+            if is_one_of!(self, EOF, ";", "}", "!", ")", "]") {
                 self.input.reset(&state);
                 break;
             }
@@ -47,12 +47,12 @@ where
 
             if !eat!(self, " ") {
                 if self.ctx.recover_from_property_value
-                    && !is_one_of!(self, EOF, ";", "}", "!", ")")
+                    && !is_one_of!(self, EOF, ";", "}", "!", ")", "]")
                 {
                     self.input.reset(&start);
 
                     let mut tokens = vec![];
-                    while !is_one_of!(self, EOF, ";", "}", "!", ")") {
+                    while !is_one_of!(self, EOF, ";", "}", "!", ")", "]") {
                         tokens.extend(self.input.bump()?);
                     }
 
@@ -213,7 +213,7 @@ where
 
             Token::Ident { .. } => return self.parse_value_ident_or_fn(),
 
-            tok!("[") => return self.parse_array_value().map(From::from),
+            tok!("[") => return self.parse_square_brackets_value().map(From::from),
 
             tok!("(") => return self.parse_paren_value().map(From::from),
 
@@ -500,22 +500,28 @@ where
         Ok(args)
     }
 
-    fn parse_array_value(&mut self) -> PResult<ArrayValue> {
+    fn parse_square_brackets_value(&mut self) -> PResult<SquareBracketBlock> {
         let span = self.input.cur_span()?;
 
         expect!(self, "[");
 
+        self.input.skip_ws()?;
+        
         let ctx = Ctx {
             is_in_delimited_value: true,
+            allow_separating_value_with_space: true,
             ..self.ctx
         };
-        let values = self.with_ctx(ctx).parse_comma_separated_value()?;
+
+        let children = Some(self.with_ctx(ctx).parse_property_values()?.0);
+        
+        self.input.skip_ws()?;
 
         expect!(self, "]");
 
-        Ok(ArrayValue {
+        Ok(SquareBracketBlock {
             span: span!(self, span.lo),
-            values,
+            children,
         })
     }
 

--- a/css/parser/tests/fixture.rs
+++ b/css/parser/tests/fixture.rs
@@ -314,7 +314,7 @@ macro_rules! mtd {
 }
 
 impl Visit for SpanVisualizer<'_> {
-    mtd!(ArrayValue, visit_array_value);
+    mtd!(SquareBracketBlock, visit_square_bracket_block);
     mtd!(AtRule, visit_at_rule);
     mtd!(AtSelector, visit_at_selector);
     mtd!(AtTextValue, visit_at_text_value);

--- a/css/parser/tests/fixture/rome/custom-properties/output.json
+++ b/css/parser/tests/fixture/rome/custom-properties/output.json
@@ -554,13 +554,13 @@
             },
             "value": [
               {
-                "type": "ArrayValue",
+                "type": "SquareBracketBlock",
                 "span": {
                   "start": 249,
                   "end": 252,
                   "ctxt": 0
                 },
-                "values": []
+                "children": []
               }
             ],
             "important": null

--- a/css/parser/tests/fixture/rome/custom-properties/span.rust-debug
+++ b/css/parser/tests/fixture/rome/custom-properties/span.rust-debug
@@ -461,7 +461,7 @@ error: Value
 14 |     --brackets: [ ];
    |                 ^^^
 
-error: ArrayValue
+error: SquareBracketBlock
   --> $DIR/tests/fixture/rome/custom-properties/input.css:14:14
    |
 14 |     --brackets: [ ];

--- a/css/parser/tests/fixture/rome/grid/repeat/line-name/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/line-name/output.json
@@ -111,13 +111,13 @@
                     "raw": "4"
                   },
                   {
-                    "type": "ArrayValue",
+                    "type": "SquareBracketBlock",
                     "span": {
                       "start": 43,
                       "end": 54,
                       "ctxt": 0
                     },
-                    "values": [
+                    "children": [
                       {
                         "type": "Text",
                         "span": {

--- a/css/parser/tests/fixture/rome/grid/repeat/line-name/span.rust-debug
+++ b/css/parser/tests/fixture/rome/grid/repeat/line-name/span.rust-debug
@@ -109,7 +109,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, [col-start]);
   |                                      ^^^^^^^^^^^
 
-error: ArrayValue
+error: SquareBracketBlock
  --> $DIR/tests/fixture/rome/grid/repeat/line-name/input.css:2:35
   |
 2 |     grid-template-columns: repeat(4, [col-start]);

--- a/css/parser/tests/fixture/rome/grid/repeat/multi-values/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/multi-values/output.json
@@ -119,13 +119,13 @@
                     },
                     "values": [
                       {
-                        "type": "ArrayValue",
+                        "type": "SquareBracketBlock",
                         "span": {
                           "start": 43,
                           "end": 54,
                           "ctxt": 0
                         },
-                        "values": [
+                        "children": [
                           {
                             "type": "Text",
                             "span": {
@@ -149,13 +149,13 @@
                         "raw": "min-content"
                       },
                       {
-                        "type": "ArrayValue",
+                        "type": "SquareBracketBlock",
                         "span": {
                           "start": 67,
                           "end": 79,
                           "ctxt": 0
                         },
-                        "values": [
+                        "children": [
                           {
                             "type": "Text",
                             "span": {
@@ -179,13 +179,13 @@
                         "raw": "max-content"
                       },
                       {
-                        "type": "ArrayValue",
+                        "type": "SquareBracketBlock",
                         "span": {
                           "start": 92,
                           "end": 101,
                           "ctxt": 0
                         },
-                        "values": [
+                        "children": [
                           {
                             "type": "Text",
                             "span": {

--- a/css/parser/tests/fixture/rome/grid/repeat/multi-values/span.rust-debug
+++ b/css/parser/tests/fixture/rome/grid/repeat/multi-values/span.rust-debug
@@ -121,7 +121,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);
   |                                      ^^^^^^^^^^^
 
-error: ArrayValue
+error: SquareBracketBlock
  --> $DIR/tests/fixture/rome/grid/repeat/multi-values/input.css:2:35
   |
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);
@@ -157,7 +157,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);
   |                                                              ^^^^^^^^^^^^
 
-error: ArrayValue
+error: SquareBracketBlock
  --> $DIR/tests/fixture/rome/grid/repeat/multi-values/input.css:2:59
   |
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);
@@ -193,7 +193,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);
   |                                                                                       ^^^^^^^^^
 
-error: ArrayValue
+error: SquareBracketBlock
  --> $DIR/tests/fixture/rome/grid/repeat/multi-values/input.css:2:84
   |
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);

--- a/css/parser/tests/fixture/value/custom-property/output.json
+++ b/css/parser/tests/fixture/value/custom-property/output.json
@@ -386,13 +386,13 @@
             },
             "value": [
               {
-                "type": "ArrayValue",
+                "type": "SquareBracketBlock",
                 "span": {
                   "start": 220,
                   "end": 229,
                   "ctxt": 0
                 },
-                "values": [
+                "children": [
                   {
                     "type": "CommaValues",
                     "span": {
@@ -644,13 +644,13 @@
             },
             "value": [
               {
-                "type": "ArrayValue",
+                "type": "SquareBracketBlock",
                 "span": {
                   "start": 306,
                   "end": 339,
                   "ctxt": 0
                 },
-                "values": [
+                "children": [
                   {
                     "type": "CommaValues",
                     "span": {
@@ -781,13 +781,13 @@
                         }
                       },
                       {
-                        "type": "ArrayValue",
+                        "type": "SquareBracketBlock",
                         "span": {
                           "start": 335,
                           "end": 338,
                           "ctxt": 0
                         },
-                        "values": [
+                        "children": [
                           {
                             "type": "Number",
                             "span": {

--- a/css/parser/tests/fixture/value/custom-property/span.rust-debug
+++ b/css/parser/tests/fixture/value/custom-property/span.rust-debug
@@ -337,7 +337,7 @@ error: Value
 12 |     --square-block: [1, 2, 3];
    |                     ^^^^^^^^^
 
-error: ArrayValue
+error: SquareBracketBlock
   --> $DIR/tests/fixture/value/custom-property/input.css:12:21
    |
 12 |     --square-block: [1, 2, 3];
@@ -547,7 +547,7 @@ error: Value
 16 |     --JSON: [1, "2", {"three": {"a":1}}, [4]];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: ArrayValue
+error: SquareBracketBlock
   --> $DIR/tests/fixture/value/custom-property/input.css:16:13
    |
 16 |     --JSON: [1, "2", {"three": {"a":1}}, [4]];
@@ -661,7 +661,7 @@ error: Value
 16 |     --JSON: [1, "2", {"three": {"a":1}}, [4]];
    |                                          ^^^
 
-error: ArrayValue
+error: SquareBracketBlock
   --> $DIR/tests/fixture/value/custom-property/input.css:16:42
    |
 16 |     --JSON: [1, "2", {"three": {"a":1}}, [4]];

--- a/css/parser/tests/fixture/value/square-brackets/input.css
+++ b/css/parser/tests/fixture/value/square-brackets/input.css
@@ -1,0 +1,7 @@
+div {
+    prop:  [];
+    prop:  [ ];
+    prop:  [row1-start];
+    prop:  [red #fff 12px];
+    prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+}

--- a/css/parser/tests/fixture/value/square-brackets/output.json
+++ b/css/parser/tests/fixture/value/square-brackets/output.json
@@ -1,0 +1,376 @@
+{
+  "type": "Stylesheet",
+  "span": {
+    "start": 0,
+    "end": 157,
+    "ctxt": 0
+  },
+  "rules": [
+    {
+      "type": "StyleRule",
+      "span": {
+        "start": 0,
+        "end": 156,
+        "ctxt": 0
+      },
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "hasNestPrefix": false,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
+                "span": {
+                  "start": 0,
+                  "end": 3,
+                  "ctxt": 0
+                },
+                "prefix": null,
+                "name": {
+                  "type": "Text",
+                  "span": {
+                    "start": 0,
+                    "end": 3,
+                    "ctxt": 0
+                  },
+                  "value": "div",
+                  "raw": "div"
+                }
+              },
+              "subclassSelectors": []
+            }
+          ]
+        }
+      ],
+      "block": {
+        "type": "Block",
+        "span": {
+          "start": 4,
+          "end": 156,
+          "ctxt": 0
+        },
+        "items": [
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 10,
+              "end": 19,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Text",
+              "span": {
+                "start": 10,
+                "end": 14,
+                "ctxt": 0
+              },
+              "value": "prop",
+              "raw": "prop"
+            },
+            "value": [
+              {
+                "type": "SquareBracketBlock",
+                "span": {
+                  "start": 17,
+                  "end": 19,
+                  "ctxt": 0
+                },
+                "children": []
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 25,
+              "end": 35,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Text",
+              "span": {
+                "start": 25,
+                "end": 29,
+                "ctxt": 0
+              },
+              "value": "prop",
+              "raw": "prop"
+            },
+            "value": [
+              {
+                "type": "SquareBracketBlock",
+                "span": {
+                  "start": 32,
+                  "end": 35,
+                  "ctxt": 0
+                },
+                "children": []
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 41,
+              "end": 60,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Text",
+              "span": {
+                "start": 41,
+                "end": 45,
+                "ctxt": 0
+              },
+              "value": "prop",
+              "raw": "prop"
+            },
+            "value": [
+              {
+                "type": "SquareBracketBlock",
+                "span": {
+                  "start": 48,
+                  "end": 60,
+                  "ctxt": 0
+                },
+                "children": [
+                  {
+                    "type": "Text",
+                    "span": {
+                      "start": 49,
+                      "end": 59,
+                      "ctxt": 0
+                    },
+                    "value": "row1-start",
+                    "raw": "row1-start"
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 66,
+              "end": 88,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Text",
+              "span": {
+                "start": 66,
+                "end": 70,
+                "ctxt": 0
+              },
+              "value": "prop",
+              "raw": "prop"
+            },
+            "value": [
+              {
+                "type": "SquareBracketBlock",
+                "span": {
+                  "start": 73,
+                  "end": 88,
+                  "ctxt": 0
+                },
+                "children": [
+                  {
+                    "type": "Text",
+                    "span": {
+                      "start": 74,
+                      "end": 77,
+                      "ctxt": 0
+                    },
+                    "value": "red",
+                    "raw": "red"
+                  },
+                  {
+                    "type": "HashValue",
+                    "span": {
+                      "start": 78,
+                      "end": 82,
+                      "ctxt": 0
+                    },
+                    "value": "fff",
+                    "raw": "fff"
+                  },
+                  {
+                    "type": "UnitValue",
+                    "span": {
+                      "start": 83,
+                      "end": 87,
+                      "ctxt": 0
+                    },
+                    "value": {
+                      "type": "Number",
+                      "span": {
+                        "start": 83,
+                        "end": 85,
+                        "ctxt": 0
+                      },
+                      "value": 12.0,
+                      "raw": "12"
+                    },
+                    "unit": {
+                      "span": {
+                        "start": 85,
+                        "end": 87,
+                        "ctxt": 0
+                      },
+                      "value": "px",
+                      "raw": "px"
+                    }
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 94,
+              "end": 153,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Text",
+              "span": {
+                "start": 94,
+                "end": 98,
+                "ctxt": 0
+              },
+              "value": "prop",
+              "raw": "prop"
+            },
+            "value": [
+              {
+                "type": "SquareBracketBlock",
+                "span": {
+                  "start": 100,
+                  "end": 112,
+                  "ctxt": 0
+                },
+                "children": [
+                  {
+                    "type": "Text",
+                    "span": {
+                      "start": 101,
+                      "end": 111,
+                      "ctxt": 0
+                    },
+                    "value": "row1-start",
+                    "raw": "row1-start"
+                  }
+                ]
+              },
+              {
+                "type": "PercentValue",
+                "span": {
+                  "start": 113,
+                  "end": 116,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 113,
+                    "end": 115,
+                    "ctxt": 0
+                  },
+                  "value": 25.0,
+                  "raw": "25"
+                }
+              },
+              {
+                "type": "SquareBracketBlock",
+                "span": {
+                  "start": 117,
+                  "end": 138,
+                  "ctxt": 0
+                },
+                "children": [
+                  {
+                    "type": "Text",
+                    "span": {
+                      "start": 118,
+                      "end": 126,
+                      "ctxt": 0
+                    },
+                    "value": "row1-end",
+                    "raw": "row1-end"
+                  },
+                  {
+                    "type": "Text",
+                    "span": {
+                      "start": 127,
+                      "end": 137,
+                      "ctxt": 0
+                    },
+                    "value": "row2-start",
+                    "raw": "row2-start"
+                  }
+                ]
+              },
+              {
+                "type": "PercentValue",
+                "span": {
+                  "start": 139,
+                  "end": 142,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 139,
+                    "end": 141,
+                    "ctxt": 0
+                  },
+                  "value": 25.0,
+                  "raw": "25"
+                }
+              },
+              {
+                "type": "SquareBracketBlock",
+                "span": {
+                  "start": 143,
+                  "end": 153,
+                  "ctxt": 0
+                },
+                "children": [
+                  {
+                    "type": "Text",
+                    "span": {
+                      "start": 144,
+                      "end": 152,
+                      "ctxt": 0
+                    },
+                    "value": "row2-end",
+                    "raw": "row2-end"
+                  }
+                ]
+              }
+            ],
+            "important": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/css/parser/tests/fixture/value/square-brackets/span.rust-debug
+++ b/css/parser/tests/fixture/value/square-brackets/span.rust-debug
@@ -1,0 +1,361 @@
+error: Stylesheet
+ --> $DIR/tests/fixture/value/square-brackets/input.css:1:1
+  |
+1 | / div {
+2 | |     prop:  [];
+3 | |     prop:  [ ];
+4 | |     prop:  [row1-start];
+5 | |     prop:  [red #fff 12px];
+6 | |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+7 | | }
+  | |__^
+
+error: Rule
+ --> $DIR/tests/fixture/value/square-brackets/input.css:1:1
+  |
+1 | / div {
+2 | |     prop:  [];
+3 | |     prop:  [ ];
+4 | |     prop:  [row1-start];
+5 | |     prop:  [red #fff 12px];
+6 | |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+7 | | }
+  | |_^
+
+error: StyleRule
+ --> $DIR/tests/fixture/value/square-brackets/input.css:1:1
+  |
+1 | / div {
+2 | |     prop:  [];
+3 | |     prop:  [ ];
+4 | |     prop:  [row1-start];
+5 | |     prop:  [red #fff 12px];
+6 | |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+7 | | }
+  | |_^
+
+error: ComplexSelector
+ --> $DIR/tests/fixture/value/square-brackets/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: CompoundSelector
+ --> $DIR/tests/fixture/value/square-brackets/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: NamespacedName
+ --> $DIR/tests/fixture/value/square-brackets/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/square-brackets/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: Block
+ --> $DIR/tests/fixture/value/square-brackets/input.css:1:5
+  |
+1 |   div {
+  |  _____^
+2 | |     prop:  [];
+3 | |     prop:  [ ];
+4 | |     prop:  [row1-start];
+5 | |     prop:  [red #fff 12px];
+6 | |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+7 | | }
+  | |_^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/square-brackets/input.css:2:5
+  |
+2 |     prop:  [];
+  |     ^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/square-brackets/input.css:2:5
+  |
+2 |     prop:  [];
+  |     ^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:2:12
+  |
+2 |     prop:  [];
+  |            ^^
+
+error: SquareBracketBlock
+ --> $DIR/tests/fixture/value/square-brackets/input.css:2:12
+  |
+2 |     prop:  [];
+  |            ^^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/square-brackets/input.css:3:5
+  |
+3 |     prop:  [ ];
+  |     ^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/square-brackets/input.css:3:5
+  |
+3 |     prop:  [ ];
+  |     ^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:3:12
+  |
+3 |     prop:  [ ];
+  |            ^^^
+
+error: SquareBracketBlock
+ --> $DIR/tests/fixture/value/square-brackets/input.css:3:12
+  |
+3 |     prop:  [ ];
+  |            ^^^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/square-brackets/input.css:4:5
+  |
+4 |     prop:  [row1-start];
+  |     ^^^^^^^^^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/square-brackets/input.css:4:5
+  |
+4 |     prop:  [row1-start];
+  |     ^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:4:12
+  |
+4 |     prop:  [row1-start];
+  |            ^^^^^^^^^^^^
+
+error: SquareBracketBlock
+ --> $DIR/tests/fixture/value/square-brackets/input.css:4:12
+  |
+4 |     prop:  [row1-start];
+  |            ^^^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:4:13
+  |
+4 |     prop:  [row1-start];
+  |             ^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/square-brackets/input.css:4:13
+  |
+4 |     prop:  [row1-start];
+  |             ^^^^^^^^^^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/square-brackets/input.css:5:5
+  |
+5 |     prop:  [red #fff 12px];
+  |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/square-brackets/input.css:5:5
+  |
+5 |     prop:  [red #fff 12px];
+  |     ^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:5:12
+  |
+5 |     prop:  [red #fff 12px];
+  |            ^^^^^^^^^^^^^^^
+
+error: SquareBracketBlock
+ --> $DIR/tests/fixture/value/square-brackets/input.css:5:12
+  |
+5 |     prop:  [red #fff 12px];
+  |            ^^^^^^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:5:13
+  |
+5 |     prop:  [red #fff 12px];
+  |             ^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/square-brackets/input.css:5:13
+  |
+5 |     prop:  [red #fff 12px];
+  |             ^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:5:17
+  |
+5 |     prop:  [red #fff 12px];
+  |                 ^^^^
+
+error: HashValue
+ --> $DIR/tests/fixture/value/square-brackets/input.css:5:17
+  |
+5 |     prop:  [red #fff 12px];
+  |                 ^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:5:22
+  |
+5 |     prop:  [red #fff 12px];
+  |                      ^^^^
+
+error: UnitValue
+ --> $DIR/tests/fixture/value/square-brackets/input.css:5:22
+  |
+5 |     prop:  [red #fff 12px];
+  |                      ^^^^
+
+error: Num
+ --> $DIR/tests/fixture/value/square-brackets/input.css:5:22
+  |
+5 |     prop:  [red #fff 12px];
+  |                      ^^
+
+error: Unit
+ --> $DIR/tests/fixture/value/square-brackets/input.css:5:24
+  |
+5 |     prop:  [red #fff 12px];
+  |                        ^^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:5
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:5
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |     ^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:11
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |           ^^^^^^^^^^^^
+
+error: SquareBracketBlock
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:11
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |           ^^^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:12
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |            ^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:12
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |            ^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:24
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                        ^^^
+
+error: PercentValue
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:24
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                        ^^^
+
+error: Num
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:24
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                        ^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:28
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                            ^^^^^^^^^^^^^^^^^^^^^
+
+error: SquareBracketBlock
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:28
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                            ^^^^^^^^^^^^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:29
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                             ^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:29
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                             ^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:38
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                                      ^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:38
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                                      ^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:50
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                                                  ^^^
+
+error: PercentValue
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:50
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                                                  ^^^
+
+error: Num
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:50
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                                                  ^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:54
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                                                      ^^^^^^^^^^
+
+error: SquareBracketBlock
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:54
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                                                      ^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:55
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                                                       ^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/value/square-brackets/input.css:6:55
+  |
+6 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
+  |                                                       ^^^^^^^^
+

--- a/css/stylis/Cargo.toml
+++ b/css/stylis/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_stylis"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.22.0"
+version = "0.23.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
 swc_common = {version = "0.14.0", path = "../../common"}
-swc_css_ast = {version = "0.23.0", path = "../ast"}
-swc_css_utils = {version = "0.20.0", path = "../utils/"}
-swc_css_visit = {version = "0.22.0", path = "../visit"}
+swc_css_ast = {version = "0.24.0", path = "../ast"}
+swc_css_utils = {version = "0.21.0", path = "../utils/"}
+swc_css_visit = {version = "0.23.0", path = "../visit"}
 
 [dev-dependencies]
-swc_css_codegen = {version = "0.23.0", path = "../codegen"}
-swc_css_parser = {version = "0.25.0", path = "../parser"}
+swc_css_codegen = {version = "0.24.0", path = "../codegen"}
+swc_css_parser = {version = "0.26.0", path = "../parser"}
 testing = {version = "0.15.0", path = "../../testing"}

--- a/css/utils/Cargo.toml
+++ b/css/utils/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.20.0"
+version = "0.21.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
 swc_common = {version = "0.14.0", path = "../../common"}
-swc_css_ast = {version = "0.23.0", path = "../ast"}
-swc_css_visit = {version = "0.22.0", path = "../visit"}
+swc_css_ast = {version = "0.24.0", path = "../ast"}
+swc_css_visit = {version = "0.23.0", path = "../visit"}

--- a/css/visit/Cargo.toml
+++ b/css/visit/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_css_visit"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.22.0"
+version = "0.23.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 swc_atoms = {version = "0.2.7", path = "../../atoms"}
 swc_common = {version = "0.14.0", path = "../../common"}
-swc_css_ast = {version = "0.23.0", path = "../ast/"}
+swc_css_ast = {version = "0.24.0", path = "../ast/"}
 swc_visit = {version = "0.2.6", path = "../../visit"}

--- a/css/visit/src/lib.rs
+++ b/css/visit/src/lib.rs
@@ -67,8 +67,8 @@ define!({
     }
 
     pub enum Value {
-         SquareBracketBlock(SquareBracketBlock),
-        
+        SquareBracketBlock(SquareBracketBlock),
+
         Paren(ParenValue),
 
         Unit(UnitValue),

--- a/css/visit/src/lib.rs
+++ b/css/visit/src/lib.rs
@@ -67,6 +67,8 @@ define!({
     }
 
     pub enum Value {
+         SquareBracketBlock(SquareBracketBlock),
+        
         Paren(ParenValue),
 
         Unit(UnitValue),
@@ -84,8 +86,6 @@ define!({
         Fn(FnValue),
 
         Bin(BinValue),
-
-        Array(ArrayValue),
 
         Space(SpaceValues),
 
@@ -134,10 +134,9 @@ define!({
         pub value: Option<Box<Value>>,
     }
 
-    pub struct ArrayValue {
+    pub struct SquareBracketBlock {
         pub span: Span,
-
-        pub values: Vec<Value>,
+        pub children: Option<Vec<Value>>,
     }
 
     pub struct HashValue {


### PR DESCRIPTION
Added `SquareBracketBlock`, we have big problems with parsing `simple block`s https://www.w3.org/TR/css-syntax-3/#ref-for-simple-block%E2%91%A3

Shortly:
- We have three types of blocks - `(`/`)`, `[`/`]`, `{`/`}` in CSS (i.e simple block in spec)
- Each `simple block` can contain `component value`
- `Component value` can contain another `simple blocks`
- There are no commas/spaces or other values inside blocks, so we should remove empty (i.e. `SpacedValue`/ `CommaValue`)
- Also here fix when we can't parse grid multiple lines with whitespaces inside
- Also `simple blocks` can be part of `at-rules` value, so when we finish `simple blocks` we will simplify at-rules logic vey well 

Future fixes:
- I will content `(` and `)` to block too
- We should have two functions `parse_simple_block` and `parse_component_value` and they should call each other
- We still break AST for `+`/`-`/`/`/`*` but I will fix it after block improvements 

Also let use `children` instead `values`, because it is more general (postcss and other parser which I known uses `children` too)