### PR TITLE
fix: resolve todo

### DIFF
--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -116,7 +116,6 @@ where
 
     fn read_token(&mut self) -> LexResult<Token> {
         self.read_comments()?;
-        // TODO: refactor me
         self.start_pos = self.input.cur_pos();
         self.consume();
 
@@ -550,8 +549,9 @@ where
                     if is_whitespace(c)
                         && (self.next_next() == Some('"') || self.next_next() == Some('\'')) =>
                 {
-                    // TODO: avoid reset
-                    self.input.reset_to(start_whitespace);
+                    // Override last position because we consumed whitespaces, but they
+                    // should not be part of token
+                    self.last_pos = Some(start_whitespace);
 
                     return Ok(Token::Function {
                         value: name.0,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

resolve todo, first todo was due problems with spaces around legacy `url` parsing, now we avoid `reset_to`, and just use `last_pos` (it was design for this goals) and it should be faster

**BREAKING CHANGE:**

No

**Related issue (if exists):**

No