### PR TITLE
fix(es/transforms/tsc): coerce bindingident with tsasexpr

### DIFF
--- a/tests/fixture/issue-2606/1/input/.swcrc
+++ b/tests/fixture/issue-2606/1/input/.swcrc
@@ -1,0 +1,11 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript"
+    },
+    "target": "es2015"
+  },
+  "module": {
+    "type": "commonjs"
+  }
+}

--- a/tests/fixture/issue-2606/1/input/index.ts
+++ b/tests/fixture/issue-2606/1/input/index.ts
@@ -1,0 +1,17 @@
+export function warn() {
+  throw new Error("this should not be called");
+}
+export const test = {};
+export const test2 = {};
+Object.defineProperty(test, "warn", {
+  get: () => warn,
+  set: (v) => {
+    (warn as any) = v;
+  },
+});
+Object.defineProperty(test2, "work", {
+  get: () => warn,
+  set: (v) => {
+    warn = v;
+  },
+});

--- a/tests/fixture/issue-2606/1/output/index.ts
+++ b/tests/fixture/issue-2606/1/output/index.ts
@@ -1,0 +1,29 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.warn = warn;
+exports.test2 = exports.test = void 0;
+function warn() {
+    throw new Error("this should not be called");
+}
+const test = {
+};
+exports.test = test;
+const test2 = {
+};
+exports.test2 = test2;
+Object.defineProperty(test, "warn", {
+    get: ()=>warn
+    ,
+    set: (v)=>{
+        exports.warn = warn = v;
+    }
+});
+Object.defineProperty(test2, "work", {
+    get: ()=>warn
+    ,
+    set: (v)=>{
+        exports.warn = warn = v;
+    }
+});


### PR DESCRIPTION
- closes https://github.com/swc-project/swc/issues/2606

This PR attempts to allow reassign fn when it is wrapped with `as` casting paren, like `(warn as any) = v`.

Change follows suggestion to coerece Pat::Ident if given Pat is wrapped paren expr - but instead of after visiting does check and coerece before to distinguish between plain assignment like `(x) = v`.

Peeking emitted output when we try to treat both as same it seems possible to treat both as same but can't 100% sure around minified outputs. For now, choose safest path to not regress existing fixtures.