### PR TITLE
(Fix #2016) Add a es2015 transform for const support

### DIFF
--- a/ecmascript/transforms/compat/src/es2015/const_readonly.rs
+++ b/ecmascript/transforms/compat/src/es2015/const_readonly.rs
@@ -1,0 +1,141 @@
+use swc_common::DUMMY_SP;
+use swc_ecma_ast::*;
+use swc_ecma_transforms_base::helper;
+use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
+
+/// # Example
+///
+/// # In
+///
+/// ```js
+/// const a = 32;
+/// a = 4
+///
+/// const b = [1, 2, 3];
+/// b[0] = 5;
+/// ```
+///
+/// ## Out
+///
+/// ```js
+/// function _readOnlyError(name) { throw new TypeError("\"" + name + "\" is read-only"); }
+///
+/// var a = 32;
+/// 4, _readOnlyError("a#1");
+///
+/// var b = [1, 2, 3];
+/// 5, _readOnlyError("b#1");
+/// ```
+pub fn check_constants() -> impl Fold + VisitMut {
+    as_folder(Consts::default())
+}
+
+fn find_lhs_id(lhs: &PatOrExpr) -> Option<Ident> {
+    fn find_lhs_id_from_expr(lhs: &Expr) -> Option<Ident> {
+        match lhs {
+            Expr::Member(m) => {
+                let obj = match &m.obj {
+                    ExprOrSuper::Super(_) => return None,
+                    ExprOrSuper::Expr(obj) => &**obj,
+                };
+                match obj {
+                    Expr::Ident(i) => Some(i.clone()),
+                    Expr::Member(..) => find_lhs_id_from_expr(&obj),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    match lhs {
+        PatOrExpr::Expr(e) => find_lhs_id_from_expr(&e),
+        PatOrExpr::Pat(pat) => match &**pat {
+            Pat::Expr(e) => find_lhs_id_from_expr(&e),
+            Pat::Ident(BindingIdent { id, type_ann: _ }) => Some(id.clone()),
+            _ => None,
+        },
+    }
+}
+
+#[derive(Debug, Default)]
+struct Consts {
+    consts: Vec<VarDeclarator>,
+}
+
+impl VisitMut for Consts {
+    noop_visit_mut_type!();
+
+    // Handle const declaration not having a initializer
+    fn visit_mut_var_decl(&mut self, decl: &mut VarDecl) {
+        decl.visit_mut_children_with(self);
+
+        match decl.kind {
+            VarDeclKind::Const => {
+                for d in decl.decls.iter() {
+                    self.consts.push(d.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // TODO
+    fn visit_mut_var_decl_or_expr(&mut self, decl: &mut VarDeclOrExpr) {
+        decl.visit_mut_children_with(self);
+        // println!("--> {:#?}", decl);
+    }
+
+    fn visit_mut_expr(&mut self, e: &mut Expr) {
+        e.visit_mut_children_with(self);
+        // println!("--> {:#?}", e);
+
+        match e {
+            Expr::Assign(AssignExpr {
+                span,
+                op: _,
+                left,
+                right,
+            }) => {
+                match find_lhs_id(left) {
+                    Some(ident) => {
+                        let consts = self.consts.clone();
+                        let const_idx = consts
+                            .into_iter()
+                            .find(|i| i.name.clone().expect_ident().id.sym == ident.sym);
+                        match const_idx {
+                            Some(..) => {
+                                let mut exprs: Vec<Box<Expr>> = vec![];
+                                let mut args = vec![];
+                                args.push(ExprOrSpread {
+                                    spread: None,
+                                    expr: Box::new(Expr::Lit(Lit::Str(Str {
+                                        span: DUMMY_SP,
+                                        value: ident.to_string().into(),
+                                        has_escape: false,
+                                        kind: Default::default(),
+                                    }))),
+                                });
+                                exprs.push(right.clone());
+                                exprs.push(Box::new(Expr::Call(CallExpr {
+                                    span: DUMMY_SP,
+                                    callee: helper!(*span, read_only_error, "readOnlyError"),
+                                    args,
+                                    type_args: Default::default(),
+                                })));
+                                *e = Expr::Seq(SeqExpr {
+                                    span: DUMMY_SP,
+                                    exprs,
+                                });
+                                ()
+                            }
+                            None => {}
+                        };
+                    }
+                    None => {}
+                };
+            }
+            _ => {}
+        }
+    }
+}

--- a/ecmascript/transforms/compat/src/es2015/mod.rs
+++ b/ecmascript/transforms/compat/src/es2015/mod.rs
@@ -1,11 +1,13 @@
 pub use self::{
     arrow::arrow, block_scoped_fn::block_scoped_functions, block_scoping::block_scoping,
-    classes::classes, computed_props::computed_properties, destructuring::destructuring,
-    duplicate_keys::duplicate_keys, for_of::for_of, function_name::function_name,
-    instanceof::instance_of, new_target::new_target, parameters::parameters,
-    regenerator::regenerator, shorthand_property::shorthand, spread::spread,
-    sticky_regex::sticky_regex, template_literal::template_literal, typeof_symbol::typeof_symbol,
+    classes::classes, computed_props::computed_properties, const_readonly::check_constants,
+    destructuring::destructuring, duplicate_keys::duplicate_keys, for_of::for_of,
+    function_name::function_name, instanceof::instance_of, new_target::new_target,
+    parameters::parameters, regenerator::regenerator, shorthand_property::shorthand,
+    spread::spread, sticky_regex::sticky_regex, template_literal::template_literal,
+    typeof_symbol::typeof_symbol,
 };
+
 use serde::Deserialize;
 use swc_common::{chain, comments::Comments, Mark};
 use swc_ecma_visit::Fold;
@@ -15,6 +17,7 @@ mod block_scoped_fn;
 mod block_scoping;
 pub mod classes;
 mod computed_props;
+mod const_readonly;
 pub mod destructuring;
 mod duplicate_keys;
 pub mod for_of;
@@ -60,7 +63,8 @@ where
         computed_properties(),
         destructuring(c.destructuring),
         regenerator(c.regenerator, global_mark),
-        block_scoping(),
+        check_constants(),
+        block_scoping()
     )
 }
 


### PR DESCRIPTION
Adds support for checking mutation on identifiers declared as const.

Transforms

```javascript
// vars aren't affected
var a;
a = 2;
a = 3;

try {
	var a = 4;
	a = 5;
} catch {}

// consts with initializers work as expected
const b = 2;
b = 3;

try {
	const b = 4;
	b = 5;
} catch {};

// FIXME: no-initializer consts should throw Syntax Error
const c;
c = 3;
c = 4;

try {
	const c;
	c = 5;
	c = 6;
} catch {};

// multi-declarations work as expected
const d = 42, e = 42;
d = 35;
e = 45;

// array/object setters work
const f = {a: 1, b: 2};
f["a"] = 3;

const g = [1, 2, 3, 4];
g[1] = 5;
```

into 

```javascript
// vars aren't affected
var a;
a = 2;
a = 3;
try {
    var a = 4;
    a = 5;
} catch (e) {
}
// consts with initializers work as expected
var b = 2;
3, _readOnlyError("b#1");
try {
    var b = 4;
    5, _readOnlyError("b#2");
} catch (e) {
}
;
// FIXME: no-initializer consts should throw Syntax Error
var c;
3, _readOnlyError("c#1");
4, _readOnlyError("c#1");
try {
    var c;
    5, _readOnlyError("c#3");
    6, _readOnlyError("c#3");
} catch (e) {
}
;
// multi-declarations work as expected
var d = 42, e = 42;
35, _readOnlyError("d#1");
45, _readOnlyError("e#1");
// array/object setters work
var f = {
    a: 1,
    b: 2
};
3, _readOnlyError("f#1");
var g = [
    1,
    2,
    3,
    4
];
5, _readOnlyError("g#1");
```

TODO:
- Raise a syntax error for [const declarations without initializers](https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-let-and-const-declarations-static-semantics-early-errors)
- Tests
