### PR TITLE
refactor(swc/plugins): load wasm plugin with cache (#3167 part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
- "gimli",
+ "gimli 0.26.1",
 ]
 
 [[package]]
@@ -121,10 +121,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "as_derive_utils"
@@ -142,7 +154,7 @@ dependencies = [
 name = "ast_node"
 version = "0.7.6"
 dependencies = [
- "darling",
+ "darling 0.10.2",
  "pmutil",
  "proc-macro2",
  "quote",
@@ -220,6 +232,20 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "blake3"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "526c210b4520e416420759af363083471656e819a75e831b8d2c9d5a584f2413"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.2",
+ "cc",
+ "cfg-if 1.0.0",
+ "constant_time_eq",
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -383,6 +409,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,12 +467,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-bforest"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6bea67967505247f54fa2c85cf4f6e0e31c4e5692c9b70e4ae58e339067333"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48194035d2752bdd5bdae429e3ab88676e95f52a2b1355a5d4e809f9e39b1d74"
+dependencies = [
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+ "gimli 0.25.0",
+ "log",
+ "regalloc",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976efb22fcab4f2cd6bd4e9913764616a54d895c1a23530128d04e03633c555f"
+dependencies = [
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279afcc0d3e651b773f94837c3d581177b348c8d69e928104b2e9fccb226f921"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
 name = "crc"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 dependencies = [
  "build_const",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -515,8 +616,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.10.2",
+ "darling_macro 0.10.2",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+dependencies = [
+ "darling_core 0.13.1",
+ "darling_macro 0.13.1",
 ]
 
 [[package]]
@@ -534,12 +645,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
- "darling_core",
+ "darling_core 0.10.2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+dependencies = [
+ "darling_core 0.13.1",
  "quote",
  "syn",
 ]
@@ -621,6 +757,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumset"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6216d2c19a6fb5f29d1ada1dc7bc4367a8cbf0fa4af5cf12e07b5bbdde6b5b2c"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6451128aa6655d880755345d085494cf7561a6bee7c8dc821e5d77e6d267ecd4"
+dependencies = [
+ "darling 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "esdiff"
 version = "0.1.0"
 dependencies = [
@@ -643,6 +800,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fixedbitset"
@@ -778,6 +941,17 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "gimli"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1001,9 +1175,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.49"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1030,6 +1204,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "lexical"
 version = "5.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,7 +1225,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "bitflags",
  "cfg-if 1.0.0",
  "ryu",
@@ -1087,12 +1267,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "loupe"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6a72dfa44fe15b5e76b94307eeb2ff995a8c5b283b55008940c02e0c5b634d"
+dependencies = [
+ "indexmap",
+ "loupe-derive",
+ "rustversion",
+]
+
+[[package]]
+name = "loupe-derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "lru"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
 dependencies = [
  "hashbrown",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1115,6 +1325,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memmap2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4647a11b578fead29cdbb34d4adef8dd3dc35b876c9c6d5240d83f205abfe96e"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -1188,6 +1407,12 @@ checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "more-asserts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "napi"
@@ -1428,6 +1653,8 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
+ "crc32fast",
+ "indexmap",
  "memchr",
 ]
 
@@ -1914,6 +2141,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc"
+version = "0.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+dependencies = [
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,6 +2176,18 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "region"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
+dependencies = [
+ "bitflags",
+ "libc",
+ "mach",
+ "winapi",
+]
 
 [[package]]
 name = "relative-path"
@@ -2090,6 +2340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2454,15 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2316,7 +2581,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3caeb13a58f859600a7b75fffe66322e1fca0122ca02cfc7262344a7e30502d1"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "static-map-macro",
 ]
 
@@ -2393,6 +2658,12 @@ name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
@@ -2942,7 +3213,7 @@ name = "swc_ecma_transforms_compat"
 version = "0.61.0"
 dependencies = [
  "ahash",
- "arrayvec",
+ "arrayvec 0.5.2",
  "indexmap",
  "is-macro",
  "num-bigint",
@@ -3332,6 +3603,8 @@ dependencies = [
  "swc_ecma_plugin_ast",
  "swc_plugin_js_api",
  "testing",
+ "wasmer",
+ "wasmer-cache",
 ]
 
 [[package]]
@@ -3406,14 +3679,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.65"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
+checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
 
 [[package]]
 name = "tempfile"
@@ -3601,6 +3880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3819,9 +4099,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.72"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3831,9 +4111,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.72"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3858,9 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.72"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3868,9 +4148,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.72"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3881,9 +4161,234 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.72"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+
+[[package]]
+name = "wasmer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f0188c23fc1b7de9bd7f8b834d0b1cd5edbe66e287452e8ce36d24418114f7"
+dependencies = [
+ "cfg-if 1.0.0",
+ "indexmap",
+ "js-sys",
+ "loupe",
+ "more-asserts",
+ "target-lexicon",
+ "thiserror",
+ "wasm-bindgen",
+ "wasmer-compiler",
+ "wasmer-compiler-cranelift",
+ "wasmer-derive",
+ "wasmer-engine",
+ "wasmer-engine-dylib",
+ "wasmer-engine-universal",
+ "wasmer-types",
+ "wasmer-vm",
+ "wat",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-cache"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75c10d11f4a62c5e152170db7831d6f81155b4524fbf0a4f5c78c1d8f7e51db"
+dependencies = [
+ "blake3",
+ "hex",
+ "thiserror",
+ "wasmer",
+]
+
+[[package]]
+name = "wasmer-compiler"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c51cc589772c5f90bd329244c2416976d6cb2ee00d59429aaa8f421d9fe447"
+dependencies = [
+ "enumset",
+ "loupe",
+ "rkyv",
+ "serde",
+ "serde_bytes",
+ "smallvec",
+ "target-lexicon",
+ "thiserror",
+ "wasmer-types",
+ "wasmer-vm",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmer-compiler-cranelift"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09691e3e323b4e1128d2127f60f9cd988b66ce49afc8184b071c2b5ab16793f2"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "gimli 0.25.0",
+ "loupe",
+ "more-asserts",
+ "rayon",
+ "smallvec",
+ "target-lexicon",
+ "tracing",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-derive"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f5cb7b09640e09f1215da95d6fb7477d2db572f064b803ff705f39ff079cc5"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmer-engine"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab20311c354fe2c12bc766417e0a1a45f399c1cd8ff262127d1dc86d0588971a"
+dependencies = [
+ "backtrace",
+ "enumset",
+ "lazy_static",
+ "loupe",
+ "memmap2",
+ "more-asserts",
+ "rustc-demangle",
+ "serde",
+ "serde_bytes",
+ "target-lexicon",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-engine-dylib"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd5b7a74731e1dcccaf10a8ff5f72216c82f12972ce17cc81c6caa1afff75ea"
+dependencies = [
+ "cfg-if 1.0.0",
+ "enumset",
+ "leb128",
+ "libloading",
+ "loupe",
+ "rkyv",
+ "serde",
+ "tempfile",
+ "tracing",
+ "wasmer-compiler",
+ "wasmer-engine",
+ "wasmer-object",
+ "wasmer-types",
+ "wasmer-vm",
+ "which",
+]
+
+[[package]]
+name = "wasmer-engine-universal"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfeae8d5b825ad7abcf9a34e66eb11e1507b21020efe7bbf9897e3dd8d7869e2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "enumset",
+ "leb128",
+ "loupe",
+ "region",
+ "rkyv",
+ "wasmer-compiler",
+ "wasmer-engine",
+ "wasmer-types",
+ "wasmer-vm",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-object"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d4714e4f3bdc3b2157c24284417d19cd99de036da31d00ec5664712dcb72f7"
+dependencies = [
+ "object",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-types"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434e1c0177da0a74ecca90b2aa7d5e86198260f07e8ba83be89feb5f0a4aeead"
+dependencies = [
+ "indexmap",
+ "loupe",
+ "rkyv",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "wasmer-vm"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc8f964ebba70d9f81340228b98a164782591f00239fc7f01e1b67afcf0e0156"
+dependencies = [
+ "backtrace",
+ "cc",
+ "cfg-if 1.0.0",
+ "indexmap",
+ "libc",
+ "loupe",
+ "memoffset",
+ "more-asserts",
+ "region",
+ "rkyv",
+ "serde",
+ "thiserror",
+ "wasmer-types",
+ "winapi",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.78.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
+
+[[package]]
+name = "wast"
+version = "38.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0d7b256bef26c898fa7344a2d627e8499f5a749432ce0a05eae1a64ff0c271"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcfaeb27e2578d2c6271a45609f4a055e6d7ba3a12eff35b1fd5ba147bdf046"
+dependencies = [
+ "wast",
+]
 
 [[package]]
 name = "web-sys"
@@ -3893,6 +4398,17 @@ checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3318,7 +3318,6 @@ dependencies = [
 name = "swc_plugin_runner"
 version = "0.23.0"
 dependencies = [
- "abi_stable",
  "anyhow",
  "libloading",
  "once_cell",

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -16,7 +16,7 @@ name = "swc"
 
 [features]
 default = ["es3"]
-# You can disable this feautre to reduce binary size.
+# You can disable this feature to reduce binary size.
 es3 = []
 # See https://github.com/swc-project/swc/issues/1108
 #

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -421,7 +421,7 @@ impl Options {
                 syntax.typescript()
             ),
             lint_to_fold(swc_ecma_lints::rules::all()),
-            crate::plugin::plugins(experimental.plugins),
+            crate::plugin::plugins(experimental),
             custom_before_pass(&program),
             // handle jsx
             Optional::new(
@@ -971,6 +971,13 @@ pub struct JscExperimental {
     /// If true, keeps import assertions in the output.
     #[serde(default)]
     pub keep_import_assertions: bool,
+    /// Location where swc may stores its intermediate cache.
+    /// Currently this is only being used for wasm plugin's bytecache.
+    /// Path should be absolute directory, which will be created if not exist.
+    /// This configuration behavior can change anytime under experimental flag
+    /// and will not be considered as breaking changes.
+    #[serde(default)]
+    pub cache_root: Option<String>,
 }
 
 impl Merge for JscExperimental {

--- a/crates/swc/src/plugin.rs
+++ b/crates/swc/src/plugin.rs
@@ -14,14 +14,59 @@ use swc_ecma_visit::{noop_fold_type, Fold};
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct PluginConfig(String, serde_json::Value);
 
+struct PluginBinary(String, Vec<u8>, String);
+
 pub fn plugins(config: crate::config::JscExperimental) -> impl Fold {
     #[cfg(feature = "plugin")]
     {
+        use anyhow::Context;
+
+        let mut plugin_binaries = vec![];
+        let mut plugin_errors = vec![];
+
+        if let Some(plugins) = &config.plugins {
+            for p in plugins {
+                let config_json = serde_json::to_string(&p.1)
+                    .context("failed to serialize plugin config as json");
+
+                if config_json.is_err() {
+                    plugin_errors.push(config_json.err().unwrap());
+                    continue;
+                }
+
+                let path = swc_plugin_runner::resolve::resolve(&p.0);
+
+                if path.is_err() {
+                    plugin_errors.push(path.err().unwrap());
+                    continue;
+                }
+
+                let module_bytes = std::fs::read(&path.unwrap().as_ref());
+
+                if module_bytes.is_err() {
+                    plugin_errors.push(
+                        module_bytes
+                            .context("Failed to read plugin binary")
+                            .err()
+                            .unwrap(),
+                    );
+                    continue;
+                }
+
+                plugin_binaries.push(PluginBinary(
+                    p.0.clone(),
+                    module_bytes.ok().unwrap(),
+                    config_json.ok().unwrap(),
+                ));
+            }
+        };
+
         let cache_root =
             swc_plugin_runner::resolve::resolve_plugin_cache_root(config.cache_root).ok();
 
         RustPlugins {
-            plugins: config.plugins,
+            plugins: plugin_binaries,
+            plugin_errors,
             plugin_cache: cache_root,
         }
     }
@@ -33,7 +78,8 @@ pub fn plugins(config: crate::config::JscExperimental) -> impl Fold {
 }
 
 struct RustPlugins {
-    plugins: Option<Vec<PluginConfig>>,
+    plugins: Vec<PluginBinary>,
+    plugin_errors: Vec<anyhow::Error>,
     /// TODO: it is unclear how we'll support plugin itself in wasm target of
     /// swc, as well as cache.
     #[cfg(feature = "plugin")]
@@ -43,23 +89,12 @@ struct RustPlugins {
 impl RustPlugins {
     #[cfg(feature = "plugin")]
     fn apply(&mut self, mut n: Program) -> Result<Program, anyhow::Error> {
-        use anyhow::Context;
+        for e in self.plugin_errors.drain(..) {
+            return Err(e);
+        }
 
-        if let Some(plugins) = &self.plugins {
-            for p in plugins {
-                let config_json = serde_json::to_string(&p.1)
-                    .context("failed to serialize plugin config as json")?;
-
-                let path = swc_plugin_runner::resolve::resolve(&p.0)?;
-
-                n = swc_plugin_runner::apply_js_plugin(
-                    &p.0,
-                    &path,
-                    &mut self.plugin_cache,
-                    &config_json,
-                    n,
-                )?;
-            }
+        for p in &self.plugins {
+            n = swc_plugin_runner::apply_js_plugin(&p.0, &p.1, &mut self.plugin_cache, &p.2, n)?;
         }
 
         Ok(n)

--- a/crates/swc_macros_common/Cargo.toml
+++ b/crates/swc_macros_common/Cargo.toml
@@ -15,4 +15,4 @@ quote = "1"
 
 [dependencies.syn]
 features = ["derive", "visit", "parsing", "full", "printing", "extra-traits"]
-version = "=1.0.65"
+version = "=1.0.84"

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["강동윤 <kdy1997.dev@gmail.com>"]
-description = "Runner for swc plugins. This crate is INTERRNAL crate and used by swc itself."
+description = "Runner for swc plugins. This crate is INTERNAL crate and used by swc itself."
 documentation = "https://rustdoc.swc.rs/swc_plugin_runner/"
 edition = "2021"
 license = "Apache-2.0"
@@ -10,7 +10,6 @@ version = "0.23.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-abi_stable = "0.10.3"
 anyhow = "1.0.42"
 libloading = "0.7.0"
 once_cell = "1.8.0"

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -23,6 +23,8 @@ swc_ecma_ast = {version = "0.61.0", path = "../swc_ecma_ast"}
 swc_ecma_parser = {version = "0.83.0", path = "../swc_ecma_parser"}
 swc_ecma_plugin_ast = {version = "0.8.0", path = "../swc_ecma_plugin_ast"}
 swc_plugin_js_api = {version = "0.6.0", path = "../swc_plugin_js_api"}
+wasmer = "2.1.1"
+wasmer-cache = "2.1.1"
 
 [dev-dependencies]
 testing = {version = "0.16.0", path = "../testing"}

--- a/crates/swc_plugin_runner/src/lib.rs
+++ b/crates/swc_plugin_runner/src/lib.rs
@@ -1,18 +1,86 @@
 use anyhow::{Context, Error};
+use resolve::PluginCache;
 use std::path::Path;
 use swc_ecma_ast::Program;
+use wasmer::{imports, Instance, Module, Store};
+use wasmer_cache::{Cache, Hash};
 
 pub mod resolve;
 
+/// Load plugin from specified path.
+/// If cache is provided, it'll try to load from cache first to avoid
+/// compilation.
+fn load_plugin(plugin_path: &Path, cache: &mut Option<PluginCache>) -> Result<Instance, Error> {
+    let wasmer_store = Store::default();
+    let module_bytes = std::fs::read(plugin_path).context("Cannot read plugin from specified path");
+
+    let load_from_cache = |c: &mut PluginCache, hash: Hash| match c {
+        PluginCache::File(filesystem_cache) => unsafe {
+            filesystem_cache.load(&wasmer_store, hash)
+        },
+    };
+
+    let store_into_cache = |c: &mut PluginCache, hash: Hash, module: &Module| match c {
+        PluginCache::File(filesystem_cache) => filesystem_cache.store(hash, module),
+    };
+
+    match module_bytes {
+        Ok(bytes) => {
+            let hash = Hash::generate(&bytes);
+
+            let load_cold_wasm_bytes =
+                || Module::new(&wasmer_store, bytes).context("Cannot compile plugin");
+
+            let module = if let Some(cache) = cache {
+                let cached_module =
+                    load_from_cache(cache, hash).context("Failed to load plugin from cache");
+
+                match cached_module {
+                    Ok(module) => Ok(module),
+                    Err(err) => {
+                        let loaded_module = load_cold_wasm_bytes().map_err(|_| err);
+                        match &loaded_module {
+                            Ok(module) => {
+                                if let Err(err) = store_into_cache(cache, hash, &module) {
+                                    loaded_module
+                                        .map_err(|_| err)
+                                        .context("Failed to store compiled plugin into cache")
+                                } else {
+                                    loaded_module
+                                }
+                            }
+                            Err(..) => loaded_module,
+                        }
+                    }
+                }
+            } else {
+                load_cold_wasm_bytes()
+            };
+
+            return match module {
+                Ok(module) => {
+                    let import_object = imports! {};
+
+                    Instance::new(&module, &import_object)
+                        .context("Failed to create plugin instance")
+                }
+                Err(err) => Err(err.into()),
+            };
+        }
+        Err(err) => Err(err),
+    }
+}
+
 pub fn apply_js_plugin(
-    plugin_name: &str,
+    _plugin_name: &str,
     path: &Path,
+    cache: &mut Option<PluginCache>,
     _config_json: &str,
     program: Program,
 ) -> Result<Program, Error> {
     (|| -> Result<_, Error> {
-        let _plugin_rt = swc_common::plugin::get_runtime_for_plugin(plugin_name.to_string());
-        //TODO: https://github.com/swc-project/swc/issues/3167
+        let _instance = load_plugin(path, cache)?;
+        // TODO: actually apply transform from plugin
         Ok(program)
     })()
     .with_context(|| {

--- a/crates/swc_plugin_runner/src/lib.rs
+++ b/crates/swc_plugin_runner/src/lib.rs
@@ -1,41 +1,19 @@
-use abi_stable::{
-    library::RootModule,
-    std_types::{RResult, RStr},
-};
-use anyhow::{anyhow, Context, Error};
-use rplugin::StableAst;
+use anyhow::{Context, Error};
 use std::path::Path;
 use swc_ecma_ast::Program;
-use swc_plugin_js_api::SwcJsPluginRef;
 
 pub mod resolve;
 
 pub fn apply_js_plugin(
     plugin_name: &str,
     path: &Path,
-    config_json: &str,
+    _config_json: &str,
     program: Program,
 ) -> Result<Program, Error> {
     (|| -> Result<_, Error> {
-        let plugin_rt = swc_common::plugin::get_runtime_for_plugin(plugin_name.to_string());
-
-        let plugin = SwcJsPluginRef::load_from_file(path).context("failed to load plugin")?;
-
-        let plugin_ast = StableAst::from_unstable(program);
-
-        let plugin_fn = plugin
-            .process_js()
-            .ok_or_else(|| anyhow!("the plugin does not support transforming js"))?;
-
-        let new_ast = plugin_fn(plugin_rt, RStr::from(config_json), plugin_ast);
-
-        let new = match new_ast {
-            RResult::ROk(v) => v,
-            RResult::RErr(err) => return Err(anyhow!("plugin returned an error\n{}", err)),
-        };
-        let new: Program = new.into_unstable();
-
-        Ok(new)
+        let _plugin_rt = swc_common::plugin::get_runtime_for_plugin(plugin_name.to_string());
+        //TODO: https://github.com/swc-project/swc/issues/3167
+        Ok(program)
     })()
     .with_context(|| {
         format!(

--- a/crates/swc_plugin_runner/src/resolve.rs
+++ b/crates/swc_plugin_runner/src/resolve.rs
@@ -9,6 +9,14 @@ use std::{
     sync::Arc,
 };
 use swc_common::collections::AHashMap;
+use wasmer_cache::FileSystemCache;
+
+/// Type of cache to store compiled bytecodes of plugins.
+/// Currently only supports filesystem, but _may_ supports
+/// other type (in-memory, etcs) for the long-running processes like devserver.
+pub enum PluginCache {
+    File(FileSystemCache),
+}
 
 /// TODO: Cache
 pub fn resolve(name: &str) -> Result<Arc<PathBuf>, Error> {
@@ -42,6 +50,33 @@ pub fn resolve(name: &str) -> Result<Arc<PathBuf>, Error> {
     }
 
     bail!("failed to resolve plugin `{}`:\n{:?}", name, errors)
+}
+
+/// Build a path to cache location where plugin's bytecode cache will be stored.
+/// This fn does a side effect to create path to cache if given path is not
+/// resolvable. If root is not specified, it'll generate default root for cache
+/// location.
+///
+/// Note SWC's plugin should not fail to load when cache location is not
+/// available. It'll make each invocation to cold start.
+pub fn resolve_plugin_cache_root(root: Option<String>) -> Result<PluginCache, Error> {
+    let root_path = match root {
+        Some(root) => {
+            let mut root = PathBuf::from(root);
+            root.push("plugins");
+            root
+        }
+        None => {
+            let mut cwd = current_dir().context("failed to get current directory")?;
+            cwd.push(".swc");
+            cwd.push("plugins");
+            cwd
+        }
+    };
+
+    FileSystemCache::new(root_path)
+        .map(|cache| PluginCache::File(cache))
+        .context("Failed to create cache location for the plugins")
 }
 
 #[derive(Deserialize)]

--- a/crates/swc_plugin_runner/tests/integration.rs
+++ b/crates/swc_plugin_runner/tests/integration.rs
@@ -60,7 +60,7 @@ fn internal() -> Result<(), Error> {
         let program = parser.parse_program().unwrap();
 
         let _program =
-            swc_plugin_runner::apply_js_plugin("internal-test", &path, &mut None, "{}", program)
+            swc_plugin_runner::apply_js_plugin("internal-test", &vec![], &mut None, "{}", program)
                 .unwrap();
 
         Ok(())

--- a/crates/swc_plugin_runner/tests/integration.rs
+++ b/crates/swc_plugin_runner/tests/integration.rs
@@ -58,7 +58,8 @@ fn internal() -> Result<(), Error> {
         let program = parser.parse_program().unwrap();
 
         let _program =
-            swc_plugin_runner::apply_js_plugin("internal-test", &path, "{}", program).unwrap();
+            swc_plugin_runner::apply_js_plugin("internal-test", &path, &None, "{}", program)
+                .unwrap();
 
         Ok(())
     })

--- a/crates/swc_plugin_runner/tests/integration.rs
+++ b/crates/swc_plugin_runner/tests/integration.rs
@@ -31,6 +31,8 @@ fn build_plugin(dir: &Path) -> Result<PathBuf, Error> {
     Err(anyhow!("Could not find built plugin"))
 }
 
+//TODO: https://github.com/swc-project/swc/issues/3167
+#[ignore]
 #[test]
 fn internal() -> Result<(), Error> {
     let path = build_plugin(
@@ -58,7 +60,7 @@ fn internal() -> Result<(), Error> {
         let program = parser.parse_program().unwrap();
 
         let _program =
-            swc_plugin_runner::apply_js_plugin("internal-test", &path, &None, "{}", program)
+            swc_plugin_runner::apply_js_plugin("internal-test", &path, &mut None, "{}", program)
                 .unwrap();
 
         Ok(())

--- a/deny.toml
+++ b/deny.toml
@@ -60,7 +60,7 @@ ignore = [
 # * Medium - CVSS Score 4.0 - 6.9
 # * High - CVSS Score 7.0 - 8.9
 # * Critical - CVSS Score 9.0 - 10.0
-#severity-threshold = 
+#severity-threshold =
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
@@ -74,6 +74,7 @@ unlicensed = "deny"
 allow = [
   "MIT",
   "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
   "BSD-2-Clause",
   "BSD-2-Clause-Patent",
   "BSD-3-Clause",
@@ -194,8 +195,8 @@ deny = [
 skip = [
   #{ name = "ansi_term", version = "=0.11.0" },
 ]
-# Similarly to `skip` allows you to skip certain crates during duplicate 
-# detection. Unlike skip, it also includes the entire tree of transitive 
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR is part 1 of #3167. PR contains a minimal set of changes, including

- deprecates abi_stable usage (in swc/plugins)
- revise plugin_runner to load wasm binary with cache support.

PR doesn't run actual transforms from loaded binary yet, only `loading` and compiling part are included.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

Techinically this is breaking changes to abi_stable based plugin, but under experimental flag we expected that'll occur.

**Related issue (if exists):**

#3167
