### PR TITLE
fix(es/parser): Fix comments of empty modules

### DIFF
--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -132,7 +132,7 @@ impl<'a, I: Input> Lexer<'a, I> {
             ctx: Default::default(),
             input,
             start_pos,
-            state: State::new(syntax),
+            state: State::new(syntax, start_pos),
             syntax,
             target,
             errors: Default::default(),

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -324,12 +324,12 @@ impl<'a, I: Input> Iterator for Lexer<'a, I> {
 }
 
 impl State {
-    pub fn new(syntax: Syntax) -> Self {
+    pub fn new(syntax: Syntax, start_pos: BytePos) -> Self {
         State {
             is_expr_allowed: true,
             is_first: true,
             had_line_break: false,
-            prev_hi: BytePos(0),
+            prev_hi: start_pos,
             context: TokenContexts(vec![TokenContext::BraceStmt]),
             token_type: None,
             start: BytePos(0),

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -198,7 +198,7 @@ impl<'a, I: Input> Iterator for Lexer<'a, I> {
                             // if the file had no tokens and no shebang, then treat any
                             // comments in the leading comments buffer as leading.
                             // Otherwise treat them as trailing.
-                            if last == BytePos(0) {
+                            if last == self.start_pos {
                                 comments_buffer.push(BufferedComment {
                                     kind: BufferedCommentKind::Leading,
                                     pos: last,

--- a/crates/swc_ecma_parser/tests/shifted/empty-with-comments/input.ts.comments
+++ b/crates/swc_ecma_parser/tests/shifted/empty-with-comments/input.ts.comments
@@ -1,0 +1,26 @@
+SingleThreadedComments {
+    leading: RefCell {
+        value: {
+            BytePos(
+                1,
+            ): [
+                Comment {
+                    kind: Line,
+                    span: Span {
+                        lo: BytePos(
+                            1,
+                        ),
+                        hi: BytePos(
+                            8,
+                        ),
+                        ctxt: #0,
+                    },
+                    text: "/ ref",
+                },
+            ],
+        },
+    },
+    trailing: RefCell {
+        value: {},
+    },
+}

--- a/crates/swc_ecma_parser/tests/typescript.rs
+++ b/crates/swc_ecma_parser/tests/typescript.rs
@@ -5,7 +5,7 @@ use std::{
     io::Read,
     path::{Path, PathBuf},
 };
-use swc_common::FileName;
+use swc_common::{comments::SingleThreadedComments, FileName};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, PResult, Parser, StringInput, Syntax, TsConfig};
 use swc_ecma_visit::FoldWith;
@@ -34,7 +34,7 @@ fn shifted(file: PathBuf) {
         );
     }
 
-    with_parser(false, &file, true, true, |p| {
+    with_parser(false, &file, true, true, |p, comments| {
         let program = p.parse_program()?.fold_with(&mut Normalizer {
             drop_span: false,
             is_test262: false,
@@ -45,6 +45,12 @@ fn shifted(file: PathBuf) {
 
         if StdErr::from(json.clone())
             .compare_to_file(&format!("{}.json", file.display()))
+            .is_err()
+        {
+            panic!()
+        }
+        if StdErr::from(format!("{:?}", comments))
+            .compare_to_file(&format!("{}.comments", file.display()))
             .is_err()
         {
             panic!()
@@ -136,7 +142,7 @@ fn spec(file: PathBuf) {
         );
     }
 
-    with_parser(false, &file, true, false, |p| {
+    with_parser(false, &file, true, false, |p, _| {
         let program = p.parse_program()?.fold_with(&mut Normalizer {
             drop_span: false,
             is_test262: false,
@@ -194,13 +200,15 @@ fn with_parser<F, Ret>(
     f: F,
 ) -> Result<Ret, StdErr>
 where
-    F: FnOnce(&mut Parser<Lexer<StringInput<'_>>>) -> PResult<Ret>,
+    F: FnOnce(&mut Parser<Lexer<StringInput<'_>>>, &SingleThreadedComments) -> PResult<Ret>,
 {
     let fname = file_name.display().to_string();
     let output = ::testing::run_test(treat_error_as_bug, |cm, handler| {
         if shift {
             cm.new_source_file(FileName::Anon, "".into());
         }
+
+        let mut comments = SingleThreadedComments::default();
 
         let fm = cm
             .load_file(file_name)
@@ -218,12 +226,12 @@ where
             }),
             EsVersion::Es2015,
             (&*fm).into(),
-            None,
+            Some(&comments),
         );
 
         let mut p = Parser::new_from(lexer);
 
-        let res = f(&mut p).map_err(|e| e.into_diagnostic(&handler).emit());
+        let res = f(&mut p, &comments).map_err(|e| e.into_diagnostic(&handler).emit());
 
         for err in p.take_errors() {
             err.into_diagnostic(&handler).emit();
@@ -257,7 +265,9 @@ fn errors(file: PathBuf) {
         );
     }
 
-    let module = with_parser(false, &file, false, false, |p| p.parse_typescript_module());
+    let module = with_parser(false, &file, false, false, |p, _| {
+        p.parse_typescript_module()
+    });
 
     let err = module.expect_err("should fail, but parsed as");
     if err

--- a/crates/swc_ecma_parser/tests/typescript.rs
+++ b/crates/swc_ecma_parser/tests/typescript.rs
@@ -208,7 +208,7 @@ where
             cm.new_source_file(FileName::Anon, "".into());
         }
 
-        let mut comments = SingleThreadedComments::default();
+        let comments = SingleThreadedComments::default();
 
         let fm = cm
             .load_file(file_name)

--- a/crates/swc_ecma_parser/tests/typescript.rs
+++ b/crates/swc_ecma_parser/tests/typescript.rs
@@ -49,7 +49,7 @@ fn shifted(file: PathBuf) {
         {
             panic!()
         }
-        if StdErr::from(format!("{:?}", comments))
+        if StdErr::from(format!("{:#?}", comments))
             .compare_to_file(&format!("{}.comments", file.display()))
             .is_err()
         {


### PR DESCRIPTION
swc_ecma_parser:
 - Use correct span for storing comments when module is empty.