### PR TITLE
refactor(css/ast): remove `UniversalSelector`

### DIFF
--- a/css/ast/src/selector.rs
+++ b/css/ast/src/selector.rs
@@ -138,12 +138,6 @@ pub struct PseudoSelector {
     pub args: Tokens,
 }
 
-/// `*`
-#[ast_node]
-pub struct UniversalSelector {
-    pub span: Span,
-}
-
 #[ast_node("IdSelector")]
 pub struct IdSelector {
     pub span: Span,

--- a/css/parser/tests/fixture.rs
+++ b/css/parser/tests/fixture.rs
@@ -348,7 +348,6 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(Tokens, visit_tokens);
     mtd!(Unit, visit_unit);
     mtd!(UnitValue, visit_unit_value);
-    mtd!(UniversalSelector, visit_universal_selector);
     mtd!(UrlValue, visit_url_value);
     mtd!(Value, visit_value);
 

--- a/css/visit/src/lib.rs
+++ b/css/visit/src/lib.rs
@@ -242,10 +242,6 @@ define!({
         pub args: Tokens,
     }
 
-    pub struct UniversalSelector {
-        pub span: Span,
-    }
-
     pub struct IdSelector {
         pub span: Span,
         pub text: Text,


### PR DESCRIPTION
Remove `UniversalSelector`, we don't use it in code (maybe we forgot to remove it when we do refactor), also `UniversalSelector` is subtype of `TypeSelector`.
