### PR TITLE
fix(es/transforms/cjs): bind reassign scope to default export fn

### DIFF
--- a/ecmascript/transforms/module/tests/fixture/commonjs/issue-2678/input.js
+++ b/ecmascript/transforms/module/tests/fixture/commonjs/issue-2678/input.js
@@ -1,0 +1,21 @@
+export default function someCall() {
+    throw new Error('this should not be called');
+}
+
+export function warn() {
+    throw new Error('this should not be called');
+}
+
+export const test = {};
+Object.defineProperty(test, 'someCall', {
+    set: (v) => {
+        someCall = v;
+    }
+})
+
+Object.defineProperty(test, 'warn', {
+    get: () => warn,
+    set: (v) => {
+        warn = v;
+    },
+});

--- a/ecmascript/transforms/module/tests/fixture/commonjs/issue-2678/output.js
+++ b/ecmascript/transforms/module/tests/fixture/commonjs/issue-2678/output.js
@@ -1,0 +1,28 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.default = someCall;
+exports.warn = warn;
+exports.test = void 0;
+function someCall() {
+    throw new Error("this should not be called");
+}
+function warn() {
+    throw new Error("this should not be called");
+}
+const test = {
+};
+exports.test = test;
+Object.defineProperty(test, "someCall", {
+    set: (v)=>{
+        exports.default = someCall = v;
+    }
+});
+Object.defineProperty(test, "warn", {
+    get: ()=>warn
+    ,
+    set: (v)=>{
+        exports.warn = warn = v;
+    }
+});


### PR DESCRIPTION
- closes #2678 

This PR attempt to fix #2678, one of the edge cases of #2549.

As same as fix for #2549, this PR sets scope to the exported. The only difference is it doesn't set scope to name of the declaration (or FnExpr's) as default export uses fixed name `default` for the export. Given current fold already creates default export member expr, reuses created one to assign into scope.
