### PR TITLE
fix(node-swc/types): add missing baseUrl to JscConfig

### DIFF
--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -494,6 +494,8 @@ export interface JscConfig {
     optimizeHygiene?: boolean
   },
 
+  baseUrl?: string
+
   paths?: {
     [from: string]: [string]
   }


### PR DESCRIPTION
Closes #2967.

`baseUrl` and `paths` first being introduced in swc back in #2227, being fixed in #2712. But only `paths` added to the type definition.