### PR TITLE
ci(actions): setup yarn cache

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -192,16 +192,13 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
+          cache: "yarn"
 
       # We explicitly do this to cache properly.
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16
 
       - uses: denoland/setup-deno@v1
         if: matrix.crate == 'swc_bundler'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: "yarn"
 
       - name: Cache
         uses: actions/cache@v2
@@ -54,6 +55,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: "yarn"
 
       - name: Cache
         uses: actions/cache@v2


### PR DESCRIPTION
### Description

context: https://discord.com/channels/889779439272075314/889780890098610176/919288953490780181

To workaround the recent CI flaky failure caused by npm pkg installation, I tried pnp. It was mostly working, but some of bundler-related tests expected physical layout of node_modules to resolve its deps.

This PR instead took easy win by setting up dep cache supported by gh actions by default: https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies

If we're lucky global cache may reduce network related failures.
