### PR TITLE
fix(ecma/transform): deconstruct array

### DIFF
--- a/crates/swc/tests/tsc-references/es6/destructuring/declarationsAndAssignments/input.ts/es5.1.normal/output.js
+++ b/crates/swc/tests/tsc-references/es6/destructuring/declarationsAndAssignments/input.ts/es5.1.normal/output.js
@@ -52,7 +52,7 @@ function f0() {
         1,
         "hello"
     ], x = ref4[0], y = ref4[1], z = ref4[2];
-    var x = 0;
+    var x = 2;
     var x;
     var y;
 }

--- a/crates/swc/tests/tsc-references/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES5/input.ts/es5.1.normal/output.js
+++ b/crates/swc/tests/tsc-references/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES5/input.ts/es5.1.normal/output.js
@@ -99,12 +99,9 @@ var ref6 = [
     2,
     3
 ], c7 = ref6[1];
-var c8 = 1;
-var c9 = 1;
+var c8 = 4;
+var c9 = 4;
 var c10 = [
-    1,
-    2,
-    3,
     4,
     "hello"
 ];

--- a/crates/swc/tests/tsc-references/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES5iterable/input.ts/es5.1.normal/output.js
+++ b/crates/swc/tests/tsc-references/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES5iterable/input.ts/es5.1.normal/output.js
@@ -100,12 +100,9 @@ var ref6 = [
     2,
     3
 ], c7 = ref6[1];
-var c8 = 1;
-var c9 = 1;
+var c8 = 4;
+var c9 = 4;
 var c10 = [
-    1,
-    2,
-    3,
     4,
     "hello"
 ];

--- a/crates/swc/tests/tsc-references/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES6/input.ts/es5.1.normal/output.js
+++ b/crates/swc/tests/tsc-references/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES6/input.ts/es5.1.normal/output.js
@@ -100,12 +100,9 @@ var ref6 = [
     2,
     3
 ], c7 = ref6[1];
-var c8 = 1;
-var c9 = 1;
+var c8 = 4;
+var c9 = 4;
 var c10 = [
-    1,
-    2,
-    3,
     4,
     "hello"
 ];

--- a/crates/swc/tests/tsc-references/es6/destructuring/destructuringVariableDeclaration2/input.ts/es5.1.normal/output.js
+++ b/crates/swc/tests/tsc-references/es6/destructuring/destructuringVariableDeclaration2/input.ts/es5.1.normal/output.js
@@ -19,21 +19,25 @@ var tmp = 3, b0 = tmp === void 0 ? 3 : tmp, tmp1 = false, b1 = tmp1 === void 0 ?
 // The type T associated with a binding element is determined as follows:
 //      If the binding element is a rest element, T is an array type with
 //          an element type E, where E is the type of the numeric index signature of S.
-var c1 = 1, c2 = 2, ref1 = {
-    c3: 4,
-    c5: 0
-}, c4 = ref1.c3, c5 = ref1.c5, c6 = []; // Error
+var ref1 = [
+    1,
+    2,
+    {
+        c3: 4,
+        c5: 0
+    }
+], c1 = ref1[0], c2 = ref1[1], ref2 = ref1[2], c4 = ref2.c3, c5 = ref2.c5, c6 = ref1.slice(4); // Error
 // When a destructuring variable declaration, binding property, or binding element specifies
 // an initializer expression, the type of the initializer expression is required to be assignable
 // to the widened form of the type associated with the destructuring variable declaration, binding property, or binding element.
-var ref2 = {
+var ref3 = {
     d: {
         d1: [
             1,
             2
         ]
     }
-}, _d = ref2.d, _d1 = _d.d1, d1 = _d1 === void 0 ? [
+}, _d = ref3.d, _d1 = _d.d1, d1 = _d1 === void 0 ? [
     "string",
     null
 ] : _d1; // Error

--- a/crates/swc/tests/tsc-references/es6/destructuring/destructuringVariableDeclaration2/input.ts/es5.2.minified/output.js
+++ b/crates/swc/tests/tsc-references/es6/destructuring/destructuringVariableDeclaration2/input.ts/es5.2.minified/output.js
@@ -3,3 +3,16 @@ var ref = {
     a2: 1
 };
 ref.a1, ref.a2;
+var ref1 = [
+    1,
+    2,
+    {
+        c3: 4,
+        c5: 0
+    }
+], c1 = ref1[0], c2 = ref1[1], ref2 = ref1[2];
+ref2.c3, ref2.c5, ref1.slice(4), void 0 === _d1;
+var _d1 = [
+    1,
+    2
+]; // Error

--- a/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
@@ -152,7 +152,8 @@ impl AssignFolder {
                 if is_literal(&init) {
                     match *init {
                         Expr::Array(arr)
-                            if elems.len() == arr.elems.len() || has_rest_pat(&elems) =>
+                            if elems.len() == arr.elems.len()
+                                || (elems.len() < arr.elems.len() && has_rest_pat(&elems)) =>
                         {
                             let mut arr_elems = Some(arr.elems.into_iter());
                             elems.into_iter().for_each(|p| match p {
@@ -193,7 +194,12 @@ impl AssignFolder {
                                     )
                                 }
 
-                                None => {}
+                                None => {
+                                    arr_elems
+                                        .as_mut()
+                                        .expect("pattern after rest element?")
+                                        .next();
+                                }
                             });
                             return;
                         }

--- a/crates/swc_ecma_transforms_compat/tests/es2015_destructuring.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2015_destructuring.rs
@@ -24,6 +24,26 @@ fn tr() -> impl Fold {
 test!(
     syntax(),
     |_| tr(),
+    issue_2819,
+    r#"const [first, , third] = ["red", "yellow", "green"]"#,
+    r#"const first = "red", third = "green";"#,
+    ok_if_code_eq
+);
+
+test!(
+    syntax(),
+    |_| tr(),
+    issue_2821,
+    r#"const [x, y, ...z] = [1];"#,
+    r#"const ref = [
+    1
+], x = ref[0], y = ref[1], z = ref.slice(2)"#,
+    ok_if_code_eq
+);
+
+test!(
+    syntax(),
+    |_| tr(),
     issue_169,
     "export class Foo {
 	func(a, b = Date.now()) {


### PR DESCRIPTION
fix #2819 fix #2821 fix #2843 
ps: 
I don't think write javascript like ```const [x, y, ...z] = [1];``` is a good practice.
may be swc should throw a warning for this case at compile time.