### PR TITLE
chore(ci): Fix publish script

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -9,12 +9,15 @@ env:
 
 on:
   push:
+    branches:
+      - ci
+      - main
     tags:
       - v*
 
 jobs:
   build:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/ci' }}
     strategy:
       fail-fast: false
       matrix:
@@ -272,7 +275,7 @@ jobs:
             swc*
           if-no-files-found: error
   test-macOS-windows-binding:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/ci' }}
     name: Test bindings on ${{ matrix.settings.target }} - node@${{ matrix.node }}
     needs:
       - build
@@ -314,7 +317,7 @@ jobs:
       - name: Test bindings
         run: yarn test
   test-linux-x64-gnu-binding:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/ci' }}
     name: Test bindings on Linux-x64-gnu - node@${{ matrix.node }}
     needs:
       - build
@@ -353,7 +356,7 @@ jobs:
       - name: Test bindings
         run: docker run --rm -v $(pwd):/swc -w /swc node:${{ matrix.node }}-slim yarn test
   test-linux-x64-musl-binding:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/ci' }}
     name: Test bindings on x86_64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
       - build
@@ -392,7 +395,7 @@ jobs:
       - name: Test bindings
         run: docker run --rm -v $(pwd):/swc -w /swc node:${{ matrix.node }}-alpine yarn test
   test-linux-aarch64-gnu-binding:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/ci' }}
     name: Test bindings on aarch64-unknown-linux-gnu - node@${{ matrix.node }}
     needs:
       - build
@@ -434,7 +437,7 @@ jobs:
             yarn test
             ls -la
   test-linux-aarch64-musl-binding:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/ci' }}
     name: Test bindings on aarch64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
       - build
@@ -469,7 +472,7 @@ jobs:
             apk add nodejs npm yarn
             yarn test
   test-linux-arm-gnueabihf-binding:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/ci' }}
     name: Test bindings on armv7-unknown-linux-gnueabihf - node@${{ matrix.node }}
     needs:
       - build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4447,3 +4447,8 @@ checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
+
+[[patch.unused]]
+name = "cranelift-codegen"
+version = "0.79.0"
+source = "git+https://github.com/kdy1/wasmtime#be24edf9d8cbaafaa1ba28307097557c9fe977c2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4447,8 +4447,3 @@ checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
-
-[[patch.unused]]
-name = "cranelift-codegen"
-version = "0.79.0"
-source = "git+https://github.com/kdy1/wasmtime#be24edf9d8cbaafaa1ba28307097557c9fe977c2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4447,3 +4447,8 @@ checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
+
+[[patch.unused]]
+name = "cranelift-codegen"
+version = "0.79.0"
+source = "git+https://github.com/kdy1/wasmtime?branch=tls#ddbbda19911b62f7b121bca69b8e81d828e458e8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,22 +460,20 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.76.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6bea67967505247f54fa2c85cf4f6e0e31c4e5692c9b70e4ae58e339067333"
+source = "git+https://github.com/kdy1/wasmtime?branch=tls#d59e6148e6b1d01430c217569c7bddb5838f11ed"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.76.0 (git+https://github.com/kdy1/wasmtime?branch=tls)",
 ]
 
 [[package]]
 name = "cranelift-codegen"
 version = "0.76.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48194035d2752bdd5bdae429e3ab88676e95f52a2b1355a5d4e809f9e39b1d74"
+source = "git+https://github.com/kdy1/wasmtime?branch=tls#d59e6148e6b1d01430c217569c7bddb5838f11ed"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
- "cranelift-entity",
+ "cranelift-entity 0.76.0 (git+https://github.com/kdy1/wasmtime?branch=tls)",
  "gimli 0.25.0",
  "log",
  "regalloc",
@@ -486,24 +484,27 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.76.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976efb22fcab4f2cd6bd4e9913764616a54d895c1a23530128d04e03633c555f"
+source = "git+https://github.com/kdy1/wasmtime?branch=tls#d59e6148e6b1d01430c217569c7bddb5838f11ed"
 dependencies = [
  "cranelift-codegen-shared",
- "cranelift-entity",
+ "cranelift-entity 0.76.0 (git+https://github.com/kdy1/wasmtime?branch=tls)",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.76.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
+source = "git+https://github.com/kdy1/wasmtime?branch=tls#d59e6148e6b1d01430c217569c7bddb5838f11ed"
 
 [[package]]
 name = "cranelift-entity"
 version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.76.0"
+source = "git+https://github.com/kdy1/wasmtime?branch=tls#d59e6148e6b1d01430c217569c7bddb5838f11ed"
 
 [[package]]
 name = "cranelift-frontend"
@@ -4183,7 +4184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09691e3e323b4e1128d2127f60f9cd988b66ce49afc8184b071c2b5ab16793f2"
 dependencies = [
  "cranelift-codegen",
- "cranelift-entity",
+ "cranelift-entity 0.76.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-frontend",
  "gimli 0.25.0",
  "loupe",
@@ -4447,8 +4448,3 @@ checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
-
-[[patch.unused]]
-name = "cranelift-codegen"
-version = "0.79.0"
-source = "git+https://github.com/kdy1/wasmtime#be24edf9d8cbaafaa1ba28307097557c9fe977c2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ name = "cranelift-bforest"
 version = "0.76.0"
 source = "git+https://github.com/kdy1/wasmtime?branch=tls#d59e6148e6b1d01430c217569c7bddb5838f11ed"
 dependencies = [
- "cranelift-entity 0.76.0 (git+https://github.com/kdy1/wasmtime?branch=tls)",
+ "cranelift-entity",
 ]
 
 [[package]]
@@ -473,7 +473,7 @@ dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
- "cranelift-entity 0.76.0 (git+https://github.com/kdy1/wasmtime?branch=tls)",
+ "cranelift-entity",
  "gimli 0.25.0",
  "log",
  "regalloc",
@@ -487,19 +487,13 @@ version = "0.76.0"
 source = "git+https://github.com/kdy1/wasmtime?branch=tls#d59e6148e6b1d01430c217569c7bddb5838f11ed"
 dependencies = [
  "cranelift-codegen-shared",
- "cranelift-entity 0.76.0 (git+https://github.com/kdy1/wasmtime?branch=tls)",
+ "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.76.0"
 source = "git+https://github.com/kdy1/wasmtime?branch=tls#d59e6148e6b1d01430c217569c7bddb5838f11ed"
-
-[[package]]
-name = "cranelift-entity"
-version = "0.76.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
 
 [[package]]
 name = "cranelift-entity"
@@ -4184,7 +4178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09691e3e323b4e1128d2127f60f9cd988b66ce49afc8184b071c2b5ab16793f2"
 dependencies = [
  "cranelift-codegen",
- "cranelift-entity 0.76.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-entity",
  "cranelift-frontend",
  "gimli 0.25.0",
  "loupe",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4451,4 +4451,4 @@ dependencies = [
 [[patch.unused]]
 name = "cranelift-codegen"
 version = "0.79.0"
-source = "git+https://github.com/kdy1/wasmtime?branch=tls#ddbbda19911b62f7b121bca69b8e81d828e458e8"
+source = "git+https://github.com/kdy1/wasmtime#be24edf9d8cbaafaa1ba28307097557c9fe977c2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,6 @@ opt-level = 3
 
 [profile.test.package.pretty_assertions]
 opt-level = 3
+
+[patch.crates-io]
+cranlift-codegen = {git = "git@github.com:kdy1/wasmtime.git", branch = "tls"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,6 @@ opt-level = 3
 
 [profile.test.package.pretty_assertions]
 opt-level = 3
+
+[patch.crates-io]
+cranelift-codegen = {git = "https://github.com/kdy1/wasmtime", ref = "d59e6148e6b1d01430c217569c7bddb5838f11ed"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,3 @@ opt-level = 3
 
 [profile.test.package.pretty_assertions]
 opt-level = 3
-
-[patch.crates-io]
-cranelift-codegen = {git = "https://github.com/kdy1/wasmtime", ref = "d59e6148e6b1d01430c217569c7bddb5838f11ed"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ opt-level = 3
 opt-level = 3
 
 [patch.crates-io]
-cranlift-codegen = {git = "https://github.com:kdy1/wasmtime.git", branch = "tls"}
+cranelift-codegen = {git = "https://github.com/kdy1/wasmtime", branch = "tls"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ opt-level = 3
 opt-level = 3
 
 [patch.crates-io]
-cranelift-codegen = {git = "https://github.com/kdy1/wasmtime", ref = "d59e6148e6b1d01430c217569c7bddb5838f11ed"}
+cranelift-codegen = {git = "https://github.com/kdy1/wasmtime", branch = "tls"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ opt-level = 3
 
 [patch.crates-io]
 cranelift-codegen = {git = "https://github.com/kdy1/wasmtime", branch = "tls"}
+cranelift-entity = {git = "https://github.com/kdy1/wasmtime", branch = "tls"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ opt-level = 3
 opt-level = 3
 
 [patch.crates-io]
-cranlift-codegen = {git = "git@github.com:kdy1/wasmtime.git", branch = "tls"}
+cranlift-codegen = {git = "https://github.com:kdy1/wasmtime.git", branch = "tls"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ opt-level = 3
 opt-level = 3
 
 [patch.crates-io]
-cranelift-codegen = {git = "https://github.com/kdy1/wasmtime", branch = "tls"}
+cranelift-codegen = {git = "https://github.com/kdy1/wasmtime", ref = "d59e6148e6b1d01430c217569c7bddb5838f11ed"}


### PR DESCRIPTION
# Context

Deployment of `swc` is failing because the thread-local storage size is too big.
I used methods in https://fasterthanli.me/articles/a-dynamic-linker-murder-mystery to debug it.

I found that `cranelift-codegen` is using too much thread-local storage space. 
