### PR TITLE
feat: update `EsVersion::latest()` to `EsVersion::Es2022`

### DIFF
--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -118,10 +118,10 @@ pub enum EsVersion {
 }
 
 impl EsVersion {
-    /// Get the latest version. This is `es2021` for now, but it will be changed
+    /// Get the latest version. This is `es2022` for now, but it will be changed
     /// if a new version of specification is released.
     pub const fn latest() -> Self {
-        EsVersion::Es2021
+        EsVersion::Es2022
     }
 }
 


### PR DESCRIPTION
Hello.

**Description:**

Updated the `EsVersion::latest()` method to return `EsVersion::Es2022`.

**BREAKING CHANGE:**

Latest ECMAScript version set to 2022.

Best wishes,
Sergey.
