### PR TITLE
feat(swc/plugin): allow multivalue for plugin fn signature

### DIFF
--- a/crates/swc_plugin_runner/src/lib.rs
+++ b/crates/swc_plugin_runner/src/lib.rs
@@ -145,10 +145,10 @@ pub fn apply_js_plugin(
 
         let plugin_process = instance
             .exports
-            .get_native_function::<(i32, u32), i32>("process")?;
+            .get_native_function::<(i32, u32), (i32, i32)>("process")?;
 
         let (alloc_ptr, len) = copy_memory_to_instance(&instance, &program)?;
-        plugin_process.call(alloc_ptr, len)?;
+        let (_returned_ptr, _returned_len) = plugin_process.call(alloc_ptr, len)?;
 
         Ok(program)
     })()

--- a/crates/swc_plugin_runner/tests/integration.rs
+++ b/crates/swc_plugin_runner/tests/integration.rs
@@ -11,11 +11,18 @@ use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, StringInput, Syntax};
 /// Returns the path to the built plugin
 fn build_plugin(dir: &Path) -> Result<PathBuf, Error> {
     {
-        let mut cmd = Command::new("cargo");
+        let mut cmd = if cfg!(windows) {
+            let mut c = Command::new("cmd");
+            c.args(&["/C", "build.cmd"]);
+            c
+        } else {
+            let mut c = Command::new("sh");
+            c.args(&["-c", "./build.sh"]);
+            c
+        };
+
         cmd.current_dir(dir);
-        cmd.args(["build", "--target=wasm32-unknown-unknown"])
-            .stderr(Stdio::inherit());
-        cmd.output()?;
+        cmd.stderr(Stdio::inherit()).output()?;
     }
 
     for entry in fs::read_dir(

--- a/tests/rust-plugins/swc_internal_plugin/.cargo/config.toml
+++ b/tests/rust-plugins/swc_internal_plugin/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+# Do not enable this config until https://github.com/rust-lang/rust/issues/73755 stablized
+# rustflags = ["-C", "target-feature=+multivalue"]

--- a/tests/rust-plugins/swc_internal_plugin/README.md
+++ b/tests/rust-plugins/swc_internal_plugin/README.md
@@ -1,0 +1,22 @@
+# SWC plugin
+
+## Multivalue-polyfill
+
+Once plugin completes transform, transformed `Program` will be re-serialized into array bytes.
+Host (SWC) will reconstruct & deserialize it via raw pointer to the array bytes plugin's `process` returns.
+However since size of serialized array bytes is non-deterministic plugin also should return size of the array as well.
+In result, signature of raw plugin process fn looks like this:
+
+```
+fn proces(...args) -> (i32, i32)
+```
+
+Rust compiler have target feature (`target-feature=+multivalue`) to genetare wasm binary with these multivalue support, but
+there are some known upstream issues like https://github.com/rust-lang/rust/issues/73755 prevents to use it. The other way around is to use
+bindings like `wasm-bindgen`.
+
+In this plugin example generated binary polyfills multivalue only instead of relying on whole wasm-bindgen workflow (https://github.com/vmx/wasm-multi-value-reverse-polyfill).
+This polyfill can be removed once upstream compiler feature works as expected or if we decide to use wasm-bindgen fully.
+
+Since cargo doesn't support workflow like `post-build` integrating whole process into build is bit unergonomic. `build.*` is naive substitution
+to mimic those behaviors. Or otherwise `multivalue-polyfill` can be excuted manually after main plugin build steps.

--- a/tests/rust-plugins/swc_internal_plugin/build.cmd
+++ b/tests/rust-plugins/swc_internal_plugin/build.cmd
@@ -1,0 +1,18 @@
+@ECHO OFF
+
+REM Iterate over arguments, check if it's release build
+SET BUILD_TARGET="debug"
+FOR %%A in (%*) DO (
+  IF /I "--release"=="%%A" (
+    SET BUILD_TARGET="release"
+  )
+)
+
+REM Build wasm binary
+cargo build %* --target=wasm32-unknown-unknown
+
+REM Build polyfill cli, run polyfill over generated wasm binary
+PUSHD multivalue-polyfill
+cargo build
+cargo run -- %BUILD_TARGET%
+POPD

--- a/tests/rust-plugins/swc_internal_plugin/build.sh
+++ b/tests/rust-plugins/swc_internal_plugin/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Iterate over arguments, check if it's release build
+export BUILD_TARGET="debug"
+for var in "$@"
+do
+  if [ "$var" = "--release" ]; then
+    export BUILD_TARGET="release"
+  fi
+done
+
+# Build wasm binary
+cargo build $@ --target=wasm32-unknown-unknown
+
+# Build polyfill cli, run polyfill over generated wasm binary
+pushd multivalue-polyfill
+cargo build
+cargo run -- $BUILD_TARGET
+popd

--- a/tests/rust-plugins/swc_internal_plugin/multivalue-polyfill/Cargo.toml
+++ b/tests/rust-plugins/swc_internal_plugin/multivalue-polyfill/Cargo.toml
@@ -1,0 +1,14 @@
+[workspace]
+
+[package]
+name = "multivalue-polyfill"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+walrus = "0.19.0"
+wasm-bindgen-multi-value-xform = "0.2.78"
+wasm-bindgen-wasm-conventions = "0.2.78"
+wit-text = "0.8.0"
+wit-validator = "0.2.1"
+wit-walrus = "0.6.0"

--- a/tests/rust-plugins/swc_internal_plugin/multivalue-polyfill/src/main.rs
+++ b/tests/rust-plugins/swc_internal_plugin/multivalue-polyfill/src/main.rs
@@ -1,0 +1,105 @@
+// https://github.com/vmx/wasm-multi-value-reverse-polyfill/blob/bba1488949059163a44784cd92c931014031dfb5/src/main.rs
+use std::{env, fs, path::PathBuf};
+use walrus::{ExportId, ExportItem, FunctionId, Module, ValType};
+
+/// Returns the export and function IDs.
+fn get_ids_by_name(module: &Module, function_name: &str) -> (ExportId, FunctionId) {
+    let export = module
+        .exports
+        .iter()
+        .find(|&exp| exp.name == function_name)
+        .expect(&format!(
+            "cannot find function with name `{}`",
+            function_name
+        ));
+
+    match export.item {
+        ExportItem::Function(function_id) => (export.id(), function_id),
+        _ => panic!("item is not a function"),
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // We'll polyfill return type of plugin's `process` interface to (i32, i32)
+    let transformations = vec![("process", vec![ValType::I32, ValType::I32])];
+
+    let target: Vec<String> = env::args().collect();
+
+    let target_path = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?)
+        .join("..")
+        .join("target")
+        .join("wasm32-unknown-unknown")
+        .join(target[1].clone());
+
+    let input_path = fs::read_dir(target_path)?
+        .enumerate()
+        .find_map(|(_size, entry)| {
+            if let Ok(entry) = entry {
+                let s = entry.file_name().to_string_lossy().into_owned();
+                if s.ends_with(".wasm") {
+                    Some(entry.path())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .expect("Binary should exist");
+
+    let input_path = input_path.as_path();
+
+    let wasm = wit_text::parse_file(&input_path)
+        .expect(&format!("input file `{:#?}` can be read", input_path));
+    wit_validator::validate(&wasm).expect(&format!("failed to validate `{:#?}`", input_path));
+    let mut module = walrus::ModuleConfig::new()
+        // Skip validation of the module as LLVM's output is
+        // generally already well-formed and so we won't gain much
+        // from re-validating. Additionally LLVM's current output
+        // for threads includes atomic instructions but doesn't
+        // include shared memory, so it fails that part of
+        // validation!
+        .strict_validate(false)
+        .on_parse(wit_walrus::on_parse)
+        .parse(&wasm)
+        .expect("failed to parse input file as wasm");
+
+    let shadow_stack_pointer = wasm_bindgen_wasm_conventions::get_shadow_stack_pointer(&module)
+        .expect("cannot get shadow stack pointer");
+    let memory = wasm_bindgen_wasm_conventions::get_memory(&module).expect("cannot get memory");
+
+    let to_xform: Vec<(FunctionId, usize, Vec<ValType>)> = transformations
+        .iter()
+        .map(|(function_name, result_types)| {
+            println!(
+                "Make `{}` function return `{:?}`.",
+                function_name, result_types
+            );
+            let (_export_id, function_id) = get_ids_by_name(&module, function_name);
+            (function_id, 0, result_types.to_vec())
+        })
+        .collect();
+    let export_ids: Vec<ExportId> = transformations
+        .iter()
+        .map(|(function_name, _)| {
+            let (export_id, _function_id) = get_ids_by_name(&module, function_name);
+            export_id
+        })
+        .collect();
+
+    let wrappers = wasm_bindgen_multi_value_xform::run(
+        &mut module,
+        memory,
+        shadow_stack_pointer,
+        &to_xform[..],
+    )?;
+
+    for (export_id, id) in export_ids.into_iter().zip(wrappers) {
+        let mut_export = module.exports.get_mut(export_id);
+        mut_export.item = id.into();
+    }
+
+    let output_bytes = module.emit_wasm();
+    fs::write(&input_path, &output_bytes).expect(&format!("failed to write `{:#?}`", input_path));
+    Ok(())
+}

--- a/tests/rust-plugins/swc_internal_plugin/src/lib.rs
+++ b/tests/rust-plugins/swc_internal_plugin/src/lib.rs
@@ -1,5 +1,5 @@
 use rkyv::{AlignedVec, Deserialize};
-use swc_plugin::{ ModuleItem, Program, VisitMut};
+use swc_plugin::{ModuleItem, Program, VisitMut};
 
 struct Dummy;
 
@@ -15,7 +15,7 @@ impl VisitMut for Dummy {
 // - swc_plugin macro to support ergonomic interfaces
 // - better developer experience: println / dbg!() doesn't emit anything
 // - typed json config instead of str, which requires additional deserialization
-pub fn process(ast_ptr: *mut u8, len: u32) -> i32 {
+pub fn process(ast_ptr: *mut u8, len: u32) -> (i32, i32) {
     let mut vec = AlignedVec::with_capacity(len.try_into().unwrap());
     let v = unsafe { std::slice::from_raw_parts(ast_ptr, len.try_into().unwrap()) };
     vec.extend_from_slice(v);
@@ -24,5 +24,5 @@ pub fn process(ast_ptr: *mut u8, len: u32) -> i32 {
     let archived = unsafe { rkyv::archived_root::<Program>(&vec[..]) };
     let _v: Program = archived.deserialize(&mut rkyv::Infallible).unwrap();
 
-    0
+    (0, 0)
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

`tests/rust-plugins/swc_internal_plugin/README.md` includes crux of changes in this PR.

Our plugin's transform doesn't guarantee deterministic size of returned value, so `process` should able to pass `ptr` + `size` to reconstruct `AlignedVec` to deserialize its result. Thanksfully there is accepted spec (https://github.com/WebAssembly/multi-value) allows to return multiple values from wasm exported fn. 

Problem is generating those bytes - while compiler supports `target-feature=+multivalue` it is not working as expected at least for the target `wasm32-unknown-unknown`. We can bring whole `wasm-bindgen` and its cli to utilize wasm-bindgen's bindings, but it's yet unclear we'll require `wasm-bindgen` for all plugin authoring.

This PR instead picks up necessary polyfill only for the multivalue against the generated wasm binary. This can be safely removed once we know compiler flag issues gets fixed. If we release plugin features before compiler fix, we may integrate this steps into our cli as well as scaffolding plugin template to avoid manual postbuild steps. For now, test-plugin relies on naive scripts to chain commands.


**Related issue (if exists):**
- https://github.com/swc-project/swc/issues/3167