### PR TITLE
refactor(es/parser): Make some verification logic optional

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -249,6 +249,11 @@ jobs:
           jest -v && mocha --version
           cargo test --color always -p ${{ matrix.crate }}
 
+      - name: Run cargo test (swc_ecma_parser)
+        if: matrix.crate == 'swc_ecma_parser'
+        run: |
+          cargo test --color always -p swc_ecma_parser --features verify
+
       - name: Run cargo test (swc_ecma_transforms)
         if: matrix.crate == 'swc_ecma_transforms'
         run: |

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -18,6 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 debug = []
 default = ["typescript"]
 typescript = []
+verify = ["swc_ecma_visit"]
 
 [dependencies]
 either = {version = "1.4"}
@@ -29,7 +30,7 @@ smallvec = "1"
 swc_atoms = {version = "0.2.3", path = "../swc_atoms"}
 swc_common = {version = "0.15.0", path = "../swc_common"}
 swc_ecma_ast = {version = "0.59.0", path = "../swc_ecma_ast"}
-swc_ecma_visit = {version = "0.45.0", path = "../swc_ecma_visit"}
+swc_ecma_visit = {version = "0.45.0", path = "../swc_ecma_visit", optional = true}
 tracing = "0.1.28"
 typed-arena = "2.0.1"
 unicode-xid = "0.2"

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -39,6 +39,7 @@ unicode-xid = "0.2"
 env_logger = "0.7"
 pretty_assertions = "0.6"
 serde_json = "1"
+swc_ecma_visit = {version = "0.45.0", path = "../swc_ecma_visit"}
 swc_node_base = {version = "0.5.0", path = "../swc_node_base"}
 testing = {version = "0.16.0", path = "../testing"}
 walkdir = "2"

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -86,6 +86,14 @@
 //! }
 //! ```
 //!
+//! ## Cargo features
+//! 
+//! ### `typescript`
+//! 
+//! Enables typescript parser.
+//! 
+//! 
+//! 
 //! ## Known issues
 //!
 //! ### Null character after `\`

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -87,13 +87,15 @@
 //! ```
 //!
 //! ## Cargo features
-//! 
+//!
 //! ### `typescript`
-//! 
+//!
 //! Enables typescript parser.
-//! 
-//! 
-//! 
+//!
+//! ### `verify`
+//!
+//! Verify more errors, using `swc_ecma_visit`.
+//!
 //! ## Known issues
 //!
 //! ### Null character after `\`

--- a/crates/swc_ecma_parser/src/parser/expr/verifier.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/verifier.rs
@@ -1,8 +1,11 @@
 use super::*;
+#[cfg(feature = "verify")]
 use swc_common::{Span, Spanned};
+#[cfg(feature = "verify")]
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 impl<'a, I: Tokens> Parser<I> {
+    #[cfg(feature = "verify")]
     pub(in crate::parser) fn verify_expr(&mut self, expr: Box<Expr>) -> PResult<Box<Expr>> {
         let mut v = Verifier { errors: vec![] };
 
@@ -14,12 +17,19 @@ impl<'a, I: Tokens> Parser<I> {
 
         return Ok(expr);
     }
+
+    #[cfg(not(feature = "verify"))]
+    pub(in crate::parser) fn verify_expr(&mut self, expr: Box<Expr>) -> PResult<Box<Expr>> {
+        Ok(expr)
+    }
 }
 
+#[cfg(feature = "verify")]
 pub(super) struct Verifier {
     pub errors: Vec<(Span, SyntaxError)>,
 }
 
+#[cfg(feature = "verify")]
 impl Visit for Verifier {
     noop_visit_type!();
 

--- a/crates/swc_ecma_parser/tests/jsx.rs
+++ b/crates/swc_ecma_parser/tests/jsx.rs
@@ -81,6 +81,7 @@ fn references(entry: PathBuf) {
     .unwrap();
 }
 
+#[cfg(feature = "verify")]
 #[testing::fixture("tests/jsx/errors/**/*.js")]
 fn error(entry: PathBuf) {
     let input = read_to_string(&entry).unwrap();

--- a/crates/swc_ecma_parser/tests/test262.rs
+++ b/crates/swc_ecma_parser/tests/test262.rs
@@ -100,6 +100,7 @@ fn add_test<F: FnOnce() + Send + 'static>(
     });
 }
 
+#[cfg(feature = "verify")]
 fn error_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
     const IGNORED_ERROR_TESTS: &[&str] = &[
         // Old (wrong) tests
@@ -350,6 +351,7 @@ fn identity() {
 }
 
 #[test]
+#[cfg(feature = "verify")]
 fn error() {
     let args: Vec<_> = env::args().collect();
     let mut tests = Vec::new();


### PR DESCRIPTION
swc_ecma_parser:
 - Make dependency on `swc_ecma_visit` optional.