### PR TITLE
fix(es/transforms/module): fix helper injection detection across import order

### DIFF
--- a/crates/swc/tests/fixture/issue-1734/case1-B/output/index.js
+++ b/crates/swc/tests/fixture/issue-1734/case1-B/output/index.js
@@ -1,8 +1,26 @@
 "use strict";
 var _a = _interopRequireWildcard(require("./A"));
-function _interopRequireDefault(obj) {
-    return obj && obj.__esModule ? obj : {
-        default: obj
-    };
+function _interopRequireWildcard(obj) {
+    if (obj && obj.__esModule) {
+        return obj;
+    } else {
+        var newObj = {
+        };
+        if (obj != null) {
+            for(var key in obj){
+                if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                    var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {
+                    };
+                    if (desc.get || desc.set) {
+                        Object.defineProperty(newObj, key, desc);
+                    } else {
+                        newObj[key] = obj[key];
+                    }
+                }
+            }
+        }
+        newObj.default = obj;
+        return newObj;
+    }
 }
 console.log(_a.default, _a.foo);

--- a/crates/swc/tests/fixture/issue-2856/1/input/.swcrc
+++ b/crates/swc/tests/fixture/issue-2856/1/input/.swcrc
@@ -1,0 +1,11 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "ecmascript"
+    },
+    "target": "es2015"
+  },
+  "module": {
+    "type": "commonjs"
+  }
+}

--- a/crates/swc/tests/fixture/issue-2856/1/input/index.js
+++ b/crates/swc/tests/fixture/issue-2856/1/input/index.js
@@ -1,0 +1,5 @@
+import { sdx } from 'boo';
+import boo from 'boo';
+
+boo.some();
+sdx();

--- a/crates/swc/tests/fixture/issue-2856/1/output/index.js
+++ b/crates/swc/tests/fixture/issue-2856/1/output/index.js
@@ -1,0 +1,27 @@
+"use strict";
+var _boo = _interopRequireWildcard(require("boo"));
+function _interopRequireWildcard(obj) {
+    if (obj && obj.__esModule) {
+        return obj;
+    } else {
+        var newObj = {
+        };
+        if (obj != null) {
+            for(var key in obj){
+                if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                    var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {
+                    };
+                    if (desc.get || desc.set) {
+                        Object.defineProperty(newObj, key, desc);
+                    } else {
+                        newObj[key] = obj[key];
+                    }
+                }
+            }
+        }
+        newObj.default = obj;
+        return newObj;
+    }
+}
+_boo.default.some();
+(0, _boo).sdx();

--- a/crates/swc_ecma_transforms_module/src/import_analysis.rs
+++ b/crates/swc_ecma_transforms_module/src/import_analysis.rs
@@ -1,7 +1,7 @@
 use super::util::Scope;
-use std::{cell::RefCell, collections::HashSet, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 use swc_atoms::{js_word, JsWord};
-use swc_common::DUMMY_SP;
+use swc_common::{collections::AHashSet, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::enable_helper;
 use swc_ecma_visit::{
@@ -11,13 +11,13 @@ use swc_ecma_visit::{
 pub fn import_analyzer(scope: Rc<RefCell<Scope>>) -> impl Fold + VisitMut {
     as_folder(ImportAnalyzer {
         scope,
-        import_srcs: HashSet::new(),
+        import_srcs: Default::default(),
     })
 }
 
 pub struct ImportAnalyzer {
     scope: Rc<RefCell<Scope>>,
-    import_srcs: HashSet<JsWord>,
+    import_srcs: AHashSet<JsWord>,
 }
 
 /// Inject required helpers methods **for** module transform passes.


### PR DESCRIPTION
- closes #2856

As commented in issue, crux is depends on import order import_analysis does not flag wildcard interop need to be used correctly. PR includes a scoped property to contain import sets to determine which interop is requred regardless of import order.