### PR TITLE
perf(node/swc): Parse input using worker thread

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -185,6 +185,7 @@ jobs:
           node-version: 16
 
       - uses: denoland/setup-deno@v1
+        if: matrix.crate == 'swc_bundler'
         with:
           deno-version: v1.x
 

--- a/node/binding/src/minify.rs
+++ b/node/binding/src/minify.rs
@@ -2,7 +2,7 @@ use crate::{
     complete_output, get_compiler,
     util::{deserialize_json, try_with, CtxtExt, MapErr},
 };
-use napi::{CallContext, JsObject, JsString, Task};
+use napi::{CallContext, JsObject, Task};
 use serde::Deserialize;
 use std::sync::Arc;
 use swc::{config::JsMinifyOptions, TransformOutput};
@@ -66,8 +66,8 @@ impl Task for MinifyTask {
 
 #[js_function(2)]
 pub fn minify(cx: CallContext) -> napi::Result<JsObject> {
-    let code = cx.get::<JsString>(0)?.into_utf8()?.as_str()?.to_owned();
-    let options = cx.get::<JsString>(0)?.into_utf8()?.as_str()?.to_owned();
+    let code = cx.get_buffer_as_string(0)?;
+    let options = cx.get_buffer_as_string(1)?;
 
     let c = get_compiler(&cx);
 

--- a/node/binding/src/parse.rs
+++ b/node/binding/src/parse.rs
@@ -102,7 +102,7 @@ impl Task for ParseFileTask {
 pub fn parse(ctx: CallContext) -> napi::Result<JsObject> {
     let c = get_compiler(&ctx);
     let src = ctx.get::<JsString>(0)?.into_utf8()?.as_str()?.to_string();
-    let options = ctx.get::<JsString>(1)?.into_utf8()?.as_str()?.to_string();
+    let options = ctx.get_buffer_as_string(1)?;
     let filename = ctx.get::<Either<JsString, JsUndefined>>(2)?;
     let filename = if let Either::A(value) = filename {
         FileName::Real(value.into_utf8()?.as_str()?.to_owned().into())

--- a/node/binding/src/parse.rs
+++ b/node/binding/src/parse.rs
@@ -9,7 +9,7 @@ use std::{
     sync::Arc,
 };
 use swc::{config::ParseOptions, Compiler};
-use swc_common::{FileName, SourceFile};
+use swc_common::FileName;
 use swc_ecma_ast::Program;
 
 // ----- Parsing -----
@@ -39,7 +39,7 @@ impl Task for ParseTask {
     type JsValue = JsString;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
-        let mut options: ParseOptions = deserialize_json(&self.options).convert_err()?;
+        let options: ParseOptions = deserialize_json(&self.options).convert_err()?;
         let fm = self
             .c
             .cm
@@ -72,7 +72,7 @@ impl Task for ParseFileTask {
     fn compute(&mut self) -> napi::Result<Self::Output> {
         try_with(self.c.cm.clone(), false, |handler| {
             self.c.run(|| {
-                let mut options: ParseOptions = deserialize_json(&self.options).convert_err()?;
+                let options: ParseOptions = deserialize_json(&self.options).convert_err()?;
 
                 let fm = self
                     .c

--- a/node/binding/src/parse.rs
+++ b/node/binding/src/parse.rs
@@ -1,6 +1,6 @@
 use crate::{
     get_compiler,
-    util::{try_with, CtxtExt, MapErr},
+    util::{deserialize_json, try_with, CtxtExt, MapErr},
 };
 use anyhow::Context as _;
 use napi::{CallContext, Either, Env, JsObject, JsString, JsUndefined, Task};
@@ -16,14 +16,15 @@ use swc_ecma_ast::Program;
 
 pub struct ParseTask {
     pub c: Arc<Compiler>,
-    pub fm: Arc<SourceFile>,
-    pub options: ParseOptions,
+    pub filename: FileName,
+    pub src: String,
+    pub options: String,
 }
 
 pub struct ParseFileTask {
     pub c: Arc<Compiler>,
     pub path: PathBuf,
-    pub options: ParseOptions,
+    pub options: String,
 }
 
 pub fn complete_parse<'a>(env: &Env, program: Program, _c: &Compiler) -> napi::Result<JsString> {
@@ -38,14 +39,20 @@ impl Task for ParseTask {
     type JsValue = JsString;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
+        let mut options: ParseOptions = deserialize_json(&self.options).convert_err()?;
+        let fm = self
+            .c
+            .cm
+            .new_source_file(self.filename.clone(), self.src.clone());
+
         let program = try_with(self.c.cm.clone(), false, |handler| {
             self.c.parse_js(
-                self.fm.clone(),
+                fm,
                 &handler,
-                self.options.target,
-                self.options.syntax,
-                self.options.is_module,
-                self.options.comments,
+                options.target,
+                options.syntax,
+                options.is_module,
+                options.comments,
             )
         })
         .convert_err()?;
@@ -65,6 +72,8 @@ impl Task for ParseFileTask {
     fn compute(&mut self) -> napi::Result<Self::Output> {
         try_with(self.c.cm.clone(), false, |handler| {
             self.c.run(|| {
+                let mut options: ParseOptions = deserialize_json(&self.options).convert_err()?;
+
                 let fm = self
                     .c
                     .cm
@@ -74,10 +83,10 @@ impl Task for ParseFileTask {
                 self.c.parse_js(
                     fm,
                     handler,
-                    self.options.target,
-                    self.options.syntax,
-                    self.options.is_module,
-                    self.options.comments,
+                    options.target,
+                    options.syntax,
+                    options.is_module,
+                    options.comments,
                 )
             })
         })
@@ -92,8 +101,8 @@ impl Task for ParseFileTask {
 #[js_function(3)]
 pub fn parse(ctx: CallContext) -> napi::Result<JsObject> {
     let c = get_compiler(&ctx);
-    let src = ctx.get::<JsString>(0)?.into_utf8()?;
-    let options: ParseOptions = ctx.get_deserialized(1)?;
+    let src = ctx.get::<JsString>(0)?.into_utf8()?.as_str()?.to_string();
+    let options = ctx.get::<JsString>(1)?.into_utf8()?.as_str()?.to_string();
     let filename = ctx.get::<Either<JsString, JsUndefined>>(2)?;
     let filename = if let Either::A(value) = filename {
         FileName::Real(value.into_utf8()?.as_str()?.to_owned().into())
@@ -101,12 +110,11 @@ pub fn parse(ctx: CallContext) -> napi::Result<JsObject> {
         FileName::Anon
     };
 
-    let fm = c.cm.new_source_file(filename, src.as_str()?.to_string());
-
     ctx.env
         .spawn(ParseTask {
             c: c.clone(),
-            fm,
+            filename,
+            src,
             options,
         })
         .map(|t| t.promise_object())
@@ -174,7 +182,7 @@ pub fn parse_file_sync(cx: CallContext) -> napi::Result<JsString> {
 pub fn parse_file(cx: CallContext) -> napi::Result<JsObject> {
     let c = get_compiler(&cx);
     let path = PathBuf::from(cx.get::<JsString>(0)?.into_utf8()?.as_str()?);
-    let options: ParseOptions = cx.get_deserialized(1)?;
+    let options = cx.get::<JsString>(1)?.into_utf8()?.as_str()?.to_string();
 
     cx.env
         .spawn(ParseFileTask { c, path, options })

--- a/node/binding/src/print.rs
+++ b/node/binding/src/print.rs
@@ -15,8 +15,8 @@ use swc_ecma_parser::JscTarget;
 
 pub struct PrintTask {
     pub c: Arc<Compiler>,
-    pub program: Program,
-    pub options: Options,
+    pub program_json: String,
+    pub options: String,
 }
 
 impl Task for PrintTask {
@@ -24,20 +24,23 @@ impl Task for PrintTask {
     type JsValue = JsObject;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
+        let program: Program = deserialize_json(&self.program_json).convert_err()?;
+        let options: Options = deserialize_json(&self.options).convert_err()?;
+
         self.c
             .print(
-                &self.program,
+                &program,
                 None,
-                self.options.output_path.clone(),
+                options.output_path.clone(),
                 true,
-                self.options.config.jsc.target.unwrap_or(JscTarget::Es2020),
-                self.options
+                options.config.jsc.target.unwrap_or(JscTarget::Es2020),
+                options
                     .source_maps
                     .clone()
                     .unwrap_or(SourceMapsConfig::Bool(false)),
                 &Default::default(),
                 None,
-                self.options.config.clone().minify,
+                options.config.clone().minify,
                 None,
             )
             .convert_err()
@@ -51,20 +54,13 @@ impl Task for PrintTask {
 #[js_function(2)]
 pub fn print(cx: CallContext) -> napi::Result<JsObject> {
     let c = get_compiler(&cx);
-    let program = cx.get::<JsString>(0)?.into_utf8()?;
-    let program: Program = deserialize_json(program.as_str()?).map_err(|e| {
-        Error::new(
-            Status::InvalidArg,
-            format!("failed to deserialize Program {}", e),
-        )
-    })?;
-
-    let options: Options = cx.get_deserialized(1)?;
+    let program_json = cx.get::<JsString>(0)?.into_utf8()?.as_str()?.to_string();
+    let options = cx.get::<JsString>(1)?.into_utf8()?.as_str()?.to_string();
 
     cx.env
         .spawn(PrintTask {
             c: c.clone(),
-            program,
+            program_json,
             options,
         })
         .map(|t| t.promise_object())

--- a/node/binding/src/print.rs
+++ b/node/binding/src/print.rs
@@ -55,7 +55,7 @@ impl Task for PrintTask {
 pub fn print(cx: CallContext) -> napi::Result<JsObject> {
     let c = get_compiler(&cx);
     let program_json = cx.get::<JsString>(0)?.into_utf8()?.as_str()?.to_string();
-    let options = cx.get::<JsString>(1)?.into_utf8()?.as_str()?.to_string();
+    let options = cx.get_buffer_as_string(1)?;
 
     cx.env
         .spawn(PrintTask {

--- a/node/binding/src/print.rs
+++ b/node/binding/src/print.rs
@@ -2,7 +2,7 @@ use crate::{
     complete_output, get_compiler,
     util::{deserialize_json, CtxtExt, MapErr},
 };
-use napi::{CallContext, Env, Error, JsObject, JsString, Status, Task};
+use napi::{CallContext, Env, JsObject, JsString, Task};
 use std::sync::Arc;
 use swc::{
     config::{Options, SourceMapsConfig},

--- a/node/binding/src/transform.rs
+++ b/node/binding/src/transform.rs
@@ -89,7 +89,7 @@ where
 
     let src = cx.get::<JsString>(0)?.into_utf8()?.as_str()?.to_owned();
     let is_module = cx.get::<JsBoolean>(1)?;
-    let options = cx.get::<JsString>(2)?.into_utf8()?.as_str()?.to_owned();
+    let options = cx.get_buffer_as_string(2)?;
 
     let task = op(&c, src, is_module.get_value()?, options);
 

--- a/node/binding/src/util.rs
+++ b/node/binding/src/util.rs
@@ -41,6 +41,8 @@ pub trait MapErr<T>: Into<Result<T, anyhow::Error>> {
 impl<T> MapErr<T> for Result<T, anyhow::Error> {}
 
 pub trait CtxtExt {
+    fn get_buffer_as_string(&self, index: usize) -> napi::Result<String>;
+
     /// Currently this uses JsBuffer
     fn get_deserialized<T>(&self, index: usize) -> napi::Result<T>
     where
@@ -48,6 +50,12 @@ pub trait CtxtExt {
 }
 
 impl CtxtExt for CallContext<'_> {
+    fn get_buffer_as_string(&self, index: usize) -> napi::Result<String> {
+        let buffer = self.get::<JsBuffer>(index)?.into_value()?;
+
+        Ok(String::from_utf8_lossy(buffer.as_ref()).to_string())
+    }
+
     fn get_deserialized<T>(&self, index: usize) -> napi::Result<T>
     where
         T: DeserializeOwned,


### PR DESCRIPTION
node_swc:
 - Make `transform` parse the options in background.
 - Make `transform` analyze the input file in background.
 - Make `minify` parse the options in background.
 - Make `minify` deserialize the input in background.
 - Make `parse` parse the options in background.
 - Make `parse` analyze the input file in background.
 - Make `print` parse the options in background.
 - Make `print` deserialize the input file in background.
