### PR TITLE
chore: Fix issue form syntax

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,8 +1,6 @@
 name: Bug Report
-about: Use this when swc breaks something
-title: ""
+description: Use this when swc breaks something
 labels: C-bug
-assignees: ""
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,8 +1,5 @@
 name: Feature Request
-about: Use this when you want a new feature
-title: ""
-labels: ""
-assignees: ""
+description: Use this when you want a new feature
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
Issue forms can't be adopted successfully due to invalid syntax:

![图片](https://user-images.githubusercontent.com/17216317/139569143-7091ba43-0249-417c-9a89-63d287ae4bc4.png)

This PR fixes it.