### PR TITLE
refactor(es/parser) Simplify skip_line_comment util

### DIFF
--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -220,14 +220,9 @@ impl<'a, I: Input> Lexer<'a, I> {
             self.bump();
             if c.is_line_terminator() {
                 self.state.had_line_break = true;
-            }
-            match c {
-                '\n' | '\r' | '\u{2028}' | '\u{2029}' => {
-                    break;
-                }
-                _ => {
-                    end = self.cur_pos();
-                }
+                break;
+            } else {
+                end = self.cur_pos();
             }
         }
 


### PR DESCRIPTION
`'\n' | '\r' | '\u{2028}' | '\u{2029}'` and `is_line_terminator` is  a same check so  extra `match`  unnecessary