### PR TITLE
refactor(visit): Remove `&dyn Node` from `Visit`

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -50,9 +50,11 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: nightly-2021-09-30
+          override: true
 
       - name: Run benchmark
-        run: cargo bench --all --exclude swc_plugin | tee output.txt
+        run: cargo +nightly-2021-09-30 bench --all --exclude swc_plugin | tee output.txt
 
       - name: Download previous benchmark results
         run: mkdir raw-data && curl -o raw-data/benchmark-data.json https://raw.githubusercontent.com/swc-project/raw-data/gh-pages/benchmark-data.json

--- a/.npmignore
+++ b/.npmignore
@@ -57,5 +57,6 @@ rust-toolchain
 .husky/
 .prettierrc
 crates/
+packages/
 cspell.json
 deny.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "path-clean",
+ "proc-macro2",
  "serde",
  "serde_json",
  "swc",
@@ -1718,9 +1719,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.33"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -20,6 +20,7 @@ backtrace = "0.3"
 napi = {version = "1", features = ["serde-json"]}
 napi-derive = {version = "1"}
 path-clean = "0.1"
+proc-macro2 = "=1.0.32"
 serde = {version = "1", features = ["derive"]}
 serde_json = {version = "1", features = ["unbounded_depth"]}
 swc = {path = "../swc", features = ["concurrent", "wrong-target", "plugin"]}

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -140,9 +140,9 @@ use swc_common::{
     input::StringInput,
     source_map::SourceMapGenConfig,
     sync::Lrc,
-    BytePos, FileName, Globals, Mark, SourceFile, SourceMap, Spanned, DUMMY_SP, GLOBALS,
+    BytePos, FileName, Globals, Mark, SourceFile, SourceMap, Spanned, GLOBALS,
 };
-use swc_ecma_ast::{EsVersion, Ident, Invalid, Program};
+use swc_ecma_ast::{EsVersion, Ident, Program};
 use swc_ecma_codegen::{self, text_writer::WriteJs, Emitter, Node};
 use swc_ecma_loader::resolvers::{
     lru::CachingResolver, node::NodeModulesResolver, tsc::TsConfigResolver,
@@ -982,7 +982,7 @@ impl Compiler {
                     names: Default::default(),
                 };
 
-                module.visit_with( &mut v);
+                module.visit_with(&mut v);
 
                 v.names
             };
@@ -1052,7 +1052,7 @@ impl Compiler {
                     names: Default::default(),
                 };
 
-                program.visit_with( &mut v);
+                program.visit_with(&mut v);
 
                 v.names
             };
@@ -1117,7 +1117,7 @@ pub struct IdentCollector {
 impl Visit for IdentCollector {
     noop_visit_type!();
 
-    fn visit_ident(&mut self, ident: &Ident, _: &dyn swc_ecma_visit::Node) {
+    fn visit_ident(&mut self, ident: &Ident) {
         self.names.insert(ident.span.lo, ident.sym.clone());
     }
 }

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -982,7 +982,7 @@ impl Compiler {
                     names: Default::default(),
                 };
 
-                module.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+                module.visit_with( &mut v);
 
                 v.names
             };
@@ -1052,7 +1052,7 @@ impl Compiler {
                     names: Default::default(),
                 };
 
-                program.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+                program.visit_with( &mut v);
 
                 v.names
             };

--- a/crates/swc_bundler/src/bundler/chunk/computed_key.rs
+++ b/crates/swc_bundler/src/bundler/chunk/computed_key.rs
@@ -186,11 +186,11 @@ struct TopLevelAwaitFinder {
 impl Visit for TopLevelAwaitFinder {
     noop_visit_type!();
 
-    fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
-    fn visit_arrow_expr(&mut self, _: &ArrowExpr, _: &dyn Node) {}
-    fn visit_class_member(&mut self, _: &ClassMember, _: &dyn Node) {}
+    fn visit_function(&mut self, _: &Function) {}
+    fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
+    fn visit_class_member(&mut self, _: &ClassMember) {}
 
-    fn visit_await_expr(&mut self, _: &AwaitExpr, _: &dyn Node) {
+    fn visit_await_expr(&mut self, _: &AwaitExpr) {
         self.found = true;
     }
 }

--- a/crates/swc_bundler/src/bundler/chunk/computed_key.rs
+++ b/crates/swc_bundler/src/bundler/chunk/computed_key.rs
@@ -5,7 +5,7 @@ use swc_atoms::js_word;
 use swc_common::{SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{find_ids, private_ident, ExprFactory};
-use swc_ecma_visit::{noop_fold_type, noop_visit_type, Fold, Node, Visit};
+use swc_ecma_visit::{noop_fold_type, noop_visit_type, Fold, Visit};
 
 impl<L, R> Bundler<'_, L, R>
 where

--- a/crates/swc_bundler/src/bundler/finalize.rs
+++ b/crates/swc_bundler/src/bundler/finalize.rs
@@ -12,7 +12,7 @@ use swc_ecma_transforms_base::{
     hygiene::hygiene,
 };
 use swc_ecma_utils::{find_ids, private_ident, ExprFactory};
-use swc_ecma_visit::{noop_fold_type, noop_visit_type, Fold, FoldWith, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_fold_type, noop_visit_type, Fold, FoldWith, Visit, VisitWith};
 
 impl<L, R> Bundler<'_, L, R>
 where

--- a/crates/swc_bundler/src/bundler/finalize.rs
+++ b/crates/swc_bundler/src/bundler/finalize.rs
@@ -143,7 +143,7 @@ where
         }
 
         let mut top_level_await_finder = TopLevelAwaitFinder::default();
-        module.visit_with(&Invalid { span: DUMMY_SP }, &mut top_level_await_finder);
+        module.visit_with(&mut top_level_await_finder);
 
         let is_async = top_level_await_finder.found;
 

--- a/crates/swc_bundler/src/bundler/finalize.rs
+++ b/crates/swc_bundler/src/bundler/finalize.rs
@@ -352,9 +352,9 @@ struct TopLevelAwaitFinder {
 impl Visit for TopLevelAwaitFinder {
     noop_visit_type!();
 
-    fn visit_stmts(&mut self, _: &[Stmt], _: &dyn Node) {}
+    fn visit_stmts(&mut self, _: &[Stmt]) {}
 
-    fn visit_await_expr(&mut self, _: &AwaitExpr, _: &dyn Node) {
+    fn visit_await_expr(&mut self, _: &AwaitExpr) {
         self.found = true;
     }
 }

--- a/crates/swc_bundler/src/bundler/load.rs
+++ b/crates/swc_bundler/src/bundler/load.rs
@@ -183,7 +183,7 @@ where
                     forced_es6: false,
                     found_other: false,
                 };
-                module.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+                module.visit_with( &mut v);
                 v.forced_es6 || !v.found_other
             };
 

--- a/crates/swc_bundler/src/bundler/load.rs
+++ b/crates/swc_bundler/src/bundler/load.rs
@@ -14,14 +14,14 @@ use is_macro::Is;
 #[cfg(feature = "rayon")]
 use rayon::iter::ParallelIterator;
 use swc_atoms::js_word;
-use swc_common::{sync::Lrc, FileName, SourceFile, SyntaxContext, DUMMY_SP};
+use swc_common::{sync::Lrc, FileName, SourceFile, SyntaxContext};
 use swc_ecma_ast::{
-    CallExpr, Expr, ExprOrSuper, Ident, ImportDecl, ImportSpecifier, Invalid, MemberExpr, Module,
+    CallExpr, Expr, ExprOrSuper, Ident, ImportDecl, ImportSpecifier, MemberExpr, Module,
     ModuleDecl, Str,
 };
 use swc_ecma_transforms_base::resolver::resolver_with_mark;
 use swc_ecma_visit::{
-    noop_visit_mut_type, noop_visit_type, FoldWith, Node, Visit, VisitMut, VisitMutWith, VisitWith,
+    noop_visit_mut_type, noop_visit_type, FoldWith, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 /// Module after applying transformations.
 #[derive(Debug, Clone)]

--- a/crates/swc_bundler/src/bundler/load.rs
+++ b/crates/swc_bundler/src/bundler/load.rs
@@ -415,7 +415,7 @@ struct Es6ModuleDetector {
 impl Visit for Es6ModuleDetector {
     noop_visit_type!();
 
-    fn visit_call_expr(&mut self, e: &CallExpr, _: &dyn Node) {
+    fn visit_call_expr(&mut self, e: &CallExpr) {
         e.visit_children_with(self);
 
         match &e.callee {
@@ -432,7 +432,7 @@ impl Visit for Es6ModuleDetector {
         }
     }
 
-    fn visit_member_expr(&mut self, e: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, e: &MemberExpr) {
         e.obj.visit_with(e as _, self);
 
         if e.computed {
@@ -462,7 +462,7 @@ impl Visit for Es6ModuleDetector {
         //
     }
 
-    fn visit_module_decl(&mut self, decl: &ModuleDecl, _: &dyn Node) {
+    fn visit_module_decl(&mut self, decl: &ModuleDecl) {
         match decl {
             ModuleDecl::Import(_)
             | ModuleDecl::ExportDecl(_)

--- a/crates/swc_bundler/src/bundler/load.rs
+++ b/crates/swc_bundler/src/bundler/load.rs
@@ -183,7 +183,7 @@ where
                     forced_es6: false,
                     found_other: false,
                 };
-                module.visit_with( &mut v);
+                module.visit_with(&mut v);
                 v.forced_es6 || !v.found_other
             };
 
@@ -433,10 +433,10 @@ impl Visit for Es6ModuleDetector {
     }
 
     fn visit_member_expr(&mut self, e: &MemberExpr) {
-        e.obj.visit_with(e as _, self);
+        e.obj.visit_with(self);
 
         if e.computed {
-            e.prop.visit_with(e as _, self);
+            e.prop.visit_with(self);
         }
 
         match &e.obj {

--- a/crates/swc_bundler/src/inline.rs
+++ b/crates/swc_bundler/src/inline.rs
@@ -2,7 +2,7 @@ use crate::{id::Id, modules::Modules, util::Readonly};
 use swc_common::{collections::AHashMap, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{
-    noop_visit_mut_type, noop_visit_type, Node, Visit, VisitMut, VisitMutWith, VisitWith,
+    noop_visit_mut_type, noop_visit_type, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 
 #[derive(Debug, Default)]

--- a/crates/swc_bundler/src/inline.rs
+++ b/crates/swc_bundler/src/inline.rs
@@ -60,15 +60,15 @@ impl Visit for Analyzer<'_> {
     noop_visit_type!();
 
     /// Noop
-    fn visit_module_decl(&mut self, _: &ModuleDecl, _: &dyn Node) {}
+    fn visit_module_decl(&mut self, _: &ModuleDecl) {}
 
     /// Noop. We don't inline variables declared in subscopes.
-    fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
+    fn visit_function(&mut self, _: &Function) {}
 
     /// Noop. We don't inline variables declared in subscopes.
-    fn visit_block_stmt(&mut self, _: &BlockStmt, _: &dyn Node) {}
+    fn visit_block_stmt(&mut self, _: &BlockStmt) {}
 
-    fn visit_var_decl(&mut self, n: &VarDecl, _: &dyn Node) {
+    fn visit_var_decl(&mut self, n: &VarDecl) {
         if n.span.ctxt != self.injected_ctxt || n.kind != VarDeclKind::Const {
             return;
         }
@@ -76,7 +76,7 @@ impl Visit for Analyzer<'_> {
         n.visit_children_with(self);
     }
 
-    fn visit_var_declarator(&mut self, n: &VarDeclarator, _: &dyn Node) {
+    fn visit_var_declarator(&mut self, n: &VarDeclarator) {
         n.visit_children_with(self);
         match (&n.name, n.init.as_deref()) {
             (Pat::Ident(from), Some(Expr::Ident(to))) => {

--- a/crates/swc_bundler/src/modules/mod.rs
+++ b/crates/swc_bundler/src/modules/mod.rs
@@ -225,8 +225,7 @@ impl Modules {
     where
         V: Visit,
     {
-        self.iter()
-            .for_each(|item| item.1.visit_with( v));
+        self.iter().for_each(|item| item.1.visit_with(v));
     }
 
     pub fn retain_mut<F>(&mut self, mut op: F)

--- a/crates/swc_bundler/src/modules/mod.rs
+++ b/crates/swc_bundler/src/modules/mod.rs
@@ -226,7 +226,7 @@ impl Modules {
         V: Visit,
     {
         self.iter()
-            .for_each(|item| item.1.visit_with(&Invalid { span: DUMMY_SP }, v));
+            .for_each(|item| item.1.visit_with( v));
     }
 
     pub fn retain_mut<F>(&mut self, mut op: F)

--- a/crates/swc_bundler/src/modules/sort/stmt.rs
+++ b/crates/swc_bundler/src/modules/sort/stmt.rs
@@ -677,7 +677,7 @@ fn calc_deps(new: &[ModuleItem]) -> StmtDepGraph {
         {
             // Find extra initializations.
             let mut v = FieldInitFinter::default();
-            item.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+            item.visit_with( &mut v);
 
             for id in v.accessed {
                 if let Some(declarator_indexes) = declared_by.get(&id) {
@@ -726,7 +726,7 @@ fn calc_deps(new: &[ModuleItem]) -> StmtDepGraph {
                 found: false,
                 in_complex: false,
             };
-            item.visit_with(&Invalid { span: DUMMY_SP }, &mut finder);
+            item.visit_with( &mut finder);
             if finder.found {
                 declared_by.entry(uninit_id).or_default().push(idx);
                 break;
@@ -741,7 +741,7 @@ fn calc_deps(new: &[ModuleItem]) -> StmtDepGraph {
 
         let mut visitor = RequirementCalculator::default();
 
-        item.visit_with(&Invalid { span: DUMMY_SP }, &mut visitor);
+        item.visit_with( &mut visitor);
 
         for (id, kind) in visitor.required_ids {
             if visitor.excluded.contains(&id) {

--- a/crates/swc_bundler/src/modules/sort/stmt.rs
+++ b/crates/swc_bundler/src/modules/sort/stmt.rs
@@ -498,7 +498,7 @@ impl Visit for InitializerFinder {
         }
 
         if e.computed {
-            e.prop.visit_with(e as _, self);
+            e.prop.visit_with(self);
         }
     }
 }
@@ -622,10 +622,10 @@ impl Visit for RequirementCalculator {
     }
 
     fn visit_member_expr(&mut self, e: &MemberExpr) {
-        e.obj.visit_with(e as _, self);
+        e.obj.visit_with(self);
 
         if e.computed {
-            e.prop.visit_with(e as _, self);
+            e.prop.visit_with(self);
         }
     }
 }

--- a/crates/swc_bundler/tests/deno.rs
+++ b/crates/swc_bundler/tests/deno.rs
@@ -1150,7 +1150,7 @@ struct ExportCollector {
 }
 
 impl Visit for ExportCollector {
-    fn visit_export_specifier(&mut self, s: &ExportSpecifier, _: &dyn Node) {
+    fn visit_export_specifier(&mut self, s: &ExportSpecifier) {
         match s {
             ExportSpecifier::Namespace(ns) => {
                 self.exports.insert(ns.name.sym.to_string());
@@ -1171,15 +1171,15 @@ impl Visit for ExportCollector {
         }
     }
 
-    fn visit_export_default_decl(&mut self, _: &ExportDefaultDecl, _: &dyn Node) {
+    fn visit_export_default_decl(&mut self, _: &ExportDefaultDecl) {
         self.exports.insert("default".into());
     }
 
-    fn visit_export_default_expr(&mut self, _: &ExportDefaultExpr, _: &dyn Node) {
+    fn visit_export_default_expr(&mut self, _: &ExportDefaultExpr) {
         self.exports.insert("default".into());
     }
 
-    fn visit_export_decl(&mut self, export: &ExportDecl, _: &dyn Node) {
+    fn visit_export_decl(&mut self, export: &ExportDecl) {
         match &export.decl {
             swc_ecma_ast::Decl::Class(ClassDecl { ident, .. })
             | swc_ecma_ast::Decl::Fn(FnDecl { ident, .. }) => {

--- a/crates/swc_bundler/tests/deno.rs
+++ b/crates/swc_bundler/tests/deno.rs
@@ -23,7 +23,7 @@ use swc_ecma_codegen::{
 use swc_ecma_minifier::option::MangleOptions;
 use swc_ecma_transforms_base::{fixer::fixer, resolver::resolver_with_mark};
 use swc_ecma_utils::{find_ids, Id};
-use swc_ecma_visit::{Node, Visit, VisitMutWith, VisitWith};
+use swc_ecma_visit::{Visit, VisitMutWith, VisitWith};
 use testing::assert_eq;
 
 #[path = "common/mod.rs"]
@@ -1139,7 +1139,7 @@ impl swc_bundler::Hook for Hook {
 
 fn collect_exports(module: &Module) -> AHashSet<String> {
     let mut v = ExportCollector::default();
-    module.visit_with(module, &mut v);
+    module.visit_with(&mut v);
 
     v.exports
 }

--- a/crates/swc_css_parser/tests/fixture.rs
+++ b/crates/swc_css_parser/tests/fixture.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use swc_common::{errors::Handler, input::SourceFileInput, Span, Spanned, DUMMY_SP};
+use swc_common::{errors::Handler, input::SourceFileInput, Span, Spanned};
 use swc_css_ast::*;
 use swc_css_parser::{
     error::ErrorKind,
@@ -266,7 +266,7 @@ struct SpanVisualizer<'a> {
 
 macro_rules! mtd {
     ($T:ty,$name:ident) => {
-        fn $name(&mut self, n: &$T, _: &dyn swc_css_visit::Node) {
+        fn $name(&mut self, n: &$T) {
             self.handler
                 .struct_span_err(n.span(), stringify!($T))
                 .emit();
@@ -349,7 +349,7 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(UnknownAtRule, visit_unknown_at_rule);
     mtd!(ViewportRule, visit_viewport_rule);
 
-    fn visit_token_and_span(&mut self, n: &TokenAndSpan, _parent: &dyn swc_css_visit::Node) {
+    fn visit_token_and_span(&mut self, n: &TokenAndSpan) {
         self.handler
             .struct_span_err(n.span, &format!("{:?}", n.token))
             .emit();
@@ -379,10 +379,7 @@ fn span(input: PathBuf) {
 
         match stylesheet {
             Ok(stylesheet) => {
-                stylesheet.visit_with(
-                    &Invalid { span: DUMMY_SP },
-                    &mut SpanVisualizer { handler: &handler },
-                );
+                stylesheet.visit_with(&mut SpanVisualizer { handler: &handler });
 
                 Err(())
             }

--- a/crates/swc_ecma_dep_graph/src/lib.rs
+++ b/crates/swc_ecma_dep_graph/src/lib.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use swc_atoms::JsWord;
 use swc_common::{
     comments::{Comment, Comments},
-    Span, DUMMY_SP,
+    Span,
 };
 use swc_ecma_ast as ast;
-use swc_ecma_visit::{self, Node, Visit, VisitWith};
+use swc_ecma_visit::{self, Visit, VisitWith};
 
 pub fn analyze_dependencies(
     module: &ast::Module,

--- a/crates/swc_ecma_dep_graph/src/lib.rs
+++ b/crates/swc_ecma_dep_graph/src/lib.rs
@@ -16,7 +16,7 @@ pub fn analyze_dependencies(
         items: vec![],
         is_top_level: true,
     };
-    module.visit_with(&ast::Invalid { span: DUMMY_SP }, &mut v);
+    module.visit_with(&mut v);
     v.items
 }
 

--- a/crates/swc_ecma_dep_graph/src/lib.rs
+++ b/crates/swc_ecma_dep_graph/src/lib.rs
@@ -63,7 +63,7 @@ impl<'a> DependencyCollector<'a> {
 }
 
 impl<'a> Visit for DependencyCollector<'a> {
-    fn visit_import_decl(&mut self, node: &ast::ImportDecl, _parent: &dyn Node) {
+    fn visit_import_decl(&mut self, node: &ast::ImportDecl) {
         let specifier = node.src.value.clone();
         let leading_comments = self.get_leading_comments(node.span);
         let kind = if node.type_only {
@@ -83,7 +83,7 @@ impl<'a> Visit for DependencyCollector<'a> {
         });
     }
 
-    fn visit_named_export(&mut self, node: &ast::NamedExport, _parent: &dyn Node) {
+    fn visit_named_export(&mut self, node: &ast::NamedExport) {
         if let Some(src) = &node.src {
             let specifier = src.value.clone();
             let leading_comments = self.get_leading_comments(node.span);
@@ -105,7 +105,7 @@ impl<'a> Visit for DependencyCollector<'a> {
         }
     }
 
-    fn visit_export_all(&mut self, node: &ast::ExportAll, _parent: &dyn Node) {
+    fn visit_export_all(&mut self, node: &ast::ExportAll) {
         let specifier = node.src.value.clone();
         let leading_comments = self.get_leading_comments(node.span);
         let import_assertions = parse_import_assertions(node.asserts.as_ref());
@@ -120,7 +120,7 @@ impl<'a> Visit for DependencyCollector<'a> {
         });
     }
 
-    fn visit_ts_import_type(&mut self, node: &ast::TsImportType, _parent: &dyn Node) {
+    fn visit_ts_import_type(&mut self, node: &ast::TsImportType) {
         let specifier = node.arg.value.clone();
         let span = node.span;
         let leading_comments = self.get_leading_comments(span);
@@ -135,20 +135,20 @@ impl<'a> Visit for DependencyCollector<'a> {
         });
     }
 
-    fn visit_module_items(&mut self, items: &[ast::ModuleItem], _parent: &dyn Node) {
-        swc_ecma_visit::visit_module_items(self, items, _parent);
+    fn visit_module_items(&mut self, items: &[ast::ModuleItem]) {
+        swc_ecma_visit::visit_module_items(self, items);
     }
 
-    fn visit_stmts(&mut self, items: &[ast::Stmt], _parent: &dyn Node) {
+    fn visit_stmts(&mut self, items: &[ast::Stmt]) {
         self.is_top_level = false;
-        swc_ecma_visit::visit_stmts(self, items, _parent);
+        swc_ecma_visit::visit_stmts(self, items);
         self.is_top_level = true;
     }
 
-    fn visit_call_expr(&mut self, node: &ast::CallExpr, _parent: &dyn Node) {
+    fn visit_call_expr(&mut self, node: &ast::CallExpr) {
         use ast::{Expr::*, ExprOrSuper::*};
 
-        swc_ecma_visit::visit_call_expr(self, node, _parent);
+        swc_ecma_visit::visit_call_expr(self, node);
         let call_expr = match node.callee.clone() {
             Super(_) => return,
             Expr(boxed) => boxed,

--- a/crates/swc_ecma_minifier/src/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/analyzer/mod.rs
@@ -63,7 +63,7 @@ pub(crate) struct VarUsageInfo {
     /// The number of reference to this identifier.
     pub ref_count: usize,
 
-    /// `true` if a varaible is conditionally initialized.
+    /// `true` if a variable is conditionally initialized.
     pub cond_init: bool,
 
     /// `false` if it's only used.
@@ -110,7 +110,7 @@ pub(crate) struct VarUsageInfo {
 
     pub used_as_callee: bool,
 
-    /// In `c = b`, `b` inffects `c`.
+    /// In `c = b`, `b` infects `c`.
     infects: Vec<Id>,
 }
 
@@ -243,7 +243,7 @@ where
                     in_pat_of_param: true,
                     ..child.ctx
                 };
-                n.params.visit_with(n, &mut *child.with_ctx(ctx));
+                n.params.visit_with(&mut *child.with_ctx(ctx));
             }
 
             match &n.body {
@@ -253,7 +253,7 @@ where
                     body.visit_children_with(child);
                 }
                 BlockStmtOrExpr::Expr(body) => {
-                    body.visit_with(n, child);
+                    body.visit_with(child);
                 }
             }
         })
@@ -266,14 +266,14 @@ where
             is_op_assign: n.op != op!("="),
             ..self.ctx
         };
-        n.left.visit_with(n, &mut *self.with_ctx(ctx));
+        n.left.visit_with(&mut *self.with_ctx(ctx));
 
         let ctx = Ctx {
             in_assign_lhs: false,
             is_exact_reassignment: false,
             ..self.ctx
         };
-        n.right.visit_with(n, &mut *self.with_ctx(ctx));
+        n.right.visit_with(&mut *self.with_ctx(ctx));
     }
 
     fn visit_await_expr(&mut self, n: &AwaitExpr) {
@@ -302,7 +302,7 @@ where
                 inline_prevented,
                 ..self.ctx
             };
-            n.callee.visit_with(n, &mut *self.with_ctx(ctx));
+            n.callee.visit_with(&mut *self.with_ctx(ctx));
         }
 
         match &n.callee {
@@ -326,7 +326,7 @@ where
                 is_exact_reassignment: false,
                 ..self.ctx
             };
-            n.args.visit_with(n, &mut *self.with_ctx(ctx));
+            n.args.visit_with(&mut *self.with_ctx(ctx));
         }
 
         match &n.callee {

--- a/crates/swc_ecma_minifier/src/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/analyzer/mod.rs
@@ -347,7 +347,7 @@ where
                 in_catch_param: true,
                 ..self.ctx
             };
-            n.param.visit_with(n, &mut *self.with_ctx(ctx));
+            n.param.visit_with(&mut *self.with_ctx(ctx));
         }
 
         {
@@ -355,7 +355,7 @@ where
                 in_cond: true,
                 ..self.ctx
             };
-            n.body.visit_with(n, &mut *self.with_ctx(ctx));
+            n.body.visit_with(&mut *self.with_ctx(ctx));
         }
     }
 
@@ -367,7 +367,7 @@ where
                 inline_prevented: true,
                 ..self.ctx
             };
-            n.super_class.visit_with(n, &mut *self.with_ctx(ctx));
+            n.super_class.visit_with(&mut *self.with_ctx(ctx));
         }
 
         n.body.visit_with(self);
@@ -387,8 +387,8 @@ where
                 in_cond: true,
                 ..self.ctx
             };
-            n.cons.visit_with(n, &mut *self.with_ctx(ctx));
-            n.alt.visit_with(n, &mut *self.with_ctx(ctx));
+            n.cons.visit_with(&mut *self.with_ctx(ctx));
+            n.alt.visit_with(&mut *self.with_ctx(ctx));
         }
     }
 
@@ -441,16 +441,16 @@ where
                 is_exact_reassignment: true,
                 ..child.ctx
             };
-            n.left.visit_with(n, &mut *child.with_ctx(ctx));
+            n.left.visit_with(&mut *child.with_ctx(ctx));
 
-            n.right.visit_with(n, child);
+            n.right.visit_with(child);
 
             let ctx = Ctx {
                 in_loop: true,
                 in_cond: true,
                 ..child.ctx
             };
-            n.body.visit_with(n, &mut *child.with_ctx(ctx));
+            n.body.visit_with(&mut *child.with_ctx(ctx));
         });
     }
 
@@ -463,14 +463,14 @@ where
                 is_exact_reassignment: true,
                 ..child.ctx
             };
-            n.left.visit_with(n, &mut *child.with_ctx(ctx));
+            n.left.visit_with(&mut *child.with_ctx(ctx));
 
             let ctx = Ctx {
                 in_loop: true,
                 in_cond: true,
                 ..child.ctx
             };
-            n.body.visit_with(n, &mut *child.with_ctx(ctx))
+            n.body.visit_with(&mut *child.with_ctx(ctx))
         });
     }
 
@@ -483,10 +483,10 @@ where
             ..self.ctx
         };
 
-        n.test.visit_with(n, &mut *self.with_ctx(ctx));
-        n.update.visit_with(n, &mut *self.with_ctx(ctx));
+        n.test.visit_with(&mut *self.with_ctx(ctx));
+        n.update.visit_with(&mut *self.with_ctx(ctx));
 
-        n.body.visit_with(n, &mut *self.with_ctx(ctx));
+        n.body.visit_with(&mut *self.with_ctx(ctx));
     }
 
     fn visit_function(&mut self, n: &Function) {
@@ -510,7 +510,7 @@ where
 
         self.with_ctx(ctx)
             .with_child(n.span.ctxt, ScopeKind::Fn, |child| {
-                n.params.visit_with(n, child);
+                n.params.visit_with(child);
 
                 match &n.body {
                     Some(body) => {
@@ -529,8 +529,8 @@ where
             ..self.ctx
         };
         n.test.visit_with(self);
-        n.cons.visit_with(n, &mut *self.with_ctx(ctx));
-        n.alt.visit_with(n, &mut *self.with_ctx(ctx));
+        n.cons.visit_with(&mut *self.with_ctx(ctx));
+        n.alt.visit_with(&mut *self.with_ctx(ctx));
     }
 
     fn visit_import_default_specifier(&mut self, n: &ImportDefaultSpecifier) {
@@ -612,7 +612,7 @@ where
                 is_exact_arg: true,
                 ..self.ctx
             };
-            n.args.visit_with(n, &mut *self.with_ctx(ctx));
+            n.args.visit_with(&mut *self.with_ctx(ctx));
         }
     }
 
@@ -632,14 +632,14 @@ where
             in_pat_of_param: false,
             ..self.ctx
         };
-        n.decorators.visit_with(n, &mut *self.with_ctx(ctx));
+        n.decorators.visit_with(&mut *self.with_ctx(ctx));
 
         let ctx = Ctx {
             in_pat_of_param: true,
             var_decl_kind_of_pat: None,
             ..self.ctx
         };
-        n.pat.visit_with(n, &mut *self.with_ctx(ctx));
+        n.pat.visit_with(&mut *self.with_ctx(ctx));
     }
 
     fn visit_pat(&mut self, n: &Pat) {
@@ -668,16 +668,16 @@ where
 
     fn visit_setter_prop(&mut self, n: &SetterProp) {
         self.with_child(n.span.ctxt, ScopeKind::Fn, |a| {
-            n.key.visit_with(n, a);
+            n.key.visit_with(a);
             {
                 let ctx = Ctx {
                     in_pat_of_param: true,
                     ..a.ctx
                 };
-                n.param.visit_with(n, &mut *a.with_ctx(ctx));
+                n.param.visit_with(&mut *a.with_ctx(ctx));
             }
 
-            n.body.visit_with(n, a);
+            n.body.visit_with(a);
         });
     }
 
@@ -712,7 +712,7 @@ where
                 in_cond: true,
                 ..self.ctx
             };
-            n.cons.visit_with(n, &mut *self.with_ctx(ctx));
+            n.cons.visit_with(&mut *self.with_ctx(ctx));
         }
     }
 
@@ -782,7 +782,7 @@ where
                 },
                 ..self.ctx
             };
-            e.name.visit_with(e, &mut *self.with_ctx(ctx));
+            e.name.visit_with(&mut *self.with_ctx(ctx));
         }
 
         {
@@ -792,7 +792,7 @@ where
                 ..self.ctx
             };
 
-            e.init.visit_with(e, &mut *self.with_ctx(ctx));
+            e.init.visit_with(&mut *self.with_ctx(ctx));
         }
     }
 

--- a/crates/swc_ecma_minifier/src/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/analyzer/mod.rs
@@ -43,7 +43,7 @@ where
         scope: Default::default(),
         ctx: Default::default(),
     };
-    n.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+    n.visit_with( &mut v);
     let top_scope = v.scope;
     v.data.top_scope().merge(top_scope, false);
 
@@ -553,7 +553,7 @@ where
                 ..self.ctx
             };
             e.obj
-                .visit_with(&Invalid { span: DUMMY_SP }, &mut *self.with_ctx(ctx));
+                .visit_with( &mut *self.with_ctx(ctx));
         }
 
         if e.computed {
@@ -563,7 +563,7 @@ where
                 ..self.ctx
             };
             e.prop
-                .visit_with(&Invalid { span: DUMMY_SP }, &mut *self.with_ctx(ctx));
+                .visit_with( &mut *self.with_ctx(ctx));
         }
 
         match &e.obj {
@@ -700,7 +700,7 @@ where
                 ..self.ctx
             };
 
-            stmt.visit_with(&Invalid { span: DUMMY_SP }, &mut *self.with_ctx(ctx));
+            stmt.visit_with( &mut *self.with_ctx(ctx));
 
             had_cond |= can_end_conditionally(stmt);
         }

--- a/crates/swc_ecma_minifier/src/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/analyzer/mod.rs
@@ -360,7 +360,7 @@ where
     }
 
     fn visit_class(&mut self, n: &Class) {
-        n.decorators.visit_with(n, self);
+        n.decorators.visit_with( self);
 
         {
             let ctx = Ctx {
@@ -370,7 +370,7 @@ where
             n.super_class.visit_with(n, &mut *self.with_ctx(ctx));
         }
 
-        n.body.visit_with(n, self);
+        n.body.visit_with( self);
     }
 
     fn visit_class_decl(&mut self, n: &ClassDecl) {
@@ -380,7 +380,7 @@ where
     }
 
     fn visit_cond_expr(&mut self, n: &CondExpr) {
-        n.test.visit_with(n, self);
+        n.test.visit_with( self);
 
         {
             let ctx = Ctx {
@@ -433,7 +433,7 @@ where
     }
 
     fn visit_for_in_stmt(&mut self, n: &ForInStmt) {
-        n.right.visit_with(n, self);
+        n.right.visit_with( self);
 
         self.with_child(n.span.ctxt, ScopeKind::Block, |child| {
             let ctx = Ctx {
@@ -455,7 +455,7 @@ where
     }
 
     fn visit_for_of_stmt(&mut self, n: &ForOfStmt) {
-        n.right.visit_with(n, self);
+        n.right.visit_with( self);
 
         self.with_child(n.span.ctxt, ScopeKind::Block, |child| {
             let ctx = Ctx {
@@ -475,7 +475,7 @@ where
     }
 
     fn visit_for_stmt(&mut self, n: &ForStmt) {
-        n.init.visit_with(n, self);
+        n.init.visit_with( self);
 
         let ctx = Ctx {
             in_loop: true,
@@ -490,7 +490,7 @@ where
     }
 
     fn visit_function(&mut self, n: &Function) {
-        n.decorators.visit_with(n, self);
+        n.decorators.visit_with( self);
 
         let is_standalone = self
             .marks
@@ -528,7 +528,7 @@ where
             in_cond: true,
             ..self.ctx
         };
-        n.test.visit_with(n, self);
+        n.test.visit_with( self);
         n.cons.visit_with(n, &mut *self.with_ctx(ctx));
         n.alt.visit_with(n, &mut *self.with_ctx(ctx));
     }
@@ -608,7 +608,7 @@ where
 
     fn visit_new_expr(&mut self, n: &NewExpr) {
         {
-            n.callee.visit_with(n, self);
+            n.callee.visit_with( self);
             let ctx = Ctx {
                 in_call_arg: true,
                 is_exact_arg: true,
@@ -707,7 +707,7 @@ where
     }
 
     fn visit_switch_case(&mut self, n: &SwitchCase) {
-        n.test.visit_with(n, self);
+        n.test.visit_with( self);
 
         {
             let ctx = Ctx {

--- a/crates/swc_ecma_minifier/src/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/analyzer/mod.rs
@@ -10,11 +10,11 @@ use std::time::Instant;
 use swc_atoms::{js_word, JsWord};
 use swc_common::{
     collections::{AHashMap, AHashSet},
-    SyntaxContext, DUMMY_SP,
+    SyntaxContext,
 };
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ident::IdentLike, Id};
-use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 mod ctx;
 pub(crate) mod storage;
@@ -43,7 +43,7 @@ where
         scope: Default::default(),
         ctx: Default::default(),
     };
-    n.visit_with( &mut v);
+    n.visit_with(&mut v);
     let top_scope = v.scope;
     v.data.top_scope().merge(top_scope, false);
 
@@ -360,7 +360,7 @@ where
     }
 
     fn visit_class(&mut self, n: &Class) {
-        n.decorators.visit_with( self);
+        n.decorators.visit_with(self);
 
         {
             let ctx = Ctx {
@@ -370,7 +370,7 @@ where
             n.super_class.visit_with(n, &mut *self.with_ctx(ctx));
         }
 
-        n.body.visit_with( self);
+        n.body.visit_with(self);
     }
 
     fn visit_class_decl(&mut self, n: &ClassDecl) {
@@ -380,7 +380,7 @@ where
     }
 
     fn visit_cond_expr(&mut self, n: &CondExpr) {
-        n.test.visit_with( self);
+        n.test.visit_with(self);
 
         {
             let ctx = Ctx {
@@ -433,7 +433,7 @@ where
     }
 
     fn visit_for_in_stmt(&mut self, n: &ForInStmt) {
-        n.right.visit_with( self);
+        n.right.visit_with(self);
 
         self.with_child(n.span.ctxt, ScopeKind::Block, |child| {
             let ctx = Ctx {
@@ -455,7 +455,7 @@ where
     }
 
     fn visit_for_of_stmt(&mut self, n: &ForOfStmt) {
-        n.right.visit_with( self);
+        n.right.visit_with(self);
 
         self.with_child(n.span.ctxt, ScopeKind::Block, |child| {
             let ctx = Ctx {
@@ -475,7 +475,7 @@ where
     }
 
     fn visit_for_stmt(&mut self, n: &ForStmt) {
-        n.init.visit_with( self);
+        n.init.visit_with(self);
 
         let ctx = Ctx {
             in_loop: true,
@@ -490,7 +490,7 @@ where
     }
 
     fn visit_function(&mut self, n: &Function) {
-        n.decorators.visit_with( self);
+        n.decorators.visit_with(self);
 
         let is_standalone = self
             .marks
@@ -528,7 +528,7 @@ where
             in_cond: true,
             ..self.ctx
         };
-        n.test.visit_with( self);
+        n.test.visit_with(self);
         n.cons.visit_with(n, &mut *self.with_ctx(ctx));
         n.alt.visit_with(n, &mut *self.with_ctx(ctx));
     }
@@ -552,8 +552,7 @@ where
                 is_exact_reassignment: false,
                 ..self.ctx
             };
-            e.obj
-                .visit_with( &mut *self.with_ctx(ctx));
+            e.obj.visit_with(&mut *self.with_ctx(ctx));
         }
 
         if e.computed {
@@ -562,8 +561,7 @@ where
                 is_exact_reassignment: false,
                 ..self.ctx
             };
-            e.prop
-                .visit_with( &mut *self.with_ctx(ctx));
+            e.prop.visit_with(&mut *self.with_ctx(ctx));
         }
 
         match &e.obj {
@@ -608,7 +606,7 @@ where
 
     fn visit_new_expr(&mut self, n: &NewExpr) {
         {
-            n.callee.visit_with( self);
+            n.callee.visit_with(self);
             let ctx = Ctx {
                 in_call_arg: true,
                 is_exact_arg: true,
@@ -700,14 +698,14 @@ where
                 ..self.ctx
             };
 
-            stmt.visit_with( &mut *self.with_ctx(ctx));
+            stmt.visit_with(&mut *self.with_ctx(ctx));
 
             had_cond |= can_end_conditionally(stmt);
         }
     }
 
     fn visit_switch_case(&mut self, n: &SwitchCase) {
-        n.test.visit_with( self);
+        n.test.visit_with(self);
 
         {
             let ctx = Ctx {

--- a/crates/swc_ecma_minifier/src/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/analyzer/mod.rs
@@ -236,7 +236,7 @@ where
 {
     noop_visit_type!();
 
-    fn visit_arrow_expr(&mut self, n: &ArrowExpr, _: &dyn Node) {
+    fn visit_arrow_expr(&mut self, n: &ArrowExpr) {
         self.with_child(n.span.ctxt, ScopeKind::Fn, |child| {
             {
                 let ctx = Ctx {
@@ -259,7 +259,7 @@ where
         })
     }
 
-    fn visit_assign_expr(&mut self, n: &AssignExpr, _: &dyn Node) {
+    fn visit_assign_expr(&mut self, n: &AssignExpr) {
         let ctx = Ctx {
             in_assign_lhs: true,
             is_exact_reassignment: true,
@@ -276,7 +276,7 @@ where
         n.right.visit_with(n, &mut *self.with_ctx(ctx));
     }
 
-    fn visit_await_expr(&mut self, n: &AwaitExpr, _: &dyn Node) {
+    fn visit_await_expr(&mut self, n: &AwaitExpr) {
         let ctx = Ctx {
             in_await_arg: true,
             ..self.ctx
@@ -284,13 +284,13 @@ where
         n.visit_children_with(&mut *self.with_ctx(ctx));
     }
 
-    fn visit_block_stmt(&mut self, n: &BlockStmt, _: &dyn Node) {
+    fn visit_block_stmt(&mut self, n: &BlockStmt) {
         self.with_child(n.span.ctxt, ScopeKind::Block, |child| {
             n.visit_children_with(child);
         })
     }
 
-    fn visit_call_expr(&mut self, n: &CallExpr, _: &dyn Node) {
+    fn visit_call_expr(&mut self, n: &CallExpr) {
         let inline_prevented = self.ctx.inline_prevented
             || self
                 .marks
@@ -340,7 +340,7 @@ where
         }
     }
 
-    fn visit_catch_clause(&mut self, n: &CatchClause, _: &dyn Node) {
+    fn visit_catch_clause(&mut self, n: &CatchClause) {
         {
             let ctx = Ctx {
                 in_cond: true,
@@ -359,7 +359,7 @@ where
         }
     }
 
-    fn visit_class(&mut self, n: &Class, _: &dyn Node) {
+    fn visit_class(&mut self, n: &Class) {
         n.decorators.visit_with(n, self);
 
         {
@@ -373,13 +373,13 @@ where
         n.body.visit_with(n, self);
     }
 
-    fn visit_class_decl(&mut self, n: &ClassDecl, _: &dyn Node) {
+    fn visit_class_decl(&mut self, n: &ClassDecl) {
         self.declare_decl(&n.ident, true, None, false);
 
         n.visit_children_with(self);
     }
 
-    fn visit_cond_expr(&mut self, n: &CondExpr, _: &dyn Node) {
+    fn visit_cond_expr(&mut self, n: &CondExpr) {
         n.test.visit_with(n, self);
 
         {
@@ -392,7 +392,7 @@ where
         }
     }
 
-    fn visit_do_while_stmt(&mut self, n: &DoWhileStmt, _: &dyn Node) {
+    fn visit_do_while_stmt(&mut self, n: &DoWhileStmt) {
         let ctx = Ctx {
             in_loop: true,
             in_cond: true,
@@ -401,11 +401,11 @@ where
         n.visit_children_with(&mut *self.with_ctx(ctx));
     }
 
-    fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier, _: &dyn Node) {
+    fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier) {
         self.report_usage(&n.orig, false)
     }
 
-    fn visit_expr(&mut self, e: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, e: &Expr) {
         e.visit_children_with(self);
 
         match e {
@@ -416,13 +416,13 @@ where
         }
     }
 
-    fn visit_fn_decl(&mut self, n: &FnDecl, _: &dyn Node) {
+    fn visit_fn_decl(&mut self, n: &FnDecl) {
         self.declare_decl(&n.ident, true, None, true);
 
         n.visit_children_with(self);
     }
 
-    fn visit_fn_expr(&mut self, n: &FnExpr, _: &dyn Node) {
+    fn visit_fn_expr(&mut self, n: &FnExpr) {
         n.visit_children_with(self);
 
         if let Some(id) = &n.ident {
@@ -432,7 +432,7 @@ where
         }
     }
 
-    fn visit_for_in_stmt(&mut self, n: &ForInStmt, _: &dyn Node) {
+    fn visit_for_in_stmt(&mut self, n: &ForInStmt) {
         n.right.visit_with(n, self);
 
         self.with_child(n.span.ctxt, ScopeKind::Block, |child| {
@@ -454,7 +454,7 @@ where
         });
     }
 
-    fn visit_for_of_stmt(&mut self, n: &ForOfStmt, _: &dyn Node) {
+    fn visit_for_of_stmt(&mut self, n: &ForOfStmt) {
         n.right.visit_with(n, self);
 
         self.with_child(n.span.ctxt, ScopeKind::Block, |child| {
@@ -474,7 +474,7 @@ where
         });
     }
 
-    fn visit_for_stmt(&mut self, n: &ForStmt, _: &dyn Node) {
+    fn visit_for_stmt(&mut self, n: &ForStmt) {
         n.init.visit_with(n, self);
 
         let ctx = Ctx {
@@ -489,7 +489,7 @@ where
         n.body.visit_with(n, &mut *self.with_ctx(ctx));
     }
 
-    fn visit_function(&mut self, n: &Function, _: &dyn Node) {
+    fn visit_function(&mut self, n: &Function) {
         n.decorators.visit_with(n, self);
 
         let is_standalone = self
@@ -523,7 +523,7 @@ where
             })
     }
 
-    fn visit_if_stmt(&mut self, n: &IfStmt, _: &dyn Node) {
+    fn visit_if_stmt(&mut self, n: &IfStmt) {
         let ctx = Ctx {
             in_cond: true,
             ..self.ctx
@@ -533,19 +533,19 @@ where
         n.alt.visit_with(n, &mut *self.with_ctx(ctx));
     }
 
-    fn visit_import_default_specifier(&mut self, n: &ImportDefaultSpecifier, _: &dyn Node) {
+    fn visit_import_default_specifier(&mut self, n: &ImportDefaultSpecifier) {
         self.declare_decl(&n.local, true, None, false);
     }
 
-    fn visit_import_named_specifier(&mut self, n: &ImportNamedSpecifier, _: &dyn Node) {
+    fn visit_import_named_specifier(&mut self, n: &ImportNamedSpecifier) {
         self.declare_decl(&n.local, true, None, false);
     }
 
-    fn visit_import_star_as_specifier(&mut self, n: &ImportStarAsSpecifier, _: &dyn Node) {
+    fn visit_import_star_as_specifier(&mut self, n: &ImportStarAsSpecifier) {
         self.declare_decl(&n.local, true, None, false);
     }
 
-    fn visit_member_expr(&mut self, e: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, e: &MemberExpr) {
         {
             let ctx = Ctx {
                 is_exact_arg: false,
@@ -591,7 +591,7 @@ where
         }
     }
 
-    fn visit_module(&mut self, n: &Module, _: &dyn Node) {
+    fn visit_module(&mut self, n: &Module) {
         let ctx = Ctx {
             skip_standalone: true,
             ..self.ctx
@@ -599,14 +599,14 @@ where
         n.visit_children_with(&mut *self.with_ctx(ctx))
     }
 
-    fn visit_named_export(&mut self, n: &NamedExport, _: &dyn Node) {
+    fn visit_named_export(&mut self, n: &NamedExport) {
         if n.src.is_some() {
             return;
         }
         n.visit_children_with(self);
     }
 
-    fn visit_new_expr(&mut self, n: &NewExpr, _: &dyn Node) {
+    fn visit_new_expr(&mut self, n: &NewExpr) {
         {
             n.callee.visit_with(n, self);
             let ctx = Ctx {
@@ -618,7 +618,7 @@ where
         }
     }
 
-    fn visit_object_pat_prop(&mut self, n: &ObjectPatProp, _: &dyn Node) {
+    fn visit_object_pat_prop(&mut self, n: &ObjectPatProp) {
         n.visit_children_with(self);
 
         match n {
@@ -629,7 +629,7 @@ where
         }
     }
 
-    fn visit_param(&mut self, n: &Param, _: &dyn Node) {
+    fn visit_param(&mut self, n: &Param) {
         let ctx = Ctx {
             in_pat_of_param: false,
             ..self.ctx
@@ -644,7 +644,7 @@ where
         n.pat.visit_with(n, &mut *self.with_ctx(ctx));
     }
 
-    fn visit_pat(&mut self, n: &Pat, _: &dyn Node) {
+    fn visit_pat(&mut self, n: &Pat) {
         n.visit_children_with(self);
 
         match n {
@@ -653,7 +653,7 @@ where
         }
     }
 
-    fn visit_prop(&mut self, n: &Prop, _: &dyn Node) {
+    fn visit_prop(&mut self, n: &Prop) {
         let ctx = Ctx {
             in_update_arg: false,
             ..self.ctx
@@ -668,7 +668,7 @@ where
         }
     }
 
-    fn visit_setter_prop(&mut self, n: &SetterProp, _: &dyn Node) {
+    fn visit_setter_prop(&mut self, n: &SetterProp) {
         self.with_child(n.span.ctxt, ScopeKind::Fn, |a| {
             n.key.visit_with(n, a);
             {
@@ -683,7 +683,7 @@ where
         });
     }
 
-    fn visit_stmt(&mut self, n: &Stmt, _: &dyn Node) {
+    fn visit_stmt(&mut self, n: &Stmt) {
         let ctx = Ctx {
             in_update_arg: false,
             ..self.ctx
@@ -691,7 +691,7 @@ where
         n.visit_children_with(&mut *self.with_ctx(ctx));
     }
 
-    fn visit_stmts(&mut self, stmts: &[Stmt], _: &dyn Node) {
+    fn visit_stmts(&mut self, stmts: &[Stmt]) {
         let mut had_cond = false;
 
         for stmt in stmts {
@@ -706,7 +706,7 @@ where
         }
     }
 
-    fn visit_switch_case(&mut self, n: &SwitchCase, _: &dyn Node) {
+    fn visit_switch_case(&mut self, n: &SwitchCase) {
         n.test.visit_with(n, self);
 
         {
@@ -718,7 +718,7 @@ where
         }
     }
 
-    fn visit_try_stmt(&mut self, n: &TryStmt, _: &dyn Node) {
+    fn visit_try_stmt(&mut self, n: &TryStmt) {
         let ctx = Ctx {
             in_cond: true,
             ..self.ctx
@@ -727,7 +727,7 @@ where
         n.visit_children_with(&mut *self.with_ctx(ctx));
     }
 
-    fn visit_update_expr(&mut self, n: &UpdateExpr, _: &dyn Node) {
+    fn visit_update_expr(&mut self, n: &UpdateExpr) {
         let ctx = Ctx {
             in_update_arg: true,
             is_exact_reassignment: true,
@@ -736,7 +736,7 @@ where
         n.visit_children_with(&mut *self.with_ctx(ctx));
     }
 
-    fn visit_var_decl(&mut self, n: &VarDecl, _: &dyn Node) {
+    fn visit_var_decl(&mut self, n: &VarDecl) {
         let ctx = Ctx {
             var_decl_kind_of_pat: Some(n.kind),
             ..self.ctx
@@ -761,7 +761,7 @@ where
         }
     }
 
-    fn visit_var_declarator(&mut self, e: &VarDeclarator, _: &dyn Node) {
+    fn visit_var_declarator(&mut self, e: &VarDeclarator) {
         let prevent_inline = match &e.name {
             Pat::Ident(BindingIdent {
                 id:
@@ -798,7 +798,7 @@ where
         }
     }
 
-    fn visit_while_stmt(&mut self, n: &WhileStmt, _: &dyn Node) {
+    fn visit_while_stmt(&mut self, n: &WhileStmt) {
         let ctx = Ctx {
             in_loop: true,
             in_cond: true,
@@ -807,7 +807,7 @@ where
         n.visit_children_with(&mut *self.with_ctx(ctx));
     }
 
-    fn visit_with_stmt(&mut self, n: &WithStmt, _: &dyn Node) {
+    fn visit_with_stmt(&mut self, n: &WithStmt) {
         self.scope.mark_with_stmt();
         n.visit_children_with(self);
     }

--- a/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
@@ -8,7 +8,7 @@ use crate::{
 use swc_common::{util::take::Take, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{prepend, undefined, StmtLike};
-use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 /// Methods related to the option `if_return`. All methods are noop if
 /// `if_return` is false.
@@ -565,7 +565,7 @@ where
     N: VisitWith<ReturnFinder>,
 {
     let mut v = ReturnFinder::default();
-    n.visit_with( &mut v);
+    n.visit_with(&mut v);
     v.count
 }
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
@@ -577,13 +577,13 @@ pub(super) struct ReturnFinder {
 impl Visit for ReturnFinder {
     noop_visit_type!();
 
-    fn visit_return_stmt(&mut self, n: &ReturnStmt, _: &dyn Node) {
+    fn visit_return_stmt(&mut self, n: &ReturnStmt) {
         n.visit_children_with(self);
         self.count += 1;
     }
 
-    fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
-    fn visit_arrow_expr(&mut self, _: &ArrowExpr, _: &dyn Node) {}
+    fn visit_function(&mut self, _: &Function) {}
+    fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
 }
 
 fn always_terminates_with_return_arg(s: &Stmt) -> bool {

--- a/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
@@ -565,7 +565,7 @@ where
     N: VisitWith<ReturnFinder>,
 {
     let mut v = ReturnFinder::default();
-    n.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+    n.visit_with( &mut v);
     v.count
 }
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -1910,7 +1910,7 @@ where
         }
 
         if cfg!(feature = "debug") && cfg!(debug_assertions) {
-            n.visit_with(&Invalid { span: DUMMY_SP }, &mut AssertValid);
+            n.visit_with(&mut AssertValid);
         }
     }
 
@@ -2023,7 +2023,7 @@ where
         self.ctx.in_asm = old_in_asm;
 
         if cfg!(feature = "debug") && cfg!(debug_assertions) {
-            n.visit_with(&Invalid { span: DUMMY_SP }, &mut AssertValid);
+            n.visit_with(&mut AssertValid);
         }
     }
 
@@ -2180,7 +2180,7 @@ where
         }
 
         if cfg!(feature = "debug") && cfg!(debug_assertions) {
-            n.visit_with(&Invalid { span: DUMMY_SP }, &mut AssertValid);
+            n.visit_with(&mut AssertValid);
         }
     }
 
@@ -2370,7 +2370,7 @@ where
         }
 
         if cfg!(feature = "debug") && cfg!(debug_assertions) {
-            s.visit_with(&Invalid { span: DUMMY_SP }, &mut AssertValid);
+            s.visit_with(&mut AssertValid);
         }
     }
 
@@ -2406,7 +2406,7 @@ where
         }
 
         if cfg!(feature = "debug") && cfg!(debug_assertions) {
-            stmts.visit_with(&Invalid { span: DUMMY_SP }, &mut AssertValid);
+            stmts.visit_with(&mut AssertValid);
         }
     }
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -17,7 +17,7 @@ use swc_ecma_ast::*;
 use swc_ecma_utils::{
     contains_this_expr, ident::IdentLike, undefined, ExprExt, Id, StmtLike, UsageFinder,
 };
-use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 use tracing::{span, Level};
 
 /// Methods related to the option `sequences`. All methods are noop if
@@ -1484,12 +1484,12 @@ impl Visit for UsageCounter<'_> {
     }
 
     fn visit_member_expr(&mut self, e: &MemberExpr) {
-        e.obj.visit_with(e, self);
+        e.obj.visit_with(self);
 
         if e.computed {
             let old = self.in_lhs;
             self.in_lhs = false;
-            e.prop.visit_with(e, self);
+            e.prop.visit_with(self);
             self.in_lhs = old;
         }
     }

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -1268,7 +1268,7 @@ where
                                     target: &*a_id,
                                     in_lhs: false,
                                 };
-                                b.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+                                b.visit_with(&mut v);
                                 if v.expr_usage != 1 || v.pat_usage != 0 {
                                     tracing::trace!(
                                         "[X] sequences: Aborting merging of an update expression \
@@ -1427,7 +1427,7 @@ where
                 target: &left_id,
                 in_lhs: false,
             };
-            b.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+            b.visit_with(&mut v);
             if v.expr_usage != 1 || v.pat_usage != 0 {
                 tracing::trace!(
                     "[X] sequences: Aborting because of usage counts ({}{:?}, ref = {}, pat = {})",

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -1473,7 +1473,7 @@ struct UsageCounter<'a> {
 impl Visit for UsageCounter<'_> {
     noop_visit_type!();
 
-    fn visit_ident(&mut self, i: &Ident, _: &dyn Node) {
+    fn visit_ident(&mut self, i: &Ident) {
         if self.target.sym == i.sym && self.target.span.ctxt == i.span.ctxt {
             if self.in_lhs {
                 self.pat_usage += 1;
@@ -1483,7 +1483,7 @@ impl Visit for UsageCounter<'_> {
         }
     }
 
-    fn visit_member_expr(&mut self, e: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, e: &MemberExpr) {
         e.obj.visit_with(e, self);
 
         if e.computed {
@@ -1494,14 +1494,14 @@ impl Visit for UsageCounter<'_> {
         }
     }
 
-    fn visit_pat(&mut self, p: &Pat, _: &dyn Node) {
+    fn visit_pat(&mut self, p: &Pat) {
         let old = self.in_lhs;
         self.in_lhs = true;
         p.visit_children_with(self);
         self.in_lhs = old;
     }
 
-    fn visit_pat_or_expr(&mut self, p: &PatOrExpr, _: &dyn Node) {
+    fn visit_pat_or_expr(&mut self, p: &PatOrExpr) {
         let old = self.in_lhs;
         self.in_lhs = true;
         p.visit_children_with(self);

--- a/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
@@ -336,27 +336,27 @@ struct BreakFinder {
 impl Visit for BreakFinder {
     noop_visit_type!();
 
-    fn visit_break_stmt(&mut self, s: &BreakStmt, _: &dyn Node) {
+    fn visit_break_stmt(&mut self, s: &BreakStmt) {
         if s.label.is_none() {
             self.found_unlabelled_break_for_stmt = true;
         }
     }
 
     /// We don't care about breaks in a lop[
-    fn visit_for_stmt(&mut self, _: &ForStmt, _: &dyn Node) {}
+    fn visit_for_stmt(&mut self, _: &ForStmt) {}
 
     /// We don't care about breaks in a lop[
-    fn visit_for_in_stmt(&mut self, _: &ForInStmt, _: &dyn Node) {}
+    fn visit_for_in_stmt(&mut self, _: &ForInStmt) {}
 
     /// We don't care about breaks in a lop[
-    fn visit_for_of_stmt(&mut self, _: &ForOfStmt, _: &dyn Node) {}
+    fn visit_for_of_stmt(&mut self, _: &ForOfStmt) {}
 
     /// We don't care about breaks in a lop[
-    fn visit_do_while_stmt(&mut self, _: &DoWhileStmt, _: &dyn Node) {}
+    fn visit_do_while_stmt(&mut self, _: &DoWhileStmt) {}
 
     /// We don't care about breaks in a lop[
-    fn visit_while_stmt(&mut self, _: &WhileStmt, _: &dyn Node) {}
+    fn visit_while_stmt(&mut self, _: &WhileStmt) {}
 
-    fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
-    fn visit_arrow_expr(&mut self, _: &ArrowExpr, _: &dyn Node) {}
+    fn visit_function(&mut self, _: &Function) {}
+    fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
 }

--- a/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
@@ -4,7 +4,7 @@ use std::mem::take;
 use swc_common::{util::take::Take, EqIgnoreSpan, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ident::IdentLike, prepend, ExprExt, StmtExt, Type, Value::Known};
-use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 /// Methods related to option `switches`.
 impl<M> Optimizer<'_, M>
@@ -48,7 +48,7 @@ where
                 let mut v = BreakFinder {
                     found_unlabelled_break_for_stmt: false,
                 };
-                case.visit_with( &mut v);
+                case.visit_with(&mut v);
                 v.found_unlabelled_break_for_stmt
             });
             if should_preserve_switch {

--- a/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
@@ -48,7 +48,7 @@ where
                 let mut v = BreakFinder {
                     found_unlabelled_break_for_stmt: false,
                 };
-                case.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+                case.visit_with( &mut v);
                 v.found_unlabelled_break_for_stmt
             });
             if should_preserve_switch {

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -394,7 +394,7 @@ where
         self.optimize_arrow_method_prop(p);
 
         if cfg!(feature = "debug") && cfg!(debug_assertions) {
-            p.visit_with( &mut AssertValid);
+            p.visit_with(&mut AssertValid);
         }
     }
 
@@ -510,7 +510,7 @@ where
         }
 
         if cfg!(feature = "debug") && cfg!(debug_assertions) {
-            s.visit_with( &mut AssertValid);
+            s.visit_with(&mut AssertValid);
         }
     }
 
@@ -525,7 +525,7 @@ where
         });
 
         if cfg!(feature = "debug") && cfg!(debug_assertions) {
-            items.visit_with( &mut AssertValid);
+            items.visit_with(&mut AssertValid);
         }
     }
 

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -394,7 +394,7 @@ where
         self.optimize_arrow_method_prop(p);
 
         if cfg!(feature = "debug") && cfg!(debug_assertions) {
-            p.visit_with(&Invalid { span: DUMMY_SP }, &mut AssertValid);
+            p.visit_with( &mut AssertValid);
         }
     }
 
@@ -510,7 +510,7 @@ where
         }
 
         if cfg!(feature = "debug") && cfg!(debug_assertions) {
-            s.visit_with(&Invalid { span: DUMMY_SP }, &mut AssertValid);
+            s.visit_with( &mut AssertValid);
         }
     }
 
@@ -525,7 +525,7 @@ where
         });
 
         if cfg!(feature = "debug") && cfg!(debug_assertions) {
-            items.visit_with(&Invalid { span: DUMMY_SP }, &mut AssertValid);
+            items.visit_with( &mut AssertValid);
         }
     }
 

--- a/crates/swc_ecma_minifier/src/compress/pure/vars.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/vars.rs
@@ -63,7 +63,7 @@ where
 
             // Check for nested variable declartions.
             let mut v = VarWithOutInitCounter::default();
-            stmts.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+            stmts.visit_with( &mut v);
             if !need_work && !v.need_work {
                 return;
             }

--- a/crates/swc_ecma_minifier/src/compress/pure/vars.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/vars.rs
@@ -113,13 +113,13 @@ pub(super) struct VarWithOutInitCounter {
 impl Visit for VarWithOutInitCounter {
     noop_visit_type!();
 
-    fn visit_arrow_expr(&mut self, _: &ArrowExpr, _: &dyn Node) {}
+    fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
 
-    fn visit_constructor(&mut self, _: &Constructor, _: &dyn Node) {}
+    fn visit_constructor(&mut self, _: &Constructor) {}
 
-    fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
+    fn visit_function(&mut self, _: &Function) {}
 
-    fn visit_var_decl(&mut self, v: &VarDecl, _: &dyn Node) {
+    fn visit_var_decl(&mut self, v: &VarDecl) {
         v.visit_children_with(self);
 
         if v.kind != VarDeclKind::Var {
@@ -148,7 +148,7 @@ impl Visit for VarWithOutInitCounter {
         }
     }
 
-    fn visit_var_decl_or_pat(&mut self, _: &VarDeclOrPat, _: &dyn Node) {}
+    fn visit_var_decl_or_pat(&mut self, _: &VarDeclOrPat) {}
 }
 
 /// Moves all varaible without initializer.

--- a/crates/swc_ecma_minifier/src/compress/pure/vars.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/vars.rs
@@ -4,7 +4,7 @@ use swc_common::{util::take::Take, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{prepend, StmtLike};
 use swc_ecma_visit::{
-    noop_visit_mut_type, noop_visit_type, Node, Visit, VisitMut, VisitMutWith, VisitWith,
+    noop_visit_mut_type, noop_visit_type, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 
 impl<M> Pure<'_, M>
@@ -63,7 +63,7 @@ where
 
             // Check for nested variable declartions.
             let mut v = VarWithOutInitCounter::default();
-            stmts.visit_with( &mut v);
+            stmts.visit_with(&mut v);
             if !need_work && !v.need_work {
                 return;
             }
@@ -151,7 +151,7 @@ impl Visit for VarWithOutInitCounter {
     fn visit_var_decl_or_pat(&mut self, _: &VarDeclOrPat) {}
 }
 
-/// Moves all varaible without initializer.
+/// Moves all variable without initializer.
 pub(super) struct VarMover {
     vars: Vec<VarDeclarator>,
     var_decl_kind: Option<VarDeclKind>,

--- a/crates/swc_ecma_minifier/src/debug.rs
+++ b/crates/swc_ecma_minifier/src/debug.rs
@@ -1,12 +1,12 @@
 use once_cell::sync::Lazy;
 use std::{env, process::Command};
-use swc_common::{sync::Lrc, SourceMap, SyntaxContext, DUMMY_SP};
+use swc_common::{sync::Lrc, SourceMap, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_codegen::{text_writer::JsWriter, Emitter};
 use swc_ecma_transforms::{fixer, hygiene};
 use swc_ecma_utils::{drop_span, DropSpan};
 use swc_ecma_visit::{
-    noop_visit_mut_type, noop_visit_type, FoldWith, Node, Visit, VisitMut, VisitMutWith, VisitWith,
+    noop_visit_mut_type, noop_visit_type, FoldWith, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 
 pub(crate) struct Debugger {}

--- a/crates/swc_ecma_minifier/src/debug.rs
+++ b/crates/swc_ecma_minifier/src/debug.rs
@@ -134,7 +134,7 @@ impl Visit for AssertValid {
     }
 
     fn visit_setter_prop(&mut self, p: &SetterProp) {
-        p.body.visit_with(p, self);
+        p.body.visit_with(self);
     }
 
     fn visit_tpl(&mut self, l: &Tpl) {

--- a/crates/swc_ecma_minifier/src/debug.rs
+++ b/crates/swc_ecma_minifier/src/debug.rs
@@ -129,15 +129,15 @@ pub(crate) struct AssertValid;
 impl Visit for AssertValid {
     noop_visit_type!();
 
-    fn visit_invalid(&mut self, _: &Invalid, _: &dyn Node) {
+    fn visit_invalid(&mut self, _: &Invalid) {
         panic!("[SWC_RUN] Invalid node found");
     }
 
-    fn visit_setter_prop(&mut self, p: &SetterProp, _: &dyn Node) {
+    fn visit_setter_prop(&mut self, p: &SetterProp) {
         p.body.visit_with(p, self);
     }
 
-    fn visit_tpl(&mut self, l: &Tpl, _: &dyn Node) {
+    fn visit_tpl(&mut self, l: &Tpl) {
         l.visit_children_with(self);
 
         assert_eq!(l.exprs.len() + 1, l.quasis.len());

--- a/crates/swc_ecma_minifier/src/debug.rs
+++ b/crates/swc_ecma_minifier/src/debug.rs
@@ -74,7 +74,7 @@ pub(crate) fn invoke(module: &Module) {
     static ENABLED: Lazy<bool> = Lazy::new(|| env::var("SWC_RUN").unwrap_or_default() == "1");
 
     if cfg!(debug_assertions) {
-        module.visit_with(&Invalid { span: DUMMY_SP }, &mut AssertValid);
+        module.visit_with(&mut AssertValid);
     }
 
     if !cfg!(feature = "debug") || !*ENABLED {

--- a/crates/swc_ecma_minifier/src/metadata/mod.rs
+++ b/crates/swc_ecma_minifier/src/metadata/mod.rs
@@ -1,12 +1,12 @@
 use crate::marks::Marks;
 use swc_common::{
     comments::{Comment, CommentKind, Comments},
-    Mark, Span, SyntaxContext, DUMMY_SP,
+    Mark, Span, SyntaxContext,
 };
 use swc_ecma_ast::*;
 use swc_ecma_utils::{find_ids, ident::IdentLike, Id};
 use swc_ecma_visit::{
-    noop_visit_mut_type, noop_visit_type, Node, Visit, VisitMut, VisitMutWith, VisitWith,
+    noop_visit_mut_type, noop_visit_type, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 
 #[cfg(test)]
@@ -169,7 +169,7 @@ impl VisitMut for InfoMarker<'_> {
                 top_level_ctxt: SyntaxContext::empty().apply_mark(self.top_level_mark),
                 bindings: Default::default(),
             };
-            m.visit_with( &mut v);
+            m.visit_with(&mut v);
             v.bindings
         };
 
@@ -237,7 +237,7 @@ impl Visit for TopLevelBindingCollector {
     }
 }
 
-fn is_standalone<N>(n: &mut N, top_level_mark: Mark, external_bingdings: &[Id]) -> bool
+fn is_standalone<N>(n: &mut N, top_level_mark: Mark, external_bindings: &[Id]) -> bool
 where
     N: VisitMutWith<IdentCollector>,
 {
@@ -273,7 +273,7 @@ where
             _ => {}
         }
 
-        if external_bingdings.contains(&used_id) {
+        if external_bindings.contains(&used_id) {
             if cfg!(feature = "debug") {
                 tracing::debug!(
                     "bundle: Due to {}{:?} (top-level), it's not a bundle",

--- a/crates/swc_ecma_minifier/src/metadata/mod.rs
+++ b/crates/swc_ecma_minifier/src/metadata/mod.rs
@@ -169,7 +169,7 @@ impl VisitMut for InfoMarker<'_> {
                 top_level_ctxt: SyntaxContext::empty().apply_mark(self.top_level_mark),
                 bindings: Default::default(),
             };
-            m.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+            m.visit_with( &mut v);
             v.bindings
         };
 

--- a/crates/swc_ecma_minifier/src/metadata/mod.rs
+++ b/crates/swc_ecma_minifier/src/metadata/mod.rs
@@ -217,17 +217,17 @@ impl TopLevelBindingCollector {
 impl Visit for TopLevelBindingCollector {
     noop_visit_type!();
 
-    fn visit_class_decl(&mut self, v: &ClassDecl, _: &dyn Node) {
+    fn visit_class_decl(&mut self, v: &ClassDecl) {
         self.add(v.ident.to_id());
     }
 
-    fn visit_fn_decl(&mut self, v: &FnDecl, _: &dyn Node) {
+    fn visit_fn_decl(&mut self, v: &FnDecl) {
         self.add(v.ident.to_id());
     }
 
-    fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
+    fn visit_function(&mut self, _: &Function) {}
 
-    fn visit_var_decl(&mut self, v: &VarDecl, _: &dyn Node) {
+    fn visit_var_decl(&mut self, v: &VarDecl) {
         v.visit_children_with(self);
         let ids: Vec<Id> = find_ids(&v.decls);
 

--- a/crates/swc_ecma_minifier/src/metadata/tests.rs
+++ b/crates/swc_ecma_minifier/src/metadata/tests.rs
@@ -34,7 +34,7 @@
 //                 mark: marks.standalone,
 //                 count: 0,
 //             };
-//             m.visit_with(&Invalid { span: DUMMY_SP }, &mut counter);
+//             m.visit_with( &mut counter);
 //             counter.count
 //         };
 //         eprintln!("Actual: {} modules in bundle", actual);

--- a/crates/swc_ecma_minifier/src/metadata/tests.rs
+++ b/crates/swc_ecma_minifier/src/metadata/tests.rs
@@ -64,7 +64,7 @@
 // }
 
 // impl Visit for MarkCounter {
-//     fn visit_span(&mut self, span: &Span, _: &dyn Node) {
+//     fn visit_span(&mut self, span: &Span) {
 //         if span.has_mark(self.mark) {
 //             self.count += 1;
 //         }

--- a/crates/swc_ecma_minifier/src/pass/hygiene/vars.rs
+++ b/crates/swc_ecma_minifier/src/pass/hygiene/vars.rs
@@ -106,10 +106,10 @@ impl Visit for VarAnalyzer<'_> {
     }
 
     fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with(n, self);
+        n.obj.visit_with(self);
 
         if n.computed {
-            n.prop.visit_with(n, self);
+            n.prop.visit_with(self);
         }
     }
 

--- a/crates/swc_ecma_minifier/src/pass/hygiene/vars.rs
+++ b/crates/swc_ecma_minifier/src/pass/hygiene/vars.rs
@@ -19,7 +19,7 @@ where
         all: &mut data,
         cur: Default::default(),
     };
-    node.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+    node.visit_with(&mut v);
 
     data
 }

--- a/crates/swc_ecma_minifier/src/pass/hygiene/vars.rs
+++ b/crates/swc_ecma_minifier/src/pass/hygiene/vars.rs
@@ -87,25 +87,25 @@ macro_rules! scoped {
 impl Visit for VarAnalyzer<'_> {
     noop_visit_type!();
 
-    fn visit_arrow_expr(&mut self, n: &ArrowExpr, _: &dyn Node) {
+    fn visit_arrow_expr(&mut self, n: &ArrowExpr) {
         scoped!(self, n);
     }
 
-    fn visit_block_stmt(&mut self, n: &BlockStmt, _: &dyn Node) {
+    fn visit_block_stmt(&mut self, n: &BlockStmt) {
         scoped!(self, n);
     }
 
-    fn visit_function(&mut self, n: &Function, _: &dyn Node) {
+    fn visit_function(&mut self, n: &Function) {
         scoped!(self, n);
     }
 
-    fn visit_ident(&mut self, i: &Ident, _: &dyn Node) {
+    fn visit_ident(&mut self, i: &Ident) {
         tracing::trace!("hygiene/vars: Found {}", i);
 
         self.cur.add(i);
     }
 
-    fn visit_member_expr(&mut self, n: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, n: &MemberExpr) {
         n.obj.visit_with(n, self);
 
         if n.computed {
@@ -113,7 +113,7 @@ impl Visit for VarAnalyzer<'_> {
         }
     }
 
-    fn visit_prop_name(&mut self, n: &PropName, _: &dyn Node) {
+    fn visit_prop_name(&mut self, n: &PropName) {
         match n {
             PropName::Computed(_) => {
                 n.visit_children_with(self);

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
@@ -78,10 +78,10 @@ impl Visit for Analyzer {
         let old = self.is_pat_decl;
 
         self.is_pat_decl = true;
-        n.param.visit_with(n, self);
+        n.param.visit_with( self);
 
         self.is_pat_decl = false;
-        n.body.visit_with(n, self);
+        n.body.visit_with( self);
 
         self.is_pat_decl = old;
     }

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
@@ -53,7 +53,7 @@ impl Analyzer {
 impl Visit for Analyzer {
     noop_visit_type!();
 
-    fn visit_arrow_expr(&mut self, e: &ArrowExpr, _: &dyn Node) {
+    fn visit_arrow_expr(&mut self, e: &ArrowExpr) {
         self.with_scope(|v| {
             let old = v.is_pat_decl;
             v.is_pat_decl = true;
@@ -64,7 +64,7 @@ impl Visit for Analyzer {
         });
     }
 
-    fn visit_assign_pat_prop(&mut self, p: &AssignPatProp, _: &dyn Node) {
+    fn visit_assign_pat_prop(&mut self, p: &AssignPatProp) {
         p.visit_children_with(self);
 
         if self.is_pat_decl {
@@ -74,7 +74,7 @@ impl Visit for Analyzer {
         }
     }
 
-    fn visit_catch_clause(&mut self, n: &CatchClause, _: &dyn Node) {
+    fn visit_catch_clause(&mut self, n: &CatchClause) {
         let old = self.is_pat_decl;
 
         self.is_pat_decl = true;
@@ -86,17 +86,17 @@ impl Visit for Analyzer {
         self.is_pat_decl = old;
     }
 
-    fn visit_class_decl(&mut self, c: &ClassDecl, _: &dyn Node) {
+    fn visit_class_decl(&mut self, c: &ClassDecl) {
         self.add_decl(c.ident.to_id());
 
         c.class.visit_with(c, self);
     }
 
-    fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier, _: &dyn Node) {
+    fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier) {
         self.add_usage(n.orig.to_id());
     }
 
-    fn visit_expr(&mut self, e: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, e: &Expr) {
         e.visit_children_with(self);
 
         match e {
@@ -105,7 +105,7 @@ impl Visit for Analyzer {
         }
     }
 
-    fn visit_fn_decl(&mut self, f: &FnDecl, _: &dyn Node) {
+    fn visit_fn_decl(&mut self, f: &FnDecl) {
         self.add_decl(f.ident.to_id());
 
         self.with_scope(|v| {
@@ -113,7 +113,7 @@ impl Visit for Analyzer {
         })
     }
 
-    fn visit_fn_expr(&mut self, f: &FnExpr, _: &dyn Node) {
+    fn visit_fn_expr(&mut self, f: &FnExpr) {
         self.with_scope(|v| {
             if let Some(id) = &f.ident {
                 v.add_decl(id.to_id());
@@ -123,19 +123,19 @@ impl Visit for Analyzer {
         })
     }
 
-    fn visit_import_default_specifier(&mut self, n: &ImportDefaultSpecifier, _: &dyn Node) {
+    fn visit_import_default_specifier(&mut self, n: &ImportDefaultSpecifier) {
         self.add_decl(n.local.to_id());
     }
 
-    fn visit_import_named_specifier(&mut self, n: &ImportNamedSpecifier, _: &dyn Node) {
+    fn visit_import_named_specifier(&mut self, n: &ImportNamedSpecifier) {
         self.add_decl(n.local.to_id());
     }
 
-    fn visit_import_star_as_specifier(&mut self, n: &ImportStarAsSpecifier, _: &dyn Node) {
+    fn visit_import_star_as_specifier(&mut self, n: &ImportStarAsSpecifier) {
         self.add_decl(n.local.to_id());
     }
 
-    fn visit_member_expr(&mut self, e: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, e: &MemberExpr) {
         e.obj.visit_with(e, self);
 
         if e.computed {
@@ -143,7 +143,7 @@ impl Visit for Analyzer {
         }
     }
 
-    fn visit_method_prop(&mut self, f: &MethodProp, _: &dyn Node) {
+    fn visit_method_prop(&mut self, f: &MethodProp) {
         f.key.visit_with(f, self);
 
         self.with_scope(|v| {
@@ -151,7 +151,7 @@ impl Visit for Analyzer {
         })
     }
 
-    fn visit_named_export(&mut self, n: &NamedExport, _: &dyn Node) {
+    fn visit_named_export(&mut self, n: &NamedExport) {
         if n.src.is_some() {
             return;
         }
@@ -159,7 +159,7 @@ impl Visit for Analyzer {
         n.visit_children_with(self);
     }
 
-    fn visit_param(&mut self, e: &Param, _: &dyn Node) {
+    fn visit_param(&mut self, e: &Param) {
         let old = self.is_pat_decl;
 
         self.is_pat_decl = false;
@@ -171,7 +171,7 @@ impl Visit for Analyzer {
         self.is_pat_decl = old;
     }
 
-    fn visit_pat(&mut self, e: &Pat, _: &dyn Node) {
+    fn visit_pat(&mut self, e: &Pat) {
         e.visit_children_with(self);
 
         match e {
@@ -186,7 +186,7 @@ impl Visit for Analyzer {
         }
     }
 
-    fn visit_prop(&mut self, p: &Prop, _: &dyn Node) {
+    fn visit_prop(&mut self, p: &Prop) {
         p.visit_children_with(self);
 
         match p {
@@ -195,7 +195,7 @@ impl Visit for Analyzer {
         }
     }
 
-    fn visit_var_declarator(&mut self, v: &VarDeclarator, _: &dyn Node) {
+    fn visit_var_declarator(&mut self, v: &VarDeclarator) {
         let old = self.is_pat_decl;
 
         self.is_pat_decl = true;

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
@@ -57,9 +57,9 @@ impl Visit for Analyzer {
         self.with_scope(|v| {
             let old = v.is_pat_decl;
             v.is_pat_decl = true;
-            e.params.visit_with(e, v);
+            e.params.visit_with(v);
             v.is_pat_decl = false;
-            e.body.visit_with(e, v);
+            e.body.visit_with(v);
             v.is_pat_decl = old;
         });
     }
@@ -89,7 +89,7 @@ impl Visit for Analyzer {
     fn visit_class_decl(&mut self, c: &ClassDecl) {
         self.add_decl(c.ident.to_id());
 
-        c.class.visit_with(c, self);
+        c.class.visit_with(self);
     }
 
     fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier) {
@@ -109,7 +109,7 @@ impl Visit for Analyzer {
         self.add_decl(f.ident.to_id());
 
         self.with_scope(|v| {
-            f.function.visit_with(f, v);
+            f.function.visit_with(v);
         })
     }
 
@@ -119,7 +119,7 @@ impl Visit for Analyzer {
                 v.add_decl(id.to_id());
             }
 
-            f.function.visit_with(f, v);
+            f.function.visit_with(v);
         })
     }
 
@@ -136,18 +136,18 @@ impl Visit for Analyzer {
     }
 
     fn visit_member_expr(&mut self, e: &MemberExpr) {
-        e.obj.visit_with(e, self);
+        e.obj.visit_with(self);
 
         if e.computed {
-            e.prop.visit_with(e, self);
+            e.prop.visit_with(self);
         }
     }
 
     fn visit_method_prop(&mut self, f: &MethodProp) {
-        f.key.visit_with(f, self);
+        f.key.visit_with(self);
 
         self.with_scope(|v| {
-            f.function.visit_with(f, v);
+            f.function.visit_with(v);
         })
     }
 
@@ -163,10 +163,10 @@ impl Visit for Analyzer {
         let old = self.is_pat_decl;
 
         self.is_pat_decl = false;
-        e.decorators.visit_with(e, self);
+        e.decorators.visit_with(self);
 
         self.is_pat_decl = true;
-        e.pat.visit_with(e, self);
+        e.pat.visit_with(self);
 
         self.is_pat_decl = old;
     }
@@ -199,10 +199,10 @@ impl Visit for Analyzer {
         let old = self.is_pat_decl;
 
         self.is_pat_decl = true;
-        v.name.visit_with(v, self);
+        v.name.visit_with(self);
 
         self.is_pat_decl = false;
-        v.init.visit_with(v, self);
+        v.init.visit_with(self);
 
         self.is_pat_decl = old;
     }

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
@@ -3,7 +3,7 @@ use swc_atoms::JsWord;
 use swc_common::collections::{AHashMap, AHashSet};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ident::IdentLike, Id};
-use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 mod scope;
 
@@ -78,10 +78,10 @@ impl Visit for Analyzer {
         let old = self.is_pat_decl;
 
         self.is_pat_decl = true;
-        n.param.visit_with( self);
+        n.param.visit_with(self);
 
         self.is_pat_decl = false;
-        n.body.visit_with( self);
+        n.body.visit_with(self);
 
         self.is_pat_decl = old;
     }

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
@@ -1,8 +1,8 @@
 use crate::option::MangleOptions;
-use swc_common::{collections::AHashSet, DUMMY_SP};
+use swc_common::collections::AHashSet;
 use swc_ecma_ast::*;
 use swc_ecma_utils::{find_ids, ident::IdentLike, Id};
-use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 pub(super) fn idents_to_preserve<N>(options: MangleOptions, n: &N) -> AHashSet<Id>
 where
@@ -14,7 +14,7 @@ where
         should_preserve: false,
         in_top_level: false,
     };
-    n.visit_with( &mut v);
+    n.visit_with(&mut v);
     v.preserved
 }
 pub(super) struct Preserver {
@@ -32,11 +32,11 @@ impl Visit for Preserver {
 
         if self.options.ie8 && !self.options.top_level {
             self.should_preserve = true;
-            n.param.visit_with( self);
+            n.param.visit_with(self);
         }
 
         self.should_preserve = old;
-        n.body.visit_with( self);
+        n.body.visit_with(self);
     }
 
     fn visit_class_decl(&mut self, n: &ClassDecl) {
@@ -97,16 +97,16 @@ impl Visit for Preserver {
     }
 
     fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with( self);
+        n.obj.visit_with(self);
         if n.computed {
-            n.prop.visit_with( self);
+            n.prop.visit_with(self);
         }
     }
 
     fn visit_module_items(&mut self, n: &[ModuleItem]) {
         for n in n {
             self.in_top_level = true;
-            n.visit_with( self);
+            n.visit_with(self);
         }
     }
 
@@ -127,7 +127,7 @@ impl Visit for Preserver {
         let old_top_level = self.in_top_level;
         for n in n {
             self.in_top_level = false;
-            n.visit_with( self);
+            n.visit_with(self);
         }
         self.in_top_level = old_top_level;
     }
@@ -138,7 +138,7 @@ impl Visit for Preserver {
         if self.in_top_level && !self.options.top_level {
             let old = self.should_preserve;
             self.should_preserve = true;
-            n.name.visit_with( self);
+            n.name.visit_with(self);
             self.should_preserve = old;
             return;
         }
@@ -148,7 +148,7 @@ impl Visit for Preserver {
                 Some(Expr::Fn(..)) | Some(Expr::Arrow(..)) => {
                     let old = self.should_preserve;
                     self.should_preserve = true;
-                    n.name.visit_with( self);
+                    n.name.visit_with(self);
                     self.should_preserve = old;
                 }
                 _ => {}

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
@@ -27,7 +27,7 @@ pub(super) struct Preserver {
 impl Visit for Preserver {
     noop_visit_type!();
 
-    fn visit_catch_clause(&mut self, n: &CatchClause, _: &dyn Node) {
+    fn visit_catch_clause(&mut self, n: &CatchClause) {
         let old = self.should_preserve;
 
         if self.options.ie8 && !self.options.top_level {
@@ -39,7 +39,7 @@ impl Visit for Preserver {
         n.body.visit_with(&Invalid { span: DUMMY_SP }, self);
     }
 
-    fn visit_class_decl(&mut self, n: &ClassDecl, _: &dyn Node) {
+    fn visit_class_decl(&mut self, n: &ClassDecl) {
         n.visit_children_with(self);
 
         if (self.in_top_level && !self.options.top_level) || self.options.keep_class_names {
@@ -47,7 +47,7 @@ impl Visit for Preserver {
         }
     }
 
-    fn visit_export_decl(&mut self, n: &ExportDecl, _: &dyn Node) {
+    fn visit_export_decl(&mut self, n: &ExportDecl) {
         n.visit_children_with(self);
 
         match &n.decl {
@@ -65,7 +65,7 @@ impl Visit for Preserver {
         }
     }
 
-    fn visit_expr(&mut self, n: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, n: &Expr) {
         n.visit_children_with(self);
 
         match n {
@@ -78,7 +78,7 @@ impl Visit for Preserver {
         }
     }
 
-    fn visit_fn_decl(&mut self, n: &FnDecl, _: &dyn Node) {
+    fn visit_fn_decl(&mut self, n: &FnDecl) {
         n.visit_children_with(self);
 
         if (self.in_top_level && !self.options.top_level) || self.options.keep_fn_names {
@@ -86,7 +86,7 @@ impl Visit for Preserver {
         }
     }
 
-    fn visit_fn_expr(&mut self, n: &FnExpr, _: &dyn Node) {
+    fn visit_fn_expr(&mut self, n: &FnExpr) {
         n.visit_children_with(self);
 
         if self.options.keep_fn_names {
@@ -96,21 +96,21 @@ impl Visit for Preserver {
         }
     }
 
-    fn visit_member_expr(&mut self, n: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, n: &MemberExpr) {
         n.obj.visit_with(n, self);
         if n.computed {
             n.prop.visit_with(n, self);
         }
     }
 
-    fn visit_module_items(&mut self, n: &[ModuleItem], _: &dyn Node) {
+    fn visit_module_items(&mut self, n: &[ModuleItem]) {
         for n in n {
             self.in_top_level = true;
             n.visit_with(&Invalid { span: DUMMY_SP }, self);
         }
     }
 
-    fn visit_pat(&mut self, n: &Pat, _: &dyn Node) {
+    fn visit_pat(&mut self, n: &Pat) {
         n.visit_children_with(self);
 
         match n {
@@ -123,7 +123,7 @@ impl Visit for Preserver {
         }
     }
 
-    fn visit_stmts(&mut self, n: &[Stmt], _: &dyn Node) {
+    fn visit_stmts(&mut self, n: &[Stmt]) {
         let old_top_level = self.in_top_level;
         for n in n {
             self.in_top_level = false;
@@ -132,7 +132,7 @@ impl Visit for Preserver {
         self.in_top_level = old_top_level;
     }
 
-    fn visit_var_declarator(&mut self, n: &VarDeclarator, _: &dyn Node) {
+    fn visit_var_declarator(&mut self, n: &VarDeclarator) {
         n.visit_children_with(self);
 
         if self.in_top_level && !self.options.top_level {

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
@@ -14,7 +14,7 @@ where
         should_preserve: false,
         in_top_level: false,
     };
-    n.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+    n.visit_with( &mut v);
     v.preserved
 }
 pub(super) struct Preserver {
@@ -32,11 +32,11 @@ impl Visit for Preserver {
 
         if self.options.ie8 && !self.options.top_level {
             self.should_preserve = true;
-            n.param.visit_with(&Invalid { span: DUMMY_SP }, self);
+            n.param.visit_with( self);
         }
 
         self.should_preserve = old;
-        n.body.visit_with(&Invalid { span: DUMMY_SP }, self);
+        n.body.visit_with( self);
     }
 
     fn visit_class_decl(&mut self, n: &ClassDecl) {
@@ -106,7 +106,7 @@ impl Visit for Preserver {
     fn visit_module_items(&mut self, n: &[ModuleItem]) {
         for n in n {
             self.in_top_level = true;
-            n.visit_with(&Invalid { span: DUMMY_SP }, self);
+            n.visit_with( self);
         }
     }
 
@@ -127,7 +127,7 @@ impl Visit for Preserver {
         let old_top_level = self.in_top_level;
         for n in n {
             self.in_top_level = false;
-            n.visit_with(&Invalid { span: DUMMY_SP }, self);
+            n.visit_with( self);
         }
         self.in_top_level = old_top_level;
     }

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
@@ -97,9 +97,9 @@ impl Visit for Preserver {
     }
 
     fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with(n, self);
+        n.obj.visit_with( self);
         if n.computed {
-            n.prop.visit_with(n, self);
+            n.prop.visit_with( self);
         }
     }
 
@@ -138,7 +138,7 @@ impl Visit for Preserver {
         if self.in_top_level && !self.options.top_level {
             let old = self.should_preserve;
             self.should_preserve = true;
-            n.name.visit_with(n, self);
+            n.name.visit_with( self);
             self.should_preserve = old;
             return;
         }
@@ -148,7 +148,7 @@ impl Visit for Preserver {
                 Some(Expr::Fn(..)) | Some(Expr::Arrow(..)) => {
                     let old = self.should_preserve;
                     self.should_preserve = true;
-                    n.name.visit_with(n, self);
+                    n.name.visit_with( self);
                     self.should_preserve = old;
                 }
                 _ => {}

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/real_impl.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/real_impl.rs
@@ -28,7 +28,7 @@ impl VisitMut for Mangler {
                 scope: Default::default(),
                 is_pat_decl: Default::default(),
             };
-            m.visit_with(&Invalid { span: DUMMY_SP }, &mut analyzer);
+            m.visit_with( &mut analyzer);
 
             analyzer.into_rename_map(&preserved)
         };
@@ -44,7 +44,7 @@ impl VisitMut for Mangler {
                 scope: Default::default(),
                 is_pat_decl: Default::default(),
             };
-            s.visit_with(&Invalid { span: DUMMY_SP }, &mut analyzer);
+            s.visit_with( &mut analyzer);
 
             analyzer.into_rename_map(&preserved)
         };

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/real_impl.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/real_impl.rs
@@ -1,6 +1,5 @@
 use super::{analyzer::Analyzer, preserver::idents_to_preserve};
 use crate::{marks::Marks, option::MangleOptions, pass::compute_char_freq::CharFreqInfo};
-use swc_common::DUMMY_SP;
 use swc_ecma_ast::*;
 use swc_ecma_transforms::hygiene::rename;
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith, VisitWith};
@@ -28,7 +27,7 @@ impl VisitMut for Mangler {
                 scope: Default::default(),
                 is_pat_decl: Default::default(),
             };
-            m.visit_with( &mut analyzer);
+            m.visit_with(&mut analyzer);
 
             analyzer.into_rename_map(&preserved)
         };
@@ -44,7 +43,7 @@ impl VisitMut for Mangler {
                 scope: Default::default(),
                 is_pat_decl: Default::default(),
             };
-            s.visit_with( &mut analyzer);
+            s.visit_with(&mut analyzer);
 
             analyzer.into_rename_map(&preserved)
         };

--- a/crates/swc_ecma_minifier/src/util/mod.rs
+++ b/crates/swc_ecma_minifier/src/util/mod.rs
@@ -388,10 +388,10 @@ impl Visit for IdentUsageCollector {
     }
 
     fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with(n, self);
+        n.obj.visit_with( self);
 
         if n.computed {
-            n.prop.visit_with(n, self);
+            n.prop.visit_with( self);
         }
     }
 

--- a/crates/swc_ecma_minifier/src/util/mod.rs
+++ b/crates/swc_ecma_minifier/src/util/mod.rs
@@ -7,7 +7,7 @@ use swc_common::{
 };
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ident::IdentLike, Id, ModuleItemLike, StmtLike, Value};
-use swc_ecma_visit::{noop_visit_type, Fold, FoldWith, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Fold, FoldWith, Visit, VisitWith};
 
 pub(crate) mod base54;
 pub(crate) mod sort;
@@ -210,7 +210,7 @@ where
     N: VisitWith<LeapFinder>,
 {
     let mut v = LeapFinder::default();
-    n.visit_with( &mut v);
+    n.visit_with(&mut v);
     v.found_yield
 }
 
@@ -346,7 +346,7 @@ where
     N: VisitWith<DeepThisExprVisitor>,
 {
     let mut visitor = DeepThisExprVisitor { found: false };
-    body.visit_with( &mut visitor);
+    body.visit_with(&mut visitor);
     visitor.found
 }
 
@@ -388,10 +388,10 @@ impl Visit for IdentUsageCollector {
     }
 
     fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with( self);
+        n.obj.visit_with(self);
 
         if n.computed {
-            n.prop.visit_with( self);
+            n.prop.visit_with(self);
         }
     }
 
@@ -413,7 +413,7 @@ where
         ignore_nested: false,
         ..Default::default()
     };
-    n.visit_with( &mut v);
+    n.visit_with(&mut v);
     v.ids
 }
 
@@ -425,7 +425,7 @@ where
         ignore_nested: true,
         ..Default::default()
     };
-    n.visit_with( &mut v);
+    n.visit_with(&mut v);
     v.ids
 }
 

--- a/crates/swc_ecma_minifier/src/util/mod.rs
+++ b/crates/swc_ecma_minifier/src/util/mod.rs
@@ -210,7 +210,7 @@ where
     N: VisitWith<LeapFinder>,
 {
     let mut v = LeapFinder::default();
-    n.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+    n.visit_with( &mut v);
     v.found_yield
 }
 
@@ -413,7 +413,7 @@ where
         ignore_nested: false,
         ..Default::default()
     };
-    n.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+    n.visit_with( &mut v);
     v.ids
 }
 
@@ -425,7 +425,7 @@ where
         ignore_nested: true,
         ..Default::default()
     };
-    n.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+    n.visit_with( &mut v);
     v.ids
 }
 

--- a/crates/swc_ecma_minifier/src/util/mod.rs
+++ b/crates/swc_ecma_minifier/src/util/mod.rs
@@ -346,7 +346,7 @@ where
     N: VisitWith<DeepThisExprVisitor>,
 {
     let mut visitor = DeepThisExprVisitor { found: false };
-    body.visit_with(&Invalid { span: DUMMY_SP } as _, &mut visitor);
+    body.visit_with( &mut visitor);
     visitor.found
 }
 

--- a/crates/swc_ecma_minifier/src/util/mod.rs
+++ b/crates/swc_ecma_minifier/src/util/mod.rs
@@ -222,12 +222,12 @@ pub(crate) struct LeapFinder {
 impl Visit for LeapFinder {
     noop_visit_type!();
 
-    fn visit_yield_expr(&mut self, _: &YieldExpr, _: &dyn Node) {
+    fn visit_yield_expr(&mut self, _: &YieldExpr) {
         self.found_yield = true;
     }
 
-    fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
-    fn visit_arrow_expr(&mut self, _: &ArrowExpr, _: &dyn Node) {}
+    fn visit_function(&mut self, _: &Function) {}
+    fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
 }
 
 /// This method returns true only if `T` is `var`. (Not `const` or `let`)
@@ -336,7 +336,7 @@ pub struct DeepThisExprVisitor {
 impl Visit for DeepThisExprVisitor {
     noop_visit_type!();
 
-    fn visit_this_expr(&mut self, _: &ThisExpr, _: &dyn Node) {
+    fn visit_this_expr(&mut self, _: &ThisExpr) {
         self.found = true;
     }
 }
@@ -359,7 +359,7 @@ pub(crate) struct IdentUsageCollector {
 impl Visit for IdentUsageCollector {
     noop_visit_type!();
 
-    fn visit_block_stmt_or_expr(&mut self, n: &BlockStmtOrExpr, _: &dyn Node) {
+    fn visit_block_stmt_or_expr(&mut self, n: &BlockStmtOrExpr) {
         if self.ignore_nested {
             return;
         }
@@ -367,7 +367,7 @@ impl Visit for IdentUsageCollector {
         n.visit_children_with(self);
     }
 
-    fn visit_constructor(&mut self, n: &Constructor, _: &dyn Node) {
+    fn visit_constructor(&mut self, n: &Constructor) {
         if self.ignore_nested {
             return;
         }
@@ -375,7 +375,7 @@ impl Visit for IdentUsageCollector {
         n.visit_children_with(self);
     }
 
-    fn visit_function(&mut self, n: &Function, _: &dyn Node) {
+    fn visit_function(&mut self, n: &Function) {
         if self.ignore_nested {
             return;
         }
@@ -383,11 +383,11 @@ impl Visit for IdentUsageCollector {
         n.visit_children_with(self);
     }
 
-    fn visit_ident(&mut self, n: &Ident, _: &dyn Node) {
+    fn visit_ident(&mut self, n: &Ident) {
         self.ids.insert(n.to_id());
     }
 
-    fn visit_member_expr(&mut self, n: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, n: &MemberExpr) {
         n.obj.visit_with(n, self);
 
         if n.computed {
@@ -395,7 +395,7 @@ impl Visit for IdentUsageCollector {
         }
     }
 
-    fn visit_prop_name(&mut self, n: &PropName, _: &dyn Node) {
+    fn visit_prop_name(&mut self, n: &PropName) {
         match n {
             PropName::Computed(..) => {
                 n.visit_children_with(self);

--- a/crates/swc_ecma_minifier/tests/compress.rs
+++ b/crates/swc_ecma_minifier/tests/compress.rs
@@ -592,151 +592,151 @@ impl Shower<'_> {
 }
 
 impl Visit for Shower<'_> {
-    fn visit_array_lit(&mut self, n: &ArrayLit, _parent: &dyn Node) {
+    fn visit_array_lit(&mut self, n: &ArrayLit) {
         self.show("ArrayLit", n);
         n.visit_children_with(self)
     }
-    fn visit_array_pat(&mut self, n: &ArrayPat, _parent: &dyn Node) {
+    fn visit_array_pat(&mut self, n: &ArrayPat) {
         self.show("ArrayPat", n);
         n.visit_children_with(self)
     }
-    fn visit_arrow_expr(&mut self, n: &ArrowExpr, _parent: &dyn Node) {
+    fn visit_arrow_expr(&mut self, n: &ArrowExpr) {
         self.show("ArrowExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_assign_expr(&mut self, n: &AssignExpr, _parent: &dyn Node) {
+    fn visit_assign_expr(&mut self, n: &AssignExpr) {
         self.show("AssignExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_assign_pat(&mut self, n: &AssignPat, _parent: &dyn Node) {
+    fn visit_assign_pat(&mut self, n: &AssignPat) {
         self.show("AssignPat", n);
         n.visit_children_with(self)
     }
-    fn visit_assign_pat_prop(&mut self, n: &AssignPatProp, _parent: &dyn Node) {
+    fn visit_assign_pat_prop(&mut self, n: &AssignPatProp) {
         self.show("AssignPatProp", n);
         n.visit_children_with(self)
     }
-    fn visit_assign_prop(&mut self, n: &AssignProp, _parent: &dyn Node) {
+    fn visit_assign_prop(&mut self, n: &AssignProp) {
         self.show("AssignProp", n);
         n.visit_children_with(self)
     }
-    fn visit_await_expr(&mut self, n: &AwaitExpr, _parent: &dyn Node) {
+    fn visit_await_expr(&mut self, n: &AwaitExpr) {
         self.show("AwaitExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_bin_expr(&mut self, n: &BinExpr, _parent: &dyn Node) {
+    fn visit_bin_expr(&mut self, n: &BinExpr) {
         self.show("BinExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_block_stmt(&mut self, n: &BlockStmt, _parent: &dyn Node) {
+    fn visit_block_stmt(&mut self, n: &BlockStmt) {
         self.show("BlockStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_block_stmt_or_expr(&mut self, n: &BlockStmtOrExpr, _parent: &dyn Node) {
+    fn visit_block_stmt_or_expr(&mut self, n: &BlockStmtOrExpr) {
         self.show("BlockStmtOrExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_bool(&mut self, n: &Bool, _parent: &dyn Node) {
+    fn visit_bool(&mut self, n: &Bool) {
         self.show("Bool", n);
         n.visit_children_with(self)
     }
-    fn visit_break_stmt(&mut self, n: &BreakStmt, _parent: &dyn Node) {
+    fn visit_break_stmt(&mut self, n: &BreakStmt) {
         self.show("BreakStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_call_expr(&mut self, n: &CallExpr, _parent: &dyn Node) {
+    fn visit_call_expr(&mut self, n: &CallExpr) {
         self.show("CallExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_catch_clause(&mut self, n: &CatchClause, _parent: &dyn Node) {
+    fn visit_catch_clause(&mut self, n: &CatchClause) {
         self.show("CatchClause", n);
         n.visit_children_with(self)
     }
-    fn visit_class(&mut self, n: &Class, _parent: &dyn Node) {
+    fn visit_class(&mut self, n: &Class) {
         self.show("Class", n);
         n.visit_children_with(self)
     }
-    fn visit_class_decl(&mut self, n: &ClassDecl, _parent: &dyn Node) {
+    fn visit_class_decl(&mut self, n: &ClassDecl) {
         self.show("ClassDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_class_expr(&mut self, n: &ClassExpr, _parent: &dyn Node) {
+    fn visit_class_expr(&mut self, n: &ClassExpr) {
         self.show("ClassExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_class_member(&mut self, n: &ClassMember, _parent: &dyn Node) {
+    fn visit_class_member(&mut self, n: &ClassMember) {
         self.show("ClassMember", n);
         n.visit_children_with(self)
     }
-    fn visit_class_method(&mut self, n: &ClassMethod, _parent: &dyn Node) {
+    fn visit_class_method(&mut self, n: &ClassMethod) {
         self.show("ClassMethod", n);
         n.visit_children_with(self)
     }
-    fn visit_class_prop(&mut self, n: &ClassProp, _parent: &dyn Node) {
+    fn visit_class_prop(&mut self, n: &ClassProp) {
         self.show("ClassProp", n);
         n.visit_children_with(self)
     }
-    fn visit_computed_prop_name(&mut self, n: &ComputedPropName, _parent: &dyn Node) {
+    fn visit_computed_prop_name(&mut self, n: &ComputedPropName) {
         self.show("ComputedPropName", n);
         n.visit_children_with(self)
     }
-    fn visit_cond_expr(&mut self, n: &CondExpr, _parent: &dyn Node) {
+    fn visit_cond_expr(&mut self, n: &CondExpr) {
         self.show("CondExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_constructor(&mut self, n: &Constructor, _parent: &dyn Node) {
+    fn visit_constructor(&mut self, n: &Constructor) {
         self.show("Constructor", n);
         n.visit_children_with(self)
     }
-    fn visit_continue_stmt(&mut self, n: &ContinueStmt, _parent: &dyn Node) {
+    fn visit_continue_stmt(&mut self, n: &ContinueStmt) {
         self.show("ContinueStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_debugger_stmt(&mut self, n: &DebuggerStmt, _parent: &dyn Node) {
+    fn visit_debugger_stmt(&mut self, n: &DebuggerStmt) {
         self.show("DebuggerStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_decl(&mut self, n: &Decl, _parent: &dyn Node) {
+    fn visit_decl(&mut self, n: &Decl) {
         self.show("Decl", n);
         n.visit_children_with(self)
     }
-    fn visit_decorator(&mut self, n: &Decorator, _parent: &dyn Node) {
+    fn visit_decorator(&mut self, n: &Decorator) {
         self.show("Decorator", n);
         n.visit_children_with(self)
     }
-    fn visit_default_decl(&mut self, n: &DefaultDecl, _parent: &dyn Node) {
+    fn visit_default_decl(&mut self, n: &DefaultDecl) {
         self.show_name("DefaultDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_do_while_stmt(&mut self, n: &DoWhileStmt, _parent: &dyn Node) {
+    fn visit_do_while_stmt(&mut self, n: &DoWhileStmt) {
         self.show("DoWhileStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_empty_stmt(&mut self, n: &EmptyStmt, _parent: &dyn Node) {
+    fn visit_empty_stmt(&mut self, n: &EmptyStmt) {
         self.show("EmptyStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_export_all(&mut self, n: &ExportAll, _parent: &dyn Node) {
+    fn visit_export_all(&mut self, n: &ExportAll) {
         self.show("ExportAll", n);
         n.visit_children_with(self)
     }
-    fn visit_export_decl(&mut self, n: &ExportDecl, _parent: &dyn Node) {
+    fn visit_export_decl(&mut self, n: &ExportDecl) {
         self.show("ExportDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_export_default_decl(&mut self, n: &ExportDefaultDecl, _parent: &dyn Node) {
+    fn visit_export_default_decl(&mut self, n: &ExportDefaultDecl) {
         self.show("ExportDefaultDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_export_default_expr(&mut self, n: &ExportDefaultExpr, _parent: &dyn Node) {
+    fn visit_export_default_expr(&mut self, n: &ExportDefaultExpr) {
         self.show("ExportDefaultExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_export_default_specifier(&mut self, n: &ExportDefaultSpecifier, _parent: &dyn Node) {
+    fn visit_export_default_specifier(&mut self, n: &ExportDefaultSpecifier) {
         self.show_name("ExportDefaultSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier, _parent: &dyn Node) {
+    fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier) {
         self.show("ExportNamedSpecifier", n);
         n.visit_children_with(self)
     }
@@ -748,363 +748,363 @@ impl Visit for Shower<'_> {
         self.show("ExportNamespaceSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_export_specifier(&mut self, n: &ExportSpecifier, _parent: &dyn Node) {
+    fn visit_export_specifier(&mut self, n: &ExportSpecifier) {
         self.show("ExportSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_expr(&mut self, n: &Expr, _parent: &dyn Node) {
+    fn visit_expr(&mut self, n: &Expr) {
         self.show("Expr", n);
         n.visit_children_with(self)
     }
-    fn visit_expr_or_spread(&mut self, n: &ExprOrSpread, _parent: &dyn Node) {
+    fn visit_expr_or_spread(&mut self, n: &ExprOrSpread) {
         self.show("ExprOrSpread", n);
         n.visit_children_with(self)
     }
-    fn visit_expr_or_super(&mut self, n: &ExprOrSuper, _parent: &dyn Node) {
+    fn visit_expr_or_super(&mut self, n: &ExprOrSuper) {
         self.show("ExprOrSuper", n);
         n.visit_children_with(self)
     }
-    fn visit_fn_decl(&mut self, n: &FnDecl, _parent: &dyn Node) {
+    fn visit_fn_decl(&mut self, n: &FnDecl) {
         self.show("FnDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_fn_expr(&mut self, n: &FnExpr, _parent: &dyn Node) {
+    fn visit_fn_expr(&mut self, n: &FnExpr) {
         self.show("FnExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_for_in_stmt(&mut self, n: &ForInStmt, _parent: &dyn Node) {
+    fn visit_for_in_stmt(&mut self, n: &ForInStmt) {
         self.show("ForInStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_for_of_stmt(&mut self, n: &ForOfStmt, _parent: &dyn Node) {
+    fn visit_for_of_stmt(&mut self, n: &ForOfStmt) {
         self.show("ForOfStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_for_stmt(&mut self, n: &ForStmt, _parent: &dyn Node) {
+    fn visit_for_stmt(&mut self, n: &ForStmt) {
         self.show("ForStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_function(&mut self, n: &Function, _parent: &dyn Node) {
+    fn visit_function(&mut self, n: &Function) {
         self.show("Function", n);
         n.visit_children_with(self)
     }
-    fn visit_getter_prop(&mut self, n: &GetterProp, _parent: &dyn Node) {
+    fn visit_getter_prop(&mut self, n: &GetterProp) {
         self.show("GetterProp", n);
         n.visit_children_with(self)
     }
-    fn visit_ident(&mut self, n: &Ident, _parent: &dyn Node) {
+    fn visit_ident(&mut self, n: &Ident) {
         self.show("Ident", n);
         n.visit_children_with(self)
     }
-    fn visit_if_stmt(&mut self, n: &IfStmt, _parent: &dyn Node) {
+    fn visit_if_stmt(&mut self, n: &IfStmt) {
         self.show("IfStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_import_decl(&mut self, n: &ImportDecl, _parent: &dyn Node) {
+    fn visit_import_decl(&mut self, n: &ImportDecl) {
         self.show("ImportDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_import_default_specifier(&mut self, n: &ImportDefaultSpecifier, _parent: &dyn Node) {
+    fn visit_import_default_specifier(&mut self, n: &ImportDefaultSpecifier) {
         self.show_name("ImportDefaultSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_import_named_specifier(&mut self, n: &ImportNamedSpecifier, _parent: &dyn Node) {
+    fn visit_import_named_specifier(&mut self, n: &ImportNamedSpecifier) {
         self.show("ImportNamedSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_import_specifier(&mut self, n: &ImportSpecifier, _parent: &dyn Node) {
+    fn visit_import_specifier(&mut self, n: &ImportSpecifier) {
         self.show_name("ImportSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_import_star_as_specifier(&mut self, n: &ImportStarAsSpecifier, _parent: &dyn Node) {
+    fn visit_import_star_as_specifier(&mut self, n: &ImportStarAsSpecifier) {
         self.show_name("ImportStarAsSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_invalid(&mut self, n: &Invalid, _parent: &dyn Node) {
+    fn visit_invalid(&mut self, n: &Invalid) {
         self.show("Invalid", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_attr(&mut self, n: &JSXAttr, _parent: &dyn Node) {
+    fn visit_jsx_attr(&mut self, n: &JSXAttr) {
         self.show("JSXAttr", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_attr_name(&mut self, n: &JSXAttrName, _parent: &dyn Node) {
+    fn visit_jsx_attr_name(&mut self, n: &JSXAttrName) {
         self.show("JSXAttrName", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_attr_or_spread(&mut self, n: &JSXAttrOrSpread, _parent: &dyn Node) {
+    fn visit_jsx_attr_or_spread(&mut self, n: &JSXAttrOrSpread) {
         self.show("JSXAttrOrSpread", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_attr_value(&mut self, n: &JSXAttrValue, _parent: &dyn Node) {
+    fn visit_jsx_attr_value(&mut self, n: &JSXAttrValue) {
         self.show("JSXAttrValue", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_closing_element(&mut self, n: &JSXClosingElement, _parent: &dyn Node) {
+    fn visit_jsx_closing_element(&mut self, n: &JSXClosingElement) {
         self.show("JSXClosingElement", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_closing_fragment(&mut self, n: &JSXClosingFragment, _parent: &dyn Node) {
+    fn visit_jsx_closing_fragment(&mut self, n: &JSXClosingFragment) {
         self.show("JSXClosingFragment", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_element(&mut self, n: &JSXElement, _parent: &dyn Node) {
+    fn visit_jsx_element(&mut self, n: &JSXElement) {
         self.show("JSXElement", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_element_child(&mut self, n: &JSXElementChild, _parent: &dyn Node) {
+    fn visit_jsx_element_child(&mut self, n: &JSXElementChild) {
         self.show("JSXElementChild", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_element_name(&mut self, n: &JSXElementName, _parent: &dyn Node) {
+    fn visit_jsx_element_name(&mut self, n: &JSXElementName) {
         self.show("JSXElementName", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_empty_expr(&mut self, n: &JSXEmptyExpr, _parent: &dyn Node) {
+    fn visit_jsx_empty_expr(&mut self, n: &JSXEmptyExpr) {
         self.show("JSXEmptyExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_expr(&mut self, n: &JSXExpr, _parent: &dyn Node) {
+    fn visit_jsx_expr(&mut self, n: &JSXExpr) {
         self.show("JSXExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_expr_container(&mut self, n: &JSXExprContainer, _parent: &dyn Node) {
+    fn visit_jsx_expr_container(&mut self, n: &JSXExprContainer) {
         self.show("JSXExprContainer", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_fragment(&mut self, n: &JSXFragment, _parent: &dyn Node) {
+    fn visit_jsx_fragment(&mut self, n: &JSXFragment) {
         self.show("JSXFragment", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_member_expr(&mut self, n: &JSXMemberExpr, _parent: &dyn Node) {
+    fn visit_jsx_member_expr(&mut self, n: &JSXMemberExpr) {
         self.show("JSXMemberExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_namespaced_name(&mut self, n: &JSXNamespacedName, _parent: &dyn Node) {
+    fn visit_jsx_namespaced_name(&mut self, n: &JSXNamespacedName) {
         self.show("JSXNamespacedName", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_object(&mut self, n: &JSXObject, _parent: &dyn Node) {
+    fn visit_jsx_object(&mut self, n: &JSXObject) {
         self.show("JSXObject", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_opening_element(&mut self, n: &JSXOpeningElement, _parent: &dyn Node) {
+    fn visit_jsx_opening_element(&mut self, n: &JSXOpeningElement) {
         self.show("JSXOpeningElement", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_opening_fragment(&mut self, n: &JSXOpeningFragment, _parent: &dyn Node) {
+    fn visit_jsx_opening_fragment(&mut self, n: &JSXOpeningFragment) {
         self.show("JSXOpeningFragment", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_spread_child(&mut self, n: &JSXSpreadChild, _parent: &dyn Node) {
+    fn visit_jsx_spread_child(&mut self, n: &JSXSpreadChild) {
         self.show("JSXSpreadChild", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_text(&mut self, n: &JSXText, _parent: &dyn Node) {
+    fn visit_jsx_text(&mut self, n: &JSXText) {
         self.show("JSXText", n);
         n.visit_children_with(self)
     }
-    fn visit_key_value_pat_prop(&mut self, n: &KeyValuePatProp, _parent: &dyn Node) {
+    fn visit_key_value_pat_prop(&mut self, n: &KeyValuePatProp) {
         self.show("KeyValuePatProp", n);
         n.visit_children_with(self)
     }
-    fn visit_key_value_prop(&mut self, n: &KeyValueProp, _parent: &dyn Node) {
+    fn visit_key_value_prop(&mut self, n: &KeyValueProp) {
         self.show("KeyValueProp", n);
         n.visit_children_with(self)
     }
-    fn visit_labeled_stmt(&mut self, n: &LabeledStmt, _parent: &dyn Node) {
+    fn visit_labeled_stmt(&mut self, n: &LabeledStmt) {
         self.show("LabeledStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_lit(&mut self, n: &Lit, _parent: &dyn Node) {
+    fn visit_lit(&mut self, n: &Lit) {
         self.show("Lit", n);
         n.visit_children_with(self)
     }
-    fn visit_member_expr(&mut self, n: &MemberExpr, _parent: &dyn Node) {
+    fn visit_member_expr(&mut self, n: &MemberExpr) {
         self.show("MemberExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_meta_prop_expr(&mut self, n: &MetaPropExpr, _parent: &dyn Node) {
+    fn visit_meta_prop_expr(&mut self, n: &MetaPropExpr) {
         self.show("MetaPropExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_method_prop(&mut self, n: &MethodProp, _parent: &dyn Node) {
+    fn visit_method_prop(&mut self, n: &MethodProp) {
         self.show("MethodProp", n);
         n.visit_children_with(self)
     }
-    fn visit_module(&mut self, n: &Module, _parent: &dyn Node) {
+    fn visit_module(&mut self, n: &Module) {
         self.show("Module", n);
         n.visit_children_with(self)
     }
-    fn visit_module_decl(&mut self, n: &ModuleDecl, _parent: &dyn Node) {
+    fn visit_module_decl(&mut self, n: &ModuleDecl) {
         self.show("ModuleDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_named_export(&mut self, n: &NamedExport, _parent: &dyn Node) {
+    fn visit_named_export(&mut self, n: &NamedExport) {
         self.show("NamedExport", n);
         n.visit_children_with(self)
     }
-    fn visit_new_expr(&mut self, n: &NewExpr, _parent: &dyn Node) {
+    fn visit_new_expr(&mut self, n: &NewExpr) {
         self.show("NewExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_null(&mut self, n: &Null, _parent: &dyn Node) {
+    fn visit_null(&mut self, n: &Null) {
         self.show_name("Null", n);
         n.visit_children_with(self)
     }
-    fn visit_number(&mut self, n: &Number, _parent: &dyn Node) {
+    fn visit_number(&mut self, n: &Number) {
         self.show("Number", n);
         n.visit_children_with(self)
     }
-    fn visit_object_lit(&mut self, n: &ObjectLit, _parent: &dyn Node) {
+    fn visit_object_lit(&mut self, n: &ObjectLit) {
         self.show("ObjectLit", n);
         n.visit_children_with(self)
     }
-    fn visit_object_pat(&mut self, n: &ObjectPat, _parent: &dyn Node) {
+    fn visit_object_pat(&mut self, n: &ObjectPat) {
         self.show("ObjectPat", n);
         n.visit_children_with(self)
     }
-    fn visit_object_pat_prop(&mut self, n: &ObjectPatProp, _parent: &dyn Node) {
+    fn visit_object_pat_prop(&mut self, n: &ObjectPatProp) {
         self.show("ObjectPatProp", n);
         n.visit_children_with(self)
     }
-    fn visit_opt_chain_expr(&mut self, n: &OptChainExpr, _parent: &dyn Node) {
+    fn visit_opt_chain_expr(&mut self, n: &OptChainExpr) {
         self.show("OptChainExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_param(&mut self, n: &Param, _parent: &dyn Node) {
+    fn visit_param(&mut self, n: &Param) {
         self.show("Param", n);
         n.visit_children_with(self)
     }
-    fn visit_param_or_ts_param_prop(&mut self, n: &ParamOrTsParamProp, _parent: &dyn Node) {
+    fn visit_param_or_ts_param_prop(&mut self, n: &ParamOrTsParamProp) {
         self.show("ParamOrTsParamProp", n);
         n.visit_children_with(self)
     }
-    fn visit_paren_expr(&mut self, n: &ParenExpr, _parent: &dyn Node) {
+    fn visit_paren_expr(&mut self, n: &ParenExpr) {
         self.show("ParenExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_pat(&mut self, n: &Pat, _parent: &dyn Node) {
+    fn visit_pat(&mut self, n: &Pat) {
         self.show("Pat", n);
         n.visit_children_with(self)
     }
-    fn visit_pat_or_expr(&mut self, n: &PatOrExpr, _parent: &dyn Node) {
+    fn visit_pat_or_expr(&mut self, n: &PatOrExpr) {
         self.show("PatOrExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_private_method(&mut self, n: &PrivateMethod, _parent: &dyn Node) {
+    fn visit_private_method(&mut self, n: &PrivateMethod) {
         self.show("PrivateMethod", n);
         n.visit_children_with(self)
     }
-    fn visit_private_name(&mut self, n: &PrivateName, _parent: &dyn Node) {
+    fn visit_private_name(&mut self, n: &PrivateName) {
         self.show("PrivateName", n);
         n.visit_children_with(self)
     }
-    fn visit_private_prop(&mut self, n: &PrivateProp, _parent: &dyn Node) {
+    fn visit_private_prop(&mut self, n: &PrivateProp) {
         self.show("PrivateProp", n);
         n.visit_children_with(self)
     }
-    fn visit_program(&mut self, n: &Program, _parent: &dyn Node) {
+    fn visit_program(&mut self, n: &Program) {
         self.show("Program", n);
         n.visit_children_with(self)
     }
-    fn visit_prop(&mut self, n: &Prop, _parent: &dyn Node) {
+    fn visit_prop(&mut self, n: &Prop) {
         self.show("Prop", n);
         n.visit_children_with(self)
     }
-    fn visit_prop_name(&mut self, n: &PropName, _parent: &dyn Node) {
+    fn visit_prop_name(&mut self, n: &PropName) {
         self.show("PropName", n);
         n.visit_children_with(self)
     }
-    fn visit_prop_or_spread(&mut self, n: &PropOrSpread, _parent: &dyn Node) {
+    fn visit_prop_or_spread(&mut self, n: &PropOrSpread) {
         self.show("PropOrSpread", n);
         n.visit_children_with(self)
     }
-    fn visit_regex(&mut self, n: &Regex, _parent: &dyn Node) {
+    fn visit_regex(&mut self, n: &Regex) {
         self.show_name("Regex", n);
         n.visit_children_with(self)
     }
-    fn visit_rest_pat(&mut self, n: &RestPat, _parent: &dyn Node) {
+    fn visit_rest_pat(&mut self, n: &RestPat) {
         self.show("RestPat", n);
         n.visit_children_with(self)
     }
-    fn visit_return_stmt(&mut self, n: &ReturnStmt, _parent: &dyn Node) {
+    fn visit_return_stmt(&mut self, n: &ReturnStmt) {
         self.show("ReturnStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_script(&mut self, n: &Script, _parent: &dyn Node) {
+    fn visit_script(&mut self, n: &Script) {
         self.show("Script", n);
         n.visit_children_with(self)
     }
-    fn visit_seq_expr(&mut self, n: &SeqExpr, _parent: &dyn Node) {
+    fn visit_seq_expr(&mut self, n: &SeqExpr) {
         self.show("SeqExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_setter_prop(&mut self, n: &SetterProp, _parent: &dyn Node) {
+    fn visit_setter_prop(&mut self, n: &SetterProp) {
         self.show("SetterProp", n);
         n.visit_children_with(self)
     }
-    fn visit_spread_element(&mut self, n: &SpreadElement, _parent: &dyn Node) {
+    fn visit_spread_element(&mut self, n: &SpreadElement) {
         self.show("SpreadElement", n);
         n.visit_children_with(self)
     }
-    fn visit_str(&mut self, n: &Str, _parent: &dyn Node) {
+    fn visit_str(&mut self, n: &Str) {
         self.show("Str", n);
         n.visit_children_with(self)
     }
-    fn visit_super(&mut self, n: &Super, _parent: &dyn Node) {
+    fn visit_super(&mut self, n: &Super) {
         self.show("Super", n);
         n.visit_children_with(self)
     }
-    fn visit_switch_case(&mut self, n: &SwitchCase, _parent: &dyn Node) {
+    fn visit_switch_case(&mut self, n: &SwitchCase) {
         self.show("SwitchCase", n);
         n.visit_children_with(self)
     }
-    fn visit_switch_stmt(&mut self, n: &SwitchStmt, _parent: &dyn Node) {
+    fn visit_switch_stmt(&mut self, n: &SwitchStmt) {
         self.show("SwitchStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_tagged_tpl(&mut self, n: &TaggedTpl, _parent: &dyn Node) {
+    fn visit_tagged_tpl(&mut self, n: &TaggedTpl) {
         self.show("TaggedTpl", n);
         n.visit_children_with(self)
     }
-    fn visit_this_expr(&mut self, n: &ThisExpr, _parent: &dyn Node) {
+    fn visit_this_expr(&mut self, n: &ThisExpr) {
         self.show("ThisExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_throw_stmt(&mut self, n: &ThrowStmt, _parent: &dyn Node) {
+    fn visit_throw_stmt(&mut self, n: &ThrowStmt) {
         self.show("ThrowStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_tpl(&mut self, n: &Tpl, _parent: &dyn Node) {
+    fn visit_tpl(&mut self, n: &Tpl) {
         self.show("Tpl", n);
         n.visit_children_with(self)
     }
-    fn visit_tpl_element(&mut self, n: &TplElement, _parent: &dyn Node) {
+    fn visit_tpl_element(&mut self, n: &TplElement) {
         self.show("TplElement", n);
         n.visit_children_with(self)
     }
-    fn visit_try_stmt(&mut self, n: &TryStmt, _parent: &dyn Node) {
+    fn visit_try_stmt(&mut self, n: &TryStmt) {
         self.show("TryStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_array_type(&mut self, n: &TsArrayType, _parent: &dyn Node) {
+    fn visit_ts_array_type(&mut self, n: &TsArrayType) {
         self.show("TsArrayType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_as_expr(&mut self, n: &TsAsExpr, _parent: &dyn Node) {
+    fn visit_ts_as_expr(&mut self, n: &TsAsExpr) {
         self.show("TsAsExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_call_signature_decl(&mut self, n: &TsCallSignatureDecl, _parent: &dyn Node) {
+    fn visit_ts_call_signature_decl(&mut self, n: &TsCallSignatureDecl) {
         self.show("TsCallSignatureDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_conditional_type(&mut self, n: &TsConditionalType, _parent: &dyn Node) {
+    fn visit_ts_conditional_type(&mut self, n: &TsConditionalType) {
         self.show("TsConditionalType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_const_assertion(&mut self, n: &TsConstAssertion, _parent: &dyn Node) {
+    fn visit_ts_const_assertion(&mut self, n: &TsConstAssertion) {
         self.show("TsConstAssertion", n);
         n.visit_children_with(self)
     }
@@ -1116,213 +1116,213 @@ impl Visit for Shower<'_> {
         self.show("TsConstructSignatureDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_constructor_type(&mut self, n: &TsConstructorType, _parent: &dyn Node) {
+    fn visit_ts_constructor_type(&mut self, n: &TsConstructorType) {
         self.show("TsConstructorType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_entity_name(&mut self, n: &TsEntityName, _parent: &dyn Node) {
+    fn visit_ts_entity_name(&mut self, n: &TsEntityName) {
         self.show("TsEntityName", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_enum_decl(&mut self, n: &TsEnumDecl, _parent: &dyn Node) {
+    fn visit_ts_enum_decl(&mut self, n: &TsEnumDecl) {
         self.show("TsEnumDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_enum_member(&mut self, n: &TsEnumMember, _parent: &dyn Node) {
+    fn visit_ts_enum_member(&mut self, n: &TsEnumMember) {
         self.show("TsEnumMember", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_enum_member_id(&mut self, n: &TsEnumMemberId, _parent: &dyn Node) {
+    fn visit_ts_enum_member_id(&mut self, n: &TsEnumMemberId) {
         self.show("TsEnumMemberId", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_export_assignment(&mut self, n: &TsExportAssignment, _parent: &dyn Node) {
+    fn visit_ts_export_assignment(&mut self, n: &TsExportAssignment) {
         self.show("TsExportAssignment", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_expr_with_type_args(&mut self, n: &TsExprWithTypeArgs, _parent: &dyn Node) {
+    fn visit_ts_expr_with_type_args(&mut self, n: &TsExprWithTypeArgs) {
         self.show("TsExprWithTypeArgs", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_external_module_ref(&mut self, n: &TsExternalModuleRef, _parent: &dyn Node) {
+    fn visit_ts_external_module_ref(&mut self, n: &TsExternalModuleRef) {
         self.show("TsExternalModuleRef", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_fn_or_constructor_type(&mut self, n: &TsFnOrConstructorType, _parent: &dyn Node) {
+    fn visit_ts_fn_or_constructor_type(&mut self, n: &TsFnOrConstructorType) {
         self.show("TsFnOrConstructorType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_fn_param(&mut self, n: &TsFnParam, _parent: &dyn Node) {
+    fn visit_ts_fn_param(&mut self, n: &TsFnParam) {
         self.show("TsFnParam", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_fn_type(&mut self, n: &TsFnType, _parent: &dyn Node) {
+    fn visit_ts_fn_type(&mut self, n: &TsFnType) {
         self.show("TsFnType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_import_equals_decl(&mut self, n: &TsImportEqualsDecl, _parent: &dyn Node) {
+    fn visit_ts_import_equals_decl(&mut self, n: &TsImportEqualsDecl) {
         self.show("TsImportEqualsDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_import_type(&mut self, n: &TsImportType, _parent: &dyn Node) {
+    fn visit_ts_import_type(&mut self, n: &TsImportType) {
         self.show("TsImportType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_index_signature(&mut self, n: &TsIndexSignature, _parent: &dyn Node) {
+    fn visit_ts_index_signature(&mut self, n: &TsIndexSignature) {
         self.show("TsIndexSignature", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_indexed_access_type(&mut self, n: &TsIndexedAccessType, _parent: &dyn Node) {
+    fn visit_ts_indexed_access_type(&mut self, n: &TsIndexedAccessType) {
         self.show("TsIndexedAccessType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_infer_type(&mut self, n: &TsInferType, _parent: &dyn Node) {
+    fn visit_ts_infer_type(&mut self, n: &TsInferType) {
         self.show("TsInferType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_interface_body(&mut self, n: &TsInterfaceBody, _parent: &dyn Node) {
+    fn visit_ts_interface_body(&mut self, n: &TsInterfaceBody) {
         self.show("TsInterfaceBody", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_interface_decl(&mut self, n: &TsInterfaceDecl, _parent: &dyn Node) {
+    fn visit_ts_interface_decl(&mut self, n: &TsInterfaceDecl) {
         self.show("TsInterfaceDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_intersection_type(&mut self, n: &TsIntersectionType, _parent: &dyn Node) {
+    fn visit_ts_intersection_type(&mut self, n: &TsIntersectionType) {
         self.show("TsIntersectionType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_keyword_type(&mut self, n: &TsKeywordType, _parent: &dyn Node) {
+    fn visit_ts_keyword_type(&mut self, n: &TsKeywordType) {
         self.show("TsKeywordType", n);
         n.visit_children_with(self)
     }
 
-    fn visit_ts_lit(&mut self, n: &TsLit, _parent: &dyn Node) {
+    fn visit_ts_lit(&mut self, n: &TsLit) {
         self.show("TsLit", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_lit_type(&mut self, n: &TsLitType, _parent: &dyn Node) {
+    fn visit_ts_lit_type(&mut self, n: &TsLitType) {
         self.show("TsLitType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_mapped_type(&mut self, n: &TsMappedType, _parent: &dyn Node) {
+    fn visit_ts_mapped_type(&mut self, n: &TsMappedType) {
         self.show("TsMappedType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_method_signature(&mut self, n: &TsMethodSignature, _parent: &dyn Node) {
+    fn visit_ts_method_signature(&mut self, n: &TsMethodSignature) {
         self.show("TsMethodSignature", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_module_block(&mut self, n: &TsModuleBlock, _parent: &dyn Node) {
+    fn visit_ts_module_block(&mut self, n: &TsModuleBlock) {
         self.show("TsModuleBlock", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_module_decl(&mut self, n: &TsModuleDecl, _parent: &dyn Node) {
+    fn visit_ts_module_decl(&mut self, n: &TsModuleDecl) {
         self.show("TsModuleDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_module_name(&mut self, n: &TsModuleName, _parent: &dyn Node) {
+    fn visit_ts_module_name(&mut self, n: &TsModuleName) {
         self.show("TsModuleName", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_module_ref(&mut self, n: &TsModuleRef, _parent: &dyn Node) {
+    fn visit_ts_module_ref(&mut self, n: &TsModuleRef) {
         self.show("TsModuleRef", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_namespace_body(&mut self, n: &TsNamespaceBody, _parent: &dyn Node) {
+    fn visit_ts_namespace_body(&mut self, n: &TsNamespaceBody) {
         self.show("TsNamespaceBody", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_namespace_decl(&mut self, n: &TsNamespaceDecl, _parent: &dyn Node) {
+    fn visit_ts_namespace_decl(&mut self, n: &TsNamespaceDecl) {
         self.show("TsNamespaceDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_namespace_export_decl(&mut self, n: &TsNamespaceExportDecl, _parent: &dyn Node) {
+    fn visit_ts_namespace_export_decl(&mut self, n: &TsNamespaceExportDecl) {
         self.show("TsNamespaceExportDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_non_null_expr(&mut self, n: &TsNonNullExpr, _parent: &dyn Node) {
+    fn visit_ts_non_null_expr(&mut self, n: &TsNonNullExpr) {
         self.show("TsNonNullExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_optional_type(&mut self, n: &TsOptionalType, _parent: &dyn Node) {
+    fn visit_ts_optional_type(&mut self, n: &TsOptionalType) {
         self.show("TsOptionalType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_param_prop(&mut self, n: &TsParamProp, _parent: &dyn Node) {
+    fn visit_ts_param_prop(&mut self, n: &TsParamProp) {
         self.show("TsParamProp", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_param_prop_param(&mut self, n: &TsParamPropParam, _parent: &dyn Node) {
+    fn visit_ts_param_prop_param(&mut self, n: &TsParamPropParam) {
         self.show("TsParamPropParam", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_parenthesized_type(&mut self, n: &TsParenthesizedType, _parent: &dyn Node) {
+    fn visit_ts_parenthesized_type(&mut self, n: &TsParenthesizedType) {
         self.show("TsParenthesizedType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_property_signature(&mut self, n: &TsPropertySignature, _parent: &dyn Node) {
+    fn visit_ts_property_signature(&mut self, n: &TsPropertySignature) {
         self.show("TsPropertySignature", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_qualified_name(&mut self, n: &TsQualifiedName, _parent: &dyn Node) {
+    fn visit_ts_qualified_name(&mut self, n: &TsQualifiedName) {
         self.show("TsQualifiedName", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_rest_type(&mut self, n: &TsRestType, _parent: &dyn Node) {
+    fn visit_ts_rest_type(&mut self, n: &TsRestType) {
         self.show("TsRestType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_this_type(&mut self, n: &TsThisType, _parent: &dyn Node) {
+    fn visit_ts_this_type(&mut self, n: &TsThisType) {
         self.show("TsThisType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_this_type_or_ident(&mut self, n: &TsThisTypeOrIdent, _parent: &dyn Node) {
+    fn visit_ts_this_type_or_ident(&mut self, n: &TsThisTypeOrIdent) {
         self.show("TsThisTypeOrIdent", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_tuple_element(&mut self, n: &TsTupleElement, _parent: &dyn Node) {
+    fn visit_ts_tuple_element(&mut self, n: &TsTupleElement) {
         self.show("TsTupleElement", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_tuple_type(&mut self, n: &TsTupleType, _parent: &dyn Node) {
+    fn visit_ts_tuple_type(&mut self, n: &TsTupleType) {
         self.show("TsTupleType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type(&mut self, n: &TsType, _parent: &dyn Node) {
+    fn visit_ts_type(&mut self, n: &TsType) {
         self.show("TsType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_alias_decl(&mut self, n: &TsTypeAliasDecl, _parent: &dyn Node) {
+    fn visit_ts_type_alias_decl(&mut self, n: &TsTypeAliasDecl) {
         self.show("TsTypeAliasDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_ann(&mut self, n: &TsTypeAnn, _parent: &dyn Node) {
+    fn visit_ts_type_ann(&mut self, n: &TsTypeAnn) {
         self.show("TsTypeAnn", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_assertion(&mut self, n: &TsTypeAssertion, _parent: &dyn Node) {
+    fn visit_ts_type_assertion(&mut self, n: &TsTypeAssertion) {
         self.show("TsTypeAssertion", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_element(&mut self, n: &TsTypeElement, _parent: &dyn Node) {
+    fn visit_ts_type_element(&mut self, n: &TsTypeElement) {
         self.show("TsTypeElement", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_lit(&mut self, n: &TsTypeLit, _parent: &dyn Node) {
+    fn visit_ts_type_lit(&mut self, n: &TsTypeLit) {
         self.show("TsTypeLit", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_operator(&mut self, n: &TsTypeOperator, _parent: &dyn Node) {
+    fn visit_ts_type_operator(&mut self, n: &TsTypeOperator) {
         self.show("TsTypeOperator", n);
         n.visit_children_with(self)
     }
 
-    fn visit_ts_type_param(&mut self, n: &TsTypeParam, _parent: &dyn Node) {
+    fn visit_ts_type_param(&mut self, n: &TsTypeParam) {
         self.show("TsTypeParam", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_param_decl(&mut self, n: &TsTypeParamDecl, _parent: &dyn Node) {
+    fn visit_ts_type_param_decl(&mut self, n: &TsTypeParamDecl) {
         self.show("TsTypeParamDecl", n);
         n.visit_children_with(self)
     }
@@ -1334,19 +1334,19 @@ impl Visit for Shower<'_> {
         self.show("TsTypeParamInstantiation", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_predicate(&mut self, n: &TsTypePredicate, _parent: &dyn Node) {
+    fn visit_ts_type_predicate(&mut self, n: &TsTypePredicate) {
         self.show("TsTypePredicate", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_query(&mut self, n: &TsTypeQuery, _parent: &dyn Node) {
+    fn visit_ts_type_query(&mut self, n: &TsTypeQuery) {
         self.show("TsTypeQuery", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_query_expr(&mut self, n: &TsTypeQueryExpr, _parent: &dyn Node) {
+    fn visit_ts_type_query_expr(&mut self, n: &TsTypeQueryExpr) {
         self.show("TsTypeQueryExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_ref(&mut self, n: &TsTypeRef, _parent: &dyn Node) {
+    fn visit_ts_type_ref(&mut self, n: &TsTypeRef) {
         self.show("TsTypeRef", n);
         n.visit_children_with(self)
     }
@@ -1358,43 +1358,43 @@ impl Visit for Shower<'_> {
         self.show("TsUnionOrIntersectionType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_union_type(&mut self, n: &TsUnionType, _parent: &dyn Node) {
+    fn visit_ts_union_type(&mut self, n: &TsUnionType) {
         self.show("TsUnionType", n);
         n.visit_children_with(self)
     }
-    fn visit_unary_expr(&mut self, n: &UnaryExpr, _parent: &dyn Node) {
+    fn visit_unary_expr(&mut self, n: &UnaryExpr) {
         self.show("UnaryExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_update_expr(&mut self, n: &UpdateExpr, _parent: &dyn Node) {
+    fn visit_update_expr(&mut self, n: &UpdateExpr) {
         self.show("UpdateExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_var_decl(&mut self, n: &VarDecl, _parent: &dyn Node) {
+    fn visit_var_decl(&mut self, n: &VarDecl) {
         self.show("VarDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_var_decl_or_expr(&mut self, n: &VarDeclOrExpr, _parent: &dyn Node) {
+    fn visit_var_decl_or_expr(&mut self, n: &VarDeclOrExpr) {
         self.show("VarDeclOrExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_var_decl_or_pat(&mut self, n: &VarDeclOrPat, _parent: &dyn Node) {
+    fn visit_var_decl_or_pat(&mut self, n: &VarDeclOrPat) {
         self.show("VarDeclOrPat", n);
         n.visit_children_with(self)
     }
-    fn visit_var_declarator(&mut self, n: &VarDeclarator, _parent: &dyn Node) {
+    fn visit_var_declarator(&mut self, n: &VarDeclarator) {
         self.show("VarDeclarator", n);
         n.visit_children_with(self)
     }
-    fn visit_while_stmt(&mut self, n: &WhileStmt, _parent: &dyn Node) {
+    fn visit_while_stmt(&mut self, n: &WhileStmt) {
         self.show("WhileStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_with_stmt(&mut self, n: &WithStmt, _parent: &dyn Node) {
+    fn visit_with_stmt(&mut self, n: &WithStmt) {
         self.show("WithStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_yield_expr(&mut self, n: &YieldExpr, _parent: &dyn Node) {
+    fn visit_yield_expr(&mut self, n: &YieldExpr) {
         self.show("YieldExpr", n);
         n.visit_children_with(self)
     }

--- a/crates/swc_ecma_minifier/tests/compress.rs
+++ b/crates/swc_ecma_minifier/tests/compress.rs
@@ -39,7 +39,7 @@ use swc_ecma_transforms::{
     resolver_with_mark,
 };
 use swc_ecma_utils::drop_span;
-use swc_ecma_visit::{FoldWith, Node, Visit, VisitMutWith, VisitWith};
+use swc_ecma_visit::{FoldWith, Visit, VisitMutWith, VisitWith};
 use testing::{assert_eq, DebugUsingDisplay, NormalizedOutput};
 
 fn load_txt(filename: &str) -> Vec<String> {
@@ -143,7 +143,7 @@ fn run(
             Err(err) => {
                 eprintln!(
                     "---- {} -----\n{:?}",
-                    Color::Green.paint("Error (of orignal source code)"),
+                    Color::Green.paint("Error (of original source code)"),
                     err
                 );
             }

--- a/crates/swc_ecma_minifier/tests/compress.rs
+++ b/crates/swc_ecma_minifier/tests/compress.rs
@@ -740,11 +740,7 @@ impl Visit for Shower<'_> {
         self.show("ExportNamedSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_export_namespace_specifier(
-        &mut self,
-        n: &ExportNamespaceSpecifier,
-        _parent: &dyn Node,
-    ) {
+    fn visit_export_namespace_specifier(&mut self, n: &ExportNamespaceSpecifier) {
         self.show("ExportNamespaceSpecifier", n);
         n.visit_children_with(self)
     }
@@ -1108,11 +1104,7 @@ impl Visit for Shower<'_> {
         self.show("TsConstAssertion", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_construct_signature_decl(
-        &mut self,
-        n: &TsConstructSignatureDecl,
-        _parent: &dyn Node,
-    ) {
+    fn visit_ts_construct_signature_decl(&mut self, n: &TsConstructSignatureDecl) {
         self.show("TsConstructSignatureDecl", n);
         n.visit_children_with(self)
     }
@@ -1326,11 +1318,7 @@ impl Visit for Shower<'_> {
         self.show("TsTypeParamDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_param_instantiation(
-        &mut self,
-        n: &TsTypeParamInstantiation,
-        _parent: &dyn Node,
-    ) {
+    fn visit_ts_type_param_instantiation(&mut self, n: &TsTypeParamInstantiation) {
         self.show("TsTypeParamInstantiation", n);
         n.visit_children_with(self)
     }
@@ -1350,11 +1338,7 @@ impl Visit for Shower<'_> {
         self.show("TsTypeRef", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_union_or_intersection_type(
-        &mut self,
-        n: &TsUnionOrIntersectionType,
-        _parent: &dyn Node,
-    ) {
+    fn visit_ts_union_or_intersection_type(&mut self, n: &TsUnionOrIntersectionType) {
         self.show("TsUnionOrIntersectionType", n);
         n.visit_children_with(self)
     }

--- a/crates/swc_ecma_parser/src/parser/expr/verifier.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/verifier.rs
@@ -6,7 +6,7 @@ impl<'a, I: Tokens> Parser<I> {
     pub(in crate::parser) fn verify_expr(&mut self, expr: Box<Expr>) -> PResult<Box<Expr>> {
         let mut v = Verifier { errors: vec![] };
 
-        v.visit_expr(&expr, &Invalid { span: DUMMY_SP } as _);
+        v.visit_expr(&expr);
 
         for (span, error) in v.errors {
             self.emit_err(span, error);

--- a/crates/swc_ecma_parser/src/parser/expr/verifier.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/verifier.rs
@@ -1,6 +1,6 @@
 use super::*;
 use swc_common::{Span, Spanned};
-use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 impl<'a, I: Tokens> Parser<I> {
     pub(in crate::parser) fn verify_expr(&mut self, expr: Box<Expr>) -> PResult<Box<Expr>> {

--- a/crates/swc_ecma_parser/src/parser/expr/verifier.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/verifier.rs
@@ -1,5 +1,5 @@
 use super::*;
-use swc_common::{Span, Spanned, DUMMY_SP};
+use swc_common::{Span, Spanned};
 use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitWith};
 
 impl<'a, I: Tokens> Parser<I> {
@@ -23,11 +23,11 @@ pub(super) struct Verifier {
 impl Visit for Verifier {
     noop_visit_type!();
 
-    fn visit_assign_prop(&mut self, p: &AssignProp, _: &dyn Node) {
+    fn visit_assign_prop(&mut self, p: &AssignProp) {
         self.errors.push((p.span(), SyntaxError::AssignProperty));
     }
 
-    fn visit_expr(&mut self, e: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, e: &Expr) {
         match *e {
             Expr::Fn(..) | Expr::Arrow(..) => {}
             _ => e.visit_children_with(self),

--- a/crates/swc_ecma_parser/tests/comments.rs
+++ b/crates/swc_ecma_parser/tests/comments.rs
@@ -85,7 +85,7 @@ struct CommentPrinter<'a> {
 }
 
 impl Visit for CommentPrinter<'_> {
-    fn visit_span(&mut self, n: &Span, _: &dyn Node) {
+    fn visit_span(&mut self, n: &Span) {
         self.comments.with_leading(n.lo, |comments| {
             for c in comments {
                 DiagnosticBuilder::new(

--- a/crates/swc_ecma_parser/tests/comments.rs
+++ b/crates/swc_ecma_parser/tests/comments.rs
@@ -3,11 +3,11 @@ use swc_common::{
     comments::SingleThreadedComments,
     errors::{DiagnosticBuilder, Handler},
     input::SourceFileInput,
-    BytePos, Span, DUMMY_SP,
+    BytePos, Span,
 };
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, Syntax, TsConfig};
-use swc_ecma_visit::{Node, Visit, VisitWith};
+use swc_ecma_visit::{Visit, VisitWith};
 use testing::{fixture, Tester};
 
 #[fixture("tests/comments/**/input.js")]
@@ -61,13 +61,10 @@ fn test(input: PathBuf) {
                 }
             };
 
-            module.visit_with(
-                &Invalid { span: DUMMY_SP },
-                &mut CommentPrinter {
-                    handler: &handler,
-                    comments,
-                },
-            );
+            module.visit_with(&mut CommentPrinter {
+                handler: &handler,
+                comments,
+            });
 
             Err(())
         })

--- a/crates/swc_ecma_parser/tests/span.rs
+++ b/crates/swc_ecma_parser/tests/span.rs
@@ -62,151 +62,151 @@ impl Shower<'_> {
 }
 
 impl Visit for Shower<'_> {
-    fn visit_array_lit(&mut self, n: &ArrayLit, _parent: &dyn Node) {
+    fn visit_array_lit(&mut self, n: &ArrayLit) {
         self.show("ArrayLit", n);
         n.visit_children_with(self)
     }
-    fn visit_array_pat(&mut self, n: &ArrayPat, _parent: &dyn Node) {
+    fn visit_array_pat(&mut self, n: &ArrayPat) {
         self.show("ArrayPat", n);
         n.visit_children_with(self)
     }
-    fn visit_arrow_expr(&mut self, n: &ArrowExpr, _parent: &dyn Node) {
+    fn visit_arrow_expr(&mut self, n: &ArrowExpr) {
         self.show("ArrowExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_assign_expr(&mut self, n: &AssignExpr, _parent: &dyn Node) {
+    fn visit_assign_expr(&mut self, n: &AssignExpr) {
         self.show("AssignExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_assign_pat(&mut self, n: &AssignPat, _parent: &dyn Node) {
+    fn visit_assign_pat(&mut self, n: &AssignPat) {
         self.show("AssignPat", n);
         n.visit_children_with(self)
     }
-    fn visit_assign_pat_prop(&mut self, n: &AssignPatProp, _parent: &dyn Node) {
+    fn visit_assign_pat_prop(&mut self, n: &AssignPatProp) {
         self.show("AssignPatProp", n);
         n.visit_children_with(self)
     }
-    fn visit_assign_prop(&mut self, n: &AssignProp, _parent: &dyn Node) {
+    fn visit_assign_prop(&mut self, n: &AssignProp) {
         self.show("AssignProp", n);
         n.visit_children_with(self)
     }
-    fn visit_await_expr(&mut self, n: &AwaitExpr, _parent: &dyn Node) {
+    fn visit_await_expr(&mut self, n: &AwaitExpr) {
         self.show("AwaitExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_bin_expr(&mut self, n: &BinExpr, _parent: &dyn Node) {
+    fn visit_bin_expr(&mut self, n: &BinExpr) {
         self.show("BinExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_block_stmt(&mut self, n: &BlockStmt, _parent: &dyn Node) {
+    fn visit_block_stmt(&mut self, n: &BlockStmt) {
         self.show("BlockStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_block_stmt_or_expr(&mut self, n: &BlockStmtOrExpr, _parent: &dyn Node) {
+    fn visit_block_stmt_or_expr(&mut self, n: &BlockStmtOrExpr) {
         self.show("BlockStmtOrExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_bool(&mut self, n: &Bool, _parent: &dyn Node) {
+    fn visit_bool(&mut self, n: &Bool) {
         self.show("Bool", n);
         n.visit_children_with(self)
     }
-    fn visit_break_stmt(&mut self, n: &BreakStmt, _parent: &dyn Node) {
+    fn visit_break_stmt(&mut self, n: &BreakStmt) {
         self.show("BreakStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_call_expr(&mut self, n: &CallExpr, _parent: &dyn Node) {
+    fn visit_call_expr(&mut self, n: &CallExpr) {
         self.show("CallExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_catch_clause(&mut self, n: &CatchClause, _parent: &dyn Node) {
+    fn visit_catch_clause(&mut self, n: &CatchClause) {
         self.show("CatchClause", n);
         n.visit_children_with(self)
     }
-    fn visit_class(&mut self, n: &Class, _parent: &dyn Node) {
+    fn visit_class(&mut self, n: &Class) {
         self.show("Class", n);
         n.visit_children_with(self)
     }
-    fn visit_class_decl(&mut self, n: &ClassDecl, _parent: &dyn Node) {
+    fn visit_class_decl(&mut self, n: &ClassDecl) {
         self.show("ClassDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_class_expr(&mut self, n: &ClassExpr, _parent: &dyn Node) {
+    fn visit_class_expr(&mut self, n: &ClassExpr) {
         self.show("ClassExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_class_member(&mut self, n: &ClassMember, _parent: &dyn Node) {
+    fn visit_class_member(&mut self, n: &ClassMember) {
         self.show("ClassMember", n);
         n.visit_children_with(self)
     }
-    fn visit_class_method(&mut self, n: &ClassMethod, _parent: &dyn Node) {
+    fn visit_class_method(&mut self, n: &ClassMethod) {
         self.show("ClassMethod", n);
         n.visit_children_with(self)
     }
-    fn visit_class_prop(&mut self, n: &ClassProp, _parent: &dyn Node) {
+    fn visit_class_prop(&mut self, n: &ClassProp) {
         self.show("ClassProp", n);
         n.visit_children_with(self)
     }
-    fn visit_computed_prop_name(&mut self, n: &ComputedPropName, _parent: &dyn Node) {
+    fn visit_computed_prop_name(&mut self, n: &ComputedPropName) {
         self.show("ComputedPropName", n);
         n.visit_children_with(self)
     }
-    fn visit_cond_expr(&mut self, n: &CondExpr, _parent: &dyn Node) {
+    fn visit_cond_expr(&mut self, n: &CondExpr) {
         self.show("CondExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_constructor(&mut self, n: &Constructor, _parent: &dyn Node) {
+    fn visit_constructor(&mut self, n: &Constructor) {
         self.show("Constructor", n);
         n.visit_children_with(self)
     }
-    fn visit_continue_stmt(&mut self, n: &ContinueStmt, _parent: &dyn Node) {
+    fn visit_continue_stmt(&mut self, n: &ContinueStmt) {
         self.show("ContinueStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_debugger_stmt(&mut self, n: &DebuggerStmt, _parent: &dyn Node) {
+    fn visit_debugger_stmt(&mut self, n: &DebuggerStmt) {
         self.show("DebuggerStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_decl(&mut self, n: &Decl, _parent: &dyn Node) {
+    fn visit_decl(&mut self, n: &Decl) {
         self.show("Decl", n);
         n.visit_children_with(self)
     }
-    fn visit_decorator(&mut self, n: &Decorator, _parent: &dyn Node) {
+    fn visit_decorator(&mut self, n: &Decorator) {
         self.show("Decorator", n);
         n.visit_children_with(self)
     }
-    fn visit_default_decl(&mut self, n: &DefaultDecl, _parent: &dyn Node) {
+    fn visit_default_decl(&mut self, n: &DefaultDecl) {
         self.show("DefaultDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_do_while_stmt(&mut self, n: &DoWhileStmt, _parent: &dyn Node) {
+    fn visit_do_while_stmt(&mut self, n: &DoWhileStmt) {
         self.show("DoWhileStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_empty_stmt(&mut self, n: &EmptyStmt, _parent: &dyn Node) {
+    fn visit_empty_stmt(&mut self, n: &EmptyStmt) {
         self.show("EmptyStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_export_all(&mut self, n: &ExportAll, _parent: &dyn Node) {
+    fn visit_export_all(&mut self, n: &ExportAll) {
         self.show("ExportAll", n);
         n.visit_children_with(self)
     }
-    fn visit_export_decl(&mut self, n: &ExportDecl, _parent: &dyn Node) {
+    fn visit_export_decl(&mut self, n: &ExportDecl) {
         self.show("ExportDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_export_default_decl(&mut self, n: &ExportDefaultDecl, _parent: &dyn Node) {
+    fn visit_export_default_decl(&mut self, n: &ExportDefaultDecl) {
         self.show("ExportDefaultDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_export_default_expr(&mut self, n: &ExportDefaultExpr, _parent: &dyn Node) {
+    fn visit_export_default_expr(&mut self, n: &ExportDefaultExpr) {
         self.show("ExportDefaultExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_export_default_specifier(&mut self, n: &ExportDefaultSpecifier, _parent: &dyn Node) {
+    fn visit_export_default_specifier(&mut self, n: &ExportDefaultSpecifier) {
         self.show("ExportDefaultSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier, _parent: &dyn Node) {
+    fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier) {
         self.show("ExportNamedSpecifier", n);
         n.visit_children_with(self)
     }
@@ -218,375 +218,375 @@ impl Visit for Shower<'_> {
         self.show("ExportNamespaceSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_export_specifier(&mut self, n: &ExportSpecifier, _parent: &dyn Node) {
+    fn visit_export_specifier(&mut self, n: &ExportSpecifier) {
         self.show("ExportSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_expr(&mut self, n: &Expr, _parent: &dyn Node) {
+    fn visit_expr(&mut self, n: &Expr) {
         self.show("Expr", n);
         n.visit_children_with(self)
     }
-    fn visit_expr_or_spread(&mut self, n: &ExprOrSpread, _parent: &dyn Node) {
+    fn visit_expr_or_spread(&mut self, n: &ExprOrSpread) {
         self.show("ExprOrSpread", n);
         n.visit_children_with(self)
     }
-    fn visit_expr_or_super(&mut self, n: &ExprOrSuper, _parent: &dyn Node) {
+    fn visit_expr_or_super(&mut self, n: &ExprOrSuper) {
         self.show("ExprOrSuper", n);
         n.visit_children_with(self)
     }
-    fn visit_expr_stmt(&mut self, n: &ExprStmt, _parent: &dyn Node) {
+    fn visit_expr_stmt(&mut self, n: &ExprStmt) {
         self.show("ExprStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_fn_decl(&mut self, n: &FnDecl, _parent: &dyn Node) {
+    fn visit_fn_decl(&mut self, n: &FnDecl) {
         self.show("FnDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_fn_expr(&mut self, n: &FnExpr, _parent: &dyn Node) {
+    fn visit_fn_expr(&mut self, n: &FnExpr) {
         self.show("FnExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_for_in_stmt(&mut self, n: &ForInStmt, _parent: &dyn Node) {
+    fn visit_for_in_stmt(&mut self, n: &ForInStmt) {
         self.show("ForInStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_for_of_stmt(&mut self, n: &ForOfStmt, _parent: &dyn Node) {
+    fn visit_for_of_stmt(&mut self, n: &ForOfStmt) {
         self.show("ForOfStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_for_stmt(&mut self, n: &ForStmt, _parent: &dyn Node) {
+    fn visit_for_stmt(&mut self, n: &ForStmt) {
         self.show("ForStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_function(&mut self, n: &Function, _parent: &dyn Node) {
+    fn visit_function(&mut self, n: &Function) {
         self.show("Function", n);
         n.visit_children_with(self)
     }
-    fn visit_getter_prop(&mut self, n: &GetterProp, _parent: &dyn Node) {
+    fn visit_getter_prop(&mut self, n: &GetterProp) {
         self.show("GetterProp", n);
         n.visit_children_with(self)
     }
-    fn visit_ident(&mut self, n: &Ident, _parent: &dyn Node) {
+    fn visit_ident(&mut self, n: &Ident) {
         self.show("Ident", n);
         n.visit_children_with(self)
     }
-    fn visit_if_stmt(&mut self, n: &IfStmt, _parent: &dyn Node) {
+    fn visit_if_stmt(&mut self, n: &IfStmt) {
         self.show("IfStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_import_decl(&mut self, n: &ImportDecl, _parent: &dyn Node) {
+    fn visit_import_decl(&mut self, n: &ImportDecl) {
         self.show("ImportDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_import_default_specifier(&mut self, n: &ImportDefaultSpecifier, _parent: &dyn Node) {
+    fn visit_import_default_specifier(&mut self, n: &ImportDefaultSpecifier) {
         self.show("ImportDefaultSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_import_named_specifier(&mut self, n: &ImportNamedSpecifier, _parent: &dyn Node) {
+    fn visit_import_named_specifier(&mut self, n: &ImportNamedSpecifier) {
         self.show("ImportNamedSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_import_specifier(&mut self, n: &ImportSpecifier, _parent: &dyn Node) {
+    fn visit_import_specifier(&mut self, n: &ImportSpecifier) {
         self.show("ImportSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_import_star_as_specifier(&mut self, n: &ImportStarAsSpecifier, _parent: &dyn Node) {
+    fn visit_import_star_as_specifier(&mut self, n: &ImportStarAsSpecifier) {
         self.show("ImportStarAsSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_invalid(&mut self, n: &Invalid, _parent: &dyn Node) {
+    fn visit_invalid(&mut self, n: &Invalid) {
         self.show("Invalid", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_attr(&mut self, n: &JSXAttr, _parent: &dyn Node) {
+    fn visit_jsx_attr(&mut self, n: &JSXAttr) {
         self.show("JSXAttr", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_attr_name(&mut self, n: &JSXAttrName, _parent: &dyn Node) {
+    fn visit_jsx_attr_name(&mut self, n: &JSXAttrName) {
         self.show("JSXAttrName", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_attr_or_spread(&mut self, n: &JSXAttrOrSpread, _parent: &dyn Node) {
+    fn visit_jsx_attr_or_spread(&mut self, n: &JSXAttrOrSpread) {
         self.show("JSXAttrOrSpread", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_attr_value(&mut self, n: &JSXAttrValue, _parent: &dyn Node) {
+    fn visit_jsx_attr_value(&mut self, n: &JSXAttrValue) {
         self.show("JSXAttrValue", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_closing_element(&mut self, n: &JSXClosingElement, _parent: &dyn Node) {
+    fn visit_jsx_closing_element(&mut self, n: &JSXClosingElement) {
         self.show("JSXClosingElement", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_closing_fragment(&mut self, n: &JSXClosingFragment, _parent: &dyn Node) {
+    fn visit_jsx_closing_fragment(&mut self, n: &JSXClosingFragment) {
         self.show("JSXClosingFragment", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_element(&mut self, n: &JSXElement, _parent: &dyn Node) {
+    fn visit_jsx_element(&mut self, n: &JSXElement) {
         self.show("JSXElement", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_element_child(&mut self, n: &JSXElementChild, _parent: &dyn Node) {
+    fn visit_jsx_element_child(&mut self, n: &JSXElementChild) {
         self.show("JSXElementChild", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_element_name(&mut self, n: &JSXElementName, _parent: &dyn Node) {
+    fn visit_jsx_element_name(&mut self, n: &JSXElementName) {
         self.show("JSXElementName", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_empty_expr(&mut self, n: &JSXEmptyExpr, _parent: &dyn Node) {
+    fn visit_jsx_empty_expr(&mut self, n: &JSXEmptyExpr) {
         self.show("JSXEmptyExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_expr(&mut self, n: &JSXExpr, _parent: &dyn Node) {
+    fn visit_jsx_expr(&mut self, n: &JSXExpr) {
         self.show("JSXExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_expr_container(&mut self, n: &JSXExprContainer, _parent: &dyn Node) {
+    fn visit_jsx_expr_container(&mut self, n: &JSXExprContainer) {
         self.show("JSXExprContainer", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_fragment(&mut self, n: &JSXFragment, _parent: &dyn Node) {
+    fn visit_jsx_fragment(&mut self, n: &JSXFragment) {
         self.show("JSXFragment", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_member_expr(&mut self, n: &JSXMemberExpr, _parent: &dyn Node) {
+    fn visit_jsx_member_expr(&mut self, n: &JSXMemberExpr) {
         self.show("JSXMemberExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_namespaced_name(&mut self, n: &JSXNamespacedName, _parent: &dyn Node) {
+    fn visit_jsx_namespaced_name(&mut self, n: &JSXNamespacedName) {
         self.show("JSXNamespacedName", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_object(&mut self, n: &JSXObject, _parent: &dyn Node) {
+    fn visit_jsx_object(&mut self, n: &JSXObject) {
         self.show("JSXObject", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_opening_element(&mut self, n: &JSXOpeningElement, _parent: &dyn Node) {
+    fn visit_jsx_opening_element(&mut self, n: &JSXOpeningElement) {
         self.show("JSXOpeningElement", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_opening_fragment(&mut self, n: &JSXOpeningFragment, _parent: &dyn Node) {
+    fn visit_jsx_opening_fragment(&mut self, n: &JSXOpeningFragment) {
         self.show("JSXOpeningFragment", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_spread_child(&mut self, n: &JSXSpreadChild, _parent: &dyn Node) {
+    fn visit_jsx_spread_child(&mut self, n: &JSXSpreadChild) {
         self.show("JSXSpreadChild", n);
         n.visit_children_with(self)
     }
-    fn visit_jsx_text(&mut self, n: &JSXText, _parent: &dyn Node) {
+    fn visit_jsx_text(&mut self, n: &JSXText) {
         self.show("JSXText", n);
         n.visit_children_with(self)
     }
-    fn visit_key_value_pat_prop(&mut self, n: &KeyValuePatProp, _parent: &dyn Node) {
+    fn visit_key_value_pat_prop(&mut self, n: &KeyValuePatProp) {
         self.show("KeyValuePatProp", n);
         n.visit_children_with(self)
     }
-    fn visit_key_value_prop(&mut self, n: &KeyValueProp, _parent: &dyn Node) {
+    fn visit_key_value_prop(&mut self, n: &KeyValueProp) {
         self.show("KeyValueProp", n);
         n.visit_children_with(self)
     }
-    fn visit_labeled_stmt(&mut self, n: &LabeledStmt, _parent: &dyn Node) {
+    fn visit_labeled_stmt(&mut self, n: &LabeledStmt) {
         self.show("LabeledStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_lit(&mut self, n: &Lit, _parent: &dyn Node) {
+    fn visit_lit(&mut self, n: &Lit) {
         self.show("Lit", n);
         n.visit_children_with(self)
     }
-    fn visit_member_expr(&mut self, n: &MemberExpr, _parent: &dyn Node) {
+    fn visit_member_expr(&mut self, n: &MemberExpr) {
         self.show("MemberExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_meta_prop_expr(&mut self, n: &MetaPropExpr, _parent: &dyn Node) {
+    fn visit_meta_prop_expr(&mut self, n: &MetaPropExpr) {
         self.show("MetaPropExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_method_prop(&mut self, n: &MethodProp, _parent: &dyn Node) {
+    fn visit_method_prop(&mut self, n: &MethodProp) {
         self.show("MethodProp", n);
         n.visit_children_with(self)
     }
-    fn visit_module(&mut self, n: &Module, _parent: &dyn Node) {
+    fn visit_module(&mut self, n: &Module) {
         self.show("Module", n);
         n.visit_children_with(self)
     }
-    fn visit_module_decl(&mut self, n: &ModuleDecl, _parent: &dyn Node) {
+    fn visit_module_decl(&mut self, n: &ModuleDecl) {
         self.show("ModuleDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_module_item(&mut self, n: &ModuleItem, _parent: &dyn Node) {
+    fn visit_module_item(&mut self, n: &ModuleItem) {
         self.show("ModuleItem", n);
         n.visit_children_with(self)
     }
-    fn visit_named_export(&mut self, n: &NamedExport, _parent: &dyn Node) {
+    fn visit_named_export(&mut self, n: &NamedExport) {
         self.show("NamedExport", n);
         n.visit_children_with(self)
     }
-    fn visit_new_expr(&mut self, n: &NewExpr, _parent: &dyn Node) {
+    fn visit_new_expr(&mut self, n: &NewExpr) {
         self.show("NewExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_null(&mut self, n: &Null, _parent: &dyn Node) {
+    fn visit_null(&mut self, n: &Null) {
         self.show("Null", n);
         n.visit_children_with(self)
     }
-    fn visit_number(&mut self, n: &Number, _parent: &dyn Node) {
+    fn visit_number(&mut self, n: &Number) {
         self.show("Number", n);
         n.visit_children_with(self)
     }
-    fn visit_object_lit(&mut self, n: &ObjectLit, _parent: &dyn Node) {
+    fn visit_object_lit(&mut self, n: &ObjectLit) {
         self.show("ObjectLit", n);
         n.visit_children_with(self)
     }
-    fn visit_object_pat(&mut self, n: &ObjectPat, _parent: &dyn Node) {
+    fn visit_object_pat(&mut self, n: &ObjectPat) {
         self.show("ObjectPat", n);
         n.visit_children_with(self)
     }
-    fn visit_object_pat_prop(&mut self, n: &ObjectPatProp, _parent: &dyn Node) {
+    fn visit_object_pat_prop(&mut self, n: &ObjectPatProp) {
         self.show("ObjectPatProp", n);
         n.visit_children_with(self)
     }
-    fn visit_opt_chain_expr(&mut self, n: &OptChainExpr, _parent: &dyn Node) {
+    fn visit_opt_chain_expr(&mut self, n: &OptChainExpr) {
         self.show("OptChainExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_param(&mut self, n: &Param, _parent: &dyn Node) {
+    fn visit_param(&mut self, n: &Param) {
         self.show("Param", n);
         n.visit_children_with(self)
     }
-    fn visit_param_or_ts_param_prop(&mut self, n: &ParamOrTsParamProp, _parent: &dyn Node) {
+    fn visit_param_or_ts_param_prop(&mut self, n: &ParamOrTsParamProp) {
         self.show("ParamOrTsParamProp", n);
         n.visit_children_with(self)
     }
-    fn visit_paren_expr(&mut self, n: &ParenExpr, _parent: &dyn Node) {
+    fn visit_paren_expr(&mut self, n: &ParenExpr) {
         self.show("ParenExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_pat(&mut self, n: &Pat, _parent: &dyn Node) {
+    fn visit_pat(&mut self, n: &Pat) {
         self.show("Pat", n);
         n.visit_children_with(self)
     }
-    fn visit_pat_or_expr(&mut self, n: &PatOrExpr, _parent: &dyn Node) {
+    fn visit_pat_or_expr(&mut self, n: &PatOrExpr) {
         self.show("PatOrExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_private_method(&mut self, n: &PrivateMethod, _parent: &dyn Node) {
+    fn visit_private_method(&mut self, n: &PrivateMethod) {
         self.show("PrivateMethod", n);
         n.visit_children_with(self)
     }
-    fn visit_private_name(&mut self, n: &PrivateName, _parent: &dyn Node) {
+    fn visit_private_name(&mut self, n: &PrivateName) {
         self.show("PrivateName", n);
         n.visit_children_with(self)
     }
-    fn visit_private_prop(&mut self, n: &PrivateProp, _parent: &dyn Node) {
+    fn visit_private_prop(&mut self, n: &PrivateProp) {
         self.show("PrivateProp", n);
         n.visit_children_with(self)
     }
-    fn visit_program(&mut self, n: &Program, _parent: &dyn Node) {
+    fn visit_program(&mut self, n: &Program) {
         self.show("Program", n);
         n.visit_children_with(self)
     }
-    fn visit_prop(&mut self, n: &Prop, _parent: &dyn Node) {
+    fn visit_prop(&mut self, n: &Prop) {
         self.show("Prop", n);
         n.visit_children_with(self)
     }
-    fn visit_prop_name(&mut self, n: &PropName, _parent: &dyn Node) {
+    fn visit_prop_name(&mut self, n: &PropName) {
         self.show("PropName", n);
         n.visit_children_with(self)
     }
-    fn visit_prop_or_spread(&mut self, n: &PropOrSpread, _parent: &dyn Node) {
+    fn visit_prop_or_spread(&mut self, n: &PropOrSpread) {
         self.show("PropOrSpread", n);
         n.visit_children_with(self)
     }
-    fn visit_regex(&mut self, n: &Regex, _parent: &dyn Node) {
+    fn visit_regex(&mut self, n: &Regex) {
         self.show("Regex", n);
         n.visit_children_with(self)
     }
-    fn visit_rest_pat(&mut self, n: &RestPat, _parent: &dyn Node) {
+    fn visit_rest_pat(&mut self, n: &RestPat) {
         self.show("RestPat", n);
         n.visit_children_with(self)
     }
-    fn visit_return_stmt(&mut self, n: &ReturnStmt, _parent: &dyn Node) {
+    fn visit_return_stmt(&mut self, n: &ReturnStmt) {
         self.show("ReturnStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_script(&mut self, n: &Script, _parent: &dyn Node) {
+    fn visit_script(&mut self, n: &Script) {
         self.show("Script", n);
         n.visit_children_with(self)
     }
-    fn visit_seq_expr(&mut self, n: &SeqExpr, _parent: &dyn Node) {
+    fn visit_seq_expr(&mut self, n: &SeqExpr) {
         self.show("SeqExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_setter_prop(&mut self, n: &SetterProp, _parent: &dyn Node) {
+    fn visit_setter_prop(&mut self, n: &SetterProp) {
         self.show("SetterProp", n);
         n.visit_children_with(self)
     }
-    fn visit_spread_element(&mut self, n: &SpreadElement, _parent: &dyn Node) {
+    fn visit_spread_element(&mut self, n: &SpreadElement) {
         self.show("SpreadElement", n);
         n.visit_children_with(self)
     }
-    fn visit_stmt(&mut self, n: &Stmt, _parent: &dyn Node) {
+    fn visit_stmt(&mut self, n: &Stmt) {
         self.show("Stmt", n);
         n.visit_children_with(self)
     }
-    fn visit_str(&mut self, n: &Str, _parent: &dyn Node) {
+    fn visit_str(&mut self, n: &Str) {
         self.show("Str", n);
         n.visit_children_with(self)
     }
-    fn visit_super(&mut self, n: &Super, _parent: &dyn Node) {
+    fn visit_super(&mut self, n: &Super) {
         self.show("Super", n);
         n.visit_children_with(self)
     }
-    fn visit_switch_case(&mut self, n: &SwitchCase, _parent: &dyn Node) {
+    fn visit_switch_case(&mut self, n: &SwitchCase) {
         self.show("SwitchCase", n);
         n.visit_children_with(self)
     }
-    fn visit_switch_stmt(&mut self, n: &SwitchStmt, _parent: &dyn Node) {
+    fn visit_switch_stmt(&mut self, n: &SwitchStmt) {
         self.show("SwitchStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_tagged_tpl(&mut self, n: &TaggedTpl, _parent: &dyn Node) {
+    fn visit_tagged_tpl(&mut self, n: &TaggedTpl) {
         self.show("TaggedTpl", n);
         n.visit_children_with(self)
     }
-    fn visit_this_expr(&mut self, n: &ThisExpr, _parent: &dyn Node) {
+    fn visit_this_expr(&mut self, n: &ThisExpr) {
         self.show("ThisExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_throw_stmt(&mut self, n: &ThrowStmt, _parent: &dyn Node) {
+    fn visit_throw_stmt(&mut self, n: &ThrowStmt) {
         self.show("ThrowStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_tpl(&mut self, n: &Tpl, _parent: &dyn Node) {
+    fn visit_tpl(&mut self, n: &Tpl) {
         self.show("Tpl", n);
         n.visit_children_with(self)
     }
-    fn visit_tpl_element(&mut self, n: &TplElement, _parent: &dyn Node) {
+    fn visit_tpl_element(&mut self, n: &TplElement) {
         self.show("TplElement", n);
         n.visit_children_with(self)
     }
-    fn visit_try_stmt(&mut self, n: &TryStmt, _parent: &dyn Node) {
+    fn visit_try_stmt(&mut self, n: &TryStmt) {
         self.show("TryStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_array_type(&mut self, n: &TsArrayType, _parent: &dyn Node) {
+    fn visit_ts_array_type(&mut self, n: &TsArrayType) {
         self.show("TsArrayType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_as_expr(&mut self, n: &TsAsExpr, _parent: &dyn Node) {
+    fn visit_ts_as_expr(&mut self, n: &TsAsExpr) {
         self.show("TsAsExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_call_signature_decl(&mut self, n: &TsCallSignatureDecl, _parent: &dyn Node) {
+    fn visit_ts_call_signature_decl(&mut self, n: &TsCallSignatureDecl) {
         self.show("TsCallSignatureDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_conditional_type(&mut self, n: &TsConditionalType, _parent: &dyn Node) {
+    fn visit_ts_conditional_type(&mut self, n: &TsConditionalType) {
         self.show("TsConditionalType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_const_assertion(&mut self, n: &TsConstAssertion, _parent: &dyn Node) {
+    fn visit_ts_const_assertion(&mut self, n: &TsConstAssertion) {
         self.show("TsConstAssertion", n);
         n.visit_children_with(self)
     }
@@ -598,213 +598,213 @@ impl Visit for Shower<'_> {
         self.show("TsConstructSignatureDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_constructor_type(&mut self, n: &TsConstructorType, _parent: &dyn Node) {
+    fn visit_ts_constructor_type(&mut self, n: &TsConstructorType) {
         self.show("TsConstructorType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_entity_name(&mut self, n: &TsEntityName, _parent: &dyn Node) {
+    fn visit_ts_entity_name(&mut self, n: &TsEntityName) {
         self.show("TsEntityName", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_enum_decl(&mut self, n: &TsEnumDecl, _parent: &dyn Node) {
+    fn visit_ts_enum_decl(&mut self, n: &TsEnumDecl) {
         self.show("TsEnumDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_enum_member(&mut self, n: &TsEnumMember, _parent: &dyn Node) {
+    fn visit_ts_enum_member(&mut self, n: &TsEnumMember) {
         self.show("TsEnumMember", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_enum_member_id(&mut self, n: &TsEnumMemberId, _parent: &dyn Node) {
+    fn visit_ts_enum_member_id(&mut self, n: &TsEnumMemberId) {
         self.show("TsEnumMemberId", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_export_assignment(&mut self, n: &TsExportAssignment, _parent: &dyn Node) {
+    fn visit_ts_export_assignment(&mut self, n: &TsExportAssignment) {
         self.show("TsExportAssignment", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_expr_with_type_args(&mut self, n: &TsExprWithTypeArgs, _parent: &dyn Node) {
+    fn visit_ts_expr_with_type_args(&mut self, n: &TsExprWithTypeArgs) {
         self.show("TsExprWithTypeArgs", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_external_module_ref(&mut self, n: &TsExternalModuleRef, _parent: &dyn Node) {
+    fn visit_ts_external_module_ref(&mut self, n: &TsExternalModuleRef) {
         self.show("TsExternalModuleRef", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_fn_or_constructor_type(&mut self, n: &TsFnOrConstructorType, _parent: &dyn Node) {
+    fn visit_ts_fn_or_constructor_type(&mut self, n: &TsFnOrConstructorType) {
         self.show("TsFnOrConstructorType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_fn_param(&mut self, n: &TsFnParam, _parent: &dyn Node) {
+    fn visit_ts_fn_param(&mut self, n: &TsFnParam) {
         self.show("TsFnParam", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_fn_type(&mut self, n: &TsFnType, _parent: &dyn Node) {
+    fn visit_ts_fn_type(&mut self, n: &TsFnType) {
         self.show("TsFnType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_import_equals_decl(&mut self, n: &TsImportEqualsDecl, _parent: &dyn Node) {
+    fn visit_ts_import_equals_decl(&mut self, n: &TsImportEqualsDecl) {
         self.show("TsImportEqualsDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_import_type(&mut self, n: &TsImportType, _parent: &dyn Node) {
+    fn visit_ts_import_type(&mut self, n: &TsImportType) {
         self.show("TsImportType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_index_signature(&mut self, n: &TsIndexSignature, _parent: &dyn Node) {
+    fn visit_ts_index_signature(&mut self, n: &TsIndexSignature) {
         self.show("TsIndexSignature", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_indexed_access_type(&mut self, n: &TsIndexedAccessType, _parent: &dyn Node) {
+    fn visit_ts_indexed_access_type(&mut self, n: &TsIndexedAccessType) {
         self.show("TsIndexedAccessType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_infer_type(&mut self, n: &TsInferType, _parent: &dyn Node) {
+    fn visit_ts_infer_type(&mut self, n: &TsInferType) {
         self.show("TsInferType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_interface_body(&mut self, n: &TsInterfaceBody, _parent: &dyn Node) {
+    fn visit_ts_interface_body(&mut self, n: &TsInterfaceBody) {
         self.show("TsInterfaceBody", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_interface_decl(&mut self, n: &TsInterfaceDecl, _parent: &dyn Node) {
+    fn visit_ts_interface_decl(&mut self, n: &TsInterfaceDecl) {
         self.show("TsInterfaceDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_intersection_type(&mut self, n: &TsIntersectionType, _parent: &dyn Node) {
+    fn visit_ts_intersection_type(&mut self, n: &TsIntersectionType) {
         self.show("TsIntersectionType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_keyword_type(&mut self, n: &TsKeywordType, _parent: &dyn Node) {
+    fn visit_ts_keyword_type(&mut self, n: &TsKeywordType) {
         self.show("TsKeywordType", n);
         n.visit_children_with(self)
     }
 
-    fn visit_ts_lit(&mut self, n: &TsLit, _parent: &dyn Node) {
+    fn visit_ts_lit(&mut self, n: &TsLit) {
         self.show("TsLit", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_lit_type(&mut self, n: &TsLitType, _parent: &dyn Node) {
+    fn visit_ts_lit_type(&mut self, n: &TsLitType) {
         self.show("TsLitType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_mapped_type(&mut self, n: &TsMappedType, _parent: &dyn Node) {
+    fn visit_ts_mapped_type(&mut self, n: &TsMappedType) {
         self.show("TsMappedType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_method_signature(&mut self, n: &TsMethodSignature, _parent: &dyn Node) {
+    fn visit_ts_method_signature(&mut self, n: &TsMethodSignature) {
         self.show("TsMethodSignature", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_module_block(&mut self, n: &TsModuleBlock, _parent: &dyn Node) {
+    fn visit_ts_module_block(&mut self, n: &TsModuleBlock) {
         self.show("TsModuleBlock", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_module_decl(&mut self, n: &TsModuleDecl, _parent: &dyn Node) {
+    fn visit_ts_module_decl(&mut self, n: &TsModuleDecl) {
         self.show("TsModuleDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_module_name(&mut self, n: &TsModuleName, _parent: &dyn Node) {
+    fn visit_ts_module_name(&mut self, n: &TsModuleName) {
         self.show("TsModuleName", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_module_ref(&mut self, n: &TsModuleRef, _parent: &dyn Node) {
+    fn visit_ts_module_ref(&mut self, n: &TsModuleRef) {
         self.show("TsModuleRef", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_namespace_body(&mut self, n: &TsNamespaceBody, _parent: &dyn Node) {
+    fn visit_ts_namespace_body(&mut self, n: &TsNamespaceBody) {
         self.show("TsNamespaceBody", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_namespace_decl(&mut self, n: &TsNamespaceDecl, _parent: &dyn Node) {
+    fn visit_ts_namespace_decl(&mut self, n: &TsNamespaceDecl) {
         self.show("TsNamespaceDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_namespace_export_decl(&mut self, n: &TsNamespaceExportDecl, _parent: &dyn Node) {
+    fn visit_ts_namespace_export_decl(&mut self, n: &TsNamespaceExportDecl) {
         self.show("TsNamespaceExportDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_non_null_expr(&mut self, n: &TsNonNullExpr, _parent: &dyn Node) {
+    fn visit_ts_non_null_expr(&mut self, n: &TsNonNullExpr) {
         self.show("TsNonNullExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_optional_type(&mut self, n: &TsOptionalType, _parent: &dyn Node) {
+    fn visit_ts_optional_type(&mut self, n: &TsOptionalType) {
         self.show("TsOptionalType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_param_prop(&mut self, n: &TsParamProp, _parent: &dyn Node) {
+    fn visit_ts_param_prop(&mut self, n: &TsParamProp) {
         self.show("TsParamProp", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_param_prop_param(&mut self, n: &TsParamPropParam, _parent: &dyn Node) {
+    fn visit_ts_param_prop_param(&mut self, n: &TsParamPropParam) {
         self.show("TsParamPropParam", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_parenthesized_type(&mut self, n: &TsParenthesizedType, _parent: &dyn Node) {
+    fn visit_ts_parenthesized_type(&mut self, n: &TsParenthesizedType) {
         self.show("TsParenthesizedType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_property_signature(&mut self, n: &TsPropertySignature, _parent: &dyn Node) {
+    fn visit_ts_property_signature(&mut self, n: &TsPropertySignature) {
         self.show("TsPropertySignature", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_qualified_name(&mut self, n: &TsQualifiedName, _parent: &dyn Node) {
+    fn visit_ts_qualified_name(&mut self, n: &TsQualifiedName) {
         self.show("TsQualifiedName", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_rest_type(&mut self, n: &TsRestType, _parent: &dyn Node) {
+    fn visit_ts_rest_type(&mut self, n: &TsRestType) {
         self.show("TsRestType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_this_type(&mut self, n: &TsThisType, _parent: &dyn Node) {
+    fn visit_ts_this_type(&mut self, n: &TsThisType) {
         self.show("TsThisType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_this_type_or_ident(&mut self, n: &TsThisTypeOrIdent, _parent: &dyn Node) {
+    fn visit_ts_this_type_or_ident(&mut self, n: &TsThisTypeOrIdent) {
         self.show("TsThisTypeOrIdent", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_tuple_element(&mut self, n: &TsTupleElement, _parent: &dyn Node) {
+    fn visit_ts_tuple_element(&mut self, n: &TsTupleElement) {
         self.show("TsTupleElement", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_tuple_type(&mut self, n: &TsTupleType, _parent: &dyn Node) {
+    fn visit_ts_tuple_type(&mut self, n: &TsTupleType) {
         self.show("TsTupleType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type(&mut self, n: &TsType, _parent: &dyn Node) {
+    fn visit_ts_type(&mut self, n: &TsType) {
         self.show("TsType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_alias_decl(&mut self, n: &TsTypeAliasDecl, _parent: &dyn Node) {
+    fn visit_ts_type_alias_decl(&mut self, n: &TsTypeAliasDecl) {
         self.show("TsTypeAliasDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_ann(&mut self, n: &TsTypeAnn, _parent: &dyn Node) {
+    fn visit_ts_type_ann(&mut self, n: &TsTypeAnn) {
         self.show("TsTypeAnn", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_assertion(&mut self, n: &TsTypeAssertion, _parent: &dyn Node) {
+    fn visit_ts_type_assertion(&mut self, n: &TsTypeAssertion) {
         self.show("TsTypeAssertion", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_element(&mut self, n: &TsTypeElement, _parent: &dyn Node) {
+    fn visit_ts_type_element(&mut self, n: &TsTypeElement) {
         self.show("TsTypeElement", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_lit(&mut self, n: &TsTypeLit, _parent: &dyn Node) {
+    fn visit_ts_type_lit(&mut self, n: &TsTypeLit) {
         self.show("TsTypeLit", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_operator(&mut self, n: &TsTypeOperator, _parent: &dyn Node) {
+    fn visit_ts_type_operator(&mut self, n: &TsTypeOperator) {
         self.show("TsTypeOperator", n);
         n.visit_children_with(self)
     }
 
-    fn visit_ts_type_param(&mut self, n: &TsTypeParam, _parent: &dyn Node) {
+    fn visit_ts_type_param(&mut self, n: &TsTypeParam) {
         self.show("TsTypeParam", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_param_decl(&mut self, n: &TsTypeParamDecl, _parent: &dyn Node) {
+    fn visit_ts_type_param_decl(&mut self, n: &TsTypeParamDecl) {
         self.show("TsTypeParamDecl", n);
         n.visit_children_with(self)
     }
@@ -816,19 +816,19 @@ impl Visit for Shower<'_> {
         self.show("TsTypeParamInstantiation", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_predicate(&mut self, n: &TsTypePredicate, _parent: &dyn Node) {
+    fn visit_ts_type_predicate(&mut self, n: &TsTypePredicate) {
         self.show("TsTypePredicate", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_query(&mut self, n: &TsTypeQuery, _parent: &dyn Node) {
+    fn visit_ts_type_query(&mut self, n: &TsTypeQuery) {
         self.show("TsTypeQuery", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_query_expr(&mut self, n: &TsTypeQueryExpr, _parent: &dyn Node) {
+    fn visit_ts_type_query_expr(&mut self, n: &TsTypeQueryExpr) {
         self.show("TsTypeQueryExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_ref(&mut self, n: &TsTypeRef, _parent: &dyn Node) {
+    fn visit_ts_type_ref(&mut self, n: &TsTypeRef) {
         self.show("TsTypeRef", n);
         n.visit_children_with(self)
     }
@@ -840,43 +840,43 @@ impl Visit for Shower<'_> {
         self.show("TsUnionOrIntersectionType", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_union_type(&mut self, n: &TsUnionType, _parent: &dyn Node) {
+    fn visit_ts_union_type(&mut self, n: &TsUnionType) {
         self.show("TsUnionType", n);
         n.visit_children_with(self)
     }
-    fn visit_unary_expr(&mut self, n: &UnaryExpr, _parent: &dyn Node) {
+    fn visit_unary_expr(&mut self, n: &UnaryExpr) {
         self.show("UnaryExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_update_expr(&mut self, n: &UpdateExpr, _parent: &dyn Node) {
+    fn visit_update_expr(&mut self, n: &UpdateExpr) {
         self.show("UpdateExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_var_decl(&mut self, n: &VarDecl, _parent: &dyn Node) {
+    fn visit_var_decl(&mut self, n: &VarDecl) {
         self.show("VarDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_var_decl_or_expr(&mut self, n: &VarDeclOrExpr, _parent: &dyn Node) {
+    fn visit_var_decl_or_expr(&mut self, n: &VarDeclOrExpr) {
         self.show("VarDeclOrExpr", n);
         n.visit_children_with(self)
     }
-    fn visit_var_decl_or_pat(&mut self, n: &VarDeclOrPat, _parent: &dyn Node) {
+    fn visit_var_decl_or_pat(&mut self, n: &VarDeclOrPat) {
         self.show("VarDeclOrPat", n);
         n.visit_children_with(self)
     }
-    fn visit_var_declarator(&mut self, n: &VarDeclarator, _parent: &dyn Node) {
+    fn visit_var_declarator(&mut self, n: &VarDeclarator) {
         self.show("VarDeclarator", n);
         n.visit_children_with(self)
     }
-    fn visit_while_stmt(&mut self, n: &WhileStmt, _parent: &dyn Node) {
+    fn visit_while_stmt(&mut self, n: &WhileStmt) {
         self.show("WhileStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_with_stmt(&mut self, n: &WithStmt, _parent: &dyn Node) {
+    fn visit_with_stmt(&mut self, n: &WithStmt) {
         self.show("WithStmt", n);
         n.visit_children_with(self)
     }
-    fn visit_yield_expr(&mut self, n: &YieldExpr, _parent: &dyn Node) {
+    fn visit_yield_expr(&mut self, n: &YieldExpr) {
         self.show("YieldExpr", n);
         n.visit_children_with(self)
     }

--- a/crates/swc_ecma_parser/tests/span.rs
+++ b/crates/swc_ecma_parser/tests/span.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use swc_common::{comments::SingleThreadedComments, errors::Handler, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
-use swc_ecma_visit::{Node, Visit, VisitWith};
+use swc_ecma_visit::{Visit, VisitWith};
 
 #[testing::fixture("tests/span/**/*.js")]
 #[testing::fixture("tests/span/**/*.ts")]
@@ -210,11 +210,7 @@ impl Visit for Shower<'_> {
         self.show("ExportNamedSpecifier", n);
         n.visit_children_with(self)
     }
-    fn visit_export_namespace_specifier(
-        &mut self,
-        n: &ExportNamespaceSpecifier,
-        _parent: &dyn Node,
-    ) {
+    fn visit_export_namespace_specifier(&mut self, n: &ExportNamespaceSpecifier) {
         self.show("ExportNamespaceSpecifier", n);
         n.visit_children_with(self)
     }
@@ -590,11 +586,7 @@ impl Visit for Shower<'_> {
         self.show("TsConstAssertion", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_construct_signature_decl(
-        &mut self,
-        n: &TsConstructSignatureDecl,
-        _parent: &dyn Node,
-    ) {
+    fn visit_ts_construct_signature_decl(&mut self, n: &TsConstructSignatureDecl) {
         self.show("TsConstructSignatureDecl", n);
         n.visit_children_with(self)
     }
@@ -808,11 +800,7 @@ impl Visit for Shower<'_> {
         self.show("TsTypeParamDecl", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_type_param_instantiation(
-        &mut self,
-        n: &TsTypeParamInstantiation,
-        _parent: &dyn Node,
-    ) {
+    fn visit_ts_type_param_instantiation(&mut self, n: &TsTypeParamInstantiation) {
         self.show("TsTypeParamInstantiation", n);
         n.visit_children_with(self)
     }
@@ -832,11 +820,7 @@ impl Visit for Shower<'_> {
         self.show("TsTypeRef", n);
         n.visit_children_with(self)
     }
-    fn visit_ts_union_or_intersection_type(
-        &mut self,
-        n: &TsUnionOrIntersectionType,
-        _parent: &dyn Node,
-    ) {
+    fn visit_ts_union_or_intersection_type(&mut self, n: &TsUnionOrIntersectionType) {
         self.show("TsUnionOrIntersectionType", n);
         n.visit_children_with(self)
     }

--- a/crates/swc_ecma_parser/tests/span.rs
+++ b/crates/swc_ecma_parser/tests/span.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use swc_common::{comments::SingleThreadedComments, errors::Handler, Spanned, DUMMY_SP};
+use swc_common::{comments::SingleThreadedComments, errors::Handler, Spanned};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
 use swc_ecma_visit::{Visit, VisitWith};
@@ -37,7 +37,7 @@ fn span(entry: PathBuf) {
                 .parse_module()
                 .map_err(|e| e.into_diagnostic(handler).emit())?;
 
-            Shower { handler }.visit_module(&module, &Invalid { span: DUMMY_SP } as _);
+            Shower { handler }.visit_module(&module);
         }
 
         Err(())

--- a/crates/swc_ecma_parser/tests/visitor.rs
+++ b/crates/swc_ecma_parser/tests/visitor.rs
@@ -6,7 +6,7 @@ use swc_ecma_visit::{All, Node, VisitAll, VisitWith};
 struct Issue1967;
 
 impl VisitAll for Issue1967 {
-    fn visit_expr(&mut self, _: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, _: &Expr) {
         panic!("intended")
     }
 }

--- a/crates/swc_ecma_parser/tests/visitor.rs
+++ b/crates/swc_ecma_parser/tests/visitor.rs
@@ -1,7 +1,7 @@
 use swc_common::{input::StringInput, FileName, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser};
-use swc_ecma_visit::{All, Node, VisitAll, VisitWith};
+use swc_ecma_visit::{All, VisitAll, VisitWith};
 
 struct Issue1967;
 

--- a/crates/swc_ecma_parser/tests/visitor.rs
+++ b/crates/swc_ecma_parser/tests/visitor.rs
@@ -27,12 +27,9 @@ fn issue_1967() {
 
         let m = parser.parse_module().unwrap();
 
-        m.visit_with(
-            &Invalid { span: DUMMY_SP },
-            &mut All {
-                visitor: Issue1967 {},
-            },
-        );
+        m.visit_with(&mut All {
+            visitor: Issue1967 {},
+        });
 
         Ok(())
     })

--- a/crates/swc_ecma_parser/tests/visitor.rs
+++ b/crates/swc_ecma_parser/tests/visitor.rs
@@ -1,4 +1,4 @@
-use swc_common::{input::StringInput, FileName, DUMMY_SP};
+use swc_common::{input::StringInput, FileName};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser};
 use swc_ecma_visit::{All, VisitAll, VisitWith};

--- a/crates/swc_ecma_preset_env/src/corejs2/mod.rs
+++ b/crates/swc_ecma_preset_env/src/corejs2/mod.rs
@@ -173,9 +173,9 @@ impl Visit for UsageVisitor {
     ///
     ///  - `Array.from`
     fn visit_member_expr(&mut self, node: &MemberExpr) {
-        node.obj.visit_with(node as _, self);
+        node.obj.visit_with(self);
         if node.computed {
-            node.prop.visit_with(node as _, self);
+            node.prop.visit_with(self);
         }
         //enter(path: NodePath) {
         //    const { node } = path;

--- a/crates/swc_ecma_preset_env/src/corejs2/mod.rs
+++ b/crates/swc_ecma_preset_env/src/corejs2/mod.rs
@@ -125,7 +125,7 @@ impl UsageVisitor {
 impl Visit for UsageVisitor {
     noop_visit_type!();
 
-    fn visit_ident(&mut self, node: &Ident, _: &dyn Node) {
+    fn visit_ident(&mut self, node: &Ident) {
         node.visit_children_with(self);
 
         for (name, builtin) in BUILTIN_TYPES {
@@ -135,7 +135,7 @@ impl Visit for UsageVisitor {
         }
     }
 
-    fn visit_var_declarator(&mut self, d: &VarDeclarator, _: &dyn Node) {
+    fn visit_var_declarator(&mut self, d: &VarDeclarator) {
         d.visit_children_with(self);
 
         if let Some(ref init) = d.init {
@@ -156,7 +156,7 @@ impl Visit for UsageVisitor {
         }
     }
 
-    fn visit_assign_expr(&mut self, e: &AssignExpr, _: &dyn Node) {
+    fn visit_assign_expr(&mut self, e: &AssignExpr) {
         e.visit_children_with(self);
 
         match &e.left {
@@ -172,7 +172,7 @@ impl Visit for UsageVisitor {
     /// Detects usage of instance properties and static properties.
     ///
     ///  - `Array.from`
-    fn visit_member_expr(&mut self, node: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, node: &MemberExpr) {
         node.obj.visit_with(node as _, self);
         if node.computed {
             node.prop.visit_with(node as _, self);
@@ -294,7 +294,7 @@ impl Visit for UsageVisitor {
 
     ///
     /// - `arr[Symbol.iterator]()`
-    fn visit_call_expr(&mut self, e: &CallExpr, _: &dyn Node) {
+    fn visit_call_expr(&mut self, e: &CallExpr) {
         e.visit_children_with(self);
 
         if match &e.callee {
@@ -315,7 +315,7 @@ impl Visit for UsageVisitor {
     ///
     /// - `Symbol.iterator in arr`
 
-    fn visit_bin_expr(&mut self, e: &BinExpr, _: &dyn Node) {
+    fn visit_bin_expr(&mut self, e: &BinExpr) {
         e.visit_children_with(self);
 
         match e.op {
@@ -326,7 +326,7 @@ impl Visit for UsageVisitor {
 
     ///
     /// - `yield*`
-    fn visit_yield_expr(&mut self, e: &YieldExpr, _: &dyn Node) {
+    fn visit_yield_expr(&mut self, e: &YieldExpr) {
         e.visit_children_with(self);
         println!("Yield");
 

--- a/crates/swc_ecma_preset_env/src/corejs2/mod.rs
+++ b/crates/swc_ecma_preset_env/src/corejs2/mod.rs
@@ -8,7 +8,7 @@ use indexmap::IndexSet;
 use swc_atoms::{js_word, JsWord};
 use swc_common::DUMMY_SP;
 use swc_ecma_ast::*;
-use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 mod builtin;
 mod data;

--- a/crates/swc_ecma_preset_env/src/corejs3/usage.rs
+++ b/crates/swc_ecma_preset_env/src/corejs3/usage.rs
@@ -15,7 +15,7 @@ use indexmap::IndexSet;
 use swc_atoms::{js_word, JsWord};
 use swc_common::DUMMY_SP;
 use swc_ecma_ast::*;
-use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 pub(crate) struct UsageVisitor {
     shipped_proposals: bool,

--- a/crates/swc_ecma_preset_env/src/corejs3/usage.rs
+++ b/crates/swc_ecma_preset_env/src/corejs3/usage.rs
@@ -228,9 +228,9 @@ impl Visit for UsageVisitor {
     }
 
     fn visit_member_expr(&mut self, e: &MemberExpr) {
-        e.obj.visit_with(e as _, self);
+        e.obj.visit_with(self);
         if e.computed {
-            e.prop.visit_with(e as _, self);
+            e.prop.visit_with(self);
         }
 
         // Object.entries

--- a/crates/swc_ecma_preset_env/src/corejs3/usage.rs
+++ b/crates/swc_ecma_preset_env/src/corejs3/usage.rs
@@ -148,13 +148,13 @@ impl Visit for UsageVisitor {
     noop_visit_type!();
 
     /// `[a, b] = c`
-    fn visit_array_pat(&mut self, p: &ArrayPat, _: &dyn Node) {
+    fn visit_array_pat(&mut self, p: &ArrayPat) {
         p.visit_children_with(self);
 
         self.add(COMMON_ITERATORS)
     }
 
-    fn visit_assign_expr(&mut self, e: &AssignExpr, _: &dyn Node) {
+    fn visit_assign_expr(&mut self, e: &AssignExpr) {
         e.visit_children_with(self);
 
         match &e.left {
@@ -167,7 +167,7 @@ impl Visit for UsageVisitor {
         }
     }
 
-    fn visit_bin_expr(&mut self, e: &BinExpr, _: &dyn Node) {
+    fn visit_bin_expr(&mut self, e: &BinExpr) {
         e.visit_children_with(self);
 
         match e.op {
@@ -181,7 +181,7 @@ impl Visit for UsageVisitor {
     }
 
     /// import('something').then(...)
-    fn visit_call_expr(&mut self, e: &CallExpr, _: &dyn Node) {
+    fn visit_call_expr(&mut self, e: &CallExpr) {
         e.visit_children_with(self);
 
         if let ExprOrSuper::Expr(expr) = &e.callee {
@@ -195,7 +195,7 @@ impl Visit for UsageVisitor {
         }
     }
 
-    fn visit_expr(&mut self, e: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, e: &Expr) {
         e.visit_children_with(self);
 
         match e {
@@ -205,7 +205,7 @@ impl Visit for UsageVisitor {
     }
 
     /// `[...spread]`
-    fn visit_expr_or_spread(&mut self, e: &ExprOrSpread, _: &dyn Node) {
+    fn visit_expr_or_spread(&mut self, e: &ExprOrSpread) {
         e.visit_children_with(self);
         if e.spread.is_some() {
             self.add(COMMON_ITERATORS)
@@ -213,13 +213,13 @@ impl Visit for UsageVisitor {
     }
 
     /// for-of
-    fn visit_for_of_stmt(&mut self, s: &ForOfStmt, _: &dyn Node) {
+    fn visit_for_of_stmt(&mut self, s: &ForOfStmt) {
         s.visit_children_with(self);
 
         self.add(COMMON_ITERATORS)
     }
 
-    fn visit_function(&mut self, f: &Function, _: &dyn Node) {
+    fn visit_function(&mut self, f: &Function) {
         f.visit_children_with(self);
 
         if f.is_async {
@@ -227,7 +227,7 @@ impl Visit for UsageVisitor {
         }
     }
 
-    fn visit_member_expr(&mut self, e: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, e: &MemberExpr) {
         e.obj.visit_with(e as _, self);
         if e.computed {
             e.prop.visit_with(e as _, self);
@@ -242,7 +242,7 @@ impl Visit for UsageVisitor {
         }
     }
 
-    fn visit_var_declarator(&mut self, d: &VarDeclarator, _: &dyn Node) {
+    fn visit_var_declarator(&mut self, d: &VarDeclarator) {
         d.visit_children_with(self);
 
         if let Some(ref init) = d.init {
@@ -266,7 +266,7 @@ impl Visit for UsageVisitor {
     // TODO: https://github.com/babel/babel/blob/00758308/packages/babel-preset-env/src/polyfills/corejs3/usage-plugin.js#L198-L206
 
     /// `yield*`
-    fn visit_yield_expr(&mut self, e: &YieldExpr, _: &dyn Node) {
+    fn visit_yield_expr(&mut self, e: &YieldExpr) {
         e.visit_children_with(self);
 
         if e.delegate {

--- a/crates/swc_ecma_preset_env/src/lib.rs
+++ b/crates/swc_ecma_preset_env/src/lib.rs
@@ -301,14 +301,14 @@ impl Fold for Polyfills {
                 let mut r = match self.corejs {
                     Version { major: 2, .. } => {
                         let mut v = corejs2::UsageVisitor::new(self.targets);
-                        m.visit_with( &mut v);
+                        m.visit_with(&mut v);
 
                         v.required
                     }
                     Version { major: 3, .. } => {
                         let mut v =
                             corejs3::UsageVisitor::new(self.targets, self.shipped_proposals);
-                        m.visit_with( &mut v);
+                        m.visit_with(&mut v);
                         v.required
                     }
 

--- a/crates/swc_ecma_preset_env/src/lib.rs
+++ b/crates/swc_ecma_preset_env/src/lib.rs
@@ -301,14 +301,14 @@ impl Fold for Polyfills {
                 let mut r = match self.corejs {
                     Version { major: 2, .. } => {
                         let mut v = corejs2::UsageVisitor::new(self.targets);
-                        m.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+                        m.visit_with( &mut v);
 
                         v.required
                     }
                     Version { major: 3, .. } => {
                         let mut v =
                             corejs3::UsageVisitor::new(self.targets, self.shipped_proposals);
-                        m.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+                        m.visit_with( &mut v);
                         v.required
                     }
 

--- a/crates/swc_ecma_preset_env/src/regenerator/mod.rs
+++ b/crates/swc_ecma_preset_env/src/regenerator/mod.rs
@@ -4,7 +4,7 @@ use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 pub(super) fn is_required<T: VisitWith<RegeneratorVisitor>>(node: &T) -> bool {
     let mut v = RegeneratorVisitor { found: false };
-    node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+    node.visit_with(&mut v);
     v.found
 }
 

--- a/crates/swc_ecma_preset_env/src/regenerator/mod.rs
+++ b/crates/swc_ecma_preset_env/src/regenerator/mod.rs
@@ -1,5 +1,3 @@
-use swc_common::DUMMY_SP;
-use swc_ecma_ast::Invalid;
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 pub(super) fn is_required<T: VisitWith<RegeneratorVisitor>>(node: &T) -> bool {

--- a/crates/swc_ecma_transforms_base/benches/deps.rs
+++ b/crates/swc_ecma_transforms_base/benches/deps.rs
@@ -6,7 +6,7 @@ use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax};
 use swc_ecma_transforms_base::pass::noop;
 use swc_ecma_utils::ExprFactory;
-use swc_ecma_visit::{FoldWith, Node, Visit, VisitWith};
+use swc_ecma_visit::{FoldWith, Visit, VisitWith};
 use test::Bencher;
 
 static SOURCE: &str = include_str!("assets/AjaxObservable.ts");
@@ -225,7 +225,7 @@ fn visit_contains_this(b: &mut Bencher) {
         }
 
         let mut visitor = Visitor { found: false };
-        body.visit_with(&Invalid { span: DUMMY_SP } as _, &mut visitor);
+        body.visit_with(&mut visitor);
         visitor.found
     }
 

--- a/crates/swc_ecma_transforms_base/benches/deps.rs
+++ b/crates/swc_ecma_transforms_base/benches/deps.rs
@@ -214,12 +214,12 @@ fn visit_contains_this(b: &mut Bencher) {
 
         impl Visit for Visitor {
             /// Don't recurse into fn
-            fn visit_fn_expr(&mut self, _: &FnExpr, _: &dyn Node) {}
+            fn visit_fn_expr(&mut self, _: &FnExpr) {}
 
             /// Don't recurse into fn
-            fn visit_fn_decl(&mut self, _: &FnDecl, _: &dyn Node) {}
+            fn visit_fn_decl(&mut self, _: &FnDecl) {}
 
-            fn visit_this_expr(&mut self, _: &ThisExpr, _: &dyn Node) {
+            fn visit_this_expr(&mut self, _: &ThisExpr) {
                 self.found = true;
             }
         }

--- a/crates/swc_ecma_transforms_base/src/hygiene/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/hygiene/mod.rs
@@ -188,7 +188,7 @@ impl Hygiene {
                 is_pat_decl: false,
             };
 
-            n.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+            n.visit_with(&mut v);
         }
 
         let ops = data.ops.into_inner();

--- a/crates/swc_ecma_transforms_base/src/hygiene/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/hygiene/mod.rs
@@ -4,7 +4,7 @@ use self::{
 };
 use crate::hygiene::{unique_scope::unique_scope, usage_analyzer::CurScope};
 use swc_atoms::JsWord;
-use swc_common::{chain, collections::AHashMap, DUMMY_SP};
+use swc_common::{chain, collections::AHashMap};
 use swc_ecma_ast::*;
 use swc_ecma_utils::Id;
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith, VisitWith};

--- a/crates/swc_ecma_transforms_base/src/hygiene/usage_analyzer.rs
+++ b/crates/swc_ecma_transforms_base/src/hygiene/usage_analyzer.rs
@@ -413,7 +413,7 @@ impl Visit for UsageAnalyzer<'_> {
         self.visit_with_scope(f.span.ctxt, ScopeKind::Fn, |v| {
             let old = v.is_pat_decl;
             v.is_pat_decl = true;
-            f.params.visit_with(f, v);
+            f.params.visit_with(v);
             v.is_pat_decl = old;
 
             match &f.body {
@@ -422,7 +422,7 @@ impl Visit for UsageAnalyzer<'_> {
                     body.visit_children_with(v);
                 }
                 BlockStmtOrExpr::Expr(body) => {
-                    body.visit_with(f, v);
+                    body.visit_with(v);
                 }
             }
         })
@@ -448,10 +448,10 @@ impl Visit for UsageAnalyzer<'_> {
         let old = self.is_pat_decl;
 
         self.is_pat_decl = true;
-        c.param.visit_with(c, self);
+        c.param.visit_with(self);
 
         self.is_pat_decl = false;
-        c.body.visit_with(c, self);
+        c.body.visit_with(self);
 
         self.is_pat_decl = old;
     }
@@ -474,7 +474,7 @@ impl Visit for UsageAnalyzer<'_> {
     fn visit_constructor(&mut self, c: &Constructor) {
         self.visit_with_scope(c.span.ctxt, ScopeKind::Fn, |v| {
             v.is_pat_decl = true;
-            c.params.visit_with(c, v);
+            c.params.visit_with(v);
             v.is_pat_decl = false;
 
             match c.body.as_ref() {
@@ -487,11 +487,11 @@ impl Visit for UsageAnalyzer<'_> {
     }
 
     fn visit_class_method(&mut self, m: &ClassMethod) {
-        m.function.decorators.visit_with(m, self);
+        m.function.decorators.visit_with(self);
 
         self.visit_with_scope(m.function.span.ctxt, ScopeKind::Fn, |v| {
             v.is_pat_decl = true;
-            m.function.params.visit_with(m, v);
+            m.function.params.visit_with(v);
             v.is_pat_decl = false;
 
             match m.function.body.as_ref() {
@@ -523,13 +523,13 @@ impl Visit for UsageAnalyzer<'_> {
     }
 
     fn visit_fn_decl(&mut self, f: &FnDecl) {
-        f.function.decorators.visit_with(f, self);
+        f.function.decorators.visit_with(self);
 
         self.add_decl(f.ident.to_id());
 
         self.visit_with_scope(f.function.span.ctxt, ScopeKind::Fn, |v| {
             v.is_pat_decl = true;
-            f.function.params.visit_with(f, v);
+            f.function.params.visit_with(v);
             v.is_pat_decl = false;
 
             match f.function.body.as_ref() {

--- a/crates/swc_ecma_transforms_base/src/hygiene/usage_analyzer.rs
+++ b/crates/swc_ecma_transforms_base/src/hygiene/usage_analyzer.rs
@@ -409,7 +409,7 @@ impl UsageAnalyzer<'_> {
 impl Visit for UsageAnalyzer<'_> {
     noop_visit_type!();
 
-    fn visit_arrow_expr(&mut self, f: &ArrowExpr, _: &dyn Node) {
+    fn visit_arrow_expr(&mut self, f: &ArrowExpr) {
         self.visit_with_scope(f.span.ctxt, ScopeKind::Fn, |v| {
             let old = v.is_pat_decl;
             v.is_pat_decl = true;
@@ -428,7 +428,7 @@ impl Visit for UsageAnalyzer<'_> {
         })
     }
 
-    fn visit_assign_pat_prop(&mut self, node: &AssignPatProp, _: &dyn Node) {
+    fn visit_assign_pat_prop(&mut self, node: &AssignPatProp) {
         node.visit_children_with(self);
 
         {
@@ -440,11 +440,11 @@ impl Visit for UsageAnalyzer<'_> {
         }
     }
 
-    fn visit_block_stmt(&mut self, f: &BlockStmt, _: &dyn Node) {
+    fn visit_block_stmt(&mut self, f: &BlockStmt) {
         self.visit_with_scope(f.span.ctxt, ScopeKind::Block, |v| f.visit_children_with(v))
     }
 
-    fn visit_catch_clause(&mut self, c: &CatchClause, _: &dyn Node) {
+    fn visit_catch_clause(&mut self, c: &CatchClause) {
         let old = self.is_pat_decl;
 
         self.is_pat_decl = true;
@@ -456,12 +456,12 @@ impl Visit for UsageAnalyzer<'_> {
         self.is_pat_decl = old;
     }
 
-    fn visit_class_decl(&mut self, c: &ClassDecl, _: &dyn Node) {
+    fn visit_class_decl(&mut self, c: &ClassDecl) {
         self.add_decl(c.ident.to_id());
         c.visit_children_with(self);
     }
 
-    fn visit_class_expr(&mut self, c: &ClassExpr, _: &dyn Node) {
+    fn visit_class_expr(&mut self, c: &ClassExpr) {
         self.visit_with_scope(c.class.span.ctxt, ScopeKind::Fn, |v| {
             if let Some(i) = &c.ident {
                 v.add_decl(i.to_id());
@@ -471,7 +471,7 @@ impl Visit for UsageAnalyzer<'_> {
         })
     }
 
-    fn visit_constructor(&mut self, c: &Constructor, _: &dyn Node) {
+    fn visit_constructor(&mut self, c: &Constructor) {
         self.visit_with_scope(c.span.ctxt, ScopeKind::Fn, |v| {
             v.is_pat_decl = true;
             c.params.visit_with(c, v);
@@ -486,7 +486,7 @@ impl Visit for UsageAnalyzer<'_> {
         })
     }
 
-    fn visit_class_method(&mut self, m: &ClassMethod, _: &dyn Node) {
+    fn visit_class_method(&mut self, m: &ClassMethod) {
         m.function.decorators.visit_with(m, self);
 
         self.visit_with_scope(m.function.span.ctxt, ScopeKind::Fn, |v| {
@@ -503,15 +503,15 @@ impl Visit for UsageAnalyzer<'_> {
         })
     }
 
-    fn visit_export_default_specifier(&mut self, n: &ExportDefaultSpecifier, _: &dyn Node) {
+    fn visit_export_default_specifier(&mut self, n: &ExportDefaultSpecifier) {
         self.add_usage(n.exported.to_id());
     }
 
-    fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier, _: &dyn Node) {
+    fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier) {
         self.add_usage(n.orig.to_id());
     }
 
-    fn visit_expr(&mut self, e: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, e: &Expr) {
         e.visit_children_with(self);
 
         match e {
@@ -522,7 +522,7 @@ impl Visit for UsageAnalyzer<'_> {
         }
     }
 
-    fn visit_fn_decl(&mut self, f: &FnDecl, _: &dyn Node) {
+    fn visit_fn_decl(&mut self, f: &FnDecl) {
         f.function.decorators.visit_with(f, self);
 
         self.add_decl(f.ident.to_id());
@@ -541,7 +541,7 @@ impl Visit for UsageAnalyzer<'_> {
         })
     }
 
-    fn visit_fn_expr(&mut self, f: &FnExpr, _: &dyn Node) {
+    fn visit_fn_expr(&mut self, f: &FnExpr) {
         f.function.decorators.visit_with(f, self);
 
         self.visit_with_scope(f.function.span.ctxt, ScopeKind::Fn, |v| {
@@ -562,19 +562,19 @@ impl Visit for UsageAnalyzer<'_> {
         })
     }
 
-    fn visit_import_default_specifier(&mut self, s: &ImportDefaultSpecifier, _: &dyn Node) {
+    fn visit_import_default_specifier(&mut self, s: &ImportDefaultSpecifier) {
         self.add_decl(s.local.to_id());
     }
 
-    fn visit_import_named_specifier(&mut self, s: &ImportNamedSpecifier, _: &dyn Node) {
+    fn visit_import_named_specifier(&mut self, s: &ImportNamedSpecifier) {
         self.add_decl(s.local.to_id());
     }
 
-    fn visit_import_star_as_specifier(&mut self, s: &ImportStarAsSpecifier, _: &dyn Node) {
+    fn visit_import_star_as_specifier(&mut self, s: &ImportStarAsSpecifier) {
         self.add_decl(s.local.to_id());
     }
 
-    fn visit_member_expr(&mut self, e: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, e: &MemberExpr) {
         e.obj.visit_with(e, self);
 
         if e.computed {
@@ -582,7 +582,7 @@ impl Visit for UsageAnalyzer<'_> {
         }
     }
 
-    fn visit_method_prop(&mut self, f: &MethodProp, _: &dyn Node) {
+    fn visit_method_prop(&mut self, f: &MethodProp) {
         f.key.visit_with(f, self);
 
         f.function.decorators.visit_with(f, self);
@@ -601,15 +601,15 @@ impl Visit for UsageAnalyzer<'_> {
         })
     }
 
-    fn visit_module(&mut self, m: &Module, _: &dyn Node) {
+    fn visit_module(&mut self, m: &Module) {
         self.visit_with_scope(m.span.ctxt, ScopeKind::Fn, |v| m.visit_children_with(v))
     }
 
-    fn visit_module_items(&mut self, stmts: &[ModuleItem], _: &dyn Node) {
+    fn visit_module_items(&mut self, stmts: &[ModuleItem]) {
         self.visit_stmt_likes(stmts);
     }
 
-    fn visit_param(&mut self, p: &Param, _: &dyn Node) {
+    fn visit_param(&mut self, p: &Param) {
         p.decorators.visit_with(p, self);
 
         let old = self.is_pat_decl;
@@ -618,7 +618,7 @@ impl Visit for UsageAnalyzer<'_> {
         self.is_pat_decl = old;
     }
 
-    fn visit_pat(&mut self, p: &Pat, _: &dyn Node) {
+    fn visit_pat(&mut self, p: &Pat) {
         p.visit_children_with(self);
 
         match p {
@@ -633,7 +633,7 @@ impl Visit for UsageAnalyzer<'_> {
         }
     }
 
-    fn visit_prop(&mut self, p: &Prop, _: &dyn Node) {
+    fn visit_prop(&mut self, p: &Prop) {
         p.visit_children_with(self);
 
         match p {
@@ -644,15 +644,15 @@ impl Visit for UsageAnalyzer<'_> {
         }
     }
 
-    fn visit_script(&mut self, s: &Script, _: &dyn Node) {
+    fn visit_script(&mut self, s: &Script) {
         self.visit_with_scope(s.span.ctxt, ScopeKind::Fn, |v| s.visit_children_with(v))
     }
 
-    fn visit_stmts(&mut self, stmts: &[Stmt], _: &dyn Node) {
+    fn visit_stmts(&mut self, stmts: &[Stmt]) {
         self.visit_stmt_likes(stmts);
     }
 
-    fn visit_var_declarator(&mut self, v: &VarDeclarator, _: &dyn Node) {
+    fn visit_var_declarator(&mut self, v: &VarDeclarator) {
         let old = self.is_pat_decl;
 
         self.is_pat_decl = true;
@@ -679,9 +679,9 @@ struct Hoister<'a, 'b> {
 impl Visit for Hoister<'_, '_> {
     noop_visit_type!();
 
-    fn visit_arrow_expr(&mut self, _: &ArrowExpr, _: &dyn Node) {}
+    fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
 
-    fn visit_assign_pat_prop(&mut self, node: &AssignPatProp, _: &dyn Node) {
+    fn visit_assign_pat_prop(&mut self, node: &AssignPatProp) {
         node.visit_children_with(self);
 
         {
@@ -700,16 +700,16 @@ impl Visit for Hoister<'_, '_> {
         }
     }
 
-    fn visit_block_stmt(&mut self, b: &BlockStmt, _: &dyn Node) {
+    fn visit_block_stmt(&mut self, b: &BlockStmt) {
         let old = self.in_block_stmt;
         self.in_block_stmt = true;
         b.visit_children_with(self);
         self.in_block_stmt = old;
     }
 
-    fn visit_block_stmt_or_expr(&mut self, _: &BlockStmtOrExpr, _: &dyn Node) {}
+    fn visit_block_stmt_or_expr(&mut self, _: &BlockStmtOrExpr) {}
 
-    fn visit_class_decl(&mut self, c: &ClassDecl, _: &dyn Node) {
+    fn visit_class_decl(&mut self, c: &ClassDecl) {
         c.visit_children_with(self);
 
         if self.in_block_stmt {
@@ -719,11 +719,11 @@ impl Visit for Hoister<'_, '_> {
         self.inner.add_decl(c.ident.to_id());
     }
 
-    fn visit_constructor(&mut self, c: &Constructor, _: &dyn Node) {
+    fn visit_constructor(&mut self, c: &Constructor) {
         c.params.visit_with(c, self);
     }
 
-    fn visit_fn_decl(&mut self, f: &FnDecl, _: &dyn Node) {
+    fn visit_fn_decl(&mut self, f: &FnDecl) {
         if LOG {
             trace!("hoister: Fn decl: `{}`", f.ident);
         }
@@ -731,11 +731,11 @@ impl Visit for Hoister<'_, '_> {
         self.inner.add_decl(f.ident.to_id());
     }
 
-    fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
+    fn visit_function(&mut self, _: &Function) {}
 
-    fn visit_param(&mut self, _: &Param, _: &dyn Node) {}
+    fn visit_param(&mut self, _: &Param) {}
 
-    fn visit_pat(&mut self, p: &Pat, _: &dyn Node) {
+    fn visit_pat(&mut self, p: &Pat) {
         p.visit_children_with(self);
 
         match p {
@@ -757,7 +757,7 @@ impl Visit for Hoister<'_, '_> {
         }
     }
 
-    fn visit_var_decl(&mut self, v: &VarDecl, _: &dyn Node) {
+    fn visit_var_decl(&mut self, v: &VarDecl) {
         let old = self.var_decl_kind;
 
         self.var_decl_kind = Some(v.kind);
@@ -766,7 +766,7 @@ impl Visit for Hoister<'_, '_> {
         self.var_decl_kind = old;
     }
 
-    fn visit_var_declarator(&mut self, v: &VarDeclarator, _: &dyn Node) {
+    fn visit_var_declarator(&mut self, v: &VarDeclarator) {
         let old = self.is_pat_decl;
 
         self.is_pat_decl = true;

--- a/crates/swc_ecma_transforms_base/src/hygiene/usage_analyzer.rs
+++ b/crates/swc_ecma_transforms_base/src/hygiene/usage_analyzer.rs
@@ -2,7 +2,7 @@ use super::{ops::Operations, LOG};
 use crate::scope::ScopeKind;
 use std::{cell::RefCell, mem::take};
 use swc_atoms::{js_word, JsWord};
-use swc_common::{collections::AHashMap, SyntaxContext, DUMMY_SP};
+use swc_common::{collections::AHashMap, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ident::IdentLike, Id, StmtOrModuleItem};
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
@@ -542,11 +542,11 @@ impl Visit for UsageAnalyzer<'_> {
     }
 
     fn visit_fn_expr(&mut self, f: &FnExpr) {
-        f.function.decorators.visit_with(f, self);
+        f.function.decorators.visit_with(self);
 
         self.visit_with_scope(f.function.span.ctxt, ScopeKind::Fn, |v| {
             v.is_pat_decl = true;
-            f.function.params.visit_with(f, v);
+            f.function.params.visit_with(v);
 
             if let Some(i) = &f.ident {
                 v.add_decl(i.to_id());
@@ -575,21 +575,21 @@ impl Visit for UsageAnalyzer<'_> {
     }
 
     fn visit_member_expr(&mut self, e: &MemberExpr) {
-        e.obj.visit_with(e, self);
+        e.obj.visit_with(self);
 
         if e.computed {
-            e.obj.visit_with(e, self);
+            e.obj.visit_with(self);
         }
     }
 
     fn visit_method_prop(&mut self, f: &MethodProp) {
-        f.key.visit_with(f, self);
+        f.key.visit_with(self);
 
-        f.function.decorators.visit_with(f, self);
+        f.function.decorators.visit_with(self);
 
         self.visit_with_scope(f.function.span.ctxt, ScopeKind::Fn, |v| {
             v.is_pat_decl = true;
-            f.function.params.visit_with(f, v);
+            f.function.params.visit_with(v);
 
             v.is_pat_decl = false;
             match f.function.body.as_ref() {
@@ -610,11 +610,11 @@ impl Visit for UsageAnalyzer<'_> {
     }
 
     fn visit_param(&mut self, p: &Param) {
-        p.decorators.visit_with(p, self);
+        p.decorators.visit_with(self);
 
         let old = self.is_pat_decl;
         self.is_pat_decl = true;
-        p.pat.visit_with(p, self);
+        p.pat.visit_with(self);
         self.is_pat_decl = old;
     }
 
@@ -656,10 +656,10 @@ impl Visit for UsageAnalyzer<'_> {
         let old = self.is_pat_decl;
 
         self.is_pat_decl = true;
-        v.name.visit_with(v, self);
+        v.name.visit_with(self);
 
         self.is_pat_decl = false;
-        v.init.visit_with(v, self);
+        v.init.visit_with(self);
 
         self.is_pat_decl = old;
     }
@@ -720,7 +720,7 @@ impl Visit for Hoister<'_, '_> {
     }
 
     fn visit_constructor(&mut self, c: &Constructor) {
-        c.params.visit_with(c, self);
+        c.params.visit_with(self);
     }
 
     fn visit_fn_decl(&mut self, f: &FnDecl) {
@@ -761,7 +761,7 @@ impl Visit for Hoister<'_, '_> {
         let old = self.var_decl_kind;
 
         self.var_decl_kind = Some(v.kind);
-        v.decls.visit_with(v, self);
+        v.decls.visit_with(self);
 
         self.var_decl_kind = old;
     }
@@ -770,10 +770,10 @@ impl Visit for Hoister<'_, '_> {
         let old = self.is_pat_decl;
 
         self.is_pat_decl = true;
-        v.name.visit_with(v, self);
+        v.name.visit_with(self);
 
         self.is_pat_decl = false;
-        v.init.visit_with(v, self);
+        v.init.visit_with(self);
 
         self.is_pat_decl = old;
     }

--- a/crates/swc_ecma_transforms_base/src/hygiene/usage_analyzer.rs
+++ b/crates/swc_ecma_transforms_base/src/hygiene/usage_analyzer.rs
@@ -5,7 +5,7 @@ use swc_atoms::{js_word, JsWord};
 use swc_common::{collections::AHashMap, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ident::IdentLike, Id, StmtOrModuleItem};
-use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 use tracing::{debug, span, trace, Level};
 
 #[derive(Debug, Default)]
@@ -307,12 +307,12 @@ impl UsageAnalyzer<'_> {
             };
 
             for stmt in stmts {
-                stmt.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+                stmt.visit_with(&mut v);
             }
         }
 
         for stmt in stmts {
-            stmt.visit_with(&Invalid { span: DUMMY_SP }, self);
+            stmt.visit_with(self);
         }
     }
 

--- a/crates/swc_ecma_transforms_base/src/perf.rs
+++ b/crates/swc_ecma_transforms_base/src/perf.rs
@@ -1,4 +1,3 @@
-use swc_common::DUMMY_SP;
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitWith};
 
@@ -12,7 +11,7 @@ where
     T: VisitWith<C>,
 {
     let mut checker = C::default();
-    n.visit_with(&Invalid { span: DUMMY_SP }, &mut checker);
+    n.visit_with(&mut checker);
     checker.should_handle()
 }
 

--- a/crates/swc_ecma_transforms_base/tests/ts_resolver.rs
+++ b/crates/swc_ecma_transforms_base/tests/ts_resolver.rs
@@ -45,7 +45,7 @@ fn no_empty(input: PathBuf) {
 struct AssertNoEmptyCtxt;
 
 impl Visit for AssertNoEmptyCtxt {
-    fn visit_class_prop(&mut self, n: &ClassProp, _: &dyn Node) {
+    fn visit_class_prop(&mut self, n: &ClassProp) {
         if n.computed {
             n.key.visit_with(n, self);
         }
@@ -55,7 +55,7 @@ impl Visit for AssertNoEmptyCtxt {
         n.decorators.visit_with(n, self);
     }
 
-    fn visit_expr(&mut self, n: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, n: &Expr) {
         n.visit_children_with(self);
 
         match n {
@@ -68,14 +68,14 @@ impl Visit for AssertNoEmptyCtxt {
         }
     }
 
-    fn visit_member_expr(&mut self, n: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, n: &MemberExpr) {
         n.obj.visit_with(n, self);
         if n.computed {
             n.prop.visit_with(n, self);
         }
     }
 
-    fn visit_pat(&mut self, n: &Pat, _: &dyn Node) {
+    fn visit_pat(&mut self, n: &Pat) {
         n.visit_children_with(self);
 
         match n {
@@ -88,7 +88,7 @@ impl Visit for AssertNoEmptyCtxt {
         }
     }
 
-    fn visit_ts_getter_signature(&mut self, n: &TsGetterSignature, _: &dyn Node) {
+    fn visit_ts_getter_signature(&mut self, n: &TsGetterSignature) {
         if n.computed {
             n.key.visit_with(n, self);
         }
@@ -96,7 +96,7 @@ impl Visit for AssertNoEmptyCtxt {
         n.type_ann.visit_with(n, self);
     }
 
-    fn visit_ts_method_signature(&mut self, n: &TsMethodSignature, _: &dyn Node) {
+    fn visit_ts_method_signature(&mut self, n: &TsMethodSignature) {
         if n.computed {
             n.key.visit_with(n, self);
         }
@@ -106,7 +106,7 @@ impl Visit for AssertNoEmptyCtxt {
         n.type_params.visit_with(n, self);
     }
 
-    fn visit_ts_property_signature(&mut self, n: &TsPropertySignature, _: &dyn Node) {
+    fn visit_ts_property_signature(&mut self, n: &TsPropertySignature) {
         if n.computed {
             n.key.visit_with(n, self);
         }
@@ -117,7 +117,7 @@ impl Visit for AssertNoEmptyCtxt {
         n.type_params.visit_with(n, self);
     }
 
-    fn visit_ts_setter_signature(&mut self, n: &TsSetterSignature, _: &dyn Node) {
+    fn visit_ts_setter_signature(&mut self, n: &TsSetterSignature) {
         if n.computed {
             n.key.visit_with(n, self);
         }
@@ -125,7 +125,7 @@ impl Visit for AssertNoEmptyCtxt {
         n.param.visit_with(n, self);
     }
 
-    fn visit_ts_tuple_element(&mut self, n: &TsTupleElement, _: &dyn Node) {
+    fn visit_ts_tuple_element(&mut self, n: &TsTupleElement) {
         n.ty.visit_with(n, self);
     }
 }

--- a/crates/swc_ecma_transforms_base/tests/ts_resolver.rs
+++ b/crates/swc_ecma_transforms_base/tests/ts_resolver.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
-use swc_common::{input::SourceFileInput, Mark, SyntaxContext, DUMMY_SP};
+use swc_common::{input::SourceFileInput, Mark, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser, Syntax, TsConfig};
 use swc_ecma_transforms_base::resolver::ts_resolver;
-use swc_ecma_visit::{FoldWith, Node, Visit, VisitWith};
+use swc_ecma_visit::{FoldWith, Visit, VisitWith};
 use testing::fixture;
 
 #[fixture("../swc_ecma_parser/tests/typescript/**/*.ts")]
@@ -35,7 +35,7 @@ fn no_empty(input: PathBuf) {
 
         let module = module.fold_with(&mut ts_resolver(Mark::fresh(Mark::root())));
 
-        module.visit_with(&Invalid { span: DUMMY_SP }, &mut AssertNoEmptyCtxt);
+        module.visit_with(&mut AssertNoEmptyCtxt);
 
         Ok(())
     })
@@ -47,12 +47,12 @@ struct AssertNoEmptyCtxt;
 impl Visit for AssertNoEmptyCtxt {
     fn visit_class_prop(&mut self, n: &ClassProp) {
         if n.computed {
-            n.key.visit_with(n, self);
+            n.key.visit_with(self);
         }
 
-        n.value.visit_with(n, self);
-        n.type_ann.visit_with(n, self);
-        n.decorators.visit_with(n, self);
+        n.value.visit_with(self);
+        n.type_ann.visit_with(self);
+        n.decorators.visit_with(self);
     }
 
     fn visit_expr(&mut self, n: &Expr) {
@@ -69,9 +69,9 @@ impl Visit for AssertNoEmptyCtxt {
     }
 
     fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with(n, self);
+        n.obj.visit_with(self);
         if n.computed {
-            n.prop.visit_with(n, self);
+            n.prop.visit_with(self);
         }
     }
 
@@ -90,15 +90,15 @@ impl Visit for AssertNoEmptyCtxt {
 
     fn visit_ts_getter_signature(&mut self, n: &TsGetterSignature) {
         if n.computed {
-            n.key.visit_with(n, self);
+            n.key.visit_with(self);
         }
 
-        n.type_ann.visit_with(n, self);
+        n.type_ann.visit_with(self);
     }
 
     fn visit_ts_method_signature(&mut self, n: &TsMethodSignature) {
         if n.computed {
-            n.key.visit_with(n, self);
+            n.key.visit_with(self);
         }
 
         n.params.visit_with(n, self);
@@ -108,18 +108,18 @@ impl Visit for AssertNoEmptyCtxt {
 
     fn visit_ts_property_signature(&mut self, n: &TsPropertySignature) {
         if n.computed {
-            n.key.visit_with(n, self);
+            n.key.visit_with(self);
         }
 
-        n.init.visit_with(n, self);
-        n.params.visit_with(n, self);
-        n.type_ann.visit_with(n, self);
-        n.type_params.visit_with(n, self);
+        n.init.visit_with(self);
+        n.params.visit_with(self);
+        n.type_ann.visit_with(self);
+        n.type_params.visit_with(self);
     }
 
     fn visit_ts_setter_signature(&mut self, n: &TsSetterSignature) {
         if n.computed {
-            n.key.visit_with(n, self);
+            n.key.visit_with(self);
         }
 
         n.param.visit_with(n, self);

--- a/crates/swc_ecma_transforms_base/tests/ts_resolver.rs
+++ b/crates/swc_ecma_transforms_base/tests/ts_resolver.rs
@@ -101,9 +101,9 @@ impl Visit for AssertNoEmptyCtxt {
             n.key.visit_with(self);
         }
 
-        n.params.visit_with(n, self);
-        n.type_ann.visit_with(n, self);
-        n.type_params.visit_with(n, self);
+        n.params.visit_with(self);
+        n.type_ann.visit_with(self);
+        n.type_params.visit_with(self);
     }
 
     fn visit_ts_property_signature(&mut self, n: &TsPropertySignature) {
@@ -122,10 +122,10 @@ impl Visit for AssertNoEmptyCtxt {
             n.key.visit_with(self);
         }
 
-        n.param.visit_with(n, self);
+        n.param.visit_with(self);
     }
 
     fn visit_ts_tuple_element(&mut self, n: &TsTupleElement) {
-        n.ty.visit_with(n, self);
+        n.ty.visit_with(self);
     }
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
@@ -606,7 +606,7 @@ where
 {
     let mut vars = vec![];
     let mut v = VarCollector { to: &mut vars };
-    node.visit_with( &mut v);
+    node.visit_with(&mut v);
 
     vars
 }
@@ -641,7 +641,7 @@ impl Visit for InfectionFinder<'_> {
         let old = self.found;
         self.found = false;
 
-        node.right.visit_with(node as _, self);
+        node.right.visit_with(self);
 
         if self.found {
             let ids = find_ids(&node.left);
@@ -669,10 +669,10 @@ impl Visit for InfectionFinder<'_> {
             return;
         }
 
-        e.obj.visit_with(e as _, self);
+        e.obj.visit_with(self);
 
         if e.computed {
-            e.prop.visit_with(e as _, self);
+            e.prop.visit_with(self);
         }
     }
 
@@ -680,7 +680,7 @@ impl Visit for InfectionFinder<'_> {
         let old = self.found;
         self.found = false;
 
-        node.init.visit_with(node as _, self);
+        node.init.visit_with(self);
 
         if self.found {
             let ids = find_ids(&node.name);

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
@@ -638,7 +638,7 @@ struct InfectionFinder<'a> {
 impl Visit for InfectionFinder<'_> {
     noop_visit_type!();
 
-    fn visit_assign_expr(&mut self, node: &AssignExpr, _: &dyn Node) {
+    fn visit_assign_expr(&mut self, node: &AssignExpr) {
         let old = self.found;
         self.found = false;
 
@@ -652,7 +652,7 @@ impl Visit for InfectionFinder<'_> {
         self.found = old;
     }
 
-    fn visit_ident(&mut self, i: &Ident, _: &dyn Node) {
+    fn visit_ident(&mut self, i: &Ident) {
         if self.found {
             return;
         }
@@ -665,7 +665,7 @@ impl Visit for InfectionFinder<'_> {
         }
     }
 
-    fn visit_member_expr(&mut self, e: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, e: &MemberExpr) {
         if self.found {
             return;
         }
@@ -677,7 +677,7 @@ impl Visit for InfectionFinder<'_> {
         }
     }
 
-    fn visit_var_declarator(&mut self, node: &VarDeclarator, _: &dyn Node) {
+    fn visit_var_declarator(&mut self, node: &VarDeclarator) {
         let old = self.found;
         self.found = false;
 
@@ -981,36 +981,36 @@ struct FunctionFinder {
 impl Visit for FunctionFinder {
     noop_visit_type!();
 
-    fn visit_arrow_expr(&mut self, _: &ArrowExpr, _: &dyn Node) {
+    fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
         self.found = true;
     }
 
     /// Do not recurse into nested loop.
     ///
     /// https://github.com/swc-project/swc/issues/2622
-    fn visit_do_while_stmt(&mut self, _: &DoWhileStmt, _: &dyn Node) {}
+    fn visit_do_while_stmt(&mut self, _: &DoWhileStmt) {}
 
     /// Do not recurse into nested loop.
     ///
     /// https://github.com/swc-project/swc/issues/2622
-    fn visit_for_in_stmt(&mut self, _: &ForInStmt, _: &dyn Node) {}
+    fn visit_for_in_stmt(&mut self, _: &ForInStmt) {}
 
     /// Do not recurse into nested loop.
     ///
     /// https://github.com/swc-project/swc/issues/2622
-    fn visit_for_of_stmt(&mut self, _: &ForOfStmt, _: &dyn Node) {}
+    fn visit_for_of_stmt(&mut self, _: &ForOfStmt) {}
 
     /// Do not recurse into nested loop.
     ///
     /// https://github.com/swc-project/swc/issues/2622
-    fn visit_for_stmt(&mut self, _: &ForStmt, _: &dyn Node) {}
+    fn visit_for_stmt(&mut self, _: &ForStmt) {}
 
-    fn visit_function(&mut self, _: &Function, _: &dyn Node) {
+    fn visit_function(&mut self, _: &Function) {
         self.found = true
     }
 
     /// Do not recurse into nested loop.
     ///
     /// https://github.com/swc-project/swc/issues/2622
-    fn visit_while_stmt(&mut self, _: &WhileStmt, _: &dyn Node) {}
+    fn visit_while_stmt(&mut self, _: &WhileStmt) {}
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
@@ -9,8 +9,7 @@ use swc_ecma_utils::{
     quote_ident, quote_str, undefined, var::VarCollector, ExprFactory, Id, StmtLike,
 };
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Node, Visit, VisitMut, VisitMutWith,
-    VisitWith,
+    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 
 ///
@@ -113,7 +112,7 @@ impl BlockScoping {
 
         {
             let mut v = FunctionFinder { found: false };
-            body_stmt.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+            body_stmt.visit_with(&mut v);
             if !v.found {
                 return;
             }
@@ -607,7 +606,7 @@ where
 {
     let mut vars = vec![];
     let mut v = VarCollector { to: &mut vars };
-    node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+    node.visit_with( &mut v);
 
     vars
 }
@@ -620,7 +619,7 @@ where
         vars: ids,
         found: false,
     };
-    node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+    node.visit_with(&mut v);
 }
 
 /// In the code below,

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/constructor.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/constructor.rs
@@ -5,7 +5,7 @@ use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
 use swc_ecma_transforms_classes::{fold_only_key, get_prototype_of};
 use swc_ecma_utils::{private_ident, quote_ident, ExprFactory};
-use swc_ecma_visit::{noop_fold_type, noop_visit_type, Fold, FoldWith, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_fold_type, noop_visit_type, Fold, FoldWith, Visit, VisitWith};
 
 pub(super) struct SuperCallFinder {
     mode: Option<SuperFoldingMode>,
@@ -36,7 +36,7 @@ impl SuperCallFinder {
             mode: None,
             in_complex: false,
         };
-        node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+        node.visit_with(&mut v);
         v.mode
     }
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/constructor.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/constructor.rs
@@ -77,7 +77,7 @@ impl Visit for SuperCallFinder {
     mark_as_complex!(visit_prop_name, PropName);
 
     fn visit_assign_expr(&mut self, node: &AssignExpr) {
-        node.left.visit_with(node as _, self);
+        node.left.visit_with(self);
 
         let old = self.in_complex;
         self.in_complex = true;

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/constructor.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/constructor.rs
@@ -60,7 +60,7 @@ macro_rules! ignore_return {
 
 macro_rules! mark_as_complex {
     ($name:ident, $T:ty) => {
-        fn $name(&mut self, node: &$T, _: &dyn Node) {
+        fn $name(&mut self, node: &$T) {
             let old = self.in_complex;
             self.in_complex = true;
             node.visit_children_with(self);
@@ -76,7 +76,7 @@ impl Visit for SuperCallFinder {
     mark_as_complex!(visit_if_stmt, IfStmt);
     mark_as_complex!(visit_prop_name, PropName);
 
-    fn visit_assign_expr(&mut self, node: &AssignExpr, _: &dyn Node) {
+    fn visit_assign_expr(&mut self, node: &AssignExpr) {
         node.left.visit_with(node as _, self);
 
         let old = self.in_complex;
@@ -85,7 +85,7 @@ impl Visit for SuperCallFinder {
         self.in_complex = old;
     }
 
-    fn visit_call_expr(&mut self, e: &CallExpr, _: &dyn Node) {
+    fn visit_call_expr(&mut self, e: &CallExpr) {
         match e.callee {
             ExprOrSuper::Super(..) => match self.mode {
                 None if !self.in_complex => self.mode = Some(SuperFoldingMode::Var),
@@ -103,12 +103,12 @@ impl Visit for SuperCallFinder {
     }
 
     /// Don't recurse into class declaration.
-    fn visit_class(&mut self, _: &Class, _: &dyn Node) {}
+    fn visit_class(&mut self, _: &Class) {}
 
     /// Don't recurse into function.
-    fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
+    fn visit_function(&mut self, _: &Function) {}
 
-    fn visit_member_expr(&mut self, e: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, e: &MemberExpr) {
         e.visit_children_with(self);
 
         match e.obj {

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
@@ -915,7 +915,7 @@ fn is_always_initialized(body: &[Stmt]) -> bool {
     impl Visit for SuperFinder {
         noop_visit_type!();
 
-        fn visit_expr_or_super(&mut self, node: &ExprOrSuper, _: &dyn Node) {
+        fn visit_expr_or_super(&mut self, node: &ExprOrSuper) {
             match *node {
                 ExprOrSuper::Super(..) => self.found = true,
                 _ => node.visit_children_with(self),
@@ -976,7 +976,7 @@ struct ClassFinder {
 impl Visit for ClassFinder {
     noop_visit_type!();
 
-    fn visit_class(&mut self, _: &Class, _: &dyn Node) {
+    fn visit_class(&mut self, _: &Class) {
         self.found = true
     }
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
@@ -15,7 +15,7 @@ use swc_ecma_utils::{
     alias_if_required, default_constructor, prepend, private_ident, prop_name_to_expr, quote_expr,
     quote_ident, quote_str, ExprFactory, IsDirective, ModuleItemLike, StmtLike,
 };
-use swc_ecma_visit::{noop_fold_type, noop_visit_type, Fold, FoldWith, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_fold_type, noop_visit_type, Fold, FoldWith, Visit, VisitWith};
 use tracing::debug;
 
 mod constructor;

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
@@ -941,7 +941,7 @@ fn is_always_initialized(body: &[Stmt]) -> bool {
     let mut v = SuperFinder { found: false };
     let body = &body[..pos];
 
-    v.visit_stmts(body, &Invalid { span: DUMMY_SP });
+    v.visit_stmts(body);
 
     if v.found {
         return false;

--- a/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
@@ -409,7 +409,7 @@ where
     N: VisitWith<ShouldWork>,
 {
     let mut v = ShouldWork { found: false };
-    node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+    node.visit_with( &mut v);
     v.found
 }
 

--- a/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
@@ -323,7 +323,7 @@ struct ComplexVisitor {
 impl Visit for ComplexVisitor {
     noop_visit_type!();
 
-    fn visit_prop_name(&mut self, pn: &PropName, _: &dyn Node) {
+    fn visit_prop_name(&mut self, pn: &PropName) {
         match *pn {
             PropName::Computed(..) => self.found = true,
             _ => {}
@@ -420,7 +420,7 @@ struct ShouldWork {
 impl Visit for ShouldWork {
     noop_visit_type!();
 
-    fn visit_prop_name(&mut self, node: &PropName, _: &dyn Node) {
+    fn visit_prop_name(&mut self, node: &PropName) {
         match *node {
             PropName::Computed(_) => self.found = true,
             _ => {}

--- a/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
@@ -4,8 +4,7 @@ use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
 use swc_ecma_utils::{quote_ident, ExprFactory, StmtLike};
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Node, Visit, VisitMut, VisitMutWith,
-    VisitWith,
+    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 
 /// `@babel/plugin-transform-computed-properties`
@@ -409,7 +408,7 @@ where
     N: VisitWith<ShouldWork>,
 {
     let mut v = ShouldWork { found: false };
-    node.visit_with( &mut v);
+    node.visit_with(&mut v);
     v.found
 }
 

--- a/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
@@ -1235,7 +1235,7 @@ struct DestructuringVisitor {
 impl Visit for DestructuringVisitor {
     noop_visit_type!();
 
-    fn visit_pat(&mut self, node: &Pat, _: &dyn Node) {
+    fn visit_pat(&mut self, node: &Pat) {
         node.visit_children_with(self);
         match *node {
             Pat::Ident(..) => {}

--- a/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
@@ -10,8 +10,7 @@ use swc_ecma_utils::{
     prop_name_to_expr, quote_ident, undefined, ExprFactory, StmtLike,
 };
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Node, Visit, VisitMut, VisitMutWith,
-    VisitWith,
+    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 
 /// `@babel/plugin-transform-destructuring`

--- a/crates/swc_ecma_transforms_compat/src/es2015/new_target.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/new_target.rs
@@ -237,7 +237,7 @@ struct ShouldWork {
 impl Visit for ShouldWork {
     noop_visit_type!();
 
-    fn visit_meta_prop_expr(&mut self, n: &MetaPropExpr, _: &dyn Node) {
+    fn visit_meta_prop_expr(&mut self, n: &MetaPropExpr) {
         match n {
             MetaPropExpr {
                 meta:

--- a/crates/swc_ecma_transforms_compat/src/es2015/new_target.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/new_target.rs
@@ -5,7 +5,7 @@ use swc_ecma_ast::*;
 use swc_ecma_transforms_base::perf::{should_work, Check};
 use swc_ecma_utils::{prepend, private_ident, quote_ident, undefined, ExprFactory};
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Node, Visit, VisitMut, VisitMutWith,
+    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith,
 };
 
 pub fn new_target() -> impl Fold + VisitMut + CompilerPass {

--- a/crates/swc_ecma_transforms_compat/src/es2015/regenerator/case.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/regenerator/case.rs
@@ -10,7 +10,7 @@ use swc_ecma_ast::*;
 use swc_ecma_utils::{
     ident::IdentLike, member_expr, quote_ident, quote_str, undefined, ExprFactory,
 };
-use swc_ecma_visit::{noop_fold_type, noop_visit_type, Fold, FoldWith, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_fold_type, noop_visit_type, Fold, FoldWith, Visit, VisitWith};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) struct Loc {

--- a/crates/swc_ecma_transforms_compat/src/es2015/regenerator/case.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/regenerator/case.rs
@@ -1565,7 +1565,7 @@ where
     T: VisitWith<LeapFinder>,
 {
     let mut v = LeapFinder { found: false };
-    node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+    node.visit_with(&mut v);
     v.found
 }
 

--- a/crates/swc_ecma_transforms_compat/src/es2015/regenerator/case.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/regenerator/case.rs
@@ -1539,7 +1539,7 @@ struct LeapFinder {
 
 macro_rules! leap {
     ($name:ident,$T:ty) => {
-        fn $name(&mut self, _: &$T, _: &dyn Node) {
+        fn $name(&mut self, _: &$T) {
             self.found = true;
         }
     };
@@ -1549,9 +1549,9 @@ impl Visit for LeapFinder {
     noop_visit_type!();
 
     /// Ignored
-    fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
+    fn visit_function(&mut self, _: &Function) {}
     /// Ignored
-    fn visit_arrow_expr(&mut self, _: &ArrowExpr, _: &dyn Node) {}
+    fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
 
     leap!(visit_yield_expr, YieldExpr);
     leap!(visit_break_stmt, BreakStmt);

--- a/crates/swc_ecma_transforms_compat/src/es2015/regenerator/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/regenerator/mod.rs
@@ -7,7 +7,7 @@ use swc_ecma_ast::*;
 use swc_ecma_utils::{
     contains_this_expr, prepend, private_ident, quote_ident, quote_str, ExprFactory, StmtLike,
 };
-use swc_ecma_visit::{noop_fold_type, noop_visit_type, Fold, FoldWith, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_fold_type, noop_visit_type, Fold, FoldWith, Visit, VisitWith};
 
 mod case;
 mod hoist;
@@ -556,7 +556,7 @@ struct Finder {
 impl Finder {
     fn find<T: VisitWith<Self>>(node: &T) -> bool {
         let mut v = Finder { found: false };
-        node.visit_with( &mut v);
+        node.visit_with(&mut v);
         v.found
     }
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/regenerator/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/regenerator/mod.rs
@@ -564,7 +564,7 @@ impl Finder {
 impl Visit for Finder {
     noop_visit_type!();
 
-    fn visit_function(&mut self, node: &Function, _: &dyn Node) {
+    fn visit_function(&mut self, node: &Function) {
         if node.is_generator {
             self.found = true;
             return;

--- a/crates/swc_ecma_transforms_compat/src/es2015/regenerator/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/regenerator/mod.rs
@@ -556,7 +556,7 @@ struct Finder {
 impl Finder {
     fn find<T: VisitWith<Self>>(node: &T) -> bool {
         let mut v = Finder { found: false };
-        node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+        node.visit_with( &mut v);
         v.found
     }
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/spread.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/spread.rs
@@ -10,8 +10,7 @@ use swc_ecma_utils::{
     StmtLike,
 };
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Node, Visit, VisitMut, VisitMutWith,
-    VisitWith,
+    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 
 pub fn spread(c: Config) -> impl Fold + VisitMut {

--- a/crates/swc_ecma_transforms_compat/src/es2015/spread.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/spread.rs
@@ -450,7 +450,7 @@ struct SpreadFinder {
 impl Visit for SpreadFinder {
     noop_visit_type!();
 
-    fn visit_expr_or_spread(&mut self, n: &ExprOrSpread, _: &dyn Node) {
+    fn visit_expr_or_spread(&mut self, n: &ExprOrSpread) {
         n.visit_children_with(self);
 
         self.found |= n.spread.is_some();

--- a/crates/swc_ecma_transforms_compat/src/es2017/async_to_generator.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2017/async_to_generator.rs
@@ -9,8 +9,7 @@ use swc_ecma_utils::{
     private_ident, quote_ident, ExprFactory, StmtLike,
 };
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Node, Visit, VisitMut, VisitMutWith,
-    VisitWith,
+    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 
 /// `@babel/plugin-transform-async-to-generator`

--- a/crates/swc_ecma_transforms_compat/src/es2017/async_to_generator.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2017/async_to_generator.rs
@@ -1044,7 +1044,7 @@ struct ShouldWork {
 impl Visit for ShouldWork {
     noop_visit_type!();
 
-    fn visit_function(&mut self, f: &Function, _: &dyn Node) {
+    fn visit_function(&mut self, f: &Function) {
         if f.is_async {
             self.found = true;
             return;
@@ -1052,7 +1052,7 @@ impl Visit for ShouldWork {
         f.visit_children_with(self);
     }
 
-    fn visit_arrow_expr(&mut self, f: &ArrowExpr, _: &dyn Node) {
+    fn visit_arrow_expr(&mut self, f: &ArrowExpr) {
         if f.is_async {
             self.found = true;
             return;

--- a/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
@@ -12,7 +12,7 @@ use swc_ecma_utils::{
     ExprFactory, StmtLike,
 };
 use swc_ecma_visit::{
-    as_folder, noop_fold_type, noop_visit_mut_type, noop_visit_type, Fold, FoldWith, Node, Visit,
+    as_folder, noop_fold_type, noop_visit_mut_type, noop_visit_type, Fold, FoldWith, Visit,
     VisitMut, VisitMutWith, VisitWith,
 };
 
@@ -193,7 +193,7 @@ where
     N: VisitWith<RestVisitor>,
 {
     let mut v = RestVisitor { found: false };
-    node.visit_with( &mut v);
+    node.visit_with(&mut v);
     v.found
 }
 
@@ -283,7 +283,7 @@ impl Fold for ObjectRest {
                 let specifiers = {
                     let mut found = vec![];
                     let mut finder = VarCollector { to: &mut found };
-                    var_decl.visit_with( &mut finder);
+                    var_decl.visit_with(&mut finder);
                     found
                         .into_iter()
                         .map(|(sym, ctxt)| ExportNamedSpecifier {

--- a/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
@@ -174,7 +174,7 @@ struct RestVisitor {
 impl Visit for RestVisitor {
     noop_visit_type!();
 
-    fn visit_object_pat_prop(&mut self, prop: &ObjectPatProp, _: &dyn Node) {
+    fn visit_object_pat_prop(&mut self, prop: &ObjectPatProp) {
         match *prop {
             ObjectPatProp::Rest(..) => self.found = true,
             _ => prop.visit_children_with(self),

--- a/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
@@ -193,7 +193,7 @@ where
     N: VisitWith<RestVisitor>,
 {
     let mut v = RestVisitor { found: false };
-    node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+    node.visit_with( &mut v);
     v.found
 }
 
@@ -283,7 +283,7 @@ impl Fold for ObjectRest {
                 let specifiers = {
                     let mut found = vec![];
                     let mut finder = VarCollector { to: &mut found };
-                    var_decl.visit_with(&Invalid { span: DUMMY_SP } as _, &mut finder);
+                    var_decl.visit_with( &mut finder);
                     found
                         .into_iter()
                         .map(|(sym, ctxt)| ExportNamedSpecifier {

--- a/crates/swc_ecma_transforms_compat/src/es2020/opt_chaining.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2020/opt_chaining.rs
@@ -670,7 +670,7 @@ struct ShouldWork {
 impl Visit for ShouldWork {
     noop_visit_type!();
 
-    fn visit_opt_chain_expr(&mut self, _: &OptChainExpr, _: &dyn Node) {
+    fn visit_opt_chain_expr(&mut self, _: &OptChainExpr) {
         self.found = true;
     }
 }

--- a/crates/swc_ecma_transforms_compat/src/es2020/opt_chaining.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2020/opt_chaining.rs
@@ -6,7 +6,7 @@ use swc_ecma_transforms_base::perf::Check;
 use swc_ecma_transforms_macros::fast_path;
 use swc_ecma_utils::{alias_if_required, prepend, private_ident, undefined, ExprFactory, StmtLike};
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Node, Visit, VisitMut, VisitMutWith,
+    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith,
 };
 
 pub fn optional_chaining(c: Config) -> impl Fold + VisitMut {

--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
@@ -17,8 +17,7 @@ use swc_ecma_utils::{
     private_ident, quote_ident, undefined, ExprFactory, ModuleItemLike, StmtLike,
 };
 use swc_ecma_visit::{
-    as_folder, noop_fold_type, noop_visit_type, Fold, FoldWith, Node, Visit, VisitMutWith,
-    VisitWith,
+    as_folder, noop_fold_type, noop_visit_type, Fold, FoldWith, Visit, VisitMutWith, VisitWith,
 };
 
 mod class_name_tdz;
@@ -418,19 +417,13 @@ impl ClassProperties {
                     }));
 
                     if !prop.is_static {
-                        prop.key.visit_with(
-                            &Invalid { span: DUMMY_SP } as _,
-                            &mut UsedNameCollector {
-                                used_names: &mut used_key_names,
-                            },
-                        );
+                        prop.key.visit_with(&mut UsedNameCollector {
+                            used_names: &mut used_key_names,
+                        });
 
-                        prop.value.visit_with(
-                            &Invalid { span: DUMMY_SP } as _,
-                            &mut UsedNameCollector {
-                                used_names: &mut used_names,
-                            },
-                        );
+                        prop.value.visit_with(&mut UsedNameCollector {
+                            used_names: &mut used_names,
+                        });
                     }
 
                     let key = match *prop.key {
@@ -527,12 +520,9 @@ impl ClassProperties {
                         // We use `self.mark` for private variables.
                         prop.key.span.apply_mark(self.mark),
                     );
-                    prop.value.visit_with(
-                        &Invalid { span: DUMMY_SP } as _,
-                        &mut UsedNameCollector {
-                            used_names: &mut used_names,
-                        },
-                    );
+                    prop.value.visit_with(&mut UsedNameCollector {
+                        used_names: &mut used_names,
+                    });
                     if prop.is_static {
                         prop.value.visit_mut_with(&mut ThisInStaticFolder {
                             ident: class_ident.clone(),
@@ -636,12 +626,9 @@ impl ClassProperties {
                         // We use `self.mark` for private variables.
                         method.key.span.apply_mark(self.mark),
                     );
-                    method.function.visit_with(
-                        &Invalid { span: DUMMY_SP } as _,
-                        &mut UsedNameCollector {
-                            used_names: &mut used_names,
-                        },
-                    );
+                    method.function.visit_with(&mut UsedNameCollector {
+                        used_names: &mut used_names,
+                    });
 
                     if should_use_map || !statics.contains(&method.key.id.sym) {
                         vars.push(VarDeclarator {

--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
@@ -835,37 +835,37 @@ struct ShouldWork {
 impl Visit for ShouldWork {
     noop_visit_type!();
 
-    fn visit_ident(&mut self, n: &Ident, _: &dyn Node) {
+    fn visit_ident(&mut self, n: &Ident) {
         if n.optional {
             self.found = true;
         }
     }
 
-    fn visit_array_pat(&mut self, n: &ArrayPat, _: &dyn Node) {
+    fn visit_array_pat(&mut self, n: &ArrayPat) {
         if n.optional {
             self.found = true;
         }
     }
 
-    fn visit_object_pat(&mut self, n: &ObjectPat, _: &dyn Node) {
+    fn visit_object_pat(&mut self, n: &ObjectPat) {
         if n.optional {
             self.found = true;
         }
     }
 
-    fn visit_class_method(&mut self, _: &ClassMethod, _: &dyn Node) {
+    fn visit_class_method(&mut self, _: &ClassMethod) {
         self.found = true;
     }
 
-    fn visit_class_prop(&mut self, _: &ClassProp, _: &dyn Node) {
+    fn visit_class_prop(&mut self, _: &ClassProp) {
         self.found = true;
     }
 
-    fn visit_private_prop(&mut self, _: &PrivateProp, _: &dyn Node) {
+    fn visit_private_prop(&mut self, _: &PrivateProp) {
         self.found = true;
     }
 
-    fn visit_constructor(&mut self, _: &Constructor, _: &dyn Node) {
+    fn visit_constructor(&mut self, _: &Constructor) {
         self.found = true;
     }
 }

--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/used_name.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/used_name.rs
@@ -9,7 +9,7 @@ pub(super) struct UsedNameCollector<'a> {
 macro_rules! noop {
     ($name:ident, $T:path) => {
         /// no-op
-        fn $name(&mut self, _: &$T, _: &dyn Node) {}
+        fn $name(&mut self, _: &$T) {}
     };
 }
 
@@ -23,7 +23,7 @@ impl<'a> Visit for UsedNameCollector<'a> {
     noop!(visit_method_prop, MethodProp);
     noop!(visit_constructor, Constructor);
 
-    fn visit_expr(&mut self, expr: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, expr: &Expr) {
         match *expr {
             Expr::Ident(ref i) => self.used_names.push(i.sym.clone()),
             _ => expr.visit_children_with(self),

--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/used_name.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/used_name.rs
@@ -1,6 +1,6 @@
 use swc_atoms::JsWord;
 use swc_ecma_ast::*;
-use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 pub(super) struct UsedNameCollector<'a> {
     pub used_names: &'a mut Vec<JsWord>,

--- a/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
@@ -12,7 +12,7 @@ use swc_ecma_utils::{
     default_constructor, ident::IdentLike, prepend, private_ident, quote_ident, ExprFactory, Id,
 };
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type, Node, Visit, VisitMut, VisitMutWith, VisitWith,
+    as_folder, noop_visit_mut_type, noop_visit_type, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 
 /// https://github.com/tc39/proposal-private-fields-in-in

--- a/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
@@ -250,7 +250,7 @@ impl VisitMut for PrivateInObject {
                 brand_check_names: &mut buf,
                 ignore_class: false,
             };
-            p.right.visit_with(p, &mut v);
+            p.right.visit_with(&mut v);
 
             if buf.is_empty() {
                 p.right.visit_mut_with(self);

--- a/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
@@ -98,7 +98,7 @@ struct ClassData {
     /// Name of private statics.
     statics: Vec<JsWord>,
 
-    consturctor_exprs: Vec<Box<Expr>>,
+    constructor_exprs: Vec<Box<Expr>>,
 
     names_used_for_brand_checks: AHashSet<JsWord>,
 }
@@ -162,7 +162,7 @@ impl VisitMut for PrivateInObject {
 
         n.visit_mut_children_with(self);
 
-        if !self.cls.consturctor_exprs.is_empty() {
+        if !self.cls.constructor_exprs.is_empty() {
             let has_constructor = n
                 .body
                 .iter()
@@ -179,7 +179,7 @@ impl VisitMut for PrivateInObject {
                     ClassMember::Constructor(Constructor {
                         body: Some(body), ..
                     }) => {
-                        for expr in take(&mut self.cls.consturctor_exprs) {
+                        for expr in take(&mut self.cls.constructor_exprs) {
                             body.stmts.push(Stmt::Expr(ExprStmt {
                                 span: DUMMY_SP,
                                 expr,
@@ -348,7 +348,7 @@ impl VisitMut for PrivateInObject {
 
                     if is_method {
                         self.cls
-                            .consturctor_exprs
+                            .constructor_exprs
                             .push(Box::new(Expr::Call(CallExpr {
                                 span: DUMMY_SP,
                                 callee: var_name

--- a/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
@@ -488,7 +488,7 @@ struct ClassAnalyzer<'a> {
 impl Visit for ClassAnalyzer<'_> {
     noop_visit_type!();
 
-    fn visit_bin_expr(&mut self, n: &BinExpr, _: &dyn Node) {
+    fn visit_bin_expr(&mut self, n: &BinExpr) {
         n.visit_children_with(self);
 
         if n.op == op!("in") {
@@ -503,7 +503,7 @@ impl Visit for ClassAnalyzer<'_> {
     }
 
     /// Noop
-    fn visit_class(&mut self, n: &Class, _: &dyn Node) {
+    fn visit_class(&mut self, n: &Class) {
         if self.ignore_class {
             return;
         }

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -216,7 +216,7 @@ where
                             let mut found: Vec<Ident> = vec![];
                             for decl in var.decls {
                                 let mut v = DestructuringFinder { found: &mut found };
-                                decl.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+                                decl.visit_with( &mut v);
 
                                 for ident in found.drain(..) {
                                     scope

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -206,17 +206,14 @@ where
 
                             let mut scope_ref_mut = self.scope.borrow_mut();
                             let scope = &mut *scope_ref_mut;
-                            var.decls.visit_with(
-                                &Invalid { span: DUMMY_SP } as _,
-                                &mut VarCollector {
-                                    to: &mut scope.declared_vars,
-                                },
-                            );
+                            var.decls.visit_with(&mut VarCollector {
+                                to: &mut scope.declared_vars,
+                            });
 
                             let mut found: Vec<Ident> = vec![];
                             for decl in var.decls {
                                 let mut v = DestructuringFinder { found: &mut found };
-                                decl.visit_with( &mut v);
+                                decl.visit_with(&mut v);
 
                                 for ident in found.drain(..) {
                                     scope

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -647,12 +647,9 @@ where
     /// - collects all declared variables for let and var.
     fn fold_var_decl(&mut self, var: VarDecl) -> VarDecl {
         if var.kind != VarDeclKind::Const {
-            var.decls.visit_with(
-                &Invalid { span: DUMMY_SP } as _,
-                &mut VarCollector {
-                    to: &mut self.scope.borrow_mut().declared_vars,
-                },
-            );
+            var.decls.visit_with(&mut VarCollector {
+                to: &mut self.scope.borrow_mut().declared_vars,
+            });
         }
 
         VarDecl {

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -310,17 +310,14 @@ where
                             ))));
 
                             let mut scope = self.scope.borrow_mut();
-                            var.decls.visit_with(
-                                &Invalid { span: DUMMY_SP } as _,
-                                &mut VarCollector {
-                                    to: &mut scope.declared_vars,
-                                },
-                            );
+                            var.decls.visit_with(&mut VarCollector {
+                                to: &mut scope.declared_vars,
+                            });
 
                             let mut found: Vec<Ident> = vec![];
                             for decl in var.decls {
                                 let mut v = DestructuringFinder { found: &mut found };
-                                decl.visit_with( &mut v);
+                                decl.visit_with(&mut v);
 
                                 for ident in found.drain(..) {
                                     scope

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -765,12 +765,9 @@ where
     /// - collects all declared variables for let and var.
     fn fold_var_decl(&mut self, var: VarDecl) -> VarDecl {
         if var.kind != VarDeclKind::Const {
-            var.decls.visit_with(
-                &Invalid { span: DUMMY_SP } as _,
-                &mut VarCollector {
-                    to: &mut self.scope.borrow_mut().declared_vars,
-                },
-            );
+            var.decls.visit_with(&mut VarCollector {
+                to: &mut self.scope.borrow_mut().declared_vars,
+            });
         }
 
         VarDecl {

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -320,7 +320,7 @@ where
                             let mut found: Vec<Ident> = vec![];
                             for decl in var.decls {
                                 let mut v = DestructuringFinder { found: &mut found };
-                                decl.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+                                decl.visit_with( &mut v);
 
                                 for ident in found.drain(..) {
                                     scope

--- a/crates/swc_ecma_transforms_module/src/import_analysis.rs
+++ b/crates/swc_ecma_transforms_module/src/import_analysis.rs
@@ -50,7 +50,7 @@ impl VisitMut for ImportAnalyzer {
 impl Visit for ImportAnalyzer {
     noop_visit_type!();
 
-    fn visit_call_expr(&mut self, n: &CallExpr, _parent: &dyn Node) {
+    fn visit_call_expr(&mut self, n: &CallExpr) {
         n.visit_children_with(self);
         let mut scope = self.scope.borrow_mut();
         match &n.callee {
@@ -76,7 +76,7 @@ impl Visit for ImportAnalyzer {
         }
     }
 
-    fn visit_export_all(&mut self, export: &ExportAll, _parent: &dyn Node) {
+    fn visit_export_all(&mut self, export: &ExportAll) {
         *self
             .scope
             .borrow_mut()
@@ -85,7 +85,7 @@ impl Visit for ImportAnalyzer {
             .or_default() = true
     }
 
-    fn visit_import_decl(&mut self, import: &ImportDecl, _parent: &dyn Node) {
+    fn visit_import_decl(&mut self, import: &ImportDecl) {
         let mut scope = self.scope.borrow_mut();
         if import.specifiers.is_empty() {
             // import 'foo';
@@ -150,7 +150,7 @@ impl Visit for ImportAnalyzer {
         }
     }
 
-    fn visit_named_export(&mut self, export: &NamedExport, _parent: &dyn Node) {
+    fn visit_named_export(&mut self, export: &NamedExport) {
         if export.specifiers.iter().any(|v| match v {
             ExportSpecifier::Namespace(..) => true,
             _ => false,

--- a/crates/swc_ecma_transforms_module/src/import_analysis.rs
+++ b/crates/swc_ecma_transforms_module/src/import_analysis.rs
@@ -1,7 +1,7 @@
 use super::util::Scope;
 use std::{cell::RefCell, rc::Rc};
 use swc_atoms::{js_word, JsWord};
-use swc_common::{collections::AHashSet, DUMMY_SP};
+use swc_common::collections::AHashSet;
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::enable_helper;
 use swc_ecma_visit::{
@@ -25,7 +25,7 @@ impl VisitMut for ImportAnalyzer {
     noop_visit_mut_type!();
 
     fn visit_mut_module(&mut self, module: &mut Module) {
-        self.visit_module(&*module, &Invalid { span: DUMMY_SP } as _);
+        self.visit_module(&*module);
 
         for (_, ty) in self.scope.borrow().import_types.iter() {
             if *ty {

--- a/crates/swc_ecma_transforms_module/src/import_analysis.rs
+++ b/crates/swc_ecma_transforms_module/src/import_analysis.rs
@@ -5,7 +5,7 @@ use swc_common::{collections::AHashSet, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::enable_helper;
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Node, Visit, VisitMut, VisitWith,
+    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitWith,
 };
 
 pub fn import_analyzer(scope: Rc<RefCell<Scope>>) -> impl Fold + VisitMut {

--- a/crates/swc_ecma_transforms_module/src/umd.rs
+++ b/crates/swc_ecma_transforms_module/src/umd.rs
@@ -226,7 +226,7 @@ where
                             let mut found: Vec<Ident> = vec![];
                             for decl in var.decls {
                                 let mut v = DestructuringFinder { found: &mut found };
-                                decl.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+                                decl.visit_with(&mut v);
 
                                 for ident in found.drain(..) {
                                     scope

--- a/crates/swc_ecma_transforms_module/src/umd.rs
+++ b/crates/swc_ecma_transforms_module/src/umd.rs
@@ -216,12 +216,9 @@ where
                             extra_stmts.push(Stmt::Decl(Decl::Var(var.clone().fold_with(self))));
 
                             let scope = &mut *self.scope.borrow_mut();
-                            var.decls.visit_with(
-                                &Invalid { span: DUMMY_SP } as _,
-                                &mut VarCollector {
-                                    to: &mut scope.declared_vars,
-                                },
-                            );
+                            var.decls.visit_with(&mut VarCollector {
+                                to: &mut scope.declared_vars,
+                            });
 
                             let mut found: Vec<Ident> = vec![];
                             for decl in var.decls {
@@ -792,12 +789,9 @@ where
     /// - collects all declared variables for let and var.
     fn fold_var_decl(&mut self, var: VarDecl) -> VarDecl {
         if var.kind != VarDeclKind::Const {
-            var.decls.visit_with(
-                &Invalid { span: DUMMY_SP } as _,
-                &mut VarCollector {
-                    to: &mut self.scope.borrow_mut().declared_vars,
-                },
-            );
+            var.decls.visit_with(&mut VarCollector {
+                to: &mut self.scope.borrow_mut().declared_vars,
+            });
         }
 
         VarDecl {

--- a/crates/swc_ecma_transforms_module/src/util.rs
+++ b/crates/swc_ecma_transforms_module/src/util.rs
@@ -648,8 +648,7 @@ impl Scope {
 
                 let mut found: Vec<(JsWord, Span)> = vec![];
                 let mut v = DestructuringFinder { found: &mut found };
-                expr.left
-                    .visit_with( &mut v);
+                expr.left.visit_with(&mut v);
                 if v.found.is_empty() {
                     return Expr::Assign(AssignExpr {
                         left: expr.left,

--- a/crates/swc_ecma_transforms_module/src/util.rs
+++ b/crates/swc_ecma_transforms_module/src/util.rs
@@ -649,7 +649,7 @@ impl Scope {
                 let mut found: Vec<(JsWord, Span)> = vec![];
                 let mut v = DestructuringFinder { found: &mut found };
                 expr.left
-                    .visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+                    .visit_with( &mut v);
                 if v.found.is_empty() {
                     return Expr::Assign(AssignExpr {
                         left: expr.left,

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -1672,7 +1672,7 @@ fn check_for_stopper(s: &[Stmt], only_conditional: bool) -> bool {
         in_cond: !only_conditional,
         found: false,
     };
-    v.visit_stmts(s, &Invalid { span: DUMMY_SP } as _);
+    v.visit_stmts(s, );
     v.found
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -1626,7 +1626,7 @@ fn check_for_stopper(s: &[Stmt], only_conditional: bool) -> bool {
         fn visit_switch_case(&mut self, node: &SwitchCase) {
             let old = self.in_cond;
             self.in_cond = true;
-            node.cons.visit_with(node as _, self);
+            node.cons.visit_with(self);
             self.in_cond = old;
         }
 
@@ -1661,9 +1661,9 @@ fn check_for_stopper(s: &[Stmt], only_conditional: bool) -> bool {
         fn visit_if_stmt(&mut self, node: &IfStmt) {
             let old = self.in_cond;
             self.in_cond = true;
-            node.cons.visit_with(node as _, self);
+            node.cons.visit_with(self);
             self.in_cond = true;
-            node.alt.visit_with(node as _, self);
+            node.alt.visit_with(self);
             self.in_cond = old;
         }
     }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -12,7 +12,7 @@ use swc_ecma_utils::{
     Hoister, IsEmpty, StmtExt, StmtLike, Value::Known,
 };
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type, Node, Visit, VisitMut, VisitMutWith, VisitWith,
+    as_folder, noop_visit_mut_type, noop_visit_type,  Visit, VisitMut, VisitMutWith, VisitWith,
 };
 
 #[cfg(test)]

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -12,7 +12,7 @@ use swc_ecma_utils::{
     Hoister, IsEmpty, StmtExt, StmtLike, Value::Known,
 };
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type,  Visit, VisitMut, VisitMutWith, VisitWith,
+    as_folder, noop_visit_mut_type, noop_visit_type, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 
 #[cfg(test)]
@@ -1672,7 +1672,7 @@ fn check_for_stopper(s: &[Stmt], only_conditional: bool) -> bool {
         in_cond: !only_conditional,
         found: false,
     };
-    v.visit_stmts(s, );
+    v.visit_stmts(s);
     v.found
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -1623,42 +1623,42 @@ fn check_for_stopper(s: &[Stmt], only_conditional: bool) -> bool {
     impl Visit for Visitor {
         noop_visit_type!();
 
-        fn visit_switch_case(&mut self, node: &SwitchCase, _: &dyn Node) {
+        fn visit_switch_case(&mut self, node: &SwitchCase) {
             let old = self.in_cond;
             self.in_cond = true;
             node.cons.visit_with(node as _, self);
             self.in_cond = old;
         }
 
-        fn visit_break_stmt(&mut self, s: &BreakStmt, _: &dyn Node) {
+        fn visit_break_stmt(&mut self, s: &BreakStmt) {
             if self.in_cond && s.label.is_none() {
                 self.found = true
             }
         }
 
-        fn visit_continue_stmt(&mut self, s: &ContinueStmt, _: &dyn Node) {
+        fn visit_continue_stmt(&mut self, s: &ContinueStmt) {
             if self.in_cond && s.label.is_none() {
                 self.found = true
             }
         }
 
-        fn visit_return_stmt(&mut self, _: &ReturnStmt, _: &dyn Node) {
+        fn visit_return_stmt(&mut self, _: &ReturnStmt) {
             if self.in_cond {
                 self.found = true
             }
         }
 
-        fn visit_throw_stmt(&mut self, _: &ThrowStmt, _: &dyn Node) {
+        fn visit_throw_stmt(&mut self, _: &ThrowStmt) {
             if self.in_cond {
                 self.found = true
             }
         }
 
-        fn visit_class(&mut self, _: &Class, _: &dyn Node) {}
+        fn visit_class(&mut self, _: &Class) {}
 
-        fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
+        fn visit_function(&mut self, _: &Function) {}
 
-        fn visit_if_stmt(&mut self, node: &IfStmt, _: &dyn Node) {
+        fn visit_if_stmt(&mut self, node: &IfStmt) {
             let old = self.in_cond;
             self.in_cond = true;
             node.cons.visit_with(node as _, self);

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -15,8 +15,7 @@ use swc_ecma_utils::{
     collect_decls, ident::IdentLike, ExprExt, Id, IsEmpty, ModuleItemLike, StmtLike, Value,
 };
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Node, Visit, VisitMut, VisitMutWith,
-    VisitWith,
+    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 use tracing::{debug, span, trace, Level};
 
@@ -188,10 +187,10 @@ impl Visit for Analyzer<'_> {
         let old = self.in_var_decl;
 
         self.in_var_decl = true;
-        v.name.visit_with(v, self);
+        v.name.visit_with(self);
 
         self.in_var_decl = false;
-        v.init.visit_with(v, self);
+        v.init.visit_with(self);
 
         self.in_var_decl = old;
     }
@@ -429,7 +428,7 @@ impl VisitMut for TreeShaker {
                 in_var_decl: false,
                 cur_fn_id: Default::default(),
             };
-            m.visit_with(&Invalid { span: DUMMY_SP }, &mut analyzer);
+            m.visit_with(&mut analyzer);
         }
         self.data = data.into();
         trace!("Used = {:?}", self.data.used_names);

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -100,13 +100,13 @@ impl Analyzer<'_> {
 impl Visit for Analyzer<'_> {
     noop_visit_type!();
 
-    fn visit_assign_pat_prop(&mut self, n: &AssignPatProp, _: &dyn Node) {
+    fn visit_assign_pat_prop(&mut self, n: &AssignPatProp) {
         n.visit_children_with(self);
 
         self.add(n.key.to_id(), true);
     }
 
-    fn visit_class_decl(&mut self, n: &ClassDecl, _: &dyn Node) {
+    fn visit_class_decl(&mut self, n: &ClassDecl) {
         n.visit_children_with(self);
 
         if !n.class.decorators.is_empty() {
@@ -114,7 +114,7 @@ impl Visit for Analyzer<'_> {
         }
     }
 
-    fn visit_class_expr(&mut self, n: &ClassExpr, _: &dyn Node) {
+    fn visit_class_expr(&mut self, n: &ClassExpr) {
         n.visit_children_with(self);
 
         if !n.class.decorators.is_empty() {
@@ -124,11 +124,11 @@ impl Visit for Analyzer<'_> {
         }
     }
 
-    fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier, _: &dyn Node) {
+    fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier) {
         self.add(n.orig.to_id(), false);
     }
 
-    fn visit_expr(&mut self, e: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, e: &Expr) {
         e.visit_children_with(self);
 
         match e {
@@ -139,7 +139,7 @@ impl Visit for Analyzer<'_> {
         }
     }
 
-    fn visit_fn_decl(&mut self, n: &FnDecl, _: &dyn Node) {
+    fn visit_fn_decl(&mut self, n: &FnDecl) {
         let old = self.cur_fn_id.take();
         self.cur_fn_id = Some(n.ident.to_id());
         n.visit_children_with(self);
@@ -150,7 +150,7 @@ impl Visit for Analyzer<'_> {
         }
     }
 
-    fn visit_fn_expr(&mut self, n: &FnExpr, _: &dyn Node) {
+    fn visit_fn_expr(&mut self, n: &FnExpr) {
         n.visit_children_with(self);
 
         if !n.function.decorators.is_empty() {
@@ -160,7 +160,7 @@ impl Visit for Analyzer<'_> {
         }
     }
 
-    fn visit_pat(&mut self, p: &Pat, _: &dyn Node) {
+    fn visit_pat(&mut self, p: &Pat) {
         p.visit_children_with(self);
 
         if !self.in_var_decl {
@@ -173,7 +173,7 @@ impl Visit for Analyzer<'_> {
         }
     }
 
-    fn visit_prop(&mut self, p: &Prop, _: &dyn Node) {
+    fn visit_prop(&mut self, p: &Prop) {
         p.visit_children_with(self);
 
         match p {
@@ -184,7 +184,7 @@ impl Visit for Analyzer<'_> {
         }
     }
 
-    fn visit_var_declarator(&mut self, v: &VarDeclarator, _: &dyn Node) {
+    fn visit_var_declarator(&mut self, v: &VarDeclarator) {
         let old = self.in_var_decl;
 
         self.in_var_decl = true;

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
@@ -9,7 +9,7 @@ use swc_ecma_ast::*;
 use swc_ecma_transforms_base::{pass::RepeatedJsPass, scope::IdentType};
 use swc_ecma_utils::{contains_this_expr, find_ids, ident::IdentLike, undefined, Id};
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type, Node, Visit, VisitMut, VisitMutWith, VisitWith,
+    as_folder, noop_visit_mut_type, noop_visit_type, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 
 mod scope;

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
@@ -3,7 +3,6 @@ use std::borrow::Cow;
 use swc_common::{
     pass::{CompilerPass, Repeated},
     util::take::Take,
-    DUMMY_SP,
 };
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::{pass::RepeatedJsPass, scope::IdentType};
@@ -422,28 +421,19 @@ impl VisitMut for Inlining<'_> {
         node.init.visit_mut_with(self);
 
         {
-            node.init.visit_with(
-                &Invalid { span: DUMMY_SP } as _,
-                &mut IdentListVisitor {
-                    scope: &mut self.scope,
-                },
-            );
+            node.init.visit_with(&mut IdentListVisitor {
+                scope: &mut self.scope,
+            });
         }
         {
-            node.test.visit_with(
-                &Invalid { span: DUMMY_SP } as _,
-                &mut IdentListVisitor {
-                    scope: &mut self.scope,
-                },
-            );
+            node.test.visit_with(&mut IdentListVisitor {
+                scope: &mut self.scope,
+            });
         }
         {
-            node.update.visit_with(
-                &Invalid { span: DUMMY_SP } as _,
-                &mut IdentListVisitor {
-                    scope: &mut self.scope,
-                },
-            );
+            node.update.visit_with(&mut IdentListVisitor {
+                scope: &mut self.scope,
+            });
         }
 
         node.test.visit_mut_with(self);
@@ -523,12 +513,9 @@ impl VisitMut for Inlining<'_> {
     }
 
     fn visit_mut_try_stmt(&mut self, node: &mut TryStmt) {
-        node.block.visit_with(
-            &Invalid { span: DUMMY_SP } as _,
-            &mut IdentListVisitor {
-                scope: &mut self.scope,
-            },
-        );
+        node.block.visit_with(&mut IdentListVisitor {
+            scope: &mut self.scope,
+        });
 
         node.handler.visit_mut_with(self)
     }
@@ -555,7 +542,7 @@ impl VisitMut for Inlining<'_> {
             scope: &mut self.scope,
         };
 
-        node.arg.visit_with(&*node as _, &mut v);
+        node.arg.visit_with(&mut v);
     }
 
     fn visit_mut_var_decl(&mut self, decl: &mut VarDecl) {
@@ -714,12 +701,9 @@ impl VisitMut for Inlining<'_> {
 
     fn visit_mut_while_stmt(&mut self, node: &mut WhileStmt) {
         {
-            node.test.visit_with(
-                &Invalid { span: DUMMY_SP } as _,
-                &mut IdentListVisitor {
-                    scope: &mut self.scope,
-                },
-            );
+            node.test.visit_with(&mut IdentListVisitor {
+                scope: &mut self.scope,
+            });
         }
 
         node.test.visit_mut_with(self);

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
@@ -129,8 +129,8 @@ impl VisitMut for Inlining<'_> {
                             scope: &mut self.scope,
                         };
 
-                        left.visit_with( &mut v);
-                        e.right.visit_with( &mut v);
+                        left.visit_with(&mut v);
+                        e.right.visit_with(&mut v);
                     }
 
                     _ => {}
@@ -149,8 +149,8 @@ impl VisitMut for Inlining<'_> {
                     scope: &mut self.scope,
                 };
 
-                e.left.visit_with( &mut v);
-                e.right.visit_with( &mut v)
+                e.left.visit_with(&mut v);
+                e.right.visit_with(&mut v)
             }
         }
 
@@ -555,8 +555,7 @@ impl VisitMut for Inlining<'_> {
                     scope: &mut self.scope,
                 };
 
-                node.arg
-                    .visit_with( &mut v);
+                node.arg.visit_with(&mut v);
                 return;
             }
 
@@ -791,10 +790,10 @@ impl Visit for IdentListVisitor<'_, '_> {
     }
 
     fn visit_member_expr(&mut self, node: &MemberExpr) {
-        node.obj.visit_with(node as _, self);
+        node.obj.visit_with(self);
 
         if node.computed {
-            node.prop.visit_with(node as _, self);
+            node.prop.visit_with(self);
         }
     }
 }
@@ -812,10 +811,10 @@ impl Visit for WriteVisitor<'_, '_> {
     }
 
     fn visit_member_expr(&mut self, node: &MemberExpr) {
-        node.obj.visit_with(node as _, self);
+        node.obj.visit_with(self);
 
         if node.computed {
-            node.prop.visit_with(node as _, self);
+            node.prop.visit_with(self);
         }
     }
 }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
@@ -232,12 +232,9 @@ impl VisitMut for Inlining<'_> {
 
     fn visit_mut_do_while_stmt(&mut self, node: &mut DoWhileStmt) {
         {
-            node.test.visit_with(
-                &Invalid { span: DUMMY_SP } as _,
-                &mut IdentListVisitor {
-                    scope: &mut self.scope,
-                },
-            );
+            node.test.visit_with(&mut IdentListVisitor {
+                scope: &mut self.scope,
+            });
         }
 
         node.test.visit_mut_with(self);
@@ -387,21 +384,15 @@ impl VisitMut for Inlining<'_> {
         node.left.visit_mut_with(self);
 
         {
-            node.left.visit_with(
-                &Invalid { span: DUMMY_SP } as _,
-                &mut IdentListVisitor {
-                    scope: &mut self.scope,
-                },
-            );
+            node.left.visit_with(&mut IdentListVisitor {
+                scope: &mut self.scope,
+            });
         }
 
         {
-            node.right.visit_with(
-                &Invalid { span: DUMMY_SP } as _,
-                &mut IdentListVisitor {
-                    scope: &mut self.scope,
-                },
-            );
+            node.right.visit_with(&mut IdentListVisitor {
+                scope: &mut self.scope,
+            });
         }
 
         node.right.visit_mut_with(self);
@@ -413,20 +404,14 @@ impl VisitMut for Inlining<'_> {
         node.left.visit_mut_with(self);
 
         {
-            node.left.visit_with(
-                &Invalid { span: DUMMY_SP } as _,
-                &mut IdentListVisitor {
-                    scope: &mut self.scope,
-                },
-            );
+            node.left.visit_with(&mut IdentListVisitor {
+                scope: &mut self.scope,
+            });
         }
         {
-            node.right.visit_with(
-                &Invalid { span: DUMMY_SP } as _,
-                &mut IdentListVisitor {
-                    scope: &mut self.scope,
-                },
-            );
+            node.right.visit_with(&mut IdentListVisitor {
+                scope: &mut self.scope,
+            });
         }
 
         node.right.visit_mut_with(self);

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
@@ -129,8 +129,8 @@ impl VisitMut for Inlining<'_> {
                             scope: &mut self.scope,
                         };
 
-                        left.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
-                        e.right.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+                        left.visit_with( &mut v);
+                        e.right.visit_with( &mut v);
                     }
 
                     _ => {}
@@ -149,8 +149,8 @@ impl VisitMut for Inlining<'_> {
                     scope: &mut self.scope,
                 };
 
-                e.left.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
-                e.right.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v)
+                e.left.visit_with( &mut v);
+                e.right.visit_with( &mut v)
             }
         }
 
@@ -556,7 +556,7 @@ impl VisitMut for Inlining<'_> {
                 };
 
                 node.arg
-                    .visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+                    .visit_with( &mut v);
                 return;
             }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
@@ -786,11 +786,11 @@ struct IdentListVisitor<'a, 'b> {
 impl Visit for IdentListVisitor<'_, '_> {
     noop_visit_type!();
 
-    fn visit_ident(&mut self, node: &Ident, _: &dyn Node) {
+    fn visit_ident(&mut self, node: &Ident) {
         self.scope.add_write(&node.to_id(), true);
     }
 
-    fn visit_member_expr(&mut self, node: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, node: &MemberExpr) {
         node.obj.visit_with(node as _, self);
 
         if node.computed {
@@ -807,11 +807,11 @@ struct WriteVisitor<'a, 'b> {
 impl Visit for WriteVisitor<'_, '_> {
     noop_visit_type!();
 
-    fn visit_ident(&mut self, node: &Ident, _: &dyn Node) {
+    fn visit_ident(&mut self, node: &Ident) {
         self.scope.add_write(&node.to_id(), false);
     }
 
-    fn visit_member_expr(&mut self, node: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, node: &MemberExpr) {
         node.obj.visit_with(node as _, self);
 
         if node.computed {

--- a/crates/swc_ecma_transforms_proposal/src/decorators.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators.rs
@@ -658,6 +658,6 @@ where
     N: VisitWith<DecoratorFinder>,
 {
     let mut v = DecoratorFinder { found: false };
-    node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+    node.visit_with( &mut v);
     v.found
 }

--- a/crates/swc_ecma_transforms_proposal/src/decorators.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators.rs
@@ -648,7 +648,7 @@ struct DecoratorFinder {
     found: bool,
 }
 impl Visit for DecoratorFinder {
-    fn visit_decorator(&mut self, _: &Decorator, _: &dyn Node) {
+    fn visit_decorator(&mut self, _: &Decorator) {
         self.found = true
     }
 }

--- a/crates/swc_ecma_transforms_proposal/src/decorators.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators.rs
@@ -9,7 +9,7 @@ use swc_ecma_utils::{
     alias_ident_for, constructor::inject_after_super, default_constructor, prepend, private_ident,
     prop_name_to_expr_value, quote_ident, quote_str, undefined, ExprFactory, IdentExt,
 };
-use swc_ecma_visit::{noop_fold_type, Fold, FoldWith, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_fold_type, Fold, FoldWith, Visit, VisitWith};
 
 mod legacy;
 
@@ -658,6 +658,6 @@ where
     N: VisitWith<DecoratorFinder>,
 {
     let mut v = DecoratorFinder { found: false };
-    node.visit_with( &mut v);
+    node.visit_with(&mut v);
     v.found
 }

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy.rs
@@ -41,7 +41,7 @@ pub(super) fn new(metadata: bool) -> Legacy {
 }
 
 impl Visit for Legacy {
-    fn visit_ts_enum_decl(&mut self, e: &TsEnumDecl, _: &dyn Node) {
+    fn visit_ts_enum_decl(&mut self, e: &TsEnumDecl) {
         let enum_kind = e
             .members
             .iter()

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy.rs
@@ -10,7 +10,7 @@ use swc_ecma_utils::{
     prop_name_to_expr_value, quote_ident, replace_ident, undefined, ExprFactory, Id,
     ModuleItemLike, StmtLike,
 };
-use swc_ecma_visit::{noop_fold_type, Fold, FoldWith, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_fold_type, Fold, FoldWith, Visit, VisitWith};
 
 mod metadata;
 
@@ -133,7 +133,7 @@ impl Fold for Legacy {
     fn fold_module(&mut self, m: Module) -> Module {
         // Collect required information.
         // For example, value type of enum affects codegen
-        m.visit_with(&Invalid { span: DUMMY_SP }, self);
+        m.visit_with(self);
 
         let mut m = m.fold_children_with(self);
 

--- a/crates/swc_ecma_transforms_react/src/refresh/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/mod.rs
@@ -71,10 +71,10 @@ fn hook_to_handle_map(hook_fn: Vec<FnWithHook>) -> (AHashMap<Ident, FnWithHook>,
     }
     (has_ident, ignore)
 }
-// funtction that use hooks
+// function that use hooks
 struct FnWithHook {
     binding: Option<Ident>, // ident of function
-    handle: Ident,          // varaible to register
+    handle: Ident,          // variable to register
     hook: Vec<Hook>,
 }
 

--- a/crates/swc_ecma_transforms_react/src/refresh/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/mod.rs
@@ -21,7 +21,7 @@ use swc_common::{
 };
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ident::IdentLike, private_ident, quote_ident, quote_str, Id};
-use swc_ecma_visit::{Fold, FoldWith, Node, Visit};
+use swc_ecma_visit::{Fold, FoldWith, Visit};
 
 pub mod options;
 use options::RefreshOptions;
@@ -754,7 +754,7 @@ impl<C: Comments> Fold for Refresh<C> {
             return module_items;
         }
 
-        self.visit_module_items(&module_items, &Invalid { span: DUMMY_SP } as _);
+        self.visit_module_items(&module_items);
 
         for item in &module_items {
             item.collect_ident(&mut self.scope_binding);

--- a/crates/swc_ecma_transforms_react/src/refresh/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/mod.rs
@@ -553,7 +553,7 @@ impl<C> Visit for Refresh<C>
 where
     C: Comments,
 {
-    fn visit_span(&mut self, n: &Span, _: &dyn Node) {
+    fn visit_span(&mut self, n: &Span) {
         if self.should_reset {
             return;
         }

--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -1418,13 +1418,13 @@ where
 {
     fn visit_assign_pat_prop(&mut self, n: &AssignPatProp) {
         if !self.in_var_pat {
-            n.key.visit_with(n, self);
+            n.key.visit_with( self);
         }
-        n.value.visit_with(n, self);
+        n.value.visit_with( self);
     }
 
     fn visit_assign_prop(&mut self, n: &AssignProp) {
-        n.value.visit_with(n, self);
+        n.value.visit_with( self);
     }
 
     fn visit_binding_ident(&mut self, n: &BindingIdent) {
@@ -1518,9 +1518,9 @@ where
     }
 
     fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with(n, self);
+        n.obj.visit_with( self);
         if n.computed {
-            n.prop.visit_with(n, self);
+            n.prop.visit_with( self);
         }
     }
 
@@ -1542,7 +1542,7 @@ where
 
     fn visit_prop_name(&mut self, n: &PropName) {
         match n {
-            PropName::Computed(e) => e.visit_with(n, self),
+            PropName::Computed(e) => e.visit_with( self),
             _ => {}
         }
     }

--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -1525,7 +1525,7 @@ where
         let old = self.non_top_level;
         self.non_top_level = false;
         n.iter().for_each(|n| {
-            n.visit_with(&Invalid { span: DUMMY_SP }, self);
+            n.visit_with( self);
         });
         self.non_top_level = old;
     }
@@ -1548,7 +1548,7 @@ where
         let old = self.non_top_level;
         self.non_top_level = true;
         n.iter()
-            .for_each(|n| n.visit_with(&Invalid { span: DUMMY_SP }, self));
+            .for_each(|n| n.visit_with( self));
         self.non_top_level = old;
     }
 
@@ -2039,7 +2039,7 @@ where
 
     fn visit_mut_module_items(&mut self, items: &mut Vec<ModuleItem>) {
         self.visit_mut_stmt_like(items);
-        items.visit_with(&Invalid { span: DUMMY_SP }, self);
+        items.visit_with( self);
 
         let mut stmts = Vec::with_capacity(items.len());
         for mut item in take(items) {

--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -15,7 +15,7 @@ use swc_ecma_utils::{
     private_ident, quote_ident, replace_ident, var::VarCollector, ExprFactory, Id, ModuleItemLike,
     StmtLike,
 };
-use swc_ecma_visit::{as_folder, Fold, Node, Visit, VisitMut, VisitMutWith, VisitWith};
+use swc_ecma_visit::{as_folder, Fold, Visit, VisitMut, VisitMutWith, VisitWith};
 
 /// Value does not contain TsLit::Bool
 type EnumValues = AHashMap<Id, TsLit>;
@@ -316,10 +316,7 @@ where
 
             Decl::Var(ref var) => {
                 let mut names = vec![];
-                var.decls.visit_with(
-                    &Invalid { span: DUMMY_SP } as _,
-                    &mut VarCollector { to: &mut names },
-                );
+                var.decls.visit_with(&mut VarCollector { to: &mut names });
 
                 for name in names {
                     self.store(name.0.clone(), name.1, true);
@@ -523,7 +520,7 @@ where
                                     // If a computed method name is encountered, dump the other key
                                     // assignments before it in a sequence expression. Note how this
                                     // always preserves the order of key computations. This
-                                    // behaviour is taken from TSC output.
+                                    // behavior is taken from TSC output.
                                     key_computations.push(name.expr.take());
                                     name.expr = Box::new(Expr::Seq(SeqExpr {
                                         span: name.span,
@@ -1418,13 +1415,13 @@ where
 {
     fn visit_assign_pat_prop(&mut self, n: &AssignPatProp) {
         if !self.in_var_pat {
-            n.key.visit_with( self);
+            n.key.visit_with(self);
         }
-        n.value.visit_with( self);
+        n.value.visit_with(self);
     }
 
     fn visit_assign_prop(&mut self, n: &AssignProp) {
-        n.value.visit_with( self);
+        n.value.visit_with(self);
     }
 
     fn visit_binding_ident(&mut self, n: &BindingIdent) {
@@ -1444,33 +1441,33 @@ where
         match n {
             Decl::Class(class) => {
                 self.decl_names.insert(class.ident.to_id());
-                class.class.visit_with(class, self);
+                class.class.visit_with(self);
             }
             Decl::Fn(f) => {
                 self.decl_names.insert(f.ident.to_id());
-                f.function.visit_with(f, self)
+                f.function.visit_with(self)
             }
             Decl::Var(ref var) => {
                 for decl in &var.decls {
                     self.in_var_pat = true;
-                    decl.name.visit_with(decl, self);
+                    decl.name.visit_with(self);
                     self.in_var_pat = false;
-                    decl.init.visit_with(decl, self);
+                    decl.init.visit_with(self);
                 }
             }
             Decl::TsEnum(e) => {
-                e.members.visit_with(e, self);
+                e.members.visit_with(self);
             }
             Decl::TsInterface(interface) => {
-                interface.extends.visit_with(interface, self);
-                interface.body.visit_with(interface, self);
+                interface.extends.visit_with(self);
+                interface.body.visit_with(self);
             }
             Decl::TsModule(module) => {
-                module.body.visit_with(module, self);
+                module.body.visit_with(self);
             }
             Decl::TsTypeAlias(alias) => {
-                alias.type_params.visit_with(alias, self);
-                alias.type_ann.visit_with(alias, self);
+                alias.type_params.visit_with(self);
+                alias.type_ann.visit_with(self);
             }
         }
         self.non_top_level = old;
@@ -1518,9 +1515,9 @@ where
     }
 
     fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with( self);
+        n.obj.visit_with(self);
         if n.computed {
-            n.prop.visit_with( self);
+            n.prop.visit_with(self);
         }
     }
 
@@ -1542,7 +1539,7 @@ where
 
     fn visit_prop_name(&mut self, n: &PropName) {
         match n {
-            PropName::Computed(e) => e.visit_with( self),
+            PropName::Computed(e) => e.visit_with(self),
             _ => {}
         }
     }

--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -1525,7 +1525,7 @@ where
         let old = self.non_top_level;
         self.non_top_level = false;
         n.iter().for_each(|n| {
-            n.visit_with( self);
+            n.visit_with(self);
         });
         self.non_top_level = old;
     }
@@ -1547,8 +1547,7 @@ where
     fn visit_stmts(&mut self, n: &[Stmt]) {
         let old = self.non_top_level;
         self.non_top_level = true;
-        n.iter()
-            .for_each(|n| n.visit_with( self));
+        n.iter().for_each(|n| n.visit_with(self));
         self.non_top_level = old;
     }
 
@@ -1564,7 +1563,7 @@ where
                     }
                 }
             }
-            TsEntityName::TsQualifiedName(ref q) => q.left.visit_with(&*q, self),
+            TsEntityName::TsQualifiedName(ref q) => q.left.visit_with(self),
         }
     }
 
@@ -2039,7 +2038,7 @@ where
 
     fn visit_mut_module_items(&mut self, items: &mut Vec<ModuleItem>) {
         self.visit_mut_stmt_like(items);
-        items.visit_with( self);
+        items.visit_with(self);
 
         let mut stmts = Vec::with_capacity(items.len());
         for mut item in take(items) {

--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -1416,24 +1416,24 @@ impl<C> Visit for Strip<C>
 where
     C: Comments,
 {
-    fn visit_assign_pat_prop(&mut self, n: &AssignPatProp, _: &dyn Node) {
+    fn visit_assign_pat_prop(&mut self, n: &AssignPatProp) {
         if !self.in_var_pat {
             n.key.visit_with(n, self);
         }
         n.value.visit_with(n, self);
     }
 
-    fn visit_assign_prop(&mut self, n: &AssignProp, _: &dyn Node) {
+    fn visit_assign_prop(&mut self, n: &AssignProp) {
         n.value.visit_with(n, self);
     }
 
-    fn visit_binding_ident(&mut self, n: &BindingIdent, _: &dyn Node) {
+    fn visit_binding_ident(&mut self, n: &BindingIdent) {
         if !self.in_var_pat {
             n.visit_children_with(self)
         }
     }
 
-    fn visit_decl(&mut self, n: &Decl, _: &dyn Node) {
+    fn visit_decl(&mut self, n: &Decl) {
         self.handle_decl(n);
 
         let old = self.non_top_level;
@@ -1476,7 +1476,7 @@ where
         self.non_top_level = old;
     }
 
-    fn visit_ident(&mut self, n: &Ident, _: &dyn Node) {
+    fn visit_ident(&mut self, n: &Ident) {
         let entry = self.scope.referenced_idents.entry(n.to_id()).or_default();
         if self.is_type_only_export {
             entry.has_type = true;
@@ -1496,7 +1496,7 @@ where
         n.visit_children_with(self);
     }
 
-    fn visit_import_decl(&mut self, n: &ImportDecl, _: &dyn Node) {
+    fn visit_import_decl(&mut self, n: &ImportDecl) {
         macro_rules! store {
             ($i:expr) => {{
                 self.scope
@@ -1517,14 +1517,14 @@ where
         }
     }
 
-    fn visit_member_expr(&mut self, n: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, n: &MemberExpr) {
         n.obj.visit_with(n, self);
         if n.computed {
             n.prop.visit_with(n, self);
         }
     }
 
-    fn visit_module_items(&mut self, n: &[ModuleItem], _: &dyn Node) {
+    fn visit_module_items(&mut self, n: &[ModuleItem]) {
         let old = self.non_top_level;
         self.non_top_level = false;
         n.iter().for_each(|n| {
@@ -1533,21 +1533,21 @@ where
         self.non_top_level = old;
     }
 
-    fn visit_named_export(&mut self, export: &NamedExport, _: &dyn Node) {
+    fn visit_named_export(&mut self, export: &NamedExport) {
         let old = self.is_type_only_export;
         self.is_type_only_export = export.type_only;
         export.visit_children_with(self);
         self.is_type_only_export = old;
     }
 
-    fn visit_prop_name(&mut self, n: &PropName, _: &dyn Node) {
+    fn visit_prop_name(&mut self, n: &PropName) {
         match n {
             PropName::Computed(e) => e.visit_with(n, self),
             _ => {}
         }
     }
 
-    fn visit_stmts(&mut self, n: &[Stmt], _: &dyn Node) {
+    fn visit_stmts(&mut self, n: &[Stmt]) {
         let old = self.non_top_level;
         self.non_top_level = true;
         n.iter()
@@ -1555,7 +1555,7 @@ where
         self.non_top_level = old;
     }
 
-    fn visit_ts_entity_name(&mut self, name: &TsEntityName, _: &dyn Node) {
+    fn visit_ts_entity_name(&mut self, name: &TsEntityName) {
         match *name {
             TsEntityName::Ident(ref i) => {
                 let entry = self.scope.referenced_idents.entry(i.to_id()).or_default();
@@ -1571,7 +1571,7 @@ where
         }
     }
 
-    fn visit_ts_import_equals_decl(&mut self, n: &TsImportEqualsDecl, _: &dyn Node) {
+    fn visit_ts_import_equals_decl(&mut self, n: &TsImportEqualsDecl) {
         match &n.module_ref {
             TsModuleRef::TsEntityName(name) => {
                 let entry = self

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -49,35 +49,35 @@ impl Visit for ThisVisitor {
     noop_visit_type!();
 
     /// Don't recurse into constructor
-    fn visit_constructor(&mut self, _: &Constructor, _: &dyn Node) {}
+    fn visit_constructor(&mut self, _: &Constructor) {}
 
     /// Don't recurse into fn
-    fn visit_fn_decl(&mut self, _: &FnDecl, _: &dyn Node) {}
+    fn visit_fn_decl(&mut self, _: &FnDecl) {}
 
     /// Don't recurse into fn
-    fn visit_fn_expr(&mut self, _: &FnExpr, _: &dyn Node) {}
+    fn visit_fn_expr(&mut self, _: &FnExpr) {}
 
     /// Don't recurse into fn
-    fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
+    fn visit_function(&mut self, _: &Function) {}
 
     /// Don't recurse into fn
-    fn visit_getter_prop(&mut self, n: &GetterProp, _: &dyn Node) {
+    fn visit_getter_prop(&mut self, n: &GetterProp) {
         n.key.visit_with(n, self);
     }
 
     /// Don't recurse into fn
-    fn visit_method_prop(&mut self, n: &MethodProp, _: &dyn Node) {
+    fn visit_method_prop(&mut self, n: &MethodProp) {
         n.key.visit_with(n, self);
         n.function.visit_with(n, self);
     }
 
     /// Don't recurse into fn
-    fn visit_setter_prop(&mut self, n: &SetterProp, _: &dyn Node) {
+    fn visit_setter_prop(&mut self, n: &SetterProp) {
         n.key.visit_with(n, self);
         n.param.visit_with(n, self);
     }
 
-    fn visit_this_expr(&mut self, _: &ThisExpr, _: &dyn Node) {
+    fn visit_this_expr(&mut self, _: &ThisExpr) {
         self.found = true;
     }
 }
@@ -117,7 +117,7 @@ pub struct IdentFinder<'a> {
 impl Visit for IdentFinder<'_> {
     noop_visit_type!();
 
-    fn visit_expr(&mut self, e: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, e: &Expr) {
         e.visit_children_with(self);
 
         match *e {
@@ -148,9 +148,9 @@ impl Visit for ArgumentsFinder {
     noop_visit_type!();
 
     /// Don't recurse into constructor
-    fn visit_constructor(&mut self, _: &Constructor, _: &dyn Node) {}
+    fn visit_constructor(&mut self, _: &Constructor) {}
 
-    fn visit_expr(&mut self, e: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, e: &Expr) {
         e.visit_children_with(self);
 
         match *e {
@@ -165,10 +165,10 @@ impl Visit for ArgumentsFinder {
     }
 
     /// Don't recurse into fn
-    fn visit_function(&mut self, _: &Function, _: &dyn Node) {}
+    fn visit_function(&mut self, _: &Function) {}
 
     /// Don't recurse into member expression prop if not computed
-    fn visit_member_expr(&mut self, m: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, m: &MemberExpr) {
         m.obj.visit_with(m, self);
         match &*m.prop {
             Expr::Ident(_) if !m.computed => {}
@@ -176,7 +176,7 @@ impl Visit for ArgumentsFinder {
         }
     }
 
-    fn visit_prop(&mut self, n: &Prop, _: &dyn Node) {
+    fn visit_prop(&mut self, n: &Prop) {
         n.visit_children_with(self);
 
         match n {
@@ -413,17 +413,17 @@ pub struct Hoister {
 impl Visit for Hoister {
     noop_visit_type!();
 
-    fn visit_assign_pat_prop(&mut self, node: &AssignPatProp, _: &dyn Node) {
+    fn visit_assign_pat_prop(&mut self, node: &AssignPatProp) {
         node.value.visit_with(node, self);
 
         self.vars.push(node.key.clone());
     }
 
-    fn visit_assign_expr(&mut self, node: &AssignExpr, _: &dyn Node) {
+    fn visit_assign_expr(&mut self, node: &AssignExpr) {
         node.right.visit_children_with(self);
     }
 
-    fn visit_pat(&mut self, p: &Pat, _: &dyn Node) {
+    fn visit_pat(&mut self, p: &Pat) {
         p.visit_children_with(self);
 
         match *p {
@@ -432,7 +432,7 @@ impl Visit for Hoister {
         }
     }
 
-    fn visit_var_decl(&mut self, v: &VarDecl, _: &dyn Node) {
+    fn visit_var_decl(&mut self, v: &VarDecl) {
         if v.kind != VarDeclKind::Var {
             return;
         }
@@ -1384,7 +1384,7 @@ pub struct RestPatVisitor {
 impl Visit for RestPatVisitor {
     noop_visit_type!();
 
-    fn visit_rest_pat(&mut self, _: &RestPat, _: &dyn Node) {
+    fn visit_rest_pat(&mut self, _: &RestPat) {
         self.found = true;
     }
 }
@@ -1421,7 +1421,7 @@ pub struct LiteralVisitor {
 impl Visit for LiteralVisitor {
     noop_visit_type!();
 
-    fn visit_array_lit(&mut self, e: &ArrayLit, _: &dyn Node) {
+    fn visit_array_lit(&mut self, e: &ArrayLit) {
         if !self.is_lit {
             return;
         }
@@ -1465,7 +1465,7 @@ impl Visit for LiteralVisitor {
         self.is_lit = false;
     }
 
-    fn visit_expr(&mut self, e: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, e: &Expr) {
         if !self.is_lit {
             return;
         }
@@ -1517,7 +1517,7 @@ impl Visit for LiteralVisitor {
         self.is_lit = false
     }
 
-    fn visit_number(&mut self, node: &Number, _: &dyn Node) {
+    fn visit_number(&mut self, node: &Number) {
         if !self.allow_non_json_value && node.value.is_infinite() {
             self.is_lit = false;
         }
@@ -1531,7 +1531,7 @@ impl Visit for LiteralVisitor {
         self.is_lit = false
     }
 
-    fn visit_prop(&mut self, p: &Prop, _: &dyn Node) {
+    fn visit_prop(&mut self, p: &Prop) {
         if !self.is_lit {
             return;
         }
@@ -1546,7 +1546,7 @@ impl Visit for LiteralVisitor {
         }
     }
 
-    fn visit_prop_name(&mut self, node: &PropName, _: &dyn Node) {
+    fn visit_prop_name(&mut self, node: &PropName) {
         if !self.is_lit {
             return;
         }
@@ -1847,14 +1847,14 @@ impl<'a, I: IdentLike> Visit for DestructuringFinder<'a, I> {
     noop_visit_type!();
 
     /// No-op (we don't care about expressions)
-    fn visit_expr(&mut self, _: &Expr, _: &dyn Node) {}
+    fn visit_expr(&mut self, _: &Expr) {}
 
-    fn visit_ident(&mut self, i: &Ident, _: &dyn Node) {
+    fn visit_ident(&mut self, i: &Ident) {
         self.found.push(I::from_ident(i));
     }
 
     /// No-op (we don't care about expressions)
-    fn visit_prop_name(&mut self, _: &PropName, _: &dyn Node) {}
+    fn visit_prop_name(&mut self, _: &PropName) {}
 }
 
 pub fn is_valid_ident(s: &JsWord) -> bool {
@@ -1897,13 +1897,13 @@ pub struct UsageFinder<'a> {
 impl<'a> Visit for UsageFinder<'a> {
     noop_visit_type!();
 
-    fn visit_ident(&mut self, i: &Ident, _: &dyn Node) {
+    fn visit_ident(&mut self, i: &Ident) {
         if i.span.ctxt == self.ident.span.ctxt && i.sym == self.ident.sym {
             self.found = true;
         }
     }
 
-    fn visit_member_expr(&mut self, e: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, e: &MemberExpr) {
         e.obj.visit_with(e as _, self);
 
         if e.computed {
@@ -2175,7 +2175,7 @@ where
 {
     noop_visit_type!();
 
-    fn visit_assign_pat_prop(&mut self, node: &AssignPatProp, _: &dyn Node) {
+    fn visit_assign_pat_prop(&mut self, node: &AssignPatProp) {
         node.value.visit_with(node, self);
 
         if self.is_pat_decl {
@@ -2183,45 +2183,45 @@ where
         }
     }
 
-    fn visit_class_decl(&mut self, node: &ClassDecl, _: &dyn Node) {
+    fn visit_class_decl(&mut self, node: &ClassDecl) {
         node.visit_children_with(self);
 
         self.add(&node.ident);
     }
 
-    fn visit_expr(&mut self, node: &Expr, _: &dyn Node) {
+    fn visit_expr(&mut self, node: &Expr) {
         let old = self.is_pat_decl;
         self.is_pat_decl = false;
         node.visit_children_with(self);
         self.is_pat_decl = old;
     }
 
-    fn visit_fn_decl(&mut self, node: &FnDecl, _: &dyn Node) {
+    fn visit_fn_decl(&mut self, node: &FnDecl) {
         node.visit_children_with(self);
 
         self.add(&node.ident);
     }
 
-    fn visit_import_default_specifier(&mut self, node: &ImportDefaultSpecifier, _: &dyn Node) {
+    fn visit_import_default_specifier(&mut self, node: &ImportDefaultSpecifier) {
         self.add(&node.local);
     }
 
-    fn visit_import_named_specifier(&mut self, node: &ImportNamedSpecifier, _: &dyn Node) {
+    fn visit_import_named_specifier(&mut self, node: &ImportNamedSpecifier) {
         self.add(&node.local);
     }
 
-    fn visit_import_star_as_specifier(&mut self, node: &ImportStarAsSpecifier, _: &dyn Node) {
+    fn visit_import_star_as_specifier(&mut self, node: &ImportStarAsSpecifier) {
         self.add(&node.local);
     }
 
-    fn visit_member_expr(&mut self, n: &MemberExpr, _: &dyn Node) {
+    fn visit_member_expr(&mut self, n: &MemberExpr) {
         n.obj.visit_with(n, self);
         if n.computed {
             n.prop.visit_with(n, self);
         }
     }
 
-    fn visit_module_items(&mut self, nodes: &[ModuleItem], _: &dyn Node) {
+    fn visit_module_items(&mut self, nodes: &[ModuleItem]) {
         #[cfg(feature = "concurrent")]
         if nodes.len() > 16 {
             use rayon::prelude::*;
@@ -2249,14 +2249,14 @@ where
         }
     }
 
-    fn visit_param(&mut self, node: &Param, _: &dyn Node) {
+    fn visit_param(&mut self, node: &Param) {
         let old = self.is_pat_decl;
         self.is_pat_decl = true;
         node.visit_children_with(self);
         self.is_pat_decl = old;
     }
 
-    fn visit_pat(&mut self, node: &Pat, _: &dyn Node) {
+    fn visit_pat(&mut self, node: &Pat) {
         node.visit_children_with(self);
 
         if self.is_pat_decl {
@@ -2267,7 +2267,7 @@ where
         }
     }
 
-    fn visit_stmts(&mut self, nodes: &[Stmt], _: &dyn Node) {
+    fn visit_stmts(&mut self, nodes: &[Stmt]) {
         #[cfg(feature = "concurrent")]
         if nodes.len() > 16 {
             use rayon::prelude::*;
@@ -2295,7 +2295,7 @@ where
         }
     }
 
-    fn visit_var_declarator(&mut self, node: &VarDeclarator, _: &dyn Node) {
+    fn visit_var_declarator(&mut self, node: &VarDeclarator) {
         let old = self.is_pat_decl;
         self.is_pat_decl = true;
         node.name.visit_with(node, self);

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -93,7 +93,7 @@ where
     N: VisitWith<ThisVisitor>,
 {
     let mut visitor = ThisVisitor { found: false };
-    body.visit_with(&Invalid { span: DUMMY_SP } as _, &mut visitor);
+    body.visit_with(&mut visitor);
     visitor.found
 }
 
@@ -105,7 +105,7 @@ where
         found: false,
         ident,
     };
-    body.visit_with(&Invalid { span: DUMMY_SP } as _, &mut visitor);
+    body.visit_with(&mut visitor);
     visitor.found
 }
 
@@ -136,7 +136,7 @@ where
     N: VisitWith<ArgumentsFinder>,
 {
     let mut visitor = ArgumentsFinder { found: false };
-    body.visit_with(&Invalid { span: DUMMY_SP } as _, &mut visitor);
+    body.visit_with(&mut visitor);
     visitor.found
 }
 
@@ -169,10 +169,10 @@ impl Visit for ArgumentsFinder {
 
     /// Don't recurse into member expression prop if not computed
     fn visit_member_expr(&mut self, m: &MemberExpr) {
-        m.obj.visit_with(m, self);
+        m.obj.visit_with(self);
         match &*m.prop {
             Expr::Ident(_) if !m.computed => {}
-            _ => m.prop.visit_with(m, self),
+            _ => m.prop.visit_with(self),
         }
     }
 

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -27,7 +27,7 @@ pub use swc_common::errors::HANDLER;
 use swc_common::{collections::AHashSet, Mark, Span, Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{
-    noop_visit_mut_type, noop_visit_type, Node, Visit, VisitMut, VisitMutWith, VisitWith,
+    noop_visit_mut_type, noop_visit_type, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 use tracing::trace;
 use unicode_xid::UnicodeXID;
@@ -62,19 +62,19 @@ impl Visit for ThisVisitor {
 
     /// Don't recurse into fn
     fn visit_getter_prop(&mut self, n: &GetterProp) {
-        n.key.visit_with(n, self);
+        n.key.visit_with(self);
     }
 
     /// Don't recurse into fn
     fn visit_method_prop(&mut self, n: &MethodProp) {
-        n.key.visit_with(n, self);
-        n.function.visit_with(n, self);
+        n.key.visit_with(self);
+        n.function.visit_with(self);
     }
 
     /// Don't recurse into fn
     fn visit_setter_prop(&mut self, n: &SetterProp) {
-        n.key.visit_with(n, self);
-        n.param.visit_with(n, self);
+        n.key.visit_with(self);
+        n.param.visit_with(self);
     }
 
     fn visit_this_expr(&mut self, _: &ThisExpr) {

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -1437,31 +1437,31 @@ impl Visit for LiteralVisitor {
         }
     }
 
-    fn visit_arrow_expr(&mut self, _: &ArrowExpr, _parent: &dyn Node) {
+    fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
         self.is_lit = false
     }
 
-    fn visit_assign_expr(&mut self, _: &AssignExpr, _parent: &dyn Node) {
+    fn visit_assign_expr(&mut self, _: &AssignExpr) {
         self.is_lit = false;
     }
 
-    fn visit_await_expr(&mut self, _: &AwaitExpr, _parent: &dyn Node) {
+    fn visit_await_expr(&mut self, _: &AwaitExpr) {
         self.is_lit = false
     }
 
-    fn visit_bin_expr(&mut self, _: &BinExpr, _parent: &dyn Node) {
+    fn visit_bin_expr(&mut self, _: &BinExpr) {
         self.is_lit = false
     }
 
-    fn visit_call_expr(&mut self, _: &CallExpr, _parent: &dyn Node) {
+    fn visit_call_expr(&mut self, _: &CallExpr) {
         self.is_lit = false
     }
 
-    fn visit_class_expr(&mut self, _: &ClassExpr, _parent: &dyn Node) {
+    fn visit_class_expr(&mut self, _: &ClassExpr) {
         self.is_lit = false
     }
 
-    fn visit_cond_expr(&mut self, _: &CondExpr, _parent: &dyn Node) {
+    fn visit_cond_expr(&mut self, _: &CondExpr) {
         self.is_lit = false;
     }
 
@@ -1477,43 +1477,43 @@ impl Visit for LiteralVisitor {
         }
     }
 
-    fn visit_fn_expr(&mut self, _: &FnExpr, _parent: &dyn Node) {
+    fn visit_fn_expr(&mut self, _: &FnExpr) {
         self.is_lit = false;
     }
 
-    fn visit_invalid(&mut self, _: &Invalid, _parent: &dyn Node) {
+    fn visit_invalid(&mut self, _: &Invalid) {
         self.is_lit = false;
     }
 
-    fn visit_jsx_element(&mut self, _: &JSXElement, _parent: &dyn Node) {
+    fn visit_jsx_element(&mut self, _: &JSXElement) {
         self.is_lit = false
     }
 
-    fn visit_jsx_empty_expr(&mut self, _: &JSXEmptyExpr, _parent: &dyn Node) {
+    fn visit_jsx_empty_expr(&mut self, _: &JSXEmptyExpr) {
         self.is_lit = false
     }
 
-    fn visit_jsx_fragment(&mut self, _: &JSXFragment, _parent: &dyn Node) {
+    fn visit_jsx_fragment(&mut self, _: &JSXFragment) {
         self.is_lit = false
     }
 
-    fn visit_jsx_member_expr(&mut self, _: &JSXMemberExpr, _parent: &dyn Node) {
+    fn visit_jsx_member_expr(&mut self, _: &JSXMemberExpr) {
         self.is_lit = false
     }
 
-    fn visit_jsx_namespaced_name(&mut self, _: &JSXNamespacedName, _parent: &dyn Node) {
+    fn visit_jsx_namespaced_name(&mut self, _: &JSXNamespacedName) {
         self.is_lit = false
     }
 
-    fn visit_member_expr(&mut self, _: &MemberExpr, _parent: &dyn Node) {
+    fn visit_member_expr(&mut self, _: &MemberExpr) {
         self.is_lit = false;
     }
 
-    fn visit_meta_prop_expr(&mut self, _: &MetaPropExpr, _parent: &dyn Node) {
+    fn visit_meta_prop_expr(&mut self, _: &MetaPropExpr) {
         self.is_lit = false
     }
 
-    fn visit_new_expr(&mut self, _: &NewExpr, _parent: &dyn Node) {
+    fn visit_new_expr(&mut self, _: &NewExpr) {
         self.is_lit = false
     }
 
@@ -1523,11 +1523,11 @@ impl Visit for LiteralVisitor {
         }
     }
 
-    fn visit_opt_chain_expr(&mut self, _: &OptChainExpr, _parent: &dyn Node) {
+    fn visit_opt_chain_expr(&mut self, _: &OptChainExpr) {
         self.is_lit = false
     }
 
-    fn visit_private_name(&mut self, _: &PrivateName, _parent: &dyn Node) {
+    fn visit_private_name(&mut self, _: &PrivateName) {
         self.is_lit = false
     }
 
@@ -1569,39 +1569,39 @@ impl Visit for LiteralVisitor {
         }
     }
 
-    fn visit_seq_expr(&mut self, _: &SeqExpr, _parent: &dyn Node) {
+    fn visit_seq_expr(&mut self, _: &SeqExpr) {
         self.is_lit = false
     }
 
-    fn visit_spread_element(&mut self, _: &SpreadElement, _parent: &dyn Node) {
+    fn visit_spread_element(&mut self, _: &SpreadElement) {
         self.is_lit = false;
     }
 
-    fn visit_tagged_tpl(&mut self, _: &TaggedTpl, _parent: &dyn Node) {
+    fn visit_tagged_tpl(&mut self, _: &TaggedTpl) {
         self.is_lit = false
     }
 
-    fn visit_this_expr(&mut self, _: &ThisExpr, _parent: &dyn Node) {
+    fn visit_this_expr(&mut self, _: &ThisExpr) {
         self.is_lit = false;
     }
 
-    fn visit_ts_const_assertion(&mut self, _: &TsConstAssertion, _parent: &dyn Node) {
+    fn visit_ts_const_assertion(&mut self, _: &TsConstAssertion) {
         self.is_lit = false
     }
 
-    fn visit_ts_non_null_expr(&mut self, _: &TsNonNullExpr, _parent: &dyn Node) {
+    fn visit_ts_non_null_expr(&mut self, _: &TsNonNullExpr) {
         self.is_lit = false
     }
 
-    fn visit_unary_expr(&mut self, _: &UnaryExpr, _parent: &dyn Node) {
+    fn visit_unary_expr(&mut self, _: &UnaryExpr) {
         self.is_lit = false;
     }
 
-    fn visit_update_expr(&mut self, _: &UpdateExpr, _parent: &dyn Node) {
+    fn visit_update_expr(&mut self, _: &UpdateExpr) {
         self.is_lit = false;
     }
 
-    fn visit_yield_expr(&mut self, _: &YieldExpr, _parent: &dyn Node) {
+    fn visit_yield_expr(&mut self, _: &YieldExpr) {
         self.is_lit = false
     }
 }

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -346,7 +346,7 @@ impl<T> IsEmpty for Vec<T> {
 /// Extracts hoisted variables
 pub fn extract_var_ids<T: VisitWith<Hoister>>(node: &T) -> Vec<Ident> {
     let mut v = Hoister { vars: vec![] };
-    node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+    node.visit_with(&mut v);
     v.vars
 }
 
@@ -414,7 +414,7 @@ impl Visit for Hoister {
     noop_visit_type!();
 
     fn visit_assign_pat_prop(&mut self, node: &AssignPatProp) {
-        node.value.visit_with(node, self);
+        node.value.visit_with(self);
 
         self.vars.push(node.key.clone());
     }
@@ -1373,7 +1373,7 @@ pub fn to_int32(d: f64) -> i32 {
 
 pub fn has_rest_pat<T: VisitWith<RestPatVisitor>>(node: &T) -> bool {
     let mut v = RestPatVisitor { found: false };
-    node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+    node.visit_with(&mut v);
     v.found
 }
 
@@ -1407,7 +1407,7 @@ where
         cost: 0,
         allow_non_json_value,
     };
-    e.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+    e.visit_with(&mut v);
 
     (v.is_lit, v.cost)
 }
@@ -1837,7 +1837,7 @@ where
 
     {
         let mut v = DestructuringFinder { found: &mut found };
-        node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+        node.visit_with(&mut v);
     }
 
     found
@@ -1904,10 +1904,10 @@ impl<'a> Visit for UsageFinder<'a> {
     }
 
     fn visit_member_expr(&mut self, e: &MemberExpr) {
-        e.obj.visit_with(e as _, self);
+        e.obj.visit_with(self);
 
         if e.computed {
-            e.prop.visit_with(e as _, self);
+            e.prop.visit_with(self);
         }
     }
 }
@@ -1921,7 +1921,7 @@ impl<'a> UsageFinder<'a> {
             ident,
             found: false,
         };
-        node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut v);
+        node.visit_with(&mut v);
         v.found
     }
 }
@@ -2176,7 +2176,7 @@ where
     noop_visit_type!();
 
     fn visit_assign_pat_prop(&mut self, node: &AssignPatProp) {
-        node.value.visit_with(node, self);
+        node.value.visit_with(self);
 
         if self.is_pat_decl {
             self.add(&node.key);
@@ -2215,9 +2215,9 @@ where
     }
 
     fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with(n, self);
+        n.obj.visit_with(self);
         if n.computed {
-            n.prop.visit_with(n, self);
+            n.prop.visit_with(self);
         }
     }
 
@@ -2233,7 +2233,7 @@ where
                         bindings: Default::default(),
                         is_pat_decl: self.is_pat_decl,
                     };
-                    node.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+                    node.visit_with(&mut v);
                     v.bindings
                 })
                 .reduce(AHashSet::default, |mut a, b| {
@@ -2279,7 +2279,7 @@ where
                         bindings: Default::default(),
                         is_pat_decl: self.is_pat_decl,
                     };
-                    node.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+                    node.visit_with(&mut v);
                     v.bindings
                 })
                 .reduce(AHashSet::default, |mut a, b| {
@@ -2298,10 +2298,10 @@ where
     fn visit_var_declarator(&mut self, node: &VarDeclarator) {
         let old = self.is_pat_decl;
         self.is_pat_decl = true;
-        node.name.visit_with(node, self);
+        node.name.visit_with(self);
 
         self.is_pat_decl = false;
-        node.init.visit_with(node, self);
+        node.init.visit_with(self);
         self.is_pat_decl = old;
     }
 }
@@ -2317,7 +2317,7 @@ where
         bindings: Default::default(),
         is_pat_decl: false,
     };
-    n.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+    n.visit_with(&mut v);
     v.bindings
 }
 
@@ -2333,7 +2333,7 @@ where
         bindings: Default::default(),
         is_pat_decl: false,
     };
-    n.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+    n.visit_with(&mut v);
     v.bindings
 }
 

--- a/crates/swc_ecma_utils/src/var.rs
+++ b/crates/swc_ecma_utils/src/var.rs
@@ -11,15 +11,15 @@ pub struct VarCollector<'a> {
 impl Visit for VarCollector<'_> {
     noop_visit_type!();
 
-    fn visit_arrow_expr(&mut self, _: &ArrowExpr, _parent: &dyn Node) {}
+    fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
 
-    fn visit_constructor(&mut self, _: &Constructor, _parent: &dyn Node) {}
+    fn visit_constructor(&mut self, _: &Constructor) {}
 
-    fn visit_expr(&mut self, _: &Expr, _parent: &dyn Node) {}
+    fn visit_expr(&mut self, _: &Expr) {}
 
-    fn visit_function(&mut self, _: &Function, _parent: &dyn Node) {}
+    fn visit_function(&mut self, _: &Function) {}
 
-    fn visit_key_value_pat_prop(&mut self, node: &KeyValuePatProp, _parent: &dyn Node) {
+    fn visit_key_value_pat_prop(&mut self, node: &KeyValuePatProp) {
         node.value.visit_with(node, self);
     }
 

--- a/crates/swc_ecma_utils/src/var.rs
+++ b/crates/swc_ecma_utils/src/var.rs
@@ -1,6 +1,6 @@
 use crate::Id;
 use swc_ecma_ast::*;
-use swc_ecma_visit::{noop_visit_type, Node, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 /// This collects variables bindings while ignoring if it's nested in
 /// expression.

--- a/crates/swc_ecma_utils/src/var.rs
+++ b/crates/swc_ecma_utils/src/var.rs
@@ -23,11 +23,11 @@ impl Visit for VarCollector<'_> {
         node.value.visit_with(node, self);
     }
 
-    fn visit_ident(&mut self, i: &Ident, _: &dyn Node) {
+    fn visit_ident(&mut self, i: &Ident) {
         self.to.push((i.sym.clone(), i.span.ctxt()))
     }
 
-    fn visit_var_declarator(&mut self, node: &VarDeclarator, _: &dyn Node) {
+    fn visit_var_declarator(&mut self, node: &VarDeclarator) {
         node.name.visit_with(node, self);
     }
 }

--- a/crates/swc_ecma_utils/src/var.rs
+++ b/crates/swc_ecma_utils/src/var.rs
@@ -20,7 +20,7 @@ impl Visit for VarCollector<'_> {
     fn visit_function(&mut self, _: &Function) {}
 
     fn visit_key_value_pat_prop(&mut self, node: &KeyValuePatProp) {
-        node.value.visit_with(node, self);
+        node.value.visit_with(self);
     }
 
     fn visit_ident(&mut self, i: &Ident) {
@@ -28,6 +28,6 @@ impl Visit for VarCollector<'_> {
     }
 
     fn visit_var_declarator(&mut self, node: &VarDeclarator) {
-        node.name.visit_with(node, self);
+        node.name.visit_with(self);
     }
 }

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -3,7 +3,7 @@
 pub extern crate swc_ecma_ast;
 
 use num_bigint::BigInt as BigIntValue;
-use std::{any::Any, borrow::Cow, fmt::Debug};
+use std::{borrow::Cow, fmt::Debug};
 use swc_atoms::JsWord;
 use swc_common::{pass::CompilerPass, Span, DUMMY_SP};
 use swc_ecma_ast::*;

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -9,11 +9,6 @@ use swc_common::{pass::CompilerPass, Span, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_visit::{define, AndThen, Repeat, Repeated};
 
-/// Visitable nodes.
-pub trait Node: Any {}
-
-impl<T: ?Sized> Node for T where T: Any {}
-
 impl<A, B> Fold for AndThen<A, B>
 where
     A: Fold,
@@ -362,7 +357,7 @@ macro_rules! noop_fold_type {
 macro_rules! noop_visit_type {
     ($name:ident, $N:tt) => {
         #[inline]
-        fn $name(&mut self, _: &$crate::swc_ecma_ast::$N, _: &dyn $crate::Node) {}
+        fn $name(&mut self, _: &$crate::swc_ecma_ast::$N) {}
     };
     () => {
         noop_visit_type!(visit_accessibility, Accessibility);

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -54,14 +54,14 @@ where
     A: Visit,
     B: Visit,
 {
-    fn visit_module(&mut self, n: &Module, _parent: &dyn Node) {
-        self.first.visit_module(n, _parent);
-        self.second.visit_module(n, _parent);
+    fn visit_module(&mut self, n: &Module) {
+        self.first.visit_module(n);
+        self.second.visit_module(n);
     }
 
-    fn visit_script(&mut self, n: &Script, _parent: &dyn Node) {
-        self.first.visit_script(n, _parent);
-        self.second.visit_script(n, _parent);
+    fn visit_script(&mut self, n: &Script) {
+        self.first.visit_script(n);
+        self.second.visit_script(n);
     }
 }
 
@@ -157,10 +157,10 @@ macro_rules! assert_eq_ignore_span {
     }};
 }
 
-/// Implemeented for passes which inject varaibles.
+/// Implemented for passes which inject variables.
 ///
 /// If a pass depends on other pass which injects variables, this trait can be
-/// used to keep the varaibles.
+/// used to keep the variables.
 pub trait InjectVars {
     fn take_vars(&mut self) -> Vec<VarDeclarator>;
 }

--- a/crates/swc_estree_compat/src/babelify/module.rs
+++ b/crates/swc_estree_compat/src/babelify/module.rs
@@ -1,7 +1,7 @@
 use crate::babelify::{Babelify, Context};
 use serde::{Deserialize, Serialize};
 use swc_common::{comments::Comment, Span};
-use swc_ecma_ast::{Invalid, Module, ModuleItem, Program, Script};
+use swc_ecma_ast::{Module, ModuleItem, Program, Script};
 use swc_ecma_visit::{Visit, VisitWith};
 use swc_estree_ast::{
     flavor::Flavor, BaseNode, File, InterpreterDirective, LineCol, Loc, ModuleDeclaration,
@@ -172,12 +172,7 @@ fn extract_all_comments(program: &Program, ctx: &Context) -> Vec<Comment> {
         comments: ctx.comments.clone(),
         collected: Vec::new(),
     };
-    program.visit_with(
-        &Invalid {
-            span: swc_common::DUMMY_SP,
-        },
-        &mut collector,
-    );
+    program.visit_with(&mut collector);
     collector.collected
 }
 

--- a/crates/swc_estree_compat/src/babelify/module.rs
+++ b/crates/swc_estree_compat/src/babelify/module.rs
@@ -2,7 +2,7 @@ use crate::babelify::{Babelify, Context};
 use serde::{Deserialize, Serialize};
 use swc_common::{comments::Comment, Span};
 use swc_ecma_ast::{Invalid, Module, ModuleItem, Program, Script};
-use swc_ecma_visit::{Node, Visit, VisitWith};
+use swc_ecma_visit::{Visit, VisitWith};
 use swc_estree_ast::{
     flavor::Flavor, BaseNode, File, InterpreterDirective, LineCol, Loc, ModuleDeclaration,
     Program as BabelProgram, SrcType, Statement,
@@ -95,7 +95,7 @@ impl Babelify for Script {
 
 /// Babel adds a trailing newline to the end of files when parsing, while swc
 /// truncates trailing whitespace. In order to get the converted base node to
-/// locations to match babel, we immitate the trailing newline for Script and
+/// locations to match babel, we imitate the trailing newline for Script and
 /// Module nodes.
 fn base_with_trailing_newline(span: Span, ctx: &Context) -> BaseNode {
     let mut base = ctx.base(span);

--- a/crates/swc_estree_compat/src/babelify/module.rs
+++ b/crates/swc_estree_compat/src/babelify/module.rs
@@ -187,7 +187,7 @@ struct CommentCollector {
 }
 
 impl Visit for CommentCollector {
-    fn visit_span(&mut self, sp: &Span, _: &dyn Node) {
+    fn visit_span(&mut self, sp: &Span) {
         let mut span_comments: Vec<Comment> = Vec::new();
         // Comments must be deduped since it's possible for a single comment to show up
         // multiple times since they are not removed from the comments map.

--- a/crates/swc_visit/tests/arc.rs
+++ b/crates/swc_visit/tests/arc.rs
@@ -1,11 +1,6 @@
 use std::{any::Any, sync::Arc};
 use swc_visit::define;
 
-/// Visitable nodes.
-pub trait Node: Any {}
-
-impl<T: ?Sized> Node for T where T: Any {}
-
 pub struct Item {
     pub item: Option<Arc<Item>>,
     pub ref_to_enum: Option<Arc<Enum>>,
@@ -33,7 +28,7 @@ define!({
 struct Panic;
 
 impl Visit for Panic {
-    fn visit_item(&mut self, _: &Item, _parent: &dyn Node) {
+    fn visit_item(&mut self, _: &Item) {
         panic!("Success")
     }
 }

--- a/crates/swc_visit/tests/arc.rs
+++ b/crates/swc_visit/tests/arc.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, sync::Arc};
+use std::sync::Arc;
 use swc_visit::define;
 
 pub struct Item {

--- a/crates/swc_visit_macros/src/lib.rs
+++ b/crates/swc_visit_macros/src/lib.rs
@@ -573,16 +573,14 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
                     });
 
                     if let Some(elem_ty) = extract_generic("Vec", ty) {
-                        let slice_ty: Type = q!(Vars { elem_ty }, (&[elem_ty])).parse();
-
                         tokens.push_tokens(&q!(
                             Vars {
-                                Type: slice_ty,
+                                elem_ty,
                                 expr,
                                 default_body,
                             },
                             {
-                                impl<V: Visit> VisitWith<V> for Type {
+                                impl<V: Visit> VisitWith<V> for [elem_ty] {
                                     fn visit_with(&self, v: &mut V) {
                                         expr
                                     }

--- a/crates/swc_visit_macros/src/lib.rs
+++ b/crates/swc_visit_macros/src/lib.rs
@@ -128,7 +128,7 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
             // &'_ mut V, Box<V>
             let block = match mode {
                 Mode::Visit | Mode::VisitAll => {
-                    q!(Vars { visit: &name }, ({ (**self).visit(n, _parent) })).parse()
+                    q!(Vars { visit: &name }, ({ (**self).visit(n) })).parse()
                 }
                 Mode::Fold | Mode::VisitMut => {
                     q!(Vars { visit: &name }, ({ (**self).visit(n) })).parse()
@@ -157,8 +157,8 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
                         Vars { visit: &name },
                         ({
                             match self {
-                                swc_visit::Either::Left(v) => v.visit(n, _parent),
-                                swc_visit::Either::Right(v) => v.visit(n, _parent),
+                                swc_visit::Either::Left(v) => v.visit(n),
+                                swc_visit::Either::Right(v) => v.visit(n),
                             }
                         })
                     )
@@ -190,7 +190,7 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
                         Vars { visit: &name },
                         ({
                             if self.enabled {
-                                self.visitor.visit(n, _parent)
+                                self.visitor.visit(n)
                             }
                         })
                     )
@@ -230,8 +230,8 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
                 block: q!(
                     Vars { visit: &name },
                     ({
-                        self.visitor.visit(n, _parent);
-                        visit(self, n, _parent);
+                        self.visitor.visit(n);
+                        visit(self, n);
                     })
                 )
                 .parse(),
@@ -260,7 +260,7 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
                 .parse(),
                 Mode::Visit => q!(Vars { fn_name: &fn_name }, {
                     {
-                        fn_name(self, n, _parent)
+                        fn_name(self, n)
                     }
                 })
                 .parse(),
@@ -324,11 +324,7 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
                 },
                 {
                     #[allow(unused_variables)]
-                    pub fn fn_name<V: ?Sized + Trait>(
-                        _visitor: &mut V,
-                        n: Type,
-                        _parent: &dyn Node,
-                    ) {
+                    pub fn fn_name<V: ?Sized + Trait>(_visitor: &mut V, n: Type) {
                         default_body
                     }
                 }
@@ -452,7 +448,7 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
         let trait_decl = match mode {
             Mode::Visit => q!({
                 pub trait VisitWith<V: Visit> {
-                    fn visit_with(&self, _parent: &dyn Node, v: &mut V);
+                    fn visit_with(&self, v: &mut V);
 
                     /// Visit children nodes of self with `v`
                     fn visit_children_with(&self, v: &mut V);
@@ -463,20 +459,19 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
                     V: Visit,
                     T: 'static + VisitWith<V>,
                 {
-                    fn visit_with(&self, _parent: &dyn Node, v: &mut V) {
-                        (**self).visit_with(_parent, v)
+                    fn visit_with(&self, v: &mut V) {
+                        (**self).visit_with(v)
                     }
 
                     /// Visit children nodes of self with `v`
                     fn visit_children_with(&self, v: &mut V) {
-                        let _parent = self as &dyn Node;
                         (**self).visit_children_with(v)
                     }
                 }
             }),
             Mode::VisitAll => q!({
                 pub trait VisitAllWith<V: VisitAll> {
-                    fn visit_all_with(&self, _parent: &dyn Node, v: &mut V);
+                    fn visit_all_with(&self, v: &mut V);
 
                     /// Visit children nodes of self with `v`
                     fn visit_all_children_with(&self, v: &mut V);
@@ -487,13 +482,12 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
                     V: VisitAll,
                     T: 'static + VisitAllWith<V>,
                 {
-                    fn visit_all_with(&self, _parent: &dyn Node, v: &mut V) {
-                        (**self).visit_all_with(_parent, v)
+                    fn visit_all_with(&self, v: &mut V) {
+                        (**self).visit_all_with(v)
                     }
 
                     /// Visit children nodes of self with `v`
                     fn visit_all_children_with(&self, v: &mut V) {
-                        let _parent = self as &dyn Node;
                         (**self).visit_all_children_with(v)
                     }
                 }
@@ -573,7 +567,7 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
                                 expr,
                                 method_name: &method_name
                             },
-                            { method_name(_visitor, expr, _parent) }
+                            { method_name(_visitor, expr) }
                         )
                         .parse()
                     });
@@ -586,12 +580,11 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
                         },
                         {
                             impl<V: Visit> VisitWith<V> for Type {
-                                fn visit_with(&self, _parent: &dyn Node, v: &mut V) {
+                                fn visit_with(&self, v: &mut V) {
                                     expr
                                 }
 
                                 fn visit_children_with(&self, _visitor: &mut V) {
-                                    let _parent = self as &dyn Node;
                                     default_body
                                 }
                             }
@@ -606,7 +599,7 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
                                 expr,
                                 method_name: &method_name
                             },
-                            { method_name(_visitor, expr, _parent) }
+                            { method_name(_visitor, expr,) }
                         )
                         .parse()
                     });
@@ -619,14 +612,13 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
                         },
                         {
                             impl<V: VisitAll> VisitAllWith<V> for Type {
-                                fn visit_all_with(&self, _parent: &dyn Node, v: &mut V) {
+                                fn visit_all_with(&self, v: &mut V) {
                                     let mut all = ::swc_visit::All { visitor: v };
                                     let mut v = &mut all;
                                     expr
                                 }
 
                                 fn visit_all_children_with(&self, _visitor: &mut V) {
-                                    let _parent = self as &dyn Node;
                                     let mut all = ::swc_visit::All { visitor: _visitor };
                                     let mut _visitor = &mut all;
                                     default_body
@@ -768,7 +760,7 @@ fn visit_expr(mode: Mode, ty: &Type, visitor: &Expr, expr: Expr) -> Expr {
                 expr,
                 visit_name
             },
-            { visitor.visit_name(expr, _parent as _) }
+            { visitor.visit_name(expr) }
         )
         .parse(),
     })
@@ -898,16 +890,6 @@ fn method_sig(mode: Mode, ty: &Type) -> Signature {
 
                 Mode::Visit | Mode::VisitAll => {
                     p.push_value(q!(Vars { Type: ty }, { n: &Type }).parse());
-                }
-            }
-            match mode {
-                Mode::Fold | Mode::VisitMut => {
-                    // We can not provide parent node because it's child node is
-                    // part of the parent node.
-                }
-                Mode::Visit | Mode::VisitAll => {
-                    p.push_punct(def_site());
-                    p.push_value(q!(Vars {}, { _parent: &dyn Node }).parse());
                 }
             }
 
@@ -1052,13 +1034,6 @@ fn create_method_sig(mode: Mode, ty: &Type) -> Signature {
                 p.push_value(q!(Vars {}, { &mut self }).parse());
                 p.push_punct(def_site());
                 p.push_value(q!(Vars { Type: ty }, { n: Type }).parse());
-                match mode {
-                    Mode::Fold | Mode::VisitMut => {}
-                    Mode::Visit | Mode::VisitAll => {
-                        p.push_punct(def_site());
-                        p.push_value(q!(Vars {}, { _parent: &dyn Node }).parse());
-                    }
-                }
 
                 p
             },
@@ -1239,7 +1214,7 @@ fn create_method_body(mode: Mode, ty: &Type) -> Block {
             Mode::Visit | Mode::VisitAll => {
                 let visit = method_name(mode, ty);
 
-                return q!(Vars { visit }, ({ _visitor.visit(n, _parent) })).parse();
+                return q!(Vars { visit }, ({ _visitor.visit(n) })).parse();
             }
             Mode::VisitMut => {
                 return Block {
@@ -1340,7 +1315,7 @@ fn create_method_body(mode: Mode, ty: &Type) -> Block {
                                             Vars { ident },
                                             ({
                                                 match n {
-                                                    Some(n) => _visitor.ident(n, _parent),
+                                                    Some(n) => _visitor.ident(n),
                                                     None => {}
                                                 }
                                             })
@@ -1403,9 +1378,8 @@ fn create_method_body(mode: Mode, ty: &Type) -> Block {
                                             Mode::Visit | Mode::VisitAll => q!(
                                                 Vars { ident },
                                                 ({
-                                                    n.iter().for_each(|v| {
-                                                        _visitor.ident(v.as_ref(), _parent)
-                                                    })
+                                                    n.iter()
+                                                        .for_each(|v| _visitor.ident(v.as_ref()))
                                                 })
                                             )
                                             .parse(),
@@ -1431,10 +1405,7 @@ fn create_method_body(mode: Mode, ty: &Type) -> Block {
 
                                             Mode::Visit | Mode::VisitAll => q!(
                                                 Vars { ident },
-                                                ({
-                                                    n.iter()
-                                                        .for_each(|v| _visitor.ident(v, _parent))
-                                                })
+                                                ({ n.iter().for_each(|v| _visitor.ident(v,)) })
                                             )
                                             .parse(),
                                         }

--- a/crates/swc_webpack_ast/src/reducer.rs
+++ b/crates/swc_webpack_ast/src/reducer.rs
@@ -8,7 +8,7 @@ use swc_common::{
 };
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ident::IdentLike, Id, IsEmpty, StmtLike, StmtOrModuleItem};
-use swc_ecma_visit::{Node, Visit, VisitMut, VisitMutWith, VisitWith};
+use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 use swc_timer::timer;
 
 /// # Usage

--- a/crates/swc_webpack_ast/src/reducer.rs
+++ b/crates/swc_webpack_ast/src/reducer.rs
@@ -159,9 +159,8 @@ impl ScopeData {
         let mut analyzer = Analyzer {
             amd_requires: AHashSet::default(),
         };
-        for i in items {
-            i.visit_with(&Invalid { span: DUMMY_SP }, &mut analyzer);
-        }
+
+        items.visit_with(&mut analyzer);
 
         ScopeData {
             imported_ids,

--- a/crates/swc_webpack_ast/src/reducer.rs
+++ b/crates/swc_webpack_ast/src/reducer.rs
@@ -70,7 +70,7 @@ struct Analyzer {
 }
 
 impl Visit for Analyzer {
-    fn visit_call_expr(&mut self, e: &CallExpr, _: &dyn Node) {
+    fn visit_call_expr(&mut self, e: &CallExpr) {
         e.visit_children_with(self);
 
         match &e.callee {

--- a/cspell.json
+++ b/cspell.json
@@ -134,7 +134,8 @@
         "Unexported",
         "Unexporter",
         "unimpl",
-        "untrusted"
+        "untrusted",
+        "variadic"
     ],
     "flagWords": [
         "actally"

--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,7 @@
         "ctxts",
         "declarators",
         "dedup",
+        "deduped",
         "dejavu",
         "delim",
         "Delim",

--- a/cspell.json
+++ b/cspell.json
@@ -53,6 +53,7 @@
         "eddyb",
         "elems",
         "esbuild",
+        "esmodule",
         "esms",
         "esnext",
         "estree",


### PR DESCRIPTION
swc_visit_macros:
 - Remove `&dyn Node` from `Visit`.
 - Implement `VisitWith<V>` for `[T]`.