### PR TITLE
fix(es/parser): Support import assertions in specifier-less imports

### DIFF
--- a/crates/swc_ecma_codegen/tests/fixture/issues/3110/input.js
+++ b/crates/swc_ecma_codegen/tests/fixture/issues/3110/input.js
@@ -1,5 +1,6 @@
 import data from "./data.json" assert { type: "json" };
-export { default as data2 } from "./data2.json" assert { type: "json" };
-export * as data3 from "./data3.json" assert { type: "json" };
+import "./data2.json" assert { type: "json" };
+export { default as data3 } from "./data3.json" assert { type: "json" };
+export * as data4 from "./data4.json" assert { type: "json" };
 
 console.log(data);

--- a/crates/swc_ecma_codegen/tests/fixture/issues/3110/output.js
+++ b/crates/swc_ecma_codegen/tests/fixture/issues/3110/output.js
@@ -1,10 +1,13 @@
 import data from "./data.json" assert {
     type: "json"
 };
-export { default as data2 } from "./data2.json" assert {
+import "./data2.json" assert {
     type: "json"
 };
-export * as data3 from "./data3.json" assert {
+export { default as data3 } from "./data3.json" assert {
+    type: "json"
+};
+export * as data4 from "./data4.json" assert {
     type: "json"
 };
 console.log(data);

--- a/crates/swc_ecma_codegen/tests/fixture/issues/3110/output.min.js
+++ b/crates/swc_ecma_codegen/tests/fixture/issues/3110/output.min.js
@@ -1,1 +1,1 @@
-import data from"./data.json"assert{type:"json"};export{default as data2}from"./data2.json"assert{type:"json"};export*as data3 from"./data3.json"assert{type:"json"};console.log(data)
+import data from"./data.json"assert{type:"json"};import"./data2.json"assert{type:"json"};export{default as data3}from"./data3.json"assert{type:"json"};export*as data4 from"./data4.json"assert{type:"json"};console.log(data)

--- a/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
@@ -65,13 +65,25 @@ impl<'a, I: Tokens> Parser<I> {
                 },
                 _ => unreachable!(),
             };
+            let _ = cur!(self, false);
+            let asserts = if self.input.syntax().import_assertions()
+                && !self.input.had_line_break_before_cur()
+                && eat!(self, "assert")
+            {
+                match *self.parse_object::<Box<Expr>>()? {
+                    Expr::Object(v) => Some(v),
+                    _ => unreachable!(),
+                }
+            } else {
+                None
+            };
             expect!(self, ';');
             return Ok(ModuleDecl::Import(ImportDecl {
                 span: span!(self, start),
                 src,
                 specifiers: vec![],
                 type_only: false,
-                asserts: None,
+                asserts,
             }))
             .map(ModuleItem::from);
         }

--- a/crates/swc_ecma_parser/tests/typescript/import-assertions/stmt/test2/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript/import-assertions/stmt/test2/input.ts
@@ -1,0 +1,1 @@
+import "./foo.json" assert { type: "json" };

--- a/crates/swc_ecma_parser/tests/typescript/import-assertions/stmt/test2/input.ts.json
+++ b/crates/swc_ecma_parser/tests/typescript/import-assertions/stmt/test2/input.ts.json
@@ -1,0 +1,72 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 0,
+    "end": 44,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ImportDeclaration",
+      "span": {
+        "start": 0,
+        "end": 44,
+        "ctxt": 0
+      },
+      "specifiers": [],
+      "source": {
+        "type": "StringLiteral",
+        "span": {
+          "start": 7,
+          "end": 19,
+          "ctxt": 0
+        },
+        "value": "./foo.json",
+        "hasEscape": false,
+        "kind": {
+          "type": "normal",
+          "containsQuote": true
+        }
+      },
+      "typeOnly": false,
+      "asserts": {
+        "type": "ObjectExpression",
+        "span": {
+          "start": 27,
+          "end": 43,
+          "ctxt": 0
+        },
+        "properties": [
+          {
+            "type": "KeyValueProperty",
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 29,
+                "end": 33,
+                "ctxt": 0
+              },
+              "value": "type",
+              "optional": false
+            },
+            "value": {
+              "type": "StringLiteral",
+              "span": {
+                "start": 35,
+                "end": 41,
+                "ctxt": 0
+              },
+              "value": "json",
+              "hasEscape": false,
+              "kind": {
+                "type": "normal",
+                "containsQuote": true
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_transforms_proposal/tests/import_assertions.rs
+++ b/crates/swc_ecma_transforms_proposal/tests/import_assertions.rs
@@ -25,6 +25,14 @@ test!(
 test!(
     syntax(),
     |_| tr(),
+    side_effect_import_with_assertions,
+    r#"import "./test.json" assert {type: "json"};"#,
+    r#"import "./test.json";"#
+);
+
+test!(
+    syntax(),
+    |_| tr(),
     named_export_with_assertions,
     r#"export {default as test} from "./test.json" assert {type: "json"};"#,
     r#"export {default as test} from "./test.json";"#


### PR DESCRIPTION
swc_ecma_parser:

* Support import assertions in specifier-less imports.

swc_ecma_codegen:

* Add tests for codegen of import assertions in specifier-less imports.

swc_ecma_transforms_proposal:

* Add tests for stripping import assertions in specifier-less imports.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Specifier-less import assertions are not currently supported by the parser, even though the spec proposal allows them.

**BREAKING CHANGE:**
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

None

**Related issue (if exists):**

Fixes #3103.
