### PR TITLE
fix(es/transforms/compat): capture this context scope for the class method

### DIFF
--- a/crates/swc/tests/fixture/issue-1341/case1/output/index.ts
+++ b/crates/swc/tests/fixture/issue-1341/case1/output/index.ts
@@ -30,16 +30,17 @@ function _asyncToGenerator(fn) {
 }
 class A {
     foo() {
-        return _asyncToGenerator((function*() {
+        var _this = this;
+        return _asyncToGenerator(function*() {
             try {
-                return yield _asyncToGenerator((function*(x) {
-                    return x + this.val;
-                }).bind(this)).bind(this)('a'); // this is undefined
+                return yield _asyncToGenerator(function*(x) {
+                    return x + _this.val;
+                })('a'); // this is undefined
             // return await Promise.all(['a', 'b'].map(async (x) => x + this.val)); // this is undefined
             } catch (e) {
                 throw e;
             }
-        }).bind(this))();
+        })();
     }
     constructor(){
         this.val = '1';

--- a/crates/swc_ecma_transforms_compat/tests/es2017_async_to_generator.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2017_async_to_generator.rs
@@ -994,34 +994,35 @@ class Class {
     r#"
     class Class {
       method() {
-          return _asyncToGenerator((function*() {
-              this;
-              ()=>this
-              ;
-              ()=>{
-                  this;
-                  ()=>this
-                  ;
-                  function x() {
-                      this;
-                      ()=>{
-                          this;
-                      };
-                      _asyncToGenerator((function*() {
-                          this;
-                      }).bind(this)).bind(this);
-                  }
-              };
-              function x() {
-                  this;
-                  ()=>{
-                      this;
-                  };
-                  _asyncToGenerator((function*() {
-                      this;
-                  }).bind(this)).bind(this);
-              }
-          }).bind(this))();
+        var _this = this;
+        return _asyncToGenerator((function*() {
+            this;
+            ()=>_this
+            ;
+            ()=>{
+                _this;
+                ()=>_this
+                ;
+                function x() {
+                    this;
+                    ()=>{
+                        _this;
+                    };
+                    _asyncToGenerator(function*() {
+                        _this;
+                    });
+                }
+            };
+            function x() {
+                this;
+                ()=>{
+                    _this;
+                };
+                _asyncToGenerator(function*() {
+                    _this;
+                });
+            }
+        }).bind(this))();
       }
     }
     "#
@@ -2261,15 +2262,16 @@ test!(
     class A {
       val = '1';
       foo() {
-          return _asyncToGenerator((function*() {
-              try {
-                  return yield _asyncToGenerator((function*(x) {
-                      return x + this.val;
-                  }).bind(this)).bind(this)('a');
-              } catch (e) {
-                  throw e;
-              }
-          }).bind(this))();
+        var _this = this;
+        return _asyncToGenerator(function*() {
+            try {
+                return yield _asyncToGenerator(function*(x) {
+                    return x + _this.val;
+                })('a');
+            } catch (e) {
+                throw e;
+            }
+        })();
       }
     }
     "
@@ -2315,11 +2317,12 @@ test!(
   class A {
     val = '1';
     foo() {
-        return _asyncToGenerator((function*() {
-          return yield _asyncToGenerator((function*(x) {
-              return x + this.val;
-          }).bind(this)).bind(this)('a');
-      }).bind(this))();
+        var _this = this;
+        return _asyncToGenerator(function*() {
+            return yield _asyncToGenerator(function*(x) {
+                return x + _this.val;
+            })('a');
+        })();
     }
   }
   "


### PR DESCRIPTION
Part 1 for #2716.

This PR is an attempt to remove explicit binding to `this`. As a first step trying to remove scoped this in class method.
However, I *do not think* this is ok to check in as-is due to some of the notable issues to be resolved. I left some comments for the known part, and there may be possibly more.

As Part 1 implies this won't resolve all of the cases. But I found trying to solve all at once would take some amount of effort,  trying to make gradual progress with known possible paths.