### PR TITLE
fix(ecma/transform): export destructured properties in TypeScript namespace

### DIFF
--- a/crates/swc/tests/fixture/issue-3073/1/input/.swcrc
+++ b/crates/swc/tests/fixture/issue-3073/1/input/.swcrc
@@ -1,0 +1,18 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": false
+        },
+        "target": "es5",
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        }
+    },
+    "module": {
+        "type": "es6"
+    },
+    "minify": false
+}

--- a/crates/swc/tests/fixture/issue-3073/1/input/index.ts
+++ b/crates/swc/tests/fixture/issue-3073/1/input/index.ts
@@ -1,0 +1,3 @@
+namespace n {
+    export const { a } = { a: 1 };
+}

--- a/crates/swc/tests/fixture/issue-3073/1/output/index.ts
+++ b/crates/swc/tests/fixture/issue-3073/1/output/index.ts
@@ -1,0 +1,8 @@
+var n;
+(function(n1) {
+    var ref;
+    ref = {
+        a: 1
+    }, n1.a = ref.a, ref;
+})(n || (n = {
+}));

--- a/crates/swc/tests/fixture/issue-3073/2/input/.swcrc
+++ b/crates/swc/tests/fixture/issue-3073/2/input/.swcrc
@@ -1,0 +1,18 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": false
+        },
+        "target": "es5",
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        }
+    },
+    "module": {
+        "type": "es6"
+    },
+    "minify": false
+}

--- a/crates/swc/tests/fixture/issue-3073/2/input/index.ts
+++ b/crates/swc/tests/fixture/issue-3073/2/input/index.ts
@@ -1,0 +1,3 @@
+namespace Foo {
+    export const { a: A, b: B } = { a: 1, b: 2 };
+}

--- a/crates/swc/tests/fixture/issue-3073/2/output/index.ts
+++ b/crates/swc/tests/fixture/issue-3073/2/output/index.ts
@@ -1,0 +1,9 @@
+var Foo;
+(function(Foo1) {
+    var ref;
+    ref = {
+        a: 1,
+        b: 2
+    }, Foo1.A = ref.a, Foo1.B = ref.b, ref;
+})(Foo || (Foo = {
+}));

--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -2699,7 +2699,15 @@ fn create_prop_pat(obj: &Ident, pat: Pat) -> Pat {
                         value: Box::new(create_prop_pat(obj, *kv.value)),
                         ..kv
                     }),
-                    ObjectPatProp::Assign(..) => prop,
+                    ObjectPatProp::Assign(assign) => ObjectPatProp::KeyValue(KeyValuePatProp {
+                        key: PropName::Ident(assign.key.clone()),
+                        value: Box::new(Pat::Expr(Box::new(Expr::Member(MemberExpr {
+                            span: DUMMY_SP,
+                            obj: ExprOrSuper::Expr(Box::new(Expr::Ident(obj.clone()))),
+                            prop: Box::new(Expr::Ident(assign.key.into())),
+                            computed: false,
+                        })))),
+                    }),
                     ObjectPatProp::Rest(_) => {
                         todo!("Rest pattern property in an exported variable from namespace")
                     }

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/1/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/1/input.ts
@@ -1,0 +1,3 @@
+namespace Foo {
+    export const { a } = { a: 1 };
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/1/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/1/output.js
@@ -1,0 +1,7 @@
+var Foo;
+(function(Foo1) {
+    ({ a: Foo1.a  } = {
+        a: 1
+    });
+})(Foo || (Foo = {
+}));

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/2/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/2/input.ts
@@ -1,0 +1,3 @@
+namespace Bar {
+    export const { a, b } = { a: 1, b: 2 };
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/2/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/2/output.js
@@ -1,0 +1,8 @@
+var Bar;
+(function(Bar1) {
+    ({ a: Bar1.a , b: Bar1.b  } = {
+        a: 1,
+        b: 2
+    });
+})(Bar || (Bar = {
+}));

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/3/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/3/input.ts
@@ -1,0 +1,3 @@
+namespace Baz {
+    export const baz = { a: 1, b: 2 };
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/3/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/3/output.js
@@ -1,0 +1,8 @@
+var Baz;
+(function(Baz1) {
+    Baz1.baz = {
+        a: 1,
+        b: 2
+    };
+})(Baz || (Baz = {
+}));

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/4/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/4/input.ts
@@ -1,0 +1,12 @@
+module A {
+    const a = 1;
+    const b = 2;
+    export const { a: A } = { a };
+    export const { b: B } = { b };
+}
+namespace A {
+    const c = 3;
+    const d = 4;
+    export const { c: C } = { c: c };
+    export const { d: D } = { d: d };
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/4/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3073/4/output.js
@@ -1,0 +1,23 @@
+var A;
+(function(A1) {
+    const a = 1;
+    const b = 2;
+    ({ a: A1.A  } = {
+        a
+    });
+    ({ b: A1.B  } = {
+        b
+    });
+})(A || (A = {
+}));
+(function(A2) {
+    const c = 3;
+    const d = 4;
+    ({ c: A2.C  } = {
+        c: c
+    });
+    ({ d: A2.D  } = {
+        d: d
+    });
+})(A || (A = {
+}));


### PR DESCRIPTION
**Related issue (if exists):**
fix #3073 