### PR TITLE
refactor(es/transforms/compat): visit_mut for class_prop:private_field

### DIFF
--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
@@ -737,7 +737,7 @@ impl ClassProperties {
             members.push(ClassMember::Constructor(c));
         }
 
-        extra_stmts.extend(private_method_fn_decls.fold_with(&mut FieldAccessFolder {
+        private_method_fn_decls.visit_mut_with(&mut FieldAccessFolder {
             mark: self.mark,
             method_mark: self.method_mark,
             private_methods: &private_methods,
@@ -745,9 +745,11 @@ impl ClassProperties {
             vars: vec![],
             class_name: &class_ident,
             in_assign_pat: false,
-        }));
+        });
 
-        let members = members.fold_with(&mut FieldAccessFolder {
+        extra_stmts.extend(private_method_fn_decls);
+
+        members.visit_mut_with(&mut FieldAccessFolder {
             mark: self.mark,
             method_mark: self.method_mark,
             private_methods: &private_methods,


### PR DESCRIPTION
Continuing https://github.com/swc-project/swc/issues/2370.

This PR refactors class_properties. As first part, updates private_field first. PR tries straightforward update as much, not touching existing logics.