### PR TITLE
fix(css/parser): Exclude whitespace from span

### DIFF
--- a/css/parser/src/parser/selector/mod.rs
+++ b/css/parser/src/parser/selector/mod.rs
@@ -26,6 +26,8 @@ where
                 break;
             }
 
+            self.input.skip_ws()?;
+
             let child = self.parse_complex_selector()?;
 
             last_pos = child.span.clone().hi;
@@ -410,8 +412,6 @@ where
     }
 
     fn parse_compound_selector(&mut self) -> PResult<CompoundSelector> {
-        self.input.skip_ws()?;
-
         let span = self.input.cur_span()?;
         let start_pos = span.lo;
 

--- a/css/parser/tests/fixture/rome/selectors/output.json
+++ b/css/parser/tests/fixture/rome/selectors/output.json
@@ -64,7 +64,7 @@
           {
             "type": "ComplexSelector",
             "span": {
-              "start": 4,
+              "start": 5,
               "end": 14,
               "ctxt": 0
             },
@@ -135,7 +135,7 @@
           {
             "type": "ComplexSelector",
             "span": {
-              "start": 15,
+              "start": 16,
               "end": 25,
               "ctxt": 0
             },
@@ -206,7 +206,7 @@
           {
             "type": "ComplexSelector",
             "span": {
-              "start": 26,
+              "start": 27,
               "end": 36,
               "ctxt": 0
             },

--- a/css/parser/tests/fixture/rome/selectors/span.rust-debug
+++ b/css/parser/tests/fixture/rome/selectors/span.rust-debug
@@ -57,10 +57,10 @@ error: Text
   | ^^^
 
 error: ComplexSelector
- --> $DIR/tests/fixture/rome/selectors/input.css:1:5
+ --> $DIR/tests/fixture/rome/selectors/input.css:1:6
   |
 1 | div, div + #id, div ~ #id, div > #id {
-  |     ^^^^^^^^^^
+  |      ^^^^^^^^^
 
 error: CompoundSelector
  --> $DIR/tests/fixture/rome/selectors/input.css:1:6
@@ -105,10 +105,10 @@ error: Text
   |            ^^^
 
 error: ComplexSelector
- --> $DIR/tests/fixture/rome/selectors/input.css:1:16
+ --> $DIR/tests/fixture/rome/selectors/input.css:1:17
   |
 1 | div, div + #id, div ~ #id, div > #id {
-  |                ^^^^^^^^^^
+  |                 ^^^^^^^^^
 
 error: CompoundSelector
  --> $DIR/tests/fixture/rome/selectors/input.css:1:17
@@ -153,10 +153,10 @@ error: Text
   |                       ^^^
 
 error: ComplexSelector
- --> $DIR/tests/fixture/rome/selectors/input.css:1:27
+ --> $DIR/tests/fixture/rome/selectors/input.css:1:28
   |
 1 | div, div + #id, div ~ #id, div > #id {
-  |                           ^^^^^^^^^^
+  |                            ^^^^^^^^^
 
 error: CompoundSelector
  --> $DIR/tests/fixture/rome/selectors/input.css:1:28

--- a/css/parser/tests/fixture/selector/comments/output.json
+++ b/css/parser/tests/fixture/selector/comments/output.json
@@ -1529,7 +1529,7 @@
           {
             "type": "ComplexSelector",
             "span": {
-              "start": 273,
+              "start": 285,
               "end": 286,
               "ctxt": 0
             },

--- a/css/parser/tests/fixture/selector/comments/span.rust-debug
+++ b/css/parser/tests/fixture/selector/comments/span.rust-debug
@@ -1050,10 +1050,10 @@ error: Text
    | ^
 
 error: ComplexSelector
-  --> $DIR/tests/fixture/selector/comments/input.css:16:15
+  --> $DIR/tests/fixture/selector/comments/input.css:16:27
    |
 16 | a /* test */ , /* test */ b {}
-   |               ^^^^^^^^^^^^^
+   |                           ^
 
 error: CompoundSelector
   --> $DIR/tests/fixture/selector/comments/input.css:16:27

--- a/css/parser/tests/recovery/vercel/001/output.json
+++ b/css/parser/tests/recovery/vercel/001/output.json
@@ -421,7 +421,7 @@
               {
                 "type": "ComplexSelector",
                 "span": {
-                  "start": 164,
+                  "start": 169,
                   "end": 188,
                   "ctxt": 0
                 },
@@ -504,7 +504,7 @@
               {
                 "type": "ComplexSelector",
                 "span": {
-                  "start": 189,
+                  "start": 194,
                   "end": 213,
                   "ctxt": 0
                 },
@@ -587,7 +587,7 @@
               {
                 "type": "ComplexSelector",
                 "span": {
-                  "start": 214,
+                  "start": 219,
                   "end": 239,
                   "ctxt": 0
                 },


### PR DESCRIPTION
Small fix, we should not include spaces before