### PR TITLE
fix(es/compat): Fix `classes` pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,6 +2817,7 @@ dependencies = [
  "string_enum",
  "swc_atoms 0.2.9",
  "swc_common",
+ "unicode-xid",
 ]
 
 [[package]]

--- a/crates/swc_ecma_ast/Cargo.toml
+++ b/crates/swc_ecma_ast/Cargo.toml
@@ -24,6 +24,7 @@ serde = {version = "1.0.88", features = ["derive"]}
 string_enum = {version = "0.3.1", path = "../string_enum"}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.15.0", path = "../swc_common"}
+unicode-xid = "0.2"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -114,6 +114,13 @@ impl Ident {
     ///
     /// Returns [Cow::Owned] if it's modified.
     pub fn symbol_for_str(s: &str) -> Cow<str> {
+        if s.is_reserved() || s.is_reserved_in_strict_mode(true) || s.is_reserved_in_strict_bind() {
+            let mut buf = String::with_capacity(s.len() + 1);
+            buf.push('_');
+            buf.push_str(s);
+            return Cow::Owned(buf);
+        }
+
         {
             let mut chars = s.chars();
 
@@ -141,11 +148,7 @@ impl Ident {
             }
         }
 
-        if buf.is_empty()
-            || buf.is_reserved()
-            || buf.is_reserved_in_strict_mode(true)
-            || buf.is_reserved_in_strict_bind()
-        {
+        if buf.is_empty() {
             buf.push('_');
         }
 

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -111,6 +111,8 @@ impl Ident {
     }
 
     /// Alternative for `toIdentifier` of babel.
+    ///
+    /// Returns [Cow::Owned] if it's modified.
     pub fn symbol_for_str(s: &str) -> Cow<str> {
         {
             let mut chars = s.chars();
@@ -139,7 +141,11 @@ impl Ident {
             }
         }
 
-        if buf.is_empty() {
+        if buf.is_empty()
+            || buf.is_reserved()
+            || buf.is_reserved_in_strict_mode(true)
+            || buf.is_reserved_in_strict_bind()
+        {
             buf.push('_');
         }
 

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -1,6 +1,6 @@
 use crate::typescript::TsTypeAnn;
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, fmt::Display};
+use std::fmt::Display;
 use swc_atoms::{js_word, JsWord};
 use swc_common::{
     ast_node, util::take::Take, EqIgnoreSpan, Span, Spanned, SyntaxContext, DUMMY_SP,
@@ -112,13 +112,14 @@ impl Ident {
 
     /// Alternative for `toIdentifier` of babel.
     ///
-    /// Returns [Cow::Owned] if it's modified.
-    pub fn symbol_for_str(s: &str) -> Cow<str> {
+    /// Returns [Ok] if it's a valid identifier and [Err] if it's not valid.
+    /// The returned [Err] contains the valid symbol.
+    pub fn verify_symbol(s: &str) -> Result<(), String> {
         if s.is_reserved() || s.is_reserved_in_strict_mode(true) || s.is_reserved_in_strict_bind() {
             let mut buf = String::with_capacity(s.len() + 1);
             buf.push('_');
             buf.push_str(s);
-            return Cow::Owned(buf);
+            return Err(buf);
         }
 
         {
@@ -127,7 +128,7 @@ impl Ident {
             if let Some(first) = chars.next() {
                 if Self::is_valid_start(first) {
                     if chars.all(Self::is_valid_continue) {
-                        return Cow::Borrowed(s);
+                        return Ok(());
                     }
                 }
             }
@@ -152,7 +153,7 @@ impl Ident {
             buf.push('_');
         }
 
-        Cow::Owned(buf)
+        Err(buf)
     }
 }
 

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
@@ -965,7 +965,7 @@ fn escape_keywords(mut e: Box<Expr>) -> Box<Expr> {
                     Cow::Owned(sym) => {
                         i.sym = sym.into();
                     }
-                    _=>{}
+                    _ => {}
                 }
             }
         }

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
@@ -5,7 +5,7 @@ use self::{
     },
     prop_name::HashKey,
 };
-use std::iter;
+use std::{borrow::Cow, iter};
 use swc_common::{comments::Comments, util::take::Take, Mark, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::{helper, native::is_native, perf::Check};
@@ -959,11 +959,13 @@ fn escape_keywords(mut e: Box<Expr>) -> Box<Expr> {
     match &mut *e {
         Expr::Fn(f) => {
             if let Some(i) = &mut f.ident {
-                if i.is_reserved()
-                    || i.is_reserved_in_strict_mode(true)
-                    || i.is_reserved_in_strict_bind()
-                {
-                    i.sym = format!("_{}", i.sym).into();
+                let sym = Ident::symbol_for_str(&i.sym);
+
+                match sym {
+                    Cow::Owned(sym) => {
+                        i.sym = sym.into();
+                    }
+                    _=>{}
                 }
             }
         }

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
@@ -5,7 +5,7 @@ use self::{
     },
     prop_name::HashKey,
 };
-use std::{borrow::Cow, iter};
+use std::iter;
 use swc_common::{comments::Comments, util::take::Take, Mark, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::{helper, native::is_native, perf::Check};
@@ -959,13 +959,10 @@ fn escape_keywords(mut e: Box<Expr>) -> Box<Expr> {
     match &mut *e {
         Expr::Fn(f) => {
             if let Some(i) = &mut f.ident {
-                let sym = Ident::symbol_for_str(&i.sym);
+                let sym = Ident::verify_symbol(&i.sym);
 
-                match sym {
-                    Cow::Owned(sym) => {
-                        i.sym = sym.into();
-                    }
-                    _ => {}
+                if let Err(new) = sym {
+                    i.sym = new.into();
                 }
             }
         }

--- a/crates/swc_ecma_transforms_compat/tests/fixture/classes/issue-3106/1/exec.js
+++ b/crates/swc_ecma_transforms_compat/tests/fixture/classes/issue-3106/1/exec.js
@@ -7,4 +7,4 @@ class ValidationStrategy {
         return 2;
     }
 }
-console.log(ValidationStrategy);
+console.log(ValidationStrategy.prototype['string!']);

--- a/crates/swc_ecma_transforms_compat/tests/fixture/classes/issue-3106/1/exec.js
+++ b/crates/swc_ecma_transforms_compat/tests/fixture/classes/issue-3106/1/exec.js
@@ -1,0 +1,10 @@
+class ValidationStrategy {
+    static "object?"(value) {
+        return 1;
+    }
+
+    static "string!"(value) {
+        return 2;
+    }
+}
+console.log(ValidationStrategy);


### PR DESCRIPTION
swc_ecma_ast:
 - Add `Ident::verify_symbol`.

swc_ecma_transforms_compat:
 - Don't generate invalid identifiers. (Closes #3106)