### PR TITLE
fix(es/codegen): Fix sourcemap bug related to multi-line comments

### DIFF
--- a/crates/swc_ecma_codegen/src/text_writer/basic_impl.rs
+++ b/crates/swc_ecma_codegen/src/text_writer/basic_impl.rs
@@ -184,6 +184,13 @@ impl<'a, W: Write> WriteJs for JsWriter<'a, W> {
 
     fn write_comment(&mut self, span: Span, s: &str) -> Result {
         self.write(Some(span), s)?;
+        {
+            let line_start_of_s = compute_line_starts(s);
+            if line_start_of_s.len() > 1 {
+                self.line_count = self.line_count + line_start_of_s.len() - 1;
+                self.line_pos = s.len() - line_start_of_s.last().cloned().unwrap_or(0);
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
swc_ecma_codegen:
 - Compute line starts in multi-line comments.

**Related issue (if exists):**
 - Closes https://github.com/swc-project/swc/issues/3013