### PR TITLE
build(package): update exclude list for the pkg

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -54,3 +54,8 @@ rust-toolchain
 .rustfmt.toml
 .gitattributes
 .travis.yml
+.husky/
+.prettierrc
+crates/
+cspell.json
+deny.toml


### PR DESCRIPTION
This is chore for the aesthetics  to exclude few more non-runtime files from the pkg. 

if you peek latest pkg https://unpkg.com/browse/@swc/core@1.2.117/ there are few non-required files are packed in pkg tarball.

In a long run, I'd like to suggest to use allowlist instead - see examples at https://github.com/ReactiveX/rxjs/blob/master/package.json#L209-L227

This'll allow explicit list of files to be included pkg.