### PR TITLE
feat(ecma/compat): object super

### DIFF
--- a/crates/swc_ecma_transforms_compat/src/es2015/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/mod.rs
@@ -2,9 +2,10 @@ pub use self::{
     arrow::arrow, block_scoped_fn::block_scoped_functions, block_scoping::block_scoping,
     classes::classes, computed_props::computed_properties, destructuring::destructuring,
     duplicate_keys::duplicate_keys, for_of::for_of, function_name::function_name,
-    instanceof::instance_of, new_target::new_target, parameters::parameters,
-    regenerator::regenerator, shorthand_property::shorthand, spread::spread,
-    sticky_regex::sticky_regex, template_literal::template_literal, typeof_symbol::typeof_symbol,
+    instanceof::instance_of, new_target::new_target, object_super::object_super,
+    parameters::parameters, regenerator::regenerator, shorthand_property::shorthand,
+    spread::spread, sticky_regex::sticky_regex, template_literal::template_literal,
+    typeof_symbol::typeof_symbol,
 };
 use serde::Deserialize;
 use swc_common::{chain, comments::Comments, Mark};
@@ -21,6 +22,7 @@ pub mod for_of;
 mod function_name;
 mod instanceof;
 pub mod new_target;
+mod object_super;
 pub mod parameters;
 pub mod regenerator;
 mod shorthand_property;
@@ -54,6 +56,7 @@ where
         function_name(),
         exprs(),
         for_of(c.for_of),
+        object_super(),
         // Should come before parameters
         // See: https://github.com/swc-project/swc/issues/1036
         parameters(c.parameters),

--- a/crates/swc_ecma_transforms_compat/src/es2015/object_super.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/object_super.rs
@@ -1,0 +1,264 @@
+use swc_atoms::js_word;
+use swc_common::{util::take::Take, DUMMY_SP};
+use swc_ecma_ast::*;
+use swc_ecma_transforms_base::helper;
+use swc_ecma_utils::{private_ident, quote_ident, ExprFactory, UsageFinder};
+use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
+
+struct ObjectSuper;
+pub fn object_super() -> impl Fold + VisitMut {
+    as_folder(ObjectSuper)
+}
+
+impl VisitMut for ObjectSuper {
+    noop_visit_mut_type!();
+
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        expr.visit_mut_children_with(self);
+        if let Expr::Object(ObjectLit { span, props }) = expr {
+            let obj_ref = private_ident!("_obj");
+            let mut replacer = SuperReplacer {
+                obj: &obj_ref,
+                processed: false,
+            };
+            for prop_or_spread in props.iter_mut() {
+                if let PropOrSpread::Prop(ref mut prop) = prop_or_spread {
+                    match &mut **prop {
+                        Prop::Method(_) => {}
+                        _ => {
+                            prop.visit_mut_with(&mut replacer);
+                        }
+                    }
+                }
+            }
+            if replacer.processed {
+                *expr = Expr::Assign(AssignExpr {
+                    span: DUMMY_SP,
+                    op: AssignOp::Assign,
+                    left: PatOrExpr::Expr(Box::new(Expr::Ident(obj_ref))),
+                    right: Box::new(expr.take()),
+                })
+            }
+        }
+    }
+}
+
+struct SuperReplacer<'a> {
+    obj: &'a Ident,
+    processed: bool,
+}
+impl SuperReplacer<'_> {
+    fn get_proto(&self) -> ExprOrSpread {
+        Expr::Call(CallExpr {
+            span: DUMMY_SP,
+            callee: helper!(get_prototype_of, "getPrototypeOf"),
+            args: vec![self.obj.clone().as_arg()],
+            type_args: Default::default(),
+        })
+        .as_arg()
+    }
+}
+impl VisitMut for SuperReplacer<'_> {
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        match expr {
+            Expr::Member(MemberExpr {
+                obj: ExprOrSuper::Super(..),
+                prop,
+                computed,
+                ..
+            }) => {
+                *expr = Expr::Call(CallExpr {
+                    span: DUMMY_SP,
+                    callee: helper!(set, "get"),
+                    args: vec![
+                        self.get_proto(),
+                        if *computed {
+                            prop.take().as_arg()
+                        } else {
+                            match *prop.take() {
+                                Expr::Ident(Ident { sym, span, .. }) => Expr::Lit(Lit::Str(Str {
+                                    span,
+                                    value: sym,
+                                    has_escape: false,
+                                    kind: Default::default(),
+                                }))
+                                .as_arg(),
+                                _ => unreachable!(),
+                            }
+                        },
+                        Expr::This(ThisExpr { span: DUMMY_SP }).as_arg(),
+                    ],
+                    type_args: Default::default(),
+                });
+                self.processed = true;
+            }
+            Expr::Assign(AssignExpr {
+                span,
+                op: op!("="),
+                left,
+                right,
+            }) => {
+                let left = left.take().normalize_expr();
+                match left {
+                    PatOrExpr::Expr(mut left_expr) => match *left_expr {
+                        Expr::Member(MemberExpr {
+                            obj: ExprOrSuper::Super(..),
+                            prop,
+                            computed,
+                            ..
+                        }) => {
+                            *expr = Expr::Call(CallExpr {
+                                span: DUMMY_SP,
+                                callee: helper!(set, "set"),
+                                args: vec![
+                                    self.get_proto(),
+                                    if computed {
+                                        prop.as_arg()
+                                    } else {
+                                        match *prop {
+                                            Expr::Ident(Ident { sym, span, .. }) => {
+                                                Expr::Lit(Lit::Str(Str {
+                                                    span,
+                                                    value: sym,
+                                                    has_escape: false,
+                                                    kind: Default::default(),
+                                                }))
+                                                .as_arg()
+                                            }
+                                            _ => unreachable!(),
+                                        }
+                                    },
+                                    right.take().as_arg(),
+                                    Expr::This(ThisExpr { span: DUMMY_SP }).as_arg(),
+                                    Expr::Lit(Lit::Bool(Bool {
+                                        span: DUMMY_SP,
+                                        value: true,
+                                    }))
+                                    .as_arg(),
+                                ],
+                                type_args: Default::default(),
+                            });
+                            self.processed = true;
+                        }
+                        _ => {
+                            *expr = Expr::Assign(AssignExpr {
+                                span: *span,
+                                left: PatOrExpr::Expr(left_expr),
+                                op: op!("="),
+                                right: right.take(),
+                            });
+                        }
+                    },
+                    _ => {
+                        *expr = Expr::Assign(AssignExpr {
+                            span: *span,
+                            left,
+                            op: op!("="),
+                            right: right.take(),
+                        });
+                    }
+                }
+            }
+            _ => {
+                expr.visit_mut_children_with(self);
+            }
+        }
+    }
+    fn visit_mut_call_expr(&mut self, expr: &mut CallExpr) {
+        // super.y(1,2,3) to
+        // _get(_getPrototypeOf(_obj), "y", this).call(this,1,2,3)
+        let tmp = self.processed;
+        self.processed = false;
+        expr.visit_mut_children_with(self);
+        if !self.processed {
+            self.processed = tmp;
+            return;
+        }
+        expr.callee = expr
+            .callee
+            .take()
+            .expect_expr()
+            .make_member(quote_ident!("call"))
+            .as_callee();
+        expr.args
+            .insert(0, Expr::This(ThisExpr { span: DUMMY_SP }).as_arg());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::es2015::{function_name, shorthand_property::shorthand};
+    use swc_common::{chain, Mark};
+    use swc_ecma_transforms_base::resolver::resolver_with_mark;
+    use swc_ecma_transforms_testing::test;
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| {
+            let top_level_mark = Mark::fresh(Mark::root());
+            chain!(
+                resolver_with_mark(top_level_mark),
+                shorthand(),
+                function_name(),
+                object_super()
+            )
+        },
+        get,
+        "let obj = {
+            a(){
+                let c = super.x;
+            }
+        }",
+        r#"let obj = _obj = {
+            a: function a() {
+                let c = _get(_getPrototypeOf(_obj), "x", this);
+            }
+        };"#
+    );
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| {
+            let top_level_mark = Mark::fresh(Mark::root());
+            chain!(
+                resolver_with_mark(top_level_mark),
+                shorthand(),
+                function_name(),
+                object_super()
+            )
+        },
+        call,
+        "let obj = {
+            a(){
+                super.y(1,2,3);
+            }
+        }",
+        r#"let obj = _obj = {
+            a: function a() {
+                _get(_getPrototypeOf(_obj), "y", this).call(this,1,2,3);
+            }
+        };"#
+    );
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
+        |_| {
+            let top_level_mark = Mark::fresh(Mark::root());
+            chain!(
+                resolver_with_mark(top_level_mark),
+                shorthand(),
+                function_name(),
+                object_super()
+            )
+        },
+        set,
+        "let obj = {
+            a(){
+                super.x = 1;
+            }
+        }",
+        r#"let obj = _obj = {
+            a: function a() {
+                _set(_getPrototypeOf(_obj), "x", 1, this, true);
+            }
+        };"#
+    );
+}


### PR DESCRIPTION
**Description:**
Compile ES2015 object super to ES5
[plugin-transform-object-super](https://babeljs.io/docs/en/babel-plugin-transform-object-super) in babel

**Related issue (if exists):**
fix #2684 