### PR TITLE
fix(es/minifier): obj, num and str comparison

### DIFF
--- a/crates/swc/tests/tsc-references/typeofOperatorWithAnyOtherType_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/typeofOperatorWithAnyOtherType_es5.2.minified.js
@@ -1,9 +1,14 @@
-var ANY, ANY1, obj, M, _typeof = function(obj1) {
-    return obj1 && "undefined" != typeof Symbol && obj1.constructor === Symbol ? "symbol" : typeof obj1;
+var ANY, ANY1, obj, M, _typeof = function(obj2) {
+    return obj2 && "undefined" != typeof Symbol && obj2.constructor === Symbol ? "symbol" : typeof obj2;
 }, ANY2 = [
     "",
     ""
-], A = function() {
+], obj1 = {
+    x: "a",
+    y: function() {}
+};
+function foo() {}
+var A = function() {
     "use strict";
     var Constructor;
     function A() {
@@ -28,11 +33,11 @@ var ANY, ANY1, obj, M, _typeof = function(obj1) {
     M1.n = n;
 }(M || (M = {}));
 var objA = new A();
-void 0 === ANY1 || _typeof(ANY1), void 0 === M || _typeof(M), void 0 === obj || _typeof(obj), _typeof(null), _typeof({}), _typeof(ANY2[0]), _typeof(objA.a), _typeof("a"), _typeof(M.n), _typeof(void 0), _typeof(A.foo()), _typeof(ANY + ANY1), _typeof(NaN), _typeof(0), _typeof(NaN), _typeof(void 0 === ANY ? "undefined" : _typeof(ANY)), _typeof(_typeof(_typeof(ANY + ANY1))), void 0 === ANY || _typeof(ANY), void 0 === ANY1 || _typeof(ANY1), _typeof(ANY2[0]), void 0 === ANY || _typeof(ANY), _typeof("a"), _typeof(objA.a), _typeof(M.n);
+void 0 === ANY1 || _typeof(ANY1), _typeof(ANY2), _typeof(A), void 0 === M || _typeof(M), void 0 === obj || _typeof(obj), _typeof(obj1), _typeof(null), _typeof({}), _typeof(ANY2[0]), _typeof(objA.a), _typeof(obj1.x), _typeof(M.n), _typeof(foo()), _typeof(A.foo()), _typeof(ANY + ANY1), _typeof(NaN), _typeof(0), _typeof(NaN), _typeof(void 0 === ANY ? "undefined" : _typeof(ANY)), _typeof(_typeof(_typeof(ANY + ANY1))), void 0 === ANY || _typeof(ANY), void 0 === ANY1 || _typeof(ANY1), _typeof(ANY2[0]), void 0 === ANY || _typeof(ANY), _typeof(obj1), _typeof(obj1.x), _typeof(objA.a), _typeof(M.n);
 z: void 0 === ANY || _typeof(ANY);
-x: ;
-r: ;
+x: _typeof(ANY2);
+r: _typeof(foo);
 z: _typeof(objA.a);
 z: _typeof(A.foo);
 z: _typeof(M.n);
-z: _typeof("a");
+z: _typeof(obj1.x);

--- a/crates/swc/tests/tsc-references/typeofOperatorWithBooleanType_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/typeofOperatorWithBooleanType_es5.2.minified.js
@@ -36,7 +36,7 @@ void 0 === BOOLEAN || _typeof(BOOLEAN), _typeof(!0), _typeof({
     y: !1
 }), _typeof(objA.a), _typeof(M.n), _typeof(foo()), _typeof(A.foo()), _typeof(void 0 === BOOLEAN ? "undefined" : _typeof(BOOLEAN)), _typeof(!0), void 0 === BOOLEAN || _typeof(BOOLEAN), _typeof(foo()), _typeof(!0), _typeof(objA.a), _typeof(M.n);
 z: void 0 === BOOLEAN || _typeof(BOOLEAN);
-r: ;
+r: _typeof(foo);
 z: _typeof(!0);
 z: _typeof(objA.a);
 z: _typeof(A.foo);

--- a/crates/swc/tests/tsc-references/typeofOperatorWithNumberType_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/typeofOperatorWithNumberType_es5.2.minified.js
@@ -1,6 +1,9 @@
 var NUMBER, M, _typeof = function(obj) {
     return obj && "undefined" != typeof Symbol && obj.constructor === Symbol ? "symbol" : typeof obj;
-}, A = function() {
+}, NUMBER1 = [
+    1,
+    2
+], A = function() {
     "use strict";
     var Constructor;
     function A() {
@@ -27,7 +30,7 @@ var NUMBER, M, _typeof = function(obj) {
     M1.n = n;
 }(M || (M = {}));
 var objA = new A();
-void 0 === NUMBER || _typeof(NUMBER), _typeof(1), _typeof({
+void 0 === NUMBER || _typeof(NUMBER), _typeof(NUMBER1), _typeof(1), _typeof({
     x: 1,
     y: 2
 }), _typeof({
@@ -35,10 +38,12 @@ void 0 === NUMBER || _typeof(NUMBER), _typeof(1), _typeof({
     y: function(n) {
         return n;
     }
-}), _typeof(objA.a), _typeof(M.n), _typeof(1), _typeof(1), _typeof(A.foo()), _typeof(NUMBER + NUMBER), _typeof(void 0 === NUMBER ? "undefined" : _typeof(NUMBER)), _typeof(_typeof(_typeof(NUMBER + NUMBER))), _typeof(1), void 0 === NUMBER || _typeof(NUMBER), _typeof(1), _typeof(objA.a), _typeof(M.n), _typeof(objA.a), M.n;
+}), _typeof(objA.a), _typeof(M.n), _typeof(NUMBER1[0]), _typeof(1), _typeof(A.foo()), _typeof(NUMBER + NUMBER), _typeof(void 0 === NUMBER ? "undefined" : _typeof(NUMBER)), _typeof(_typeof(_typeof(NUMBER + NUMBER))), _typeof(1), void 0 === NUMBER || _typeof(NUMBER), _typeof(NUMBER1), _typeof(1), _typeof(objA.a), _typeof(M.n), _typeof(objA.a), M.n;
 z: void 0 === NUMBER || _typeof(NUMBER);
-x: ;
-r: ;
+x: _typeof(NUMBER1);
+r: _typeof(function() {
+    return 1;
+});
 z: _typeof(1);
 z: _typeof(objA.a);
 z: _typeof(A.foo);

--- a/crates/swc/tests/tsc-references/typeofOperatorWithStringType_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/typeofOperatorWithStringType_es5.2.minified.js
@@ -1,6 +1,9 @@
 var STRING, M, _typeof = function(obj) {
     return obj && "undefined" != typeof Symbol && obj.constructor === Symbol ? "symbol" : typeof obj;
-};
+}, STRING1 = [
+    "",
+    "abc"
+];
 function foo() {
     return "abc";
 }
@@ -31,7 +34,7 @@ var A = function() {
     M1.n = n;
 }(M || (M = {}));
 var objA = new A();
-void 0 === STRING || _typeof(STRING), _typeof(""), _typeof({
+void 0 === STRING || _typeof(STRING), _typeof(STRING1), _typeof(""), _typeof({
     x: "",
     y: ""
 }), _typeof({
@@ -39,10 +42,10 @@ void 0 === STRING || _typeof(STRING), _typeof(""), _typeof({
     y: function(s) {
         return s;
     }
-}), _typeof(objA.a), _typeof(M.n), _typeof(""), _typeof(foo()), _typeof(A.foo()), _typeof(STRING + STRING), _typeof(STRING.charAt(0)), _typeof(void 0 === STRING ? "undefined" : _typeof(STRING)), _typeof(_typeof(_typeof(STRING + STRING))), _typeof(""), void 0 === STRING || _typeof(STRING), _typeof(foo()), _typeof(objA.a), M.n;
+}), _typeof(objA.a), _typeof(M.n), _typeof(STRING1[0]), _typeof(foo()), _typeof(A.foo()), _typeof(STRING + STRING), _typeof(STRING.charAt(0)), _typeof(void 0 === STRING ? "undefined" : _typeof(STRING)), _typeof(_typeof(_typeof(STRING + STRING))), _typeof(""), void 0 === STRING || _typeof(STRING), _typeof(STRING1), _typeof(foo()), _typeof(objA.a), M.n;
 z: void 0 === STRING || _typeof(STRING);
-x: ;
-r: ;
+x: _typeof(STRING1);
+r: _typeof(foo);
 z: _typeof("");
 z: _typeof(objA.a);
 z: _typeof(A.foo);

--- a/crates/swc_ecma_minifier/tests/compress/fixture/issues/2257/full/output.js
+++ b/crates/swc_ecma_minifier/tests/compress/fixture/issues/2257/full/output.js
@@ -6047,7 +6047,7 @@
                     s = "" === s ? t : s + repeat.call("0", 7 - t.length) + t;
                 }
                 return s;
-            }, FORCED = !fails(function() {
+            }, FORCED = nativeToFixed && !0 || !fails(function() {
                 nativeToFixed.call({});
             });
             $({

--- a/crates/swc_ecma_minifier/tests/compress/fixture/issues/lit_comparisons/config.json
+++ b/crates/swc_ecma_minifier/tests/compress/fixture/issues/lit_comparisons/config.json
@@ -1,0 +1,5 @@
+{
+    "comparisons": true,
+    "reduce_vars": true,
+    "toplevel": true
+}

--- a/crates/swc_ecma_minifier/tests/compress/fixture/issues/lit_comparisons/input.js
+++ b/crates/swc_ecma_minifier/tests/compress/fixture/issues/lit_comparisons/input.js
@@ -1,0 +1,10 @@
+const a = 3;
+const b = 4;
+const c = "3";
+const d = "4";
+const e = {};
+const f = {};
+const g = true;
+const h = false;
+const j = null;
+console.log(a === b, c === d, e === f, g === h, h === j);

--- a/crates/swc_ecma_minifier/tests/compress/fixture/issues/lit_comparisons/output.js
+++ b/crates/swc_ecma_minifier/tests/compress/fixture/issues/lit_comparisons/output.js
@@ -1,0 +1,10 @@
+const a = 3;
+const b = 4;
+const c = "3";
+const d = "4";
+const e;
+const f;
+const g = true;
+const h = false;
+const j = null;
+console.log(false, false, ({}) == {}, false, false);


### PR DESCRIPTION
Description:

optimize_lit_cmp does not compare `number` and `string` correctly.

input
```js
const a = 3;
const b = 4;
const c = "3";
const d = "4";
const e = {};
const f = {};
const g = true;
const h = false;
const j = null;
console.log(a === b, c === d, e === f, g === h, h === j);
```
previous out
```js
const a = 3;
const b = 4;
const c = "3";
const d = "4";
const e = {};
const f = {};
const g = true;
const h = false;
const j = null;
console.log(true, true, true, false, false);
```
current out
```js
const a = 3;
const b = 4;
const c = "3";
const d = "4";
const e;
const f;
const g = true;
const h = false;
const j = null;
console.log(false, false, false, ({}) === {}, false);
```