### PR TITLE
fix(es/lexer): Don't report lexer errors while backtracking

### DIFF
--- a/crates/swc/tests/tsc-references/jsx/tsxReactEmitEntitiesx/input.tsx/es2015.1.normal/output.js
+++ b/crates/swc/tests/tsc-references/jsx/tsxReactEmitEntitiesx/input.tsx/es2015.1.normal/output.js
@@ -1,0 +1,19 @@
+/*#__PURE__*/ React.createElement("div", null, "Dot goes here: \xb7 &notAnEntity; ");
+/*#__PURE__*/ React.createElement("div", null, "Be careful of \"-ed strings!");
+/*#__PURE__*/ React.createElement("div", null, "{{braces}}");
+// Escapes do nothing
+/*#__PURE__*/ React.createElement("div", null, "\\n");
+// Also works in string literal attributes
+/*#__PURE__*/ React.createElement("div", {
+    attr: "{…}\\"
+});
+// Does not happen for a string literal that happens to be inside an attribute (and escapes then work)
+/*#__PURE__*/ React.createElement("div", {
+    attr: "&#0123;&hellip;&#x7D;\""
+});
+// Preserves single quotes
+/*#__PURE__*/ React.createElement("div", {
+    attr: "\""
+});
+// https://github.com/microsoft/TypeScript/issues/35732
+/*#__PURE__*/ React.createElement("div", null, "🐈🐕🐇🐑");

--- a/crates/swc/tests/tsc-references/jsx/tsxReactEmitEntitiesx/input.tsx/es2015.2.minified/output.js
+++ b/crates/swc/tests/tsc-references/jsx/tsxReactEmitEntitiesx/input.tsx/es2015.2.minified/output.js
@@ -1,0 +1,7 @@
+React.createElement("div", null, "Dot goes here: \xb7 &notAnEntity; "), React.createElement("div", null, "Be careful of \"-ed strings!"), React.createElement("div", null, "{{braces}}"), React.createElement("div", null, "\\n"), React.createElement("div", {
+    attr: "{…}\\"
+}), React.createElement("div", {
+    attr: "&#0123;&hellip;&#x7D;\""
+}), React.createElement("div", {
+    attr: "\""
+}), React.createElement("div", null, "🐈🐕🐇🐑");

--- a/crates/swc/tests/tsc-references/jsx/tsxReactEmitEntitiesx/input.tsx/es5.1.normal/output.js
+++ b/crates/swc/tests/tsc-references/jsx/tsxReactEmitEntitiesx/input.tsx/es5.1.normal/output.js
@@ -1,0 +1,19 @@
+/*#__PURE__*/ React.createElement("div", null, "Dot goes here: \xb7 &notAnEntity; ");
+/*#__PURE__*/ React.createElement("div", null, "Be careful of \"-ed strings!");
+/*#__PURE__*/ React.createElement("div", null, "{{braces}}");
+// Escapes do nothing
+/*#__PURE__*/ React.createElement("div", null, "\\n");
+// Also works in string literal attributes
+/*#__PURE__*/ React.createElement("div", {
+    attr: "{…}\\"
+});
+// Does not happen for a string literal that happens to be inside an attribute (and escapes then work)
+/*#__PURE__*/ React.createElement("div", {
+    attr: "&#0123;&hellip;&#x7D;\""
+});
+// Preserves single quotes
+/*#__PURE__*/ React.createElement("div", {
+    attr: "\""
+});
+// https://github.com/microsoft/TypeScript/issues/35732
+/*#__PURE__*/ React.createElement("div", null, "🐈🐕🐇🐑");

--- a/crates/swc/tests/tsc-references/jsx/tsxReactEmitEntitiesx/input.tsx/es5.2.minified/output.js
+++ b/crates/swc/tests/tsc-references/jsx/tsxReactEmitEntitiesx/input.tsx/es5.2.minified/output.js
@@ -1,0 +1,7 @@
+React.createElement("div", null, "Dot goes here: \xb7 &notAnEntity; "), React.createElement("div", null, "Be careful of \"-ed strings!"), React.createElement("div", null, "{{braces}}"), React.createElement("div", null, "\\n"), React.createElement("div", {
+    attr: "{…}\\"
+}), React.createElement("div", {
+    attr: "&#0123;&hellip;&#x7D;\""
+}), React.createElement("div", {
+    attr: "\""
+}), React.createElement("div", null, "🐈🐕🐇🐑");

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -16,6 +16,7 @@ use swc_common::{
     comments::{Comment, CommentKind},
     BytePos, Span, SyntaxContext,
 };
+use tracing::warn;
 use unicode_xid::UnicodeXID;
 
 /// Collector for raw string.
@@ -117,6 +118,8 @@ impl<'a, I: Input> Lexer<'a, I> {
     #[cold]
     #[inline(never)]
     pub(super) fn emit_error_span(&mut self, span: Span, kind: SyntaxError) {
+        warn!("Lexer error at {:?}", span);
+
         let err = Error {
             error: Box::new((span, kind)),
         };

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -118,8 +118,11 @@ impl<'a, I: Input> Lexer<'a, I> {
     #[cold]
     #[inline(never)]
     pub(super) fn emit_error_span(&mut self, span: Span, kind: SyntaxError) {
-        warn!("Lexer error at {:?}", span);
+        if self.ctx.ignore_error {
+            return;
+        }
 
+        warn!("Lexer error at {:?}", span);
         let err = Error {
             error: Box::new((span, kind)),
         };

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -326,6 +326,9 @@ pub struct EsConfig {
 /// Syntactic context.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Context {
+    /// `true` while backtracking
+    ignore_error: bool,
+
     /// Is in module code?
     module: bool,
     can_be_module: bool,

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -513,6 +513,12 @@ impl<I: Tokens> Parser<I> {
         if !self.input.syntax().typescript() {
             return None;
         }
+        #[cfg(feature = "debug")]
+        let _tracing = {
+            let cur = format!("{:?}", self.input.cur());
+            tracing::span!(tracing::Level::ERROR, "try_parse_ts", cur = &*cur).entered()
+        };
+
         trace_cur!(self, try_parse_ts);
         let prev_emit_err = self.emit_err;
 

--- a/crates/swc_ecma_parser/tests/typescript/issue-2896/input.tsx
+++ b/crates/swc_ecma_parser/tests/typescript/issue-2896/input.tsx
@@ -1,0 +1,1 @@
+<div>children</div>; '<>hello</>';

--- a/crates/swc_ecma_parser/tests/typescript/issue-2896/input.tsx.json
+++ b/crates/swc_ecma_parser/tests/typescript/issue-2896/input.tsx.json
@@ -1,0 +1,100 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 0,
+    "end": 34,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 0,
+        "end": 20,
+        "ctxt": 0
+      },
+      "expression": {
+        "type": "JSXElement",
+        "span": {
+          "start": 0,
+          "end": 19,
+          "ctxt": 0
+        },
+        "opening": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "Identifier",
+            "span": {
+              "start": 1,
+              "end": 4,
+              "ctxt": 0
+            },
+            "value": "div",
+            "optional": false
+          },
+          "span": {
+            "start": 0,
+            "end": 5,
+            "ctxt": 0
+          },
+          "attributes": [],
+          "selfClosing": false,
+          "typeArguments": null
+        },
+        "children": [
+          {
+            "type": "JSXText",
+            "span": {
+              "start": 5,
+              "end": 13,
+              "ctxt": 0
+            },
+            "value": "children",
+            "raw": "children"
+          }
+        ],
+        "closing": {
+          "type": "JSXClosingElement",
+          "span": {
+            "start": 13,
+            "end": 19,
+            "ctxt": 0
+          },
+          "name": {
+            "type": "Identifier",
+            "span": {
+              "start": 15,
+              "end": 18,
+              "ctxt": 0
+            },
+            "value": "div",
+            "optional": false
+          }
+        }
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 21,
+        "end": 34,
+        "ctxt": 0
+      },
+      "expression": {
+        "type": "StringLiteral",
+        "span": {
+          "start": 21,
+          "end": 33,
+          "ctxt": 0
+        },
+        "value": "<>hello</>",
+        "hasEscape": false,
+        "kind": {
+          "type": "normal",
+          "containsQuote": true
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
swc_ecma_parser:
 - Share backtracking state with the lexer.
 - Don't report lexing errors while backtracking (Closes #2896)