### PR TITLE
type(node-swc): `exported` field could be null for `NamedExportSpecifier`

### DIFF
--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -1564,7 +1564,7 @@ export interface NamedExportSpecifier extends Node, HasSpan {
   /**
    * `Some(bar)` in `export { foo as bar }`
    */
-  exported: Identifier;
+  exported: Identifier | null;
 }
 
 interface HasInterpreter {


### PR DESCRIPTION
https://play.swc.rs/?version=1.2.115&code=H4sIAAAAAAAAA0utKMgvKlGodsvPV0gsVnBKLKrl4kpFCBrVAgDstLzyIgAAAA%3D%3D&config=H4sIAAAAAAAAA0VOOw7DIAy9i%2BcMbcbcoYdA1ImI%2BMl2qiLE3WsQVTa%2FvyucbGGrkA0xUr%2B4RDFf2EBKRrbkssACwkrtxjM2BYYOFLUgr4%2F1qbJPiXEaFgguur30MptCJmS%2BJRMP%2F3c27QrpfXWijj3t1EhI8WRod9EMO35Nt9ClGONnBMc7ugHQ2g%2FWQohQ0gAAAA%3D%3D