### PR TITLE
fix(es/optimization): Fix inlining

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "2048"]
+#![allow(dead_code)]
 
 #[macro_use]
 extern crate napi_derive;

--- a/crates/swc/tests/fixture/issue-2108/input/.swcrc
+++ b/crates/swc/tests/fixture/issue-2108/input/.swcrc
@@ -1,0 +1,20 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript"
+        },
+        "transform": {
+            "optimizer": {
+                "globals": {
+                    "vars": {}
+                }
+            }
+        },
+        "loose": true,
+        "target": "es2021",
+        "externalHelpers": true
+    },
+    "module": {
+        "type": "commonjs"
+    }
+}

--- a/crates/swc/tests/fixture/issue-2108/input/index.js
+++ b/crates/swc/tests/fixture/issue-2108/input/index.js
@@ -1,0 +1,9 @@
+function foo() {
+  let arr = []
+  arr = [1, 2, 3]
+
+  // NOTE: `return { arr }` works fine
+  return { arr: arr }
+}
+
+foo()

--- a/crates/swc/tests/fixture/issue-2108/output/index.js
+++ b/crates/swc/tests/fixture/issue-2108/output/index.js
@@ -1,0 +1,14 @@
+"use strict";
+function foo() {
+    let arr = [];
+    arr = [
+        1,
+        2,
+        3
+    ];
+    // NOTE: `return { arr }` works fine
+    return {
+        arr: arr
+    };
+}
+foo();

--- a/crates/swc/tests/fixture/issue-2108/output/index.js
+++ b/crates/swc/tests/fixture/issue-2108/output/index.js
@@ -1,6 +1,6 @@
 "use strict";
 function foo() {
-    let arr = [];
+    let arr;
     arr = [
         1,
         2,

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
@@ -120,7 +120,30 @@ impl VisitMut for Inlining<'_> {
 
                 e.left.visit_with(&mut v);
                 e.right.visit_with(&mut v);
+
+                match &mut e.left {
+                    PatOrExpr::Expr(left) => {
+                        //
+                        match &**left {
+                            Expr::Member(ref left) => {
+                                tracing::trace!("Assign to member expression!");
+                                let mut v = IdentListVisitor {
+                                    scope: &mut self.scope,
+                                };
+
+                                left.visit_with(&mut v);
+                                e.right.visit_with(&mut v);
+                            }
+
+                            _ => {}
+                        }
+                    }
+                    PatOrExpr::Pat(p) => {
+                        p.visit_mut_with(self);
+                    }
+                }
             }
+
             _ => {
                 let mut v = IdentListVisitor {
                     scope: &mut self.scope,
@@ -130,8 +153,6 @@ impl VisitMut for Inlining<'_> {
                 e.right.visit_with(&mut v)
             }
         }
-
-        e.left.visit_mut_with(self);
 
         e.right.visit_mut_with(self);
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
@@ -165,24 +165,26 @@ impl VisitMut for Inlining<'_> {
             return;
         }
 
-        match *e.right {
-            Expr::Lit(..) | Expr::Ident(..) => {
-                //
-                match e.left.as_ident() {
-                    Some(i) => {
-                        let id = i.to_id();
-                        self.scope.add_write(&id, false);
+        //
+        match e.left.as_ident() {
+            Some(i) => {
+                let id = i.to_id();
+                self.scope.add_write(&id, false);
 
-                        if let Some(var) = self.scope.find_binding(&id) {
-                            if !var.is_inline_prevented() {
+                if let Some(var) = self.scope.find_binding(&id) {
+                    if !var.is_inline_prevented() {
+                        match *e.right {
+                            Expr::Lit(..) | Expr::Ident(..) => {
                                 *var.value.borrow_mut() = Some(*e.right.clone());
+                            }
+
+                            _ => {
+                                *var.value.borrow_mut() = None;
                             }
                         }
                     }
-                    _ => {}
                 }
             }
-
             _ => {}
         }
     }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
@@ -304,12 +304,16 @@ impl VisitMut for Inlining<'_> {
                                 let expr = var.value.borrow();
 
                                 if let Some(expr) = &*expr {
+                                    tracing::debug!("Inlining: {:?}", id);
+
                                     if *node != *expr {
                                         self.changed = true;
                                     }
 
                                     Some(expr.clone())
                                 } else {
+                                    tracing::debug!("Inlining: {:?} as undefined", id);
+
                                     if var.is_undefined.get() {
                                         *node = *undefined(i.span);
                                         return;

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
@@ -108,27 +108,17 @@ impl VisitMut for Inlining<'_> {
 
         e.left.map_with_mut(|n| n.normalize_expr());
 
-        match &mut e.left {
-            PatOrExpr::Expr(left) => {
-                //
-                match &**left {
-                    Expr::Member(ref left) => {
-                        tracing::trace!("Assign to member expression!");
-                        let mut v = IdentListVisitor {
-                            scope: &mut self.scope,
-                        };
+        {
+            let mut v = IdentListVisitor {
+                scope: &mut self.scope,
+            };
 
-                        left.visit_with(&mut v);
-                        e.right.visit_with(&mut v);
-                    }
-
-                    _ => {}
-                }
-            }
-            PatOrExpr::Pat(p) => {
-                p.visit_mut_with(self);
-            }
+            e.left.visit_with(&mut v);
+            e.right.visit_with(&mut v);
         }
+
+        e.left.visit_mut_with(self);
+
         e.right.visit_mut_with(self);
 
         match e.op {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
@@ -112,21 +112,15 @@ impl VisitMut for Inlining<'_> {
 
         e.left.map_with_mut(|n| n.normalize_expr());
 
-        {
-            let mut v = IdentListVisitor {
-                scope: &mut self.scope,
-            };
-
-            e.left.visit_with(&mut v);
-            e.right.visit_with(&mut v);
-        }
-
-        e.left.visit_mut_with(self);
-
-        e.right.visit_mut_with(self);
-
         match e.op {
-            op!("=") => {}
+            op!("=") => {
+                let mut v = WriteVisitor {
+                    scope: &mut self.scope,
+                };
+
+                e.left.visit_with(&mut v);
+                e.right.visit_with(&mut v);
+            }
             _ => {
                 let mut v = IdentListVisitor {
                     scope: &mut self.scope,
@@ -136,6 +130,10 @@ impl VisitMut for Inlining<'_> {
                 e.right.visit_with(&mut v)
             }
         }
+
+        e.left.visit_mut_with(self);
+
+        e.right.visit_mut_with(self);
 
         if self.scope.is_inline_prevented(&e.right) {
             // Prevent inline for lhd

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/scope.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/scope.rs
@@ -436,7 +436,8 @@ impl<'a> Scope<'a> {
             "add_write",
             force_no_inline = force_no_inline,
             id = &*format!("{:?}", id)
-        );
+        )
+        .entered();
 
         if self.write_prevents_inline(id) {
             tracing::trace!("prevent inlining because of write: {}", id.0);

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/scope.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/scope.rs
@@ -12,6 +12,7 @@ use swc_common::collections::{AHashMap, AHashSet};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::ext::ExprRefExt;
 use swc_ecma_utils::{ident::IdentLike, Id};
+use tracing::{span, Level};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScopeKind {
@@ -51,6 +52,7 @@ impl Inlining<'_> {
                 ident_type: self.ident_type,
                 pat_mode: self.pat_mode,
                 in_test: self.in_test,
+                pass: self.pass,
             };
 
             op(&mut child);
@@ -429,6 +431,13 @@ impl<'a> Scope<'a> {
     }
 
     pub fn add_write(&mut self, id: &Id, force_no_inline: bool) {
+        let _tracing = span!(
+            Level::DEBUG,
+            "add_write",
+            force_no_inline = force_no_inline,
+            id = &*format!("{:?}", id)
+        );
+
         if self.write_prevents_inline(id) {
             tracing::trace!("prevent inlining because of write: {}", id.0);
 


### PR DESCRIPTION
swc_ecma_transforms_optimization:
 - `inlining`: Mark all usages as modification. (Closes #2108)