### PR TITLE
Refactor parser and lexer

### DIFF
--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -58,16 +58,6 @@ where
             .map_err(|kind| Error::new(span, kind))
     }
 
-    fn skip_whitespaces(&mut self) -> PResult<()> {
-        let start = self.input.cur_pos();
-
-        let token = self.skip_ws();
-        let end = self.input.cur_pos();
-        let span = Span::new(start, end, Default::default());
-
-        token.map_err(|kind| Error::new(span, kind))
-    }
-
     fn start_pos(&mut self) -> swc_common::BytePos {
         self.input.cur_pos()
     }
@@ -443,6 +433,7 @@ where
                 }
             }
 
+            // TODO: fix me
             self.start_pos = self.input.cur_pos();
         } else if self.config.allow_wrong_line_comments
             && self.input.cur() == Some('/')

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -441,9 +441,6 @@ where
                         }
                     }
                 }
-
-                // TODO: invalid
-                self.skip_ws()?;
             }
 
             self.start_pos = self.input.cur_pos();
@@ -472,9 +469,6 @@ where
                         }
                     }
                 }
-
-                // TODO: invalid
-                self.skip_ws()?;
             }
 
             self.start_pos = self.input.cur_pos();

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -221,7 +221,7 @@ where
                     break;
                 }
 
-                if self.input.is_eof()? {
+                if is!(self, EOF) {
                     break;
                 }
                 let token = self.input.bump()?;

--- a/crates/swc_css_parser/src/parser/input.rs
+++ b/crates/swc_css_parser/src/parser/input.rs
@@ -51,7 +51,7 @@ where
 
     pub fn cur_span(&mut self) -> PResult<Span> {
         if self.cur.is_none() {
-            self.bump_inner(false)?;
+            self.bump_inner()?;
         }
 
         Ok(self.cur.as_ref().map(|cur| cur.span).unwrap_or_default())
@@ -59,7 +59,7 @@ where
 
     pub fn cur(&mut self) -> PResult<Option<&Token>> {
         if self.cur.is_none() {
-            self.bump_inner(true)?;
+            self.bump_inner()?;
         }
 
         Ok(self.cur.as_ref().map(|v| &v.token))
@@ -88,12 +88,12 @@ where
 
         let token = self.cur.take();
 
-        self.bump_inner(false)?;
+        self.bump_inner()?;
 
         Ok(token)
     }
 
-    fn bump_inner(&mut self, skip_whitespace: bool) -> PResult<()> {
+    fn bump_inner(&mut self) -> PResult<()> {
         if let Some(cur) = &self.cur {
             self.last_pos = cur.span.hi;
         }
@@ -101,20 +101,7 @@ where
         self.cur = None;
 
         if let Some(next) = self.peeked.take() {
-            if skip_whitespace {
-                match next.token {
-                    tok!(" ") => {}
-                    _ => {
-                        self.cur = Some(next);
-                    }
-                }
-            } else {
-                self.cur = Some(next);
-            }
-        }
-
-        if skip_whitespace {
-            self.input.skip_whitespaces()?;
+            self.cur = Some(next);
         }
 
         if self.cur.is_none() {
@@ -138,7 +125,7 @@ where
     pub(super) fn skip_ws(&mut self) -> PResult<()> {
         match self.cur.as_ref().map(|v| &v.token) {
             Some(tok!(" ")) => {
-                self.bump_inner(true)?;
+                self.bump_inner()?;
                 Ok(())
             }
 

--- a/crates/swc_css_parser/src/parser/input.rs
+++ b/crates/swc_css_parser/src/parser/input.rs
@@ -208,18 +208,22 @@ impl ParserInput for TokensInput<'_> {
     }
 
     fn skip_whitespaces(&mut self) -> PResult<()> {
-        let cur = self.tokens.tokens.get(self.idx);
-        let cur = match cur {
-            Some(cur) => cur,
-            None => return Ok(()),
-        };
+        loop {
+            let cur = self.tokens.tokens.get(self.idx);
+            let cur = match cur {
+                Some(cur) => cur,
+                None => return Ok(()),
+            };
 
-        match cur.token {
-            tok!(" ") => {
-                self.idx += 1;
+            match cur.token {
+                tok!(" ") => {
+                    self.idx += 1;
+                }
+
+                _ => {
+                    break;
+                }
             }
-
-            _ => {}
         }
 
         Ok(())

--- a/crates/swc_css_parser/src/parser/input.rs
+++ b/crates/swc_css_parser/src/parser/input.rs
@@ -43,10 +43,6 @@ where
         }
     }
 
-    pub fn is_eof(&mut self) -> PResult<bool> {
-        Ok(self.cur()?.is_none())
-    }
-
     pub fn last_pos(&mut self) -> PResult<BytePos> {
         self.cur()?;
 

--- a/crates/swc_css_parser/src/parser/style_rule.rs
+++ b/crates/swc_css_parser/src/parser/style_rule.rs
@@ -16,7 +16,7 @@ where
 
         loop {
             // TODO: remove `}`
-            if self.input.is_eof()? || is!(self, "}") {
+            if is!(self, EOF) || is!(self, "}") {
                 return Ok(rules);
             }
 
@@ -117,7 +117,7 @@ where
         let mut declarations = vec![];
 
         loop {
-            if self.input.is_eof()? {
+            if is!(self, EOF) {
                 return Ok(declarations);
             }
 
@@ -166,7 +166,7 @@ where
         let mut value = vec![];
         let mut end = self.input.cur_span()?.hi;
 
-        if !self.input.is_eof()? {
+        if !is!(self, EOF) {
             let ctx = Ctx {
                 allow_operation_in_value: false,
                 recover_from_property_value: true,

--- a/crates/swc_css_parser/tests/fixture/at-rule/charset/invalid/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/charset/invalid/output.json
@@ -2,7 +2,7 @@
   "type": "Stylesheet",
   "span": {
     "start": 0,
-    "end": 146,
+    "end": 211,
     "ctxt": 0
   },
   "rules": [

--- a/crates/swc_css_parser/tests/fixture/at-rule/charset/invalid/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/charset/invalid/span.rust-debug
@@ -4,7 +4,7 @@ error: Stylesheet
 1 | / @charset 'iso-8859-15'; /* Invalid, wrong quoting style used */
 2 | | @charset  "UTF-8";      /* Invalid, more than one space */
 3 | | @charset "UTF-8";      /* Invalid, there is a character (a space) before the at-rule */
-  | |_______________________^
+  | |________________________________________________________________________________________^
 
 error: Rule
  --> $DIR/tests/fixture/at-rule/charset/invalid/input.css:1:1

--- a/crates/swc_css_parser/tests/fixture/at-rule/unknown/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/unknown/output.json
@@ -1,7 +1,7 @@
 {
   "type": "Stylesheet",
   "span": {
-    "start": 147,
+    "start": 13,
     "end": 1286,
     "ctxt": 0
   },

--- a/crates/swc_css_parser/tests/fixture/at-rule/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/unknown/span.rust-debug
@@ -1,10 +1,11 @@
 error: Stylesheet
-  --> $DIR/tests/fixture/at-rule/unknown/input.css:9:1
+  --> $DIR/tests/fixture/at-rule/unknown/input.css:1:14
    |
-9  | / @unknown {}
-10 | | @\unknown {}
-11 | | /*@unknown a b {}*/
-12 | | @unknown {p:v}
+1  |   /*@unknown;*/
+   |  ______________^
+2  | | /*@unknown x y;*/
+3  | | /*@unknown \"blah\";*/
+4  | | /*@unknown!*test*!;*/
 ...  |
 35 | |     <!-- {}
 36 | | }

--- a/crates/swc_css_parser/tests/fixture/comment/output.json
+++ b/crates/swc_css_parser/tests/fixture/comment/output.json
@@ -2,7 +2,7 @@
   "type": "Stylesheet",
   "span": {
     "start": 13,
-    "end": 361,
+    "end": 505,
     "ctxt": 0
   },
   "rules": [

--- a/crates/swc_css_parser/tests/fixture/comment/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/comment/span.rust-debug
@@ -7,9 +7,9 @@ error: Stylesheet
 3  | | /* comment */color/* comment */:/* comment */red/* comment */;
 4  | | }
 ...  |
-25 | |
-26 | | /*!test*/
-   | |_
+35 | | /*************** FOO *****************/
+36 | | /* comment *//* comment */
+   | |___________________________^
 
 error: Rule
  --> $DIR/tests/fixture/comment/input.css:1:14

--- a/crates/swc_css_parser/tests/fixture/rome/comment/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/comment/output.json
@@ -1,7 +1,7 @@
 {
   "type": "Stylesheet",
   "span": {
-    "start": 20,
+    "start": 18,
     "end": 127,
     "ctxt": 0
   },

--- a/crates/swc_css_parser/tests/fixture/rome/comment/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/comment/span.rust-debug
@@ -1,10 +1,11 @@
 error: Stylesheet
-  --> $DIR/tests/fixture/rome/comment/input.css:5:1
+  --> $DIR/tests/fixture/rome/comment/input.css:3:4
    |
-5  | / a {
+3  |    */
+   |  ____^
+4  | |
+5  | | a {
 6  | |     color: white; /* comment */
-7  | | }
-8  | |
 ...  |
 14 | |     color: white;
 15 | | }

--- a/crates/swc_css_parser/tests/fixture/rome/smoke/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/smoke/output.json
@@ -1,8 +1,8 @@
 {
   "type": "Stylesheet",
   "span": {
-    "start": 22,
-    "end": 80,
+    "start": 21,
+    "end": 220,
     "ctxt": 0
   },
   "rules": [

--- a/crates/swc_css_parser/tests/fixture/rome/smoke/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/smoke/span.rust-debug
@@ -1,13 +1,15 @@
 error: Stylesheet
- --> $DIR/tests/fixture/rome/smoke/input.css:2:1
-  |
-2 | / body {
-3 | |     background: red;
-4 | |     width: calc(1px + 2%);
-5 | | }
-6 | |
-7 | | /*@media screen and (min-width: 1337px) {*/
-  | |_
+  --> $DIR/tests/fixture/rome/smoke/input.css:1:22
+   |
+1  |   /*This is a comment*/
+   |  ______________________^
+2  | | body {
+3  | |     background: red;
+4  | |     width: calc(1px + 2%);
+...  |
+11 | | /*    }*/
+12 | | /*}*/
+   | |______^
 
 error: Rule
  --> $DIR/tests/fixture/rome/smoke/input.css:2:1

--- a/crates/swc_css_parser/tests/recovery/comments/input.css
+++ b/crates/swc_css_parser/tests/recovery/comments/input.css
@@ -1,0 +1,4 @@
+a {
+    prop: url("test") /* comment */   /* comment */
+        /* comment */:
+}

--- a/crates/swc_css_parser/tests/recovery/comments/output.json
+++ b/crates/swc_css_parser/tests/recovery/comments/output.json
@@ -1,0 +1,210 @@
+{
+  "type": "Stylesheet",
+  "span": {
+    "start": 0,
+    "end": 80,
+    "ctxt": 0
+  },
+  "rules": [
+    {
+      "type": "StyleRule",
+      "span": {
+        "start": 0,
+        "end": 80,
+        "ctxt": 0
+      },
+      "selectors": {
+        "type": "SelectorList",
+        "span": {
+          "start": 0,
+          "end": 1,
+          "ctxt": 0
+        },
+        "children": [
+          {
+            "type": "ComplexSelector",
+            "span": {
+              "start": 0,
+              "end": 1,
+              "ctxt": 0
+            },
+            "children": [
+              {
+                "type": "CompoundSelector",
+                "span": {
+                  "start": 0,
+                  "end": 1,
+                  "ctxt": 0
+                },
+                "nestingSelector": null,
+                "typeSelector": {
+                  "type": "TypeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 1,
+                    "ctxt": 0
+                  },
+                  "prefix": null,
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 0,
+                      "end": 1,
+                      "ctxt": 0
+                    },
+                    "value": "a",
+                    "raw": "a"
+                  }
+                },
+                "subclassSelectors": []
+              }
+            ]
+          }
+        ]
+      },
+      "block": {
+        "type": "Block",
+        "span": {
+          "start": 2,
+          "end": 80,
+          "ctxt": 0
+        },
+        "items": [
+          {
+            "type": "Tokens",
+            "span": {
+              "start": 8,
+              "end": 79,
+              "ctxt": 0
+            },
+            "tokens": [
+              {
+                "span": {
+                  "start": 8,
+                  "end": 12,
+                  "ctxt": 0
+                },
+                "token": {
+                  "Ident": {
+                    "value": "prop",
+                    "raw": "prop"
+                  }
+                }
+              },
+              {
+                "span": {
+                  "start": 12,
+                  "end": 13,
+                  "ctxt": 0
+                },
+                "token": "Colon"
+              },
+              {
+                "span": {
+                  "start": 13,
+                  "end": 14,
+                  "ctxt": 0
+                },
+                "token": {
+                  "WhiteSpace": {
+                    "value": " "
+                  }
+                }
+              },
+              {
+                "span": {
+                  "start": 14,
+                  "end": 18,
+                  "ctxt": 0
+                },
+                "token": {
+                  "Function": {
+                    "value": "url",
+                    "raw": "url"
+                  }
+                }
+              },
+              {
+                "span": {
+                  "start": 18,
+                  "end": 24,
+                  "ctxt": 0
+                },
+                "token": {
+                  "Str": {
+                    "value": "test",
+                    "raw": "\"test\""
+                  }
+                }
+              },
+              {
+                "span": {
+                  "start": 24,
+                  "end": 25,
+                  "ctxt": 0
+                },
+                "token": "RParen"
+              },
+              {
+                "span": {
+                  "start": 25,
+                  "end": 26,
+                  "ctxt": 0
+                },
+                "token": {
+                  "WhiteSpace": {
+                    "value": " "
+                  }
+                }
+              },
+              {
+                "span": {
+                  "start": 39,
+                  "end": 42,
+                  "ctxt": 0
+                },
+                "token": {
+                  "WhiteSpace": {
+                    "value": "   "
+                  }
+                }
+              },
+              {
+                "span": {
+                  "start": 55,
+                  "end": 64,
+                  "ctxt": 0
+                },
+                "token": {
+                  "WhiteSpace": {
+                    "value": "\n        "
+                  }
+                }
+              },
+              {
+                "span": {
+                  "start": 77,
+                  "end": 78,
+                  "ctxt": 0
+                },
+                "token": "Colon"
+              },
+              {
+                "span": {
+                  "start": 78,
+                  "end": 79,
+                  "ctxt": 0
+                },
+                "token": {
+                  "WhiteSpace": {
+                    "value": "\n"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/crates/swc_css_parser/tests/recovery/comments/output.json
+++ b/crates/swc_css_parser/tests/recovery/comments/output.json
@@ -7,13 +7,13 @@
   },
   "rules": [
     {
-      "type": "StyleRule",
+      "type": "QualifiedRule",
       "span": {
         "start": 0,
         "end": 80,
         "ctxt": 0
       },
-      "selectors": {
+      "prelude": {
         "type": "SelectorList",
         "span": {
           "start": 0,

--- a/crates/swc_css_parser/tests/recovery/comments/output.swc-stderr
+++ b/crates/swc_css_parser/tests/recovery/comments/output.swc-stderr
@@ -1,0 +1,6 @@
+error: Expected Declaration value
+ --> $DIR/tests/recovery/comments/input.css:3:22
+  |
+3 |         /* comment */:
+  |                      ^
+


### PR DESCRIPTION
@kdy1 Very important fix, because we handle whitespaces incorrectly, look at example:
```css
a { 
  color: /* comment */ /*comment*/ red;
        ^             ^           ^
          /* whitespace tokens */
}
```

Before we eat whitespaces tokens between comments, so tokens in recovery mode was wrong, after this PR now we have valid count of whitespace tokens.

I remove `skip_whitespaces`, we should not rely on whitespaces inside file, lexer generates whitespace tokens, tokens input - already have whitespace tokens inside, also this logic is invalid, because whitespaces can be between comments.

Also we have broken `span` in some cases because they did not take into account whitespaces and comments at the beginning and at the end of the file, so `span` for `Stylesheet` has incorrect values, but `Stylesheet` should represent the entire file, not where the code start.

Also skipping whitespaces for peeked value is wrong, because there are situations when whitespaces token followed by whitespace token (between comments) and rely on whitespace characters in code is wrong

Also we don't need `is_eof`, because we have macro.

Also added `TODO` for future `span` fixes (because we get span before whitespaces in some places, but it is wrong).

Example:
```
div /* test */ > a { color: red; }
```

In this example comment should be part of complex selector.