### PR TITLE
fix(es/transform/resolver): avoid ident collapse for the reexport

### DIFF
--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3114/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3114/input.ts
@@ -1,0 +1,7 @@
+import type { foo } from 'bar';
+import { type bar, bee } from 'baz';
+import { boo } from 'baz2';
+
+export { foo } from 'bar';
+export { bar } from 'port';
+export { boo } from 'some';

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3114/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-3114/output.js
@@ -1,0 +1,4 @@
+import { boo } from 'baz2';
+export { foo } from 'bar';
+export { bar } from 'port';
+export { boo } from 'some';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Attempts to close #3114. 

This PR applies new mark to named export if

- named export comes from direct reexport (`export { some } from 'xxx'`)
- and export's ident collapses to existing ident

In case of #3114, existing logic treat reexported ident is same as imported one via `import type {...}`, ends up stripping its existence. However, if named export comes from direct reexport it is ensured it won't come from any ident in existing scope. PR attempts to assign new context for those cases.

Disclaimer this may not be the correct approach and I may did wrong.

**Related issue (if exists):**
- closes #3114 
