### PR TITLE
fix(es): Move `TargetEnv` to loader from ast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2720,8 +2720,6 @@ dependencies = [
  "serde_json",
  "swc_atoms 0.2.9",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
  "testing",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "jsdoc"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2371,7 +2371,7 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "swc"
-version = "0.83.2"
+version = "0.84.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.80.0"
+version = "0.81.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "arbitrary",
  "is-macro",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "bitflags",
  "memchr",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_dep_graph"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "swc_atoms 0.2.9",
  "swc_common",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "phf",
  "swc_atoms 0.2.9",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "ahash",
  "ansi_term 0.12.1",
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.77.0"
+version = "0.78.0"
 dependencies = [
  "either",
  "enum_kind",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_plugin_ast"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "abi_stable",
  "num-bigint",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "ahash",
  "dashmap",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.93.0"
+version = "0.94.0"
 dependencies = [
  "pretty_assertions 0.6.1",
  "sourcemap",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.43.1"
+version = "0.44.0"
 dependencies = [
  "once_cell",
  "phf",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "swc_atoms 0.2.9",
  "swc_common",
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.50.5"
+version = "0.51.0"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.56.2"
+version = "0.57.0"
 dependencies = [
  "Inflector",
  "ahash",
@@ -2948,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "ahash",
  "dashmap",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "either",
  "serde",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.58.1"
+version = "0.59.0"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "serde",
  "swc_atoms 0.2.9",
@@ -3072,7 +3072,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "once_cell",
  "rayon",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "num-bigint",
  "swc_atoms 0.2.9",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.85.0"
+version = "0.86.0"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "abi_stable",
  "anyhow",
@@ -3198,7 +3198,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "abi_stable",
  "anyhow",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_testing"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "swc_atoms 0.2.9",

--- a/crates/jsdoc/Cargo.toml
+++ b/crates/jsdoc/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/jsdoc/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "jsdoc"
-version = "0.46.0"
+version = "0.47.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,7 +18,7 @@ swc_common = {version = "0.14.0", path = "../swc_common"}
 [dev-dependencies]
 anyhow = "1"
 dashmap = "4.0.2"
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
 testing = {version = "0.15.0", path = "../testing"}
 walkdir = "2"

--- a/crates/node/src/bundle.rs
+++ b/crates/node/src/bundle.rs
@@ -19,9 +19,8 @@ use swc_bundler::{BundleKind, Bundler, Load, ModuleRecord, Resolve};
 use swc_common::{collections::AHashMap, Span};
 use swc_ecma_ast::{
     Bool, Expr, ExprOrSuper, Ident, KeyValueProp, Lit, MemberExpr, MetaPropExpr, PropName, Str,
-    TargetEnv,
 };
-use swc_ecma_loader::NODE_BUILTINS;
+use swc_ecma_loader::{TargetEnv, NODE_BUILTINS};
 
 struct ConfigItem {
     loader: Box<dyn Load>,

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -9,7 +9,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.83.2"
+version = "0.84.0"
 
 [lib]
 name = "swc"
@@ -49,14 +49,14 @@ serde_json = "1"
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common", features = ["sourcemap", "concurrent"]}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_codegen = {version = "0.79.0", path = "../swc_ecma_codegen"}
-swc_ecma_ext_transforms = {version = "0.37.0", path = "../swc_ecma_ext_transforms"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_codegen = {version = "0.80.0", path = "../swc_ecma_codegen"}
+swc_ecma_ext_transforms = {version = "0.38.0", path = "../swc_ecma_ext_transforms"}
 swc_ecma_loader = {version = "0.24.1", path = "../swc_ecma_loader", features = ["lru", "node", "tsc"]}
-swc_ecma_minifier = {version = "0.49.0", path = "../swc_ecma_minifier"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
-swc_ecma_preset_env = {version = "0.64.0", path = "../swc_ecma_preset_env"}
-swc_ecma_transforms = {version = "0.93.0", path = "../swc_ecma_transforms", features = [
+swc_ecma_minifier = {version = "0.50.0", path = "../swc_ecma_minifier"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
+swc_ecma_preset_env = {version = "0.65.0", path = "../swc_ecma_preset_env"}
+swc_ecma_transforms = {version = "0.94.0", path = "../swc_ecma_transforms", features = [
   "compat",
   "module",
   "optimization",
@@ -64,12 +64,12 @@ swc_ecma_transforms = {version = "0.93.0", path = "../swc_ecma_transforms", feat
   "react",
   "typescript",
 ]}
-swc_ecma_transforms_base = {version = "0.43.0", path = "../swc_ecma_transforms_base"}
-swc_ecma_transforms_compat = {version = "0.50.0", path = "../swc_ecma_transforms_compat"}
-swc_ecma_transforms_optimization = {version = "0.63.0", path = "../swc_ecma_transforms_optimization"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
-swc_ecmascript = {version = "0.85.0", path = "../swc_ecmascript"}
+swc_ecma_transforms_base = {version = "0.44.0", path = "../swc_ecma_transforms_base"}
+swc_ecma_transforms_compat = {version = "0.51.0", path = "../swc_ecma_transforms_compat"}
+swc_ecma_transforms_optimization = {version = "0.64.0", path = "../swc_ecma_transforms_optimization"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
+swc_ecmascript = {version = "0.86.0", path = "../swc_ecmascript"}
 swc_visit = {version = "0.2.3", path = "../swc_visit"}
 tracing = "0.1.28"
 

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -165,9 +165,9 @@ pub mod resolver {
     use crate::config::CompiledPaths;
     use std::path::PathBuf;
     use swc_common::collections::AHashMap;
-    use swc_ecma_ast::TargetEnv;
-    use swc_ecma_loader::resolvers::{
-        lru::CachingResolver, node::NodeModulesResolver, tsc::TsConfigResolver,
+    use swc_ecma_loader::{
+        resolvers::{lru::CachingResolver, node::NodeModulesResolver, tsc::TsConfigResolver},
+        TargetEnv,
     };
 
     pub type NodeResolver = CachingResolver<NodeModulesResolver>;

--- a/crates/swc_bundler/Cargo.toml
+++ b/crates/swc_bundler/Cargo.toml
@@ -9,7 +9,7 @@ include = ["Cargo.toml", "build.rs", "src/**/*.rs", "src/**/*.js"]
 license = "Apache-2.0/MIT"
 name = "swc_bundler"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.80.0"
+version = "0.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -38,14 +38,14 @@ relative-path = "1.2"
 retain_mut = "0.1.2"
 swc_atoms = {version = "0.2.4", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_codegen = {version = "0.79.0", path = "../swc_ecma_codegen"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_codegen = {version = "0.80.0", path = "../swc_ecma_codegen"}
 swc_ecma_loader = {version = "0.24.0", path = "../swc_ecma_loader"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
-swc_ecma_transforms_base = {version = "0.43.0", path = "../swc_ecma_transforms_base"}
-swc_ecma_transforms_optimization = {version = "0.63.0", path = "../swc_ecma_transforms_optimization"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
+swc_ecma_transforms_base = {version = "0.44.0", path = "../swc_ecma_transforms_base"}
+swc_ecma_transforms_optimization = {version = "0.64.0", path = "../swc_ecma_transforms_optimization"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 tracing = "0.1.28"
 
 [dev-dependencies]
@@ -55,9 +55,9 @@ path-clean = "=0.1.0"
 reqwest = {version = "0.11.4", features = ["blocking"]}
 sha-1 = "0.9"
 swc_ecma_loader = {version = "0.24.0", path = "../swc_ecma_loader", features = ["node", "lru"]}
-swc_ecma_minifier = {version = "0.49.0", path = "../swc_ecma_minifier"}
-swc_ecma_transforms_react = {version = "0.58.0", path = "../swc_ecma_transforms_react"}
-swc_ecma_transforms_typescript = {version = "0.59.0", path = "../swc_ecma_transforms_typescript"}
+swc_ecma_minifier = {version = "0.50.0", path = "../swc_ecma_minifier"}
+swc_ecma_transforms_react = {version = "0.59.0", path = "../swc_ecma_transforms_react"}
+swc_ecma_transforms_typescript = {version = "0.60.0", path = "../swc_ecma_transforms_typescript"}
 swc_node_base = {version = "0.5.0", path = "../swc_node_base"}
 tempfile = "3.1.0"
 testing = {version = "0.15.0", path = "../testing"}

--- a/crates/swc_bundler/examples/bundle.rs
+++ b/crates/swc_bundler/examples/bundle.rs
@@ -18,7 +18,10 @@ use swc_common::{
 };
 use swc_ecma_ast::*;
 use swc_ecma_codegen::{text_writer::JsWriter, Emitter};
-use swc_ecma_loader::resolvers::{lru::CachingResolver, node::NodeModulesResolver};
+use swc_ecma_loader::{
+    resolvers::{lru::CachingResolver, node::NodeModulesResolver},
+    TargetEnv,
+};
 use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, StringInput, Syntax};
 
 fn print_bundles(cm: Lrc<SourceMap>, modules: Vec<Bundle>) {

--- a/crates/swc_ecma_ast/Cargo.toml
+++ b/crates/swc_ecma_ast/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ast"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.57.0"
+version = "0.58.0"
 
 [features]
 default = []

--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -129,18 +129,3 @@ impl Default for EsVersion {
         EsVersion::Es5
     }
 }
-
-/// Target runtime environment.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
-pub enum TargetEnv {
-    #[serde(rename = "browser")]
-    Browser,
-    #[serde(rename = "node")]
-    Node,
-}
-
-impl Default for TargetEnv {
-    fn default() -> Self {
-        TargetEnv::Browser
-    }
-}

--- a/crates/swc_ecma_codegen/Cargo.toml
+++ b/crates/swc_ecma_codegen/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_codegen"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.79.0"
+version = "0.80.0"
 
 [dependencies]
 bitflags = "1"
@@ -17,9 +17,9 @@ once_cell = "1.8.0"
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
 swc_ecma_codegen_macros = {version = "0.6.0", path = "../swc_ecma_codegen_macros"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/swc_ecma_dep_graph/Cargo.toml
+++ b/crates/swc_ecma_dep_graph/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_dep_graph"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.46.0"
+version = "0.47.0"
 
 [dependencies]
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 
 [dev-dependencies]
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
 testing = {version = "0.15.0", path = "../testing"}

--- a/crates/swc_ecma_ext_transforms/Cargo.toml
+++ b/crates/swc_ecma_ext_transforms/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_ext_transforms/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_ext_transforms"
-version = "0.37.0"
+version = "0.38.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,7 +13,7 @@ version = "0.37.0"
 phf = {version = "0.8.0", features = ["macros"]}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}

--- a/crates/swc_ecma_loader/Cargo.toml
+++ b/crates/swc_ecma_loader/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 default = []
 
 # Enable node js resolver
-node = ["normpath", "serde", "serde_json", "dashmap", "once_cell", "path-clean"]
+node = ["normpath", "serde_json", "dashmap", "once_cell", "path-clean"]
 # Enable support for `paths` of tsconfig.json
 tsc = ["dashmap", "once_cell", "regex"]
 
@@ -27,7 +27,7 @@ lru = {version = "0.6.5", optional = true}
 once_cell = {version = "1.8.0", optional = true}
 path-clean = {version = "=0.1.0", optional = true}
 regex = {version = "1", optional = true}
-serde = {version = "1.0.126", optional = true}
+serde = {version = "1", features = ["derive"]}
 serde_json = {version = "1.0.64", optional = true}
 swc_atoms = {version = "0.2.3", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}

--- a/crates/swc_ecma_loader/Cargo.toml
+++ b/crates/swc_ecma_loader/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_loader"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.24.1"
+version = "0.24.2"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -31,8 +31,6 @@ serde = {version = "1.0.126", optional = true}
 serde_json = {version = "1.0.64", optional = true}
 swc_atoms = {version = "0.2.3", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
 tracing = "0.1.28"
 
 [dev-dependencies]

--- a/crates/swc_ecma_loader/src/lib.rs
+++ b/crates/swc_ecma_loader/src/lib.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 pub mod resolve;
 pub mod resolvers;
 
@@ -69,3 +71,18 @@ pub const NODE_BUILTINS: &[&str] = &[
     "worker_threads",
     "zlib",
 ];
+
+/// Target runtime environment.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
+pub enum TargetEnv {
+    #[serde(rename = "browser")]
+    Browser,
+    #[serde(rename = "node")]
+    Node,
+}
+
+impl Default for TargetEnv {
+    fn default() -> Self {
+        TargetEnv::Browser
+    }
+}

--- a/crates/swc_ecma_loader/src/resolvers/node.rs
+++ b/crates/swc_ecma_loader/src/resolvers/node.rs
@@ -2,7 +2,7 @@
 //!
 //! See: https://github.com/goto-bus-stop/node-resolve
 
-use crate::{resolve::Resolve, NODE_BUILTINS};
+use crate::{resolve::Resolve, TargetEnv, NODE_BUILTINS};
 use anyhow::{bail, Context, Error};
 use dashmap::{DashMap, DashSet};
 #[cfg(windows)]
@@ -16,7 +16,6 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 use swc_common::{collections::AHashMap, FileName};
-use swc_ecma_ast::TargetEnv;
 use tracing::debug;
 
 static PACKAGE: &str = "package.json";

--- a/crates/swc_ecma_minifier/Cargo.toml
+++ b/crates/swc_ecma_minifier/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "src/lists/*.json"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_minifier"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.49.1"
+version = "0.50.0"
 
 [features]
 debug = ["backtrace"]
@@ -26,13 +26,13 @@ serde_json = "1.0.61"
 serde_regex = "1.1.0"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_codegen = {version = "0.79.0", path = "../swc_ecma_codegen"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
-swc_ecma_transforms = {version = "0.93.0", path = "../swc_ecma_transforms/", features = ["optimization"]}
-swc_ecma_transforms_base = {version = "0.43.0", path = "../swc_ecma_transforms_base"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_codegen = {version = "0.80.0", path = "../swc_ecma_codegen"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
+swc_ecma_transforms = {version = "0.94.0", path = "../swc_ecma_transforms/", features = ["optimization"]}
+swc_ecma_transforms_base = {version = "0.44.0", path = "../swc_ecma_transforms_base"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 tracing = "0.1.28"
 unicode-xid = "0.2.2"
 

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_parser"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.77.0"
+version = "0.78.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -27,8 +27,8 @@ serde = {version = "1", features = ["derive"]}
 smallvec = "1"
 swc_atoms = {version = "0.2.3", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 tracing = "0.1.28"
 typed-arena = "2.0.1"
 unicode-xid = "0.2"

--- a/crates/swc_ecma_plugin_ast/Cargo.toml
+++ b/crates/swc_ecma_plugin_ast/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_plugin_ast"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.1.0"
+version = "0.2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,11 +15,11 @@ num-bigint = "0.2"
 rplugin = {version = "0.1", path = "../rplugin/"}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.6", path = "../swc_common", features = ["plugin-base"]}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast/"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast/"}
 
 [dev-dependencies]
 serde = "1"
 serde_json = "1"
-swc_ecma_parser = {version = "0.77", path = "../swc_ecma_parser"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
 swc_node_base = {version = "0.5.1", path = "../swc_node_base"}
 testing = {version = "0.15.1", path = "../testing"}

--- a/crates/swc_ecma_preset_env/Cargo.toml
+++ b/crates/swc_ecma_preset_env/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_preset_env/"
 edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_preset_env"
-version = "0.64.0"
+version = "0.65.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,14 +21,14 @@ st-map = "0.1.2"
 string_enum = {version = "0.3.1", path = "../string_enum"}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_transforms = {version = "0.93.0", path = "../swc_ecma_transforms", features = ["compat", "proposal"]}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_transforms = {version = "0.94.0", path = "../swc_ecma_transforms", features = ["compat", "proposal"]}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 walkdir = "2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
-swc_ecma_codegen = {version = "0.79.0", path = "../swc_ecma_codegen"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
+swc_ecma_codegen = {version = "0.80.0", path = "../swc_ecma_codegen"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
 testing = {version = "0.15.0", path = "../testing"}

--- a/crates/swc_ecma_transforms/Cargo.toml
+++ b/crates/swc_ecma_transforms/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.93.0"
+version = "0.94.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -24,24 +24,24 @@ typescript = ["swc_ecma_transforms_typescript"]
 [dependencies]
 swc_atoms = {version = "0.2.0", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
-swc_ecma_transforms_base = {version = "0.43.0", path = "../swc_ecma_transforms_base"}
-swc_ecma_transforms_compat = {version = "0.50.0", path = "../swc_ecma_transforms_compat", optional = true}
-swc_ecma_transforms_module = {version = "0.56.0", path = "../swc_ecma_transforms_module", optional = true}
-swc_ecma_transforms_optimization = {version = "0.63.0", path = "../swc_ecma_transforms_optimization", optional = true}
-swc_ecma_transforms_proposal = {version = "0.56.0", path = "../swc_ecma_transforms_proposal", optional = true}
-swc_ecma_transforms_react = {version = "0.58.0", path = "../swc_ecma_transforms_react", optional = true}
-swc_ecma_transforms_typescript = {version = "0.59.0", path = "../swc_ecma_transforms_typescript", optional = true}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
+swc_ecma_transforms_base = {version = "0.44.0", path = "../swc_ecma_transforms_base"}
+swc_ecma_transforms_compat = {version = "0.51.0", path = "../swc_ecma_transforms_compat", optional = true}
+swc_ecma_transforms_module = {version = "0.57.0", path = "../swc_ecma_transforms_module", optional = true}
+swc_ecma_transforms_optimization = {version = "0.64.0", path = "../swc_ecma_transforms_optimization", optional = true}
+swc_ecma_transforms_proposal = {version = "0.57.0", path = "../swc_ecma_transforms_proposal", optional = true}
+swc_ecma_transforms_react = {version = "0.59.0", path = "../swc_ecma_transforms_react", optional = true}
+swc_ecma_transforms_typescript = {version = "0.60.0", path = "../swc_ecma_transforms_typescript", optional = true}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
 sourcemap = "6"
-swc_ecma_codegen = {version = "0.79.0", path = "../swc_ecma_codegen"}
-swc_ecma_transforms_testing = {version = "0.44.0", path = "../swc_ecma_transforms_testing"}
+swc_ecma_codegen = {version = "0.80.0", path = "../swc_ecma_codegen"}
+swc_ecma_transforms_testing = {version = "0.45.0", path = "../swc_ecma_transforms_testing"}
 tempfile = "3"
 testing = {version = "0.15.0", path = "../testing"}
 walkdir = "2"

--- a/crates/swc_ecma_transforms_base/Cargo.toml
+++ b/crates/swc_ecma_transforms_base/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_base"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.43.1"
+version = "0.44.0"
 
 [features]
 concurrent = [
@@ -22,13 +22,13 @@ scoped-tls = "1.0.0"
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 tracing = "0.1"
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.79.0", path = "../swc_ecma_codegen"}
+swc_ecma_codegen = {version = "0.80.0", path = "../swc_ecma_codegen"}
 swc_ecma_transforms_macros = {version = "0.3.0", path = "../swc_ecma_transforms_macros"}
 testing = {version = "0.15.0", path = "../testing"}

--- a/crates/swc_ecma_transforms_classes/Cargo.toml
+++ b/crates/swc_ecma_transforms_classes/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_classes"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.29.0"
+version = "0.30.0"
 
 [dependencies]
 swc_atoms = {version = "0.2.6", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_transforms_base = {version = "0.43.0", path = "../swc_ecma_transforms_base"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_transforms_base = {version = "0.44.0", path = "../swc_ecma_transforms_base"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}

--- a/crates/swc_ecma_transforms_compat/Cargo.toml
+++ b/crates/swc_ecma_transforms_compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_compat"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.50.5"
+version = "0.51.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -28,15 +28,15 @@ serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2.5", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_transforms_base = {version = "0.43.0", path = "../swc_ecma_transforms_base"}
-swc_ecma_transforms_classes = {version = "0.29.0", path = "../swc_ecma_transforms_classes"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_transforms_base = {version = "0.44.0", path = "../swc_ecma_transforms_base"}
+swc_ecma_transforms_classes = {version = "0.30.0", path = "../swc_ecma_transforms_classes"}
 swc_ecma_transforms_macros = {version = "0.3.0", path = "../swc_ecma_transforms_macros"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 
 [dev-dependencies]
 serde_json = "1.0.66"
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
-swc_ecma_transforms_testing = {version = "0.44.0", path = "../swc_ecma_transforms_testing"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
+swc_ecma_transforms_testing = {version = "0.45.0", path = "../swc_ecma_transforms_testing"}
 testing = {version = "0.15.0", path = "../testing"}

--- a/crates/swc_ecma_transforms_module/Cargo.toml
+++ b/crates/swc_ecma_transforms_module/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_module"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.56.2"
+version = "0.57.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -18,14 +18,14 @@ pathdiff = "0.2.0"
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
 swc_ecma_loader = {version = "0.24.1", path = "../swc_ecma_loader", features = ["node"]}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
-swc_ecma_transforms_base = {version = "0.43.0", path = "../swc_ecma_transforms_base"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
+swc_ecma_transforms_base = {version = "0.44.0", path = "../swc_ecma_transforms_base"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.50.0", path = "../swc_ecma_transforms_compat"}
-swc_ecma_transforms_testing = {version = "0.44.0", path = "../swc_ecma_transforms_testing/"}
+swc_ecma_transforms_compat = {version = "0.51.0", path = "../swc_ecma_transforms_compat"}
+swc_ecma_transforms_testing = {version = "0.45.0", path = "../swc_ecma_transforms_testing/"}
 testing = {version = "0.15.0", path = "../testing/"}

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_optimization"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.63.0"
+version = "0.64.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -28,19 +28,19 @@ retain_mut = "0.1.2"
 serde_json = "1.0.61"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
-swc_ecma_transforms_base = {version = "0.43.0", path = "../swc_ecma_transforms_base"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
+swc_ecma_transforms_base = {version = "0.44.0", path = "../swc_ecma_transforms_base"}
 swc_ecma_transforms_macros = {version = "0.3.0", path = "../swc_ecma_transforms_macros"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 tracing = "0.1.28"
 
 [dev-dependencies]
-swc_ecma_transforms_compat = {version = "0.50.0", path = "../swc_ecma_transforms_compat"}
-swc_ecma_transforms_module = {version = "0.56.0", path = "../swc_ecma_transforms_module"}
-swc_ecma_transforms_proposal = {version = "0.56.0", path = "../swc_ecma_transforms_proposal"}
-swc_ecma_transforms_react = {version = "0.58.0", path = "../swc_ecma_transforms_react"}
-swc_ecma_transforms_testing = {version = "0.44.0", path = "../swc_ecma_transforms_testing"}
-swc_ecma_transforms_typescript = {version = "0.59.0", path = "../swc_ecma_transforms_typescript"}
+swc_ecma_transforms_compat = {version = "0.51.0", path = "../swc_ecma_transforms_compat"}
+swc_ecma_transforms_module = {version = "0.57.0", path = "../swc_ecma_transforms_module"}
+swc_ecma_transforms_proposal = {version = "0.57.0", path = "../swc_ecma_transforms_proposal"}
+swc_ecma_transforms_react = {version = "0.59.0", path = "../swc_ecma_transforms_react"}
+swc_ecma_transforms_testing = {version = "0.45.0", path = "../swc_ecma_transforms_testing"}
+swc_ecma_transforms_typescript = {version = "0.60.0", path = "../swc_ecma_transforms_typescript"}
 testing = {version = "0.15.0", path = "../testing"}

--- a/crates/swc_ecma_transforms_proposal/Cargo.toml
+++ b/crates/swc_ecma_transforms_proposal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_proposal"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.56.0"
+version = "0.57.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,18 +20,18 @@ serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
 swc_ecma_loader = {version = "0.24.0", path = "../swc_ecma_loader", optional = true}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
-swc_ecma_transforms_base = {version = "0.43.0", path = "../swc_ecma_transforms_base"}
-swc_ecma_transforms_classes = {version = "0.29.0", path = "../swc_ecma_transforms_classes"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
+swc_ecma_transforms_base = {version = "0.44.0", path = "../swc_ecma_transforms_base"}
+swc_ecma_transforms_classes = {version = "0.30.0", path = "../swc_ecma_transforms_classes"}
 swc_ecma_transforms_macros = {version = "0.3.0", path = "../swc_ecma_transforms_macros"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 
 [dev-dependencies]
 serde_json = "1.0.66"
-swc_ecma_transforms_compat = {version = "0.50.0", path = "../swc_ecma_transforms_compat"}
-swc_ecma_transforms_module = {version = "0.56.0", path = "../swc_ecma_transforms_module"}
-swc_ecma_transforms_testing = {version = "0.44.0", path = "../swc_ecma_transforms_testing"}
+swc_ecma_transforms_compat = {version = "0.51.0", path = "../swc_ecma_transforms_compat"}
+swc_ecma_transforms_module = {version = "0.57.0", path = "../swc_ecma_transforms_module"}
+swc_ecma_transforms_testing = {version = "0.45.0", path = "../swc_ecma_transforms_testing"}
 testing = {version = "0.15.0", path = "../testing"}

--- a/crates/swc_ecma_transforms_react/Cargo.toml
+++ b/crates/swc_ecma_transforms_react/Cargo.toml
@@ -7,7 +7,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_react"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.58.1"
+version = "0.59.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -22,16 +22,16 @@ sha-1 = "0.9.4"
 string_enum = {version = "0.3.1", path = "../string_enum"}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
-swc_ecma_transforms_base = {version = "0.43.0", path = "../swc_ecma_transforms_base"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
+swc_ecma_transforms_base = {version = "0.44.0", path = "../swc_ecma_transforms_base"}
 swc_ecma_transforms_macros = {version = "0.3.0", path = "../swc_ecma_transforms_macros"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.79.0", path = "../swc_ecma_codegen/"}
-swc_ecma_transforms_compat = {version = "0.50.0", path = "../swc_ecma_transforms_compat/"}
-swc_ecma_transforms_module = {version = "0.56.0", path = "../swc_ecma_transforms_module"}
-swc_ecma_transforms_testing = {version = "0.44.0", path = "../swc_ecma_transforms_testing/"}
+swc_ecma_codegen = {version = "0.80.0", path = "../swc_ecma_codegen/"}
+swc_ecma_transforms_compat = {version = "0.51.0", path = "../swc_ecma_transforms_compat/"}
+swc_ecma_transforms_module = {version = "0.57.0", path = "../swc_ecma_transforms_module"}
+swc_ecma_transforms_testing = {version = "0.45.0", path = "../swc_ecma_transforms_testing/"}
 testing = {version = "0.15.0", path = "../testing"}

--- a/crates/swc_ecma_transforms_testing/Cargo.toml
+++ b/crates/swc_ecma_transforms_testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.44.0"
+version = "0.45.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,11 +18,11 @@ serde = "1"
 serde_json = "1"
 sha-1 = "0.9.8"
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_codegen = {version = "0.79.0", path = "../swc_ecma_codegen"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
-swc_ecma_transforms_base = {version = "0.43.0", path = "../swc_ecma_transforms_base"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_codegen = {version = "0.80.0", path = "../swc_ecma_codegen"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
+swc_ecma_transforms_base = {version = "0.44.0", path = "../swc_ecma_transforms_base"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 tempfile = "3.1.0"
 testing = {version = "0.15.0", path = "../testing"}

--- a/crates/swc_ecma_transforms_typescript/Cargo.toml
+++ b/crates/swc_ecma_transforms_typescript/Cargo.toml
@@ -6,25 +6,25 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_transforms_typescript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.59.0"
+version = "0.60.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
-swc_ecma_transforms_base = {version = "0.43.0", path = "../swc_ecma_transforms_base"}
-swc_ecma_transforms_react = {version = "0.58.0", path = "../swc_ecma_transforms_react"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
+swc_ecma_transforms_base = {version = "0.44.0", path = "../swc_ecma_transforms_base"}
+swc_ecma_transforms_react = {version = "0.59.0", path = "../swc_ecma_transforms_react"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.79.0", path = "../swc_ecma_codegen"}
-swc_ecma_transforms_compat = {version = "0.50.0", path = "../swc_ecma_transforms_compat"}
-swc_ecma_transforms_module = {version = "0.56.0", path = "../swc_ecma_transforms_module"}
-swc_ecma_transforms_proposal = {version = "0.56.0", path = "../swc_ecma_transforms_proposal"}
-swc_ecma_transforms_testing = {version = "0.44.0", path = "../swc_ecma_transforms_testing"}
+swc_ecma_codegen = {version = "0.80.0", path = "../swc_ecma_codegen"}
+swc_ecma_transforms_compat = {version = "0.51.0", path = "../swc_ecma_transforms_compat"}
+swc_ecma_transforms_module = {version = "0.57.0", path = "../swc_ecma_transforms_module"}
+swc_ecma_transforms_proposal = {version = "0.57.0", path = "../swc_ecma_transforms_proposal"}
+swc_ecma_transforms_testing = {version = "0.45.0", path = "../swc_ecma_transforms_testing"}
 testing = {version = "0.15.0", path = "../testing"}
 walkdir = "2.3.1"

--- a/crates/swc_ecma_utils/Cargo.toml
+++ b/crates/swc_ecma_utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_utils"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.51.0"
+version = "0.52.0"
 
 [features]
 # Process in parallel.
@@ -20,8 +20,8 @@ once_cell = "1"
 rayon = {version = "1.5.1", optional = true}
 swc_atoms = {version = "0.2.0", path = "../swc_atoms"}
 swc_common = {version = "0.14.3", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 unicode-xid = "0.2"
 
 [dev-dependencies]

--- a/crates/swc_ecma_visit/Cargo.toml
+++ b/crates/swc_ecma_visit/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecma_visit"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.43.0"
+version = "0.44.0"
 
 [dependencies]
 num-bigint = {version = "0.2", features = ["serde"]}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
 swc_visit = {version = "0.2.3", path = "../swc_visit"}

--- a/crates/swc_ecmascript/Cargo.toml
+++ b/crates/swc_ecmascript/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_ecmascript"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.85.0"
+version = "0.86.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -32,14 +32,14 @@ react = ["swc_ecma_transforms/react"]
 typescript = ["typescript-parser", "swc_ecma_transforms/typescript"]
 
 [dependencies]
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_codegen = {version = "0.79.0", path = "../swc_ecma_codegen", optional = true}
-swc_ecma_dep_graph = {version = "0.46.0", path = "../swc_ecma_dep_graph", optional = true}
-swc_ecma_minifier = {version = "0.49.0", path = "../swc_ecma_minifier", optional = true}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser", optional = true, default-features = false}
-swc_ecma_preset_env = {version = "0.64.0", path = "../swc_ecma_preset_env", optional = true}
-swc_ecma_transforms = {version = "0.93.0", path = "../swc_ecma_transforms", optional = true}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils", optional = true}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit", optional = true}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_codegen = {version = "0.80.0", path = "../swc_ecma_codegen", optional = true}
+swc_ecma_dep_graph = {version = "0.47.0", path = "../swc_ecma_dep_graph", optional = true}
+swc_ecma_minifier = {version = "0.50.0", path = "../swc_ecma_minifier", optional = true}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser", optional = true, default-features = false}
+swc_ecma_preset_env = {version = "0.65.0", path = "../swc_ecma_preset_env", optional = true}
+swc_ecma_transforms = {version = "0.94.0", path = "../swc_ecma_transforms", optional = true}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils", optional = true}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit", optional = true}
 
 [dev-dependencies]

--- a/crates/swc_node_bundler/src/config/mod.rs
+++ b/crates/swc_node_bundler/src/config/mod.rs
@@ -9,7 +9,8 @@ use std::{collections::HashMap, fmt, marker::PhantomData, path::PathBuf};
 use string_enum::StringEnum;
 use swc_atoms::JsWord;
 use swc_common::{collections::AHashMap, FileName};
-use swc_ecma_ast::{EsVersion, TargetEnv};
+use swc_ecma_ast::EsVersion;
+use swc_ecma_loader::TargetEnv;
 
 mod module;
 mod optimization;

--- a/crates/swc_node_bundler/tests/fixture.rs
+++ b/crates/swc_node_bundler/tests/fixture.rs
@@ -12,9 +12,9 @@ use swc_bundler::{BundleKind, Bundler, Config, ModuleRecord};
 use swc_common::{FileName, Span, GLOBALS};
 use swc_ecma_ast::{
     Bool, EsVersion, Expr, ExprOrSuper, Ident, KeyValueProp, Lit, MemberExpr, MetaPropExpr,
-    PropName, Str, TargetEnv,
+    PropName, Str,
 };
-use swc_ecma_loader::NODE_BUILTINS;
+use swc_ecma_loader::{TargetEnv, NODE_BUILTINS};
 use swc_ecma_transforms::fixer;
 use swc_ecma_visit::FoldWith;
 use swc_node_bundler::loaders::swc::SwcLoader;

--- a/crates/swc_plugin/Cargo.toml
+++ b/crates/swc_plugin/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_plugin"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.12.0"
+version = "0.13.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -17,6 +17,6 @@ serde = "1.0.126"
 serde_json = "1.0.64"
 swc_atoms = {version = "0.2.7", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common", features = ["plugin-mode"]}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 swc_plugin_api = {version = "0.3.0", path = "../swc_plugin_api"}

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_plugin_runner"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.16.0"
+version = "0.17.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -17,10 +17,10 @@ serde = {version = "1.0.126", features = ["derive"]}
 serde_json = "1.0.64"
 swc_atoms = "0.2.7"
 swc_common = {version = "0.14.0", path = "../swc_common", features = ["plugin-rt"]}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_parser = {version = "0.77.0", path = "../swc_ecma_parser"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_parser = {version = "0.78.0", path = "../swc_ecma_parser"}
 swc_plugin_api = {version = "0.3.0", path = "../swc_plugin_api"}
 
 [dev-dependencies]
-swc_ecma_codegen = {version = "0.79.0", path = "../swc_ecma_codegen"}
+swc_ecma_codegen = {version = "0.80.0", path = "../swc_ecma_codegen"}
 testing = {version = "0.15.0", path = "../testing"}

--- a/crates/swc_plugin_testing/Cargo.toml
+++ b/crates/swc_plugin_testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 name = "swc_plugin_testing"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.18.0"
+version = "0.19.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,8 +14,8 @@ version = "0.18.0"
 anyhow = "1.0.41"
 swc_atoms = {version = "0.2.7", path = "../swc_atoms"}
 swc_common = {version = "0.14.0", path = "../swc_common"}
-swc_ecma_ast = {version = "0.57.0", path = "../swc_ecma_ast"}
-swc_ecma_codegen = {version = "0.79.0", path = "../swc_ecma_codegen"}
-swc_ecma_utils = {version = "0.51.0", path = "../swc_ecma_utils"}
-swc_ecma_visit = {version = "0.43.0", path = "../swc_ecma_visit"}
+swc_ecma_ast = {version = "0.58.0", path = "../swc_ecma_ast"}
+swc_ecma_codegen = {version = "0.80.0", path = "../swc_ecma_codegen"}
+swc_ecma_utils = {version = "0.52.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.44.0", path = "../swc_ecma_visit"}
 swc_plugin_api = {version = "0.3.0", path = "../swc_plugin_api"}


### PR DESCRIPTION
swc_ecma_ast:
 - Move `TargetEnv` to `swc_ecma_loader`.

swc_ecma_loader:
 - Drop unused dependencies.

---

This is required to use `swc_ecma_loader` from the new typescript type checker.