### PR TITLE
Feat added nesting selector

### DIFF
--- a/css/ast/src/selector.rs
+++ b/css/ast/src/selector.rs
@@ -20,7 +20,6 @@ pub struct ComplexSelector {
 pub struct CompoundSelector {
     pub span: Span,
     /// "&"
-    pub has_nest_prefix: bool,
     pub nesting_selector: Option<NestingSelector>,
     pub combinator: Option<SelectorCombinator>,
     pub type_selector: Option<TypeSelector>,
@@ -40,6 +39,8 @@ pub enum SelectorCombinator {
 
     /// `~`
     LaterSibling,
+}
+
 #[ast_node("NestingSelector")]
 pub struct NestingSelector {
     pub span: Span,

--- a/css/ast/src/selector.rs
+++ b/css/ast/src/selector.rs
@@ -21,6 +21,7 @@ pub struct CompoundSelector {
     pub span: Span,
     /// "&"
     pub has_nest_prefix: bool,
+    pub nesting_selector: Option<NestingSelector>,
     pub combinator: Option<SelectorCombinator>,
     pub type_selector: Option<TypeSelector>,
     pub subclass_selectors: Vec<SubclassSelector>,
@@ -39,6 +40,9 @@ pub enum SelectorCombinator {
 
     /// `~`
     LaterSibling,
+#[ast_node("NestingSelector")]
+pub struct NestingSelector {
+    pub span: Span,
 }
 
 #[ast_node("TypeSelector")]

--- a/css/codegen/src/lib.rs
+++ b/css/codegen/src/lib.rs
@@ -695,15 +695,13 @@ where
 
     #[emitter]
     fn emit_compound_selector(&mut self, n: &CompoundSelector) -> Result {
-        let ctx = Ctx { ..self.ctx };
-
-        emit!(&mut *self.with_ctx(ctx), n.nesting_selector);
+        emit!(&mut *self.with_ctx(self.ctx), n.nesting_selector);
 
         if let Some(combinator) = &n.combinator {
             self.wr.write_punct(None, combinator.as_str())?;
         }
 
-        emit!(&mut *self.with_ctx(ctx), n.type_selector);
+        emit!(&mut *self.with_ctx(self.ctx), n.type_selector);
 
         self.emit_list(&n.subclass_selectors, ListFormat::NotDelimited)?;
     }

--- a/css/codegen/src/lib.rs
+++ b/css/codegen/src/lib.rs
@@ -689,16 +689,20 @@ where
     }
 
     #[emitter]
+    fn emit_nesting_selector(&mut self, _: &NestingSelector) -> Result {
+        punct!(self, "&");
+    }
+
+    #[emitter]
     fn emit_compound_selector(&mut self, n: &CompoundSelector) -> Result {
-        if n.has_nest_prefix {
-            punct!(self, "&");
-        }
+        let ctx = Ctx { ..self.ctx };
+
+        emit!(&mut *self.with_ctx(ctx), n.nesting_selector);
 
         if let Some(combinator) = &n.combinator {
             self.wr.write_punct(None, combinator.as_str())?;
         }
 
-        let ctx = Ctx { ..self.ctx };
         emit!(&mut *self.with_ctx(ctx), n.type_selector);
 
         self.emit_list(&n.subclass_selectors, ListFormat::NotDelimited)?;

--- a/css/parser/src/parser/selector/mod.rs
+++ b/css/parser/src/parser/selector/mod.rs
@@ -98,7 +98,9 @@ where
         Ok(None)
     }
 
-    fn parse_ns_prefix(&mut self, span: Span) -> PResult<Option<Text>> {
+    fn parse_ns_prefix(&mut self) -> PResult<Option<Text>> {
+        let span = self.input.cur_span()?;
+
         if is!(self, Ident) && peeked_is!(self, "|") {
             let token = bump!(self);
             let text = match token {
@@ -139,8 +141,7 @@ where
             || is!(self, "*") && peeked_is!(self, "|")
             || is!(self, "|")
         {
-            let span = self.input.cur_span()?;
-            let prefix = self.parse_ns_prefix(span)?;
+            let prefix = self.parse_ns_prefix()?;
 
             if is!(self, Ident) {
                 let span = self.input.cur_span()?;
@@ -181,7 +182,7 @@ where
 
         let mut prefix = None;
 
-        if let Ok(result) = self.parse_ns_prefix(span) {
+        if let Ok(result) = self.parse_ns_prefix() {
             prefix = result;
         }
 

--- a/css/parser/src/parser/selector/mod.rs
+++ b/css/parser/src/parser/selector/mod.rs
@@ -442,11 +442,14 @@ where
         let span = self.input.cur_span()?;
         let start_pos = span.lo;
 
-        let mut has_nest_prefix = false;
+        let mut nesting_selector = None;
 
+        // TODO: move under option, because it is draft
         // This is an extension: https://drafts.csswg.org/css-nesting-1/
         if eat!(self, "&") {
-            has_nest_prefix = true;
+            nesting_selector = Some(NestingSelector {
+                span: span!(self, start_pos),
+            });
         }
 
         let type_selector = self.parse_type_selector(span).unwrap();
@@ -527,13 +530,13 @@ where
 
         let span = span!(self, start_pos);
 
-        if !has_nest_prefix && type_selector.is_none() && subclass_selectors.len() == 0 {
+        if nesting_selector.is_none() && type_selector.is_none() && subclass_selectors.len() == 0 {
             return Err(Error::new(span, ErrorKind::InvalidSelector));
         }
 
         Ok(CompoundSelector {
             span,
-            has_nest_prefix,
+            nesting_selector,
             combinator: None,
             type_selector,
             subclass_selectors,

--- a/css/parser/src/parser/selector/mod.rs
+++ b/css/parser/src/parser/selector/mod.rs
@@ -269,8 +269,6 @@ where
 
         self.input.skip_ws()?;
 
-        let start_span = self.input.cur_span()?;
-        let name_start_pos = self.input.cur_span()?.lo;
         let prefix;
         let name;
         let mut attr_matcher = None;

--- a/css/parser/src/parser/selector/mod.rs
+++ b/css/parser/src/parser/selector/mod.rs
@@ -132,13 +132,14 @@ where
         Ok(None)
     }
 
-    fn parse_wq_name(&mut self, span: Span) -> PResult<(Option<Text>, Option<Text>)> {
+    fn parse_wq_name(&mut self) -> PResult<(Option<Text>, Option<Text>)> {
         let state = self.input.state();
 
         if is!(self, Ident) && peeked_is!(self, "|")
             || is!(self, "*") && peeked_is!(self, "|")
             || is!(self, "|")
         {
+            let span = self.input.cur_span()?;
             let prefix = self.parse_ns_prefix(span)?;
 
             if is!(self, Ident) {
@@ -268,13 +269,14 @@ where
         self.input.skip_ws()?;
 
         let start_span = self.input.cur_span()?;
+        let name_start_pos = self.input.cur_span()?.lo;
         let prefix;
         let name;
         let mut attr_matcher = None;
         let mut matcher_value = None;
         let mut matcher_modifier = None;
 
-        if let Ok((p, Some(n))) = self.parse_wq_name(start_span) {
+        if let Ok((p, Some(n))) = self.parse_wq_name() {
             prefix = p;
             name = n;
         } else {

--- a/css/parser/tests/fixture.rs
+++ b/css/parser/tests/fixture.rs
@@ -329,6 +329,7 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(SquareBracketBlock, visit_square_bracket_block);
     mtd!(FnValue, visit_fn_value);
     mtd!(HashValue, visit_hash_value);
+    mtd!(NestingSelector, visit_nesting_selector);
     mtd!(IdSelector, visit_id_selector);
     mtd!(TypeSelector, visit_type_selector);
     mtd!(Num, visit_num);

--- a/css/parser/tests/fixture/comment/output.json
+++ b/css/parser/tests/fixture/comment/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 13,
-            "end": 14,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 13,
-                "end": 14,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 13,
                   "end": 14,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -150,32 +130,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 132,
-            "end": 135,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 132,
-                "end": 135,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 132,
                   "end": 135,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -300,32 +260,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 237,
-            "end": 238,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 237,
-                "end": 238,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 237,
                   "end": 238,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/comment/output.json
+++ b/css/parser/tests/fixture/comment/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 13,
+            "end": 14,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 13,
+                "end": 14,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 13,
                   "end": 14,
@@ -130,6 +150,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 132,
+            "end": 135,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 132,
+                "end": 135,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 132,
                   "end": 135,
@@ -260,6 +300,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 237,
+            "end": 238,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 237,
+                "end": 238,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 237,
                   "end": 238,

--- a/css/parser/tests/fixture/declaration-list/output.json
+++ b/css/parser/tests/fixture/declaration-list/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/declaration-list/output.json
+++ b/css/parser/tests/fixture/declaration-list/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/delim/backslash/output.json
+++ b/css/parser/tests/fixture/delim/backslash/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/delim/backslash/output.json
+++ b/css/parser/tests/fixture/delim/backslash/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/dimension/basic/output.json
+++ b/css/parser/tests/fixture/dimension/basic/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/dimension/basic/output.json
+++ b/css/parser/tests/fixture/dimension/basic/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/-4j83DwgJa0nPQIjlb0RIA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-4j83DwgJa0nPQIjlb0RIA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/-4j83DwgJa0nPQIjlb0RIA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-4j83DwgJa0nPQIjlb0RIA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/-8o_H6sq86TDAHqF7YO0hg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-8o_H6sq86TDAHqF7YO0hg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/-8o_H6sq86TDAHqF7YO0hg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-8o_H6sq86TDAHqF7YO0hg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/-GZJfOA9TK6La2KGGNgCkg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-GZJfOA9TK6La2KGGNgCkg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 55,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 55,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 55,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/-GZJfOA9TK6La2KGGNgCkg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-GZJfOA9TK6La2KGGNgCkg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 55,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 55,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 55,

--- a/css/parser/tests/fixture/esbuild/misc/-JoxoRcnA-zaaEC7RjXKvQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-JoxoRcnA-zaaEC7RjXKvQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/-JoxoRcnA-zaaEC7RjXKvQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-JoxoRcnA-zaaEC7RjXKvQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/-b4VODLSeaV93gwC2Ot2tw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-b4VODLSeaV93gwC2Ot2tw/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 7,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/-b4VODLSeaV93gwC2Ot2tw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-b4VODLSeaV93gwC2Ot2tw/output.json
@@ -36,41 +36,12 @@
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 7,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/-shTP60AAG6a4mCJUpV1cQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-shTP60AAG6a4mCJUpV1cQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 5,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/-shTP60AAG6a4mCJUpV1cQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/-shTP60AAG6a4mCJUpV1cQ/output.json
@@ -36,41 +36,12 @@
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 5,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/07tvJxvZrgDeTmptOclErA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/07tvJxvZrgDeTmptOclErA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/07tvJxvZrgDeTmptOclErA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/07tvJxvZrgDeTmptOclErA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/0Zlgi2sdsFfTrdnWOHUqeg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/0Zlgi2sdsFfTrdnWOHUqeg/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/0Zlgi2sdsFfTrdnWOHUqeg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/0Zlgi2sdsFfTrdnWOHUqeg/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/0qqdP6EmNqzSa3h8c8lYUQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/0qqdP6EmNqzSa3h8c8lYUQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 3,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/0qqdP6EmNqzSa3h8c8lYUQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/0qqdP6EmNqzSa3h8c8lYUQ/output.json
@@ -36,41 +36,12 @@
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 3,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/0yo6flt6jo-UA8rUEFjrWA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/0yo6flt6jo-UA8rUEFjrWA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 4,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 4,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/0yo6flt6jo-UA8rUEFjrWA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/0yo6flt6jo-UA8rUEFjrWA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 4,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 4,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/10VLLYwNo7xaTisP9r9Kfg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/10VLLYwNo7xaTisP9r9Kfg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/10VLLYwNo7xaTisP9r9Kfg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/10VLLYwNo7xaTisP9r9Kfg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 6,

--- a/css/parser/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/1JQzQJ1QtQJ1onUzZx7BVg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/1JQzQJ1QtQJ1onUzZx7BVg/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 5,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/1JQzQJ1QtQJ1onUzZx7BVg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/1JQzQJ1QtQJ1onUzZx7BVg/output.json
@@ -36,41 +36,12 @@
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 5,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/1naykwaIKZc6zuHRNIccLQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/1naykwaIKZc6zuHRNIccLQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/1naykwaIKZc6zuHRNIccLQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/1naykwaIKZc6zuHRNIccLQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/2nNBhRWO2cNcBJf09zDxjw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/2nNBhRWO2cNcBJf09zDxjw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/2nNBhRWO2cNcBJf09zDxjw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/2nNBhRWO2cNcBJf09zDxjw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/36qnNuIUvbIrMnJKDxwE5A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/36qnNuIUvbIrMnJKDxwE5A/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/36qnNuIUvbIrMnJKDxwE5A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/36qnNuIUvbIrMnJKDxwE5A/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/39pbt1sIeFh8WWhCalZS4g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/39pbt1sIeFh8WWhCalZS4g/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/39pbt1sIeFh8WWhCalZS4g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/39pbt1sIeFh8WWhCalZS4g/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/3EgMpLwjJNG0ht4U_r6cnw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/3EgMpLwjJNG0ht4U_r6cnw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/3EgMpLwjJNG0ht4U_r6cnw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/3EgMpLwjJNG0ht4U_r6cnw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/3JGye8AhworwNFoUL1gKbg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/3JGye8AhworwNFoUL1gKbg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/3JGye8AhworwNFoUL1gKbg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/3JGye8AhworwNFoUL1gKbg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/4-S1C8qZOZ6Mm7WdRUH72Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/4-S1C8qZOZ6Mm7WdRUH72Q/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/4-S1C8qZOZ6Mm7WdRUH72Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/4-S1C8qZOZ6Mm7WdRUH72Q/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/485Ns9qQHa89OJU5Lhjx-Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/485Ns9qQHa89OJU5Lhjx-Q/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/485Ns9qQHa89OJU5Lhjx-Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/485Ns9qQHa89OJU5Lhjx-Q/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/486QvEO8dmLFsXYp6xgKVw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/486QvEO8dmLFsXYp6xgKVw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/486QvEO8dmLFsXYp6xgKVw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/486QvEO8dmLFsXYp6xgKVw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/4Tjjgepnha63E4UiXXDNEA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/4Tjjgepnha63E4UiXXDNEA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/4Tjjgepnha63E4UiXXDNEA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/4Tjjgepnha63E4UiXXDNEA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/4UaOTazLwrr9gd5xkBBlnw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/4UaOTazLwrr9gd5xkBBlnw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/4UaOTazLwrr9gd5xkBBlnw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/4UaOTazLwrr9gd5xkBBlnw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/52obp49U0CyYOskQAEoIJw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/52obp49U0CyYOskQAEoIJw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/52obp49U0CyYOskQAEoIJw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/52obp49U0CyYOskQAEoIJw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/54mhLGCwQMwsuiVkiTzAAQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/54mhLGCwQMwsuiVkiTzAAQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 11,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 11,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 11,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/54mhLGCwQMwsuiVkiTzAAQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/54mhLGCwQMwsuiVkiTzAAQ/output.json
@@ -36,41 +36,12 @@
                   "end": 11,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 11,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 11,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 11,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/5al65IRQbw_x4yG3ke74fQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/5al65IRQbw_x4yG3ke74fQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/5al65IRQbw_x4yG3ke74fQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/5al65IRQbw_x4yG3ke74fQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/5cnGKjYPm1XBeqTmw3oCag/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/5cnGKjYPm1XBeqTmw3oCag/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/5cnGKjYPm1XBeqTmw3oCag/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/5cnGKjYPm1XBeqTmw3oCag/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/5nNFwUYmVb5_MMMzIvIeQg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/5nNFwUYmVb5_MMMzIvIeQg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -81,16 +61,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": "~",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 6,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": "~",
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/5nNFwUYmVb5_MMMzIvIeQg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/5nNFwUYmVb5_MMMzIvIeQg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -61,6 +81,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": "~",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 6,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/5yer6GUWydidDHrfgacUkA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/5yer6GUWydidDHrfgacUkA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/5yer6GUWydidDHrfgacUkA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/5yer6GUWydidDHrfgacUkA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/62BQJI-uDjHXNJ7kyL8HiA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/62BQJI-uDjHXNJ7kyL8HiA/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 11,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 11,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 11,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/62BQJI-uDjHXNJ7kyL8HiA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/62BQJI-uDjHXNJ7kyL8HiA/output.json
@@ -36,41 +36,12 @@
                   "end": 11,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 11,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 11,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 11,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/6IWHWiWjsuGkPiPAp2KmoA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6IWHWiWjsuGkPiPAp2KmoA/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 10,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 10,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 10,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/6IWHWiWjsuGkPiPAp2KmoA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6IWHWiWjsuGkPiPAp2KmoA/output.json
@@ -36,41 +36,12 @@
                   "end": 10,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 10,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 10,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 10,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/6WYwXsqP1SJOa-6oDBobzQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6WYwXsqP1SJOa-6oDBobzQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/6WYwXsqP1SJOa-6oDBobzQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6WYwXsqP1SJOa-6oDBobzQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/6fufNZ3PA6_-pNwY-IP61Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6fufNZ3PA6_-pNwY-IP61Q/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -81,16 +61,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": "+",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 2,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": "+",
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/6fufNZ3PA6_-pNwY-IP61Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6fufNZ3PA6_-pNwY-IP61Q/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -61,6 +81,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": "+",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 2,
                   "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/6kUhG0W7hwZxIuaCsZ7pHg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6kUhG0W7hwZxIuaCsZ7pHg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/6kUhG0W7hwZxIuaCsZ7pHg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6kUhG0W7hwZxIuaCsZ7pHg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/6s_VBuRPHbPiUrh1fWCR_Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6s_VBuRPHbPiUrh1fWCR_Q/output.json
@@ -42,6 +42,36 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 15,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 15,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 15,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 15,

--- a/css/parser/tests/fixture/esbuild/misc/6s_VBuRPHbPiUrh1fWCR_Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/6s_VBuRPHbPiUrh1fWCR_Q/output.json
@@ -36,42 +36,12 @@
                   "end": 15,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 15,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 15,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 15,
-                    "ctxt": 0
-                  },
-                  "isElement": false,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 15,

--- a/css/parser/tests/fixture/esbuild/misc/7CK6ZYt4CWz7Ge5KWLKBYg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/7CK6ZYt4CWz7Ge5KWLKBYg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/7CK6ZYt4CWz7Ge5KWLKBYg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/7CK6ZYt4CWz7Ge5KWLKBYg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/7S9dyZUmnJW4VKAa7gcKvw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/7S9dyZUmnJW4VKAa7gcKvw/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/7S9dyZUmnJW4VKAa7gcKvw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/7S9dyZUmnJW4VKAa7gcKvw/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/7Wto7epgdmJCos0XkrnMww/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/7Wto7epgdmJCos0XkrnMww/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -61,6 +81,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": "+",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 6,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/7Wto7epgdmJCos0XkrnMww/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/7Wto7epgdmJCos0XkrnMww/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -81,16 +61,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": "+",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 6,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": "+",
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/8R-UUShF-1EmQSj6_GQwrA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/8R-UUShF-1EmQSj6_GQwrA/output.json
@@ -36,41 +36,12 @@
                   "end": 4,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 4,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 4,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 4,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/8R-UUShF-1EmQSj6_GQwrA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/8R-UUShF-1EmQSj6_GQwrA/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 4,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 4,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 4,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/9IIa-42s3YQFw8ilk39GdQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/9IIa-42s3YQFw8ilk39GdQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/9IIa-42s3YQFw8ilk39GdQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/9IIa-42s3YQFw8ilk39GdQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/9aSeJQPn4WHMexejaMQQoQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/9aSeJQPn4WHMexejaMQQoQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 10,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 10,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 10,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/9aSeJQPn4WHMexejaMQQoQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/9aSeJQPn4WHMexejaMQQoQ/output.json
@@ -36,41 +36,12 @@
                   "end": 10,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 10,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 10,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 10,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/ACQUsGVQAmGzhMqBRmS6Mw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ACQUsGVQAmGzhMqBRmS6Mw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/ACQUsGVQAmGzhMqBRmS6Mw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ACQUsGVQAmGzhMqBRmS6Mw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/AVaQlt9z0lhJC6bHHDPVeA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/AVaQlt9z0lhJC6bHHDPVeA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/AVaQlt9z0lhJC6bHHDPVeA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/AVaQlt9z0lhJC6bHHDPVeA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Aby-BQPnUhIoK9wn-kUcDQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Aby-BQPnUhIoK9wn-kUcDQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 7,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/Aby-BQPnUhIoK9wn-kUcDQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Aby-BQPnUhIoK9wn-kUcDQ/output.json
@@ -36,41 +36,12 @@
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 7,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/Ae5_auBp274oaSQ0kls9sw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Ae5_auBp274oaSQ0kls9sw/output.json
@@ -36,41 +36,12 @@
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 7,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/Ae5_auBp274oaSQ0kls9sw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Ae5_auBp274oaSQ0kls9sw/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 7,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/Afm91-TMNbzd52HsPrCCNA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Afm91-TMNbzd52HsPrCCNA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Afm91-TMNbzd52HsPrCCNA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Afm91-TMNbzd52HsPrCCNA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/AigZ338AGwCqF4M9a3Quqw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/AigZ338AGwCqF4M9a3Quqw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/AigZ338AGwCqF4M9a3Quqw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/AigZ338AGwCqF4M9a3Quqw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/AocxkR5Gt30Hu6JV7J56Wg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/AocxkR5Gt30Hu6JV7J56Wg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/AocxkR5Gt30Hu6JV7J56Wg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/AocxkR5Gt30Hu6JV7J56Wg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/AwZM5l5vBlyrbgG-Fk0_EQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/AwZM5l5vBlyrbgG-Fk0_EQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/AwZM5l5vBlyrbgG-Fk0_EQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/AwZM5l5vBlyrbgG-Fk0_EQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/BKyQWW5j9vRP-kr41nqcjg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/BKyQWW5j9vRP-kr41nqcjg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/BKyQWW5j9vRP-kr41nqcjg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/BKyQWW5j9vRP-kr41nqcjg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/BltaGv1fY5VvJahyCRNxqQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/BltaGv1fY5VvJahyCRNxqQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -81,16 +61,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": "~",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 2,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": "~",
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/BltaGv1fY5VvJahyCRNxqQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/BltaGv1fY5VvJahyCRNxqQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -61,6 +81,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": "~",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 2,
                   "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/BrJMdtdKJAuIZIG5MVWUYA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/BrJMdtdKJAuIZIG5MVWUYA/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 9,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 9,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 9,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 9,

--- a/css/parser/tests/fixture/esbuild/misc/BrJMdtdKJAuIZIG5MVWUYA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/BrJMdtdKJAuIZIG5MVWUYA/output.json
@@ -36,41 +36,12 @@
                   "end": 9,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 9,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 9,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 9,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 9,

--- a/css/parser/tests/fixture/esbuild/misc/C419dJQ48QjmgKufnQhNVw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/C419dJQ48QjmgKufnQhNVw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -61,6 +81,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": ">",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 4,
                   "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/C419dJQ48QjmgKufnQhNVw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/C419dJQ48QjmgKufnQhNVw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -81,16 +61,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": ">",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 4,
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": ">",
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/C4I0cdQcSbpaGOS-V8fwew/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/C4I0cdQcSbpaGOS-V8fwew/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/C4I0cdQcSbpaGOS-V8fwew/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/C4I0cdQcSbpaGOS-V8fwew/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/C6gS3Kl0KEwGsFaUUGXzFg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/C6gS3Kl0KEwGsFaUUGXzFg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/C6gS3Kl0KEwGsFaUUGXzFg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/C6gS3Kl0KEwGsFaUUGXzFg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/C9nXM9jBTT9WvCQHrwH24Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/C9nXM9jBTT9WvCQHrwH24Q/output.json
@@ -42,6 +42,42 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 4,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 4,
+                "ctxt": 0
+              },
+              "nestingSelector": {
+                "type": "NestingSelector",
+                "span": {
+                  "start": 0,
+                  "end": 1,
+                  "ctxt": 0
+                }
+              },
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 1,
+                    "end": 4,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 1,
                       "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/C9nXM9jBTT9WvCQHrwH24Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/C9nXM9jBTT9WvCQHrwH24Q/output.json
@@ -36,48 +36,19 @@
                   "end": 4,
                   "ctxt": 0
                 },
-                "hasNestPrefix": true,
+                "nestingSelector": {
+                  "type": "NestingSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 1,
+                    "ctxt": 0
+                  }
+                },
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 4,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 4,
-                "ctxt": 0
-              },
-              "nestingSelector": {
-                "type": "NestingSelector",
-                "span": {
-                  "start": 0,
-                  "end": 1,
-                  "ctxt": 0
-                }
-              },
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 1,
-                    "end": 4,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 1,
                       "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/C9nXM9jBTT9WvCQHrwH24Q/span.rust-debug
+++ b/css/parser/tests/fixture/esbuild/misc/C9nXM9jBTT9WvCQHrwH24Q/span.rust-debug
@@ -34,6 +34,12 @@ error: CompoundSelector
 1 | &[a] {}
   | ^^^^
 
+error: NestingSelector
+ --> $DIR/tests/fixture/esbuild/misc/C9nXM9jBTT9WvCQHrwH24Q/input.css:1:1
+  |
+1 | &[a] {}
+  | ^
+
 error: SubclassSelector
  --> $DIR/tests/fixture/esbuild/misc/C9nXM9jBTT9WvCQHrwH24Q/input.css:1:2
   |

--- a/css/parser/tests/fixture/esbuild/misc/CQiowK9DjojqKtlpQifemA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/CQiowK9DjojqKtlpQifemA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/CQiowK9DjojqKtlpQifemA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/CQiowK9DjojqKtlpQifemA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/CiejHTPFd8U5szvvY3uRjw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/CiejHTPFd8U5szvvY3uRjw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/CiejHTPFd8U5szvvY3uRjw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/CiejHTPFd8U5szvvY3uRjw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/CqrYlHva8qUNgSPb8EwWjg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/CqrYlHva8qUNgSPb8EwWjg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/CqrYlHva8qUNgSPb8EwWjg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/CqrYlHva8qUNgSPb8EwWjg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Cz4vXE_NaBs6qNXE1kUyqQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Cz4vXE_NaBs6qNXE1kUyqQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Cz4vXE_NaBs6qNXE1kUyqQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Cz4vXE_NaBs6qNXE1kUyqQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/D5Oyf1ABeS8lie5Lg-5pqg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/D5Oyf1ABeS8lie5Lg-5pqg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/D5Oyf1ABeS8lie5Lg-5pqg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/D5Oyf1ABeS8lie5Lg-5pqg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Dl_KXhjnyR5RfRaNMKBEdw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Dl_KXhjnyR5RfRaNMKBEdw/output.json
@@ -42,6 +42,43 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": {
+                "type": "NestingSelector",
+                "span": {
+                  "start": 0,
+                  "end": 1,
+                  "ctxt": 0
+                }
+              },
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 1,
+                    "end": 3,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 1,
                       "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/Dl_KXhjnyR5RfRaNMKBEdw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Dl_KXhjnyR5RfRaNMKBEdw/output.json
@@ -36,49 +36,19 @@
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": true,
+                "nestingSelector": {
+                  "type": "NestingSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 1,
+                    "ctxt": 0
+                  }
+                },
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": {
-                "type": "NestingSelector",
-                "span": {
-                  "start": 0,
-                  "end": 1,
-                  "ctxt": 0
-                }
-              },
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 1,
-                    "end": 3,
-                    "ctxt": 0
-                  },
-                  "isElement": false,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 1,
                       "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/Dl_KXhjnyR5RfRaNMKBEdw/span.rust-debug
+++ b/css/parser/tests/fixture/esbuild/misc/Dl_KXhjnyR5RfRaNMKBEdw/span.rust-debug
@@ -34,6 +34,12 @@ error: CompoundSelector
 1 | &:b {}
   | ^^^
 
+error: NestingSelector
+ --> $DIR/tests/fixture/esbuild/misc/Dl_KXhjnyR5RfRaNMKBEdw/input.css:1:1
+  |
+1 | &:b {}
+  | ^
+
 error: SubclassSelector
  --> $DIR/tests/fixture/esbuild/misc/Dl_KXhjnyR5RfRaNMKBEdw/input.css:1:2
   |

--- a/css/parser/tests/fixture/esbuild/misc/Drl1Excz8WEwlfIfA2oRQg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Drl1Excz8WEwlfIfA2oRQg/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 11,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 11,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 11,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/Drl1Excz8WEwlfIfA2oRQg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Drl1Excz8WEwlfIfA2oRQg/output.json
@@ -36,41 +36,12 @@
                   "end": 11,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 11,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 11,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 11,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/DrlXteRB-ppLVxi4_N4dhA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/DrlXteRB-ppLVxi4_N4dhA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/DrlXteRB-ppLVxi4_N4dhA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/DrlXteRB-ppLVxi4_N4dhA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/DstCRLR-k3tqe3B46li15Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/DstCRLR-k3tqe3B46li15Q/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 4,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 4,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 4,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/DstCRLR-k3tqe3B46li15Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/DstCRLR-k3tqe3B46li15Q/output.json
@@ -36,41 +36,12 @@
                   "end": 4,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 4,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 4,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 4,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/EB1IJLfMRoP0XwlJOGLTPA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EB1IJLfMRoP0XwlJOGLTPA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/EB1IJLfMRoP0XwlJOGLTPA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EB1IJLfMRoP0XwlJOGLTPA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/EC04FJYJG-jwsR3Sbo9Rfg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EC04FJYJG-jwsR3Sbo9Rfg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/EC04FJYJG-jwsR3Sbo9Rfg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EC04FJYJG-jwsR3Sbo9Rfg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/EJ3xE2oHAiQiiAA6TOFfLA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EJ3xE2oHAiQiiAA6TOFfLA/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/EJ3xE2oHAiQiiAA6TOFfLA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EJ3xE2oHAiQiiAA6TOFfLA/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/EJPa4WhTn_fRRrDiA2bczg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EJPa4WhTn_fRRrDiA2bczg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/EJPa4WhTn_fRRrDiA2bczg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EJPa4WhTn_fRRrDiA2bczg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/EX6W7U27ut-K7x8AfSlQSg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EX6W7U27ut-K7x8AfSlQSg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -61,6 +81,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": ">",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 2,
                   "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/EX6W7U27ut-K7x8AfSlQSg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EX6W7U27ut-K7x8AfSlQSg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -81,16 +61,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": ">",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 2,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": ">",
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/EYFn-trzBus37dDEvK1jUQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EYFn-trzBus37dDEvK1jUQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/EYFn-trzBus37dDEvK1jUQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EYFn-trzBus37dDEvK1jUQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/ElFW4lY06Cb-VFYtK0WX4A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ElFW4lY06Cb-VFYtK0WX4A/output.json
@@ -60,6 +60,26 @@
                 "selectors": [
                   {
                     "type": "CompoundSelector",
+          "selectors": [
+            {
+              "type": "ComplexSelector",
+              "span": {
+                "start": 30,
+                "end": 32,
+                "ctxt": 0
+              },
+              "selectors": [
+                {
+                  "type": "CompoundSelector",
+                  "span": {
+                    "start": 30,
+                    "end": 32,
+                    "ctxt": 0
+                  },
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 30,
                       "end": 32,

--- a/css/parser/tests/fixture/esbuild/misc/ElFW4lY06Cb-VFYtK0WX4A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ElFW4lY06Cb-VFYtK0WX4A/output.json
@@ -60,32 +60,12 @@
                 "selectors": [
                   {
                     "type": "CompoundSelector",
-          "selectors": [
-            {
-              "type": "ComplexSelector",
-              "span": {
-                "start": 30,
-                "end": 32,
-                "ctxt": 0
-              },
-              "selectors": [
-                {
-                  "type": "CompoundSelector",
-                  "span": {
-                    "start": 30,
-                    "end": 32,
-                    "ctxt": 0
-                  },
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 30,
                       "end": 32,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": {
                       "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/EmvZzoCy9JnSP70AqHmNNA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EmvZzoCy9JnSP70AqHmNNA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -81,16 +61,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 2,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/EmvZzoCy9JnSP70AqHmNNA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/EmvZzoCy9JnSP70AqHmNNA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -61,6 +81,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 2,
                   "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/F-AbRDwG_3dGLhE7pzr5aA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/F-AbRDwG_3dGLhE7pzr5aA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/F-AbRDwG_3dGLhE7pzr5aA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/F-AbRDwG_3dGLhE7pzr5aA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/FTOGKsI_y1QxMNEu_Fgq7Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/FTOGKsI_y1QxMNEu_Fgq7Q/output.json
@@ -82,41 +82,12 @@
                         "end": 29,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 20,
-                  "end": 29,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 20,
-                      "end": 29,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 20,
-                          "end": 29,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 20,
                             "end": 29,

--- a/css/parser/tests/fixture/esbuild/misc/FTOGKsI_y1QxMNEu_Fgq7Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/FTOGKsI_y1QxMNEu_Fgq7Q/output.json
@@ -88,6 +88,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 20,
+                  "end": 29,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 20,
+                      "end": 29,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 20,
+                          "end": 29,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 20,
                             "end": 29,

--- a/css/parser/tests/fixture/esbuild/misc/FlqjDLebWxQvNIxKppBllw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/FlqjDLebWxQvNIxKppBllw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/FlqjDLebWxQvNIxKppBllw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/FlqjDLebWxQvNIxKppBllw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Fm7gvlx7uRyvrfzUC7rJxg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Fm7gvlx7uRyvrfzUC7rJxg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Fm7gvlx7uRyvrfzUC7rJxg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Fm7gvlx7uRyvrfzUC7rJxg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Ft7g4H2gHwlEjiFMDwEkYQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Ft7g4H2gHwlEjiFMDwEkYQ/output.json
@@ -42,6 +42,36 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 14,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 14,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 14,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 14,

--- a/css/parser/tests/fixture/esbuild/misc/Ft7g4H2gHwlEjiFMDwEkYQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Ft7g4H2gHwlEjiFMDwEkYQ/output.json
@@ -36,42 +36,12 @@
                   "end": 14,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 14,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 14,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 14,
-                    "ctxt": 0
-                  },
-                  "isElement": false,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 14,

--- a/css/parser/tests/fixture/esbuild/misc/GC0pcFQY1xSlq9QsgSvEVg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GC0pcFQY1xSlq9QsgSvEVg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/GC0pcFQY1xSlq9QsgSvEVg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GC0pcFQY1xSlq9QsgSvEVg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/GI1rffTXev-78n9ei_53wQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GI1rffTXev-78n9ei_53wQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/GI1rffTXev-78n9ei_53wQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GI1rffTXev-78n9ei_53wQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/GNiHtd4OPiZDQlN5KGAmRQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GNiHtd4OPiZDQlN5KGAmRQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/GNiHtd4OPiZDQlN5KGAmRQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GNiHtd4OPiZDQlN5KGAmRQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/GVqeF3thmlPBqLweHlqIJQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GVqeF3thmlPBqLweHlqIJQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -81,16 +61,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 5,
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/GVqeF3thmlPBqLweHlqIJQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GVqeF3thmlPBqLweHlqIJQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -61,6 +81,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 5,
                   "end": 6,

--- a/css/parser/tests/fixture/esbuild/misc/GjvJfQVAaNQonYJwt8QRDQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GjvJfQVAaNQonYJwt8QRDQ/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/GjvJfQVAaNQonYJwt8QRDQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GjvJfQVAaNQonYJwt8QRDQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/GpePX8ZJM8IP14hXFTKKxQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GpePX8ZJM8IP14hXFTKKxQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/GpePX8ZJM8IP14hXFTKKxQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/GpePX8ZJM8IP14hXFTKKxQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Gt3Lw4L5Pe4aLLDPz9cxRg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Gt3Lw4L5Pe4aLLDPz9cxRg/output.json
@@ -36,41 +36,12 @@
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 5,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/Gt3Lw4L5Pe4aLLDPz9cxRg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Gt3Lw4L5Pe4aLLDPz9cxRg/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 5,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/HBQJEriDrHgN_kXjKrVW9g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/HBQJEriDrHgN_kXjKrVW9g/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 11,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 11,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 11,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/HBQJEriDrHgN_kXjKrVW9g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/HBQJEriDrHgN_kXjKrVW9g/output.json
@@ -36,41 +36,12 @@
                   "end": 11,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 11,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 11,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 11,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/HDNE73X9waUrBkTAzz-20g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/HDNE73X9waUrBkTAzz-20g/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/HDNE73X9waUrBkTAzz-20g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/HDNE73X9waUrBkTAzz-20g/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/HGH4crVp9Whp_G0PY6BaQA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/HGH4crVp9Whp_G0PY6BaQA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 4,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 4,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/HGH4crVp9Whp_G0PY6BaQA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/HGH4crVp9Whp_G0PY6BaQA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 4,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 4,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/I33LxmnLDtSRSbNrHmoNRA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/I33LxmnLDtSRSbNrHmoNRA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -81,16 +61,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": "+",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 4,
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": "+",
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/I33LxmnLDtSRSbNrHmoNRA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/I33LxmnLDtSRSbNrHmoNRA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -61,6 +81,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": "+",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 4,
                   "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/ISvhgCbFuiTTWo41R3UVRA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ISvhgCbFuiTTWo41R3UVRA/output.json
@@ -36,41 +36,12 @@
                   "end": 10,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 10,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 10,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 10,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/ISvhgCbFuiTTWo41R3UVRA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ISvhgCbFuiTTWo41R3UVRA/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 10,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 10,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 10,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/Jir2h5-Giw9AVhE3ep3_sg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Jir2h5-Giw9AVhE3ep3_sg/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/Jir2h5-Giw9AVhE3ep3_sg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Jir2h5-Giw9AVhE3ep3_sg/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/LoeMqdekBkn3XKYHQFHOZA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/LoeMqdekBkn3XKYHQFHOZA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/LoeMqdekBkn3XKYHQFHOZA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/LoeMqdekBkn3XKYHQFHOZA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Loy9sX2qaylR2OySt7N-BQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Loy9sX2qaylR2OySt7N-BQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Loy9sX2qaylR2OySt7N-BQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Loy9sX2qaylR2OySt7N-BQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/MCJc58-6bYzpgizSxt8jQg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MCJc58-6bYzpgizSxt8jQg/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 12,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 12,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 12,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 12,

--- a/css/parser/tests/fixture/esbuild/misc/MCJc58-6bYzpgizSxt8jQg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MCJc58-6bYzpgizSxt8jQg/output.json
@@ -36,41 +36,12 @@
                   "end": 12,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 12,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 12,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 12,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 12,

--- a/css/parser/tests/fixture/esbuild/misc/MHzCL6d2nAk4bByQ_ja7xg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MHzCL6d2nAk4bByQ_ja7xg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/MHzCL6d2nAk4bByQ_ja7xg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MHzCL6d2nAk4bByQ_ja7xg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/MK5PGiCFMf7RHDp05gnDCw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MK5PGiCFMf7RHDp05gnDCw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/MK5PGiCFMf7RHDp05gnDCw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MK5PGiCFMf7RHDp05gnDCw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/MU8JgGd_-h5ocqkfawNxeQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MU8JgGd_-h5ocqkfawNxeQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/MU8JgGd_-h5ocqkfawNxeQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MU8JgGd_-h5ocqkfawNxeQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/MmOsa9XFdPMS9x4ITbWSzg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MmOsa9XFdPMS9x4ITbWSzg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/MmOsa9XFdPMS9x4ITbWSzg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MmOsa9XFdPMS9x4ITbWSzg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/MvD7ThpMVIxU3dzF71Gpcg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MvD7ThpMVIxU3dzF71Gpcg/output.json
@@ -42,6 +42,36 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 6,
+                    "ctxt": 0
+                  },
+                  "isElement": true,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/esbuild/misc/MvD7ThpMVIxU3dzF71Gpcg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MvD7ThpMVIxU3dzF71Gpcg/output.json
@@ -36,42 +36,12 @@
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 6,
-                    "ctxt": 0
-                  },
-                  "isElement": true,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/esbuild/misc/MxxFvoxSpp02tFmpbNdA8g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MxxFvoxSpp02tFmpbNdA8g/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/MxxFvoxSpp02tFmpbNdA8g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/MxxFvoxSpp02tFmpbNdA8g/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/O2EvcnNp_CVyX3xq5-eM-g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/O2EvcnNp_CVyX3xq5-eM-g/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/O2EvcnNp_CVyX3xq5-eM-g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/O2EvcnNp_CVyX3xq5-eM-g/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/Oc6Obl7mbH-MlFllIoAbdg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Oc6Obl7mbH-MlFllIoAbdg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Oc6Obl7mbH-MlFllIoAbdg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Oc6Obl7mbH-MlFllIoAbdg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/OjiW46YAJSt_cq_MHhs2Bw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/OjiW46YAJSt_cq_MHhs2Bw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 4,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 4,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/OjiW46YAJSt_cq_MHhs2Bw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/OjiW46YAJSt_cq_MHhs2Bw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 4,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 4,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/OtM9lGhbFLqI-r3dvNTUjQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/OtM9lGhbFLqI-r3dvNTUjQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/OtM9lGhbFLqI-r3dvNTUjQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/OtM9lGhbFLqI-r3dvNTUjQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/PRqD5VDViUThMCxIEmwIcg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/PRqD5VDViUThMCxIEmwIcg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/PRqD5VDViUThMCxIEmwIcg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/PRqD5VDViUThMCxIEmwIcg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/PSncmPJMuHC-CjpwiYtkDw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/PSncmPJMuHC-CjpwiYtkDw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/PSncmPJMuHC-CjpwiYtkDw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/PSncmPJMuHC-CjpwiYtkDw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/output.json
@@ -31,63 +31,32 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 4,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 4,
-                "ctxt": 0
-              },
-              "nestingSelector": {
-                "type": "NestingSelector",
-                "span": {
-                  "start": 0,
-                  "end": 1,
-                  "ctxt": 0
-                }
-              },
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,
                   "ctxt": 0
                 },
-                "hasNestPrefix": true,
+                "nestingSelector": {
+                  "type": "NestingSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 1,
+                    "ctxt": 0
+                  }
+                },
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
                   "span": {
                     "start": 0,
-                    "start": 1,
-                    "end": 2,
-                    "ctxt": 0
-                  },
-                  "value": "*",
-                  "raw": "*"
-                },
-                "name": {
-                  "type": "Text",
-                  "span": {
-                    "start": 3,
                     "end": 4,
                     "ctxt": 0
                   },
                   "prefix": {
                     "type": "Text",
                     "span": {
-                      "start": 0,
-                      "end": 1,
+                      "start": 1,
+                      "end": 2,
                       "ctxt": 0
                     },
                     "value": "*",

--- a/css/parser/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/output.json
@@ -31,6 +31,33 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 4,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 4,
+                "ctxt": 0
+              },
+              "nestingSelector": {
+                "type": "NestingSelector",
+                "span": {
+                  "start": 0,
+                  "end": 1,
+                  "ctxt": 0
+                }
+              },
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/output.json
@@ -69,6 +69,17 @@
                   "type": "TypeSelector",
                   "span": {
                     "start": 0,
+                    "start": 1,
+                    "end": 2,
+                    "ctxt": 0
+                  },
+                  "value": "*",
+                  "raw": "*"
+                },
+                "name": {
+                  "type": "Text",
+                  "span": {
+                    "start": 3,
                     "end": 4,
                     "ctxt": 0
                   },

--- a/css/parser/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/span.rust-debug
+++ b/css/parser/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/span.rust-debug
@@ -41,10 +41,10 @@ error: TypeSelector
   | ^^^^
 
 error: Text
- --> $DIR/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/input.css:1:1
+ --> $DIR/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/input.css:1:2
   |
 1 | &*|b {}
-  | ^
+  |  ^
 
 error: Text
  --> $DIR/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/input.css:1:4

--- a/css/parser/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/span.rust-debug
+++ b/css/parser/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/span.rust-debug
@@ -34,6 +34,12 @@ error: CompoundSelector
 1 | &*|b {}
   | ^^^^
 
+error: NestingSelector
+ --> $DIR/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/input.css:1:1
+  |
+1 | &*|b {}
+  | ^
+
 error: TypeSelector
  --> $DIR/tests/fixture/esbuild/misc/Pkkf0GfuA1VzI7L4dGjS-A/input.css:1:1
   |

--- a/css/parser/tests/fixture/esbuild/misc/PwUHqMTSmtZW7IYn9gsinQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/PwUHqMTSmtZW7IYn9gsinQ/output.json
@@ -36,41 +36,12 @@
                   "end": 4,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 4,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 4,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 4,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/PwUHqMTSmtZW7IYn9gsinQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/PwUHqMTSmtZW7IYn9gsinQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 4,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 4,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 4,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/Q42FDvG6_mtoeI7PoHqgQw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Q42FDvG6_mtoeI7PoHqgQw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -46,6 +66,30 @@
                     "ctxt": 0
                   },
                   "prefix": null,
+                  "value": "a",
+                  "raw": "a"
+                }
+              },
+              "subclassSelectors": []
+            },
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 2,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 2,
+                    "end": 5,
+                    "ctxt": 0
+                  },
                   "name": {
                     "type": "Text",
                     "span": {

--- a/css/parser/tests/fixture/esbuild/misc/Q42FDvG6_mtoeI7PoHqgQw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Q42FDvG6_mtoeI7PoHqgQw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -66,30 +46,6 @@
                     "ctxt": 0
                   },
                   "prefix": null,
-                  "value": "a",
-                  "raw": "a"
-                }
-              },
-              "subclassSelectors": []
-            },
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 2,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 2,
-                    "end": 5,
-                    "ctxt": 0
-                  },
                   "name": {
                     "type": "Text",
                     "span": {
@@ -110,7 +66,7 @@
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [

--- a/css/parser/tests/fixture/esbuild/misc/QLHVnSGDdGN_iDeP3OAXfQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/QLHVnSGDdGN_iDeP3OAXfQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 11,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 11,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 11,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/QLHVnSGDdGN_iDeP3OAXfQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/QLHVnSGDdGN_iDeP3OAXfQ/output.json
@@ -36,41 +36,12 @@
                   "end": 11,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 11,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 11,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 11,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/Q_wA-fPw3o2m3R7gyWNxbQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Q_wA-fPw3o2m3R7gyWNxbQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Q_wA-fPw3o2m3R7gyWNxbQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Q_wA-fPw3o2m3R7gyWNxbQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/R6OYU1g_sB_euLV8Yzjw6w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/R6OYU1g_sB_euLV8Yzjw6w/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/R6OYU1g_sB_euLV8Yzjw6w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/R6OYU1g_sB_euLV8Yzjw6w/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/RmGccmub1dooAN8WPKTwhQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/RmGccmub1dooAN8WPKTwhQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/RmGccmub1dooAN8WPKTwhQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/RmGccmub1dooAN8WPKTwhQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/S2Mhk5rU2YxQPgm9rtF9WA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/S2Mhk5rU2YxQPgm9rtF9WA/output.json
@@ -71,32 +71,12 @@
                 "selectors": [
                   {
                     "type": "CompoundSelector",
-          "selectors": [
-            {
-              "type": "ComplexSelector",
-              "span": {
-                "start": 44,
-                "end": 46,
-                "ctxt": 0
-              },
-              "selectors": [
-                {
-                  "type": "CompoundSelector",
-                  "span": {
-                    "start": 44,
-                    "end": 46,
-                    "ctxt": 0
-                  },
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 44,
                       "end": 46,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": {
                       "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/S2Mhk5rU2YxQPgm9rtF9WA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/S2Mhk5rU2YxQPgm9rtF9WA/output.json
@@ -71,6 +71,26 @@
                 "selectors": [
                   {
                     "type": "CompoundSelector",
+          "selectors": [
+            {
+              "type": "ComplexSelector",
+              "span": {
+                "start": 44,
+                "end": 46,
+                "ctxt": 0
+              },
+              "selectors": [
+                {
+                  "type": "CompoundSelector",
+                  "span": {
+                    "start": 44,
+                    "end": 46,
+                    "ctxt": 0
+                  },
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 44,
                       "end": 46,

--- a/css/parser/tests/fixture/esbuild/misc/SFBgyV9jnFbMzWZoo9VbSQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/SFBgyV9jnFbMzWZoo9VbSQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/SFBgyV9jnFbMzWZoo9VbSQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/SFBgyV9jnFbMzWZoo9VbSQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Ssg_Qhdw7h_c6ZtY52Qe4A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Ssg_Qhdw7h_c6ZtY52Qe4A/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Ssg_Qhdw7h_c6ZtY52Qe4A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Ssg_Qhdw7h_c6ZtY52Qe4A/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Sy2aOxINv1bvZmbK_Pc5Mg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Sy2aOxINv1bvZmbK_Pc5Mg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Sy2aOxINv1bvZmbK_Pc5Mg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Sy2aOxINv1bvZmbK_Pc5Mg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/T1SOp4KXmIb1WNsyPFEKqg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/T1SOp4KXmIb1WNsyPFEKqg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/T1SOp4KXmIb1WNsyPFEKqg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/T1SOp4KXmIb1WNsyPFEKqg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/TdBn3uBF54mw96CCUwpgew/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/TdBn3uBF54mw96CCUwpgew/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 5,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/TdBn3uBF54mw96CCUwpgew/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/TdBn3uBF54mw96CCUwpgew/output.json
@@ -36,41 +36,12 @@
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 5,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/TyMkoZpPOEhvUBOmUhGOXQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/TyMkoZpPOEhvUBOmUhGOXQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/TyMkoZpPOEhvUBOmUhGOXQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/TyMkoZpPOEhvUBOmUhGOXQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/U-MOOs2vmQ3m-i8XisYj8w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/U-MOOs2vmQ3m-i8XisYj8w/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 10,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 10,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 10,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/U-MOOs2vmQ3m-i8XisYj8w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/U-MOOs2vmQ3m-i8XisYj8w/output.json
@@ -36,41 +36,12 @@
                   "end": 10,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 10,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 10,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 10,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/U2nuhvtnEWZ_kMd6i7EDWA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/U2nuhvtnEWZ_kMd6i7EDWA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/U2nuhvtnEWZ_kMd6i7EDWA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/U2nuhvtnEWZ_kMd6i7EDWA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/UeHn9b5w6R3dVjrtRCGxkA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/UeHn9b5w6R3dVjrtRCGxkA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 2,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 2,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 2,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/UeHn9b5w6R3dVjrtRCGxkA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/UeHn9b5w6R3dVjrtRCGxkA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 2,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 2,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 2,

--- a/css/parser/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/V6ATfoZsbJDwKWSnlREl-w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/V6ATfoZsbJDwKWSnlREl-w/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/V6ATfoZsbJDwKWSnlREl-w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/V6ATfoZsbJDwKWSnlREl-w/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/VOQJsreB5pi_yJysozWgcA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/VOQJsreB5pi_yJysozWgcA/output.json
@@ -125,6 +125,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 43,
+                  "end": 59,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 43,
+                      "end": 59,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 43,
+                          "end": 59,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 43,
                             "end": 59,
@@ -224,6 +253,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 82,
+                  "end": 91,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 82,
+                      "end": 91,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 82,
+                          "end": 91,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 82,
                             "end": 91,
@@ -323,6 +381,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 113,
+                  "end": 124,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 113,
+                      "end": 124,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 113,
+                          "end": 124,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 113,
                             "end": 124,
@@ -422,6 +509,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 146,
+                  "end": 156,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 146,
+                      "end": 156,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 146,
+                          "end": 156,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 146,
                             "end": 156,
@@ -521,6 +637,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 178,
+                  "end": 195,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 178,
+                      "end": 195,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 178,
+                          "end": 195,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 178,
                             "end": 195,
@@ -620,6 +765,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 218,
+                  "end": 237,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 218,
+                      "end": 237,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 218,
+                          "end": 237,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 218,
                             "end": 237,
@@ -719,6 +893,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 260,
+                  "end": 272,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 260,
+                      "end": 272,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 260,
+                          "end": 272,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 260,
                             "end": 272,
@@ -818,6 +1021,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 294,
+                  "end": 308,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 294,
+                      "end": 308,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 294,
+                          "end": 308,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 294,
                             "end": 308,
@@ -917,6 +1149,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 330,
+                  "end": 343,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 330,
+                      "end": 343,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 330,
+                          "end": 343,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 330,
                             "end": 343,
@@ -1016,6 +1277,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 365,
+                  "end": 385,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 365,
+                      "end": 385,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 365,
+                          "end": 385,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 365,
                             "end": 385,
@@ -1115,6 +1405,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 408,
+                  "end": 417,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 408,
+                      "end": 417,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 408,
+                          "end": 417,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 408,
                             "end": 417,
@@ -1214,6 +1533,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 439,
+                  "end": 451,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 439,
+                      "end": 451,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 439,
+                          "end": 451,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 439,
                             "end": 451,
@@ -1313,6 +1661,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 473,
+                  "end": 485,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 473,
+                      "end": 485,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 473,
+                          "end": 485,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 473,
                             "end": 485,
@@ -1412,6 +1789,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 507,
+                  "end": 517,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 507,
+                      "end": 517,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 507,
+                          "end": 517,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 507,
                             "end": 517,
@@ -1511,6 +1917,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 539,
+                  "end": 552,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 539,
+                      "end": 552,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 539,
+                          "end": 552,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 539,
                             "end": 552,
@@ -1610,6 +2045,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 574,
+                  "end": 587,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 574,
+                      "end": 587,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 574,
+                          "end": 587,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 574,
                             "end": 587,

--- a/css/parser/tests/fixture/esbuild/misc/VOQJsreB5pi_yJysozWgcA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/VOQJsreB5pi_yJysozWgcA/output.json
@@ -119,41 +119,12 @@
                         "end": 59,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 43,
-                  "end": 59,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 43,
-                      "end": 59,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 43,
-                          "end": 59,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 43,
                             "end": 59,
@@ -247,41 +218,12 @@
                         "end": 91,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 82,
-                  "end": 91,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 82,
-                      "end": 91,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 82,
-                          "end": 91,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 82,
                             "end": 91,
@@ -375,41 +317,12 @@
                         "end": 124,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 113,
-                  "end": 124,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 113,
-                      "end": 124,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 113,
-                          "end": 124,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 113,
                             "end": 124,
@@ -503,41 +416,12 @@
                         "end": 156,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 146,
-                  "end": 156,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 146,
-                      "end": 156,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 146,
-                          "end": 156,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 146,
                             "end": 156,
@@ -631,41 +515,12 @@
                         "end": 195,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 178,
-                  "end": 195,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 178,
-                      "end": 195,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 178,
-                          "end": 195,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 178,
                             "end": 195,
@@ -759,41 +614,12 @@
                         "end": 237,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 218,
-                  "end": 237,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 218,
-                      "end": 237,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 218,
-                          "end": 237,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 218,
                             "end": 237,
@@ -887,41 +713,12 @@
                         "end": 272,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 260,
-                  "end": 272,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 260,
-                      "end": 272,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 260,
-                          "end": 272,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 260,
                             "end": 272,
@@ -1015,41 +812,12 @@
                         "end": 308,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 294,
-                  "end": 308,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 294,
-                      "end": 308,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 294,
-                          "end": 308,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 294,
                             "end": 308,
@@ -1143,41 +911,12 @@
                         "end": 343,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 330,
-                  "end": 343,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 330,
-                      "end": 343,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 330,
-                          "end": 343,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 330,
                             "end": 343,
@@ -1271,41 +1010,12 @@
                         "end": 385,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 365,
-                  "end": 385,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 365,
-                      "end": 385,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 365,
-                          "end": 385,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 365,
                             "end": 385,
@@ -1399,41 +1109,12 @@
                         "end": 417,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 408,
-                  "end": 417,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 408,
-                      "end": 417,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 408,
-                          "end": 417,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 408,
                             "end": 417,
@@ -1527,41 +1208,12 @@
                         "end": 451,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 439,
-                  "end": 451,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 439,
-                      "end": 451,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 439,
-                          "end": 451,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 439,
                             "end": 451,
@@ -1655,41 +1307,12 @@
                         "end": 485,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 473,
-                  "end": 485,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 473,
-                      "end": 485,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 473,
-                          "end": 485,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 473,
                             "end": 485,
@@ -1783,41 +1406,12 @@
                         "end": 517,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 507,
-                  "end": 517,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 507,
-                      "end": 517,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 507,
-                          "end": 517,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 507,
                             "end": 517,
@@ -1911,41 +1505,12 @@
                         "end": 552,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 539,
-                  "end": 552,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 539,
-                      "end": 552,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 539,
-                          "end": 552,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 539,
                             "end": 552,
@@ -2039,41 +1604,12 @@
                         "end": 587,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 574,
-                  "end": 587,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 574,
-                      "end": 587,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 574,
-                          "end": 587,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 574,
                             "end": 587,

--- a/css/parser/tests/fixture/esbuild/misc/W3R-c5DPSkhG9QWYdcFdFg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/W3R-c5DPSkhG9QWYdcFdFg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/W3R-c5DPSkhG9QWYdcFdFg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/W3R-c5DPSkhG9QWYdcFdFg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/WQWdwW4B4hm60AQgxTU08Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/WQWdwW4B4hm60AQgxTU08Q/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/WQWdwW4B4hm60AQgxTU08Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/WQWdwW4B4hm60AQgxTU08Q/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/Wb-aVu7CEQfCy1QL2yUrEw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Wb-aVu7CEQfCy1QL2yUrEw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Wb-aVu7CEQfCy1QL2yUrEw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Wb-aVu7CEQfCy1QL2yUrEw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/WnrbfdZnESKVnJxygl6yYA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/WnrbfdZnESKVnJxygl6yYA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -81,16 +61,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": ">",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 6,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": ">",
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/WnrbfdZnESKVnJxygl6yYA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/WnrbfdZnESKVnJxygl6yYA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -61,6 +81,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": ">",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 6,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/Wplrqmb_IDjNC-o-eqLw4A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Wplrqmb_IDjNC-o-eqLw4A/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Wplrqmb_IDjNC-o-eqLw4A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Wplrqmb_IDjNC-o-eqLw4A/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/X-yuwO0x1B-l1Js4JkKJZg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/X-yuwO0x1B-l1Js4JkKJZg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/X-yuwO0x1B-l1Js4JkKJZg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/X-yuwO0x1B-l1Js4JkKJZg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/XVtQeQIEHAyQlpmKRigHcg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/XVtQeQIEHAyQlpmKRigHcg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -81,16 +61,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": "~",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 4,
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": "~",
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/XVtQeQIEHAyQlpmKRigHcg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/XVtQeQIEHAyQlpmKRigHcg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -61,6 +81,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": "~",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 4,
                   "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/XetGJrWBJuC-NtgpX2eq1Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/XetGJrWBJuC-NtgpX2eq1Q/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/XetGJrWBJuC-NtgpX2eq1Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/XetGJrWBJuC-NtgpX2eq1Q/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/YIW6UUMmxrTYJjJ3JSL3uQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/YIW6UUMmxrTYJjJ3JSL3uQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/YIW6UUMmxrTYJjJ3JSL3uQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/YIW6UUMmxrTYJjJ3JSL3uQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/YUPpw78_zYmKpAkI2SzNsg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/YUPpw78_zYmKpAkI2SzNsg/output.json
@@ -42,6 +42,36 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 16,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 16,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 16,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 16,

--- a/css/parser/tests/fixture/esbuild/misc/YUPpw78_zYmKpAkI2SzNsg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/YUPpw78_zYmKpAkI2SzNsg/output.json
@@ -36,42 +36,12 @@
                   "end": 16,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 16,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 16,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 16,
-                    "ctxt": 0
-                  },
-                  "isElement": false,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 16,

--- a/css/parser/tests/fixture/esbuild/misc/Yc70giIIGDIddrjD858dDw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Yc70giIIGDIddrjD858dDw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Yc70giIIGDIddrjD858dDw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Yc70giIIGDIddrjD858dDw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Ys7z8C2qi5O_HM9ElZQrUQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Ys7z8C2qi5O_HM9ElZQrUQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Ys7z8C2qi5O_HM9ElZQrUQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Ys7z8C2qi5O_HM9ElZQrUQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/Z4J4sVA4UnGhTMiN5tdMMQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Z4J4sVA4UnGhTMiN5tdMMQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/Z4J4sVA4UnGhTMiN5tdMMQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/Z4J4sVA4UnGhTMiN5tdMMQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/_APxY5Pe47Bb71-CwD1nhw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_APxY5Pe47Bb71-CwD1nhw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/_APxY5Pe47Bb71-CwD1nhw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_APxY5Pe47Bb71-CwD1nhw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/_U4zAUbS93Xo7_tJOolGuA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_U4zAUbS93Xo7_tJOolGuA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/_U4zAUbS93Xo7_tJOolGuA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_U4zAUbS93Xo7_tJOolGuA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/_XB1oeHz4bZ49LCE2cBI6g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_XB1oeHz4bZ49LCE2cBI6g/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/_XB1oeHz4bZ49LCE2cBI6g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_XB1oeHz4bZ49LCE2cBI6g/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/_d22bZcPKDgNEKSyJ2NRsQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_d22bZcPKDgNEKSyJ2NRsQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/_d22bZcPKDgNEKSyJ2NRsQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_d22bZcPKDgNEKSyJ2NRsQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/_e6qpZBWfowEh1P3Wn3orA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_e6qpZBWfowEh1P3Wn3orA/output.json
@@ -42,6 +42,36 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 16,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 16,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 16,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 16,

--- a/css/parser/tests/fixture/esbuild/misc/_e6qpZBWfowEh1P3Wn3orA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_e6qpZBWfowEh1P3Wn3orA/output.json
@@ -36,42 +36,12 @@
                   "end": 16,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 16,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 16,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 16,
-                    "ctxt": 0
-                  },
-                  "isElement": false,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 16,

--- a/css/parser/tests/fixture/esbuild/misc/_qcmYeHAxw35hMnF2IST8A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_qcmYeHAxw35hMnF2IST8A/output.json
@@ -36,41 +36,12 @@
                   "end": 9,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 9,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 9,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 9,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 9,

--- a/css/parser/tests/fixture/esbuild/misc/_qcmYeHAxw35hMnF2IST8A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/_qcmYeHAxw35hMnF2IST8A/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 9,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 9,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 9,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 9,

--- a/css/parser/tests/fixture/esbuild/misc/a0Yurt7E7InOYieD7nMCXg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/a0Yurt7E7InOYieD7nMCXg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/a0Yurt7E7InOYieD7nMCXg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/a0Yurt7E7InOYieD7nMCXg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/a7KElWOMF9ilrSsoliHkcg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/a7KElWOMF9ilrSsoliHkcg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/a7KElWOMF9ilrSsoliHkcg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/a7KElWOMF9ilrSsoliHkcg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/aEF_NRb2u-g7UzHxaKpOfA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/aEF_NRb2u-g7UzHxaKpOfA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/aEF_NRb2u-g7UzHxaKpOfA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/aEF_NRb2u-g7UzHxaKpOfA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/aVG5R30iWKuuw8iOGrgVmw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/aVG5R30iWKuuw8iOGrgVmw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/aVG5R30iWKuuw8iOGrgVmw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/aVG5R30iWKuuw8iOGrgVmw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/avMO0PRST3qaooxANKWiIw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/avMO0PRST3qaooxANKWiIw/output.json
@@ -36,41 +36,12 @@
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 5,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/avMO0PRST3qaooxANKWiIw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/avMO0PRST3qaooxANKWiIw/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 5,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/axTS8OYqxbJ3cRQm9h4ZYA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/axTS8OYqxbJ3cRQm9h4ZYA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/axTS8OYqxbJ3cRQm9h4ZYA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/axTS8OYqxbJ3cRQm9h4ZYA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/b102IE1MrM3aGTKCRrSU6Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/b102IE1MrM3aGTKCRrSU6Q/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/b102IE1MrM3aGTKCRrSU6Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/b102IE1MrM3aGTKCRrSU6Q/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/b2m1STf0F5CKity6Nd4vmQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/b2m1STf0F5CKity6Nd4vmQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/b2m1STf0F5CKity6Nd4vmQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/b2m1STf0F5CKity6Nd4vmQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/b6WBp-DsAKNB9xg6pcRTzQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/b6WBp-DsAKNB9xg6pcRTzQ/output.json
@@ -36,41 +36,12 @@
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 5,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/b6WBp-DsAKNB9xg6pcRTzQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/b6WBp-DsAKNB9xg6pcRTzQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 5,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/bMhJJBpJJs8SIl3cQ4UjFw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/bMhJJBpJJs8SIl3cQ4UjFw/output.json
@@ -82,41 +82,12 @@
                         "end": 29,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 20,
-                  "end": 29,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 20,
-                      "end": 29,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 20,
-                          "end": 29,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 20,
                             "end": 29,

--- a/css/parser/tests/fixture/esbuild/misc/bMhJJBpJJs8SIl3cQ4UjFw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/bMhJJBpJJs8SIl3cQ4UjFw/output.json
@@ -88,6 +88,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 20,
+                  "end": 29,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 20,
+                      "end": 29,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 20,
+                          "end": 29,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 20,
                             "end": 29,

--- a/css/parser/tests/fixture/esbuild/misc/bO5VdzMYGbUbK2CCYCMKTA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/bO5VdzMYGbUbK2CCYCMKTA/output.json
@@ -36,41 +36,12 @@
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 5,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/bO5VdzMYGbUbK2CCYCMKTA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/bO5VdzMYGbUbK2CCYCMKTA/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 5,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/bdiLSVQWZCfQNNwD_OM6qA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/bdiLSVQWZCfQNNwD_OM6qA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/bdiLSVQWZCfQNNwD_OM6qA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/bdiLSVQWZCfQNNwD_OM6qA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/biImEvafuG5pEuEW8LgCCw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/biImEvafuG5pEuEW8LgCCw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/biImEvafuG5pEuEW8LgCCw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/biImEvafuG5pEuEW8LgCCw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/btdQp-3m090Q73vMHSpKgw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/btdQp-3m090Q73vMHSpKgw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/btdQp-3m090Q73vMHSpKgw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/btdQp-3m090Q73vMHSpKgw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/c3bWgxp_3BNOH3BSgNg7-Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/c3bWgxp_3BNOH3BSgNg7-Q/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 4,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 4,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/c3bWgxp_3BNOH3BSgNg7-Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/c3bWgxp_3BNOH3BSgNg7-Q/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 4,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 4,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/cFk0V1dktTRk2wWOux0Y9A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cFk0V1dktTRk2wWOux0Y9A/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/cFk0V1dktTRk2wWOux0Y9A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cFk0V1dktTRk2wWOux0Y9A/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/cfNrGQbCQ18L8pQmD7lBZQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cfNrGQbCQ18L8pQmD7lBZQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/cfNrGQbCQ18L8pQmD7lBZQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cfNrGQbCQ18L8pQmD7lBZQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/coHEK8Dkb2Zflw3JwafU5Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/coHEK8Dkb2Zflw3JwafU5Q/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/coHEK8Dkb2Zflw3JwafU5Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/coHEK8Dkb2Zflw3JwafU5Q/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/cpoL0JfVO7TLrlcAga939A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cpoL0JfVO7TLrlcAga939A/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/cpoL0JfVO7TLrlcAga939A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cpoL0JfVO7TLrlcAga939A/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/cxYYDM0_rXbkvaqi8UPWOg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cxYYDM0_rXbkvaqi8UPWOg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/cxYYDM0_rXbkvaqi8UPWOg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/cxYYDM0_rXbkvaqi8UPWOg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/d1BWbOHfSbCE8-_qEz-luA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/d1BWbOHfSbCE8-_qEz-luA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/d1BWbOHfSbCE8-_qEz-luA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/d1BWbOHfSbCE8-_qEz-luA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/d6iTYxGk5HHi4hIZcn73Bw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/d6iTYxGk5HHi4hIZcn73Bw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/d6iTYxGk5HHi4hIZcn73Bw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/d6iTYxGk5HHi4hIZcn73Bw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/d8Q6MceynW9-IQJ4l0OGzA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/d8Q6MceynW9-IQJ4l0OGzA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/d8Q6MceynW9-IQJ4l0OGzA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/d8Q6MceynW9-IQJ4l0OGzA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/dVUzkh7NtbXySLzWGW0t9g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/dVUzkh7NtbXySLzWGW0t9g/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -150,32 +130,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 17,
-            "end": 18,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 17,
-                "end": 18,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 17,
                   "end": 18,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -269,32 +229,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 36,
-            "end": 37,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 36,
-                "end": 37,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 36,
                   "end": 37,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/dVUzkh7NtbXySLzWGW0t9g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/dVUzkh7NtbXySLzWGW0t9g/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -130,6 +150,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 17,
+            "end": 18,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 17,
+                "end": 18,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 17,
                   "end": 18,
@@ -229,6 +269,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 36,
+            "end": 37,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 36,
+                "end": 37,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 36,
                   "end": 37,

--- a/css/parser/tests/fixture/esbuild/misc/dnJiFdC_77rVfPM-yerzTQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/dnJiFdC_77rVfPM-yerzTQ/output.json
@@ -36,41 +36,12 @@
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 3,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/dnJiFdC_77rVfPM-yerzTQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/dnJiFdC_77rVfPM-yerzTQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 3,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/dqE2h21N1vX-ivcowP16dQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/dqE2h21N1vX-ivcowP16dQ/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/dqE2h21N1vX-ivcowP16dQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/dqE2h21N1vX-ivcowP16dQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/eBC_tv-_FNqjWVMq-no99A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eBC_tv-_FNqjWVMq-no99A/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/eBC_tv-_FNqjWVMq-no99A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eBC_tv-_FNqjWVMq-no99A/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/eRzlGAuJZZYbPU6hnTADoA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eRzlGAuJZZYbPU6hnTADoA/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/eRzlGAuJZZYbPU6hnTADoA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eRzlGAuJZZYbPU6hnTADoA/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/eVSpM_pYsIvyyewUkjTa2A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eVSpM_pYsIvyyewUkjTa2A/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/eVSpM_pYsIvyyewUkjTa2A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eVSpM_pYsIvyyewUkjTa2A/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/eWp7_8m3btY6p4erQ5c2JQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eWp7_8m3btY6p4erQ5c2JQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/eWp7_8m3btY6p4erQ5c2JQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eWp7_8m3btY6p4erQ5c2JQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/e_FDMPgmGFzIY3W0EbjxHA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/e_FDMPgmGFzIY3W0EbjxHA/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 11,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 11,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 11,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/e_FDMPgmGFzIY3W0EbjxHA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/e_FDMPgmGFzIY3W0EbjxHA/output.json
@@ -36,41 +36,12 @@
                   "end": 11,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 11,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 11,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 11,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/egyt9Hk9xnn2Xfbi3Ckfrg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/egyt9Hk9xnn2Xfbi3Ckfrg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/egyt9Hk9xnn2Xfbi3Ckfrg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/egyt9Hk9xnn2Xfbi3Ckfrg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/eivsIn6ub-xYiqErLqd8oA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eivsIn6ub-xYiqErLqd8oA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/eivsIn6ub-xYiqErLqd8oA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/eivsIn6ub-xYiqErLqd8oA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/fT3vLBT7xnGwPlQ-kXdN1g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fT3vLBT7xnGwPlQ-kXdN1g/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/fT3vLBT7xnGwPlQ-kXdN1g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fT3vLBT7xnGwPlQ-kXdN1g/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/fTZzFds73kLZoyY9Y2gZdQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fTZzFds73kLZoyY9Y2gZdQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/fTZzFds73kLZoyY9Y2gZdQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fTZzFds73kLZoyY9Y2gZdQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/fYJdtIZOdQKTLI8JJC2b_g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fYJdtIZOdQKTLI8JJC2b_g/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 10,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 10,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 10,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/fYJdtIZOdQKTLI8JJC2b_g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fYJdtIZOdQKTLI8JJC2b_g/output.json
@@ -36,41 +36,12 @@
                   "end": 10,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 10,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 10,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 10,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/fe2WQQLV9qt16pYQLzZrpw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fe2WQQLV9qt16pYQLzZrpw/output.json
@@ -36,41 +36,12 @@
                   "end": 9,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 9,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 9,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 9,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 9,

--- a/css/parser/tests/fixture/esbuild/misc/fe2WQQLV9qt16pYQLzZrpw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fe2WQQLV9qt16pYQLzZrpw/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 9,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 9,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 9,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 9,

--- a/css/parser/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/fp9AcaoyGYHGTzXDXcy_ZQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fp9AcaoyGYHGTzXDXcy_ZQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 10,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 10,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 10,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/fp9AcaoyGYHGTzXDXcy_ZQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fp9AcaoyGYHGTzXDXcy_ZQ/output.json
@@ -36,41 +36,12 @@
                   "end": 10,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 10,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 10,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 10,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/ftc5-zf_sliOrFRRBGGS-g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ftc5-zf_sliOrFRRBGGS-g/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/ftc5-zf_sliOrFRRBGGS-g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ftc5-zf_sliOrFRRBGGS-g/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/fxosM7xcuYbDyErN-ODVbw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fxosM7xcuYbDyErN-ODVbw/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/fxosM7xcuYbDyErN-ODVbw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/fxosM7xcuYbDyErN-ODVbw/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/gxBoWO36fKxIuYwPzrWyKQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/gxBoWO36fKxIuYwPzrWyKQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/gxBoWO36fKxIuYwPzrWyKQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/gxBoWO36fKxIuYwPzrWyKQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/hYoP2sEvEyLualMll8L_RQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/hYoP2sEvEyLualMll8L_RQ/output.json
@@ -31,6 +31,33 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 2,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 2,
+                "ctxt": 0
+              },
+              "nestingSelector": {
+                "type": "NestingSelector",
+                "span": {
+                  "start": 0,
+                  "end": 1,
+                  "ctxt": 0
+                }
+              },
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 2,

--- a/css/parser/tests/fixture/esbuild/misc/hYoP2sEvEyLualMll8L_RQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/hYoP2sEvEyLualMll8L_RQ/output.json
@@ -31,39 +31,19 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 2,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 2,
-                "ctxt": 0
-              },
-              "nestingSelector": {
-                "type": "NestingSelector",
-                "span": {
-                  "start": 0,
-                  "end": 1,
-                  "ctxt": 0
-                }
-              },
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 2,
                   "ctxt": 0
                 },
-                "hasNestPrefix": true,
+                "nestingSelector": {
+                  "type": "NestingSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 1,
+                    "ctxt": 0
+                  }
+                },
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/hYoP2sEvEyLualMll8L_RQ/span.rust-debug
+++ b/css/parser/tests/fixture/esbuild/misc/hYoP2sEvEyLualMll8L_RQ/span.rust-debug
@@ -34,6 +34,12 @@ error: CompoundSelector
 1 | &* {}
   | ^^
 
+error: NestingSelector
+ --> $DIR/tests/fixture/esbuild/misc/hYoP2sEvEyLualMll8L_RQ/input.css:1:1
+  |
+1 | &* {}
+  | ^
+
 error: TypeSelector
  --> $DIR/tests/fixture/esbuild/misc/hYoP2sEvEyLualMll8L_RQ/input.css:1:1
   |

--- a/css/parser/tests/fixture/esbuild/misc/hfprsTDi2yEOOmPdjb8Cew/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/hfprsTDi2yEOOmPdjb8Cew/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/hfprsTDi2yEOOmPdjb8Cew/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/hfprsTDi2yEOOmPdjb8Cew/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/i7oy_7cYzOxuhIPcZo1yow/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/i7oy_7cYzOxuhIPcZo1yow/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 10,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 10,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 10,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/i7oy_7cYzOxuhIPcZo1yow/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/i7oy_7cYzOxuhIPcZo1yow/output.json
@@ -36,41 +36,12 @@
                   "end": 10,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 10,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 10,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 10,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/inMW5rttJFPDfH0aKVFg_Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/inMW5rttJFPDfH0aKVFg_Q/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/inMW5rttJFPDfH0aKVFg_Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/inMW5rttJFPDfH0aKVFg_Q/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/isfWm5W8qb6_aJSz_bdwDw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/isfWm5W8qb6_aJSz_bdwDw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/isfWm5W8qb6_aJSz_bdwDw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/isfWm5W8qb6_aJSz_bdwDw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/j9dr5-Ih68VDH1exMwsmZA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/j9dr5-Ih68VDH1exMwsmZA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/j9dr5-Ih68VDH1exMwsmZA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/j9dr5-Ih68VDH1exMwsmZA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/jD_IvFQVk8LtCrictrWpxw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/jD_IvFQVk8LtCrictrWpxw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/jD_IvFQVk8LtCrictrWpxw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/jD_IvFQVk8LtCrictrWpxw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/jdLujY0rTP02e0KuCnvbvg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/jdLujY0rTP02e0KuCnvbvg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/jdLujY0rTP02e0KuCnvbvg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/jdLujY0rTP02e0KuCnvbvg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/jzpj5gTOBgKB1ITBDfJiNA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/jzpj5gTOBgKB1ITBDfJiNA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/jzpj5gTOBgKB1ITBDfJiNA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/jzpj5gTOBgKB1ITBDfJiNA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/kVdd5WJZqKSou4cGvcL40g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/kVdd5WJZqKSou4cGvcL40g/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/kVdd5WJZqKSou4cGvcL40g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/kVdd5WJZqKSou4cGvcL40g/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/kdJ9F7n35563o0T6W1TEXw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/kdJ9F7n35563o0T6W1TEXw/output.json
@@ -51,41 +51,12 @@
                         "end": 17,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 8,
-                  "end": 17,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 8,
-                      "end": 17,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 8,
-                          "end": 17,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 8,
                             "end": 17,

--- a/css/parser/tests/fixture/esbuild/misc/kdJ9F7n35563o0T6W1TEXw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/kdJ9F7n35563o0T6W1TEXw/output.json
@@ -57,6 +57,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 8,
+                  "end": 17,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 8,
+                      "end": 17,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 8,
+                          "end": 17,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 8,
                             "end": 17,

--- a/css/parser/tests/fixture/esbuild/misc/kubgOdBUY3iT30KfPRcbsA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/kubgOdBUY3iT30KfPRcbsA/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 12,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 12,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 12,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 12,

--- a/css/parser/tests/fixture/esbuild/misc/kubgOdBUY3iT30KfPRcbsA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/kubgOdBUY3iT30KfPRcbsA/output.json
@@ -36,41 +36,12 @@
                   "end": 12,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 12,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 12,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 12,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 12,

--- a/css/parser/tests/fixture/esbuild/misc/lFIVvsKPgxD4lJlULqKluw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/lFIVvsKPgxD4lJlULqKluw/output.json
@@ -36,41 +36,12 @@
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 8,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/lFIVvsKPgxD4lJlULqKluw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/lFIVvsKPgxD4lJlULqKluw/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 8,

--- a/css/parser/tests/fixture/esbuild/misc/mJEhy0k_dxoszsTVHb3x_Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mJEhy0k_dxoszsTVHb3x_Q/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/mJEhy0k_dxoszsTVHb3x_Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mJEhy0k_dxoszsTVHb3x_Q/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/mTLdgh264Uoe84INHS3fAw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mTLdgh264Uoe84INHS3fAw/output.json
@@ -42,6 +42,36 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 3,
+                    "ctxt": 0
+                  },
+                  "isElement": true,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/mTLdgh264Uoe84INHS3fAw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mTLdgh264Uoe84INHS3fAw/output.json
@@ -36,42 +36,12 @@
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 3,
-                    "ctxt": 0
-                  },
-                  "isElement": true,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/mn3ADjaNJuY6IF0Nqms-VQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mn3ADjaNJuY6IF0Nqms-VQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/mn3ADjaNJuY6IF0Nqms-VQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mn3ADjaNJuY6IF0Nqms-VQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/mnQPy45Xrp2Ze7IdrwV0Ow/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mnQPy45Xrp2Ze7IdrwV0Ow/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 4,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 4,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/mnQPy45Xrp2Ze7IdrwV0Ow/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mnQPy45Xrp2Ze7IdrwV0Ow/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 4,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 4,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/nTOoTMumkTvMLx_Y_al5RQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/nTOoTMumkTvMLx_Y_al5RQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/nTOoTMumkTvMLx_Y_al5RQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/nTOoTMumkTvMLx_Y_al5RQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/niufyVEBI4s-ZqSXdfhptA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/niufyVEBI4s-ZqSXdfhptA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/niufyVEBI4s-ZqSXdfhptA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/niufyVEBI4s-ZqSXdfhptA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/nlYSjWzJfpf38YhsJNbwmA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/nlYSjWzJfpf38YhsJNbwmA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/nlYSjWzJfpf38YhsJNbwmA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/nlYSjWzJfpf38YhsJNbwmA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/oNUbYW5wdxqAQR8cAY1YBA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/oNUbYW5wdxqAQR8cAY1YBA/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 10,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 10,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 10,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/oNUbYW5wdxqAQR8cAY1YBA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/oNUbYW5wdxqAQR8cAY1YBA/output.json
@@ -36,41 +36,12 @@
                   "end": 10,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 10,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 10,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 10,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/octeetJYrV7Yu6rAS3AUFQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/octeetJYrV7Yu6rAS3AUFQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 11,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 11,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 11,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/octeetJYrV7Yu6rAS3AUFQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/octeetJYrV7Yu6rAS3AUFQ/output.json
@@ -36,41 +36,12 @@
                   "end": 11,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 11,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 11,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 11,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/oj5Yn0RxnGFEbVphKqrL2Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/oj5Yn0RxnGFEbVphKqrL2Q/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/oj5Yn0RxnGFEbVphKqrL2Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/oj5Yn0RxnGFEbVphKqrL2Q/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/ottVCVON2IlQB3WCD-lu_A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ottVCVON2IlQB3WCD-lu_A/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/ottVCVON2IlQB3WCD-lu_A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ottVCVON2IlQB3WCD-lu_A/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/p4k8Aj2Nw7Pd4QNaHfLCyg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/p4k8Aj2Nw7Pd4QNaHfLCyg/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 10,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 10,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 10,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/p4k8Aj2Nw7Pd4QNaHfLCyg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/p4k8Aj2Nw7Pd4QNaHfLCyg/output.json
@@ -36,41 +36,12 @@
                   "end": 10,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 10,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 10,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 10,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/pJGP-gxqsiFs_ruNrpY3bw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pJGP-gxqsiFs_ruNrpY3bw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/pJGP-gxqsiFs_ruNrpY3bw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pJGP-gxqsiFs_ruNrpY3bw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/pLQn9swtbpZ-CVZMGw0EwA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pLQn9swtbpZ-CVZMGw0EwA/output.json
@@ -42,6 +42,36 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 16,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 16,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 16,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 16,

--- a/css/parser/tests/fixture/esbuild/misc/pLQn9swtbpZ-CVZMGw0EwA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pLQn9swtbpZ-CVZMGw0EwA/output.json
@@ -36,42 +36,12 @@
                   "end": 16,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 16,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 16,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 16,
-                    "ctxt": 0
-                  },
-                  "isElement": false,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 16,

--- a/css/parser/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/pOZgFOB3GdVvQ0hiAsWfpQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pOZgFOB3GdVvQ0hiAsWfpQ/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 11,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 11,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 11,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/pOZgFOB3GdVvQ0hiAsWfpQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pOZgFOB3GdVvQ0hiAsWfpQ/output.json
@@ -36,41 +36,12 @@
                   "end": 11,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 11,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 11,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 11,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 11,

--- a/css/parser/tests/fixture/esbuild/misc/pQWwEpWgxuUS6-uSAJR0nQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pQWwEpWgxuUS6-uSAJR0nQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/pQWwEpWgxuUS6-uSAJR0nQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pQWwEpWgxuUS6-uSAJR0nQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/pRKMU9FUvZ77y9hGWxYQnw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pRKMU9FUvZ77y9hGWxYQnw/output.json
@@ -36,41 +36,12 @@
                   "end": 9,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 9,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 9,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 9,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 9,

--- a/css/parser/tests/fixture/esbuild/misc/pRKMU9FUvZ77y9hGWxYQnw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pRKMU9FUvZ77y9hGWxYQnw/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 9,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 9,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 9,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 9,

--- a/css/parser/tests/fixture/esbuild/misc/pTW2Z7kJ0nR_yQzsOsjAwQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pTW2Z7kJ0nR_yQzsOsjAwQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/pTW2Z7kJ0nR_yQzsOsjAwQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pTW2Z7kJ0nR_yQzsOsjAwQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/pUymwoCxUAxDqtaTC7CaOQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pUymwoCxUAxDqtaTC7CaOQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/pUymwoCxUAxDqtaTC7CaOQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pUymwoCxUAxDqtaTC7CaOQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/pqHD3F10M6OunHKOop7-lA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pqHD3F10M6OunHKOop7-lA/output.json
@@ -36,41 +36,12 @@
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 5,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/pqHD3F10M6OunHKOop7-lA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/pqHD3F10M6OunHKOop7-lA/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 5,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/prqRW0qUpem2SVAI9WN-5w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/prqRW0qUpem2SVAI9WN-5w/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 2,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 2,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 2,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/prqRW0qUpem2SVAI9WN-5w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/prqRW0qUpem2SVAI9WN-5w/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 2,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 2,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 2,

--- a/css/parser/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/puXMOLryMROitDKRX2oMmw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/puXMOLryMROitDKRX2oMmw/output.json
@@ -36,41 +36,12 @@
                   "end": 4,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 4,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 4,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 4,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/puXMOLryMROitDKRX2oMmw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/puXMOLryMROitDKRX2oMmw/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 4,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 4,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 4,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/qgkE_nOj4HtPukMzEjCY5w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/qgkE_nOj4HtPukMzEjCY5w/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/qgkE_nOj4HtPukMzEjCY5w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/qgkE_nOj4HtPukMzEjCY5w/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/qmXSF9N8euK5gfPoFGmV_Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/qmXSF9N8euK5gfPoFGmV_Q/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/qmXSF9N8euK5gfPoFGmV_Q/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/qmXSF9N8euK5gfPoFGmV_Q/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/qsC9vwnhYfmqVreVrA1SEg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/qsC9vwnhYfmqVreVrA1SEg/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 10,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 10,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 10,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/qsC9vwnhYfmqVreVrA1SEg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/qsC9vwnhYfmqVreVrA1SEg/output.json
@@ -36,41 +36,12 @@
                   "end": 10,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 10,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 10,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 10,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/rAzJtA56igpCO-gN3gRrYw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/rAzJtA56igpCO-gN3gRrYw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/rAzJtA56igpCO-gN3gRrYw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/rAzJtA56igpCO-gN3gRrYw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/rGv8hpoRRBbCTlyQ-70xVw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/rGv8hpoRRBbCTlyQ-70xVw/output.json
@@ -42,6 +42,36 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 14,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 14,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 14,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 14,

--- a/css/parser/tests/fixture/esbuild/misc/rGv8hpoRRBbCTlyQ-70xVw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/rGv8hpoRRBbCTlyQ-70xVw/output.json
@@ -36,42 +36,12 @@
                   "end": 14,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 14,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 14,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 14,
-                    "ctxt": 0
-                  },
-                  "isElement": false,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 14,

--- a/css/parser/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/rZIFO-RMBeLmmQK8U6nNmQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/rZIFO-RMBeLmmQK8U6nNmQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/rZIFO-RMBeLmmQK8U6nNmQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/rZIFO-RMBeLmmQK8U6nNmQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/s6SbuS-mSQuuf1eQzngAFw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/s6SbuS-mSQuuf1eQzngAFw/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 5,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/s6SbuS-mSQuuf1eQzngAFw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/s6SbuS-mSQuuf1eQzngAFw/output.json
@@ -36,41 +36,12 @@
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 5,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/esbuild/misc/sAlB53zm7iv9WuhRVKadHQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sAlB53zm7iv9WuhRVKadHQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 4,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 4,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/sAlB53zm7iv9WuhRVKadHQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sAlB53zm7iv9WuhRVKadHQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 4,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 4,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/sEqPCrxONsC0GxTLw0X7IA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sEqPCrxONsC0GxTLw0X7IA/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 13,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 13,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 13,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 13,

--- a/css/parser/tests/fixture/esbuild/misc/sEqPCrxONsC0GxTLw0X7IA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sEqPCrxONsC0GxTLw0X7IA/output.json
@@ -36,41 +36,12 @@
                   "end": 13,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 13,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 13,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 13,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 13,

--- a/css/parser/tests/fixture/esbuild/misc/sI7kJsMAHm4ehV5Ec9i9hg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sI7kJsMAHm4ehV5Ec9i9hg/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 10,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 10,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 10,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/sI7kJsMAHm4ehV5Ec9i9hg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sI7kJsMAHm4ehV5Ec9i9hg/output.json
@@ -36,41 +36,12 @@
                   "end": 10,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 10,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 10,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 10,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/sNuIucY7tsVtjkcMTIXaGw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sNuIucY7tsVtjkcMTIXaGw/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 10,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 10,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 10,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/sNuIucY7tsVtjkcMTIXaGw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sNuIucY7tsVtjkcMTIXaGw/output.json
@@ -36,41 +36,12 @@
                   "end": 10,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 10,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 10,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 10,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 10,

--- a/css/parser/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/tJNGkqEMVKFfOWjyOm5TSg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/tJNGkqEMVKFfOWjyOm5TSg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/tJNGkqEMVKFfOWjyOm5TSg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/tJNGkqEMVKFfOWjyOm5TSg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/tr7rB0yt-SnlIRotrT7uFA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/tr7rB0yt-SnlIRotrT7uFA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/tr7rB0yt-SnlIRotrT7uFA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/tr7rB0yt-SnlIRotrT7uFA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,

--- a/css/parser/tests/fixture/esbuild/misc/uUAQc0UQ6MBf-ScTmlXMow/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/uUAQc0UQ6MBf-ScTmlXMow/output.json
@@ -31,30 +31,19 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": {
-                "type": "NestingSelector",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": true,
+                "nestingSelector": {
+                  "type": "NestingSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 1,
+                    "ctxt": 0
+                  }
+                },
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": []
@@ -63,15 +52,6 @@
           }
         ]
       },
-                }
-              },
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": []
-            }
-          ]
-        }
-      ],
       "block": {
         "type": "Block",
         "span": {

--- a/css/parser/tests/fixture/esbuild/misc/uUAQc0UQ6MBf-ScTmlXMow/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/uUAQc0UQ6MBf-ScTmlXMow/output.json
@@ -31,6 +31,24 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": {
+                "type": "NestingSelector",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -45,6 +63,15 @@
           }
         ]
       },
+                }
+              },
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": []
+            }
+          ]
+        }
+      ],
       "block": {
         "type": "Block",
         "span": {

--- a/css/parser/tests/fixture/esbuild/misc/uUAQc0UQ6MBf-ScTmlXMow/span.rust-debug
+++ b/css/parser/tests/fixture/esbuild/misc/uUAQc0UQ6MBf-ScTmlXMow/span.rust-debug
@@ -34,6 +34,12 @@ error: CompoundSelector
 1 | & {}
   | ^
 
+error: NestingSelector
+ --> $DIR/tests/fixture/esbuild/misc/uUAQc0UQ6MBf-ScTmlXMow/input.css:1:1
+  |
+1 | & {}
+  | ^
+
 error: Block
  --> $DIR/tests/fixture/esbuild/misc/uUAQc0UQ6MBf-ScTmlXMow/input.css:1:3
   |

--- a/css/parser/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/vCiwe_ipn8ReAa4wyU52Ng/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vCiwe_ipn8ReAa4wyU52Ng/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/vCiwe_ipn8ReAa4wyU52Ng/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vCiwe_ipn8ReAa4wyU52Ng/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/vJrDZy-xgYNUTNK3uei3cg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vJrDZy-xgYNUTNK3uei3cg/output.json
@@ -36,41 +36,12 @@
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 3,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/vJrDZy-xgYNUTNK3uei3cg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vJrDZy-xgYNUTNK3uei3cg/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 3,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 3,

--- a/css/parser/tests/fixture/esbuild/misc/vK9rUBJhwa0FsjBe18lL0w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vK9rUBJhwa0FsjBe18lL0w/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/vK9rUBJhwa0FsjBe18lL0w/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vK9rUBJhwa0FsjBe18lL0w/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/vN7xRB9YekSqanW68eIoNA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vN7xRB9YekSqanW68eIoNA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/vN7xRB9YekSqanW68eIoNA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/vN7xRB9YekSqanW68eIoNA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/wEB80kxMinK4EZaPb3My1A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/wEB80kxMinK4EZaPb3My1A/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/wEB80kxMinK4EZaPb3My1A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/wEB80kxMinK4EZaPb3My1A/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/wIDDuubF_bj7wmG8T_koVw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/wIDDuubF_bj7wmG8T_koVw/output.json
@@ -36,41 +36,12 @@
                   "end": 4,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 4,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 4,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 4,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/wIDDuubF_bj7wmG8T_koVw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/wIDDuubF_bj7wmG8T_koVw/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 4,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 4,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 4,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 4,

--- a/css/parser/tests/fixture/esbuild/misc/wwLEw52LUKMFH3Wp5CaBAQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/wwLEw52LUKMFH3Wp5CaBAQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/wwLEw52LUKMFH3Wp5CaBAQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/wwLEw52LUKMFH3Wp5CaBAQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/xVWGh0UpWtRUrgqbJEENWA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/xVWGh0UpWtRUrgqbJEENWA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/xVWGh0UpWtRUrgqbJEENWA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/xVWGh0UpWtRUrgqbJEENWA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/xVqT8wNU4CEhaDlbLxGyaw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/xVqT8wNU4CEhaDlbLxGyaw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/xVqT8wNU4CEhaDlbLxGyaw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/xVqT8wNU4CEhaDlbLxGyaw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/xc1mD3YfHByTKL-N-FL49A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/xc1mD3YfHByTKL-N-FL49A/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/xc1mD3YfHByTKL-N-FL49A/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/xc1mD3YfHByTKL-N-FL49A/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/xdJ7w6fdV3po3r2aWrgPdA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/xdJ7w6fdV3po3r2aWrgPdA/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/xdJ7w6fdV3po3r2aWrgPdA/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/xdJ7w6fdV3po3r2aWrgPdA/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/yOHW3TOE35U7DAf9Hn7-Ew/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/yOHW3TOE35U7DAf9Hn7-Ew/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/yOHW3TOE35U7DAf9Hn7-Ew/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/yOHW3TOE35U7DAf9Hn7-Ew/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/yVqdwpiB7OK23Te5mXKdFw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/yVqdwpiB7OK23Te5mXKdFw/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/yVqdwpiB7OK23Te5mXKdFw/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/yVqdwpiB7OK23Te5mXKdFw/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/yboE7Tr5zjKHy9-m10AZTg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/yboE7Tr5zjKHy9-m10AZTg/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/yboE7Tr5zjKHy9-m10AZTg/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/yboE7Tr5zjKHy9-m10AZTg/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/zUuWz4A8Y6yZO8JMLAe2fQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/zUuWz4A8Y6yZO8JMLAe2fQ/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/zUuWz4A8Y6yZO8JMLAe2fQ/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/zUuWz4A8Y6yZO8JMLAe2fQ/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/output.json
+++ b/css/parser/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/function/url/output.json
+++ b/css/parser/tests/fixture/function/url/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/function/url/output.json
+++ b/css/parser/tests/fixture/function/url/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/hex-colors/output.json
+++ b/css/parser/tests/fixture/hex-colors/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/hex-colors/output.json
+++ b/css/parser/tests/fixture/hex-colors/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/important/basic/output.json
+++ b/css/parser/tests/fixture/important/basic/output.json
@@ -36,41 +36,12 @@
                   "end": 2,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 2,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 2,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 2,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 2,

--- a/css/parser/tests/fixture/important/basic/output.json
+++ b/css/parser/tests/fixture/important/basic/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 2,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 2,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 2,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 2,

--- a/css/parser/tests/fixture/number/output.json
+++ b/css/parser/tests/fixture/number/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/number/output.json
+++ b/css/parser/tests/fixture/number/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/fixture/property/escaped/output.json
+++ b/css/parser/tests/fixture/property/escaped/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/property/escaped/output.json
+++ b/css/parser/tests/fixture/property/escaped/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 5,

--- a/css/parser/tests/fixture/rome/at-page/output.json
+++ b/css/parser/tests/fixture/rome/at-page/output.json
@@ -85,6 +85,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 22,
+                  "end": 33,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 22,
+                      "end": 33,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 22,
+                          "end": 33,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 22,
                             "end": 33,
@@ -269,6 +298,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 90,
+                  "end": 101,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 90,
+                      "end": 101,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 90,
+                          "end": 101,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 90,
                             "end": 101,
@@ -434,6 +492,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 151,
+                  "end": 162,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 151,
+                      "end": 162,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 151,
+                          "end": 162,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 151,
                             "end": 162,
@@ -599,6 +686,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 212,
+                  "end": 223,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 212,
+                      "end": 223,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 212,
+                          "end": 223,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 212,
                             "end": 223,

--- a/css/parser/tests/fixture/rome/at-page/output.json
+++ b/css/parser/tests/fixture/rome/at-page/output.json
@@ -79,41 +79,12 @@
                         "end": 33,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 22,
-                  "end": 33,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 22,
-                      "end": 33,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 22,
-                          "end": 33,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 22,
                             "end": 33,
@@ -292,41 +263,12 @@
                         "end": 101,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 90,
-                  "end": 101,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 90,
-                      "end": 101,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 90,
-                          "end": 101,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 90,
                             "end": 101,
@@ -486,41 +428,12 @@
                         "end": 162,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 151,
-                  "end": 162,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 151,
-                      "end": 162,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 151,
-                          "end": 162,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 151,
                             "end": 162,
@@ -680,41 +593,12 @@
                         "end": 223,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 212,
-                  "end": 223,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 212,
-                      "end": 223,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 212,
-                          "end": 223,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 212,
                             "end": 223,

--- a/css/parser/tests/fixture/rome/at-page/page-margin-properties/output.json
+++ b/css/parser/tests/fixture/rome/at-page/page-margin-properties/output.json
@@ -57,6 +57,35 @@
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
+            "prelude": [
+              {
+                "type": "ComplexSelector",
+                "span": {
+                  "start": 9,
+                  "end": 20,
+                  "ctxt": 0
+                },
+                "selectors": [
+                  {
+                    "type": "CompoundSelector",
+                    "span": {
+                      "start": 9,
+                      "end": 20,
+                      "ctxt": 0
+                    },
+                    "nestingSelector": null,
+                    "combinator": null,
+                    "typeSelector": null,
+                    "subclassSelectors": [
+                      {
+                        "type": "AtSelector",
+                        "span": {
+                          "start": 9,
+                          "end": 20,
+                          "ctxt": 0
+                        },
+                        "text": {
+                          "type": "Text",
                           "span": {
                             "start": 9,
                             "end": 20,

--- a/css/parser/tests/fixture/rome/at-page/page-margin-properties/output.json
+++ b/css/parser/tests/fixture/rome/at-page/page-margin-properties/output.json
@@ -51,41 +51,12 @@
                         "end": 20,
                         "ctxt": 0
                       },
-                      "hasNestPrefix": false,
+                      "nestingSelector": null,
                       "combinator": null,
                       "typeSelector": null,
                       "subclassSelectors": [
                         {
                           "type": "AtSelector",
-            "prelude": [
-              {
-                "type": "ComplexSelector",
-                "span": {
-                  "start": 9,
-                  "end": 20,
-                  "ctxt": 0
-                },
-                "selectors": [
-                  {
-                    "type": "CompoundSelector",
-                    "span": {
-                      "start": 9,
-                      "end": 20,
-                      "ctxt": 0
-                    },
-                    "nestingSelector": null,
-                    "combinator": null,
-                    "typeSelector": null,
-                    "subclassSelectors": [
-                      {
-                        "type": "AtSelector",
-                        "span": {
-                          "start": 9,
-                          "end": 20,
-                          "ctxt": 0
-                        },
-                        "text": {
-                          "type": "Text",
                           "span": {
                             "start": 9,
                             "end": 20,

--- a/css/parser/tests/fixture/rome/calc/output.json
+++ b/css/parser/tests/fixture/rome/calc/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 6,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/calc/output.json
+++ b/css/parser/tests/fixture/rome/calc/output.json
@@ -36,41 +36,12 @@
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 6,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/comment/output.json
+++ b/css/parser/tests/fixture/rome/comment/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 20,
+            "end": 21,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 20,
+                "end": 21,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 20,
                   "end": 21,
@@ -130,6 +150,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 56,
+            "end": 57,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 56,
+                "end": 57,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 56,
                   "end": 57,
@@ -229,6 +269,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 92,
+            "end": 93,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 92,
+                "end": 93,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 92,
                   "end": 93,

--- a/css/parser/tests/fixture/rome/comment/output.json
+++ b/css/parser/tests/fixture/rome/comment/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 20,
-            "end": 21,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 20,
-                "end": 21,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 20,
                   "end": 21,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -150,32 +130,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 56,
-            "end": 57,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 56,
-                "end": 57,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 56,
                   "end": 57,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -269,32 +229,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 92,
-            "end": 93,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 92,
-                "end": 93,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 92,
                   "end": 93,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/rome/custom-properties/output.json
+++ b/css/parser/tests/fixture/rome/custom-properties/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 6,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/custom-properties/output.json
+++ b/css/parser/tests/fixture/rome/custom-properties/output.json
@@ -36,41 +36,12 @@
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 6,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/fit-content/output.json
+++ b/css/parser/tests/fixture/rome/fit-content/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 6,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/fit-content/output.json
+++ b/css/parser/tests/fixture/rome/fit-content/output.json
@@ -36,41 +36,12 @@
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 6,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/functions/output.json
+++ b/css/parser/tests/fixture/rome/functions/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 6,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/functions/output.json
+++ b/css/parser/tests/fixture/rome/functions/output.json
@@ -36,41 +36,12 @@
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 6,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/grid/minmax/output.json
+++ b/css/parser/tests/fixture/rome/grid/minmax/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 6,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/grid/minmax/output.json
+++ b/css/parser/tests/fixture/rome/grid/minmax/output.json
@@ -36,41 +36,12 @@
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 6,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/grid/repeat/fit-content/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/fit-content/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 6,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/grid/repeat/fit-content/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/fit-content/output.json
@@ -36,41 +36,12 @@
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 6,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/grid/repeat/flex/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/flex/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 6,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/grid/repeat/flex/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/flex/output.json
@@ -36,41 +36,12 @@
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 6,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/grid/repeat/line-name/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/line-name/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 6,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/grid/repeat/line-name/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/line-name/output.json
@@ -36,41 +36,12 @@
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 6,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/grid/repeat/minmax/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/minmax/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 6,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/grid/repeat/minmax/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/minmax/output.json
@@ -36,41 +36,12 @@
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 6,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/grid/repeat/multi-values/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/multi-values/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 6,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/grid/repeat/multi-values/output.json
+++ b/css/parser/tests/fixture/rome/grid/repeat/multi-values/output.json
@@ -36,41 +36,12 @@
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 6,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/media/condition/output.json
+++ b/css/parser/tests/fixture/rome/media/condition/output.json
@@ -884,6 +884,26 @@
                 "selectors": [
                   {
                     "type": "CompoundSelector",
+          "selectors": [
+            {
+              "type": "ComplexSelector",
+              "span": {
+                "start": 383,
+                "end": 384,
+                "ctxt": 0
+              },
+              "selectors": [
+                {
+                  "type": "CompoundSelector",
+                  "span": {
+                    "start": 383,
+                    "end": 384,
+                    "ctxt": 0
+                  },
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 383,
                       "end": 384,
@@ -962,6 +982,35 @@
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
+          "selectors": [
+            {
+              "type": "ComplexSelector",
+              "span": {
+                "start": 392,
+                "end": 398,
+                "ctxt": 0
+              },
+              "selectors": [
+                {
+                  "type": "CompoundSelector",
+                  "span": {
+                    "start": 392,
+                    "end": 398,
+                    "ctxt": 0
+                  },
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": null,
+                  "subclassSelectors": [
+                    {
+                      "type": "ClassSelector",
+                      "span": {
+                        "start": 392,
+                        "end": 398,
+                        "ctxt": 0
+                      },
+                      "text": {
+                        "type": "Text",
                         "span": {
                           "start": 392,
                           "end": 398,

--- a/css/parser/tests/fixture/rome/media/condition/output.json
+++ b/css/parser/tests/fixture/rome/media/condition/output.json
@@ -884,32 +884,12 @@
                 "selectors": [
                   {
                     "type": "CompoundSelector",
-          "selectors": [
-            {
-              "type": "ComplexSelector",
-              "span": {
-                "start": 383,
-                "end": 384,
-                "ctxt": 0
-              },
-              "selectors": [
-                {
-                  "type": "CompoundSelector",
-                  "span": {
-                    "start": 383,
-                    "end": 384,
-                    "ctxt": 0
-                  },
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 383,
                       "end": 384,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": {
                       "type": "TypeSelector",
@@ -976,41 +956,12 @@
                       "end": 398,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": null,
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
-          "selectors": [
-            {
-              "type": "ComplexSelector",
-              "span": {
-                "start": 392,
-                "end": 398,
-                "ctxt": 0
-              },
-              "selectors": [
-                {
-                  "type": "CompoundSelector",
-                  "span": {
-                    "start": 392,
-                    "end": 398,
-                    "ctxt": 0
-                  },
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": null,
-                  "subclassSelectors": [
-                    {
-                      "type": "ClassSelector",
-                      "span": {
-                        "start": 392,
-                        "end": 398,
-                        "ctxt": 0
-                      },
-                      "text": {
-                        "type": "Text",
                         "span": {
                           "start": 392,
                           "end": 398,

--- a/css/parser/tests/fixture/rome/min-and-max/output.json
+++ b/css/parser/tests/fixture/rome/min-and-max/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 6,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/min-and-max/output.json
+++ b/css/parser/tests/fixture/rome/min-and-max/output.json
@@ -36,41 +36,12 @@
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 6,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,

--- a/css/parser/tests/fixture/rome/selectors/output.json
+++ b/css/parser/tests/fixture/rome/selectors/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -91,24 +71,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 5,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 5,
                   "end": 8,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -119,31 +87,6 @@
                   },
                   "prefix": null,
                   "name": {
-                  "value": "div",
-                  "raw": "div"
-                }
-              },
-              "subclassSelectors": []
-            },
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 11,
-                "end": 14,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": "+",
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 11,
-                    "end": 14,
-                    "ctxt": 0
-                  },
-                  "text": {
                     "type": "Text",
                     "span": {
                       "start": 5,
@@ -163,7 +106,7 @@
                   "end": 14,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": "+",
                 "typeSelector": null,
                 "subclassSelectors": [
@@ -199,24 +142,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 16,
-                "end": 19,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 16,
                   "end": 19,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -227,31 +158,6 @@
                   },
                   "prefix": null,
                   "name": {
-                  "value": "div",
-                  "raw": "div"
-                }
-              },
-              "subclassSelectors": []
-            },
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 22,
-                "end": 25,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": "~",
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 22,
-                    "end": 25,
-                    "ctxt": 0
-                  },
-                  "text": {
                     "type": "Text",
                     "span": {
                       "start": 16,
@@ -271,7 +177,7 @@
                   "end": 25,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": "~",
                 "typeSelector": null,
                 "subclassSelectors": [
@@ -307,24 +213,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 27,
-                "end": 30,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 27,
                   "end": 30,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -335,31 +229,6 @@
                   },
                   "prefix": null,
                   "name": {
-                  "value": "div",
-                  "raw": "div"
-                }
-              },
-              "subclassSelectors": []
-            },
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 33,
-                "end": 36,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": ">",
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 33,
-                    "end": 36,
-                    "ctxt": 0
-                  },
-                  "text": {
                     "type": "Text",
                     "span": {
                       "start": 27,
@@ -379,7 +248,7 @@
                   "end": 36,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": ">",
                 "typeSelector": null,
                 "subclassSelectors": [
@@ -447,41 +316,12 @@
                   "end": 64,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 43,
-            "end": 64,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 43,
-                "end": 64,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 43,
-                    "end": 64,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 43,
                       "end": 64,
@@ -544,41 +384,12 @@
                   "end": 77,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 71,
-            "end": 81,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 71,
-                "end": 77,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 71,
-                    "end": 77,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 71,
                       "end": 77,
@@ -599,16 +410,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": "+",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 80,
                   "end": 81,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": "+",
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -670,32 +477,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 88,
-            "end": 96,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 88,
-                "end": 96,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 88,
                   "end": 96,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -812,32 +599,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 119,
-            "end": 137,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 119,
-                "end": 137,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 119,
                   "end": 137,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -963,32 +730,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 160,
-            "end": 179,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 160,
-                "end": 179,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 160,
                   "end": 179,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1114,32 +861,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 202,
-            "end": 239,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 202,
-                "end": 239,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 202,
                   "end": 239,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1296,32 +1023,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 261,
-            "end": 282,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 261,
-                "end": 282,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 261,
                   "end": 282,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1431,42 +1138,12 @@
                   "end": 301,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 288,
-            "end": 301,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 288,
-                "end": 301,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 288,
-                    "end": 301,
-                    "ctxt": 0
-                  },
-                  "isElement": false,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 288,
                       "end": 301,
@@ -1586,42 +1263,12 @@
                   "end": 322,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 307,
-            "end": 322,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 307,
-                "end": 322,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 307,
-                    "end": 322,
-                    "ctxt": 0
-                  },
-                  "isElement": true,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 307,
                       "end": 322,
@@ -1694,42 +1341,12 @@
                   "end": 347,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 328,
-            "end": 347,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 328,
-                "end": 347,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 328,
-                    "end": 347,
-                    "ctxt": 0
-                  },
-                  "isElement": true,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 328,
                       "end": 347,

--- a/css/parser/tests/fixture/rome/selectors/output.json
+++ b/css/parser/tests/fixture/rome/selectors/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
@@ -71,6 +91,18 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 5,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 5,
                   "end": 8,
@@ -87,6 +119,31 @@
                   },
                   "prefix": null,
                   "name": {
+                  "value": "div",
+                  "raw": "div"
+                }
+              },
+              "subclassSelectors": []
+            },
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 11,
+                "end": 14,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": "+",
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 11,
+                    "end": 14,
+                    "ctxt": 0
+                  },
+                  "text": {
                     "type": "Text",
                     "span": {
                       "start": 5,
@@ -142,6 +199,18 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 16,
+                "end": 19,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 16,
                   "end": 19,
@@ -158,6 +227,31 @@
                   },
                   "prefix": null,
                   "name": {
+                  "value": "div",
+                  "raw": "div"
+                }
+              },
+              "subclassSelectors": []
+            },
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 22,
+                "end": 25,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": "~",
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 22,
+                    "end": 25,
+                    "ctxt": 0
+                  },
+                  "text": {
                     "type": "Text",
                     "span": {
                       "start": 16,
@@ -213,6 +307,18 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 27,
+                "end": 30,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 27,
                   "end": 30,
@@ -229,6 +335,31 @@
                   },
                   "prefix": null,
                   "name": {
+                  "value": "div",
+                  "raw": "div"
+                }
+              },
+              "subclassSelectors": []
+            },
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 33,
+                "end": 36,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": ">",
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 33,
+                    "end": 36,
+                    "ctxt": 0
+                  },
+                  "text": {
                     "type": "Text",
                     "span": {
                       "start": 27,
@@ -322,6 +453,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 43,
+            "end": 64,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 43,
+                "end": 64,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 43,
+                    "end": 64,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 43,
                       "end": 64,
@@ -390,6 +550,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 71,
+            "end": 81,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 71,
+                "end": 77,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 71,
+                    "end": 77,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 71,
                       "end": 77,
@@ -410,6 +599,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": "+",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 80,
                   "end": 81,
@@ -477,6 +670,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 88,
+            "end": 96,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 88,
+                "end": 96,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 88,
                   "end": 96,
@@ -599,6 +812,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 119,
+            "end": 137,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 119,
+                "end": 137,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 119,
                   "end": 137,
@@ -730,6 +963,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 160,
+            "end": 179,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 160,
+                "end": 179,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 160,
                   "end": 179,
@@ -861,6 +1114,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 202,
+            "end": 239,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 202,
+                "end": 239,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 202,
                   "end": 239,
@@ -1023,6 +1296,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 261,
+            "end": 282,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 261,
+                "end": 282,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 261,
                   "end": 282,
@@ -1144,6 +1437,36 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 288,
+            "end": 301,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 288,
+                "end": 301,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 288,
+                    "end": 301,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 288,
                       "end": 301,
@@ -1269,6 +1592,36 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 307,
+            "end": 322,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 307,
+                "end": 322,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 307,
+                    "end": 322,
+                    "ctxt": 0
+                  },
+                  "isElement": true,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 307,
                       "end": 322,
@@ -1347,6 +1700,36 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 328,
+            "end": 347,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 328,
+                "end": 347,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 328,
+                    "end": 347,
+                    "ctxt": 0
+                  },
+                  "isElement": true,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 328,
                       "end": 347,

--- a/css/parser/tests/fixture/rome/smoke/output.json
+++ b/css/parser/tests/fixture/rome/smoke/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 22,
-            "end": 26,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 22,
-                "end": 26,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 22,
                   "end": 26,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/rome/smoke/output.json
+++ b/css/parser/tests/fixture/rome/smoke/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 22,
+            "end": 26,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 22,
+                "end": 26,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 22,
                   "end": 26,

--- a/css/parser/tests/fixture/rome/values/output.json
+++ b/css/parser/tests/fixture/rome/values/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 9,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 9,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 9,
@@ -170,6 +190,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 38,
+            "end": 45,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 38,
+                "end": 45,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 38,
+                    "end": 45,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 38,
                       "end": 45,
@@ -368,6 +417,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 117,
+            "end": 120,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 117,
+                "end": 120,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 117,
                   "end": 120,
@@ -467,6 +536,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 141,
+            "end": 144,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 141,
+                "end": 144,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 141,
                   "end": 144,

--- a/css/parser/tests/fixture/rome/values/output.json
+++ b/css/parser/tests/fixture/rome/values/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 9,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 9,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 9,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -184,41 +164,12 @@
                   "end": 45,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 38,
-            "end": 45,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 38,
-                "end": 45,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 38,
-                    "end": 45,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 38,
                       "end": 45,
@@ -417,32 +368,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 117,
-            "end": 120,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 117,
-                "end": 120,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 117,
                   "end": 120,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -536,32 +467,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 141,
-            "end": 144,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 141,
-                "end": 144,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 141,
                   "end": 144,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/selector/attribute/output.json
+++ b/css/parser/tests/fixture/selector/attribute/output.json
@@ -36,41 +36,12 @@
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 7,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 7,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 7,
@@ -137,41 +108,12 @@
                   "end": 22,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 11,
-            "end": 22,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 11,
-                "end": 22,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 11,
-                    "end": 22,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 11,
                       "end": 22,
@@ -247,41 +189,12 @@
                   "end": 39,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 26,
-            "end": 39,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 26,
-                "end": 39,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 26,
-                    "end": 39,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 26,
                       "end": 39,
@@ -357,41 +270,12 @@
                   "end": 60,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 43,
-            "end": 58,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 43,
-                "end": 58,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 43,
-                    "end": 58,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 43,
                       "end": 60,
@@ -467,41 +351,12 @@
                   "end": 89,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 62,
-            "end": 74,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 62,
-                "end": 74,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 62,
-                    "end": 74,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 64,
                       "end": 89,
@@ -577,41 +432,12 @@
                   "end": 108,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 78,
-            "end": 89,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 78,
-                "end": 89,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 78,
-                    "end": 89,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 93,
                       "end": 108,
@@ -687,41 +513,12 @@
                   "end": 124,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 93,
-            "end": 107,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 93,
-                "end": 107,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 93,
-                    "end": 107,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 112,
                       "end": 124,
@@ -797,41 +594,12 @@
                   "end": 139,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 111,
-            "end": 128,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 111,
-                "end": 128,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 111,
-                    "end": 128,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 128,
                       "end": 139,
@@ -907,41 +675,12 @@
                   "end": 157,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 132,
-            "end": 155,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 132,
-                "end": 155,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 132,
-                    "end": 155,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 143,
                       "end": 157,
@@ -1017,41 +756,12 @@
                   "end": 178,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 159,
-            "end": 182,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 159,
-                "end": 182,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 159,
-                    "end": 182,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 161,
                       "end": 178,
@@ -1127,41 +837,12 @@
                   "end": 205,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 186,
-            "end": 202,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 186,
-                "end": 202,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 186,
-                    "end": 202,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 182,
                       "end": 205,
@@ -1237,41 +918,12 @@
                   "end": 232,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 206,
-            "end": 222,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 206,
-                "end": 222,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 206,
-                    "end": 222,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 209,
                       "end": 232,
@@ -1347,7 +999,7 @@
                   "end": 252,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
@@ -1428,7 +1080,7 @@
                   "end": 272,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
@@ -1509,41 +1161,12 @@
                   "end": 289,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 226,
-            "end": 239,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 226,
-                "end": 239,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 226,
-                    "end": 239,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 276,
                       "end": 289,
@@ -1628,7 +1251,7 @@
                   "end": 300,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
@@ -1709,41 +1332,12 @@
                   "end": 317,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 243,
-            "end": 250,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 243,
-                "end": 250,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 243,
-                    "end": 250,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 304,
                       "end": 317,
@@ -1819,41 +1413,12 @@
                   "end": 327,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 254,
-            "end": 260,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 254,
-                "end": 260,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 254,
-                    "end": 260,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 321,
                       "end": 327,
@@ -1929,7 +1494,7 @@
                   "end": 339,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
@@ -2010,7 +1575,7 @@
                   "end": 355,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
@@ -2091,41 +1656,12 @@
                   "end": 364,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 264,
-            "end": 269,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 264,
-                "end": 269,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 264,
-                    "end": 269,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 359,
                       "end": 364,
@@ -2187,32 +1723,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 273,
-            "end": 292,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 273,
-                "end": 292,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 368,
                   "end": 375,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
@@ -2284,7 +1800,7 @@
                   "end": 390,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
@@ -2356,7 +1872,7 @@
                   "end": 413,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -2450,32 +1966,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 296,
-            "end": 323,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 296,
-                "end": 323,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 417,
                   "end": 444,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -2574,7 +2070,7 @@
                   "end": 473,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
@@ -2655,41 +2151,12 @@
                   "end": 508,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 327,
-            "end": 352,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 327,
-                "end": 352,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 327,
-                    "end": 352,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 477,
                       "end": 508,
@@ -2765,7 +2232,7 @@
                   "end": 549,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
@@ -2846,41 +2313,12 @@
                   "end": 565,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 356,
-            "end": 368,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 356,
-                "end": 368,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "AttributeSelector",
-                  "span": {
-                    "start": 356,
-                    "end": 368,
-                    "ctxt": 0
-                  },
-                  "name": {
-                    "type": "NamespacedName",
                     "span": {
                       "start": 553,
                       "end": 565,

--- a/css/parser/tests/fixture/selector/attribute/output.json
+++ b/css/parser/tests/fixture/selector/attribute/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 7,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 7,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 0,
                       "end": 7,
@@ -114,6 +143,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 11,
+            "end": 22,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 11,
+                "end": 22,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 11,
+                    "end": 22,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 11,
                       "end": 22,
@@ -195,6 +253,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 26,
+            "end": 39,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 26,
+                "end": 39,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 26,
+                    "end": 39,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 26,
                       "end": 39,
@@ -276,6 +363,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 43,
+            "end": 58,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 43,
+                "end": 58,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 43,
+                    "end": 58,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 43,
                       "end": 60,
@@ -357,6 +473,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 62,
+            "end": 74,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 62,
+                "end": 74,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 62,
+                    "end": 74,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 64,
                       "end": 89,
@@ -438,6 +583,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 78,
+            "end": 89,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 78,
+                "end": 89,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 78,
+                    "end": 89,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 93,
                       "end": 108,
@@ -519,6 +693,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 93,
+            "end": 107,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 93,
+                "end": 107,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 93,
+                    "end": 107,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 112,
                       "end": 124,
@@ -600,6 +803,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 111,
+            "end": 128,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 111,
+                "end": 128,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 111,
+                    "end": 128,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 128,
                       "end": 139,
@@ -681,6 +913,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 132,
+            "end": 155,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 132,
+                "end": 155,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 132,
+                    "end": 155,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 143,
                       "end": 157,
@@ -762,6 +1023,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 159,
+            "end": 182,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 159,
+                "end": 182,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 159,
+                    "end": 182,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 161,
                       "end": 178,
@@ -843,6 +1133,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 186,
+            "end": 202,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 186,
+                "end": 202,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 186,
+                    "end": 202,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 182,
                       "end": 205,
@@ -924,6 +1243,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 206,
+            "end": 222,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 206,
+                "end": 222,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 206,
+                    "end": 222,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 209,
                       "end": 232,
@@ -1167,6 +1515,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 226,
+            "end": 239,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 226,
+                "end": 239,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 226,
+                    "end": 239,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 276,
                       "end": 289,
@@ -1338,6 +1715,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 243,
+            "end": 250,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 243,
+                "end": 250,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 243,
+                    "end": 250,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 304,
                       "end": 317,
@@ -1419,6 +1825,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 254,
+            "end": 260,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 254,
+                "end": 260,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 254,
+                    "end": 260,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 321,
                       "end": 327,
@@ -1662,6 +2097,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 264,
+            "end": 269,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 264,
+                "end": 269,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 264,
+                    "end": 269,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 359,
                       "end": 364,
@@ -1723,6 +2187,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 273,
+            "end": 292,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 273,
+                "end": 292,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 368,
                   "end": 375,
@@ -1966,6 +2450,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 296,
+            "end": 323,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 296,
+                "end": 323,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 417,
                   "end": 444,
@@ -2157,6 +2661,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 327,
+            "end": 352,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 327,
+                "end": 352,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 327,
+                    "end": 352,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 477,
                       "end": 508,
@@ -2319,6 +2852,35 @@
                 "subclassSelectors": [
                   {
                     "type": "AttributeSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 356,
+            "end": 368,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 356,
+                "end": 368,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "AttributeSelector",
+                  "span": {
+                    "start": 356,
+                    "end": 368,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "NamespacedName",
                     "span": {
                       "start": 553,
                       "end": 565,

--- a/css/parser/tests/fixture/selector/class/output.json
+++ b/css/parser/tests/fixture/selector/class/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 6,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 6,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 6,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,
@@ -110,6 +139,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 10,
+            "end": 14,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 10,
+                "end": 14,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 10,
+                    "end": 14,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 10,
                       "end": 14,
@@ -178,6 +236,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 18,
+            "end": 21,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 18,
+                "end": 21,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 18,
+                    "end": 21,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 18,
                       "end": 21,
@@ -246,6 +333,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 25,
+            "end": 38,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 25,
+                "end": 38,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 25,
+                    "end": 38,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 25,
                       "end": 38,
@@ -314,6 +430,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 42,
+            "end": 49,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 42,
+                "end": 49,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 42,
+                    "end": 49,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 42,
                       "end": 49,
@@ -382,6 +527,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 53,
+            "end": 60,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 53,
+                "end": 60,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 53,
+                    "end": 60,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 53,
                       "end": 60,
@@ -450,6 +624,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 64,
+            "end": 81,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 64,
+                "end": 81,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 64,
+                    "end": 81,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 64,
                       "end": 81,
@@ -518,6 +721,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 85,
+            "end": 90,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 85,
+                "end": 90,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 85,
+                    "end": 90,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 85,
                       "end": 90,
@@ -586,6 +818,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 94,
+            "end": 97,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 94,
+                "end": 97,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 94,
+                    "end": 97,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 94,
                       "end": 97,
@@ -654,6 +915,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 101,
+            "end": 104,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 101,
+                "end": 104,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 101,
+                    "end": 104,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 101,
                       "end": 104,
@@ -722,6 +1012,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 108,
+            "end": 111,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 108,
+                "end": 111,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 108,
+                    "end": 111,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 108,
                       "end": 111,
@@ -790,6 +1109,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 115,
+            "end": 119,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 115,
+                "end": 119,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 115,
+                    "end": 119,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 115,
                       "end": 119,
@@ -858,6 +1206,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 126,
+            "end": 130,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 126,
+                "end": 130,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 126,
+                    "end": 130,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 126,
                       "end": 130,
@@ -926,6 +1303,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 139,
+            "end": 146,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 139,
+                "end": 146,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 139,
+                    "end": 146,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 139,
                       "end": 146,
@@ -994,6 +1400,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 150,
+            "end": 160,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 150,
+                "end": 160,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 150,
+                    "end": 160,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 150,
                       "end": 160,
@@ -1062,6 +1497,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 164,
+            "end": 170,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 164,
+                "end": 170,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 164,
+                    "end": 170,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 164,
                       "end": 170,
@@ -1130,6 +1594,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 174,
+            "end": 193,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 174,
+                "end": 193,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 174,
+                    "end": 193,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 174,
                       "end": 193,
@@ -1198,6 +1691,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 197,
+            "end": 420,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 197,
+                "end": 420,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 197,
+                    "end": 420,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 197,
                       "end": 420,
@@ -1266,6 +1788,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 424,
+            "end": 427,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 424,
+                "end": 427,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 424,
+                    "end": 427,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 424,
                       "end": 427,
@@ -1334,6 +1885,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 431,
+            "end": 436,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 431,
+                "end": 436,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 431,
+                    "end": 436,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 431,
                       "end": 436,
@@ -1402,6 +1982,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 440,
+            "end": 451,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 440,
+                "end": 451,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 440,
+                    "end": 451,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 440,
                       "end": 451,
@@ -1470,6 +2079,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 455,
+            "end": 458,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 455,
+                "end": 458,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 455,
+                    "end": 458,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 455,
                       "end": 458,
@@ -1538,6 +2176,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 462,
+            "end": 467,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 462,
+                "end": 467,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 462,
+                    "end": 467,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 462,
                       "end": 467,
@@ -1606,6 +2273,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 471,
+            "end": 485,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 471,
+                "end": 485,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 471,
+                    "end": 485,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 471,
                       "end": 485,
@@ -1674,6 +2370,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 489,
+            "end": 498,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 489,
+                "end": 498,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 489,
+                    "end": 498,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 489,
                       "end": 498,
@@ -1742,6 +2467,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 502,
+            "end": 512,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 502,
+                "end": 512,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 502,
+                    "end": 512,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 502,
                       "end": 512,
@@ -1810,6 +2564,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 516,
+            "end": 545,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 516,
+                "end": 545,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 516,
+                    "end": 545,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 516,
                       "end": 545,
@@ -1878,6 +2661,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 549,
+            "end": 565,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 549,
+                "end": 565,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 549,
+                    "end": 565,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 549,
                       "end": 565,
@@ -1946,6 +2758,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 569,
+            "end": 577,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 569,
+                "end": 577,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 569,
+                    "end": 577,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 569,
                       "end": 577,
@@ -2014,6 +2855,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 581,
+            "end": 589,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 581,
+                "end": 589,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 581,
+                    "end": 589,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 581,
                       "end": 589,
@@ -2082,6 +2952,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 593,
+            "end": 601,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 593,
+                "end": 601,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 593,
+                    "end": 601,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 593,
                       "end": 601,
@@ -2150,6 +3049,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 605,
+            "end": 613,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 605,
+                "end": 613,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 605,
+                    "end": 613,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 605,
                       "end": 613,
@@ -2218,6 +3146,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 617,
+            "end": 625,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 617,
+                "end": 625,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 617,
+                    "end": 625,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 617,
                       "end": 625,
@@ -2286,6 +3243,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 629,
+            "end": 637,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 629,
+                "end": 637,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 629,
+                    "end": 637,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 629,
                       "end": 637,
@@ -2354,6 +3340,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 641,
+            "end": 649,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 641,
+                "end": 649,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 641,
+                    "end": 649,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 641,
                       "end": 649,
@@ -2422,6 +3437,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 653,
+            "end": 661,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 653,
+                "end": 661,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 653,
+                    "end": 661,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 653,
                       "end": 661,
@@ -2490,6 +3534,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 665,
+            "end": 675,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 665,
+                "end": 675,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 665,
+                    "end": 675,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 665,
                       "end": 675,

--- a/css/parser/tests/fixture/selector/class/output.json
+++ b/css/parser/tests/fixture/selector/class/output.json
@@ -36,41 +36,12 @@
                   "end": 6,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 6,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 6,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 6,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 6,
@@ -133,41 +104,12 @@
                   "end": 14,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 10,
-            "end": 14,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 10,
-                "end": 14,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 10,
-                    "end": 14,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 10,
                       "end": 14,
@@ -230,41 +172,12 @@
                   "end": 21,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 18,
-            "end": 21,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 18,
-                "end": 21,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 18,
-                    "end": 21,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 18,
                       "end": 21,
@@ -327,41 +240,12 @@
                   "end": 38,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 25,
-            "end": 38,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 25,
-                "end": 38,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 25,
-                    "end": 38,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 25,
                       "end": 38,
@@ -424,41 +308,12 @@
                   "end": 49,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 42,
-            "end": 49,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 42,
-                "end": 49,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 42,
-                    "end": 49,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 42,
                       "end": 49,
@@ -521,41 +376,12 @@
                   "end": 60,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 53,
-            "end": 60,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 53,
-                "end": 60,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 53,
-                    "end": 60,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 53,
                       "end": 60,
@@ -618,41 +444,12 @@
                   "end": 81,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 64,
-            "end": 81,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 64,
-                "end": 81,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 64,
-                    "end": 81,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 64,
                       "end": 81,
@@ -715,41 +512,12 @@
                   "end": 90,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 85,
-            "end": 90,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 85,
-                "end": 90,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 85,
-                    "end": 90,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 85,
                       "end": 90,
@@ -812,41 +580,12 @@
                   "end": 97,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 94,
-            "end": 97,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 94,
-                "end": 97,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 94,
-                    "end": 97,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 94,
                       "end": 97,
@@ -909,41 +648,12 @@
                   "end": 104,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 101,
-            "end": 104,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 101,
-                "end": 104,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 101,
-                    "end": 104,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 101,
                       "end": 104,
@@ -1006,41 +716,12 @@
                   "end": 111,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 108,
-            "end": 111,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 108,
-                "end": 111,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 108,
-                    "end": 111,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 108,
                       "end": 111,
@@ -1103,41 +784,12 @@
                   "end": 119,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 115,
-            "end": 119,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 115,
-                "end": 119,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 115,
-                    "end": 119,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 115,
                       "end": 119,
@@ -1200,41 +852,12 @@
                   "end": 130,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 126,
-            "end": 130,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 126,
-                "end": 130,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 126,
-                    "end": 130,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 126,
                       "end": 130,
@@ -1297,41 +920,12 @@
                   "end": 146,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 139,
-            "end": 146,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 139,
-                "end": 146,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 139,
-                    "end": 146,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 139,
                       "end": 146,
@@ -1394,41 +988,12 @@
                   "end": 160,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 150,
-            "end": 160,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 150,
-                "end": 160,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 150,
-                    "end": 160,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 150,
                       "end": 160,
@@ -1491,41 +1056,12 @@
                   "end": 170,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 164,
-            "end": 170,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 164,
-                "end": 170,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 164,
-                    "end": 170,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 164,
                       "end": 170,
@@ -1588,41 +1124,12 @@
                   "end": 193,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 174,
-            "end": 193,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 174,
-                "end": 193,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 174,
-                    "end": 193,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 174,
                       "end": 193,
@@ -1685,41 +1192,12 @@
                   "end": 420,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 197,
-            "end": 420,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 197,
-                "end": 420,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 197,
-                    "end": 420,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 197,
                       "end": 420,
@@ -1782,41 +1260,12 @@
                   "end": 427,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 424,
-            "end": 427,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 424,
-                "end": 427,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 424,
-                    "end": 427,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 424,
                       "end": 427,
@@ -1879,41 +1328,12 @@
                   "end": 436,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 431,
-            "end": 436,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 431,
-                "end": 436,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 431,
-                    "end": 436,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 431,
                       "end": 436,
@@ -1976,41 +1396,12 @@
                   "end": 451,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 440,
-            "end": 451,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 440,
-                "end": 451,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 440,
-                    "end": 451,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 440,
                       "end": 451,
@@ -2073,41 +1464,12 @@
                   "end": 458,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 455,
-            "end": 458,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 455,
-                "end": 458,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 455,
-                    "end": 458,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 455,
                       "end": 458,
@@ -2170,41 +1532,12 @@
                   "end": 467,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 462,
-            "end": 467,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 462,
-                "end": 467,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 462,
-                    "end": 467,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 462,
                       "end": 467,
@@ -2267,41 +1600,12 @@
                   "end": 485,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 471,
-            "end": 485,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 471,
-                "end": 485,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 471,
-                    "end": 485,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 471,
                       "end": 485,
@@ -2364,41 +1668,12 @@
                   "end": 498,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 489,
-            "end": 498,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 489,
-                "end": 498,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 489,
-                    "end": 498,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 489,
                       "end": 498,
@@ -2461,41 +1736,12 @@
                   "end": 512,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 502,
-            "end": 512,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 502,
-                "end": 512,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 502,
-                    "end": 512,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 502,
                       "end": 512,
@@ -2558,41 +1804,12 @@
                   "end": 545,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 516,
-            "end": 545,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 516,
-                "end": 545,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 516,
-                    "end": 545,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 516,
                       "end": 545,
@@ -2655,41 +1872,12 @@
                   "end": 565,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 549,
-            "end": 565,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 549,
-                "end": 565,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 549,
-                    "end": 565,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 549,
                       "end": 565,
@@ -2752,41 +1940,12 @@
                   "end": 577,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 569,
-            "end": 577,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 569,
-                "end": 577,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 569,
-                    "end": 577,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 569,
                       "end": 577,
@@ -2849,41 +2008,12 @@
                   "end": 589,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 581,
-            "end": 589,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 581,
-                "end": 589,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 581,
-                    "end": 589,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 581,
                       "end": 589,
@@ -2946,41 +2076,12 @@
                   "end": 601,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 593,
-            "end": 601,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 593,
-                "end": 601,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 593,
-                    "end": 601,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 593,
                       "end": 601,
@@ -3043,41 +2144,12 @@
                   "end": 613,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 605,
-            "end": 613,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 605,
-                "end": 613,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 605,
-                    "end": 613,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 605,
                       "end": 613,
@@ -3140,41 +2212,12 @@
                   "end": 625,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 617,
-            "end": 625,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 617,
-                "end": 625,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 617,
-                    "end": 625,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 617,
                       "end": 625,
@@ -3237,41 +2280,12 @@
                   "end": 637,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 629,
-            "end": 637,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 629,
-                "end": 637,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 629,
-                    "end": 637,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 629,
                       "end": 637,
@@ -3334,41 +2348,12 @@
                   "end": 649,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 641,
-            "end": 649,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 641,
-                "end": 649,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 641,
-                    "end": 649,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 641,
                       "end": 649,
@@ -3431,41 +2416,12 @@
                   "end": 661,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 653,
-            "end": 661,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 653,
-                "end": 661,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 653,
-                    "end": 661,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 653,
                       "end": 661,
@@ -3528,41 +2484,12 @@
                   "end": 675,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 665,
-            "end": 675,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 665,
-                "end": 675,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 665,
-                    "end": 675,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 665,
                       "end": 675,

--- a/css/parser/tests/fixture/selector/combinators/output.json
+++ b/css/parser/tests/fixture/selector/combinators/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 9,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 7,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
@@ -61,6 +81,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 8,
                   "end": 9,
@@ -128,6 +152,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 13,
+            "end": 24,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 13,
+                "end": 20,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 13,
                   "end": 20,
@@ -158,6 +202,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 23,
                   "end": 24,
@@ -225,6 +273,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 30,
+            "end": 41,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 30,
+                "end": 37,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 30,
                   "end": 37,
@@ -255,6 +323,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": ">",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 40,
                   "end": 41,
@@ -322,6 +394,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 45,
+            "end": 62,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 45,
+                "end": 52,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 45,
                   "end": 52,
@@ -352,6 +444,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": ">",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 61,
                   "end": 62,
@@ -419,6 +515,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 69,
+            "end": 76,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 69,
+                "end": 70,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 69,
                   "end": 70,
@@ -449,6 +565,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": "+",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 73,
                   "end": 76,
@@ -516,6 +636,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 80,
+            "end": 91,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 80,
+                "end": 81,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 80,
                   "end": 81,
@@ -546,6 +686,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": "+",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 88,
                   "end": 91,
@@ -613,6 +757,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 95,
+            "end": 102,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 95,
+                "end": 96,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 95,
                   "end": 96,
@@ -643,6 +807,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": "~",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 99,
                   "end": 102,
@@ -710,6 +878,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 106,
+            "end": 119,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 106,
+                "end": 107,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 106,
                   "end": 107,
@@ -740,6 +928,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": "~",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 116,
                   "end": 119,
@@ -807,6 +999,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 123,
+            "end": 138,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 123,
+                "end": 130,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 123,
                   "end": 130,
@@ -837,6 +1049,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": ">",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 133,
                   "end": 134,
@@ -867,6 +1083,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": ">",
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 137,
                   "end": 138,

--- a/css/parser/tests/fixture/selector/combinators/output.json
+++ b/css/parser/tests/fixture/selector/combinators/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 9,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 7,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 7,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -81,16 +61,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 8,
                   "end": 9,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -152,32 +128,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 13,
-            "end": 24,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 13,
-                "end": 20,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 13,
                   "end": 20,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -202,16 +158,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 23,
                   "end": 24,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -273,32 +225,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 30,
-            "end": 41,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 30,
-                "end": 37,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 30,
                   "end": 37,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -323,16 +255,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": ">",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 40,
                   "end": 41,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": ">",
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -394,32 +322,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 45,
-            "end": 62,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 45,
-                "end": 52,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 45,
                   "end": 52,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -444,16 +352,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": ">",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 61,
                   "end": 62,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": ">",
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -515,32 +419,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 69,
-            "end": 76,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 69,
-                "end": 70,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 69,
                   "end": 70,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -565,16 +449,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": "+",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 73,
                   "end": 76,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": "+",
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -636,32 +516,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 80,
-            "end": 91,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 80,
-                "end": 81,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 80,
                   "end": 81,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -686,16 +546,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": "+",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 88,
                   "end": 91,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": "+",
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -757,32 +613,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 95,
-            "end": 102,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 95,
-                "end": 96,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 95,
                   "end": 96,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -807,16 +643,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": "~",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 99,
                   "end": 102,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": "~",
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -878,32 +710,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 106,
-            "end": 119,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 106,
-                "end": 107,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 106,
                   "end": 107,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -928,16 +740,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": "~",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 116,
                   "end": 119,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": "~",
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -999,32 +807,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 123,
-            "end": 138,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 123,
-                "end": 130,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 123,
                   "end": 130,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1049,16 +837,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": ">",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 133,
                   "end": 134,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": ">",
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1083,16 +867,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": ">",
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 137,
                   "end": 138,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": ">",
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/selector/comments/output.json
+++ b/css/parser/tests/fixture/selector/comments/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 9,
+            "end": 12,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 9,
+                "end": 10,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 9,
                   "end": 10,
@@ -61,6 +81,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 11,
                   "end": 12,
@@ -128,6 +152,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 26,
+            "end": 29,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 26,
+                "end": 27,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 26,
                   "end": 27,
@@ -158,6 +202,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 28,
                   "end": 29,
@@ -225,6 +273,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 43,
+            "end": 46,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 43,
+                "end": 44,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 43,
                   "end": 44,
@@ -255,6 +323,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 45,
                   "end": 46,
@@ -322,6 +394,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 61,
+            "end": 64,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 61,
+                "end": 62,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 61,
                   "end": 62,
@@ -352,6 +444,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 63,
                   "end": 64,
@@ -419,6 +515,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 68,
+            "end": 79,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 68,
+                "end": 69,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 68,
                   "end": 69,
@@ -449,6 +565,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 78,
                   "end": 79,
@@ -516,6 +636,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 83,
+            "end": 95,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 83,
+                "end": 84,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 83,
                   "end": 84,
@@ -546,6 +686,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 94,
                   "end": 95,
@@ -613,6 +757,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 99,
+            "end": 112,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 99,
+                "end": 100,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 99,
                   "end": 100,
@@ -643,6 +807,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 111,
                   "end": 112,
@@ -710,6 +878,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 116,
+            "end": 130,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 116,
+                "end": 117,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 116,
                   "end": 117,
@@ -740,6 +928,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 129,
                   "end": 130,
@@ -807,6 +999,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 134,
+            "end": 137,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 134,
+                "end": 135,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 134,
                   "end": 135,
@@ -837,6 +1049,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 136,
                   "end": 137,
@@ -904,6 +1120,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 150,
+            "end": 153,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 150,
+                "end": 151,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 150,
                   "end": 151,
@@ -934,6 +1170,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 152,
                   "end": 153,
@@ -1001,6 +1241,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 167,
+            "end": 170,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 167,
+                "end": 168,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 167,
                   "end": 168,
@@ -1031,6 +1291,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 169,
                   "end": 170,
@@ -1098,6 +1362,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 184,
+            "end": 187,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 184,
+                "end": 185,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 184,
                   "end": 185,
@@ -1128,6 +1412,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 186,
                   "end": 187,
@@ -1195,6 +1483,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 202,
+            "end": 205,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 202,
+                "end": 203,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 202,
                   "end": 203,
@@ -1225,6 +1533,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 204,
                   "end": 205,
@@ -1292,6 +1604,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 217,
+            "end": 220,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 217,
+                "end": 218,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 217,
                   "end": 218,
@@ -1322,6 +1654,10 @@
               },
               {
                 "type": "CompoundSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 219,
                   "end": 220,
@@ -1389,6 +1725,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 233,
+            "end": 234,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 233,
+                "end": 234,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 233,
                   "end": 234,
@@ -1429,6 +1785,18 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 255,
+                "end": 256,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 255,
                   "end": 256,
@@ -1496,6 +1864,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 259,
+            "end": 260,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 259,
+                "end": 260,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 259,
                   "end": 260,
@@ -1536,6 +1924,18 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 285,
+                "end": 286,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 285,
                   "end": 286,

--- a/css/parser/tests/fixture/selector/comments/output.json
+++ b/css/parser/tests/fixture/selector/comments/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 9,
-            "end": 12,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 9,
-                "end": 10,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 9,
                   "end": 10,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -81,16 +61,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 11,
                   "end": 12,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -152,32 +128,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 26,
-            "end": 29,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 26,
-                "end": 27,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 26,
                   "end": 27,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -202,16 +158,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 28,
                   "end": 29,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -273,32 +225,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 43,
-            "end": 46,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 43,
-                "end": 44,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 43,
                   "end": 44,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -323,16 +255,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 45,
                   "end": 46,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -394,32 +322,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 61,
-            "end": 64,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 61,
-                "end": 62,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 61,
                   "end": 62,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -444,16 +352,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 63,
                   "end": 64,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -515,32 +419,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 68,
-            "end": 79,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 68,
-                "end": 69,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 68,
                   "end": 69,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -565,16 +449,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 78,
                   "end": 79,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -636,32 +516,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 83,
-            "end": 95,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 83,
-                "end": 84,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 83,
                   "end": 84,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -686,16 +546,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 94,
                   "end": 95,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -757,32 +613,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 99,
-            "end": 112,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 99,
-                "end": 100,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 99,
                   "end": 100,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -807,16 +643,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 111,
                   "end": 112,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -878,32 +710,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 116,
-            "end": 130,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 116,
-                "end": 117,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 116,
                   "end": 117,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -928,16 +740,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 129,
                   "end": 130,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -999,32 +807,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 134,
-            "end": 137,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 134,
-                "end": 135,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 134,
                   "end": 135,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1049,16 +837,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 136,
                   "end": 137,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1120,32 +904,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 150,
-            "end": 153,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 150,
-                "end": 151,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 150,
                   "end": 151,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1170,16 +934,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 152,
                   "end": 153,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1241,32 +1001,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 167,
-            "end": 170,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 167,
-                "end": 168,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 167,
                   "end": 168,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1291,16 +1031,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 169,
                   "end": 170,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1362,32 +1098,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 184,
-            "end": 187,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 184,
-                "end": 185,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 184,
                   "end": 185,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1412,16 +1128,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 186,
                   "end": 187,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1483,32 +1195,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 202,
-            "end": 205,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 202,
-                "end": 203,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 202,
                   "end": 203,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1533,16 +1225,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 204,
                   "end": 205,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1604,32 +1292,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 217,
-            "end": 220,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 217,
-                "end": 218,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 217,
                   "end": 218,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1654,16 +1322,12 @@
               },
               {
                 "type": "CompoundSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 219,
                   "end": 220,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1725,32 +1389,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 233,
-            "end": 234,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 233,
-                "end": 234,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 233,
                   "end": 234,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1785,24 +1429,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 255,
-                "end": 256,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 255,
                   "end": 256,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1864,32 +1496,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 259,
-            "end": 260,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 259,
-                "end": 260,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 259,
                   "end": 260,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -1924,24 +1536,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 285,
-                "end": 286,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 285,
                   "end": 286,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/selector/id/output.json
+++ b/css/parser/tests/fixture/selector/id/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 3,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 3,
@@ -110,6 +139,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 7,
+            "end": 11,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 7,
+                "end": 11,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 7,
+                    "end": 11,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 7,
                       "end": 11,
@@ -178,6 +236,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 15,
+            "end": 18,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 15,
+                "end": 18,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 15,
+                    "end": 18,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 15,
                       "end": 18,
@@ -246,6 +333,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 22,
+            "end": 35,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 22,
+                "end": 35,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 22,
+                    "end": 35,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 22,
                       "end": 35,
@@ -314,6 +430,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 39,
+            "end": 46,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 39,
+                "end": 46,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 39,
+                    "end": 46,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 39,
                       "end": 46,
@@ -382,6 +527,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 50,
+            "end": 57,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 50,
+                "end": 57,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 50,
+                    "end": 57,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 50,
                       "end": 57,
@@ -450,6 +624,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 61,
+            "end": 78,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 61,
+                "end": 78,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 61,
+                    "end": 78,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 61,
                       "end": 78,
@@ -518,6 +721,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 82,
+            "end": 87,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 82,
+                "end": 87,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 82,
+                    "end": 87,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 82,
                       "end": 87,
@@ -586,6 +818,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 91,
+            "end": 94,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 91,
+                "end": 94,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 91,
+                    "end": 94,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 91,
                       "end": 94,
@@ -654,6 +915,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 98,
+            "end": 101,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 98,
+                "end": 101,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 98,
+                    "end": 101,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 98,
                       "end": 101,
@@ -722,6 +1012,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 105,
+            "end": 108,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 105,
+                "end": 108,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 105,
+                    "end": 108,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 105,
                       "end": 108,
@@ -790,6 +1109,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 112,
+            "end": 116,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 112,
+                "end": 116,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 112,
+                    "end": 116,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 112,
                       "end": 116,
@@ -858,6 +1206,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 123,
+            "end": 127,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 123,
+                "end": 127,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 123,
+                    "end": 127,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 123,
                       "end": 127,
@@ -926,6 +1303,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 136,
+            "end": 143,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 136,
+                "end": 143,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 136,
+                    "end": 143,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 136,
                       "end": 143,
@@ -994,6 +1400,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 147,
+            "end": 157,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 147,
+                "end": 157,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 147,
+                    "end": 157,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 147,
                       "end": 157,
@@ -1062,6 +1497,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 161,
+            "end": 167,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 161,
+                "end": 167,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 161,
+                    "end": 167,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 161,
                       "end": 167,
@@ -1130,6 +1594,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 171,
+            "end": 190,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 171,
+                "end": 190,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 171,
+                    "end": 190,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 171,
                       "end": 190,
@@ -1198,6 +1691,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 194,
+            "end": 417,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 194,
+                "end": 417,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 194,
+                    "end": 417,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 194,
                       "end": 417,
@@ -1266,6 +1788,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 421,
+            "end": 424,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 421,
+                "end": 424,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 421,
+                    "end": 424,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 421,
                       "end": 424,
@@ -1334,6 +1885,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 428,
+            "end": 433,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 428,
+                "end": 433,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 428,
+                    "end": 433,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 428,
                       "end": 433,
@@ -1402,6 +1982,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 437,
+            "end": 448,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 437,
+                "end": 448,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 437,
+                    "end": 448,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 437,
                       "end": 448,
@@ -1470,6 +2079,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 452,
+            "end": 455,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 452,
+                "end": 455,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 452,
+                    "end": 455,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 452,
                       "end": 455,
@@ -1538,6 +2176,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 459,
+            "end": 464,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 459,
+                "end": 464,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 459,
+                    "end": 464,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 459,
                       "end": 464,
@@ -1606,6 +2273,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 468,
+            "end": 482,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 468,
+                "end": 482,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 468,
+                    "end": 482,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 468,
                       "end": 482,
@@ -1674,6 +2370,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 486,
+            "end": 495,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 486,
+                "end": 495,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 486,
+                    "end": 495,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 486,
                       "end": 495,
@@ -1742,6 +2467,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 499,
+            "end": 509,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 499,
+                "end": 509,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 499,
+                    "end": 509,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 499,
                       "end": 509,
@@ -1810,6 +2564,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 513,
+            "end": 542,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 513,
+                "end": 542,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 513,
+                    "end": 542,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 513,
                       "end": 542,
@@ -1878,6 +2661,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 546,
+            "end": 562,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 546,
+                "end": 562,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 546,
+                    "end": 562,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 546,
                       "end": 562,
@@ -1946,6 +2758,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 566,
+            "end": 574,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 566,
+                "end": 574,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 566,
+                    "end": 574,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 566,
                       "end": 574,
@@ -2014,6 +2855,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 578,
+            "end": 586,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 578,
+                "end": 586,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 578,
+                    "end": 586,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 578,
                       "end": 586,
@@ -2082,6 +2952,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 590,
+            "end": 598,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 590,
+                "end": 598,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 590,
+                    "end": 598,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 590,
                       "end": 598,
@@ -2150,6 +3049,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 602,
+            "end": 610,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 602,
+                "end": 610,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 602,
+                    "end": 610,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 602,
                       "end": 610,
@@ -2218,6 +3146,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 614,
+            "end": 622,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 614,
+                "end": 622,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 614,
+                    "end": 622,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 614,
                       "end": 622,
@@ -2286,6 +3243,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 626,
+            "end": 634,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 626,
+                "end": 634,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 626,
+                    "end": 634,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 626,
                       "end": 634,
@@ -2354,6 +3340,35 @@
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 638,
+            "end": 646,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 638,
+                "end": 646,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "IdSelector",
+                  "span": {
+                    "start": 638,
+                    "end": 646,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 638,
                       "end": 646,

--- a/css/parser/tests/fixture/selector/id/output.json
+++ b/css/parser/tests/fixture/selector/id/output.json
@@ -36,41 +36,12 @@
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 3,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 3,
@@ -133,41 +104,12 @@
                   "end": 11,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 7,
-            "end": 11,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 7,
-                "end": 11,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 7,
-                    "end": 11,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 7,
                       "end": 11,
@@ -230,41 +172,12 @@
                   "end": 18,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 15,
-            "end": 18,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 15,
-                "end": 18,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 15,
-                    "end": 18,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 15,
                       "end": 18,
@@ -327,41 +240,12 @@
                   "end": 35,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 22,
-            "end": 35,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 22,
-                "end": 35,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 22,
-                    "end": 35,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 22,
                       "end": 35,
@@ -424,41 +308,12 @@
                   "end": 46,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 39,
-            "end": 46,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 39,
-                "end": 46,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 39,
-                    "end": 46,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 39,
                       "end": 46,
@@ -521,41 +376,12 @@
                   "end": 57,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 50,
-            "end": 57,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 50,
-                "end": 57,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 50,
-                    "end": 57,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 50,
                       "end": 57,
@@ -618,41 +444,12 @@
                   "end": 78,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 61,
-            "end": 78,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 61,
-                "end": 78,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 61,
-                    "end": 78,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 61,
                       "end": 78,
@@ -715,41 +512,12 @@
                   "end": 87,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 82,
-            "end": 87,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 82,
-                "end": 87,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 82,
-                    "end": 87,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 82,
                       "end": 87,
@@ -812,41 +580,12 @@
                   "end": 94,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 91,
-            "end": 94,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 91,
-                "end": 94,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 91,
-                    "end": 94,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 91,
                       "end": 94,
@@ -909,41 +648,12 @@
                   "end": 101,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 98,
-            "end": 101,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 98,
-                "end": 101,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 98,
-                    "end": 101,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 98,
                       "end": 101,
@@ -1006,41 +716,12 @@
                   "end": 108,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 105,
-            "end": 108,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 105,
-                "end": 108,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 105,
-                    "end": 108,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 105,
                       "end": 108,
@@ -1103,41 +784,12 @@
                   "end": 116,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 112,
-            "end": 116,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 112,
-                "end": 116,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 112,
-                    "end": 116,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 112,
                       "end": 116,
@@ -1200,41 +852,12 @@
                   "end": 127,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 123,
-            "end": 127,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 123,
-                "end": 127,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 123,
-                    "end": 127,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 123,
                       "end": 127,
@@ -1297,41 +920,12 @@
                   "end": 143,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 136,
-            "end": 143,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 136,
-                "end": 143,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 136,
-                    "end": 143,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 136,
                       "end": 143,
@@ -1394,41 +988,12 @@
                   "end": 157,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 147,
-            "end": 157,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 147,
-                "end": 157,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 147,
-                    "end": 157,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 147,
                       "end": 157,
@@ -1491,41 +1056,12 @@
                   "end": 167,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 161,
-            "end": 167,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 161,
-                "end": 167,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 161,
-                    "end": 167,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 161,
                       "end": 167,
@@ -1588,41 +1124,12 @@
                   "end": 190,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 171,
-            "end": 190,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 171,
-                "end": 190,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 171,
-                    "end": 190,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 171,
                       "end": 190,
@@ -1685,41 +1192,12 @@
                   "end": 417,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 194,
-            "end": 417,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 194,
-                "end": 417,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 194,
-                    "end": 417,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 194,
                       "end": 417,
@@ -1782,41 +1260,12 @@
                   "end": 424,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 421,
-            "end": 424,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 421,
-                "end": 424,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 421,
-                    "end": 424,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 421,
                       "end": 424,
@@ -1879,41 +1328,12 @@
                   "end": 433,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 428,
-            "end": 433,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 428,
-                "end": 433,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 428,
-                    "end": 433,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 428,
                       "end": 433,
@@ -1976,41 +1396,12 @@
                   "end": 448,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 437,
-            "end": 448,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 437,
-                "end": 448,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 437,
-                    "end": 448,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 437,
                       "end": 448,
@@ -2073,41 +1464,12 @@
                   "end": 455,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 452,
-            "end": 455,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 452,
-                "end": 455,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 452,
-                    "end": 455,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 452,
                       "end": 455,
@@ -2170,41 +1532,12 @@
                   "end": 464,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 459,
-            "end": 464,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 459,
-                "end": 464,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 459,
-                    "end": 464,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 459,
                       "end": 464,
@@ -2267,41 +1600,12 @@
                   "end": 482,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 468,
-            "end": 482,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 468,
-                "end": 482,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 468,
-                    "end": 482,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 468,
                       "end": 482,
@@ -2364,41 +1668,12 @@
                   "end": 495,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 486,
-            "end": 495,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 486,
-                "end": 495,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 486,
-                    "end": 495,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 486,
                       "end": 495,
@@ -2461,41 +1736,12 @@
                   "end": 509,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 499,
-            "end": 509,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 499,
-                "end": 509,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 499,
-                    "end": 509,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 499,
                       "end": 509,
@@ -2558,41 +1804,12 @@
                   "end": 542,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 513,
-            "end": 542,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 513,
-                "end": 542,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 513,
-                    "end": 542,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 513,
                       "end": 542,
@@ -2655,41 +1872,12 @@
                   "end": 562,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 546,
-            "end": 562,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 546,
-                "end": 562,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 546,
-                    "end": 562,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 546,
                       "end": 562,
@@ -2752,41 +1940,12 @@
                   "end": 574,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 566,
-            "end": 574,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 566,
-                "end": 574,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 566,
-                    "end": 574,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 566,
                       "end": 574,
@@ -2849,41 +2008,12 @@
                   "end": 586,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 578,
-            "end": 586,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 578,
-                "end": 586,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 578,
-                    "end": 586,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 578,
                       "end": 586,
@@ -2946,41 +2076,12 @@
                   "end": 598,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 590,
-            "end": 598,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 590,
-                "end": 598,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 590,
-                    "end": 598,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 590,
                       "end": 598,
@@ -3043,41 +2144,12 @@
                   "end": 610,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 602,
-            "end": 610,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 602,
-                "end": 610,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 602,
-                    "end": 610,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 602,
                       "end": 610,
@@ -3140,41 +2212,12 @@
                   "end": 622,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 614,
-            "end": 622,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 614,
-                "end": 622,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 614,
-                    "end": 622,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 614,
                       "end": 622,
@@ -3237,41 +2280,12 @@
                   "end": 634,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 626,
-            "end": 634,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 626,
-                "end": 634,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 626,
-                    "end": 634,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 626,
                       "end": 634,
@@ -3334,41 +2348,12 @@
                   "end": 646,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "IdSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 638,
-            "end": 646,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 638,
-                "end": 646,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "IdSelector",
-                  "span": {
-                    "start": 638,
-                    "end": 646,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 638,
                       "end": 646,

--- a/css/parser/tests/fixture/selector/nesting/input.css
+++ b/css/parser/tests/fixture/selector/nesting/input.css
@@ -1,0 +1,1 @@
+& > .bar { color: red; }

--- a/css/parser/tests/fixture/selector/nesting/output.json
+++ b/css/parser/tests/fixture/selector/nesting/output.json
@@ -13,68 +13,76 @@
         "end": 24,
         "ctxt": 0
       },
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 8,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": {
-                "type": "NestingSelector",
+      "selectors": {
+        "type": "SelectorList",
+        "span": {
+          "start": 0,
+          "end": 8,
+          "ctxt": 0
+        },
+        "children": [
+          {
+            "type": "ComplexSelector",
+            "span": {
+              "start": 0,
+              "end": 8,
+              "ctxt": 0
+            },
+            "selectors": [
+              {
+                "type": "CompoundSelector",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
-                }
-              },
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": []
-            },
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 4,
-                "end": 8,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": ">",
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
+                },
+                "nestingSelector": {
+                  "type": "NestingSelector",
                   "span": {
-                    "start": 4,
-                    "end": 8,
+                    "start": 0,
+                    "end": 1,
                     "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
+                  }
+                },
+                "combinator": null,
+                "typeSelector": null,
+                "subclassSelectors": []
+              },
+              {
+                "type": "CompoundSelector",
+                "span": {
+                  "start": 4,
+                  "end": 8,
+                  "ctxt": 0
+                },
+                "nestingSelector": null,
+                "combinator": ">",
+                "typeSelector": null,
+                "subclassSelectors": [
+                  {
+                    "type": "ClassSelector",
                     "span": {
-                      "start": 5,
+                      "start": 4,
                       "end": 8,
                       "ctxt": 0
                     },
-                    "value": "bar",
-                    "raw": "bar"
+                    "text": {
+                      "type": "Text",
+                      "span": {
+                        "start": 5,
+                        "end": 8,
+                        "ctxt": 0
+                      },
+                      "value": "bar",
+                      "raw": "bar"
+                    }
                   }
-                }
-              ]
-            }
-          ]
-        }
-      ],
+                ]
+              }
+            ]
+          }
+        ]
+      },
       "block": {
         "type": "Block",
         "span": {

--- a/css/parser/tests/fixture/selector/nesting/output.json
+++ b/css/parser/tests/fixture/selector/nesting/output.json
@@ -1,0 +1,121 @@
+{
+  "type": "Stylesheet",
+  "span": {
+    "start": 0,
+    "end": 24,
+    "ctxt": 0
+  },
+  "rules": [
+    {
+      "type": "StyleRule",
+      "span": {
+        "start": 0,
+        "end": 24,
+        "ctxt": 0
+      },
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": {
+                "type": "NestingSelector",
+                "span": {
+                  "start": 0,
+                  "end": 1,
+                  "ctxt": 0
+                }
+              },
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": []
+            },
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 4,
+                "end": 8,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": ">",
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 4,
+                    "end": 8,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
+                    "span": {
+                      "start": 5,
+                      "end": 8,
+                      "ctxt": 0
+                    },
+                    "value": "bar",
+                    "raw": "bar"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "block": {
+        "type": "Block",
+        "span": {
+          "start": 9,
+          "end": 24,
+          "ctxt": 0
+        },
+        "items": [
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 11,
+              "end": 21,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Text",
+              "span": {
+                "start": 11,
+                "end": 16,
+                "ctxt": 0
+              },
+              "value": "color",
+              "raw": "color"
+            },
+            "value": [
+              {
+                "type": "Text",
+                "span": {
+                  "start": 18,
+                  "end": 21,
+                  "ctxt": 0
+                },
+                "value": "red",
+                "raw": "red"
+              }
+            ],
+            "important": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/css/parser/tests/fixture/selector/nesting/span.rust-debug
+++ b/css/parser/tests/fixture/selector/nesting/span.rust-debug
@@ -1,0 +1,90 @@
+error: Stylesheet
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:1
+  |
+1 | & > .bar { color: red; }
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Rule
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:1
+  |
+1 | & > .bar { color: red; }
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: StyleRule
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:1
+  |
+1 | & > .bar { color: red; }
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: ComplexSelector
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:1
+  |
+1 | & > .bar { color: red; }
+  | ^^^^^^^^
+
+error: CompoundSelector
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:1
+  |
+1 | & > .bar { color: red; }
+  | ^
+
+error: NestingSelector
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:1
+  |
+1 | & > .bar { color: red; }
+  | ^
+
+error: CompoundSelector
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:5
+  |
+1 | & > .bar { color: red; }
+  |     ^^^^
+
+error: SubclassSelector
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:5
+  |
+1 | & > .bar { color: red; }
+  |     ^^^^
+
+error: ClassSelector
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:5
+  |
+1 | & > .bar { color: red; }
+  |     ^^^^
+
+error: Text
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:6
+  |
+1 | & > .bar { color: red; }
+  |      ^^^
+
+error: Block
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:10
+  |
+1 | & > .bar { color: red; }
+  |          ^^^^^^^^^^^^^^^
+
+error: Declaration
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:12
+  |
+1 | & > .bar { color: red; }
+  |            ^^^^^^^^^^
+
+error: Text
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:12
+  |
+1 | & > .bar { color: red; }
+  |            ^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:19
+  |
+1 | & > .bar { color: red; }
+  |                   ^^^
+
+error: Text
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:19
+  |
+1 | & > .bar { color: red; }
+  |                   ^^^
+

--- a/css/parser/tests/fixture/selector/nesting/span.rust-debug
+++ b/css/parser/tests/fixture/selector/nesting/span.rust-debug
@@ -16,6 +16,12 @@ error: StyleRule
 1 | & > .bar { color: red; }
   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: SelectorList
+ --> $DIR/tests/fixture/selector/nesting/input.css:1:1
+  |
+1 | & > .bar { color: red; }
+  | ^^^^^^^^
+
 error: ComplexSelector
  --> $DIR/tests/fixture/selector/nesting/input.css:1:1
   |

--- a/css/parser/tests/fixture/selector/type/output.json
+++ b/css/parser/tests/fixture/selector/type/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
@@ -107,6 +127,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 7,
+            "end": 13,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 7,
+                "end": 13,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 7,
                   "end": 13,
@@ -183,6 +223,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 17,
+            "end": 22,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 17,
+                "end": 22,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 17,
                   "end": 22,
@@ -259,6 +319,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 26,
+            "end": 29,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 26,
+                "end": 29,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 26,
                   "end": 29,
@@ -335,6 +415,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 33,
+            "end": 37,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 33,
+                "end": 37,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 33,
                   "end": 37,
@@ -411,6 +511,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 41,
+            "end": 43,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 41,
+                "end": 43,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 41,
                   "end": 43,

--- a/css/parser/tests/fixture/selector/type/output.json
+++ b/css/parser/tests/fixture/selector/type/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -127,32 +107,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 7,
-            "end": 13,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 7,
-                "end": 13,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 7,
                   "end": 13,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -223,32 +183,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 17,
-            "end": 22,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 17,
-                "end": 22,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 17,
                   "end": 22,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -319,32 +259,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 26,
-            "end": 29,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 26,
-                "end": 29,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 26,
                   "end": 29,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -415,32 +335,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 33,
-            "end": 37,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 33,
-                "end": 37,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 33,
                   "end": 37,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -511,32 +411,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 41,
-            "end": 43,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 41,
-                "end": 43,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 41,
                   "end": 43,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/selector/universal/output.json
+++ b/css/parser/tests/fixture/selector/universal/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/selector/universal/output.json
+++ b/css/parser/tests/fixture/selector/universal/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/styled-jsx/selector/1/output.json
+++ b/css/parser/tests/fixture/styled-jsx/selector/1/output.json
@@ -36,42 +36,12 @@
                   "end": 17,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 17,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 17,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 17,
-                    "ctxt": 0
-                  },
-                  "isElement": false,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 17,

--- a/css/parser/tests/fixture/styled-jsx/selector/1/output.json
+++ b/css/parser/tests/fixture/styled-jsx/selector/1/output.json
@@ -42,6 +42,36 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 17,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 17,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 17,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 17,

--- a/css/parser/tests/fixture/styled-jsx/selector/2/output.json
+++ b/css/parser/tests/fixture/styled-jsx/selector/2/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 26,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
@@ -46,6 +66,31 @@
                     "ctxt": 0
                   },
                   "prefix": null,
+                  "value": "p",
+                  "raw": "p"
+                }
+              },
+              "subclassSelectors": []
+            },
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 2,
+                "end": 26,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 2,
+                    "end": 26,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
                   "name": {
                     "type": "Text",
                     "span": {

--- a/css/parser/tests/fixture/styled-jsx/selector/2/output.json
+++ b/css/parser/tests/fixture/styled-jsx/selector/2/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 26,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -66,31 +46,6 @@
                     "ctxt": 0
                   },
                   "prefix": null,
-                  "value": "p",
-                  "raw": "p"
-                }
-              },
-              "subclassSelectors": []
-            },
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 2,
-                "end": 26,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 2,
-                    "end": 26,
-                    "ctxt": 0
-                  },
-                  "isElement": false,
                   "name": {
                     "type": "Text",
                     "span": {
@@ -111,7 +66,7 @@
                   "end": 26,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [

--- a/css/parser/tests/fixture/stylis/comma/01/output.json
+++ b/css/parser/tests/fixture/stylis/comma/01/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/stylis/comma/01/output.json
+++ b/css/parser/tests/fixture/stylis/comma/01/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/fixture/value/custom-property/output.json
+++ b/css/parser/tests/fixture/value/custom-property/output.json
@@ -42,6 +42,36 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 5,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/value/custom-property/output.json
+++ b/css/parser/tests/fixture/value/custom-property/output.json
@@ -36,42 +36,12 @@
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 5,
-                    "ctxt": 0
-                  },
-                  "isElement": false,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 5,

--- a/css/parser/tests/fixture/value/escaped/output.json
+++ b/css/parser/tests/fixture/value/escaped/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 5,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 5,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 5,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/value/escaped/output.json
+++ b/css/parser/tests/fixture/value/escaped/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 5,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 5,

--- a/css/parser/tests/fixture/value/quotes/output.json
+++ b/css/parser/tests/fixture/value/quotes/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 9,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 9,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 9,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -737,32 +717,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 880,
-            "end": 917,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 880,
-                "end": 917,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 880,
                   "end": 917,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",
@@ -888,32 +848,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 938,
-            "end": 973,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 938,
-                "end": 973,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 938,
                   "end": 973,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/value/quotes/output.json
+++ b/css/parser/tests/fixture/value/quotes/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 9,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 9,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 9,
@@ -717,6 +737,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 880,
+            "end": 917,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 880,
+                "end": 917,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 880,
                   "end": 917,
@@ -848,6 +888,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 938,
+            "end": 973,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 938,
+                "end": 973,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 938,
                   "end": 973,

--- a/css/parser/tests/fixture/value/square-brackets/output.json
+++ b/css/parser/tests/fixture/value/square-brackets/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/fixture/value/square-brackets/output.json
+++ b/css/parser/tests/fixture/value/square-brackets/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/line-comment/css-in-js/1/output.json
+++ b/css/parser/tests/line-comment/css-in-js/1/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 16,
+            "end": 19,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 16,
+                "end": 19,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 16,
                   "end": 19,

--- a/css/parser/tests/line-comment/css-in-js/1/output.json
+++ b/css/parser/tests/line-comment/css-in-js/1/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 16,
-            "end": 19,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 16,
-                "end": 19,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 16,
                   "end": 19,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/line-comment/css-in-js/2/output.json
+++ b/css/parser/tests/line-comment/css-in-js/2/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/line-comment/css-in-js/2/output.json
+++ b/css/parser/tests/line-comment/css-in-js/2/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/line-comment/css-in-js/3/output.json
+++ b/css/parser/tests/line-comment/css-in-js/3/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/line-comment/css-in-js/3/output.json
+++ b/css/parser/tests/line-comment/css-in-js/3/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/line-comment/css-in-js/4/output.json
+++ b/css/parser/tests/line-comment/css-in-js/4/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/line-comment/css-in-js/4/output.json
+++ b/css/parser/tests/line-comment/css-in-js/4/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/recovery/bad-url-token/double-quotes/output.json
+++ b/css/parser/tests/recovery/bad-url-token/double-quotes/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/bad-url-token/double-quotes/output.json
+++ b/css/parser/tests/recovery/bad-url-token/double-quotes/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/recovery/bad-url-token/left-parenthesis/output.json
+++ b/css/parser/tests/recovery/bad-url-token/left-parenthesis/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/bad-url-token/left-parenthesis/output.json
+++ b/css/parser/tests/recovery/bad-url-token/left-parenthesis/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/recovery/bad-url-token/single-quotes/output.json
+++ b/css/parser/tests/recovery/bad-url-token/single-quotes/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/bad-url-token/single-quotes/output.json
+++ b/css/parser/tests/recovery/bad-url-token/single-quotes/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/recovery/bad-url-token/whitespace/output.json
+++ b/css/parser/tests/recovery/bad-url-token/whitespace/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 3,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 3,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/bad-url-token/whitespace/output.json
+++ b/css/parser/tests/recovery/bad-url-token/whitespace/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 3,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 3,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 3,

--- a/css/parser/tests/recovery/delim-token/ampersand/output.json
+++ b/css/parser/tests/recovery/delim-token/ampersand/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/ampersand/output.json
+++ b/css/parser/tests/recovery/delim-token/ampersand/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/asterisk/output.json
+++ b/css/parser/tests/recovery/delim-token/asterisk/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/asterisk/output.json
+++ b/css/parser/tests/recovery/delim-token/asterisk/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/at-sign/output.json
+++ b/css/parser/tests/recovery/delim-token/at-sign/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/at-sign/output.json
+++ b/css/parser/tests/recovery/delim-token/at-sign/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/bang/output.json
+++ b/css/parser/tests/recovery/delim-token/bang/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/bang/output.json
+++ b/css/parser/tests/recovery/delim-token/bang/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/bar/output.json
+++ b/css/parser/tests/recovery/delim-token/bar/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/bar/output.json
+++ b/css/parser/tests/recovery/delim-token/bar/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/caret/output.json
+++ b/css/parser/tests/recovery/delim-token/caret/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/caret/output.json
+++ b/css/parser/tests/recovery/delim-token/caret/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/div/output.json
+++ b/css/parser/tests/recovery/delim-token/div/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/div/output.json
+++ b/css/parser/tests/recovery/delim-token/div/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/dollar/output.json
+++ b/css/parser/tests/recovery/delim-token/dollar/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/dollar/output.json
+++ b/css/parser/tests/recovery/delim-token/dollar/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/equals/output.json
+++ b/css/parser/tests/recovery/delim-token/equals/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/equals/output.json
+++ b/css/parser/tests/recovery/delim-token/equals/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/greater-than/output.json
+++ b/css/parser/tests/recovery/delim-token/greater-than/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/greater-than/output.json
+++ b/css/parser/tests/recovery/delim-token/greater-than/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/hash/output.json
+++ b/css/parser/tests/recovery/delim-token/hash/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/hash/output.json
+++ b/css/parser/tests/recovery/delim-token/hash/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/less-than/output.json
+++ b/css/parser/tests/recovery/delim-token/less-than/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/less-than/output.json
+++ b/css/parser/tests/recovery/delim-token/less-than/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/minus/output.json
+++ b/css/parser/tests/recovery/delim-token/minus/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/minus/output.json
+++ b/css/parser/tests/recovery/delim-token/minus/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/percent/output.json
+++ b/css/parser/tests/recovery/delim-token/percent/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/percent/output.json
+++ b/css/parser/tests/recovery/delim-token/percent/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/plus/output.json
+++ b/css/parser/tests/recovery/delim-token/plus/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/plus/output.json
+++ b/css/parser/tests/recovery/delim-token/plus/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/question-mark/output.json
+++ b/css/parser/tests/recovery/delim-token/question-mark/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/question-mark/output.json
+++ b/css/parser/tests/recovery/delim-token/question-mark/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/star/output.json
+++ b/css/parser/tests/recovery/delim-token/star/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/star/output.json
+++ b/css/parser/tests/recovery/delim-token/star/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/delim-token/tilde/output.json
+++ b/css/parser/tests/recovery/delim-token/tilde/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/delim-token/tilde/output.json
+++ b/css/parser/tests/recovery/delim-token/tilde/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/function-token/output.json
+++ b/css/parser/tests/recovery/function-token/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/function-token/output.json
+++ b/css/parser/tests/recovery/function-token/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/parser/tests/recovery/styled-jsx/1/output.json
+++ b/css/parser/tests/recovery/styled-jsx/1/output.json
@@ -36,41 +36,12 @@
                   "end": 15,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 15,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 15,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 15,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 15,
@@ -227,41 +198,12 @@
                   "end": 126,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 111,
-            "end": 158,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 111,
-                "end": 126,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 111,
-                    "end": 126,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 111,
                       "end": 126,
@@ -287,26 +229,12 @@
                   "end": 158,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 127,
-                    "end": 158,
-                    "ctxt": 0
-                  },
-                  "isElement": false,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 127,
                       "end": 158,
@@ -609,41 +537,12 @@
                       "end": 323,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": null,
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
-          "selectors": [
-            {
-              "type": "ComplexSelector",
-              "span": {
-                "start": 308,
-                "end": 355,
-                "ctxt": 0
-              },
-              "selectors": [
-                {
-                  "type": "CompoundSelector",
-                  "span": {
-                    "start": 308,
-                    "end": 323,
-                    "ctxt": 0
-                  },
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": null,
-                  "subclassSelectors": [
-                    {
-                      "type": "ClassSelector",
-                      "span": {
-                        "start": 308,
-                        "end": 323,
-                        "ctxt": 0
-                      },
-                      "text": {
-                        "type": "Text",
                         "span": {
                           "start": 308,
                           "end": 323,
@@ -669,26 +568,12 @@
                       "end": 355,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": null,
                     "subclassSelectors": [
                       {
                         "type": "PseudoSelector",
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": null,
-                  "subclassSelectors": [
-                    {
-                      "type": "PseudoSelector",
-                      "span": {
-                        "start": 324,
-                        "end": 355,
-                        "ctxt": 0
-                      },
-                      "isElement": false,
-                      "name": {
-                        "type": "Text",
                         "span": {
                           "start": 324,
                           "end": 355,
@@ -900,41 +785,12 @@
                       "end": 452,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": null,
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
-          "selectors": [
-            {
-              "type": "ComplexSelector",
-              "span": {
-                "start": 437,
-                "end": 484,
-                "ctxt": 0
-              },
-              "selectors": [
-                {
-                  "type": "CompoundSelector",
-                  "span": {
-                    "start": 437,
-                    "end": 452,
-                    "ctxt": 0
-                  },
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": null,
-                  "subclassSelectors": [
-                    {
-                      "type": "ClassSelector",
-                      "span": {
-                        "start": 437,
-                        "end": 452,
-                        "ctxt": 0
-                      },
-                      "text": {
-                        "type": "Text",
                         "span": {
                           "start": 437,
                           "end": 452,
@@ -960,26 +816,12 @@
                       "end": 484,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": null,
                     "subclassSelectors": [
                       {
                         "type": "PseudoSelector",
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": null,
-                  "subclassSelectors": [
-                    {
-                      "type": "PseudoSelector",
-                      "span": {
-                        "start": 453,
-                        "end": 484,
-                        "ctxt": 0
-                      },
-                      "isElement": false,
-                      "name": {
-                        "type": "Text",
                         "span": {
                           "start": 453,
                           "end": 484,

--- a/css/parser/tests/recovery/styled-jsx/1/output.json
+++ b/css/parser/tests/recovery/styled-jsx/1/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 15,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 15,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 15,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 15,
@@ -204,6 +233,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 111,
+            "end": 158,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 111,
+                "end": 126,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 111,
+                    "end": 126,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 111,
                       "end": 126,
@@ -235,6 +293,20 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 127,
+                    "end": 158,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 127,
                       "end": 158,
@@ -543,6 +615,35 @@
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
+          "selectors": [
+            {
+              "type": "ComplexSelector",
+              "span": {
+                "start": 308,
+                "end": 355,
+                "ctxt": 0
+              },
+              "selectors": [
+                {
+                  "type": "CompoundSelector",
+                  "span": {
+                    "start": 308,
+                    "end": 323,
+                    "ctxt": 0
+                  },
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": null,
+                  "subclassSelectors": [
+                    {
+                      "type": "ClassSelector",
+                      "span": {
+                        "start": 308,
+                        "end": 323,
+                        "ctxt": 0
+                      },
+                      "text": {
+                        "type": "Text",
                         "span": {
                           "start": 308,
                           "end": 323,
@@ -574,6 +675,20 @@
                     "subclassSelectors": [
                       {
                         "type": "PseudoSelector",
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": null,
+                  "subclassSelectors": [
+                    {
+                      "type": "PseudoSelector",
+                      "span": {
+                        "start": 324,
+                        "end": 355,
+                        "ctxt": 0
+                      },
+                      "isElement": false,
+                      "name": {
+                        "type": "Text",
                         "span": {
                           "start": 324,
                           "end": 355,
@@ -791,6 +906,35 @@
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
+          "selectors": [
+            {
+              "type": "ComplexSelector",
+              "span": {
+                "start": 437,
+                "end": 484,
+                "ctxt": 0
+              },
+              "selectors": [
+                {
+                  "type": "CompoundSelector",
+                  "span": {
+                    "start": 437,
+                    "end": 452,
+                    "ctxt": 0
+                  },
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": null,
+                  "subclassSelectors": [
+                    {
+                      "type": "ClassSelector",
+                      "span": {
+                        "start": 437,
+                        "end": 452,
+                        "ctxt": 0
+                      },
+                      "text": {
+                        "type": "Text",
                         "span": {
                           "start": 437,
                           "end": 452,
@@ -822,6 +966,20 @@
                     "subclassSelectors": [
                       {
                         "type": "PseudoSelector",
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": null,
+                  "subclassSelectors": [
+                    {
+                      "type": "PseudoSelector",
+                      "span": {
+                        "start": 453,
+                        "end": 484,
+                        "ctxt": 0
+                      },
+                      "isElement": false,
+                      "name": {
+                        "type": "Text",
                         "span": {
                           "start": 453,
                           "end": 484,

--- a/css/parser/tests/recovery/styled-jsx/2/output.json
+++ b/css/parser/tests/recovery/styled-jsx/2/output.json
@@ -36,41 +36,12 @@
                   "end": 2,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 16,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 2,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "ClassSelector",
-                  "span": {
-                    "start": 0,
-                    "end": 2,
-                    "ctxt": 0
-                  },
-                  "text": {
-                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 2,
@@ -96,26 +67,12 @@
                   "end": 16,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": null,
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": null,
-              "subclassSelectors": [
-                {
-                  "type": "PseudoSelector",
-                  "span": {
-                    "start": 3,
-                    "end": 16,
-                    "ctxt": 0
-                  },
-                  "isElement": false,
-                  "name": {
-                    "type": "Text",
                     "span": {
                       "start": 3,
                       "end": 16,

--- a/css/parser/tests/recovery/styled-jsx/2/output.json
+++ b/css/parser/tests/recovery/styled-jsx/2/output.json
@@ -42,6 +42,35 @@
                 "subclassSelectors": [
                   {
                     "type": "ClassSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 16,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 2,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "ClassSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 2,
+                    "ctxt": 0
+                  },
+                  "text": {
+                    "type": "Text",
                     "span": {
                       "start": 0,
                       "end": 2,
@@ -73,6 +102,20 @@
                 "subclassSelectors": [
                   {
                     "type": "PseudoSelector",
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": null,
+              "subclassSelectors": [
+                {
+                  "type": "PseudoSelector",
+                  "span": {
+                    "start": 3,
+                    "end": 16,
+                    "ctxt": 0
+                  },
+                  "isElement": false,
+                  "name": {
+                    "type": "Text",
                     "span": {
                       "start": 3,
                       "end": 16,

--- a/css/parser/tests/recovery/value/quotes/output.json
+++ b/css/parser/tests/recovery/value/quotes/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 9,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 9,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 9,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/value/quotes/output.json
+++ b/css/parser/tests/recovery/value/quotes/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 9,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 9,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 9,

--- a/css/parser/tests/recovery/vercel/001/output.json
+++ b/css/parser/tests/recovery/vercel/001/output.json
@@ -98,6 +98,35 @@
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
+          "selectors": [
+            {
+              "type": "ComplexSelector",
+              "span": {
+                "start": 32,
+                "end": 52,
+                "ctxt": 0
+              },
+              "selectors": [
+                {
+                  "type": "CompoundSelector",
+                  "span": {
+                    "start": 32,
+                    "end": 52,
+                    "ctxt": 0
+                  },
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": null,
+                  "subclassSelectors": [
+                    {
+                      "type": "ClassSelector",
+                      "span": {
+                        "start": 32,
+                        "end": 38,
+                        "ctxt": 0
+                      },
+                      "text": {
+                        "type": "Text",
                         "span": {
                           "start": 32,
                           "end": 38,
@@ -242,6 +271,35 @@
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
+          "selectors": [
+            {
+              "type": "ComplexSelector",
+              "span": {
+                "start": 90,
+                "end": 107,
+                "ctxt": 0
+              },
+              "selectors": [
+                {
+                  "type": "CompoundSelector",
+                  "span": {
+                    "start": 90,
+                    "end": 107,
+                    "ctxt": 0
+                  },
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": null,
+                  "subclassSelectors": [
+                    {
+                      "type": "ClassSelector",
+                      "span": {
+                        "start": 90,
+                        "end": 96,
+                        "ctxt": 0
+                      },
+                      "text": {
+                        "type": "Text",
                         "span": {
                           "start": 90,
                           "end": 96,
@@ -370,6 +428,35 @@
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
+          "selectors": [
+            {
+              "type": "ComplexSelector",
+              "span": {
+                "start": 145,
+                "end": 163,
+                "ctxt": 0
+              },
+              "selectors": [
+                {
+                  "type": "CompoundSelector",
+                  "span": {
+                    "start": 145,
+                    "end": 163,
+                    "ctxt": 0
+                  },
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": null,
+                  "subclassSelectors": [
+                    {
+                      "type": "ClassSelector",
+                      "span": {
+                        "start": 145,
+                        "end": 151,
+                        "ctxt": 0
+                      },
+                      "text": {
+                        "type": "Text",
                         "span": {
                           "start": 145,
                           "end": 151,
@@ -439,6 +526,27 @@
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
+              "selectors": [
+                {
+                  "type": "CompoundSelector",
+                  "span": {
+                    "start": 169,
+                    "end": 188,
+                    "ctxt": 0
+                  },
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": null,
+                  "subclassSelectors": [
+                    {
+                      "type": "ClassSelector",
+                      "span": {
+                        "start": 169,
+                        "end": 175,
+                        "ctxt": 0
+                      },
+                      "text": {
+                        "type": "Text",
                         "span": {
                           "start": 169,
                           "end": 175,
@@ -522,6 +630,27 @@
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
+              "selectors": [
+                {
+                  "type": "CompoundSelector",
+                  "span": {
+                    "start": 194,
+                    "end": 213,
+                    "ctxt": 0
+                  },
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": null,
+                  "subclassSelectors": [
+                    {
+                      "type": "ClassSelector",
+                      "span": {
+                        "start": 194,
+                        "end": 200,
+                        "ctxt": 0
+                      },
+                      "text": {
+                        "type": "Text",
                         "span": {
                           "start": 194,
                           "end": 200,
@@ -605,6 +734,27 @@
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
+              "selectors": [
+                {
+                  "type": "CompoundSelector",
+                  "span": {
+                    "start": 219,
+                    "end": 239,
+                    "ctxt": 0
+                  },
+                  "nestingSelector": null,
+                  "combinator": null,
+                  "typeSelector": null,
+                  "subclassSelectors": [
+                    {
+                      "type": "ClassSelector",
+                      "span": {
+                        "start": 219,
+                        "end": 225,
+                        "ctxt": 0
+                      },
+                      "text": {
+                        "type": "Text",
                         "span": {
                           "start": 219,
                           "end": 225,

--- a/css/parser/tests/recovery/vercel/001/output.json
+++ b/css/parser/tests/recovery/vercel/001/output.json
@@ -92,41 +92,12 @@
                       "end": 52,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": null,
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
-          "selectors": [
-            {
-              "type": "ComplexSelector",
-              "span": {
-                "start": 32,
-                "end": 52,
-                "ctxt": 0
-              },
-              "selectors": [
-                {
-                  "type": "CompoundSelector",
-                  "span": {
-                    "start": 32,
-                    "end": 52,
-                    "ctxt": 0
-                  },
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": null,
-                  "subclassSelectors": [
-                    {
-                      "type": "ClassSelector",
-                      "span": {
-                        "start": 32,
-                        "end": 38,
-                        "ctxt": 0
-                      },
-                      "text": {
-                        "type": "Text",
                         "span": {
                           "start": 32,
                           "end": 38,
@@ -265,41 +236,12 @@
                       "end": 107,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": null,
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
-          "selectors": [
-            {
-              "type": "ComplexSelector",
-              "span": {
-                "start": 90,
-                "end": 107,
-                "ctxt": 0
-              },
-              "selectors": [
-                {
-                  "type": "CompoundSelector",
-                  "span": {
-                    "start": 90,
-                    "end": 107,
-                    "ctxt": 0
-                  },
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": null,
-                  "subclassSelectors": [
-                    {
-                      "type": "ClassSelector",
-                      "span": {
-                        "start": 90,
-                        "end": 96,
-                        "ctxt": 0
-                      },
-                      "text": {
-                        "type": "Text",
                         "span": {
                           "start": 90,
                           "end": 96,
@@ -422,41 +364,12 @@
                       "end": 163,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": null,
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
-          "selectors": [
-            {
-              "type": "ComplexSelector",
-              "span": {
-                "start": 145,
-                "end": 163,
-                "ctxt": 0
-              },
-              "selectors": [
-                {
-                  "type": "CompoundSelector",
-                  "span": {
-                    "start": 145,
-                    "end": 163,
-                    "ctxt": 0
-                  },
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": null,
-                  "subclassSelectors": [
-                    {
-                      "type": "ClassSelector",
-                      "span": {
-                        "start": 145,
-                        "end": 151,
-                        "ctxt": 0
-                      },
-                      "text": {
-                        "type": "Text",
                         "span": {
                           "start": 145,
                           "end": 151,
@@ -520,33 +433,12 @@
                       "end": 188,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": null,
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
-              "selectors": [
-                {
-                  "type": "CompoundSelector",
-                  "span": {
-                    "start": 169,
-                    "end": 188,
-                    "ctxt": 0
-                  },
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": null,
-                  "subclassSelectors": [
-                    {
-                      "type": "ClassSelector",
-                      "span": {
-                        "start": 169,
-                        "end": 175,
-                        "ctxt": 0
-                      },
-                      "text": {
-                        "type": "Text",
                         "span": {
                           "start": 169,
                           "end": 175,
@@ -624,33 +516,12 @@
                       "end": 213,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": null,
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
-              "selectors": [
-                {
-                  "type": "CompoundSelector",
-                  "span": {
-                    "start": 194,
-                    "end": 213,
-                    "ctxt": 0
-                  },
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": null,
-                  "subclassSelectors": [
-                    {
-                      "type": "ClassSelector",
-                      "span": {
-                        "start": 194,
-                        "end": 200,
-                        "ctxt": 0
-                      },
-                      "text": {
-                        "type": "Text",
                         "span": {
                           "start": 194,
                           "end": 200,
@@ -728,33 +599,12 @@
                       "end": 239,
                       "ctxt": 0
                     },
-                    "hasNestPrefix": false,
+                    "nestingSelector": null,
                     "combinator": null,
                     "typeSelector": null,
                     "subclassSelectors": [
                       {
                         "type": "ClassSelector",
-              "selectors": [
-                {
-                  "type": "CompoundSelector",
-                  "span": {
-                    "start": 219,
-                    "end": 239,
-                    "ctxt": 0
-                  },
-                  "nestingSelector": null,
-                  "combinator": null,
-                  "typeSelector": null,
-                  "subclassSelectors": [
-                    {
-                      "type": "ClassSelector",
-                      "span": {
-                        "start": 219,
-                        "end": 225,
-                        "ctxt": 0
-                      },
-                      "text": {
-                        "type": "Text",
                         "span": {
                           "start": 219,
                           "end": 225,

--- a/css/parser/tests/recovery/whitespaces/output.json
+++ b/css/parser/tests/recovery/whitespaces/output.json
@@ -31,32 +31,12 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
-      "selectors": [
-        {
-          "type": "ComplexSelector",
-          "span": {
-            "start": 0,
-            "end": 1,
-            "ctxt": 0
-          },
-          "selectors": [
-            {
-              "type": "CompoundSelector",
-              "span": {
-                "start": 0,
-                "end": 1,
-                "ctxt": 0
-              },
-              "nestingSelector": null,
-              "combinator": null,
-              "typeSelector": {
-                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,
                   "ctxt": 0
                 },
-                "hasNestPrefix": false,
+                "nestingSelector": null,
                 "combinator": null,
                 "typeSelector": {
                   "type": "TypeSelector",

--- a/css/parser/tests/recovery/whitespaces/output.json
+++ b/css/parser/tests/recovery/whitespaces/output.json
@@ -31,6 +31,26 @@
             "selectors": [
               {
                 "type": "CompoundSelector",
+      "selectors": [
+        {
+          "type": "ComplexSelector",
+          "span": {
+            "start": 0,
+            "end": 1,
+            "ctxt": 0
+          },
+          "selectors": [
+            {
+              "type": "CompoundSelector",
+              "span": {
+                "start": 0,
+                "end": 1,
+                "ctxt": 0
+              },
+              "nestingSelector": null,
+              "combinator": null,
+              "typeSelector": {
+                "type": "NamespacedName",
                 "span": {
                   "start": 0,
                   "end": 1,

--- a/css/visit/src/lib.rs
+++ b/css/visit/src/lib.rs
@@ -184,27 +184,20 @@ define!({
 
     pub struct CompoundSelector {
         pub span: Span,
-        pub has_nest_prefix: bool,
+        pub nesting_selector: Option<NestingSelector>,
         pub combinator: Option<SelectorCombinator>,
         pub type_selector: Option<TypeSelector>,
         pub subclass_selectors: Vec<SubclassSelector>,
     }
 
     pub struct TypeSelector {
-        pub nesting_selector: Option<NestingSelector>,
-        pub combinator: Option<SelectorCombinator>,
-        pub type_selector: Option<NamespacedName>,
-        pub subclass_selectors: Vec<SubclassSelector>,
+        pub span: Span,
+        pub prefix: Option<Text>,
+        pub name: Text,
     }
 
     pub struct NestingSelector {
         pub span: Span,
-    }
-
-    pub struct NamespacedName {
-        pub span: Span,
-        pub prefix: Option<Text>,
-        pub name: Text,
     }
 
     pub enum SubclassSelector {

--- a/css/visit/src/lib.rs
+++ b/css/visit/src/lib.rs
@@ -191,6 +191,17 @@ define!({
     }
 
     pub struct TypeSelector {
+        pub nesting_selector: Option<NestingSelector>,
+        pub combinator: Option<SelectorCombinator>,
+        pub type_selector: Option<NamespacedName>,
+        pub subclass_selectors: Vec<SubclassSelector>,
+    }
+
+    pub struct NestingSelector {
+        pub span: Span,
+    }
+
+    pub struct NamespacedName {
         pub span: Span,
         pub prefix: Option<Text>,
         pub name: Text,


### PR DESCRIPTION
Added `NestingSelector` as separate node, if we need to support:
```
.foo {
  color: blue;
  & > .bar { color: red; }
}
```

i.e. nested nesting selector, we should keep them in `SubclassSelector` (same for TypeSelector (NamespacedName)), and validate it is first or not (I will fix it in future)

Also we fix here span for `*` selector