### PR TITLE
ci(actions): include swc_cli into optional deps package

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -22,15 +22,22 @@ jobs:
           - host: macos-latest
             target: x86_64-apple-darwin
             build: |
+              cargo build -p swc_cli --release
+              cp ./target/release/swc .
               yarn build
               strip -x *.node
           - host: windows-latest
-            build: yarn build
+            build: |
+              yarn build
+              cargo build -p swc_cli --release
+              cp target/release/swc .
             target: x86_64-pc-windows-msvc
           - host: windows-latest
             build: |
               export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=32;
               export CARGO_PROFILE_RELEASE_LTO=false
+              cargo build -p swc_cli --release --target i686-pc-windows-msvc
+              cp target/i686-pc-windows-msvc/release/swc .
               yarn build --target i686-pc-windows-msvc
               yarn test
             target: i686-pc-windows-msvc
@@ -44,6 +51,7 @@ jobs:
               docker pull $DOCKER_REGISTRY_URL/napi-rs/napi-rs/nodejs-rust:lts-debian
               docker tag $DOCKER_REGISTRY_URL/napi-rs/napi-rs/nodejs-rust:lts-debian builder
             build: |
+              docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder sh -c "cargo build -p swc_cli --release; rm -rf target/release/.cargo-lock" && cp target/release/swc .
               docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder yarn build && strip swc.linux-x64-gnu.node
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
@@ -51,7 +59,9 @@ jobs:
               docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $DOCKER_REGISTRY_URL
               docker pull $DOCKER_REGISTRY_URL/napi-rs/napi-rs/nodejs-rust:lts-alpine
               docker tag $DOCKER_REGISTRY_URL/napi-rs/napi-rs/nodejs-rust:lts-alpine builder
-            build: docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder yarn build && strip swc.linux-x64-musl.node
+            build: |
+              docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder sh -c "cargo build -p swc_cli --release; rm -rf target/release/.cargo-lock" && cp target/release/swc .
+              docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder yarn build && strip swc.linux-x64-musl.node
           - host: macos-latest
             target: aarch64-apple-darwin
             build: |
@@ -60,6 +70,8 @@ jobs:
               export CXX=$(xcrun -f clang++);
               SYSROOT=$(xcrun --sdk macosx --show-sdk-path);
               export CFLAGS="-isysroot $SYSROOT -isystem $SYSROOT";
+              cargo build -p swc_cli --release --target=aarch64-apple-darwin
+              cp ./target/aarch64-apple-darwin/release/swc .
               yarn build --target=aarch64-apple-darwin
               strip -x *.node
           - host: ubuntu-latest
@@ -68,6 +80,8 @@ jobs:
               sudo apt-get update
               sudo apt-get install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu -y
             build: |
+              cargo build -p swc_cli --release --target=aarch64-unknown-linux-gnu
+              cp ./target/aarch64-unknown-linux-gnu/release/swc .
               yarn build --target=aarch64-unknown-linux-gnu
               aarch64-linux-gnu-strip swc.linux-arm64-gnu.node
           - host: ubuntu-latest
@@ -76,12 +90,16 @@ jobs:
               sudo apt-get update
               sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf -y
             build: |
+              cargo build -p swc_cli --release --target=armv7-unknown-linux-gnueabihf
+              cp ./target/armv7-unknown-linux-gnueabihf/release/swc .
               yarn build --target=armv7-unknown-linux-gnueabihf
               arm-linux-gnueabihf-strip swc.linux-arm-gnueabihf.node
           - host: ubuntu-latest
             target: aarch64-linux-android
             build: |
               export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang"
+              cargo build -p swc_cli --release --target aarch64-linux-android
+              cp ./target/aarch64-linux-android/release/swc .
               yarn build --target aarch64-linux-android
               ${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-strip *.node
           - host: ubuntu-latest
@@ -92,10 +110,14 @@ jobs:
               docker pull ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
               docker tag ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine builder
             build: |
+              docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder sh -c "rustup toolchain install $(cat ./rust-toolchain) && rustup target add aarch64-unknown-linux-musl && cargo build -p swc_cli --release --target=aarch64-unknown-linux-musl && rm -rf target/release/.cargo-lock" && cp target/aarch64-unknown-linux-musl/release/swc .
               docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder sh -c "rustup toolchain install $(cat ./rust-toolchain) && rustup target add aarch64-unknown-linux-musl && yarn build --target=aarch64-unknown-linux-musl && /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip swc.linux-arm64-musl.node"
           - host: windows-latest
             target: aarch64-pc-windows-msvc
-            build: yarn build --target aarch64-pc-windows-msvc
+            build: |
+              cargo build -p swc_cli --release --target aarch64-pc-windows-msvc
+              cp target/aarch64-pc-windows-msvc/release/swc.exe .
+              yarn build --target aarch64-pc-windows-msvc
     name: stable - ${{ matrix.settings.target }} - node@14
     runs-on: ${{ matrix.settings.host }}
     steps:
@@ -150,7 +172,8 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: bindings-${{ matrix.settings.target }}
-          path: swc.*.node
+          path: |
+            swc*
           if-no-files-found: error
   build-freebsd:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
@@ -222,6 +245,8 @@ jobs:
             freebsd-version
             yarn install --ignore-scripts --registry https://registry.npmjs.org --network-timeout 300000
             yarn build
+            cargo build -p swc_cli --release
+            cp ./target/release/swc .
             yarn test
             rm -rf node_modules
             rm -rf target
@@ -229,7 +254,8 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: bindings-freebsd
-          path: swc.*.node
+          path: |
+            swc*
           if-no-files-found: error
   test-macOS-windows-binding:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
@@ -514,7 +540,9 @@ jobs:
 
       - name: Move binaries
         shell: bash
-        run: npm run artifacts
+        run: |
+          ./scripts/cli_artifacts.sh
+          npm run artifacts
 
       - name: List npm
         run: ls -R ./scripts/npm

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 native/artifacts.json
 artifacts.json
 *.node
+/scripts/npm/**/swc
+/scripts/npm/**/swc.exe
 
 
 target/

--- a/.npmignore
+++ b/.npmignore
@@ -60,3 +60,7 @@ crates/
 packages/
 cspell.json
 deny.toml
+.mocha.setup.js
+.mocharc.js
+jest.config.js
+cliff.toml

--- a/scripts/cli_artifacts.sh
+++ b/scripts/cli_artifacts.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Naive substitution to napi artifacts for the cli binary.
+for filename in artifacts/*/*.node
+do
+  BINDING_NAME=${filename#*.}
+  BINDING_ABI=${BINDING_NAME%%.*}
+  CLI_BINARY_PATH=${filename%%.*}
+
+  if [ -f "$CLI_BINARY_PATH" ]; then
+      mv $CLI_BINARY_PATH ./scripts/npm/$BINDING_ABI
+  else
+      mv $CLI_BINARY_PATH.exe ./scripts/npm/$BINDING_ABI
+  fi
+done

--- a/scripts/npm/android-arm64/package.json
+++ b/scripts/npm/android-arm64/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "swc.android-arm64.node",
   "files": [
-    "swc.android-arm64.node"
+    "swc.android-arm64.node",
+    "swc"
   ],
   "description": "Super-fast alternative for babel",
   "keywords": [

--- a/scripts/npm/darwin-arm64/package.json
+++ b/scripts/npm/darwin-arm64/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "swc.darwin-arm64.node",
   "files": [
-    "swc.darwin-arm64.node"
+    "swc.darwin-arm64.node",
+    "swc"
   ],
   "description": "Super-fast alternative for babel",
   "keywords": [

--- a/scripts/npm/darwin-x64/package.json
+++ b/scripts/npm/darwin-x64/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "swc.darwin-x64.node",
   "files": [
-    "swc.darwin-x64.node"
+    "swc.darwin-x64.node",
+    "swc"
   ],
   "description": "Super-fast alternative for babel",
   "keywords": [

--- a/scripts/npm/freebsd-x64/package.json
+++ b/scripts/npm/freebsd-x64/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "swc.freebsd-x64.node",
   "files": [
-    "swc.freebsd-x64.node"
+    "swc.freebsd-x64.node",
+    "swc"
   ],
   "description": "Super-fast alternative for babel",
   "keywords": [

--- a/scripts/npm/linux-arm-gnueabihf/package.json
+++ b/scripts/npm/linux-arm-gnueabihf/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "swc.linux-arm-gnueabihf.node",
   "files": [
-    "swc.linux-arm-gnueabihf.node"
+    "swc.linux-arm-gnueabihf.node",
+    "swc"
   ],
   "description": "Super-fast alternative for babel",
   "keywords": [

--- a/scripts/npm/linux-arm64-gnu/package.json
+++ b/scripts/npm/linux-arm64-gnu/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "swc.linux-arm64-gnu.node",
   "files": [
-    "swc.linux-arm64-gnu.node"
+    "swc.linux-arm64-gnu.node",
+    "swc"
   ],
   "description": "Super-fast alternative for babel",
   "keywords": [

--- a/scripts/npm/linux-arm64-musl/package.json
+++ b/scripts/npm/linux-arm64-musl/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "swc.linux-arm64-musl.node",
   "files": [
-    "swc.linux-arm64-musl.node"
+    "swc.linux-arm64-musl.node",
+    "swc"
   ],
   "description": "Super-fast alternative for babel",
   "keywords": [

--- a/scripts/npm/linux-x64-gnu/package.json
+++ b/scripts/npm/linux-x64-gnu/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "swc.linux-x64-gnu.node",
   "files": [
-    "swc.linux-x64-gnu.node"
+    "swc.linux-x64-gnu.node",
+    "swc"
   ],
   "description": "Super-fast alternative for babel",
   "keywords": [

--- a/scripts/npm/linux-x64-musl/package.json
+++ b/scripts/npm/linux-x64-musl/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "swc.linux-x64-musl.node",
   "files": [
-    "swc.linux-x64-musl.node"
+    "swc.linux-x64-musl.node",
+    "swc"
   ],
   "description": "Super-fast alternative for babel",
   "keywords": [

--- a/scripts/npm/win32-arm64-msvc/package.json
+++ b/scripts/npm/win32-arm64-msvc/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "swc.win32-arm64-msvc.node",
   "files": [
-    "swc.win32-arm64-msvc.node"
+    "swc.win32-arm64-msvc.node",
+    "swc.exe"
   ],
   "description": "Super-fast alternative for babel",
   "keywords": [

--- a/scripts/npm/win32-ia32-msvc/package.json
+++ b/scripts/npm/win32-ia32-msvc/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "swc.win32-ia32-msvc.node",
   "files": [
-    "swc.win32-ia32-msvc.node"
+    "swc.win32-ia32-msvc.node",
+    "swc.exe"
   ],
   "description": "Super-fast alternative for babel",
   "keywords": [

--- a/scripts/npm/win32-x64-msvc/package.json
+++ b/scripts/npm/win32-x64-msvc/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "swc.win32-x64-msvc.node",
   "files": [
-    "swc.win32-x64-msvc.node"
+    "swc.win32-x64-msvc.node",
+    "swc.exe"
   ],
   "description": "Super-fast alternative for babel",
   "keywords": [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
This PR continues CLI implementation, update publish script to each platform specific optional dep to include cli binary as well. Main entrypoint (@swc/cli) and optional dep doesn't point to those binary yet, so this is safe from any breaking changes. 

To conform with existing artifact packaging I did small bend over to copy release binary into specific platform path side by side to node bindings.

**Related issue (if exists):**

- https://github.com/swc-project/swc/issues/1589