### PR TITLE
fix(binding): recover on non existing ldd

### DIFF
--- a/node-swc/src/binding.js
+++ b/node-swc/src/binding.js
@@ -5,8 +5,18 @@ const { platform, arch } = process
 
 let nativeBinding = null
 let localFileExisted = false
-let isMusl = false
 let loadError = null
+
+const isMusl = () => {
+  try {
+    const isMusl = readFileSync('/usr/bin/ldd', 'utf8').includes('musl')
+    
+    return isMusl;
+  } catch(e) {
+    return false;
+  }
+}
+
 
 switch (platform) {
   case 'android':
@@ -122,8 +132,7 @@ switch (platform) {
   case 'linux':
     switch (arch) {
       case 'x64':
-        isMusl = readFileSync('/usr/bin/ldd', 'utf8').includes('musl')
-        if (isMusl) {
+        if (isMusl()) {
           localFileExisted = existsSync(
             join(__dirname, 'swc.linux-x64-musl.node')
           )
@@ -152,8 +161,7 @@ switch (platform) {
         }
         break
       case 'arm64':
-        isMusl = readFileSync('/usr/bin/ldd', 'utf8').includes('musl')
-        if (isMusl) {
+        if (isMusl()) {
           localFileExisted = existsSync(
             join(__dirname, 'swc.linux-arm64-musl.node')
           )


### PR DESCRIPTION
**Description:**

There are linux environments where LDD does not exist (for example, think of a `node` binary that is linked statically and it built `FROM scratch`)
In order to support those environments, in case `LDD` doesn't exist, the code will use the `gnu` binary.
