### PR TITLE
feat(swc/plugin_runner): support plugin targets wasm32-wasi

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -194,7 +194,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          target: wasm32-unknown-unknown
+          target: wasm32-wasi
 
       - uses: denoland/setup-deno@v1
         if: matrix.crate == 'swc_bundler'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+
+[[package]]
 name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,7 +291,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.43",
  "wasm-bindgen",
  "winapi",
 ]
@@ -339,6 +351,12 @@ dependencies = [
  "proc-macro-hack",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "const_fn"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "constant_time_eq"
@@ -673,6 +691,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +841,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generational-arena"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
+dependencies = [
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -2386,6 +2419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2455,6 +2494,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "standback"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "static-map-macro"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2519,55 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "string_cache"
@@ -3441,6 +3538,7 @@ dependencies = [
  "testing",
  "wasmer",
  "wasmer-cache",
+ "wasmer-wasi",
 ]
 
 [[package]]
@@ -3629,6 +3727,44 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check",
+ "winapi",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn",
 ]
 
 [[package]]
@@ -4166,6 +4302,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmer-vfs"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3a58a3700781aa4f5344915ea082086e75ba7ebe294f60ae499614db92dd00"
+dependencies = [
+ "libc",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "wasmer-vm"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4185,6 +4332,36 @@ dependencies = [
  "thiserror",
  "wasmer-types",
  "winapi",
+]
+
+[[package]]
+name = "wasmer-wasi"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2b1d981ad312dac6e74a41a35b9bca41a6d1157c3e6a575fb1041e4b516610"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generational-arena",
+ "getrandom 0.2.3",
+ "libc",
+ "thiserror",
+ "tracing",
+ "wasm-bindgen",
+ "wasmer",
+ "wasmer-vfs",
+ "wasmer-wasi-types",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-wasi-types"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7731240c0ae536623414beb73091dddf68d1a080f49086fc31ec916536b1af98"
+dependencies = [
+ "byteorder",
+ "time 0.2.27",
+ "wasmer-types",
 ]
 
 [[package]]

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -21,6 +21,7 @@ swc_ecma_ast = {version = "0.65.0", path = "../swc_ecma_ast", features = ["rkyv-
 swc_ecma_parser = {version = "0.87.0", path = "../swc_ecma_parser"}
 wasmer = "2.1.1"
 wasmer-cache = "2.1.1"
+wasmer-wasi = "2.1.1"
 
 [dev-dependencies]
 testing = {version = "0.18.0", path = "../testing"}

--- a/crates/swc_plugin_runner/src/lib.rs
+++ b/crates/swc_plugin_runner/src/lib.rs
@@ -8,8 +8,9 @@ use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use resolve::PluginCache;
 use swc_common::{collections::AHashMap, plugin::Serialized};
-use wasmer::{imports, Array, Instance, Memory, MemoryType, Module, Store, WasmPtr};
+use wasmer::{Array, Exports, Instance, Memory, MemoryType, Module, Store, WasmPtr};
 use wasmer_cache::{Cache, Hash};
+use wasmer_wasi::WasiState;
 
 pub mod resolve;
 
@@ -96,11 +97,25 @@ fn load_plugin(plugin_path: &Path, cache: &mut Option<PluginCache>) -> Result<In
     return match module {
         Ok(module) => {
             let memory = Memory::new(&wasmer_store, MemoryType::new(1, None, false))?;
-            let import_object = imports! {
-                "env" => {
-                    "memory" => memory
-                }
-            };
+
+            // Create the `WasiEnv`. We expect plugin targets wasm32-wasi to enable system
+            // related fn calls, such as `println!`.
+            let mut wasi_env = WasiState::new(
+                plugin_path
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .expect("Plugin path missing file name"),
+            )
+            .finalize()?;
+
+            // Generate an `ImportObject` from wasi_env
+            let mut import_object = wasi_env.import_object(&module)?;
+
+            // Inject `memory` into generated import_object, this is required to allocate
+            // guest (plugin)'s memory space from the host (SWC).
+            let mut env = Exports::new();
+            env.insert("memory", memory);
+            import_object.register("env", env);
 
             Instance::new(&module, &import_object).context("Failed to create plugin instance")
         }

--- a/crates/swc_plugin_runner/tests/integration.rs
+++ b/crates/swc_plugin_runner/tests/integration.rs
@@ -26,11 +26,7 @@ fn build_plugin(dir: &Path) -> Result<PathBuf, Error> {
         cmd.stderr(Stdio::inherit()).output()?;
     }
 
-    for entry in fs::read_dir(
-        &dir.join("target")
-            .join("wasm32-unknown-unknown")
-            .join("debug"),
-    )? {
+    for entry in fs::read_dir(&dir.join("target").join("wasm32-wasi").join("debug"))? {
         let entry = entry?;
 
         let s = entry.file_name().to_string_lossy().into_owned();

--- a/tests/rust-plugins/swc_internal_plugin/build.cmd
+++ b/tests/rust-plugins/swc_internal_plugin/build.cmd
@@ -9,7 +9,7 @@ FOR %%A in (%*) DO (
 )
 
 REM Build wasm binary
-cargo build %* --target=wasm32-unknown-unknown
+cargo build %* --target=wasm32-wasi
 
 REM Build polyfill cli, run polyfill over generated wasm binary
 PUSHD multivalue-polyfill

--- a/tests/rust-plugins/swc_internal_plugin/build.sh
+++ b/tests/rust-plugins/swc_internal_plugin/build.sh
@@ -10,7 +10,7 @@ do
 done
 
 # Build wasm binary
-cargo build $@ --target=wasm32-unknown-unknown
+cargo build $@ --target=wasm32-wasi
 
 # Build polyfill cli, run polyfill over generated wasm binary
 pushd multivalue-polyfill

--- a/tests/rust-plugins/swc_internal_plugin/multivalue-polyfill/src/main.rs
+++ b/tests/rust-plugins/swc_internal_plugin/multivalue-polyfill/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let target_path = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?)
         .join("..")
         .join("target")
-        .join("wasm32-unknown-unknown")
+        .join("wasm32-wasi")
         .join(target[1].clone());
 
     let input_path = fs::read_dir(target_path)?


### PR DESCRIPTION
**Description:**

This PR changes plugin target to be built against `wasm32-wasi`, instead of previous target `wasm32-unknown-unknown`. Plugin runner adjusted to setup proper env to run wasi plugin binaries.

`unknown-unknown` works well for our general purpose, but due to it assumes host target is `unknown`, lot of std calls gets into stub:

> wasm32-unknown-unknown - this target, like the WASI one, is focused on producing single *.wasm binaries. The standard library, however, is largely stubbed out since the "unknown" part of the target means libstd can't assume anything. This means that while binaries will likely work in wasmtime, common conveniences like println! or panic! won't work.

(https://docs.wasmtime.dev/wasm-rust.html)

As description says, plugin author won't have easy way to use `println!` or any other std related calls while making a plugin. wasi target allows to use those seamlessly.

Comparing size between those 2 using our `internal-plugin` test cases, bytesize increase is negligible.

```
./bulid.sh --release

 993335 Jan 15 00:08 swc_internal_plugin.wasm //wasm32-unknown-unknown
1021056 Jan 15 00:11 swc_internal_plugin.wasm //wasm32-wasi
```

**This is opt-in change: plugin_runner supports `wasm32-unknown-unknown` and `wasm32-wasi` binary both. Plugin author can choose depends on requirement to std in plugin.**


** Possible problem
- it is unclear how this'll affect runtimes like browser, However, we don't have any clear path to support plugin for `@swc/wasm` at all yet. so it's not a hard blocker for now.

** Possible alternative
- we may able to expose limited capabilites via wrapper fn exposed into guest from host, like `print_via_host` which proxies call to host. It'll involve serialization / deserialization and possibly limits output format as only known one.

**BREAKING CHANGE:**

~I doubt it, but if any plugin is written in `wasm32-unknown-unknown` plugin need to be re-built against wasm32-wasi.~

PR updated to support unknown-unknown and wasi both.

**Related issue (if exists):**

- https://github.com/swc-project/swc/issues/3167
