### PR TITLE
chore: Make `rust-analyzer` faster

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
   "cSpell.allowCompoundWords": true,
   "cSpell.caseSensitive": true,
   "rust-analyzer.checkOnSave.features": [
+    // We use this to make IDE faster
     "rust-analyzer"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,4 +20,7 @@
   "eslint.enable": false,
   "cSpell.allowCompoundWords": true,
   "cSpell.caseSensitive": true,
+  "rust-analyzer.checkOnSave.features": [
+    "rust-analyzer"
+  ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "testing_macros"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "glob",

--- a/crates/testing_macros/Cargo.toml
+++ b/crates/testing_macros/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 name = "testing_macros"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.2.4"
+version = "0.2.5"
 
 [features]
 # Skip generating fixtures so the editor becomes faster again

--- a/crates/testing_macros/Cargo.toml
+++ b/crates/testing_macros/Cargo.toml
@@ -8,6 +8,10 @@ name = "testing_macros"
 repository = "https://github.com/swc-project/swc.git"
 version = "0.2.4"
 
+[features]
+# Skip generating fixtures so the editor becomes faster again
+rust-analyzer = []
+
 [lib]
 proc-macro = true
 

--- a/crates/testing_macros/src/lib.rs
+++ b/crates/testing_macros/src/lib.rs
@@ -53,6 +53,10 @@ mod fixture;
 /// - Support async function
 #[proc_macro_attribute]
 pub fn fixture(attr: TokenStream, item: TokenStream) -> TokenStream {
+    if cfg!(feature = "rust-analyzer") {
+        return item;
+    }
+
     let item: ItemFn = syn::parse(item).expect("failed to parse input as a function item");
     let config: self::fixture::Config =
         syn::parse(attr).expect("failed to parse input passed to #[fixture]");

--- a/crates/testing_macros/src/lib.rs
+++ b/crates/testing_macros/src/lib.rs
@@ -1,3 +1,4 @@
+use pmutil::q;
 use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::ItemFn;
@@ -53,11 +54,16 @@ mod fixture;
 /// - Support async function
 #[proc_macro_attribute]
 pub fn fixture(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let item: ItemFn = syn::parse(item).expect("failed to parse input as a function item");
+
     if cfg!(feature = "rust-analyzer") {
-        return item;
+        return q!(Vars { item }, {
+            #[allow(unused)]
+            item
+        })
+        .into();
     }
 
-    let item: ItemFn = syn::parse(item).expect("failed to parse input as a function item");
     let config: self::fixture::Config =
         syn::parse(attr).expect("failed to parse input passed to #[fixture]");
 


### PR DESCRIPTION
testing_macros:
 - Skip generating test functions if cargo feature `rust-analyzer` is enabled.