### PR TITLE
fix(es/transforms/compat): Fix block scoping

### DIFF
--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
@@ -985,7 +985,22 @@ impl Visit for FunctionFinder {
         self.found = true;
     }
 
+    /// Do not recurse into nested loop.
+    fn visit_do_while_stmt(&mut self, _: &DoWhileStmt, _: &dyn Node) {}
+
+    /// Do not recurse into nested loop.
+    fn visit_for_in_stmt(&mut self, _: &ForInStmt, _: &dyn Node) {}
+
+    /// Do not recurse into nested loop.
+    fn visit_for_of_stmt(&mut self, _: &ForOfStmt, _: &dyn Node) {}
+
+    /// Do not recurse into nested loop.
+    fn visit_for_stmt(&mut self, _: &ForStmt, _: &dyn Node) {}
+
     fn visit_function(&mut self, _: &Function, _: &dyn Node) {
         self.found = true
     }
+
+    /// Do not recurse into nested loop.
+    fn visit_while_stmt(&mut self, _: &WhileStmt, _: &dyn Node) {}
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
@@ -986,15 +986,23 @@ impl Visit for FunctionFinder {
     }
 
     /// Do not recurse into nested loop.
+    ///
+    /// https://github.com/swc-project/swc/issues/2622
     fn visit_do_while_stmt(&mut self, _: &DoWhileStmt, _: &dyn Node) {}
 
     /// Do not recurse into nested loop.
+    ///
+    /// https://github.com/swc-project/swc/issues/2622
     fn visit_for_in_stmt(&mut self, _: &ForInStmt, _: &dyn Node) {}
 
     /// Do not recurse into nested loop.
+    ///
+    /// https://github.com/swc-project/swc/issues/2622
     fn visit_for_of_stmt(&mut self, _: &ForOfStmt, _: &dyn Node) {}
 
     /// Do not recurse into nested loop.
+    ///
+    /// https://github.com/swc-project/swc/issues/2622
     fn visit_for_stmt(&mut self, _: &ForStmt, _: &dyn Node) {}
 
     fn visit_function(&mut self, _: &Function, _: &dyn Node) {
@@ -1002,5 +1010,7 @@ impl Visit for FunctionFinder {
     }
 
     /// Do not recurse into nested loop.
+    ///
+    /// https://github.com/swc-project/swc/issues/2622
     fn visit_while_stmt(&mut self, _: &WhileStmt, _: &dyn Node) {}
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
@@ -742,6 +742,14 @@ impl VisitMut for FlowHelper<'_> {
     }
 
     /// https://github.com/swc-project/swc/pull/2916
+    fn visit_mut_do_while_stmt(&mut self, s: &mut DoWhileStmt) {
+        let old = self.in_nested_loop;
+        self.in_nested_loop = true;
+        s.visit_mut_children_with(self);
+        self.in_nested_loop = old;
+    }
+
+    /// https://github.com/swc-project/swc/pull/2916
     fn visit_mut_for_in_stmt(&mut self, s: &mut ForInStmt) {
         let old = self.in_nested_loop;
         self.in_nested_loop = true;
@@ -846,6 +854,14 @@ impl VisitMut for FlowHelper<'_> {
             _ => {}
         }
         n.visit_mut_children_with(self);
+    }
+
+    /// https://github.com/swc-project/swc/pull/2916
+    fn visit_mut_while_stmt(&mut self, s: &mut WhileStmt) {
+        let old = self.in_nested_loop;
+        self.in_nested_loop = true;
+        s.visit_mut_children_with(self);
+        self.in_nested_loop = old;
     }
 }
 

--- a/crates/swc_ecma_transforms_compat/tests/fixture/for-of/issue-2622/1/exec.js
+++ b/crates/swc_ecma_transforms_compat/tests/fixture/for-of/issue-2622/1/exec.js
@@ -1,0 +1,8 @@
+for (let a = 0; a < 2; a++) {
+    for (let b = 0; b < 2; b++) {
+        () => { };
+        for (let c = 0; c < 2; c++) {
+            console.log(b);
+        }
+    }
+}

--- a/crates/swc_ecma_transforms_compat/tests/fixture/for-of/issue-2799/1/exec.js
+++ b/crates/swc_ecma_transforms_compat/tests/fixture/for-of/issue-2799/1/exec.js
@@ -1,0 +1,12 @@
+const block = () => {
+    for (const value in { a: 1, b: 2, c: 3 }) {
+        for (let i = 0; i < 10; i++) {
+            function something() { }
+            continue
+
+            return { value }
+        }
+    }
+}
+console.log(block());
+console.log('OK?')

--- a/crates/swc_ecma_transforms_compat/tests/fixture/for-of/issue-2915/1/exec.js
+++ b/crates/swc_ecma_transforms_compat/tests/fixture/for-of/issue-2915/1/exec.js
@@ -1,21 +1,17 @@
+
 function foo(baz) {
-    console.log(baz);
     for (const g in baz) {
+        console.log(g);
+
         for (let j = 0; j < g.length; j++) {
-            const b = a[j];
-            const { k, f } = b;
-            const l = f.findIndex((x) => x === k);
-            const [x, y] = foo(a, b, c);
-            for (const a of foos) {
-                console.log(a);
-            }
+            console.log(j);
         }
     }
 }
 
 
 console.log(foo({
-    a: 1,
-    b: 2,
-    c: 3
+    a: [1],
+    b: [2, 2],
+    c: [3, 3, 3]
 }))

--- a/crates/swc_ecma_transforms_compat/tests/fixture/for-of/issue-2915/1/exec.js
+++ b/crates/swc_ecma_transforms_compat/tests/fixture/for-of/issue-2915/1/exec.js
@@ -1,0 +1,21 @@
+function foo(baz) {
+    console.log(baz);
+    for (const g in baz) {
+        for (let j = 0; j < g.length; j++) {
+            const b = a[j];
+            const { k, f } = b;
+            const l = f.findIndex((x) => x === k);
+            const [x, y] = foo(a, b, c);
+            for (const a of foos) {
+                console.log(a);
+            }
+        }
+    }
+}
+
+
+console.log(foo({
+    a: 1,
+    b: 2,
+    c: 3
+}))

--- a/crates/swc_ecma_transforms_compat/tests/fixture/for-of/next-31757/1/exec.js
+++ b/crates/swc_ecma_transforms_compat/tests/fixture/for-of/next-31757/1/exec.js
@@ -1,0 +1,10 @@
+let message = 0;
+for (let x of [1, 2, 3, 4, 5]) {
+    for (let y of ["a", "b", "c", "d"]) {
+        console.log("Message", ++message, x, y);
+        [].forEach(() => { });
+        break;
+    }
+}
+console.log("WHY", message == 5);
+

--- a/crates/swc_ecma_transforms_compat/tests/fixture/for-of/next-31757/2/exec.js
+++ b/crates/swc_ecma_transforms_compat/tests/fixture/for-of/next-31757/2/exec.js
@@ -1,0 +1,9 @@
+let message = 0;
+for (let x of [1, 2, 3, 4, 5]) {
+    for (let y of ["a", "b", "c", "d"]) {
+        console.log("Message", ++message, x, y);
+        break;
+    }
+}
+console.log("WHY", message == 5);
+


### PR DESCRIPTION
swc_ecma_transforms_compat:
 - `block_scoping`: Track if we are in nested loops.
 - `block_scoping`: Don't treat `break` nor `continue` in nested loops as leaper. (https://github.com/vercel/next.js/issues/31757, Closes #2799, Closes #2915)
 - `block_scoping`: Don't recurse into nested loops while looking for functions. (Closes #2622)
