### PR TITLE
feat(es/parser): non-fatal unterminated string parsing

### DIFF
--- a/crates/swc_ecma_parser/src/lexer/jsx.rs
+++ b/crates/swc_ecma_parser/src/lexer/jsx.rs
@@ -148,7 +148,8 @@ impl<'a, I: Input> Lexer<'a, I> {
                 Some(c) => c,
                 None => {
                     let start = self.state.start;
-                    self.error(start, SyntaxError::UnterminatedStrLit)?
+                    self.emit_error(start, SyntaxError::UnterminatedStrLit);
+                    break;
                 }
             };
 
@@ -184,7 +185,13 @@ impl<'a, I: Input> Lexer<'a, I> {
         }
         let cur_pos = self.input.cur_pos();
         out.push_str(self.input.slice(chunk_start, cur_pos));
-        self.input.bump();
+
+        // it might be at the end of the file when
+        // the string literal is unterminated
+        if self.input.peek_ahead().is_some() {
+            self.input.bump();
+        }
+
         Ok(Token::Str {
             value: out.into(),
             has_escape,

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -883,7 +883,7 @@ impl<'a, I: Input> Lexer<'a, I> {
                         }
                         has_escape = true
                     }
-                    c if c.is_line_break() => l.error(start, SyntaxError::UnterminatedStrLit)?,
+                    c if c.is_line_break() => break,
                     _ => {
                         out.push(c);
                         l.bump();
@@ -891,7 +891,11 @@ impl<'a, I: Input> Lexer<'a, I> {
                 }
             }
 
-            l.error(start, SyntaxError::UnterminatedStrLit)?
+            l.emit_error(start, SyntaxError::UnterminatedStrLit);
+            return Ok(Token::Str {
+                value: (&**out).into(),
+                has_escape,
+            });
         })
     }
 

--- a/crates/swc_ecma_parser/tests/jsx/errors/unterminated-string/input.js.stderr
+++ b/crates/swc_ecma_parser/tests/jsx/errors/unterminated-string/input.js.stderr
@@ -4,3 +4,9 @@ error: Unexpected eof
 1 | <foo bar="
   |            ^
 
+error: Unterminated string constant
+ --> $DIR/tests/jsx/errors/unterminated-string/input.js:1:10
+  |
+1 | <foo bar="
+  |          ^^
+

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/0ffb1c3ecf85660e.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/0ffb1c3ecf85660e.js.stderr
@@ -1,6 +1,24 @@
+error: Expected ';', '}' or <eof>
+ --> $DIR/tests/test262-parser/fail/0ffb1c3ecf85660e.js:2:6
+  |
+2 | World"
+  |      ^
+  |
+note: This is the expression part of an expression statement
+ --> $DIR/tests/test262-parser/fail/0ffb1c3ecf85660e.js:2:1
+  |
+2 | World"
+  | ^^^^^
+
 error: Unterminated string constant
  --> $DIR/tests/test262-parser/fail/0ffb1c3ecf85660e.js:1:1
   |
 1 | "Hello
   | ^^^^^^
+
+error: Unterminated string constant
+ --> $DIR/tests/test262-parser/fail/0ffb1c3ecf85660e.js:2:6
+  |
+2 | World"
+  |      ^
 

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/5427bdf48f3eb6d9.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/5427bdf48f3eb6d9.js.stderr
@@ -1,3 +1,9 @@
+error: Invalid unicode escape
+ --> $DIR/tests/test262-parser/fail/5427bdf48f3eb6d9.js:1:3
+  |
+1 | ('\u{2028')
+  |   ^^^^^^^
+
 error: Unterminated string constant
  --> $DIR/tests/test262-parser/fail/5427bdf48f3eb6d9.js:1:10
   |

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/575367951ac8635d.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/575367951ac8635d.js.stderr
@@ -1,3 +1,9 @@
+error: Expected 4 hex characters
+ --> $DIR/tests/test262-parser/fail/575367951ac8635d.js:1:3
+  |
+1 | ('\u')
+  |   ^^
+
 error: Unterminated string constant
  --> $DIR/tests/test262-parser/fail/575367951ac8635d.js:1:5
   |

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/89036b2edb64c00c.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/89036b2edb64c00c.js.stderr
@@ -1,3 +1,15 @@
+error: Expected ',', got 'string literal ())'
+ --> $DIR/tests/test262-parser/fail/89036b2edb64c00c.js:2:1
+  |
+2 | ')
+  | ^^
+
+error: Unterminated string constant
+ --> $DIR/tests/test262-parser/fail/89036b2edb64c00c.js:1:2
+  |
+1 | ('
+  |  ^
+
 error: Unterminated string constant
  --> $DIR/tests/test262-parser/fail/89036b2edb64c00c.js:2:1
   |

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/b3fc8ced7ce28c35.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/b3fc8ced7ce28c35.js.stderr
@@ -1,3 +1,9 @@
+error: Expected 2 hex characters
+ --> $DIR/tests/test262-parser/fail/b3fc8ced7ce28c35.js:1:3
+  |
+1 | ('\x')
+  |   ^^
+
 error: Unterminated string constant
  --> $DIR/tests/test262-parser/fail/b3fc8ced7ce28c35.js:1:5
   |

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/b61406dafcaab4b7.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/b61406dafcaab4b7.js.stderr
@@ -1,3 +1,9 @@
+error: Expected 2 hex characters
+ --> $DIR/tests/test262-parser/fail/b61406dafcaab4b7.js:1:3
+  |
+1 | ('\x0')
+  |   ^^^
+
 error: Unterminated string constant
  --> $DIR/tests/test262-parser/fail/b61406dafcaab4b7.js:1:6
   |

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/dc431bcf293513a0.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/dc431bcf293513a0.js.stderr
@@ -4,3 +4,9 @@ error: Unexpected eof
 1 | (')
   |    ^
 
+error: Unterminated string constant
+ --> $DIR/tests/test262-parser/fail/dc431bcf293513a0.js:1:2
+  |
+1 | (')
+  |  ^^
+


### PR DESCRIPTION
This is part of #1178 for improving SWC support in editors. It allows getting an AST in spite of a unterminated string literal similar to the TypeScript compiler: https://ts-ast-viewer.com/#code/OQFwpgziCWB2DmAoR4oG5kCIRA

In Deno, this will help us do import completions when the user hasn't yet added a quote on a module specifier:

```ts
import * as something from "./
```