### PR TITLE
fix(es/minifier): Drop unreachable statements eagerly

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/drop_console.rs
+++ b/crates/swc_ecma_minifier/src/compress/drop_console.rs
@@ -72,7 +72,7 @@ impl VisitMut for DropConsole {
                             }
                         }
 
-                        // Sioplifier will remove side-effect-free items.
+                        // Simplifier will remove side-effect-free items.
                         *n = Expr::Seq(SeqExpr {
                             span: *span,
                             exprs: take(args).into_iter().map(|arg| arg.expr).collect(),

--- a/crates/swc_ecma_minifier/src/compress/pure/if_return.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/if_return.rs
@@ -1,9 +1,43 @@
 use super::Pure;
-use crate::compress::util::{is_fine_for_if_cons, negate};
+use crate::compress::util::{always_terminates, is_fine_for_if_cons, negate};
 use swc_common::{util::take::Take, DUMMY_SP};
 use swc_ecma_ast::*;
 
 impl<M> Pure<'_, M> {
+    pub(super) fn drop_unreachable_stmts(&mut self, stmts: &mut Vec<Stmt>) {
+        if !self.options.dead_code && !self.options.side_effects {
+            return;
+        }
+
+        let idx = stmts
+            .iter()
+            .enumerate()
+            .find(|(_, stmt)| always_terminates(&stmt));
+
+        if let Some((idx, _)) = idx {
+            stmts.iter_mut().skip(idx + 1).for_each(|stmt| match stmt {
+                Stmt::Decl(
+                    Decl::Var(VarDecl {
+                        kind: VarDeclKind::Var,
+                        ..
+                    })
+                    | Decl::Fn(..),
+                ) => {
+                    // Preserve
+                }
+
+                Stmt::Empty(..) => {
+                    // noop
+                }
+
+                _ => {
+                    self.changed = true;
+                    stmt.take();
+                }
+            });
+        }
+    }
+
     /// # Input
     ///
     /// ```js

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -96,7 +96,7 @@ where
 
     fn optimize_fn_stmts(&mut self, stmts: &mut Vec<Stmt>) {
         self.drop_unreachable_stmts(stmts);
-        
+
         self.remove_useless_return(stmts);
 
         self.negate_if_terminate(stmts, true, false);

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -95,6 +95,8 @@ where
     }
 
     fn optimize_fn_stmts(&mut self, stmts: &mut Vec<Stmt>) {
+        self.drop_unreachable_stmts(stmts);
+        
         self.remove_useless_return(stmts);
 
         self.negate_if_terminate(stmts, true, false);

--- a/crates/swc_ecma_minifier/tests/compress/fixture/issues/2257/full/output.js
+++ b/crates/swc_ecma_minifier/tests/compress/fixture/issues/2257/full/output.js
@@ -17340,13 +17340,8 @@
         },
         87832: function(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
             "use strict";
-            __webpack_require__.r(__webpack_exports__);
-            var prefix = "Invariant failed";
-            __webpack_exports__.default = function(condition, message) {
-                if (!condition) {
-                    throw new Error(prefix);
-                    throw new Error(prefix + ": " + (message || ""));
-                }
+            __webpack_require__.r(__webpack_exports__), __webpack_exports__.default = function(condition, message) {
+                if (!condition) throw new Error("Invariant failed");
             };
         },
         98009: function(__unused_webpack_module, __webpack_exports__, __webpack_require__) {

--- a/crates/swc_ecma_minifier/tests/compress/fixture/issues/3173/1/input.js
+++ b/crates/swc_ecma_minifier/tests/compress/fixture/issues/3173/1/input.js
@@ -1,0 +1,10 @@
+export const IndexPage = (value) => {
+    if (value === "loading") {
+        return 1;
+    } else if (value === "error") {
+        return 2;
+    } else {
+        return 3;
+    }
+    return 4;
+};

--- a/crates/swc_ecma_minifier/tests/compress/fixture/issues/3173/1/output.js
+++ b/crates/swc_ecma_minifier/tests/compress/fixture/issues/3173/1/output.js
@@ -1,0 +1,2 @@
+export const IndexPage = (value)=>"loading" === value ? 1 : "error" === value ? 2 : 3
+;

--- a/cspell.json
+++ b/cspell.json
@@ -100,6 +100,7 @@
         "nncs",
         "noinline",
         "NOINLINE",
+        "optimizable",
         "paren",
         "Paren",
         "pmutil",


### PR DESCRIPTION
swc_ecma_minifier:
 - `pure`: Drop unreachable statements. (Closes #3173)