### PR TITLE
Test that string input sends null characters

### DIFF
--- a/crates/swc_common/src/lib.rs
+++ b/crates/swc_common/src/lib.rs
@@ -70,6 +70,8 @@ pub mod serializer;
 pub mod source_map;
 pub mod sync;
 mod syntax_pos;
+#[cfg(test)]
+mod tests;
 pub mod util;
 
 #[cfg(all(not(debug_assertions), feature = "plugin-rt", feature = "plugin-mode"))]

--- a/crates/swc_common/src/tests.rs
+++ b/crates/swc_common/src/tests.rs
@@ -1,0 +1,10 @@
+use super::*;
+use crate::sync::Lrc;
+
+#[test]
+fn issue_2853() {
+    let source_map = SourceMap::default();
+    let source_file = source_map.new_source_file(FileName::Anon, "const a = \"\u{0000}a\"".into());
+
+    assert_eq!(source_file.src, Lrc::new("const a = \"\u{0000}a\"".into()));
+}

--- a/crates/wasm/__tests__/issues.js
+++ b/crates/wasm/__tests__/issues.js
@@ -1,0 +1,6 @@
+const swc = require("../pkg");
+
+it("sends NULL character literals (2853)", function () {
+  expect(swc.transformSync(`const a = "\0a"`, {})).toEqual({code: `var a = "\\x00a";\n`});
+  expect(swc.transformSync(`const a = "\\0a"`, {})).toEqual({code: `var a = "\\x00a";\n`});
+});


### PR DESCRIPTION
**Description:**

This ensures that the code responsible for reading JS strings handles NULL character literals by escaping them.

I'm pretty sure, given these tests, that the problem lies somewhere in wasm-bindgen, or was fixed somehow by recent changes.

**Related issue (if exists):** https://github.com/swc-project/swc/issues/2853
