### PR TITLE
Repair broken Babel comparison link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Check out the documentation [in the website](https://swc.rs/docs/installation/).
 
 # Features
 
-Please see [comparison with babel](https://swc.rs/docs/comparison-babel).
+Please see [comparison with babel](https://swc.rs/docs/migrating-from-babel).
 
 # Performance
 


### PR DESCRIPTION
## Issue
Currently, the swc project's README incorrectly points to https://swc.rs/docs/comparison-babel for a Babel comparison.

## Expected Behavior
The link should point to https://swc.rs/docs/migrating-from-babel

## Resolution
The broken link can either be resolved via direct change here or via redirect in the website's `next.config.js` file. I have made pull requests for both and will create an issue here linking to those pull requests.


---

Closes #2738 