### PR TITLE
fix(es/transforms): Fix detection of `this`

### DIFF
--- a/ecmascript/transforms/compat/src/es2015/arrow.rs
+++ b/ecmascript/transforms/compat/src/es2015/arrow.rs
@@ -284,4 +284,21 @@ impl VisitMut for ThisReplacer<'_> {
     }
 
     fn visit_mut_function(&mut self, _: &mut Function) {}
+
+    /// Don't recurse into fn
+    fn visit_mut_getter_prop(&mut self, n: &mut GetterProp) {
+        n.key.visit_mut_with(self);
+    }
+
+    /// Don't recurse into fn
+    fn visit_mut_method_prop(&mut self, n: &mut MethodProp) {
+        n.key.visit_mut_with(self);
+        n.function.visit_mut_with(self);
+    }
+
+    /// Don't recurse into fn
+    fn visit_mut_setter_prop(&mut self, n: &mut SetterProp) {
+        n.key.visit_mut_with(self);
+        n.param.visit_mut_with(self);
+    }
 }

--- a/ecmascript/transforms/compat/src/es2015/parameters.rs
+++ b/ecmascript/transforms/compat/src/es2015/parameters.rs
@@ -576,4 +576,21 @@ impl VisitMut for ThisReplacer<'_> {
     }
 
     fn visit_mut_function(&mut self, _: &mut Function) {}
+
+    /// Don't recurse into fn
+    fn visit_mut_getter_prop(&mut self, n: &mut GetterProp) {
+        n.key.visit_mut_with(self);
+    }
+
+    /// Don't recurse into fn
+    fn visit_mut_method_prop(&mut self, n: &mut MethodProp) {
+        n.key.visit_mut_with(self);
+        n.function.visit_mut_with(self);
+    }
+
+    /// Don't recurse into fn
+    fn visit_mut_setter_prop(&mut self, n: &mut SetterProp) {
+        n.key.visit_mut_with(self);
+        n.param.visit_mut_with(self);
+    }
 }

--- a/ecmascript/utils/src/lib.rs
+++ b/ecmascript/utils/src/lib.rs
@@ -58,11 +58,34 @@ impl Visit for ThisVisitor {
     /// Don't recurse into fn
     fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
 
+    /// Don't recurse into fn
+    fn visit_getter_prop(&mut self, n: &GetterProp, _: &dyn Node) {
+        n.key.visit_with(n, self);
+    }
+
+    /// Don't recurse into fn
+    fn visit_method_prop(&mut self, n: &MethodProp, _: &dyn Node) {
+        n.key.visit_with(n, self);
+        n.function.visit_with(n, self);
+    }
+
+    /// Don't recurse into fn
+    fn visit_setter_prop(&mut self, n: &SetterProp, _: &dyn Node) {
+        n.key.visit_with(n, self);
+        n.param.visit_with(n, self);
+    }
+
     fn visit_this_expr(&mut self, _: &ThisExpr, _: &dyn Node) {
         self.found = true;
     }
 }
 
+/// This does not recurse into a function if `this` is changed by it.
+///
+/// e.g.
+///
+///   - The body of an arrow expression is visited.
+///   - The body of a function expression is **not** visited.
 pub fn contains_this_expr<N>(body: &N) -> bool
 where
     N: VisitWith<ThisVisitor>,

--- a/tests/vercel/loader-only/next-30592/1/input/index.js
+++ b/tests/vercel/loader-only/next-30592/1/input/index.js
@@ -1,0 +1,16 @@
+const navigation = (path) => [
+    {
+        name: "Home",
+        href: `/`,
+        get current() {
+            return this.href === path;
+        },
+    },
+    {
+        name: "Dashboard",
+        href: `/dashboard`,
+        get current() {
+            return this.href === path;
+        },
+    },
+];

--- a/tests/vercel/loader-only/next-30592/1/output/index.js
+++ b/tests/vercel/loader-only/next-30592/1/output/index.js
@@ -1,0 +1,18 @@
+var navigation = function(path) {
+    return [
+        {
+            name: "Home",
+            href: "/",
+            get current () {
+                return this.href === path;
+            }
+        },
+        {
+            name: "Dashboard",
+            href: "/dashboard",
+            get current () {
+                return this.href === path;
+            }
+        }, 
+    ];
+};


### PR DESCRIPTION
swc_ecma_utils:
 - `contains_this_expr`: Exclude `this` in object properties.

swc_ecma_transforms_compat:
 - `arrow`: Exclude `this` in object properties. (https://github.com/vercel/next.js/issues/30592)
 - `parameters`: Exclude `this` in object properties.