### PR TITLE
fix(ecma/lexer/jsx): jsx back slash escape parse

### DIFF
--- a/crates/swc/tests/fixture/issue-2162/case1/input/.swcrc
+++ b/crates/swc/tests/fixture/issue-2162/case1/input/.swcrc
@@ -1,0 +1,8 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": true
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issue-2162/case1/input/index.js
+++ b/crates/swc/tests/fixture/issue-2162/case1/input/index.js
@@ -1,0 +1,7 @@
+function test() {
+    return (
+        <>
+            <A b='\' />
+        </>
+    );
+}

--- a/crates/swc/tests/fixture/issue-2162/case1/output/index.js
+++ b/crates/swc/tests/fixture/issue-2162/case1/output/index.js
@@ -1,0 +1,5 @@
+function test() {
+    return(/*#__PURE__*/ React.createElement(React.Fragment, null, /*#__PURE__*/ React.createElement(A, {
+        b: "\\"
+    })));
+}

--- a/crates/swc/tests/fixture/issue-2162/case2/input/.swcrc
+++ b/crates/swc/tests/fixture/issue-2162/case2/input/.swcrc
@@ -1,0 +1,8 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": true
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issue-2162/case2/input/index.js
+++ b/crates/swc/tests/fixture/issue-2162/case2/input/index.js
@@ -1,0 +1,7 @@
+function test() {
+    return (
+        <>
+            <A b="\" />
+        </>
+    );
+}

--- a/crates/swc/tests/fixture/issue-2162/case2/output/index.js
+++ b/crates/swc/tests/fixture/issue-2162/case2/output/index.js
@@ -1,0 +1,5 @@
+function test() {
+    return(/*#__PURE__*/ React.createElement(React.Fragment, null, /*#__PURE__*/ React.createElement(A, {
+        b: "\\"
+    })));
+}

--- a/crates/swc/tests/fixture/issue-2162/case3/input/.swcrc
+++ b/crates/swc/tests/fixture/issue-2162/case3/input/.swcrc
@@ -1,0 +1,8 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": true
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issue-2162/case3/input/index.js
+++ b/crates/swc/tests/fixture/issue-2162/case3/input/index.js
@@ -1,0 +1,7 @@
+function test() {
+    return (
+        <>
+            <A b="\x21" />
+        </>
+    );
+}

--- a/crates/swc/tests/fixture/issue-2162/case3/output/index.js
+++ b/crates/swc/tests/fixture/issue-2162/case3/output/index.js
@@ -1,0 +1,5 @@
+function test() {
+    return(/*#__PURE__*/ React.createElement(React.Fragment, null, /*#__PURE__*/ React.createElement(A, {
+        b: "\\x21"
+    })));
+}

--- a/crates/swc/tests/fixture/issue-2162/case4/input/.swcrc
+++ b/crates/swc/tests/fixture/issue-2162/case4/input/.swcrc
@@ -1,0 +1,8 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": true
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issue-2162/case4/input/index.js
+++ b/crates/swc/tests/fixture/issue-2162/case4/input/index.js
@@ -1,0 +1,8 @@
+function test() {
+    return (
+        <>
+            <A b="\
+            " />
+        </>
+    );
+}

--- a/crates/swc/tests/fixture/issue-2162/case4/output/index.js
+++ b/crates/swc/tests/fixture/issue-2162/case4/output/index.js
@@ -1,0 +1,5 @@
+function test() {
+    return(/*#__PURE__*/ React.createElement(React.Fragment, null, /*#__PURE__*/ React.createElement(A, {
+        b: "\\ "
+    })));
+}

--- a/crates/swc/tests/fixture/issue-2162/case5/input/.swcrc
+++ b/crates/swc/tests/fixture/issue-2162/case5/input/.swcrc
@@ -1,0 +1,8 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": true
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issue-2162/case5/input/index.js
+++ b/crates/swc/tests/fixture/issue-2162/case5/input/index.js
@@ -1,0 +1,7 @@
+function test() {
+    return (
+        <>
+            <A b="\u54e6"/>
+        </>
+    );
+}

--- a/crates/swc/tests/fixture/issue-2162/case5/output/index.js
+++ b/crates/swc/tests/fixture/issue-2162/case5/output/index.js
@@ -1,0 +1,5 @@
+function test() {
+    return(/*#__PURE__*/ React.createElement(React.Fragment, null, /*#__PURE__*/ React.createElement(A, {
+        b: "\\u54e6"
+    })));
+}

--- a/crates/swc/tests/fixture/issue-2162/case6/input/.swcrc
+++ b/crates/swc/tests/fixture/issue-2162/case6/input/.swcrc
@@ -1,0 +1,8 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": true
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issue-2162/case6/input/index.js
+++ b/crates/swc/tests/fixture/issue-2162/case6/input/index.js
@@ -1,0 +1,7 @@
+function test() {
+    return (
+        <>
+            <A b="\'"/>
+        </>
+    );
+}

--- a/crates/swc/tests/fixture/issue-2162/case6/output/index.js
+++ b/crates/swc/tests/fixture/issue-2162/case6/output/index.js
@@ -1,0 +1,5 @@
+function test() {
+    return(/*#__PURE__*/ React.createElement(React.Fragment, null, /*#__PURE__*/ React.createElement(A, {
+        b: "\\'"
+    })));
+}


### PR DESCRIPTION
attempt to fix #2162 
maybe relate to #299
I think babel only escape `\` to `\\` [babel playground](https://babeljs.io/repl#?browsers=IE%208&build=&builtIns=false&corejs=false&spec=true&loose=true&code_lz=MYewdgzgLgBAhjAvDAPAPgFAoIIwEaIDkAOoTAPRoDcWuBJArgKwAsApgGxmU075HEAHgCYAjN2q1-JUhUl96xDDAm9KQA&debug=false&forceAllTransforms=true&shippedProposals=true&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=false&presets=env%2Creact%2Ctypescript&prettier=true&targets=&version=7.16.3&externalPlugins=&assumptions=%7B%7D)