### PR TITLE
test(es/transforms/compat): update test cases for block_scoping

### DIFF
--- a/crates/swc_ecma_transforms_compat/tests/es2015_block_scoping.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2015_block_scoping.rs
@@ -956,3 +956,51 @@ test!(
     for(var key in keys)_loop(key);
     "
 );
+
+test!(
+    ::swc_ecma_parser::Syntax::default(),
+    |_| block_scoping(),
+    issue_2998_1,
+    "
+    let a = 5;
+for (let b = 0; b < a; b++) {
+    let c = 0, b = 10, d = 100;
+    console.log(b);
+}
+    ",
+    "
+    var a = 5;
+for(var b = 0; b < a; b++){
+    var c = 0, b1 = 10, d = 100;
+    console.log(b);
+}
+    "
+);
+
+test!(
+    ::swc_ecma_parser::Syntax::default(),
+    |_| block_scoping(),
+    issue_2998_2,
+    "
+    for (var a; ;) { }
+    for (var a = ['a', 'b']; ;) { }
+    ",
+    "
+    for (var a; ;) { }
+    for (var a = ['a', 'b']; ;) { }
+    "
+);
+
+test_exec!(
+    ::swc_ecma_parser::Syntax::default(),
+    |_| block_scoping(),
+    issue_2998_3,
+    "let a = 5;
+const expected = [];
+for (let b = 0; b < a; b++) {
+    let c = 0, b = 10, d = 100;
+    expected.push(b);
+}
+expect(expected).toEqual([0,1,2,3,4]);
+"
+);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR attempts to fix #2998 by assigning a new ident if same one found in loop nodes. To avoid re-renaming loop node's init, PR introduces new flag to let visit_mut_var_decl indicate if it's in loop's body or not and only reassign new ident in loop body and there are existing ident.

**Related issue (if exists):**

- closes #2998
