### PR TITLE
fix(node/swc): correctly deserialize parsefile options

### DIFF
--- a/crates/node/src/parse.rs
+++ b/crates/node/src/parse.rs
@@ -182,7 +182,7 @@ pub fn parse_file_sync(cx: CallContext) -> napi::Result<JsString> {
 pub fn parse_file(cx: CallContext) -> napi::Result<JsObject> {
     let c = get_compiler(&cx);
     let path = PathBuf::from(cx.get::<JsString>(0)?.into_utf8()?.as_str()?);
-    let options = cx.get::<JsString>(1)?.into_utf8()?.as_str()?.to_string();
+    let options = cx.get_buffer_as_string(1)?;
 
     cx.env
         .spawn(ParseFileTask { c, path, options })


### PR DESCRIPTION
- closes #2878 

minor fix to parseFile, per its interface https://github.com/swc-project/swc/blob/2462b9941f94bc475cf9ff9c67e3b7c1f98739cc/node-swc/src/index.ts#L237-L248 option is always an object but parse_file trying to read it as string and deserialize later.