### PR TITLE
refactor: Remove trailing whitespace

### DIFF
--- a/bundler/src/modules/sort/tests.rs
+++ b/bundler/src/modules/sort/tests.rs
@@ -60,7 +60,7 @@ fn sort_001() {
         &["_9[0] = 133;", "const _9 = new ByteArray(32);"],
         "
         const _9 = new ByteArray(32);
-        _9[0] = 133; 
+        _9[0] = 133;
         ",
     )
 }
@@ -130,7 +130,7 @@ fn sort_005() {
         }
         const a = new A();
         const b = 1;
-        use(b);        
+        use(b);
         use(a);
         ",
     );
@@ -199,7 +199,7 @@ fn deno_jszip_03() {
         function X() {
             console.log(Q.A)
         }
-        const v = X() 
+        const v = X()
         ",
     );
 }
@@ -342,7 +342,7 @@ fn sort_011() {
         class BufWriterSync extends AbstractBufBase {
         }
         use(BufWriter);
-        use(BufWriterSync);        
+        use(BufWriterSync);
         ",
     );
 }

--- a/css/codegen/macros/src/lib.rs
+++ b/css/codegen/macros/src/lib.rs
@@ -42,8 +42,8 @@ fn expand(i: ImplItemMethod) -> ImplItemMethod {
                     }
                 })
                 .expect(
-                    "#[emitter] methods should have signature of 
-fn (&mut self, node: Node) -> Result; 
+                    "#[emitter] methods should have signature of
+fn (&mut self, node: Node) -> Result;
     ",
                 )
         };

--- a/ecmascript/codegen/macros/src/lib.rs
+++ b/ecmascript/codegen/macros/src/lib.rs
@@ -44,8 +44,8 @@ fn expand(i: ImplItemMethod) -> ImplItemMethod {
                     }
                 })
                 .expect(
-                    "#[emitter] methods should have signature of 
-fn (&mut self, node: Node) -> Result; 
+                    "#[emitter] methods should have signature of
+fn (&mut self, node: Node) -> Result;
     ",
                 )
         };

--- a/ecmascript/jsdoc/src/lib.rs
+++ b/ecmascript/jsdoc/src/lib.rs
@@ -679,7 +679,7 @@ mod tests {
     fn issue_1058() {
         let (i, ret) = parse(input(
             r#"
-            * 
+            *
             * @param list - LinkedList<T>
             * @example <caption>Linkedlists.compareWith</caption>
             * import { LinkedList } from './js_test/linkedlist.ts'
@@ -766,7 +766,7 @@ mod tests {
     #[test]
     fn skip_1() {
         let i = skip(input(
-            "   
+            "
         *
         * @yields ",
         ));

--- a/ecmascript/minifier/tests/eval.rs
+++ b/ecmascript/minifier/tests/eval.rs
@@ -218,7 +218,7 @@ fn partial_1() {
     PartialInliner::expect(
         "
             const color = 'red'
-            
+
             export const foo = css`
             div {
                 color: ${color};
@@ -274,7 +274,7 @@ fn partial_3() {
         const animationDuration = '200ms'
         const animationName = 'my-cool-animation'
         const obj = { display: 'block' }
-        
+
         export const s1 = css`
             p.${color} {
                 color: ${otherColor};
@@ -290,13 +290,13 @@ fn partial_3() {
         const animationDuration = '200ms'
         const animationName = 'my-cool-animation'
         const obj = { display: 'block' }
-        
+
         export const s1 = css`
             p.red {
                 color: green;
                 display: block;
             }
-        `    
+        `
         ",
     );
 }
@@ -313,7 +313,7 @@ fn partial_4() {
         const animationDuration = '200ms'
         const animationName = 'my-cool-animation'
         const obj = { display: 'block' }
-        
+
         export const s2 = css`
             p.${color} {
                 color: ${darken(color)};
@@ -328,7 +328,7 @@ fn partial_4() {
         const animationDuration = '200ms'
         const animationName = 'my-cool-animation'
         const obj = { display: 'block' }
-        
+
         export const s2 = css`
         p.red {
             color: 'red';
@@ -350,7 +350,7 @@ fn partial_5() {
         const animationDuration = '200ms'
         const animationName = 'my-cool-animation'
         const obj = { display: 'block' }
-        
+
         export const s3 = css`
             p.${color} {
                 color: ${darken(color) + 2};
@@ -365,7 +365,7 @@ fn partial_5() {
         const animationDuration = '200ms'
         const animationName = 'my-cool-animation'
         const obj = { display: 'block' }
-        
+
         export const s3 = css`
             p.red {
                 color: 'red2';
@@ -386,7 +386,7 @@ fn partial_6() {
         const animationDuration = '200ms'
         const animationName = 'my-cool-animation'
         const obj = { display: 'block' }
-        
+
         export const s4 = css`
             @media (min-width: ${mediumScreen}) {
                 p {
@@ -409,7 +409,7 @@ fn partial_6() {
         const animationDuration = '200ms'
         const animationName = 'my-cool-animation'
         const obj = { display: 'block' }
-        
+
         export const s4 = css`
             @media (min-width: 680px) {
                 p {
@@ -438,7 +438,7 @@ fn partial_7() {
         const animationDuration = '200ms'
         const animationName = 'my-cool-animation'
         const obj = { display: 'block' }
-        
+
         export default ({ display }) => (
             css`
                 span {
@@ -455,7 +455,7 @@ fn partial_7() {
         const animationDuration = '200ms'
         const animationName = 'my-cool-animation'
         const obj = { display: 'block' }
-        
+
         export default ({ display }) => (
             css`
                 span {

--- a/ecmascript/parser/src/parser/expr/tests.rs
+++ b/ecmascript/parser/src/parser/expr/tests.rs
@@ -50,7 +50,7 @@ fn regex_expr() -> Box<Expr> {
 fn regex_single_line_comment() {
     assert_eq_ignore_span!(
         expr(
-            r#"re = // ... 
+            r#"re = // ...
             /w+/"#
         ),
         regex_expr()
@@ -65,7 +65,7 @@ fn regex_multi_line_comment() {
 fn regex_multi_line_comment_with_lines() {
     assert_eq_ignore_span!(
         expr(
-            r#"re = 
+            r#"re =
             /*
              ...
              */

--- a/ecmascript/preset-env/benches/polyfills.rs
+++ b/ecmascript/preset-env/benches/polyfills.rs
@@ -57,9 +57,9 @@ console.log(y[0]); // 21
 var buffer = new ArrayBuffer(16);
 var z = new Float32Array(buffer, 0, 4);
 
-// From an iterable 
-var iterable = function*(){ yield* [1,2,3]; }(); 
-var float32 = new Float32Array(iterable); 
+// From an iterable
+var iterable = function*(){ yield* [1,2,3]; }();
+var float32 = new Float32Array(iterable);
 // Float32Array[1, 2, 3]
 "#;
 

--- a/ecmascript/transforms/base/src/hygiene/tests.rs
+++ b/ecmascript/transforms/base/src/hygiene/tests.rs
@@ -564,7 +564,7 @@ fn block_in_fn() {
             }))])
         },
         "
-        // Ideal: 
+        // Ideal:
         //
         // function Foo() {
         //     var bar;
@@ -833,7 +833,7 @@ fn regression_001() {
     function Foo() {
         _classCallCheck(this, Foo);
         foo.set(this, {
-             writable: true, value: 0 
+             writable: true, value: 0
         });
     }
     _createClass(Foo, [{
@@ -843,7 +843,7 @@ fn regression_001() {
                      1), old;
                      _classPrivateFieldSet(_obj = other.obj, foo, (old = \
                      +_classPrivateFieldGet(_obj, foo)) + 1), old;
-                } 
+                }
         }]);
     return Foo;
 }();
@@ -858,7 +858,7 @@ fn regression_001() {
     function Foo() {
         _classCallCheck(this, Foo);
         foo.set(this, {
-             writable: true, value: 0 
+             writable: true, value: 0
         });
     }
     _createClass(Foo, [{
@@ -868,7 +868,7 @@ fn regression_001() {
          old;
                 _classPrivateFieldSet(_obj = other.obj, foo, (old1 = +_classPrivateFieldGet(_obj1, \
          foo)) + 1), old1;
-                } 
+                }
         }]);
     return Foo;
 }();
@@ -893,7 +893,7 @@ fn regression_002() {
                      1), old;
                      _classPrivateFieldSet(_obj = other.obj, foo, (old = \
                      +_classPrivateFieldGet(_obj, foo)) + 1), old;
-                } 
+                }
         }])",
                 )?
                 .fold_with(&mut OnceMarker::new(&[(
@@ -908,7 +908,7 @@ fn regression_002() {
          1), old;
                      _classPrivateFieldSet(_obj = other.obj, foo, (old1 = \
          +_classPrivateFieldGet(_obj, foo)) + 1), old1;
-                } 
+                }
         }]);",
     );
 }
@@ -1521,7 +1521,7 @@ fn opt_6() {
             }
 
         }
-        
+
         ",
     );
 }
@@ -1582,7 +1582,7 @@ fn issue_2211_2() {
                         const _bar = () => _bar();
 
                         const alfa = () => _bar();
-                      
+
                         return { alfa };
                     };
                     ",
@@ -1702,7 +1702,7 @@ fn var_awareness_2() {
         },
         "
         for (var i of [1, 2, 3]) {
-            
+
         }
         for (var i1 of [4, 5, 6]) {
             console.log(i1)

--- a/ecmascript/transforms/compat/src/bugfixes/async_arrows_in_class.rs
+++ b/ecmascript/transforms/compat/src/bugfixes/async_arrows_in_class.rs
@@ -117,7 +117,7 @@ mod tests {
                     return await 1;
                 };
             }
-          
+
             bar() {
                 (async function () {})();
             }

--- a/ecmascript/transforms/compat/src/es2015/typeof_symbol.rs
+++ b/ecmascript/transforms/compat/src/es2015/typeof_symbol.rs
@@ -174,7 +174,7 @@ mod tests {
         function isUndef(type) {
             return type === 'undefined';
         }
-        
+
         var isWeb = !isUndef(typeof window) && 'onload' in window;
         exports.isWeb = isWeb;
         var isNode = !isUndef(typeof process) && !!(process.versions && process.versions.node);
@@ -186,7 +186,7 @@ mod tests {
         function isUndef(type) {
         return type === 'undefined';
         }
-        
+
         var isWeb =
         !isUndef(typeof window === 'undefined' ? 'undefined' : _typeof(window)) &&
         'onload' in window;

--- a/ecmascript/transforms/compat/src/es2020/nullish_coalescing/tests.rs
+++ b/ecmascript/transforms/compat/src/es2020/nullish_coalescing/tests.rs
@@ -59,7 +59,7 @@ test!(
     |_| tr(()),
     transform_in_function,
     r#"
-  
+
 function foo(opts) {
   var foo = opts.foo ?? "default";
 }
@@ -78,7 +78,7 @@ test!(
     |_| tr(()),
     transform_static_refs_in_default,
     r#"
-  
+
 function foo(foo, bar = foo ?? "bar") {}
 
 "#,

--- a/ecmascript/transforms/compat/tests/es2015_block_scoping.rs
+++ b/ecmascript/transforms/compat/tests/es2015_block_scoping.rs
@@ -361,7 +361,7 @@ test!(
         for(var i1 = 0; i1 < 5; i1++){
             var _ret = _loop(i1);
             if (_ret === "continue") continue;
-        }        
+        }
         "#
 );
 
@@ -593,24 +593,24 @@ test!(
     "
     function combineOverlappingMatches(matches) {
         let hasOverlaps = false
-        
+
         for (let i = matches.length - 1; i >= 0; i--) {
             let currentMatch = matches[i]
             let overlap = matches.find(match => {
                 return match !== currentMatch && match.itemsType === currentMatch.itemsType
             })
-            
+
             if (overlap) {
                 hasOverlaps = true
                 matches.splice(i, 1)
             }
         }
-        
+
         if (hasOverlaps) {
             combineOverlappingMatches(matches)
         }
     }
-    
+
     combineOverlappingMatches([1])
     ",
     "
@@ -666,7 +666,7 @@ test!(
             }
             infoMap.set(item, info); // important
         }
-        
+
         function getInfo(item) {
             if (!infoMap.has(item)) {
             throw new Error('no info yet');
@@ -844,18 +844,18 @@ test!(
         for (var i = 1; i < arguments.length; i++) {
             var source = arguments[i] != null ? arguments[i] : {};
             var ownKeys = Object.keys(source);
-        
+
             if (typeof Object.getOwnPropertySymbols === 'function') {
             ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) {
                 return Object.getOwnPropertyDescriptor(source, sym).enumerable;
             }));
             }
-        
+
             ownKeys.forEach(function (key) {
             defineProperty(target, key, source[key]);
             });
         }
-        
+
         return target;
     }
     ",
@@ -890,9 +890,9 @@ test!(
         a: 1,
         b: 2,
     }
-      
+
     const controller = {}
-      
+
     for (const key in keys) {
         controller[key] = (c, ...d) => {
             console.log(keys[key])
@@ -928,9 +928,9 @@ test!(
         a: 1,
         b: 2,
     }
-      
+
     const controller = {}
-      
+
     for (const key in keys) {
         controller[key] = (c, ...d) => {
             console.log(keys[key])

--- a/ecmascript/transforms/compat/tests/es2015_classes.rs
+++ b/ecmascript/transforms/compat/tests/es2015_classes.rs
@@ -115,7 +115,7 @@ class Hello{
     return {
       toString () {
         return 'hello';
-      } 
+      }
     };
   }
 }
@@ -2547,7 +2547,7 @@ var Test = function Test() {
 
 var Foo =
 /*#__PURE__*/
-function (Bar) {  
+function (Bar) {
   'use strict';
 
   _inherits(Foo, Bar);
@@ -2564,7 +2564,7 @@ function (Bar) {
 }(Bar);
 
 var ConstructorScoping = function ConstructorScoping() {
-  'use strict';  
+  'use strict';
 
   _classCallCheck(this, ConstructorScoping);
   var bar;
@@ -2619,7 +2619,7 @@ var MyCtrl2 = function MyCtrl2(a) {
   "a";
   "b";
   'use strict';
-  
+
   _classCallCheck(this, MyCtrl2);
   foo;
 };

--- a/ecmascript/transforms/compat/tests/es2015_regenerator.rs
+++ b/ecmascript/transforms/compat/tests/es2015_regenerator.rs
@@ -121,7 +121,7 @@ var _marked = regeneratorRuntime.mark(foo);
 
 function foo(a, b, c) {
   return regeneratorRuntime.wrap(function foo$(_ctx) {
-    while (1) 
+    while (1)
       switch (_ctx.prev = _ctx.next) {
         case 0:
         case "end":
@@ -137,7 +137,7 @@ test_exec!(
     |_| tr(Default::default()),
     conditional_return_1,
     "
-    
+
 let v = (function* (){
   yield 3;
   if (true)
@@ -154,7 +154,7 @@ test_exec!(
     |_| tr(Default::default()),
     conditional_return_2,
     "
-    
+
 let v = (function* (){
   if (false)
 	  return a
@@ -173,7 +173,7 @@ test_exec!(
     |_| tr(Default::default()),
     conditional_return_exec_1,
     "
-    
+
     let v = (function* (){
   yield 3;
   if (true)
@@ -191,7 +191,7 @@ test_exec!(
     |_| tr(Default::default()),
     conditional_return_exec_2,
     "
-    
+
     let v = (function* (){
   yield 3;
   if (false)
@@ -210,7 +210,7 @@ test_exec!(
     |_| tr(Default::default()),
     conditional_yield_1,
     "
-    
+
     let v = (function* () {
   if (true)
   	yield 1
@@ -226,7 +226,7 @@ test_exec!(
     |_| tr(Default::default()),
     conditional_yield_2,
     "
-    
+
     let v = (function* () {
   if (true)
   	yield 1
@@ -246,7 +246,7 @@ test_exec!(
     |_| tr(Default::default()),
     yield_in_seq,
     "
-    
+
     let v = (function* () {
     return (1, yield 2, yield 3, 4, yield 5);
 })();
@@ -263,7 +263,7 @@ test_exec!(
     |_| tr(Default::default()),
     yield_in_cond_seq,
     "
-    
+
     let v = (function* () {
     if (true)
         return (1, yield 2, yield 3, 4, yield 5);
@@ -281,9 +281,9 @@ test_exec!(
     |_| tr(Default::default()),
     yield_in_return_and_call,
     "
-    
+
     function id(v) { return v; }
-    
+
     let v = (function* () {
     if (true)
         return (1, id(yield id(2)));
@@ -299,9 +299,9 @@ test_exec!(
     |_| tr(Default::default()),
     yield_in_call,
     "
-    
+
 function id(v) { return v; }
-    
+
 let v = (function* () {
   return (1, id(yield id(2)));
   return (3, id(yield id(4)));
@@ -318,9 +318,9 @@ test_exec!(
     |_| tr(Default::default()),
     yield_temp,
     "
-    
+
 function id(v) { return v; }
-    
+
 let v = (function* () {
   yield (1, id(yield id(2), 2));
   return (3, id(yield id(4)));
@@ -339,7 +339,7 @@ test_exec!(
     |_| tr(Default::default()),
     yield_next_value,
     "
-    
+
 let v = (function* () {
   let bar = yield 'foo';
   yield bar
@@ -356,7 +356,7 @@ test_exec!(
     |_| tr(Default::default()),
     only_yield,
     "
-    
+
 let v = (function* () {
     yield 1
 })();
@@ -371,7 +371,7 @@ test_exec!(
     |_| tr(Default::default()),
     expr_cond,
     "
-    
+
 let v = (function* (){
   true ? yield 1 : yield 2;
 })();
@@ -386,7 +386,7 @@ test_exec!(
     |_| tr(Default::default()),
     expr_array,
     "
-    
+
 let v = (function* (){
   yield [yield 1, 2];
 })();
@@ -402,7 +402,7 @@ test_exec!(
     |_| tr(Default::default()),
     expr_object,
     "
-    
+
 let v = (function* (){
   yield { a: 1 };
 })();
@@ -417,7 +417,7 @@ test_exec!(
     |_| tr(Default::default()),
     expr_logical_and,
     "
-    
+
 let v = (function* (){
   (yield 1) && (yield 2);
 })();
@@ -432,7 +432,7 @@ test_exec!(
     |_| tr(Default::default()),
     expr_logical_or,
     "
-    
+
 let v = (function* (){
   (yield 1) || (yield 2);
 })();
@@ -448,7 +448,7 @@ test_exec!(
     |_| tr(Default::default()),
     expr_update_prefix,
     "
-    
+
 let v = (function* (){
   let i = 0;
   yield ++i;
@@ -466,7 +466,7 @@ test_exec!(
     |_| tr(Default::default()),
     expr_update_postfix,
     "
-    
+
 let v = (function* (){
   let i = 0;
   yield i++;
@@ -484,7 +484,7 @@ test_exec!(
     |_| tr(Default::default()),
     bin_expr_1,
     "
-    
+
 let v = (function* (){
   yield ((yield 1) + (yield 2));
 })();
@@ -501,7 +501,7 @@ test_exec!(
     |_| tr(Default::default()),
     try_stmt_1,
     "
-    
+
 let v = (function* (){
   try {
     yield 1;
@@ -519,7 +519,7 @@ test_exec!(
     |_| tr(Default::default()),
     try_stmt_2,
     "
-    
+
 let v = (function* (){
   try {
     yield 1;
@@ -539,7 +539,7 @@ test_exec!(
     |_| tr(Default::default()),
     try_stmt_3,
     "
-    
+
 let v = (function* (){
   try {
     yield 1;
@@ -560,7 +560,7 @@ test_exec!(
     |_| tr(Default::default()),
     try_stmt_4,
     "
-    
+
 let v = (function* (){
   try {
     yield 1;
@@ -584,7 +584,7 @@ test_exec!(
     |_| tr(Default::default()),
     try_stmt_5,
     "
-    
+
 let v = (function* (){
   try {
     yield 1;
@@ -607,7 +607,7 @@ test_exec!(
     |_| tr(Default::default()),
     labeled_stmt_1,
     "
-    
+
 let v = (function* (){
 })();
 
@@ -621,7 +621,7 @@ test_exec!(
     |_| tr(Default::default()),
     break_stmt_1,
     "
-    
+
 let v = (function* (){
 })();
 
@@ -635,7 +635,7 @@ test_exec!(
     |_| tr(Default::default()),
     continue_stmt_1,
     "
-    
+
 let v = (function* (){
 })();
 
@@ -648,10 +648,10 @@ test_exec!(
     |_| tr(Default::default()),
     switch_stmt_1,
     "
-    
+
 let v = (function* (){
   switch(1) {
-  	case 1: 
+  	case 1:
       yield 1
       yield 2
   }
@@ -668,10 +668,10 @@ test_exec!(
     |_| tr(Default::default()),
     switch_stmt_2,
     "
-    
+
 let v = (function* (){
   switch(2) {
-  	case 1: 
+  	case 1:
       yield 1
       yield 2
   }
@@ -686,10 +686,10 @@ test_exec!(
     |_| tr(Default::default()),
     switch_stmt_3,
     "
-    
+
 let v = (function* (){
   switch(2) {
-  	default: 
+  	default:
       yield 1
       yield 2
   }
@@ -706,12 +706,12 @@ test_exec!(
     |_| tr(Default::default()),
     switch_stmt_4,
     "
-    
+
 let v = (function* (){
   switch(1) {
-  	case 1: 
+  	case 1:
       yield 1
-  	case 2: 
+  	case 2:
       yield 2
   }
 })();
@@ -727,19 +727,19 @@ test_exec!(
     |_| tr(Default::default()),
     switch_stmt_5,
     "
-    
+
 let v = (function* (){
   switch(1) {
-  	case 1: 
+  	case 1:
       yield 1;
       break;
-  	case 2: 
+  	case 2:
       yield 2;
       break;
-  	case 3: 
+  	case 3:
       yield 3;
       break;
-  	case 4: 
+  	case 4:
       yield 4;
       break;
   }
@@ -756,7 +756,7 @@ test_exec!(
     |_| tr(Default::default()),
     throw_stmt_1,
     "
-    
+
 let v = (function* (){
 })();
 
@@ -769,7 +769,7 @@ test_exec!(
     |_| tr(Default::default()),
     while_stmt_1,
     "
-    
+
 let v = (function* (){
     let i = 0;
     while (true) {
@@ -790,7 +790,7 @@ test_exec!(
     |_| tr(Default::default()),
     do_while_stmt_1,
     "
-    
+
 let v = (function* (){
     let i = 0;
     do {
@@ -811,7 +811,7 @@ test_exec!(
     |_| tr(Default::default()),
     do_while_stmt_2,
     "
-    
+
 let v = (function* (){
     do {
         yield 1;
@@ -829,7 +829,7 @@ test_exec!(
     |_| tr(Default::default()),
     for_stmt_1,
     "
-    
+
 let v = (function* (){
 })();
 
@@ -843,7 +843,7 @@ test_exec!(
     |_| tr(Default::default()),
     for_of_stmt_1,
     "
-    
+
 let v = (function* (){
 })();
 
@@ -857,7 +857,7 @@ test_exec!(
     |_| tr(Default::default()),
     for_in_stmt_1,
     "
-    
+
 let v = (function* (){
 })();
 
@@ -870,7 +870,7 @@ test_exec!(
     |_| tr(Default::default()),
     bin_expr_2,
     "
-    
+
 let v = (function* (){
   let a = 1;
   let b = 2;
@@ -891,7 +891,7 @@ test_exec!(
     |_| tr(Default::default()),
     arguments_1,
     "
-    
+
 function* gen(){
     yield Array.prototype.slice.call(arguments);
 }
@@ -907,7 +907,7 @@ test_exec!(
     |_| tr(Default::default()),
     arguments_2,
     "
-    
+
 function* gen(){
     yield arguments[0];
     yield arguments[1];
@@ -975,7 +975,7 @@ test_exec!(
             }
         }
     }
-    
+
     var v = foo();
     expect(v.next()).toEqual({ value: 1, done: false });
     expect(v.next()).toEqual({ value: 2, done: false });
@@ -990,7 +990,7 @@ test_exec!(
     "function* myGenerator() {
         yield* [1,2,3];
     }
-    
+
     const v = myGenerator();
     expect(v.next()).toEqual({ value: 1, done: false });
     expect(v.next()).toEqual({ value: 2, done: false });
@@ -1062,7 +1062,7 @@ test_exec!(
     |_| es2015::regenerator(Default::default(), Mark::fresh(Mark::root())),
     issue_853_1,
     "function throwingFn() { throw 'Error' }
-function* gen() { 
+function* gen() {
     try { yield throwingFn() } catch (e) { yield e }
 };
 const v = gen();
@@ -1188,7 +1188,7 @@ test!(
     function test() {
         return _test.apply(this, arguments);
     }
-    
+
     test();
     ",
     "
@@ -1197,18 +1197,18 @@ test!(
     function _test() {
         _test = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
           return regeneratorRuntime.wrap(function _callee$(_ctx) {
-            while (1) 
+            while (1)
               switch (_ctx.prev = _ctx.next) {
                 case 0:
                   _ctx.prev = 0;
                   _ctx.next = 3;
                   return 1;
-      
+
                 case 3:
                   _ctx.prev = 3;
                   console.log(2);
                   return _ctx.finish(3);
-      
+
                 case 6:
                 case 'end':
                   return _ctx.stop();
@@ -1217,11 +1217,11 @@ test!(
         }));
         return _test.apply(this, arguments);
       }
-      
+
       function test() {
         return _test.apply(this, arguments);
       }
-      
+
       test();
     "
 );
@@ -1245,7 +1245,7 @@ test!(
 
     function foo() {
         return regeneratorRuntime.wrap(function foo$(_ctx) {
-            while (1) 
+            while (1)
             switch (_ctx.prev = _ctx.next) {
                 case 0:
                 _ctx.prev = 0;
@@ -1291,16 +1291,16 @@ test!(
               _ctx.prev = 0;
               _ctx.next = 3;
               return 1;
-    
+
             case 3:
               _ctx.next = 8;
               break;
-    
+
             case 5:
               _ctx.prev = 5;
               _ctx.t0 = _ctx['catch'](0);
               console.log(2);
-    
+
             case 8:
             case 'end':
               return _ctx.stop();

--- a/ecmascript/transforms/compat/tests/es2015_template_literals.rs
+++ b/ecmascript/transforms/compat/tests/es2015_template_literals.rs
@@ -30,7 +30,7 @@ test_exec!(
 const write = (text) => {
   console.log(text)
 }
-write(1) 
+write(1)
 write('2')
 write`3`"
 );
@@ -922,8 +922,8 @@ test!(
       };
       return data;
     }
-  
-    const myVar = T(_templateObject());    
+
+    const myVar = T(_templateObject());
     ",
     ok_if_code_eq
 );

--- a/ecmascript/transforms/compat/tests/es2017_async_to_generator.rs
+++ b/ecmascript/transforms/compat/tests/es2017_async_to_generator.rs
@@ -2151,7 +2151,7 @@ test!(
       return function() {
           return _ref.apply(this, arguments);
       };
-    }();  
+    }();
     "
 );
 
@@ -2247,8 +2247,8 @@ test()
   function test() {
     return _test.apply(this, arguments);
   }
-  
-  
+
+
   test();
   "
 );
@@ -2261,7 +2261,7 @@ test!(
     class A {
       val = '1';
       async foo() {
-          try {           
+          try {
               return await (async (x) => x + this.val)('a');
           } catch (e) {
               throw e;
@@ -2298,14 +2298,14 @@ test_exec!(
     class A {
       val = '1';
       async foo() {
-          try {           
+          try {
               return await (async (x) => x + this.val)('a');
           } catch (e) {
               throw e;
           }
       }
     }
-    
+
     const a = new A();
     expect(a.foo()).resolves.toEqual('a1')
     "
@@ -2371,7 +2371,7 @@ test!(
           return result;
       },
     };
-    
+
     obj.byPlatform('foo').then(v => console.log(v))
     ",
     "
@@ -2447,11 +2447,11 @@ test!(
       var _main = _asyncToGenerator(function* () {
         console.log(1);
       });
-    
+
       function main() {
         return _main.apply(this, arguments);
       }
-    
+
       return main;
     })()(foo);
     "
@@ -2643,14 +2643,14 @@ test_exec!(
         yield result
       }
     }
-    
+
     async function printValues() {
       const iterator = generate()
       for await (const value of iterator) {
         console.log(`iterator value: ${value}`)
       }
     }
-    
+
     printValues()
     "
 );

--- a/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
+++ b/ecmascript/transforms/compat/tests/es2020_optional_chaining.rs
@@ -712,7 +712,7 @@ test!(
     function bug() {
       const arrowFn = (arg) => this.object[arg]?.();
     }
-    
+
     bug();
     ",
     "

--- a/ecmascript/transforms/compat/tests/es2021_logcal_assignments.rs
+++ b/ecmascript/transforms/compat/tests/es2021_logcal_assignments.rs
@@ -34,7 +34,7 @@ test!(
     class Foo {
         method() {
             return super.f ||= b
-        } 
+        }
     }
     ",
     "

--- a/ecmascript/transforms/compat/tests/es2022_class_properties.rs
+++ b/ecmascript/transforms/compat/tests/es2022_class_properties.rs
@@ -401,8 +401,8 @@ function withContext(ComposedComponent) {
       context: PropTypes.shape({
         addCss: PropTypes.func,
         setTitle: PropTypes.func,
-        setMeta: PropTypes.func 
-      }) 
+        setMeta: PropTypes.func
+      })
     });
     return WithContext;
   })();
@@ -757,7 +757,7 @@ class Foo {
 "#,
     r#"
 var Foo = function Foo() {
-  'use strict';  
+  'use strict';
 
   _classCallCheck(this, Foo);
 };
@@ -1056,22 +1056,22 @@ var MyClass = function() {
     }
     _createClass(MyClass, [{
              key: tmp, get: function () {
-                } 
+                }
         }, {
              key: tmp1, set: function (value) {
-                } 
+                }
         }, {
              key: tmp2, get: function () {
-                } 
+                }
         }, {
              key: tmp3, set: function (value) {
-                } 
+                }
         }, {
              key: tmp4, value: function () {
-                } 
+                }
         }], [{
              key: tmp5, value: function () {
-                } 
+                }
         }]);
     return MyClass;
 }();
@@ -1717,7 +1717,7 @@ var _prop = new WeakMap();
 var Bar =
 /*#__PURE__*/
 function (Foo) {
-  'use strict';  
+  'use strict';
 
   _inherits(Bar, Foo);
 
@@ -2262,12 +2262,12 @@ export default ((param)=>{
       key: 'getParam',
       value: function getParam() {
         return param;
-      } 
+      }
     }]);
     return App;
   }();
   _defineProperty(App, 'props', {
-    prop1: 'prop1', prop2: 'prop2' 
+    prop1: 'prop1', prop2: 'prop2'
   });
   return App;
 });
@@ -3502,7 +3502,7 @@ class MyClass3 {
 }
 var _myAsyncMethod1 = new WeakMap();
 export { MyClass3 as default };
-  
+
 
 "#
 );
@@ -3569,7 +3569,7 @@ for (let i = 0; i <= 10; ++i) {
 for(let i=0; i<= 10; ++i) {
   const clazz = classes[i];
   expect(clazz.foo).toBe('static field ' + i);
-  
+
   const instance = new clazz();
   expect(Object.getOwnPropertyNames(instance)).toEqual([String(i)])
   expect(instance[i]).toBe('computed field ' + i);
@@ -4811,11 +4811,11 @@ test!(
     r#"
   class Animal {
     #name;
-  
+
     constructor(name) {
       this.#name = name
     }
-  
+
     noise() {
       return this.#name
     }
@@ -4900,7 +4900,7 @@ test!(
     "
   class Test {
     #ws;
-    
+
     _packet(raw) {
         /** @type {DiscordPacket} */
         let pak;
@@ -5073,7 +5073,7 @@ test!(
     "
     class Test {
       #ws;
-    
+
       _packet(raw) {
         /** @type {DiscordPacket} */
         let pak;
@@ -5116,7 +5116,7 @@ test!(
       }
   }
   var _ws = new WeakMap();
-  
+
     "
 );
 
@@ -5127,7 +5127,7 @@ test!(
     "
   class Test {
     #ws;
-  
+
     _packet(raw) {
       /** @type {DiscordPacket} */
       let pak;
@@ -5286,18 +5286,18 @@ test!(
     class Foo {
       #y;
       static #z = 3;
-    
+
       constructor() {
         this.x = 1;
         this.#y = 2;
         this.#sssss();
       }
-    
+
       #sssss() {
         console.log(this.x, this.#y, Foo.#z);
       }
     }
-    
+
     const instance = new Foo();
     ",
     "
@@ -5337,7 +5337,7 @@ test!(
         return 1;
       }
       // #value = 1;
-    
+
       get(target) {
         return target.#value;
       }
@@ -5368,7 +5368,7 @@ test_exec!(
       #tag() {
         return this;
       }
-      
+
       #tag2 = this.#tag;
 
       constructor() {
@@ -5395,7 +5395,7 @@ test_exec!(
     #tag() {
       return this;
     }
-    
+
     #tag2 = this.#tag;
 
     constructor() {
@@ -5419,7 +5419,7 @@ test!(
       #tag() {
         return this;
       }
-      
+
       #tag2 = this.#tag;
 
       constructor() {
@@ -5527,7 +5527,7 @@ test!(
       constructor(props) {
         super(props);
       }
-    
+
       input = this.props.item;
     }
     ",

--- a/ecmascript/transforms/module/tests/umd.rs
+++ b/ecmascript/transforms/module/tests/umd.rs
@@ -1915,7 +1915,7 @@ test!(
               return _interopRequireWildcard(require(\"foo\"));
           }));
       }
-  });      
+  });
     ",
     ok_if_code_eq
 );

--- a/ecmascript/transforms/optimization/src/simplify/branch/tests.rs
+++ b/ecmascript/transforms/optimization/src/simplify/branch/tests.rs
@@ -541,7 +541,7 @@ fn test_optimize_switch_4() {
         "foo();",
     );
     test(
-        "switch (true) {\ncase true:\n  foo();\n  break;\ncase false:\n  bar();\n break; 
+        "switch (true) {\ncase true:\n  foo();\n  break;\ncase false:\n  bar();\n break;
             default: foobar(); break; \n}",
         "foo();",
     );
@@ -1779,7 +1779,7 @@ fn issue_1825() {
         function p(){
             throw new Error('Something');
         }
-        
+
         while ((p(), 1)) {
             console.log('Hello world');
         }

--- a/ecmascript/transforms/optimization/tests/simplify.rs
+++ b/ecmascript/transforms/optimization/tests/simplify.rs
@@ -481,7 +481,7 @@ test!(
         resolve: any;
         reject: any;
     }
-    
+
     function d(): D {
         let methods;
         const promise = new Promise((resolve, reject) => {
@@ -492,16 +492,16 @@ test!(
 
     class A {
         private s: D = d();
-      
+
         a() {
             this.s.resolve();
         }
-      
+
         b() {
             this.s = d();
         }
     }
-      
+
     new A();
     ",
     "
@@ -579,7 +579,7 @@ test!(
     issue_1619_1,
     r#"
     "use strict";
-	
+
     console.log("\x00" + "\x31");
 
     "#,
@@ -600,7 +600,7 @@ test!(
             console.log(this === globalThis);
         },
     };
-    
+
     X.run();
     (0, X.run)();
     ",
@@ -610,7 +610,7 @@ test!(
             console.log(this === globalThis);
         },
     };
-    
+
     X.run();
     (0, X.run)();
     "

--- a/ecmascript/transforms/optimization/tests/simplify_dce.rs
+++ b/ecmascript/transforms/optimization/tests/simplify_dce.rs
@@ -73,7 +73,7 @@ noop!(
     noop_2,
     "
 switch (1){
-    case 1: 
+    case 1:
         a = '1';
 }
 
@@ -168,7 +168,7 @@ to!(
       RESOURCE_INSTAGRAM,
       RESOURCE_WEBSITE,
   } from '../../../../consts'
-  
+
     export const resources = [
       {
           value: RESOURCE_WEBSITE,
@@ -213,7 +213,7 @@ to!(
       RESOURCE_INSTAGRAM,
       RESOURCE_WEBSITE,
   } from '../../../../consts'
-  
+
     const resources = [
       {
           value: RESOURCE_WEBSITE,
@@ -283,7 +283,7 @@ resources.map(v => v)"
 noop!(
     issue_763_4,
     "import { RESOURCE_FACEBOOK, RESOURCE_INSTAGRAM, RESOURCE_WEBSITE } from './consts';
-    
+
     const resources = [
       {
         value: RESOURCE_WEBSITE,
@@ -298,7 +298,7 @@ noop!(
         label: 'Instagram',
       },
     ];
-    
+
     export function foo(websites) {
         const a = resources.map((resource) => (
             {
@@ -376,7 +376,7 @@ noop!(
     spack_issue_009,
     "
 class A {
-    
+
 }
 function a() {
     return new A();
@@ -541,7 +541,7 @@ test!(
         resolve: any;
         reject: any;
     }
-      
+
     export function d(): D {
         let methods;
         const promise = new Promise((resolve, reject) => {
@@ -576,7 +576,7 @@ test!(
         resolve: any;
         reject: any;
     }
-    
+
     function d(): D {
         let methods;
         const promise = new Promise((resolve, reject) => {
@@ -587,16 +587,16 @@ test!(
 
     class A {
         private s: D = d();
-      
+
         a() {
             this.s.resolve();
         }
-      
+
         b() {
             this.s = d();
         }
     }
-      
+
     new A();
     ",
     "
@@ -670,7 +670,7 @@ test!(
         resolve: any;
         reject: any;
     }
-    
+
     function d(): D {
         let methods;
         const promise = new Promise((resolve, reject) => {
@@ -681,12 +681,12 @@ test!(
 
     class A {
         private s: D = d();
-      
+
         a() {
             this.s.resolve();
         }
     }
-      
+
     new A();
     ",
     "

--- a/ecmascript/transforms/optimization/tests/simplify_inlining.rs
+++ b/ecmascript/transforms/optimization/tests/simplify_inlining.rs
@@ -103,7 +103,7 @@ identical!(
     switch ('a') {
       case 'a':
             break;
-      default: 
+      default:
             x = 1;
             break;
     }
@@ -157,7 +157,7 @@ to!(
 ",
     "let y;
     {
-        let y;  
+        let y;
         x;
     }
     y;"
@@ -2157,7 +2157,7 @@ test!(
         resolve: any;
         reject: any;
     }
-      
+
     export function d(): D {
         let methods;
         const promise = new Promise((resolve, reject) => {
@@ -2192,7 +2192,7 @@ test!(
         resolve: any;
         reject: any;
     }
-    
+
     function d(): D {
         let methods;
         const promise = new Promise((resolve, reject) => {
@@ -2203,16 +2203,16 @@ test!(
 
     class A {
         private s: D = d();
-      
+
         a() {
             this.s.resolve();
         }
-      
+
         b() {
             this.s = d();
         }
     }
-      
+
     new A();
     ",
     "
@@ -2262,7 +2262,7 @@ const STATUS_TEXT = new Map([
     [
         Status.SwitchingProtocols,
         "Switching Protocols"
-    ] 
+    ]
 ]);
     "#,
     r#"
@@ -2281,7 +2281,7 @@ const STATUS_TEXT = new Map([
             Status1.SwitchingProtocols,
             "Switching Protocols"
         ]
-    ]);    
+    ]);
     "#
 );
 

--- a/ecmascript/transforms/react/src/refresh/tests.rs
+++ b/ecmascript/transforms/react/src/refresh/tests.rs
@@ -414,9 +414,9 @@ test!(
     export default _c7 = React.memo(_c6 = forwardRef(_c5 = (props, ref) => {
       return <h1>Foo</h1>;
     }));
-    
+
     var _c, _c1, _c2, _c3, _c4, _c5, _c6, _c7;
-    
+
     $RefreshReg$(_c, "A$forwardRef");
     $RefreshReg$(_c1, "A");
     $RefreshReg$(_c2, "B$memo$React.forwardRef");
@@ -444,9 +444,9 @@ test!(
     export default _c2 = React.memo(_c1 = forwardRef(_c = function (props, ref) {
       return <h1>Foo</h1>;
     }));
-    
+
     var _c, _c1, _c2;
-    
+
     $RefreshReg$(_c, "%default%$React.memo$forwardRef");
     $RefreshReg$(_c1, "%default%$React.memo");
     $RefreshReg$(_c2, "%default%");
@@ -469,9 +469,9 @@ test!(
     export default _c2 = React.memo(_c1 = forwardRef(_c = function Named(props, ref) {
       return <h1>Foo</h1>;
     }));
-    
+
     var _c, _c1, _c2;
-    
+
     $RefreshReg$(_c, "%default%$React.memo$forwardRef");
     $RefreshReg$(_c1, "%default%$React.memo");
     $RefreshReg$(_c2, "%default%");
@@ -524,11 +524,11 @@ test!(
     const throttledAlert = throttle(function () {
       alert('Hi');
     });
-    
+
     const TooComplex = function () {
       return hello;
     }(() => {});
-    
+
     if (cond) {
       const Foo = thing(() => {});
     }
@@ -584,11 +584,11 @@ test!(
     let Alias1 = A;
     let Alias2 = A.Foo;
     const Dict = {};
-    
+
     function Foo() {
       return <div><A /><B /><StyledFactory1 /><StyledFactory2 /><StyledFactory3 /><Alias1 /><Alias2 /><Header /><Dict.X /></div>;
     }
-    
+
     _c4 = Foo;
     const B = hoc(A); // This is currently registered as a false positive:
 
@@ -598,7 +598,7 @@ test!(
     _c6 = NotAComponent;
 
     var _c, _c1, _c2, _c3, _c4, _c5, _c6;
-    
+
     $RefreshReg$(_c, "Header");
     $RefreshReg$(_c1, "StyledFactory1");
     $RefreshReg$(_c2, "StyledFactory2");
@@ -671,11 +671,11 @@ test!(
     let Alias1 = A;
     let Alias2 = A.Foo;
     const Dict = {};
-    
+
     function Foo() {
       return [React.createElement(A), React.createElement(B), React.createElement(StyledFactory1), React.createElement(StyledFactory2), React.createElement(StyledFactory3), React.createElement(Alias1), React.createElement(Alias2), jsx(Header), React.createElement(Dict.X)];
     }
-    
+
     _c4 = Foo;
     React.createContext(Store);
     const B = hoc(A); // This is currently registered as a false positive:
@@ -684,9 +684,9 @@ test!(
     const NotAComponent = wow(A); // We could avoid it but it also doesn't hurt.
 
     _c6 = NotAComponent;
-    
+
     var _c, _c1, _c2, _c3, _c4, _c5, _c6;
-    
+
     $RefreshReg$(_c, "Header");
     $RefreshReg$(_c1, "StyledFactory1");
     $RefreshReg$(_c2, "StyledFactory2");
@@ -716,7 +716,7 @@ test!(
     function Foo() {
       return <h1>Hi</h1>;
     }
-    
+
     _c = Foo;
     export default _c1 = hoc(Foo);
     export const A = hoc(Foo);
@@ -752,18 +752,18 @@ test!(
 
     export default function App() {
       _s();
-    
+
       const [foo, setFoo] = useState(0);
       React.useEffect(() => {});
       return <h1>{foo}</h1>;
     }
 
     _s(App, "useState{[foo, setFoo](0)}\nuseEffect{}");
-    
+
     _c = App;
-    
+
     var _c;
-    
+
     $RefreshReg$(_c, "App");
 "#
 );
@@ -796,26 +796,26 @@ test!(
 
     export function Foo() {
       _s();
-  
+
       const [foo, setFoo] = useState(0);
       React.useEffect(() => {});
       return <h1>{foo}</h1>;
     }
 
     _s(Foo, "useState{[foo, setFoo](0)}\nuseEffect{}");
-  
+
     _c = Foo;
 
     function Bar() {
       _s1();
-  
+
       const [foo, setFoo] = useState(0);
       React.useEffect(() => {});
       return <h1>{foo}</h1>;
     }
 
     _s1(Bar, "useState{[foo, setFoo](0)}\nuseEffect{}");
-  
+
     _c1 = Bar;
 
     function baz() {
@@ -826,7 +826,7 @@ test!(
     _s2(baz, "useState{}\nuseState{}");
 
     var _c, _c1;
-  
+
     $RefreshReg$(_c, "Foo");
     $RefreshReg$(_c1, "Bar");
 "#
@@ -864,7 +864,7 @@ test!(
 
     export const A = _s2(React.memo(_c1 = _s2 (React.forwardRef(_c = _s2((props, ref) => {
       _s2();
-    
+
       const [foo, setFoo] = useState(0);
       React.useEffect(() => {});
       return <h1 ref={ref}>{foo}</h1>;
@@ -872,7 +872,7 @@ test!(
     _c2 = A;
     export const B = _s1(React.memo(_c4 = _s1(React.forwardRef(_c3 = _s1(function (props, ref) {
       _s1();
-    
+
       const [foo, setFoo] = useState(0);
       React.useEffect(() => {});
       return <h1 ref={ref}>{foo}</h1>;
@@ -1119,9 +1119,9 @@ test!(
     exports.default = App;
     var _hooks = require("./hooks");
     var _foo = _interopRequireDefault(require("./foo"));
-    
+
     var _s = $RefreshSig$();
-    
+
     function App() {
       _s();
 
@@ -1129,15 +1129,15 @@ test!(
       const foo = (0, _foo).default();
       return <h1>{bar}</h1>;
     }
-    
+
     _s(App, "useFancyState{bar}\nuseFoo{foo}", false, function () {
       return [_hooks.useFancyState, _foo.default];
     });
-    
+
     _c = App;
-    
+
     var _c;
-    
+
     $RefreshReg$(_c, "App");
 "#
 );
@@ -1182,22 +1182,22 @@ test!(
       }
 
       _s1(useFancyState, "useState{[foo, setFoo](0)}\nuseFancyEffect{}", true);
-    
+
       const bar = useFancyState();
       const baz = FancyHook.useThing();
       React.useState();
       useThePlatform();
       return <h1>{bar}{baz}</h1>;
     }
-    
+
     _s(App, "useFancyState{bar}\nuseThing{baz}\nuseState{}\nuseThePlatform{}", true, function () {
       return [FancyHook.useThing];
     });
-    
+
     _c = App;
-    
+
     var _c;
-    
+
     $RefreshReg$(_c, "App");
 "#
 );
@@ -1244,9 +1244,9 @@ test!(
         </div>;
     }
     _c = App;
-    
+
     var _c;
-    
+
     $RefreshReg$(_c, "App");
 "#
 );
@@ -1323,10 +1323,10 @@ test!(
     r#"
     while (item) {
       var _s = $RefreshSig$();
-    
+
       _s(item => {
         _s();
-    
+
         useFoo();
       }, "useFoo{}", true)(item);
     }
@@ -1366,17 +1366,17 @@ test!(
 
     export default function Bar() {
       _s();
-    
+
       useContext(X);
       return <Foo />;
     }
-    
+
     _s(Bar, "useContext{}");
-    
+
     _c = Bar;
-    
+
     var _c;
-    
+
     import_meta_refreshReg(_c, "Bar");
 "#
 );
@@ -1392,7 +1392,7 @@ test!(
     function useHooks() {
       return useMemo(() => 1);
     }
-  
+
     declare module 'x' {}
 "#,
     r#"

--- a/ecmascript/transforms/tests/decorators.rs
+++ b/ecmascript/transforms/tests/decorators.rs
@@ -75,7 +75,7 @@ class A {}
 "#,
     r#"
 let A = _decorate([dec()], function (_initialize) {
-  
+
 
   class A {
     constructor() {
@@ -116,7 +116,7 @@ class B extends A {
 "#,
     r#"
 let B = _decorate([dec], function (_initialize, _A) {
-  
+
 
   class B extends _A {
     constructor() {
@@ -197,7 +197,7 @@ class B extends A {
 "#,
     r#"
 let B = _decorate([dec], function (_initialize, _A) {
-  
+
 
   class B extends _A {
     constructor() {
@@ -297,7 +297,7 @@ class Foo {
     r#"
 var method = 1;
 let Foo = _decorate([decorator], function (_initialize) {
-  
+
 
   class Foo {
     constructor() {
@@ -432,7 +432,7 @@ class Foo {
 "#,
     r#"
 let Foo = _decorate([_ => desc = _], function (_initialize) {
-  
+
 
   class Foo {
     constructor() {
@@ -542,7 +542,7 @@ class Sub extends Super {
 "#,
     r#"
 let Sub = _decorate([decorator(parameter)], function (_initialize, _Super) {
-  
+
 
   class Sub extends _Super {
     constructor() {
@@ -599,7 +599,7 @@ class A {
 "#,
     r#"
 let A = _decorate([dec(a, b, ...c)], function (_initialize) {
-  
+
 
   class A {
     constructor() {
@@ -723,7 +723,7 @@ class B extends A {
 "#,
     r#"
 let B = _decorate([dec], function (_initialize, _A) {
-  
+
 
   class B extends _A {
     constructor() {
@@ -938,7 +938,7 @@ test!(
     transformation_strict_directive,
     r#"
 (() => {
-  
+
 
   @dec
   class Foo {
@@ -956,7 +956,7 @@ test!(
 "#,
     r#"
 () => {
-  
+
 
   let Foo = _decorate([dec], function (_initialize) {
     class Foo {
@@ -979,7 +979,7 @@ test!(
 
 () => {
   let Foo = _decorate([dec], function (_initialize2) {
-    
+
 
     class Foo {
       constructor() {
@@ -1172,7 +1172,7 @@ test!(
 "#,
     r#"
 let A = _decorate([dec], function (_initialize, _B) {
-  
+
 
   class A extends _B {
     constructor(...args) {
@@ -1206,7 +1206,7 @@ async function g() {
     r#"
 async function g() {
   let A = _decorate([dec], function (_initialize, _super) {
-    
+
 
     class A extends _super {
       constructor(...args) {
@@ -1240,7 +1240,7 @@ function* g() {
     r#"
 function* g() {
   let A = _decorate([dec], function (_initialize, _super) {
-    
+
 
     class A extends _super {
       constructor(...args) {
@@ -1431,7 +1431,7 @@ class B extends A {
 "#,
     r#"
 let B = _decorate([dec], function (_initialize, _A) {
-  
+
 
   class B extends _A {
     constructor() {
@@ -1672,7 +1672,7 @@ test!(
 "#,
     r#"
 _decorate([dec()], function (_initialize) {
-  
+
 
   class _class {
     constructor() {
@@ -1736,7 +1736,7 @@ class Foo {
 "#,
     r#"
 let Foo = _decorate([_ => desc = _], function (_initialize) {
-  
+
 
   class Foo {
     constructor() {
@@ -4441,7 +4441,7 @@ export class Product extends TimestampedEntity {
 
   @OneToMany(() => Discount, (discount) => discount.product)
   public discounts!: Discount[];
-}   
+}
 ",
     "var _class, _descriptor, _dec, _descriptor1, _dec1, _descriptor2, _dec2, _descriptor3, \
      _dec3, _descriptor4, _dec4, _descriptor5, _dec5;
@@ -4666,7 +4666,7 @@ test!(
       private generic: Generic<A>,
       generic2: Generic<A, B>
     ) {}
-  
+
     @Run
     method(
       generic: Inter<A>,
@@ -4739,13 +4739,13 @@ test!(
     @Controller()
     export class AppController {
       constructor(private appService: AppService) {}
-    
+
       @Inject()
       appService: AppService;
-    
+
       @Inject()
       private appService2: AppService;
-    
+
       @Get()
       getHello(): string {
         return this.appService.getHello();
@@ -4831,28 +4831,28 @@ test!(
     "class Injected {}
 
     class MyClass {
-      constructor(@inject() parameter: Injected) {}  
+      constructor(@inject() parameter: Injected) {}
     }
-    
+
     class MyOtherClass {
       constructor(
-        @inject() private readonly parameter: Injected, 
+        @inject() private readonly parameter: Injected,
         @inject('KIND') otherParam: Injected
       ) {}
-    
+
       methodUndecorated(@demo() param: string, otherParam) {}
-    
+
       @decorate('named')
       method(@inject() param: Injected, @arg() schema: Schema) {}
     }
-    
+
     @Decorate
     class DecoratedClass {
       constructor(
         @inject() private readonly module: Injected,
         @inject() otherModule: Injected
       ) {}
-      
+
       @decorate('example')
       method(@inject() param: string) {}
     }",
@@ -4942,16 +4942,16 @@ test!(
     legacy_metadata_type_serialization,
     "import { Service } from './service';
     import { Decorate } from './Decorate';
-    
+
     const sym = Symbol();
-    
+
     @Decorate()
     class Sample {
       constructor(
         private p0: String,
         p1: Number,
         p2: 10,
-        p3: 'ABC',    
+        p3: 'ABC',
         p4: boolean,
         p5: string,
         p6: number,
@@ -4968,7 +4968,7 @@ test!(
         p17: true,
         p18: string = 'abc'
       ) {}
-    
+
       @Decorate
       method(
         @Arg() p0: Symbol,
@@ -4990,16 +4990,16 @@ test!(
         p16: any,
         p17: bigint,
       ) {}
-    
+
       /**
        * Member Expression
        */
       @Decorate()
       method2(
         p0: Decorate.Name = 'abc',
-        p1: Decorate.Name 
+        p1: Decorate.Name
       ) {}
-    
+
       /**
        * Assignments
        */
@@ -5097,12 +5097,12 @@ test!(
       x = \"xxx\",
       y = \"yyy\"
     }
-    
+
     class Xpto {
       @Decorator()
       value!: MyEnum;
     }
-    
+
     function Decorator() {
       return function (...args) {};
     }
@@ -5765,7 +5765,7 @@ test!(
     @dec
     someMethod() {}
   }
-  
+
   class OtherClass extends SomeClass {
     @dec
     anotherMethod() {

--- a/tests/rust_api.rs
+++ b/tests/rust_api.rs
@@ -69,7 +69,7 @@ fn shopify_1_check_filename() {
             "
             import React from 'react';
             import { useI18n } from '@shopify/react-i18n';
-            
+
             export function App() {
                 const [i18n] = useI18n();
                 return <h1>{i18n.translate('foo')}</h1>
@@ -170,7 +170,7 @@ fn shopify_2_same_opt() {
             "
             import React from 'react';
             import { useI18n } from '@shopify/react-i18n';
-            
+
             export function App() {
                 const [i18n] = useI18n();
                 return <h1>{i18n.translate('foo')}</h1>
@@ -232,7 +232,7 @@ fn shopify_3_reduce_defaults() {
             "
             import React from 'react';
             import { useI18n } from '@shopify/react-i18n';
-            
+
             export function App() {
                 const [i18n] = useI18n();
                 return <h1>{i18n.translate('foo')}</h1>
@@ -288,7 +288,7 @@ fn shopify_4_reduce_more() {
             "
             import React from 'react';
             import { useI18n } from '@shopify/react-i18n';
-            
+
             export function App() {
                 const [i18n] = useI18n();
                 return <h1>{i18n.translate('foo')}</h1>


### PR DESCRIPTION
from discussion https://github.com/swc-project/swc/pull/2667#pullrequestreview-799506549

This PR removes trailing whitespace from codes in the repo. Note PR only touches src codes (*.rs). Some of fixture test will fail if fixture strips whitespace as it'll change spans.