### PR TITLE
fix(es/parser): Drop outdated options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3822,7 +3822,7 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm"
-version = "1.2.117"
+version = "1.2.118"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1479,19 +1479,10 @@ impl Merge for Syntax {
 impl Merge for swc_ecma_parser::EsConfig {
     fn merge(&mut self, from: &Self) {
         self.jsx |= from.jsx;
-        self.class_private_props |= from.class_private_props;
-        self.class_private_methods |= from.class_private_methods;
-        self.class_props |= from.class_props;
         self.fn_bind |= from.fn_bind;
         self.decorators |= from.decorators;
         self.decorators_before_export |= from.decorators_before_export;
         self.export_default_from |= from.export_default_from;
-        self.export_namespace_from |= from.export_namespace_from;
-        self.dynamic_import |= from.dynamic_import;
-        self.nullish_coalescing |= from.nullish_coalescing;
-        self.optional_chaining |= from.optional_chaining;
-        self.import_meta |= from.import_meta;
-        self.top_level_await |= from.top_level_await;
         self.import_assertions |= from.import_assertions;
         self.static_blocks |= from.static_blocks;
         self.private_in_object |= from.private_in_object;
@@ -1503,6 +1494,7 @@ impl Merge for swc_ecma_parser::TsConfig {
         self.tsx |= from.tsx;
         self.decorators |= from.decorators;
         self.dynamic_import |= from.dynamic_import;
+        self.import_assertions |= from.import_assertions;
     }
 }
 

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1493,8 +1493,6 @@ impl Merge for swc_ecma_parser::TsConfig {
     fn merge(&mut self, from: &Self) {
         self.tsx |= from.tsx;
         self.decorators |= from.decorators;
-        self.dynamic_import |= from.dynamic_import;
-        self.import_assertions |= from.import_assertions;
     }
 }
 

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -966,10 +966,8 @@ impl Compiler {
                         jsx: true,
                         decorators: true,
                         decorators_before_export: true,
-                        top_level_await: true,
                         import_assertions: true,
                         private_in_object: true,
-                        dynamic_import: true,
 
                         ..Default::default()
                     }),

--- a/crates/swc/tests/rust_api.rs
+++ b/crates/swc/tests/rust_api.rs
@@ -132,7 +132,6 @@ fn shopify_2_same_opt() {
                     syntax: Some(Syntax::Typescript(TsConfig {
                         tsx: true,
                         decorators: false,
-                        dynamic_import: true,
                         dts: false,
                         no_early_errors: false,
                     })),
@@ -207,7 +206,6 @@ fn shopify_3_reduce_defaults() {
                 jsc: JscConfig {
                     syntax: Some(Syntax::Typescript(TsConfig {
                         tsx: true,
-                        dynamic_import: true,
                         ..Default::default()
                     })),
                     ..Default::default()

--- a/crates/swc/tests/simple.rs
+++ b/crates/swc/tests/simple.rs
@@ -61,8 +61,6 @@ const someValue = 'test' ?? 'default value';",
             config: Config {
                 jsc: JscConfig {
                     syntax: Some(Syntax::Es(EsConfig {
-                        nullish_coalescing: true,
-                        optional_chaining: true,
                         ..Default::default()
                     })),
                     ..Default::default()
@@ -83,7 +81,6 @@ fn issue_834_3() {
             config: Config {
                 jsc: JscConfig {
                     syntax: Some(Syntax::Es(EsConfig {
-                        nullish_coalescing: true,
                         ..Default::default()
                     })),
                     ..Default::default()

--- a/crates/swc/tests/tsc.rs
+++ b/crates/swc/tests/tsc.rs
@@ -120,7 +120,6 @@ fn compile(input: &Path, output: &Path, opts: Options) {
                             syntax: Some(Syntax::Typescript(TsConfig {
                                 tsx: input.to_string_lossy().ends_with(".tsx"),
                                 decorators: true,
-                                dynamic_import: true,
                                 dts: false,
                                 no_early_errors: true,
                             })),

--- a/crates/swc_bundler/tests/common/mod.rs
+++ b/crates/swc_bundler/tests/common/mod.rs
@@ -115,7 +115,6 @@ impl Load for Loader {
             Syntax::Typescript(TsConfig {
                 decorators: true,
                 tsx,
-                dynamic_import: true,
                 ..Default::default()
             }),
             EsVersion::Es2020,

--- a/crates/swc_ecma_codegen/src/tests.rs
+++ b/crates/swc_ecma_codegen/src/tests.rs
@@ -279,7 +279,6 @@ fn export_namespace_from() {
         "export * as Foo from 'foo';",
         Default::default(),
         Syntax::Es(EsConfig {
-            export_namespace_from: true,
             ..EsConfig::default()
         }),
     );
@@ -292,7 +291,6 @@ fn export_namespace_from_min() {
         "export*as Foo from'foo'",
         Config { minify: true },
         Syntax::Es(EsConfig {
-            export_namespace_from: true,
             ..EsConfig::default()
         }),
     );
@@ -525,7 +523,7 @@ fn integration_01_reduced_01() {
 }
 
 #[test]
-fn dneo_8541_1() {
+fn deno_8541_1() {
     test_from_to(
         "React.createElement('span', null, '\\u{b7}');",
         "React.createElement('span', null, '\\u{b7}');",

--- a/crates/swc_ecma_codegen/src/tests.rs
+++ b/crates/swc_ecma_codegen/src/tests.rs
@@ -303,7 +303,6 @@ fn named_and_namespace_export_from() {
         "export * as Foo, { bar } from 'foo';",
         Default::default(),
         Syntax::Es(EsConfig {
-            export_namespace_from: true,
             ..EsConfig::default()
         }),
     );
@@ -316,7 +315,6 @@ fn named_and_namespace_export_from_min() {
         "export*as Foo,{bar}from'foo'",
         Config { minify: true },
         Syntax::Es(EsConfig {
-            export_namespace_from: true,
             ..EsConfig::default()
         }),
     );

--- a/crates/swc_ecma_dep_graph/src/lib.rs
+++ b/crates/swc_ecma_dep_graph/src/lib.rs
@@ -228,7 +228,6 @@ mod tests {
                 Syntax::Typescript(TsConfig {
                     dts: file_name.ends_with(".d.ts"),
                     tsx: file_name.contains("tsx"),
-                    dynamic_import: true,
                     decorators: true,
                     no_early_errors: true,
                     ..Default::default()

--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -109,7 +109,6 @@ pub enum SyntaxError {
     ReservedWordInObjShorthandOrPat,
 
     NullishCoalescingWithLogicalOp,
-    NullishCoalescingNotEnabled,
 
     MultipleDefault {
         /// Span of the previous default case
@@ -406,9 +405,7 @@ impl SyntaxError {
             SyntaxError::DeclarePrivateIdentifier => {
                 "'declare' modifier cannot be used with a private identifier".into()
             }
-            SyntaxError::ClassProperty => {
-                "Class property requires `jsc.parser.classProperty` to be true".into()
-            }
+
             SyntaxError::ReadOnlyMethod => "A method cannot be readonly".into(),
             SyntaxError::TsBindingPatCannotBeOptional => "A binding pattern parameter cannot be \
                                                           optional in an implementation signature."
@@ -417,15 +414,10 @@ impl SyntaxError {
             SyntaxError::TrailingCommaInsideImport => {
                 "Trailing comma is disallowed inside import(...) arguments".into()
             }
-            SyntaxError::DynamicImport => {
-                "import(...) expressions requires `jsc.parser.dynamicImport` to be true".into()
-            }
+
             SyntaxError::ExportDefaultWithOutFrom => {
                 "export default statements required from '...';".into()
             }
-            SyntaxError::ExportNamespaceFrom => "export * as Foo from 'foo'; requires \
-                                                 `jsc.parser.exportNamespaceFrom` to be true"
-                .into(),
 
             SyntaxError::DotsWithoutIdentifier => {
                 "`...` must be followed by an identifier in declaration contexts".into()
@@ -438,9 +430,6 @@ impl SyntaxError {
             SyntaxError::NullishCoalescingWithLogicalOp => {
                 "Nullish coalescing operator(??) requires parens when mixing with logical operators"
                     .into()
-            }
-            SyntaxError::NullishCoalescingNotEnabled => {
-                "Nullish coalescing operator(??) requires jsc.parser.nullishCoalescing".into()
             }
 
             SyntaxError::TS1056 => {

--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -123,7 +123,7 @@ pub enum SyntaxError {
     InvalidExpr,
     NotSimpleAssign,
     ExpectedIdent,
-    ExpctedSemi,
+    ExpectedSemi,
     DuplicateLabel(JsWord),
     AsyncGenerator,
     NonTopLevelImportExport,
@@ -334,7 +334,7 @@ impl SyntaxError {
             // TODO
             SyntaxError::NotSimpleAssign => "Cannot assign to this".into(),
             SyntaxError::ExpectedIdent => "Expected ident".into(),
-            SyntaxError::ExpctedSemi => "Expected ';' or line break".into(),
+            SyntaxError::ExpectedSemi => "Expected ';' or line break".into(),
             SyntaxError::DuplicateLabel(ref label) => {
                 format!("Label {} is already declared", label).into()
             }
@@ -390,7 +390,7 @@ impl SyntaxError {
                 "A required element cannot follow an optional element.".into()
             }
             SyntaxError::TsInvalidParamPropPat => {
-                "Typescript parameter property must be identifer or assignment pattern".into()
+                "Typescript parameter property must be an identifier or assignment pattern".into()
             }
             SyntaxError::SpaceBetweenHashAndIdent => {
                 "Unexpected space between # and identifier".into()

--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -159,16 +159,13 @@ pub enum SyntaxError {
     AsyncConstructor,
     PropertyNamedConstructor,
     DeclarePrivateIdentifier,
-    ClassProperty,
     ReadOnlyMethod,
     GeneratorConstructor,
     TsBindingPatCannotBeOptional,
 
     TrailingCommaInsideImport,
-    DynamicImport,
 
     ExportDefaultWithOutFrom,
-    ExportNamespaceFrom,
 
     DotsWithoutIdentifier,
 

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -448,12 +448,8 @@ impl<'a, I: Input> Lexer<'a, I> {
             return Ok(None);
         }
 
-        if self.syntax.class_private_props() || self.syntax.class_private_methods() {
-            self.input.bump(); // '#'
-            return Ok(Some(Token::Hash));
-        }
-
-        self.error(start, SyntaxError::Hash)?
+        self.input.bump(); // '#'
+        return Ok(Some(Token::Hash));
     }
 
     fn read_token_interpreter(&mut self) -> LexResult<bool> {

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -442,8 +442,6 @@ impl<'a, I: Input> Lexer<'a, I> {
     fn read_token_number_sign(&mut self) -> LexResult<Option<Token>> {
         debug_assert!(self.cur().is_some());
 
-        let start = self.input.cur_pos();
-
         if self.input.is_at_start() && self.read_token_interpreter()? {
             return Ok(None);
         }

--- a/crates/swc_ecma_parser/src/lexer/number.rs
+++ b/crates/swc_ecma_parser/src/lexer/number.rs
@@ -347,7 +347,7 @@ impl<'a, I: Input> Lexer<'a, I> {
 
         let mut prev = None;
         while let Some(c) = self.cur() {
-            if allow_num_separator && self.syntax.num_sep() && c == '_' {
+            if allow_num_separator && c == '_' {
                 let is_allowed = |c: Option<char>| {
                     if c.is_none() {
                         return false;
@@ -438,7 +438,6 @@ mod tests {
         crate::with_test_sess(s, |_, fm| {
             let mut l = Lexer::new(
                 Syntax::Es(EsConfig {
-                    num_sep: true,
                     ..Default::default()
                 }),
                 Default::default(),

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -188,10 +188,6 @@ impl Syntax {
         }
     }
 
-    pub const fn num_sep(self) -> bool {
-        true
-    }
-
     pub fn decorators(self) -> bool {
         match self {
             Syntax::Es(EsConfig {
@@ -202,18 +198,6 @@ impl Syntax {
             }) => true,
             _ => false,
         }
-    }
-
-    pub const fn class_private_methods(self) -> bool {
-        true
-    }
-
-    pub const fn class_private_props(self) -> bool {
-        true
-    }
-
-    pub const fn class_props(self) -> bool {
-        true
     }
 
     pub fn decorators_before_export(self) -> bool {
@@ -250,24 +234,6 @@ impl Syntax {
             }) => true,
             _ => false,
         }
-    }
-
-    /// `true`
-    pub const fn export_namespace_from(self) -> bool {
-        true
-    }
-
-    /// `true`
-    pub const fn nullish_coalescing(self) -> bool {
-        true
-    }
-
-    pub const fn import_meta(self) -> bool {
-        true
-    }
-
-    pub const fn top_level_await(self) -> bool {
-        true
     }
 
     pub fn dts(self) -> bool {
@@ -319,23 +285,6 @@ pub struct TsConfig {
 pub struct EsConfig {
     #[serde(default)]
     pub jsx: bool,
-    /// Support numeric separator.
-    /// Stage 3.
-    #[serde(rename = "numericSeparator")]
-    #[serde(default)]
-    pub num_sep: bool,
-
-    #[serde(rename = "classPrivateProperty")]
-    #[serde(default)]
-    pub class_private_props: bool,
-
-    #[serde(rename = "privateMethod")]
-    #[serde(default)]
-    pub class_private_methods: bool,
-
-    #[serde(rename = "classProperty")]
-    #[serde(default)]
-    pub class_props: bool,
 
     /// Support function bind expression.
     #[serde(rename = "functionBind")]
@@ -355,27 +304,6 @@ pub struct EsConfig {
 
     #[serde(default)]
     pub export_default_from: bool,
-
-    #[serde(default)]
-    pub export_namespace_from: bool,
-
-    #[serde(default)]
-    pub dynamic_import: bool,
-
-    /// Stage 3.
-    #[serde(default)]
-    pub nullish_coalescing: bool,
-
-    #[serde(default)]
-    pub optional_chaining: bool,
-
-    /// Stage 3.
-    #[serde(default)]
-    pub import_meta: bool,
-
-    /// Stage 3.
-    #[serde(default)]
-    pub top_level_await: bool,
 
     /// Stage 3.
     #[serde(default)]

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -261,7 +261,7 @@ impl Syntax {
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct TsConfig {
     #[serde(default)]
     pub tsx: bool,
@@ -278,7 +278,7 @@ pub struct TsConfig {
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct EsConfig {
     #[serde(default)]
     pub jsx: bool,

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -269,9 +269,6 @@ pub struct TsConfig {
     #[serde(default)]
     pub decorators: bool,
 
-    #[serde(default)]
-    pub dynamic_import: bool,
-
     /// `.d.ts`
     #[serde(skip, default)]
     pub dts: bool,

--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -902,10 +902,6 @@ impl<'a, I: Tokens> Parser<I> {
         is_abstract: bool,
         is_override: bool,
     ) -> PResult<ClassMember> {
-        if !self.input.syntax().class_props() {
-            syntax_error!(self, span!(self, start), SyntaxError::ClassProperty)
-        }
-
         if is_constructor(&key) {
             syntax_error!(self, key.span(), SyntaxError::PropertyNamedConstructor);
         }
@@ -922,9 +918,6 @@ impl<'a, I: Tokens> Parser<I> {
         };
         self.with_ctx(ctx).parse_with(|p| {
             let value = if is!(p, '=') {
-                if !p.input.syntax().class_props() {
-                    syntax_error!(p, span!(p, start), SyntaxError::ClassProperty);
-                }
                 assert_and_bump!(p, '=');
                 Some(p.parse_assignment_expr()?)
             } else {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1664,10 +1664,6 @@ impl<'a, I: Tokens> Parser<I> {
         start: BytePos,
         import_ident: Ident,
     ) -> PResult<Box<Expr>> {
-        if !self.input.syntax().dynamic_import() {
-            syntax_error!(self, span!(self, start), SyntaxError::DynamicImport);
-        }
-
         let args = self.parse_args(true)?;
         let import = Box::new(Expr::Call(CallExpr {
             span: span!(self, start),

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -249,7 +249,7 @@ impl<'a, I: Tokens> Parser<I> {
 
                 tok!("import") => {
                     let import = self.parse_ident_name()?;
-                    if self.input.syntax().import_meta() && is!(self, '.') {
+                    if is!(self, '.') {
                         self.state.found_module_item = true;
                         if !self.ctx().can_be_module {
                             let span = span!(self, start);

--- a/crates/swc_ecma_parser/src/parser/expr/ops.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/ops.rs
@@ -131,10 +131,6 @@ impl<'a, I: Tokens> Parser<I> {
             }
         };
 
-        if !self.syntax().nullish_coalescing() && op == op!("??") {
-            self.emit_err(left.span(), SyntaxError::NullishCoalescingNotEnabled);
-        }
-
         if op.precedence() <= min_prec {
             if cfg!(feature = "debug") {
                 trace!(

--- a/crates/swc_ecma_parser/src/parser/expr/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/tests.rs
@@ -432,7 +432,7 @@ fn issue_380() {
     expr(
         " import('../foo/bar')
     .then(bar => {
-        // bar should be {default: DEFAULT_EXPORTED_THING_IN_BAR} or atleast what it is supposed \
+        // bar should be {default: DEFAULT_EXPORTED_THING_IN_BAR} or at least what it is supposed \
          to be
     })
 }",

--- a/crates/swc_ecma_parser/src/parser/expr/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/tests.rs
@@ -9,7 +9,6 @@ use test::Bencher;
 
 fn syntax() -> Syntax {
     Syntax::Es(EsConfig {
-        dynamic_import: true,
         ..Default::default()
     })
 }
@@ -374,7 +373,6 @@ fn issue_328() {
         test_parser(
             "import('test')",
             Syntax::Es(EsConfig {
-                dynamic_import: true,
                 ..Default::default()
             }),
             |p| { p.parse_stmt(true) }

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -1624,7 +1624,6 @@ export default function waitUntil(callback, options = {}) {
                 }
             }",
             Syntax::Es(EsConfig {
-                dynamic_import: true,
                 ..Default::default()
             }),
             |p| p.parse_module(),
@@ -1824,7 +1823,6 @@ export default function waitUntil(callback, options = {}) {
         test_parser(
             src,
             Syntax::Es(EsConfig {
-                import_meta: true,
                 ..Default::default()
             }),
             |p| p.parse_script(),
@@ -1837,7 +1835,6 @@ export default function waitUntil(callback, options = {}) {
         test_parser(
             src,
             Syntax::Es(EsConfig {
-                import_meta: true,
                 ..Default::default()
             }),
             |p| p.parse_program(),
@@ -1851,7 +1848,6 @@ export default function waitUntil(callback, options = {}) {
         test_parser(
             src,
             Syntax::Es(EsConfig {
-                dynamic_import: true,
                 ..Default::default()
             }),
             |p| p.parse_script(),
@@ -1865,7 +1861,6 @@ export default function waitUntil(callback, options = {}) {
         test_parser(
             src,
             Syntax::Es(EsConfig {
-                top_level_await: true,
                 ..Default::default()
             }),
             |p| p.parse_script(),
@@ -1878,7 +1873,6 @@ export default function waitUntil(callback, options = {}) {
         test_parser(
             src,
             Syntax::Es(EsConfig {
-                top_level_await: true,
                 ..Default::default()
             }),
             |p| p.parse_program(),

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -98,7 +98,7 @@ impl<'a, I: Tokens> Parser<I> {
         trace_cur!(self, parse_stmt_internal);
 
         if top_level && is!(self, "await") {
-            let valid = self.target() >= EsVersion::Es2017 && self.syntax().top_level_await();
+            let valid = self.target() >= EsVersion::Es2017;
 
             if !valid {
                 self.emit_err(self.input.cur_span(), SyntaxError::TopLevelAwait);
@@ -1189,7 +1189,7 @@ impl<'a, I: Tokens> StmtLikeParser<'a, Stmt> for Parser<I> {
             .into());
         }
 
-        if self.input.syntax().import_meta() && is!(self, "import") && peeked_is!(self, '.') {
+        if is!(self, "import") && peeked_is!(self, '.') {
             let expr = self.parse_expr()?;
 
             eat!(self, ';');
@@ -1514,7 +1514,6 @@ let x = 4";
             "export * as Foo from 'bar';",
             Syntax::Es(EsConfig {
                 export_default_from: true,
-                export_namespace_from: true,
                 ..Default::default()
             }),
             |p| p.parse_module(),
@@ -1609,7 +1608,6 @@ export default function waitUntil(callback, options = {}) {
         test_parser(
             "import(filePath).then(bar => {})",
             Syntax::Es(EsConfig {
-                dynamic_import: true,
                 ..Default::default()
             }),
             |p| p.parse_module(),
@@ -1650,7 +1648,6 @@ export default function waitUntil(callback, options = {}) {
         test_parser(
             "await foo",
             Syntax::Es(EsConfig {
-                top_level_await: true,
                 ..Default::default()
             }),
             |p| p.parse_module(),

--- a/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
@@ -404,9 +404,6 @@ impl<'a, I: Tokens> Parser<I> {
                 }));
             }
             if eat!(self, "as") {
-                if !self.input.syntax().export_namespace_from() {
-                    syntax_error!(self, span!(self, start), SyntaxError::ExportNamespaceFrom)
-                }
                 let _ = cur!(self, false);
 
                 let name = self.parse_ident_name()?;

--- a/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
@@ -5,7 +5,7 @@ impl<'a, I: Tokens> Parser<I> {
     fn parse_import(&mut self) -> PResult<ModuleItem> {
         let start = cur_pos!(self);
 
-        if self.input.syntax().import_meta() && peeked_is!(self, '.') {
+        if peeked_is!(self, '.') {
             let expr = self.parse_expr()?;
 
             eat!(self, ';');

--- a/crates/swc_ecma_parser/tests/comments.rs
+++ b/crates/swc_ecma_parser/tests/comments.rs
@@ -24,20 +24,10 @@ fn test(input: PathBuf) {
             let syntax = match &*ext {
                 "js" => Syntax::Es(EsConfig {
                     jsx: false,
-                    num_sep: true,
-                    class_private_props: true,
-                    class_private_methods: true,
-                    class_props: true,
                     fn_bind: false,
                     decorators: true,
                     decorators_before_export: false,
                     export_default_from: true,
-                    export_namespace_from: true,
-                    dynamic_import: true,
-                    nullish_coalescing: true,
-                    optional_chaining: true,
-                    import_meta: true,
-                    top_level_await: true,
                     import_assertions: true,
                     static_blocks: true,
                     ..Default::default()
@@ -45,7 +35,6 @@ fn test(input: PathBuf) {
                 "ts" | "tsx" => Syntax::Typescript(TsConfig {
                     tsx: ext == "tsx",
                     decorators: true,
-                    dynamic_import: true,
                     no_early_errors: true,
                     ..Default::default()
                 }),

--- a/crates/swc_ecma_parser/tests/typescript-errors/class/parameter-properties-binding-patterns/input.ts.stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/class/parameter-properties-binding-patterns/input.ts.stderr
@@ -1,4 +1,4 @@
-error: Typescript parameter property must be identifer or assignment pattern
+error: Typescript parameter property must be an identifier or assignment pattern
  --> $DIR/tests/typescript-errors/class/parameter-properties-binding-patterns/input.ts:2:24
   |
 2 |     constructor(public []) {}

--- a/crates/swc_ecma_parser/tests/typescript.rs
+++ b/crates/swc_ecma_parser/tests/typescript.rs
@@ -218,7 +218,6 @@ where
             Syntax::Typescript(TsConfig {
                 dts: fname.ends_with(".d.ts"),
                 tsx: fname.contains("tsx"),
-                dynamic_import: true,
                 decorators: true,
                 no_early_errors,
                 ..Default::default()

--- a/crates/swc_ecma_preset_env/tests/test.rs
+++ b/crates/swc_ecma_preset_env/tests/test.rs
@@ -174,7 +174,6 @@ fn exec(c: PresetConfig, dir: PathBuf) -> Result<(), Error> {
                 .expect("failed to load file");
             let mut p = Parser::new(
                 Syntax::Es(EsConfig {
-                    dynamic_import: true,
                     ..Default::default()
                 }),
                 StringInput::from(&*fm),
@@ -218,7 +217,6 @@ fn exec(c: PresetConfig, dir: PathBuf) -> Result<(), Error> {
 
                 let mut p = Parser::new(
                     Syntax::Es(EsConfig {
-                        dynamic_import: true,
                         ..Default::default()
                     }),
                     StringInput::from(&*fm),

--- a/crates/swc_ecma_transforms/tests/decorators.rs
+++ b/crates/swc_ecma_transforms/tests/decorators.rs
@@ -31,7 +31,6 @@ fn syntax(decorators_before_export: bool) -> Syntax {
     Syntax::Es(EsConfig {
         decorators_before_export,
         decorators: true,
-        class_props: true,
         ..Default::default()
     })
 }

--- a/crates/swc_ecma_transforms_base/tests/ts_resolver.rs
+++ b/crates/swc_ecma_transforms_base/tests/ts_resolver.rs
@@ -18,7 +18,6 @@ fn no_empty(input: PathBuf) {
             Syntax::Typescript(TsConfig {
                 tsx: input.ends_with("tsx"),
                 decorators: true,
-                dynamic_import: true,
                 no_early_errors: true,
                 ..Default::default()
             }),

--- a/crates/swc_ecma_transforms_compat/src/es2020/nullish_coalescing/tests.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2020/nullish_coalescing/tests.rs
@@ -8,7 +8,6 @@ fn tr(c: Config) -> impl Fold {
 
 fn syntax() -> Syntax {
     Syntax::Es(EsConfig {
-        nullish_coalescing: true,
         ..Default::default()
     })
 }

--- a/crates/swc_ecma_transforms_compat/tests/es2022_class_properties.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2022_class_properties.rs
@@ -22,8 +22,6 @@ fn ts() -> Syntax {
 
 fn syntax() -> Syntax {
     Syntax::Es(EsConfig {
-        class_private_props: true,
-        class_props: true,
         ..Default::default()
     })
 }

--- a/crates/swc_ecma_transforms_module/tests/amd.rs
+++ b/crates/swc_ecma_transforms_module/tests/amd.rs
@@ -11,7 +11,6 @@ use swc_ecma_visit::Fold;
 
 fn syntax() -> Syntax {
     Syntax::Es(EsConfig {
-        dynamic_import: true,
         ..Default::default()
     })
 }

--- a/crates/swc_ecma_transforms_module/tests/common_js.rs
+++ b/crates/swc_ecma_transforms_module/tests/common_js.rs
@@ -24,8 +24,6 @@ use swc_ecma_visit::Fold;
 
 fn syntax() -> Syntax {
     Syntax::Es(EsConfig {
-        dynamic_import: true,
-        top_level_await: true,
         static_blocks: true,
         ..Default::default()
     })

--- a/crates/swc_ecma_transforms_module/tests/umd.rs
+++ b/crates/swc_ecma_transforms_module/tests/umd.rs
@@ -11,7 +11,6 @@ use swc_ecma_visit::Fold;
 
 fn syntax() -> Syntax {
     Syntax::Es(EsConfig {
-        dynamic_import: true,
         ..Default::default()
     })
 }

--- a/crates/swc_ecma_transforms_optimization/tests/fixture.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/fixture.rs
@@ -11,7 +11,6 @@ fn dce_single_pass(input: PathBuf) {
     test_fixture(
         Syntax::Es(EsConfig {
             decorators: true,
-            dynamic_import: true,
             ..Default::default()
         }),
         &|_| dce(Default::default()),
@@ -27,7 +26,6 @@ fn dce_repeated(input: PathBuf) {
     test_fixture(
         Syntax::Es(EsConfig {
             decorators: true,
-            dynamic_import: true,
             ..Default::default()
         }),
         &|_| Repeat::new(dce(Default::default())),
@@ -42,7 +40,6 @@ fn expr(input: PathBuf) {
 
     test_fixture(
         Syntax::Es(EsConfig {
-            dynamic_import: true,
             ..Default::default()
         }),
         &|_| Repeat::new(expr_simplifier(Default::default())),

--- a/crates/swc_ecma_transforms_optimization/tests/simplify.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/simplify.rs
@@ -538,7 +538,6 @@ test!(
 
 test!(
     Syntax::Es(EsConfig {
-        dynamic_import: true,
         ..Default::default()
     }),
     |t| {

--- a/crates/swc_ecma_transforms_proposal/tests/export.rs
+++ b/crates/swc_ecma_transforms_proposal/tests/export.rs
@@ -13,7 +13,6 @@ fn syntax_default() -> Syntax {
 }
 fn syntax_namespace() -> Syntax {
     Syntax::Es(EsConfig {
-        export_namespace_from: true,
         ..Default::default()
     })
 }

--- a/crates/swc_ecma_transforms_react/src/pure_annotations/tests.rs
+++ b/crates/swc_ecma_transforms_react/src/pure_annotations/tests.rs
@@ -12,7 +12,6 @@ fn parse(
 ) -> Result<(Module, Lrc<SourceMap>, Lrc<SingleThreadedComments>), ()> {
     let syntax = ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
         jsx: true,
-        dynamic_import: true,
         ..Default::default()
     });
     let source_map = Lrc::new(SourceMap::default());

--- a/crates/swc_ecma_transforms_react/src/refresh/tests.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/tests.rs
@@ -1205,7 +1205,6 @@ test!(
 test!(
     ::swc_ecma_parser::Syntax::Typescript(::swc_ecma_parser::TsConfig {
         tsx: true,
-        dynamic_import: true,
         ..Default::default()
     }),
     tr,
@@ -1336,7 +1335,6 @@ test!(
 test!(
     ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
         jsx: true,
-        dynamic_import: true,
         ..Default::default()
     }),
     |t| {

--- a/crates/swc_ecma_transforms_typescript/examples/ts_to_js.rs
+++ b/crates/swc_ecma_transforms_typescript/examples/ts_to_js.rs
@@ -38,7 +38,6 @@ fn main() {
     let lexer = Lexer::new(
         Syntax::Typescript(TsConfig {
             tsx: input.ends_with(".tsx"),
-            dynamic_import: true,
             ..Default::default()
         }),
         Default::default(),

--- a/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
@@ -95,7 +95,6 @@ fn identity(entry: PathBuf) {
             Syntax::Typescript(TsConfig {
                 tsx: file_name.contains("tsx"),
                 decorators: true,
-                dynamic_import: true,
                 dts: false,
                 no_early_errors: false,
             }),
@@ -151,19 +150,9 @@ fn identity(entry: PathBuf) {
         let mut parser: Parser<Lexer<StringInput>> = Parser::new(
             Syntax::Es(EsConfig {
                 jsx: file_name.contains("tsx"),
-                num_sep: true,
-                class_private_props: true,
-                class_private_methods: true,
-                class_props: true,
                 decorators: true,
                 decorators_before_export: true,
                 export_default_from: true,
-                export_namespace_from: true,
-                dynamic_import: true,
-                nullish_coalescing: true,
-                optional_chaining: true,
-                import_meta: true,
-                top_level_await: true,
                 private_in_object: true,
                 ..Default::default()
             }),

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "wasm"
 publish = false
 repository = "https://github.com/swc-project/swc.git"
-version = "1.2.117"
+version = "1.2.118"
 
 [lib]
 crate-type = ["cdylib"]

--- a/cspell.json
+++ b/cspell.json
@@ -65,6 +65,7 @@
         "iife",
         "impls",
         "indexmap",
+        "initializers",
         "instanceof",
         "interner",
         "intrinsics",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@swc/core",
-    "version": "1.2.117",
+    "version": "1.2.118",
     "description": "Super-fast alternative for babel",
     "homepage": "https://swc.rs",
     "main": "./index.js",


### PR DESCRIPTION
swc_ecma_parser:
 - Drop flags in `EsConfig`.
 - Drop flags in `TsConfig`.
 - Drop unused variants from `SyntaxError`.