### PR TITLE
chore: Update playground link in issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
     id: repro-link
     attributes:
       label: Playground link
-      description: You can use [swc playground](https://swc-play.vercel.app/) to create a reproduction link, then paste the link here.
+      description: You can use [swc playground](https://play.swc.rs/) to create a reproduction link, then paste the link here.
   - type: textarea
     id: expected-behavior
     attributes:


### PR DESCRIPTION
The playground was assigned a new domain name, so this PR updates corresponding URL.