### PR TITLE
Ensure Git feature.manyFiles is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     },
     "types": "./index.d.ts",
     "scripts": {
-        "prepare": "husky install",
+        "prepare": "husky install && git config feature.manyFiles true",
         "artifacts": "napi artifacts --dist scripts/npm",
         "prepublishOnly": "tsc -d && napi prepublish -p scripts/npm --tagstyle npm",
         "build": "tsc -d && napi build --platform --release --cargo-name node --cargo-flags=\"-p node\"",


### PR DESCRIPTION
I noticed that `git status` is super slow on the SWC repo. After doing some research I found that there's a Git feature flag that changes some defaults to work well for large repositories: https://github.blog/2019-11-03-highlights-from-git-2-24/
Given that `git config` is local and can't be pushed the config is set in the script that is ran automatically by yarn after dependency installs.
