### PR TITLE
docs(adr): setting up adr, start to write 00001-plugin

### DIFF
--- a/docs/adr/00000-whats-the-big-idea.md
+++ b/docs/adr/00000-whats-the-big-idea.md
@@ -1,0 +1,1 @@
+### This adr attempts to describe 10,000ft view for the swc project itself. To be filled gradually.

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -44,10 +44,12 @@ This decision is taken because
 
 [example | description | pointer to more information | …] <!-- optional -->
 
--   Good, because [argument a]
--   Good, because [argument b]
--   Bad, because [argument c]
--   … <!-- numbers of pros and cons can vary -->
+-   Good, because users can use rich echosystem of babel.
+-   Good, because users are used to javascript.
+-   Bad, because js plugins require and block the main javascript thread.
+-   Bad, because the main javascript is singled threaded and be bottleneck.
+-   Bad, because `napi` (renamed to `node-api`) does not provide a way to get the return value of a function called from other thread than js thread. To workaround this, we should implement a complex request-response system based using lots of mutex.
+-   Bad, because node js worker thread is not an event loop. This means worker we cannot `yield` from a worker thread when we need to call js plugin. As a result, the when main js thread is busy because of js plugins, worker threads are also blocked without doing any task.
 
 ### [option 2] Plugins based on `abi_stable` and native dynamic libraries
 

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -71,29 +71,25 @@ Plugins are written in rust, and built as native libraries for each platforms. S
 
 SWC embeds `wasmtime`, loads plugin built as web assembly.
 
--   Good, because [argument a]
--   Good, because [argument b]
+-   Good, because it's fast except the first run.
+-   Good, because configuring CI is simple.
 -   Good, because plugin authors can publish a plugin without CI, even with a single machine.
 -   Bad, because `@swc/wasm` has no way to support plugins.
--   Bad, because first load is slow.
+-   Bad, because first run is slow.
+-   Bad, because we have to manage the cache of compiled wasm files.
 -   Bad, because `wasmtime` does not support all platforms.
--   Bad, because [argument c]
--   … <!-- numbers of pros and cons can vary -->
 
 ### [option 4] Wasm plugins based on `wasmer`
 
 SWC embeds web assembly runtime (https://wasmer.io/), loads plugin built as web assembly.
 
-[example | description | pointer to more information | …] <!-- optional -->
-
--   Good, because [argument a]
--   Good, because [argument b]
+-   Good, because it's fast except the first run.
+-   Good, because configuring CI is simple.
 -   Good, because plugin authors can publish a plugin without CI, even with a single machine.
--   Good, because in future `@swc/wasm` can support plugins as `wasmer` officially supports using it within a wasm file.
--   Bad, because first load is slow.
--   Bad, because [argument c]
+-   Good, because `@swc/wasm` can support plugins in future as `wasmer` officially supports using it within a wasm file.
+-   Bad, because first run is slow.
+-   Bad, because we have to manage the cache of compiled wasm files.
 -   Bad, because `wasmer` does not support all platforms.
--   … <!-- numbers of pros and cons can vary -->
 
 ## Links
 

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -60,6 +60,7 @@ Plugins are written in rust, and built as native libraries for each platforms. S
 
 -   Good, because it's fast, even on the first run.
 -   Bad, because configuring CI for publishing plugins is very hard.
+-   Bad, because plugin developer cannot publish a plugin from a single machine.
 -   Bad, because loading of plugins is complex. Path for dynamic libraries are platform-dependant.
 -   Bad, because we have to handle quirks of each platforms.
 -   Bad, because `@swc/wasm` has no way to support plugins.

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -1,0 +1,69 @@
+# Support transform plugin in native rust binaries
+
+* Status: accepted <!-- optional -->
+* Deciders: @kdy1, @kwonoj <!-- optional -->
+* Date: 2021-01-01 <!-- optional -->
+
+Technical Story: [Issue](https://github.com/swc-project/swc/issues/2635) <!-- optional -->
+
+## Context and Problem Statement
+
+SWC wants to support load, run plugins in the native binary for the custom transform behavior. SWC already have priliminary support to load plugins in its node.js JS bindings but it has known limitations.
+
+## Decision Drivers <!-- optional -->
+
+* Allow to write a plugin binary can be loaded in the SWC's native binary without involving JS binding interop.
+* Provide good, satisfactory performance while loading, running plugin's custom transformation.
+* Keep abi stability as much, plugin binary should work across different versions of SWC host binary except intended breaking changes.
+* Allow to write a plugin without caring much around the native platform targets binaries.
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3] SWC embeds web assembly runtime (https://wasmer.io/), loads plugin built as web assembly.
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: **[option 3] SWC embeds web assembly runtime (https://wasmer.io/), loads plugin built as web assembly.**
+
+This decision is taken because
+- It was relatively easy plugin author to generate single binary works across most of platforms SWC's host binary supports, without concern of cross-target compilations.
+- It was relatively easy to achieve abi-stable between SWC host to plugin binaries.
+- It doesn't require to have separate, specialized AST struct (named `plugin_ast`) to pass into ffi boundary of the plugin.
+- Its serialization / deserialization performance is near identical or faster than `abi_stable` based ffi
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -59,6 +59,8 @@ This includes babel plugins, to make migration from babel more convenient.
 Plugins are written in rust, and built as native libraries for each platforms. SWC pass data to plugin using special form of AST, which has stable memory representation regardless of the version of `rustc`.
 
 -   Good, because it's fast, even on the first run.
+-   Good, because it does not require very complex request-response system.
+-   Good, because plugin authors can use all features of rust.
 -   Bad, because configuring CI for publishing plugins is very hard.
 -   Bad, because plugin developer cannot publish a plugin from a single machine.
 -   Bad, because loading of plugins is complex. Path for dynamic libraries are platform-dependant.
@@ -67,11 +69,13 @@ Plugins are written in rust, and built as native libraries for each platforms. S
 
 ### [option 3] Wasm plugins based on `wasmtime`
 
-[example | description | pointer to more information | …] <!-- optional -->
+SWC embeds `wasmtime`, loads plugin built as web assembly.
 
 -   Good, because [argument a]
 -   Good, because [argument b]
+-   Good, because plugin authors can
 -   Bad, because `@swc/wasm` has no way to support plugins.
+-   Bad, because first load is slow.
 -   Bad, because `wasmtime` does not support all platforms.
 -   Bad, because [argument c]
 -   … <!-- numbers of pros and cons can vary -->
@@ -85,6 +89,7 @@ SWC embeds web assembly runtime (https://wasmer.io/), loads plugin built as web 
 -   Good, because [argument a]
 -   Good, because [argument b]
 -   Good, because in future `@swc/wasm` can support plugins as `wasmer` officially supports using it within a wasm file.
+-   Bad, because first load is slow.
 -   Bad, because [argument c]
 -   Bad, because `wasmer` does not support all platforms.
 -   … <!-- numbers of pros and cons can vary -->

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -48,7 +48,7 @@ This includes babel plugins, to make migration from babel more convenient.
 -   Good, because users can use rich ecosystem of babel.
 -   Good, because users are used to javascript.
 -   Good, because all platforms are supported.
--   Bad, because passing data to and from javascript is very costly.
+-   Bad, because passing data to and from javascript is very costly. ([SWC issue: Speed up `parse`](https://github.com/swc-project/swc/issues/2175))
 -   Bad, because js plugins require and block the main javascript thread.
 -   Bad, because the main javascript is singled threaded and be bottleneck.
 -   Bad, because `napi` (renamed to `node-api`) does not provide a way to get the return value of a function called from other thread than js thread. To workaround this, we should implement a complex request-response system based using lots of mutex.
@@ -92,6 +92,3 @@ SWC embeds web assembly runtime (https://wasmer.io/), loads plugin built as web 
 -   Bad, because `wasmer` does not support all platforms.
 
 ## Links
-
--   [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
--   … <!-- numbers of links can vary -->

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -73,7 +73,7 @@ SWC embeds `wasmtime`, loads plugin built as web assembly.
 
 -   Good, because [argument a]
 -   Good, because [argument b]
--   Good, because plugin authors can
+-   Good, because plugin authors can publish a plugin without CI, even with a single machine.
 -   Bad, because `@swc/wasm` has no way to support plugins.
 -   Bad, because first load is slow.
 -   Bad, because `wasmtime` does not support all platforms.
@@ -88,6 +88,7 @@ SWC embeds web assembly runtime (https://wasmer.io/), loads plugin built as web 
 
 -   Good, because [argument a]
 -   Good, because [argument b]
+-   Good, because plugin authors can publish a plugin without CI, even with a single machine.
 -   Good, because in future `@swc/wasm` can support plugins as `wasmer` officially supports using it within a wasm file.
 -   Bad, because first load is slow.
 -   Bad, because [argument c]

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -55,6 +55,8 @@ This includes babel plugins, to make migration from babel more convenient.
 
 ### [option 2] Plugins based on `abi_stable` and native dynamic libraries
 
+Plugins are written in rust, and built as native libraries for each platforms. SWC pass data to plugin using special form of AST, which has stable memory representation regardless of the version of `rustc`.
+
 [example | description | pointer to more information | …] <!-- optional -->
 
 -   Good, because [argument a]

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -42,7 +42,8 @@ This decision is taken because
 
 ### [option 1] JS-based plugins, including babel plugins
 
-[example | description | pointer to more information | …] <!-- optional -->
+SWC allow implementing plugins using javascript, and call it from worker threads as required.
+This includes babel plugins, to make migration from babel more convenient.
 
 -   Good, because users can use rich echosystem of babel.
 -   Good, because users are used to javascript.

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -70,6 +70,7 @@ Plugins are written in rust, and built as native libraries for each platforms. S
 -   Good, because [argument a]
 -   Good, because [argument b]
 -   Bad, because `@swc/wasm` has no way to support plugins.
+-   Bad, because `wasmtime` does not support all platforms.
 -   Bad, because [argument c]
 -   … <!-- numbers of pros and cons can vary -->
 
@@ -83,6 +84,7 @@ SWC embeds web assembly runtime (https://wasmer.io/), loads plugin built as web 
 -   Good, because [argument b]
 -   Good, because in future `@swc/wasm` can support plugins as `wasmer` officially supports using it within a wasm file.
 -   Bad, because [argument c]
+-   Bad, because `wasmer` does not support all platforms.
 -   … <!-- numbers of pros and cons can vary -->
 
 ## Links

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -60,6 +60,7 @@ Plugins are written in rust, and built as native libraries for each platforms. S
 -   Good, because it's fast, even on the first run.
 -   Bad, because configuring CI for publishing plugins is very hard.
 -   Bad, because loading of plugins is complex. Path for dynamic libraries are platform-dependant.
+-   Bad, because we have to handle quirks of each platforms.
 -   Bad, because `@swc/wasm` has no way to support plugins.
 
 ### [option 3] Wasm plugins based on `wasmtime`

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -57,10 +57,9 @@ This includes babel plugins, to make migration from babel more convenient.
 
 Plugins are written in rust, and built as native libraries for each platforms. SWC pass data to plugin using special form of AST, which has stable memory representation regardless of the version of `rustc`.
 
--   Good, because [argument a]
--   Good, because [argument b]
--   Bad, because [argument c]
--   … <!-- numbers of pros and cons can vary -->
+-   Good, because it's fast, even on the first run.
+-   Bad, because configuring CI for publishing plugins is very hard.
+-   Bad, because `@swc/wasm` has no way to support plugins.
 
 ### [option 3] Wasm plugins based on `wasmtime`
 
@@ -68,6 +67,7 @@ Plugins are written in rust, and built as native libraries for each platforms. S
 
 -   Good, because [argument a]
 -   Good, because [argument b]
+-   Bad, because `@swc/wasm` has no way to support plugins.
 -   Bad, because [argument c]
 -   … <!-- numbers of pros and cons can vary -->
 
@@ -79,6 +79,7 @@ SWC embeds web assembly runtime (https://wasmer.io/), loads plugin built as web 
 
 -   Good, because [argument a]
 -   Good, because [argument b]
+-   Good, because in future `@swc/wasm` can support plugins as `wasmer` officially supports using it within a wasm file.
 -   Bad, because [argument c]
 -   … <!-- numbers of pros and cons can vary -->
 

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -42,7 +42,7 @@ This decision is taken because
 
 ## Pros and Cons of the Options <!-- optional -->
 
-### [option 1]
+### [option 1] JS-based plugins, including babel plugins
 
 [example | description | pointer to more information | …] <!-- optional -->
 
@@ -51,7 +51,7 @@ This decision is taken because
 -   Bad, because [argument c]
 -   … <!-- numbers of pros and cons can vary -->
 
-### [option 2]
+### [option 2] Plugins based on `abi_stable` and native dynamic libraries
 
 [example | description | pointer to more information | …] <!-- optional -->
 
@@ -60,7 +60,7 @@ This decision is taken because
 -   Bad, because [argument c]
 -   … <!-- numbers of pros and cons can vary -->
 
-### [option 3]
+### [option 3] Wasm plugins based on `wasmtime`
 
 [example | description | pointer to more information | …] <!-- optional -->
 
@@ -69,7 +69,7 @@ This decision is taken because
 -   Bad, because [argument c]
 -   … <!-- numbers of pros and cons can vary -->
 
-### [option 4]
+### [option 4] Wasm plugins based on `wasmer`
 
 [example | description | pointer to more information | …] <!-- optional -->
 

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -59,6 +59,7 @@ Plugins are written in rust, and built as native libraries for each platforms. S
 
 -   Good, because it's fast, even on the first run.
 -   Bad, because configuring CI for publishing plugins is very hard.
+-   Bad, because loading of plugins is complex. Path for dynamic libraries are platform-dependant.
 -   Bad, because `@swc/wasm` has no way to support plugins.
 
 ### [option 3] Wasm plugins based on `wasmtime`

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -27,8 +27,6 @@ SWC wants to support load, run plugins in the native binary for the custom trans
 
 -   **[option 4]** Wasm plugins based on `wasmer`
 
-SWC embeds web assembly runtime (https://wasmer.io/), loads plugin built as web assembly.
-
 ## Decision Outcome
 
 Chosen option: **[option 4] Wasm plugins based on `wasmer`**
@@ -70,6 +68,8 @@ This decision is taken because
 -   … <!-- numbers of pros and cons can vary -->
 
 ### [option 4] Wasm plugins based on `wasmer`
+
+SWC embeds web assembly runtime (https://wasmer.io/), loads plugin built as web assembly.
 
 [example | description | pointer to more information | …] <!-- optional -->
 

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -45,7 +45,7 @@ This decision is taken because
 SWC allow implementing plugins using javascript, and call it from worker threads as required.
 This includes babel plugins, to make migration from babel more convenient.
 
--   Good, because users can use rich echosystem of babel.
+-   Good, because users can use rich ecosystem of babel.
 -   Good, because users are used to javascript.
 -   Bad, because passing data to and from javascript is very costly.
 -   Bad, because js plugins require and block the main javascript thread.
@@ -56,8 +56,6 @@ This includes babel plugins, to make migration from babel more convenient.
 ### [option 2] Plugins based on `abi_stable` and native dynamic libraries
 
 Plugins are written in rust, and built as native libraries for each platforms. SWC pass data to plugin using special form of AST, which has stable memory representation regardless of the version of `rustc`.
-
-[example | description | pointer to more information | …] <!-- optional -->
 
 -   Good, because [argument a]
 -   Good, because [argument b]

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -46,6 +46,7 @@ This decision is taken because
 
 -   Good, because users can use rich echosystem of babel.
 -   Good, because users are used to javascript.
+-   Bad, because passing data to and from javascript is very costly.
 -   Bad, because js plugins require and block the main javascript thread.
 -   Bad, because the main javascript is singled threaded and be bottleneck.
 -   Bad, because `napi` (renamed to `node-api`) does not provide a way to get the return value of a function called from other thread than js thread. To workaround this, we should implement a complex request-response system based using lots of mutex.

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -47,6 +47,7 @@ This includes babel plugins, to make migration from babel more convenient.
 
 -   Good, because users can use rich ecosystem of babel.
 -   Good, because users are used to javascript.
+-   Good, because all platforms are supported.
 -   Bad, because passing data to and from javascript is very costly.
 -   Bad, because js plugins require and block the main javascript thread.
 -   Bad, because the main javascript is singled threaded and be bottleneck.

--- a/docs/adr/00001-support-transformation-plugin-native.md
+++ b/docs/adr/00001-support-transformation-plugin-native.md
@@ -1,8 +1,8 @@
 # Support transform plugin in native rust binaries
 
-* Status: accepted <!-- optional -->
-* Deciders: @kdy1, @kwonoj <!-- optional -->
-* Date: 2021-01-01 <!-- optional -->
+-   Status: accepted <!-- optional -->
+-   Deciders: @kdy1, @kwonoj <!-- optional -->
+-   Date: 2021-01-01 <!-- optional -->
 
 Technical Story: [Issue](https://github.com/swc-project/swc/issues/2635) <!-- optional -->
 
@@ -12,27 +12,33 @@ SWC wants to support load, run plugins in the native binary for the custom trans
 
 ## Decision Drivers <!-- optional -->
 
-* Allow to write a plugin binary can be loaded in the SWC's native binary without involving JS binding interop.
-* Provide good, satisfactory performance while loading, running plugin's custom transformation.
-* Keep abi stability as much, plugin binary should work across different versions of SWC host binary except intended breaking changes.
-* Allow to write a plugin without caring much around the native platform targets binaries.
+-   Allow to write a plugin binary can be loaded in the SWC's native binary without involving JS binding interop.
+-   Provide good, satisfactory performance while loading, running plugin's custom transformation.
+-   Keep abi stability as much, plugin binary should work across different versions of SWC host binary except intended breaking changes.
+-   Allow to write a plugin without caring much around the native platform targets binaries.
 
 ## Considered Options
 
-* [option 1]
-* [option 2]
-* [option 3] SWC embeds web assembly runtime (https://wasmer.io/), loads plugin built as web assembly.
-* … <!-- numbers of options can vary -->
+-   [option 1] JS-based plugins, including babel plugins
+
+-   [option 2] Plugins based on `abi_stable` and native dynamic libraries
+
+-   [option 3] Wasm plugins based on `wasmtime`
+
+-   **[option 4]** Wasm plugins based on `wasmer`
+
+SWC embeds web assembly runtime (https://wasmer.io/), loads plugin built as web assembly.
 
 ## Decision Outcome
 
-Chosen option: **[option 3] SWC embeds web assembly runtime (https://wasmer.io/), loads plugin built as web assembly.**
+Chosen option: **[option 4] Wasm plugins based on `wasmer`**
 
 This decision is taken because
-- It was relatively easy plugin author to generate single binary works across most of platforms SWC's host binary supports, without concern of cross-target compilations.
-- It was relatively easy to achieve abi-stable between SWC host to plugin binaries.
-- It doesn't require to have separate, specialized AST struct (named `plugin_ast`) to pass into ffi boundary of the plugin.
-- Its serialization / deserialization performance is near identical or faster than `abi_stable` based ffi
+
+-   It was relatively easy plugin author to generate single binary works across most of platforms SWC's host binary supports, without concern of cross-target compilations.
+-   It was relatively easy to achieve abi-stable between SWC host to plugin binaries.
+-   It doesn't require to have separate, specialized AST struct (named `plugin_ast`) to pass into ffi boundary of the plugin.
+-   Its serialization / deserialization performance is near identical or faster than `abi_stable` based ffi
 
 ## Pros and Cons of the Options <!-- optional -->
 
@@ -40,30 +46,39 @@ This decision is taken because
 
 [example | description | pointer to more information | …] <!-- optional -->
 
-* Good, because [argument a]
-* Good, because [argument b]
-* Bad, because [argument c]
-* … <!-- numbers of pros and cons can vary -->
+-   Good, because [argument a]
+-   Good, because [argument b]
+-   Bad, because [argument c]
+-   … <!-- numbers of pros and cons can vary -->
 
 ### [option 2]
 
 [example | description | pointer to more information | …] <!-- optional -->
 
-* Good, because [argument a]
-* Good, because [argument b]
-* Bad, because [argument c]
-* … <!-- numbers of pros and cons can vary -->
+-   Good, because [argument a]
+-   Good, because [argument b]
+-   Bad, because [argument c]
+-   … <!-- numbers of pros and cons can vary -->
 
 ### [option 3]
 
 [example | description | pointer to more information | …] <!-- optional -->
 
-* Good, because [argument a]
-* Good, because [argument b]
-* Bad, because [argument c]
-* … <!-- numbers of pros and cons can vary -->
+-   Good, because [argument a]
+-   Good, because [argument b]
+-   Bad, because [argument c]
+-   … <!-- numbers of pros and cons can vary -->
 
-## Links <!-- optional -->
+### [option 4]
 
-* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
-* … <!-- numbers of links can vary -->
+[example | description | pointer to more information | …] <!-- optional -->
+
+-   Good, because [argument a]
+-   Good, because [argument b]
+-   Bad, because [argument c]
+-   … <!-- numbers of pros and cons can vary -->
+
+## Links
+
+-   [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+-   … <!-- numbers of links can vary -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,13 @@
+# Architectural Decision Records
+
+This directory contains a series of [Architectural Decision Records](https://adr.github.io/)
+or "ADRs" for the `swc` project. We're going to try to use it as a kind of collective
+memory of the decisions we've made and the path we've taken to get the project to its current
+point.
+
+Note that these are *historical references* that do not supersede (but might enhance) the living
+documentation of the project itself, which you can find inline in the source code.
+
+Proposing a non-trivial change to the way `swc` works? You might like to start with an ADR
+by copying `template.md` into a new file, filling out a first version of the proposal, and
+posting it as a PR on the github repo for discussion.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,72 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- optional -->
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
One of the biggest challenge I had to deal with large codebase was finding out historical context for some behavior, in short `why we do this from beginning`? And sometimes, I made changes without knowing those context then find out changed attempt was already tried and not chosen for various reasons.

For those reason I came to believe maintaining some decision records, history even if it's some short form of text can be meaningful. Among those I am in favor of https://adr.github.io/ and would like to propose we'd do the similar thing.

As a first step, this PR attempts to create initial template - mostly blind copy-paste from https://github.com/mozilla/uniffi-rs/tree/main/docs/adr and trying to fill some gaps for the plugin features we are changing now. I don't have full context for all the stories of plugin as well, so I may ask @kdy1 to fill some gaps especially prior decisions we made & why we don't do it.

**Related issue (if exists):**

- https://github.com/swc-project/swc/issues/2635