### PR TITLE
feat(es/ast): Improve AST api for plugin authors

### DIFF
--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -1004,48 +1004,6 @@ impl Take for PatOrExpr {
     }
 }
 
-impl From<bool> for Expr {
-    fn from(value: bool) -> Self {
-        Expr::Lit(Lit::Bool(Bool {
-            span: DUMMY_SP,
-            value,
-        }))
-    }
-}
-
-impl From<f64> for Expr {
-    fn from(value: f64) -> Self {
-        Expr::Lit(Lit::Num(Number {
-            span: DUMMY_SP,
-            value,
-        }))
-    }
-}
-
-impl From<Bool> for Expr {
-    fn from(v: Bool) -> Self {
-        Expr::Lit(Lit::Bool(v))
-    }
-}
-
-impl From<Number> for Expr {
-    fn from(v: Number) -> Self {
-        Expr::Lit(Lit::Num(v))
-    }
-}
-
-impl From<Str> for Expr {
-    fn from(v: Str) -> Self {
-        Expr::Lit(Lit::Str(v))
-    }
-}
-
-impl From<BigInt> for Expr {
-    fn from(v: BigInt) -> Self {
-        Expr::Lit(Lit::BigInt(v))
-    }
-}
-
 #[ast_node("OptionalChainingExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -4,7 +4,7 @@ use crate::{
     function::Function,
     ident::{Ident, PrivateName},
     jsx::{JSXElement, JSXEmptyExpr, JSXFragment, JSXMemberExpr, JSXNamespacedName},
-    lit::{Bool, Lit, Number, Str},
+    lit::{Lit, Str},
     operators::{AssignOp, BinaryOp, UnaryOp, UpdateOp},
     pat::Pat,
     prop::Prop,
@@ -13,7 +13,7 @@ use crate::{
         TsAsExpr, TsConstAssertion, TsNonNullExpr, TsTypeAnn, TsTypeAssertion, TsTypeParamDecl,
         TsTypeParamInstantiation,
     },
-    BigInt, ComputedPropName, Invalid,
+    ComputedPropName, Invalid,
 };
 use is_macro::Is;
 use serde::{self, Deserialize, Serialize};

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -52,7 +52,6 @@ bridge_expr_from!(Lit, Null);
 bridge_expr_from!(Lit, JSXText);
 
 bridge_lit_from!(Str, &'_ str);
-bridge_lit_from!(Str, Box<str>);
 bridge_lit_from!(Str, JsWord);
 bridge_lit_from!(Str, Cow<'_, str>);
 bridge_lit_from!(Str, String);

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -49,6 +49,7 @@ bridge_expr_from!(Lit, Number);
 bridge_expr_from!(Lit, BigInt);
 bridge_expr_from!(Lit, Regex);
 bridge_expr_from!(Lit, Null);
+bridge_expr_from!(Lit, JSXText);
 
 bridge_lit_from!(Str, &'_ str);
 bridge_lit_from!(Str, Box<str>);

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -353,7 +353,6 @@ impl From<JsWord> for Str {
 
 bridge_from!(Str, JsWord, &'_ str);
 bridge_from!(Str, JsWord, String);
-bridge_from!(Str, JsWord, Box<str>);
 bridge_from!(Str, JsWord, Cow<'_, str>);
 
 impl From<bool> for Bool {

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -50,6 +50,10 @@ bridge_expr_from!(Lit, Regex);
 bridge_expr_from!(Lit, Null);
 
 bridge_lit_from!(Str, &'_ str);
+bridge_lit_from!(Str, Box<str>);
+bridge_lit_from!(Str, JsWord);
+bridge_lit_from!(Str, Cow<'_, str>);
+bridge_lit_from!(Str, String);
 bridge_lit_from!(Bool, bool);
 bridge_lit_from!(Number, f64);
 bridge_lit_from!(BigInt, BigIntValue);

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -36,8 +36,9 @@ pub enum Lit {
 }
 
 macro_rules! bridge_lit_from {
-    ($src:ty) => {
+    ($bridge: ty, $src:ty) => {
         bridge_expr_from!(crate::Lit, $src);
+        bridge_from!(Lit, $bridge, $src);
     };
 }
 
@@ -48,10 +49,10 @@ bridge_expr_from!(Lit, BigInt);
 bridge_expr_from!(Lit, Regex);
 bridge_expr_from!(Lit, Null);
 
-bridge_lit_from!(&'_ str);
-bridge_lit_from!(bool);
-bridge_lit_from!(f64);
-bridge_lit_from!(BigIntValue);
+bridge_lit_from!(Str, &'_ str);
+bridge_lit_from!(Bool, bool);
+bridge_lit_from!(Number, f64);
+bridge_lit_from!(BigInt, BigIntValue);
 
 #[ast_node("BigIntLiteral")]
 #[derive(Eq, Hash, EqIgnoreSpan)]

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -2,6 +2,7 @@ use crate::jsx::JSXText;
 use num_bigint::BigInt as BigIntValue;
 use serde::{Deserialize, Serialize};
 use std::{
+    borrow::Cow,
     fmt::{self, Display, Formatter},
     hash::{Hash, Hasher},
     mem,

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -35,6 +35,24 @@ pub enum Lit {
     JSXText(JSXText),
 }
 
+macro_rules! bridge_lit_from {
+    ($src:ty) => {
+        bridge_expr_from!(crate::Lit, $src);
+    };
+}
+
+bridge_expr_from!(Lit, Str);
+bridge_expr_from!(Lit, Bool);
+bridge_expr_from!(Lit, Number);
+bridge_expr_from!(Lit, BigInt);
+bridge_expr_from!(Lit, Regex);
+bridge_expr_from!(Lit, Null);
+
+bridge_lit_from!(&'_ str);
+bridge_lit_from!(bool);
+bridge_lit_from!(f64);
+bridge_lit_from!(BigIntValue);
+
 #[ast_node("BigIntLiteral")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 pub struct BigInt {

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -58,6 +58,7 @@ bridge_lit_from!(Str, Cow<'_, str>);
 bridge_lit_from!(Str, String);
 bridge_lit_from!(Bool, bool);
 bridge_lit_from!(Number, f64);
+bridge_lit_from!(Number, usize);
 bridge_lit_from!(BigInt, BigIntValue);
 
 #[ast_node("BigIntLiteral")]
@@ -335,6 +336,63 @@ impl Display for Number {
             }
         } else {
             Display::fmt(&self.value, f)
+        }
+    }
+}
+
+impl From<JsWord> for Str {
+    #[inline]
+    fn from(value: JsWord) -> Self {
+        Str {
+            span: DUMMY_SP,
+            value,
+            has_escape: Default::default(),
+            kind: Default::default(),
+        }
+    }
+}
+
+bridge_from!(Str, JsWord, &'_ str);
+bridge_from!(Str, JsWord, String);
+bridge_from!(Str, JsWord, Box<str>);
+bridge_from!(Str, JsWord, Cow<'_, str>);
+
+impl From<bool> for Bool {
+    #[inline]
+    fn from(value: bool) -> Self {
+        Bool {
+            span: DUMMY_SP,
+            value,
+        }
+    }
+}
+
+impl From<f64> for Number {
+    #[inline]
+    fn from(value: f64) -> Self {
+        Number {
+            span: DUMMY_SP,
+            value,
+        }
+    }
+}
+
+impl From<usize> for Number {
+    #[inline]
+    fn from(value: usize) -> Self {
+        Number {
+            span: DUMMY_SP,
+            value: value as _,
+        }
+    }
+}
+
+impl From<BigIntValue> for BigInt {
+    #[inline]
+    fn from(value: BigIntValue) -> Self {
+        BigInt {
+            span: DUMMY_SP,
+            value,
         }
     }
 }

--- a/crates/swc_ecma_ast/src/macros.rs
+++ b/crates/swc_ecma_ast/src/macros.rs
@@ -184,6 +184,15 @@ macro_rules! test_de {
     };
 }
 
+/// Implement `From<$src>` for $dst, by using implementation of `From<$src>` for
+/// $bridge.
+///
+/// - `$dst` must implement `From<$bridge>`.
+/// - `$bridge` must implement `From<$src>`.
+///
+///
+/// e.g. For `&str` -> `Box<Expr>`, we convert it by `&str` -> `JsWord` -> `Str`
+/// -> `Lit` -> `Expr` -> `Box<Expr>`.
 macro_rules! bridge_from {
     ($dst:ty, $bridge:ty, $src:ty) => {
         impl From<$src> for $dst {

--- a/crates/swc_ecma_ast/src/macros.rs
+++ b/crates/swc_ecma_ast/src/macros.rs
@@ -185,7 +185,7 @@ macro_rules! test_de {
 }
 
 macro_rules! bridge_from {
-    ($dst:path, $Bridge:path, $src:path) => {
+    ($dst:path, $bridge:path, $src:path) => {
         impl From<$src> for $dst {
             fn from(src: $src) -> $dst {
                 $dst::from($bridge::from(src))

--- a/crates/swc_ecma_ast/src/macros.rs
+++ b/crates/swc_ecma_ast/src/macros.rs
@@ -183,3 +183,13 @@ macro_rules! test_de {
         }
     };
 }
+
+macro_rules! bridge_from {
+    ($dst:path, $Bridge:path, $src:path) => {
+        impl From<$src> for $dst {
+            fn from(src: $src) -> $dst {
+                $dst::from($bridge::from(src))
+            }
+        }
+    };
+}

--- a/crates/swc_ecma_ast/src/macros.rs
+++ b/crates/swc_ecma_ast/src/macros.rs
@@ -215,6 +215,7 @@ macro_rules! bridge_expr_from {
 macro_rules! bridge_pat_from {
     ($bridge:ty, $src:ty) => {
         bridge_from!(crate::Pat, $bridge, $src);
+        bridge_from!(crate::Param, crate::Pat, $src);
         bridge_from!(Box<crate::Pat>, crate::Pat, $src);
     };
 }

--- a/crates/swc_ecma_ast/src/macros.rs
+++ b/crates/swc_ecma_ast/src/macros.rs
@@ -211,3 +211,10 @@ macro_rules! bridge_expr_from {
         bridge_from!(Box<crate::Expr>, crate::Expr, $src);
     };
 }
+
+macro_rules! bridge_pat_from {
+    ($bridge:ty, $src:ty) => {
+        bridge_from!(crate::Pat, $bridge, $src);
+        bridge_from!(Box<crate::Pat>, crate::Pat, $src);
+    };
+}

--- a/crates/swc_ecma_ast/src/macros.rs
+++ b/crates/swc_ecma_ast/src/macros.rs
@@ -184,8 +184,8 @@ macro_rules! test_de {
     };
 }
 
-/// Implement `From<$src>` for $dst, by using implementation of `From<$src>` for
-/// $bridge.
+/// Implement `From<$src>` for `$dst`, by using implementation of `From<$src>`
+/// for `$bridge`.
 ///
 /// - `$dst` must implement `From<$bridge>`.
 /// - `$bridge` must implement `From<$src>`.

--- a/crates/swc_ecma_ast/src/macros.rs
+++ b/crates/swc_ecma_ast/src/macros.rs
@@ -185,11 +185,20 @@ macro_rules! test_de {
 }
 
 macro_rules! bridge_from {
-    ($dst:path, $bridge:path, $src:path) => {
+    ($dst:ty, $bridge:ty, $src:ty) => {
         impl From<$src> for $dst {
+            #[cfg_attr(not(debug_assertions), inline(always))]
             fn from(src: $src) -> $dst {
-                $dst::from($bridge::from(src))
+                let src: $bridge = src.into();
+                src.into()
             }
         }
+    };
+}
+
+macro_rules! bridge_expr_from {
+    ($bridge:ty, $src:ty) => {
+        bridge_from!(crate::Expr, $bridge, $src);
+        bridge_from!(Box<crate::Expr>, crate::Expr, $src);
     };
 }

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -8,12 +8,6 @@ use crate::{
 use is_macro::Is;
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 
-impl From<Ident> for Pat {
-    fn from(i: Ident) -> Self {
-        BindingIdent::from(i).into()
-    }
-}
-
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -46,6 +40,8 @@ impl Take for Pat {
         Pat::Invalid(Invalid { span: DUMMY_SP })
     }
 }
+
+bridge_pat_from!(BindingIdent, Ident);
 
 #[ast_node("ArrayPattern")]
 #[derive(Eq, Hash, EqIgnoreSpan)]

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -42,6 +42,8 @@ impl Take for Pat {
 }
 
 bridge_pat_from!(BindingIdent, Ident);
+bridge_from!(crate::Param, crate::Pat, BindingIdent);
+bridge_from!(Box<crate::Pat>, crate::Pat, BindingIdent);
 
 #[ast_node("ArrayPattern")]
 #[derive(Eq, Hash, EqIgnoreSpan)]

--- a/crates/swc_ecma_transforms_base/src/ext.rs
+++ b/crates/swc_ecma_transforms_base/src/ext.rs
@@ -72,12 +72,12 @@ impl PatOrExprExt for PatOrExpr {
     fn normalize_ident(self) -> Self {
         match self {
             PatOrExpr::Expr(expr) => match *expr {
-                Expr::Ident(i) => PatOrExpr::Pat(Box::new(Pat::Ident(i.into()))),
+                Expr::Ident(i) => PatOrExpr::Pat(i.into()),
                 _ => PatOrExpr::Expr(expr),
             },
             PatOrExpr::Pat(pat) => match *pat {
                 Pat::Expr(expr) => match *expr {
-                    Expr::Ident(i) => PatOrExpr::Pat(Box::new(Pat::Ident(i.into()))),
+                    Expr::Ident(i) => PatOrExpr::Pat(i.into()),
                     _ => PatOrExpr::Expr(expr),
                 },
                 _ => PatOrExpr::Pat(pat),

--- a/crates/swc_ecma_transforms_base/src/hygiene/ops.rs
+++ b/crates/swc_ecma_transforms_base/src/hygiene/ops.rs
@@ -108,7 +108,7 @@ impl<'a> VisitMut for Operator<'a> {
                 if let Some(expr) = expr {
                     let var = VarDeclarator {
                         span,
-                        name: Pat::Ident(cls.ident.clone().into()),
+                        name: cls.ident.clone().into(),
                         init: Some(Box::new(Expr::Class(expr))),
                         definite: false,
                     };
@@ -352,11 +352,11 @@ impl<'a> VisitMut for Operator<'a> {
                     value: match p.value.take() {
                         Some(default_expr) => Box::new(Pat::Assign(AssignPat {
                             span: p.span,
-                            left: Box::new(Pat::Ident(renamed.into())),
+                            left: renamed.into(),
                             right: default_expr,
                             type_ann: None,
                         })),
-                        None => Box::new(Pat::Ident(renamed.into())),
+                        None => renamed.into(),
                     },
                 }
                 .into();

--- a/crates/swc_ecma_transforms_base/src/hygiene/tests.rs
+++ b/crates/swc_ecma_transforms_base/src/hygiene/tests.rs
@@ -512,7 +512,7 @@ fn fn_args() {
                     params: vec![Param {
                         span: DUMMY_SP,
                         decorators: vec![],
-                        pat: Pat::Ident(quote_ident!("force").into()),
+                        pat: quote_ident!("force").into(),
                     }
                     .fold_with(&mut marker(&[("force", mark1)]))],
                     type_params: Default::default(),
@@ -647,16 +647,12 @@ fn params_in_fn() {
                         Param {
                             span: DUMMY_SP,
                             decorators: Default::default(),
-                            pat: Pat::Ident(
-                                Ident::new("param".into(), DUMMY_SP.apply_mark(mark1)).into(),
-                            ),
+                            pat: Ident::new("param".into(), DUMMY_SP.apply_mark(mark1)).into(),
                         },
                         Param {
                             span: DUMMY_SP,
                             decorators: Default::default(),
-                            pat: Pat::Ident(
-                                Ident::new("param".into(), DUMMY_SP.apply_mark(mark2)).into(),
-                            ),
+                            pat: Ident::new("param".into(), DUMMY_SP.apply_mark(mark2)).into(),
                         },
                     ],
                     type_params: Default::default(),

--- a/crates/swc_ecma_transforms_classes/src/super_field.rs
+++ b/crates/swc_ecma_transforms_classes/src/super_field.rs
@@ -159,12 +159,7 @@ impl<'a> SuperFieldAccessFolder<'a> {
                 if args.len() == 1 && is_rest_arguments(&args[0]) {
                     *n = Expr::Call(CallExpr {
                         span: DUMMY_SP,
-                        callee: MemberExpr {
-                            span: DUMMY_SP,
-                            obj: Box::new(callee),
-                            prop: MemberProp::Ident(quote_ident!("apply")),
-                        }
-                        .as_callee(),
+                        callee: callee.make_member(quote_ident!("apply")).as_callee(),
                         args: iter::once(this)
                             .chain(iter::once({
                                 let mut arg = args.pop().unwrap();
@@ -172,21 +167,16 @@ impl<'a> SuperFieldAccessFolder<'a> {
                                 arg
                             }))
                             .collect(),
-                        type_args: type_args.clone(),
+                        type_args: Default::default(),
                     });
                     return;
                 }
 
                 *n = Expr::Call(CallExpr {
                     span: DUMMY_SP,
-                    callee: MemberExpr {
-                        span: DUMMY_SP,
-                        obj: Box::new(callee),
-                        prop: MemberProp::Ident(quote_ident!("call")),
-                    }
-                    .as_callee(),
+                    callee: callee.make_member(quote_ident!("call")).as_callee(),
                     args: iter::once(this).chain(args).collect(),
-                    type_args: type_args.clone(),
+                    type_args: Default::default(),
                 });
             }
         }

--- a/crates/swc_ecma_transforms_classes/src/super_field.rs
+++ b/crates/swc_ecma_transforms_classes/src/super_field.rs
@@ -350,7 +350,7 @@ impl<'a> SuperFieldAccessFolder<'a> {
             // Memoize
             self.vars.push(VarDeclarator {
                 span: DUMMY_SP,
-                name: Pat::Ident(ref_ident.clone().into()),
+                name: ref_ident.clone().into(),
                 init: None,
                 definite: false,
             });
@@ -358,7 +358,7 @@ impl<'a> SuperFieldAccessFolder<'a> {
             if is_update {
                 self.vars.push(VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(update_ident.clone().into()),
+                    name: update_ident.clone().into(),
                     init: None,
                     definite: false,
                 });
@@ -387,7 +387,7 @@ impl<'a> SuperFieldAccessFolder<'a> {
             op!("=") => prop_arg.as_arg(),
             _ => AssignExpr {
                 span: DUMMY_SP,
-                left: PatOrExpr::Pat(Box::new(Pat::Ident(ref_ident.clone().into()))),
+                left: PatOrExpr::Pat(ref_ident.clone().into()),
                 op: op!("="),
                 right: prop_arg,
             }
@@ -408,7 +408,7 @@ impl<'a> SuperFieldAccessFolder<'a> {
                     Box::new(
                         AssignExpr {
                             span: DUMMY_SP,
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(update_ident.clone().into()))),
+                            left: PatOrExpr::Pat(update_ident.clone().into()),
                             op: op!("="),
                             right: Box::new(Expr::Unary(UnaryExpr {
                                 span: DUMMY_SP,

--- a/crates/swc_ecma_transforms_classes/src/super_field.rs
+++ b/crates/swc_ecma_transforms_classes/src/super_field.rs
@@ -213,16 +213,7 @@ impl<'a> SuperFieldAccessFolder<'a> {
                         op!("--") => op!("-="),
                     };
 
-                    *n = self.super_to_set_call(
-                        *super_token,
-                        true,
-                        prop.take(),
-                        op,
-                        Box::new(Expr::Lit(Lit::Num(Number {
-                            span: DUMMY_SP,
-                            value: 1.0,
-                        }))),
-                    );
+                    *n = self.super_to_set_call(*super_token, true, prop.take(), op, 1.0.into());
                 }
             }
 
@@ -480,11 +471,7 @@ impl<'a> SuperFieldAccessFolder<'a> {
                 rhs_arg,
                 this_arg,
                 // strict
-                Lit::Bool(Bool {
-                    span: DUMMY_SP,
-                    value: true,
-                })
-                .as_arg(),
+                true.as_arg(),
             ],
             type_args: Default::default(),
         });

--- a/crates/swc_ecma_transforms_classes/src/super_field.rs
+++ b/crates/swc_ecma_transforms_classes/src/super_field.rs
@@ -136,7 +136,6 @@ impl<'a> SuperFieldAccessFolder<'a> {
         if let Expr::Call(CallExpr {
             callee: Callee::Expr(callee_expr),
             args,
-            type_args,
             ..
         }) = n
         {

--- a/crates/swc_ecma_transforms_compat/src/bugfixes/edge_default_param.rs
+++ b/crates/swc_ecma_transforms_compat/src/bugfixes/edge_default_param.rs
@@ -44,7 +44,7 @@ impl VisitMut for EdgeDefaultParam {
                     key: PropName::Ident(key.clone()),
                     value: Box::new(Pat::Assign(AssignPat {
                         span: *span,
-                        left: Box::new(Pat::Ident(BindingIdent::from(key.clone()))),
+                        left: key.clone().into(),
                         right: value.clone(),
                         type_ann: None,
                     })),

--- a/crates/swc_ecma_transforms_compat/src/bugfixes/template_literal_caching.rs
+++ b/crates/swc_ecma_transforms_compat/src/bugfixes/template_literal_caching.rs
@@ -32,7 +32,7 @@ impl TemplateLiteralCaching {
         let init = init.map(Box::new);
         self.decls.push(VarDeclarator {
             span: DUMMY_SP,
-            name: Pat::Ident(BindingIdent::from(name)),
+            name: name.into(),
             init,
             definite: false,
         })
@@ -69,7 +69,7 @@ impl Fold for TemplateLiteralCaching {
                         helper_ident,
                         Some(Expr::Arrow(ArrowExpr {
                             span: DUMMY_SP,
-                            params: vec![Pat::Ident(BindingIdent::from(t.clone()))],
+                            params: vec![t.clone().into()],
                             body: BlockStmtOrExpr::Expr(Box::new(Expr::Ident(t))),
                             is_async: false,
                             is_generator: false,
@@ -105,8 +105,8 @@ impl Fold for TemplateLiteralCaching {
                     left: Box::new(Expr::Ident(t.clone())),
                     right: Box::new(Expr::Assign(AssignExpr {
                         span: DUMMY_SP,
-                        op: AssignOp::Assign,
-                        left: PatOrExpr::Pat(Box::new(Pat::Ident(BindingIdent::from(t)))),
+                        op: op!("="),
+                        left: PatOrExpr::Pat(t.into()),
                         right: Box::new(Expr::TaggedTpl(template)),
                     })),
                 });

--- a/crates/swc_ecma_transforms_compat/src/bugfixes/template_literal_caching.rs
+++ b/crates/swc_ecma_transforms_compat/src/bugfixes/template_literal_caching.rs
@@ -90,17 +90,7 @@ impl Fold for TemplateLiteralCaching {
                     tpl: Tpl {
                         span: DUMMY_SP,
                         quasis: n.tpl.quasis,
-                        exprs: n
-                            .tpl
-                            .exprs
-                            .iter()
-                            .map(|_| {
-                                Box::new(Expr::Lit(Lit::Num(Number {
-                                    span: DUMMY_SP,
-                                    value: 0.0,
-                                })))
-                            })
-                            .collect(),
+                        exprs: n.tpl.exprs.iter().map(|_| 0.0.into()).collect(),
                     },
                     type_params: None,
                 };

--- a/crates/swc_ecma_transforms_compat/src/bugfixes/template_literal_caching.rs
+++ b/crates/swc_ecma_transforms_compat/src/bugfixes/template_literal_caching.rs
@@ -101,7 +101,7 @@ impl Fold for TemplateLiteralCaching {
                 self.create_binding(t.clone(), None);
                 let inline_cache = Expr::Bin(BinExpr {
                     span: DUMMY_SP,
-                    op: BinaryOp::LogicalOr,
+                    op: op!("||"),
                     left: Box::new(Expr::Ident(t.clone())),
                     right: Box::new(Expr::Assign(AssignExpr {
                         span: DUMMY_SP,

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoped_fn.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoped_fn.rs
@@ -40,7 +40,7 @@ impl VisitMut for BlockScopedFns {
                             kind: VarDeclKind::Let,
                             decls: vec![VarDeclarator {
                                 span: DUMMY_SP,
-                                name: Pat::Ident(decl.ident.clone().into()),
+                                name: decl.ident.clone().into(),
                                 init: Some(Box::new(Expr::Fn(FnExpr {
                                     ident: Some(decl.ident),
                                     function: decl.function,

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
@@ -270,7 +270,7 @@ impl BlockScoping {
                             span: DUMMY_SP,
                             test: Box::new(Expr::Bin(BinExpr {
                                 span: DUMMY_SP,
-                                op: BinaryOp::EqEqEq,
+                                op: op!("==="),
                                 left: {
                                     // _typeof(_ret)
                                     let callee = helper!(type_of, "typeof");
@@ -836,7 +836,7 @@ impl VisitMut for FlowHelper<'_> {
                             value: s.arg.take().unwrap_or_else(|| {
                                 Box::new(Expr::Unary(UnaryExpr {
                                     span: DUMMY_SP,
-                                    op: UnaryOp::Void,
+                                    op: op!("void"),
                                     arg: undefined(DUMMY_SP),
                                 }))
                             }),

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
@@ -128,7 +128,7 @@ impl BlockScoping {
                 let ident = private_ident!("_this");
                 self.vars.push(VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(ident.clone().into()),
+                    name: ident.clone().into(),
                     init: Some(Box::new(Expr::This(ThisExpr { span: DUMMY_SP }))),
                     definite: false,
                 });
@@ -141,7 +141,7 @@ impl BlockScoping {
                 let ident = private_ident!("_arguments");
                 self.vars.push(VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(ident.clone().into()),
+                    name: ident.clone().into(),
                     init: Some(Box::new(Expr::Ident(quote_ident!("arguments")))),
                     definite: false,
                 });
@@ -197,7 +197,7 @@ impl BlockScoping {
 
             self.vars.push(VarDeclarator {
                 span: DUMMY_SP,
-                name: Pat::Ident(var_name.clone().into()),
+                name: var_name.clone().into(),
                 init: Some(Box::new(
                     FnExpr {
                         ident: None,
@@ -211,10 +211,8 @@ impl BlockScoping {
                                     Param {
                                         span: DUMMY_SP,
                                         decorators: Default::default(),
-                                        pat: Pat::Ident(
-                                            Ident::new(i.0.clone(), DUMMY_SP.with_ctxt(ctxt))
-                                                .into(),
-                                        ),
+                                        pat: Ident::new(i.0.clone(), DUMMY_SP.with_ctxt(ctxt))
+                                            .into(),
                                     }
                                 })
                                 .collect(),

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
@@ -254,7 +254,7 @@ impl BlockScoping {
                         declare: false,
                         decls: vec![VarDeclarator {
                             span: DUMMY_SP,
-                            name: Pat::Ident(ret.clone().into()),
+                            name: ret.clone().into(),
                             init: Some(Box::new(call.take().into())),
                             definite: false,
                         }],
@@ -892,9 +892,7 @@ impl MutationHandler<'_> {
         for (id, ctxt) in &*self.map {
             exprs.push(Box::new(Expr::Assign(AssignExpr {
                 span: DUMMY_SP,
-                left: PatOrExpr::Pat(Box::new(Pat::Ident(
-                    Ident::new(id.0.clone(), DUMMY_SP.with_ctxt(id.1)).into(),
-                ))),
+                left: PatOrExpr::Pat(Ident::new(id.0.clone(), DUMMY_SP.with_ctxt(id.1)).into()),
                 op: op!("="),
                 right: Box::new(Expr::Ident(Ident::new(
                     id.0.clone(),

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
@@ -289,13 +289,7 @@ impl BlockScoping {
                                     .into()
                                 },
                                 //"object"
-                                right: Expr::Lit(Lit::Str(Str {
-                                    span: DUMMY_SP,
-                                    value: js_word!("object"),
-                                    has_escape: false,
-                                    kind: Default::default(),
-                                }))
-                                .into(),
+                                right: js_word!("object").into(),
                             })),
                             cons: Box::new(Stmt::Return(ReturnStmt {
                                 span: DUMMY_SP,

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/constructor.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/constructor.rs
@@ -220,7 +220,7 @@ impl ConstructorFolder<'_> {
 
             self.vars.push(VarDeclarator {
                 span: DUMMY_SP,
-                name: Pat::Ident(this_super.clone().into()),
+                name: this_super.clone().into(),
                 init: None,
                 definite: Default::default(),
             });
@@ -413,9 +413,9 @@ impl VisitMut for ConstructorFolder<'_> {
 
                 *expr = Expr::Assign(AssignExpr {
                     span: DUMMY_SP,
-                    left: PatOrExpr::Pat(Box::new(Pat::Ident(
+                    left: PatOrExpr::Pat(
                         quote_ident!(DUMMY_SP.apply_mark(self.mark), "_this").into(),
-                    ))),
+                    ),
                     op: op!("="),
                     right,
                 });
@@ -482,9 +482,9 @@ impl VisitMut for ConstructorFolder<'_> {
                     Some(SuperFoldingMode::Assign) => {
                         *stmt = AssignExpr {
                             span: DUMMY_SP,
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(
+                            left: PatOrExpr::Pat(
                                 quote_ident!(DUMMY_SP.apply_mark(self.mark), "_this").into(),
-                            ))),
+                            ),
                             op: op!("="),
                             right: expr,
                         }
@@ -497,9 +497,7 @@ impl VisitMut for ConstructorFolder<'_> {
                             kind: VarDeclKind::Var,
                             decls: vec![VarDeclarator {
                                 span: DUMMY_SP,
-                                name: Pat::Ident(
-                                    quote_ident!(DUMMY_SP.apply_mark(self.mark), "_this").into(),
-                                ),
+                                name: quote_ident!(DUMMY_SP.apply_mark(self.mark), "_this").into(),
                                 init: Some(expr),
                                 definite: false,
                             }],

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
@@ -267,7 +267,7 @@ where
             let params = vec![Param {
                 span: DUMMY_SP,
                 decorators: Default::default(),
-                pat: Pat::Ident(super_param.clone().into()),
+                pat: super_param.clone().into(),
             }];
 
             let super_class = class.super_class.clone().unwrap();
@@ -439,7 +439,7 @@ where
                 declare: Default::default(),
                 decls: vec![VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(var.clone().into()),
+                    name: var.clone().into(),
                     init: Some(Box::new(Expr::Call(CallExpr {
                         span: DUMMY_SP,
                         callee: helper!(create_super, "createSuper"),
@@ -535,7 +535,7 @@ where
                 if insert_this {
                     vars.push(VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(this.clone().into()),
+                        name: this.clone().into(),
                         init: None,
                         definite: false,
                     });
@@ -681,7 +681,7 @@ where
                     kind: VarDeclKind::Var,
                     decls: vec![VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(quote_ident!(DUMMY_SP.apply_mark(mark), "_this").into()),
+                        name: quote_ident!(DUMMY_SP.apply_mark(mark), "_this").into(),
                         init: Some(Box::new(Expr::This(ThisExpr { span: DUMMY_SP }))),
                         definite: false,
                     }],
@@ -828,9 +828,7 @@ where
                         kind: VarDeclKind::Var,
                         decls: vec![VarDeclarator {
                             span: DUMMY_SP,
-                            name: Pat::Ident(
-                                quote_ident!(DUMMY_SP.apply_mark(mark), "_this").into(),
-                            ),
+                            name: quote_ident!(DUMMY_SP.apply_mark(mark), "_this").into(),
                             init: Some(Box::new(Expr::This(ThisExpr { span: DUMMY_SP }))),
                             definite: false,
                         }],

--- a/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
@@ -108,7 +108,7 @@ impl VisitMut for ComputedProps {
                     } else {
                         Box::new(Expr::Assign(AssignExpr {
                             span: DUMMY_SP,
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(obj_ident.clone().into()))),
+                            left: PatOrExpr::Pat(obj_ident.clone().into()),
                             op: op!("="),
                             right: Box::new(Expr::Object(ObjectLit {
                                 span: DUMMY_SP,
@@ -288,14 +288,14 @@ impl VisitMut for ComputedProps {
 
                 self.vars.push(VarDeclarator {
                     span: *span,
-                    name: Pat::Ident(obj_ident.clone().into()),
+                    name: obj_ident.clone().into(),
                     init: None,
                     definite: false,
                 });
                 if self.used_define_enum_props {
                     self.vars.push(VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(mutator_map.clone().into()),
+                        name: mutator_map.clone().into(),
                         init: Some(Box::new(Expr::Object(ObjectLit {
                             span: DUMMY_SP,
                             props: vec![],

--- a/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
@@ -267,7 +267,7 @@ impl VisitMut for ComputedProps {
                         };
                         Box::new(Expr::Assign(AssignExpr {
                             span,
-                            op: AssignOp::Assign,
+                            op: op!("="),
                             left: PatOrExpr::Expr(Box::new(left)),
                             right: value.into(),
                         }))

--- a/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
@@ -65,7 +65,7 @@ macro_rules! impl_for_for_stmt {
                     let left = VarDeclOrPat::VarDecl(VarDecl {
                         decls: vec![VarDeclarator {
                             span: DUMMY_SP,
-                            name: Pat::Ident(ref_ident.clone().into()),
+                            name: ref_ident.clone().into(),
                             init: None,
                             definite: false,
                         }],
@@ -271,7 +271,7 @@ impl AssignFolder {
                 if aliased {
                     decls.push(VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(ident.clone().into()),
+                        name: ident.clone().into(),
                         init: decl.init,
                         definite: false,
                     });
@@ -288,7 +288,7 @@ impl AssignFolder {
                 //
                 decls.push(VarDeclarator {
                     span,
-                    name: Pat::Ident(ident.clone().into()),
+                    name: ident.clone().into(),
                     init: Some(Box::new(Expr::Cond(CondExpr {
                         span: DUMMY_SP,
                         test: Box::new(Expr::Bin(BinExpr {
@@ -332,7 +332,7 @@ impl AssignFolder {
                         ObjectPatProp::Assign(p @ AssignPatProp { value: None, .. }) => {
                             decls.push(VarDeclarator {
                                 span: decl.span,
-                                name: Pat::Ident(p.key.clone().into()),
+                                name: p.key.clone().into(),
                                 init: Some(Box::new(decl.init.unwrap().make_member(p.key.clone()))),
                                 definite: false,
                             });
@@ -401,7 +401,7 @@ impl AssignFolder {
 
                                     let var_decl = VarDeclarator {
                                         span: prop_span,
-                                        name: Pat::Ident(key.clone().into()),
+                                        name: key.clone().into(),
                                         init: Some(Box::new(make_cond_expr(ref_ident, value))),
                                         definite: false,
                                     };
@@ -412,7 +412,7 @@ impl AssignFolder {
                                 None => {
                                     let var_decl = VarDeclarator {
                                         span: prop_span,
-                                        name: Pat::Ident(key.clone().into()),
+                                        name: key.clone().into(),
                                         init: Some(Box::new(make_ref_prop_expr(
                                             &ref_ident,
                                             Box::new(key.clone().into()),
@@ -459,7 +459,7 @@ impl AssignFolder {
                     let tmp_ident = private_ident!(span, "tmp");
                     decls.push(VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(tmp_ident.clone().into()),
+                        name: tmp_ident.clone().into(),
                         init,
                         definite: false,
                     });
@@ -521,7 +521,7 @@ impl Destructuring {
                     params.push(Param {
                         span: DUMMY_SP,
                         decorators: Default::default(),
-                        pat: Pat::Ident(ref_ident.clone().into()),
+                        pat: ref_ident.clone().into(),
                     });
                     decls.push(VarDeclarator {
                         span,
@@ -689,7 +689,7 @@ impl VisitMut for AssignFolder {
                         exprs.push(Box::new(Expr::Assign(AssignExpr {
                             span: DUMMY_SP,
                             op: op!("="),
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(ref_ident.clone().into()))),
+                            left: PatOrExpr::Pat(ref_ident.clone().into()),
                             right: if self.c.loose {
                                 right.take()
                             } else {
@@ -756,9 +756,7 @@ impl VisitMut for AssignFolder {
                                         make_ref_ident(self.c, &mut self.vars, None);
                                     exprs.push(Box::new(Expr::Assign(AssignExpr {
                                         span: DUMMY_SP,
-                                        left: PatOrExpr::Pat(Box::new(Pat::Ident(
-                                            assign_ref_ident.clone().into(),
-                                        ))),
+                                        left: PatOrExpr::Pat(assign_ref_ident.clone().into()),
                                         op: op!("="),
                                         right: Box::new(
                                             ref_ident.clone().computed_member(i as f64),
@@ -826,9 +824,7 @@ impl VisitMut for AssignFolder {
                                     *expr = Expr::Assign(AssignExpr {
                                         span: *span,
                                         op: op!("="),
-                                        left: PatOrExpr::Pat(Box::new(Pat::Ident(
-                                            p.key.clone().into(),
-                                        ))),
+                                        left: PatOrExpr::Pat(p.key.clone().into()),
                                         right: Box::new(right.take().make_member(p.key.clone())),
                                     });
                                     return;
@@ -843,7 +839,7 @@ impl VisitMut for AssignFolder {
 
                         exprs.push(Box::new(Expr::Assign(AssignExpr {
                             span: *span,
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(ref_ident.clone().into()))),
+                            left: PatOrExpr::Pat(ref_ident.clone().into()),
                             op: op!("="),
                             right: right.take(),
                         })));
@@ -881,9 +877,7 @@ impl VisitMut for AssignFolder {
 
                                             exprs.push(Box::new(Expr::Assign(AssignExpr {
                                                 span,
-                                                left: PatOrExpr::Pat(Box::new(Pat::Ident(
-                                                    prop_ident.clone().into(),
-                                                ))),
+                                                left: PatOrExpr::Pat(prop_ident.clone().into()),
                                                 op: op!("="),
                                                 right: Box::new(make_ref_prop_expr(
                                                     &ref_ident,
@@ -894,9 +888,7 @@ impl VisitMut for AssignFolder {
 
                                             exprs.push(Box::new(Expr::Assign(AssignExpr {
                                                 span,
-                                                left: PatOrExpr::Pat(Box::new(Pat::Ident(
-                                                    key.clone().into(),
-                                                ))),
+                                                left: PatOrExpr::Pat(key.clone().into()),
                                                 op: op!("="),
                                                 right: Box::new(make_cond_expr(
                                                     prop_ident,
@@ -907,9 +899,7 @@ impl VisitMut for AssignFolder {
                                         None => {
                                             exprs.push(Box::new(Expr::Assign(AssignExpr {
                                                 span,
-                                                left: PatOrExpr::Pat(Box::new(Pat::Ident(
-                                                    key.clone().into(),
-                                                ))),
+                                                left: PatOrExpr::Pat(key.clone().into()),
                                                 op: op!("="),
                                                 right: Box::new(make_ref_prop_expr(
                                                     &ref_ident,
@@ -947,7 +937,7 @@ impl VisitMut for AssignFolder {
                         exprs.push(Box::new(
                             AssignExpr {
                                 span: *span,
-                                left: Box::new(Pat::Ident(ref_ident.clone().into())).into(),
+                                left: PatOrExpr::Pat(ref_ident.clone().into()),
                                 op: op!("="),
                                 right: right.take(),
                             }
@@ -1111,7 +1101,7 @@ fn make_ref_ident_for_array(
     if aliased {
         decls.push(VarDeclarator {
             span,
-            name: Pat::Ident(ref_ident.clone().into()),
+            name: ref_ident.clone().into(),
             init: init.map(|v| {
                 if c.loose
                     || match *v {

--- a/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
@@ -295,7 +295,7 @@ impl AssignFolder {
                             span: DUMMY_SP,
                             left: Box::new(Expr::Ident(ident.clone())),
                             op: op!("!=="),
-                            right: Box::new(Expr::Lit(Lit::Null(Null { span: DUMMY_SP }))),
+                            right: Null { span: DUMMY_SP }.into(),
                         })),
                         cons: Box::new(Expr::Ident(ident.clone())),
                         alt: Box::new(Expr::Call(CallExpr {
@@ -309,13 +309,7 @@ impl AssignFolder {
                                         "TypeError".into(),
                                         DUMMY_SP,
                                     ))),
-                                    args: Some(vec![Lit::Str(Str {
-                                        span: DUMMY_SP,
-                                        value: "Cannot destructure undefined".into(),
-                                        has_escape: false,
-                                        kind: Default::default(),
-                                    })
-                                    .as_arg()]),
+                                    args: Some(vec!["Cannot destructure undefined".as_arg()]),
                                     type_args: Default::default(),
                                 }
                                 .as_arg(),
@@ -734,11 +728,7 @@ impl VisitMut for AssignFolder {
                                                     ),
                                                     args: vec![
                                                         right.take().as_arg(),
-                                                        Lit::Num(Number {
-                                                            span: DUMMY_SP,
-                                                            value: elems.len() as _,
-                                                        })
-                                                        .as_arg(),
+                                                        elems.len().as_arg(),
                                                     ],
                                                     type_args: Default::default(),
                                                 }
@@ -1146,14 +1136,7 @@ fn make_ref_ident_for_array(
                             CallExpr {
                                 span: DUMMY_SP,
                                 callee: helper!(sliced_to_array, "slicedToArray"),
-                                args: vec![
-                                    v.as_arg(),
-                                    Lit::Num(Number {
-                                        span: DUMMY_SP,
-                                        value: value as _,
-                                    })
-                                    .as_arg(),
-                                ],
+                                args: vec![v.as_arg(), value.as_arg()],
                                 type_args: Default::default(),
                             }
                             .into(),
@@ -1199,10 +1182,7 @@ fn make_cond_expr(tmp: Ident, def_value: Box<Expr>) -> Expr {
             right: Box::new(Expr::Unary(UnaryExpr {
                 span: DUMMY_SP,
                 op: op!("void"),
-                arg: Box::new(Expr::Lit(Lit::Num(Number {
-                    span: DUMMY_SP,
-                    value: 0.0,
-                }))),
+                arg: 0.0.into(),
             })),
         })),
         cons: def_value,

--- a/crates/swc_ecma_transforms_compat/src/es2015/duplicate_keys.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/duplicate_keys.rs
@@ -59,7 +59,7 @@ impl VisitMut for PropFolder {
                     *prop = Prop::KeyValue(KeyValueProp {
                         key: PropName::Computed(ComputedPropName {
                             span: ident.span,
-                            expr: Box::new(Expr::Lit(Lit::Str(quote_str!(ident.sym.clone())))),
+                            expr: quote_str!(ident.sym.clone()).into(),
                         }),
                         value: Box::new(Expr::Ident(ident.clone())),
                     })
@@ -116,7 +116,7 @@ impl<'a> VisitMut for PropNameFolder<'a> {
                 if !self.props.insert(s.value.clone()) {
                     *name = PropName::Computed(ComputedPropName {
                         span: s.span,
-                        expr: Box::new(Expr::Lit(Lit::Str(s.clone()))),
+                        expr: s.clone().into(),
                     })
                 }
             }

--- a/crates/swc_ecma_transforms_compat/src/es2015/for_of.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/for_of.rs
@@ -111,7 +111,7 @@ impl ForOf {
             let mut decls = Vec::with_capacity(2);
             decls.push(VarDeclarator {
                 span: DUMMY_SP,
-                name: Pat::Ident(i.clone().into()),
+                name: i.clone().into(),
                 init: Some(0.into()),
                 definite: false,
             });
@@ -119,7 +119,7 @@ impl ForOf {
             if aliased {
                 decls.push(VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(arr.clone().into()),
+                    name: arr.clone().into(),
                     init: Some(right),
                     definite: false,
                 });
@@ -236,21 +236,21 @@ impl ForOf {
         let normal_completion_ident = Ident::new("_iteratorNormalCompletion".into(), var_span);
         self.top_level_vars.push(VarDeclarator {
             span: DUMMY_SP,
-            name: Pat::Ident(normal_completion_ident.clone().into()),
+            name: normal_completion_ident.clone().into(),
             init: Some(true.into()),
             definite: false,
         });
         let error_flag_ident = Ident::new("_didIteratorError".into(), var_span);
         self.top_level_vars.push(VarDeclarator {
             span: DUMMY_SP,
-            name: Pat::Ident(error_flag_ident.clone().into()),
+            name: error_flag_ident.clone().into(),
             init: Some(false.into()),
             definite: false,
         });
         let error_ident = Ident::new("_iteratorError".into(), var_span);
         self.top_level_vars.push(VarDeclarator {
             span: DUMMY_SP,
-            name: Pat::Ident(error_ident.clone().into()),
+            name: error_ident.clone().into(),
             init: Some(Box::new(Expr::Ident(Ident::new(
                 js_word!("undefined"),
                 DUMMY_SP,
@@ -267,7 +267,7 @@ impl ForOf {
                 decls: vec![
                     VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(iterator.clone().into()),
+                        name: iterator.clone().into(),
                         init: Some(Box::new(Expr::Call(CallExpr {
                             span: DUMMY_SP,
                             callee: right
@@ -280,7 +280,7 @@ impl ForOf {
                     },
                     VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(step.clone().into()),
+                        name: step.clone().into(),
                         init: None,
                         definite: false,
                     },
@@ -293,7 +293,7 @@ impl ForOf {
                 arg: {
                     let step_expr = Box::new(Expr::Assign(AssignExpr {
                         span: DUMMY_SP,
-                        left: PatOrExpr::Pat(Box::new(Pat::Ident(step.into()))),
+                        left: PatOrExpr::Pat(step.into()),
                         op: op!("="),
                         // `_iterator.next()`
                         right: Box::new(Expr::Call(CallExpr {
@@ -307,9 +307,7 @@ impl ForOf {
 
                     let iteration_normal_completion = Box::new(Expr::Assign(AssignExpr {
                         span: DUMMY_SP,
-                        left: PatOrExpr::Pat(Box::new(Pat::Ident(
-                            normal_completion_ident.clone().into(),
-                        ))),
+                        left: PatOrExpr::Pat(normal_completion_ident.clone().into()),
                         op: op!("="),
                         right: Box::new(step_expr.make_member(quote_ident!("done"))),
                     }));
@@ -321,7 +319,7 @@ impl ForOf {
             // `_iteratorNormalCompletion = true`
             update: Some(Box::new(Expr::Assign(AssignExpr {
                 span: DUMMY_SP,
-                left: PatOrExpr::Pat(Box::new(Pat::Ident(normal_completion_ident.clone().into()))),
+                left: PatOrExpr::Pat(normal_completion_ident.clone().into()),
                 op: op!("="),
                 right: true.into(),
             }))),
@@ -346,7 +344,7 @@ impl ForOf {
             },
             handler: Some(CatchClause {
                 span: DUMMY_SP,
-                param: Some(Pat::Ident(quote_ident!("err").into())),
+                param: Some(quote_ident!("err").into()),
                 // _didIteratorError = true;
                 // _iteratorError = err;
                 body: BlockStmt {
@@ -355,9 +353,7 @@ impl ForOf {
                         // _didIteratorError = true;
                         AssignExpr {
                             span: DUMMY_SP,
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(
-                                error_flag_ident.clone().into(),
-                            ))),
+                            left: PatOrExpr::Pat(error_flag_ident.clone().into()),
                             op: op!("="),
                             right: true.into(),
                         }
@@ -365,7 +361,7 @@ impl ForOf {
                         // _iteratorError = err;
                         AssignExpr {
                             span: DUMMY_SP,
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(error_ident.clone().into()))),
+                            left: PatOrExpr::Pat(error_ident.clone().into()),
                             op: op!("="),
                             right: Box::new(Expr::Ident(quote_ident!("err"))),
                         }

--- a/crates/swc_ecma_transforms_compat/src/es2015/for_of.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/for_of.rs
@@ -112,10 +112,7 @@ impl ForOf {
             decls.push(VarDeclarator {
                 span: DUMMY_SP,
                 name: Pat::Ident(i.clone().into()),
-                init: Some(Box::new(Expr::Lit(Lit::Num(Number {
-                    span: DUMMY_SP,
-                    value: 0f64,
-                })))),
+                init: Some(0.into()),
                 definite: false,
             });
 
@@ -240,20 +237,14 @@ impl ForOf {
         self.top_level_vars.push(VarDeclarator {
             span: DUMMY_SP,
             name: Pat::Ident(normal_completion_ident.clone().into()),
-            init: Some(Box::new(Expr::Lit(Lit::Bool(Bool {
-                span: DUMMY_SP,
-                value: true,
-            })))),
+            init: Some(true.into()),
             definite: false,
         });
         let error_flag_ident = Ident::new("_didIteratorError".into(), var_span);
         self.top_level_vars.push(VarDeclarator {
             span: DUMMY_SP,
             name: Pat::Ident(error_flag_ident.clone().into()),
-            init: Some(Box::new(Expr::Lit(Lit::Bool(Bool {
-                span: DUMMY_SP,
-                value: false,
-            })))),
+            init: Some(false.into()),
             definite: false,
         });
         let error_ident = Ident::new("_iteratorError".into(), var_span);
@@ -332,10 +323,7 @@ impl ForOf {
                 span: DUMMY_SP,
                 left: PatOrExpr::Pat(Box::new(Pat::Ident(normal_completion_ident.clone().into()))),
                 op: op!("="),
-                right: Box::new(Expr::Lit(Lit::Bool(Bool {
-                    span: DUMMY_SP,
-                    value: true,
-                }))),
+                right: true.into(),
             }))),
             body: Box::new(Stmt::Block(body)),
         }
@@ -371,10 +359,7 @@ impl ForOf {
                                 error_flag_ident.clone().into(),
                             ))),
                             op: op!("="),
-                            right: Box::new(Expr::Lit(Lit::Bool(Bool {
-                                span: DUMMY_SP,
-                                value: true,
-                            }))),
+                            right: true.into(),
                         }
                         .into_stmt(),
                         // _iteratorError = err;
@@ -442,7 +427,7 @@ fn make_finally_block(
                             span: DUMMY_SP,
                             left: iterator_return.clone(),
                             op: op!("!="),
-                            right: Box::new(Expr::Lit(Lit::Null(Null { span: DUMMY_SP }))),
+                            right: Null { span: DUMMY_SP }.into(),
                         })),
                     })),
                     cons: Box::new(Stmt::Block(BlockStmt {

--- a/crates/swc_ecma_transforms_compat/src/es2015/new_target.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/new_target.rs
@@ -42,7 +42,7 @@ impl VisitMut for NewTarget {
             v.visit_mut_with(self);
             self.var.get_or_insert_with(|| VarDeclarator {
                 span: DUMMY_SP,
-                name: Pat::Ident(private_ident!("_newtarget").into()),
+                name: private_ident!("_newtarget").into(),
                 init: Some(Box::new(v)),
                 definite: Default::default(),
             });

--- a/crates/swc_ecma_transforms_compat/src/es2015/object_super.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/object_super.rs
@@ -34,7 +34,7 @@ impl VisitMut for ObjectSuper {
                         .into_iter()
                         .map(|v| VarDeclarator {
                             span: DUMMY_SP,
-                            name: Pat::Ident(v.into()),
+                            name: v.into(),
                             init: None,
                             definite: false,
                         })
@@ -58,7 +58,7 @@ impl VisitMut for ObjectSuper {
                         .into_iter()
                         .map(|v| VarDeclarator {
                             span: DUMMY_SP,
-                            name: Pat::Ident(v.into()),
+                            name: v.into(),
                             init: None,
                             definite: false,
                         })
@@ -93,7 +93,7 @@ impl VisitMut for ObjectSuper {
                                                 .drain(..)
                                                 .map(|v| VarDeclarator {
                                                     span: DUMMY_SP,
-                                                    name: Pat::Ident(v.into()),
+                                                    name: v.into(),
                                                     init: None,
                                                     definite: false,
                                                 })
@@ -420,7 +420,7 @@ impl SuperReplacer {
                         self.vars.push(ref_ident.clone());
                         *prop = Expr::Assign(AssignExpr {
                             span: DUMMY_SP,
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(ref_ident.clone().into()))),
+                            left: PatOrExpr::Pat(ref_ident.clone().into()),
                             op: op!("="),
                             right: prop.take(),
                         });
@@ -459,9 +459,9 @@ impl SuperReplacer {
                                             Box::new(
                                                 AssignExpr {
                                                     span: DUMMY_SP,
-                                                    left: PatOrExpr::Pat(Box::new(Pat::Ident(
+                                                    left: PatOrExpr::Pat(
                                                         update_ident.clone().into(),
-                                                    ))),
+                                                    ),
                                                     op: op!("="),
                                                     right: Box::new(Expr::Unary(UnaryExpr {
                                                         span: DUMMY_SP,

--- a/crates/swc_ecma_transforms_compat/src/es2015/object_super.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/object_super.rs
@@ -270,17 +270,7 @@ impl SuperReplacer {
                         op!("++") => op!("+="),
                         op!("--") => op!("-="),
                     };
-                    *n = self.super_to_set_call(
-                        *super_token,
-                        true,
-                        prop,
-                        op,
-                        Box::new(Expr::Lit(Lit::Num(Number {
-                            span: DUMMY_SP,
-                            value: 1.0,
-                        }))),
-                        *prefix,
-                    );
+                    *n = self.super_to_set_call(*super_token, true, prop, op, 1.0.into(), *prefix);
                 }
                 _ => {}
             },
@@ -400,11 +390,7 @@ impl SuperReplacer {
                 rhs,
                 ThisExpr { span: super_token }.as_arg(),
                 // strict
-                Lit::Bool(Bool {
-                    span: DUMMY_SP,
-                    value: true,
-                })
-                .as_arg(),
+                true.as_arg(),
             ],
             type_args: Default::default(),
         })

--- a/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
@@ -102,7 +102,7 @@ impl Params {
                         let binding = private_ident!(span, "param");
 
                         params.push(Param {
-                            pat: Pat::Ident(binding.clone().into()),
+                            pat: binding.clone().into(),
                             ..param
                         });
                         let decl = VarDeclarator {
@@ -153,7 +153,7 @@ impl Params {
                         if let Pat::Ident(ident) = left.as_ref() {
                             params.push(Param {
                                 span,
-                                pat: Pat::Ident(ident.clone()),
+                                pat: ident.clone(),
                                 decorators: Vec::new(),
                             });
                             loose_stmt.push(Stmt::If(IfStmt {
@@ -180,7 +180,7 @@ impl Params {
                             params.push(Param {
                                 span: DUMMY_SP,
                                 decorators: Default::default(),
-                                pat: Pat::Ident(binding.clone().into()),
+                                pat: binding.clone().into(),
                             });
                             loose_stmt.push(Stmt::Decl(Decl::Var(VarDecl {
                                 span,
@@ -284,14 +284,14 @@ impl Params {
                                 // _len = arguments.length - i
                                 VarDeclarator {
                                     span,
-                                    name: Pat::Ident(len_ident.clone().into()),
+                                    name: len_ident.clone().into(),
                                     init: Some(member_expr!(span, arguments.length)),
                                     definite: false,
                                 },
                                 // a1 = new Array(_len - $i)
                                 VarDeclarator {
                                     span,
-                                    name: Pat::Ident(arg.clone().into()),
+                                    name: arg.clone().into(),
                                     init: Some(Box::new(Expr::New(NewExpr {
                                         span,
                                         callee: Box::new(quote_ident!("Array").into()),
@@ -306,7 +306,7 @@ impl Params {
                                 // _key = 0
                                 VarDeclarator {
                                     span,
-                                    name: Pat::Ident(idx_ident.clone().into()),
+                                    name: idx_ident.clone().into(),
                                     init: Some(Box::new(Expr::Lit(Lit::Num(Number {
                                         span,
                                         value: i as f64,

--- a/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
@@ -153,7 +153,7 @@ impl Params {
                         if let Pat::Ident(ident) = left.as_ref() {
                             params.push(Param {
                                 span,
-                                pat: ident.clone(),
+                                pat: ident.clone().into(),
                                 decorators: Vec::new(),
                             });
                             loose_stmt.push(Stmt::If(IfStmt {

--- a/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
@@ -135,7 +135,7 @@ impl Params {
                                 span,
                                 test: Box::new(Expr::Bin(BinExpr {
                                     left: Box::new(check_arg_len(i)),
-                                    op: BinaryOp::LogicalAnd,
+                                    op: op!("&&"),
                                     right: Box::new(Expr::Bin(BinExpr {
                                         left: Box::new(make_arg_nth(i)),
                                         op: BinaryOp::NotEqEq,

--- a/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
@@ -138,7 +138,7 @@ impl Params {
                                     op: op!("&&"),
                                     right: Box::new(Expr::Bin(BinExpr {
                                         left: Box::new(make_arg_nth(i)),
-                                        op: BinaryOp::NotEqEq,
+                                        op: op!("!=="),
                                         right: undefined(DUMMY_SP),
                                         span: DUMMY_SP,
                                     })),
@@ -193,7 +193,7 @@ impl Params {
                                         test: Box::new(Expr::Bin(BinExpr {
                                             span: DUMMY_SP,
                                             left: Box::new(Expr::Ident(binding.clone())),
-                                            op: BinaryOp::EqEqEq,
+                                            op: op!("==="),
                                             right: undefined(DUMMY_SP),
                                         })),
                                         cons: right,
@@ -665,7 +665,7 @@ fn check_arg_len(n: usize) -> Expr {
             Expr::Ident(Ident::new(js_word!("arguments"), DUMMY_SP))
                 .make_member(Ident::new(js_word!("length"), DUMMY_SP)),
         ),
-        op: BinaryOp::Gt,
+        op: op!(">"),
         right: n.into(),
         span: DUMMY_SP,
     })

--- a/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
@@ -169,7 +169,7 @@ impl Params {
                                     expr: Box::new(Expr::Assign(AssignExpr {
                                         span,
                                         left: PatOrExpr::Pat(left),
-                                        op: AssignOp::Assign,
+                                        op: op!("="),
                                         right,
                                     })),
                                 })),

--- a/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
@@ -270,7 +270,7 @@ impl Params {
                                     .into(),
                                 ),
                                 cons: Box::new(bin),
-                                alt: Box::new(Expr::Lit(Lit::Num(Number { span, value: 0.0 }))),
+                                alt: 0.into(),
                             })
                         }
                     };
@@ -656,12 +656,7 @@ impl VisitMut for Params {
 }
 
 fn make_arg_nth(n: usize) -> Expr {
-    Expr::Ident(Ident::new(js_word!("arguments"), DUMMY_SP)).computed_member(Expr::Lit(Lit::Num(
-        Number {
-            span: DUMMY_SP,
-            value: n as f64,
-        },
-    )))
+    Expr::Ident(Ident::new(js_word!("arguments"), DUMMY_SP)).computed_member(n)
 }
 
 fn check_arg_len(n: usize) -> Expr {
@@ -671,10 +666,7 @@ fn check_arg_len(n: usize) -> Expr {
                 .make_member(Ident::new(js_word!("length"), DUMMY_SP)),
         ),
         op: BinaryOp::Gt,
-        right: Box::new(Expr::Lit(Lit::Num(Number {
-            span: DUMMY_SP,
-            value: n as f64,
-        }))),
+        right: n.into(),
         span: DUMMY_SP,
     })
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/regenerator/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/regenerator/mod.rs
@@ -155,7 +155,7 @@ impl VisitMut for Regenerator {
 
             self.top_level_vars.push(VarDeclarator {
                 span: DUMMY_SP,
-                name: Pat::Ident(marked.clone().into()),
+                name: marked.clone().into(),
                 init: Some(Box::new(Expr::Call(CallExpr {
                     span: DUMMY_SP,
                     callee: self
@@ -344,14 +344,14 @@ impl Regenerator {
         let mut outer_fn_vars = vec![];
         outer_fn_vars.extend(hoister.vars.into_iter().map(|id| VarDeclarator {
             span: DUMMY_SP,
-            name: Pat::Ident(id.into()),
+            name: id.into(),
             init: None,
             definite: false,
         }));
         outer_fn_vars.extend(hoister.arguments.into_iter().map(|id| {
             VarDeclarator {
                 span: DUMMY_SP,
-                name: Pat::Ident(id.clone().into()),
+                name: id.clone().into(),
                 init: Some(Box::new(
                     Ident {
                         sym: js_word!("arguments"),
@@ -462,7 +462,7 @@ impl Regenerator {
                                         params: vec![Param {
                                             span: DUMMY_SP,
                                             decorators: Default::default(),
-                                            pat: Pat::Ident(ctx.clone().into()),
+                                            pat: ctx.clone().into(),
                                         }],
                                         decorators: Default::default(),
                                         span: DUMMY_SP,

--- a/crates/swc_ecma_transforms_compat/src/es2015/regenerator/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/regenerator/mod.rs
@@ -50,7 +50,7 @@ fn require_rt(global_mark: Mark, rt: Ident, src: Option<JsWord>) -> Stmt {
         declare: false,
         decls: vec![VarDeclarator {
             span: DUMMY_SP,
-            name: Pat::Ident(rt.into()),
+            name: rt.into(),
             init: Some(Box::new(Expr::Call(CallExpr {
                 span: DUMMY_SP,
                 callee: quote_ident!(DUMMY_SP.apply_mark(global_mark), "require").as_callee(),

--- a/crates/swc_ecma_transforms_compat/src/es2015/spread.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/spread.rs
@@ -99,7 +99,7 @@ impl VisitMut for Spread {
                             span: DUMMY_SP,
                             definite: false,
                             // Initialized by paren expression.
-                            name: Pat::Ident(ident.clone().into()),
+                            name: ident.clone().into(),
                             // Initialized by paren expression.
                             init: None,
                         });
@@ -107,7 +107,7 @@ impl VisitMut for Spread {
                         let this = Box::new(Expr::Ident(ident.clone()));
                         let callee = Expr::Assign(AssignExpr {
                             span: DUMMY_SP,
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(ident.into()))),
+                            left: PatOrExpr::Pat(ident.into()),
                             op: op!("="),
                             right: obj.clone(),
                         });

--- a/crates/swc_ecma_transforms_compat/src/es2015/template_literal.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/template_literal.rs
@@ -179,7 +179,7 @@ impl VisitMut for TemplateLiteral {
                                 for arg in args {
                                     obj = Box::new(Expr::Bin(BinExpr {
                                         span: span.with_hi(expr_span.hi() + BytePos(1)),
-                                        op: BinaryOp::Add,
+                                        op: op!(bin, "+"),
                                         left: obj,
                                         right: arg,
                                     }))
@@ -219,7 +219,7 @@ impl VisitMut for TemplateLiteral {
                                     }
                                     obj = Box::new(Expr::Bin(BinExpr {
                                         span: span.with_hi(expr_span.hi() + BytePos(1)),
-                                        op: BinaryOp::Add,
+                                        op: op!(bin, "+"),
                                         left: obj,
                                         right: arg,
                                     }))

--- a/crates/swc_ecma_transforms_compat/src/es2017/async_to_generator.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2017/async_to_generator.rs
@@ -371,12 +371,12 @@ impl MethodFolder {
 
         self.vars.push(VarDeclarator {
             span: DUMMY_SP,
-            name: Pat::Ident(ident.clone().into()),
+            name: ident.clone().into(),
             init: Some(Box::new(Expr::Arrow(ArrowExpr {
                 span: DUMMY_SP,
                 is_async: false,
                 is_generator: false,
-                params: vec![Pat::Ident(args_ident.clone().into())],
+                params: vec![args_ident.clone().into()],
                 body: BlockStmtOrExpr::Expr(Box::new(Expr::Assign(AssignExpr {
                     span: DUMMY_SP,
                     left: PatOrExpr::Expr(Box::new(
@@ -487,7 +487,7 @@ impl VisitMut for MethodFolder {
 
                 self.vars.push(VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(ident.clone().into()),
+                    name: ident.clone().into(),
                     init: Some(Box::new(Expr::Arrow(ArrowExpr {
                         span: DUMMY_SP,
                         is_async: false,
@@ -495,7 +495,7 @@ impl VisitMut for MethodFolder {
                         params: vec![Pat::Rest(RestPat {
                             span: DUMMY_SP,
                             dot3_token: DUMMY_SP,
-                            arg: Box::new(Pat::Ident(args_ident.clone().into())),
+                            arg: args_ident.clone().into(),
                             type_ann: Default::default(),
                         })],
                         body: BlockStmtOrExpr::Expr(Box::new(Expr::Call(CallExpr {
@@ -530,7 +530,7 @@ impl VisitMut for MethodFolder {
                 let (_, ident) = self.ident_for_super(&prop);
                 self.vars.push(VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(ident.clone().into()),
+                    name: ident.clone().into(),
                     init: Some(Box::new(Expr::Arrow(ArrowExpr {
                         span: DUMMY_SP,
                         is_async: false,
@@ -792,7 +792,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
             // let value = _step.value;
             let value_var = VarDeclarator {
                 span: DUMMY_SP,
-                name: Pat::Ident(value.clone().into()),
+                name: value.clone().into(),
                 init: Some(Box::new(step.clone().make_member(quote_ident!("value")))),
                 definite: false,
             };
@@ -844,7 +844,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
         // _iterator = _asyncIterator(lol())
         init_var_decls.push(VarDeclarator {
             span: DUMMY_SP,
-            name: Pat::Ident(iterator.clone().into()),
+            name: iterator.clone().into(),
             init: {
                 let callee = helper!(async_iterator, "asyncIterator");
 
@@ -859,7 +859,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
         });
         init_var_decls.push(VarDeclarator {
             span: DUMMY_SP,
-            name: Pat::Ident(step.clone().into()),
+            name: step.clone().into(),
             init: None,
             definite: false,
         });
@@ -897,7 +897,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
                 let assign_to_step = Expr::Assign(AssignExpr {
                     span: DUMMY_SP,
                     op: op!("="),
-                    left: PatOrExpr::Pat(Box::new(Pat::Ident(step.clone().into()))),
+                    left: PatOrExpr::Pat(step.clone().into()),
                     right: Box::new(Expr::Yield(YieldExpr {
                         span: DUMMY_SP,
                         arg: Some(yield_arg),
@@ -911,9 +911,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
                     arg: Box::new(assign_to_step.make_member(quote_ident!("done"))),
                 }));
 
-                let left = PatOrExpr::Pat(Box::new(Pat::Ident(
-                    iterator_abrupt_completion.clone().into(),
-                )));
+                let left = PatOrExpr::Pat(iterator_abrupt_completion.clone().into());
 
                 Some(Box::new(Expr::Assign(AssignExpr {
                     span: DUMMY_SP,
@@ -926,9 +924,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
             update: Some(Box::new(Expr::Assign(AssignExpr {
                 span: DUMMY_SP,
                 op: op!("="),
-                left: PatOrExpr::Pat(Box::new(Pat::Ident(
-                    iterator_abrupt_completion.clone().into(),
-                ))),
+                left: PatOrExpr::Pat(iterator_abrupt_completion.clone().into()),
                 right: Box::new(Expr::Lit(Lit::Bool(Bool {
                     span: DUMMY_SP,
                     value: false,
@@ -950,7 +946,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
             expr: Box::new(Expr::Assign(AssignExpr {
                 span: DUMMY_SP,
                 op: op!("="),
-                left: PatOrExpr::Pat(Box::new(Pat::Ident(did_iteration_error.clone().into()))),
+                left: PatOrExpr::Pat(did_iteration_error.clone().into()),
                 right: Box::new(Expr::Lit(Lit::Bool(Bool {
                     span: DUMMY_SP,
                     value: true,
@@ -963,14 +959,14 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
             expr: Box::new(Expr::Assign(AssignExpr {
                 span: DUMMY_SP,
                 op: op!("="),
-                left: PatOrExpr::Pat(Box::new(Pat::Ident(iterator_error.clone().into()))),
+                left: PatOrExpr::Pat(iterator_error.clone().into()),
                 right: Box::new(Expr::Ident(err_param.clone())),
             })),
         });
 
         CatchClause {
             span: DUMMY_SP,
-            param: Some(Pat::Ident(err_param.clone().into())),
+            param: Some(err_param.clone().into()),
             body: BlockStmt {
                 span: DUMMY_SP,
                 stmts: vec![mark_as_errorred, store_error],
@@ -1072,7 +1068,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
             // var _iteratorAbruptCompletion = false;
             decls.push(VarDeclarator {
                 span: DUMMY_SP,
-                name: Pat::Ident(iterator_abrupt_completion.into()),
+                name: iterator_abrupt_completion.into(),
                 init: Some(Box::new(Expr::Lit(Lit::Bool(Bool {
                     span: DUMMY_SP,
                     value: false,
@@ -1083,7 +1079,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
             // var _didIteratorError = false;
             decls.push(VarDeclarator {
                 span: DUMMY_SP,
-                name: Pat::Ident(did_iteration_error.into()),
+                name: did_iteration_error.into(),
                 init: Some(Box::new(Expr::Lit(Lit::Bool(Bool {
                     span: DUMMY_SP,
                     value: false,
@@ -1094,7 +1090,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
             // var _iteratorError;
             decls.push(VarDeclarator {
                 span: DUMMY_SP,
-                name: Pat::Ident(iterator_error.clone().into()),
+                name: iterator_error.clone().into(),
                 init: None,
                 definite: false,
             });

--- a/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
@@ -225,14 +225,14 @@ impl VisitMut for ObjectRest {
                 // println!("Var: var_ident = None");
                 self.mutable_vars.push(VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(var_ident.clone().into()),
+                    name: var_ident.clone().into(),
                     init: None,
                     definite: false,
                 });
                 // println!("Expr: var_ident = right");
                 self.exprs.push(Box::new(Expr::Assign(AssignExpr {
                     span: DUMMY_SP,
-                    left: PatOrExpr::Pat(Box::new(Pat::Ident(var_ident.clone().into()))),
+                    left: PatOrExpr::Pat(var_ident.clone().into()),
                     op: op!("="),
                     right: right.take(),
                 })));
@@ -399,7 +399,7 @@ impl VisitMut for ObjectRest {
                         // println!("Var: var_ident = init",);
                         self.push_var_if_not_empty(VarDeclarator {
                             span: DUMMY_SP,
-                            name: Pat::Ident(var_ident.clone().into()),
+                            name: var_ident.clone().into(),
                             init: Some(init),
                             definite: false,
                         });
@@ -590,7 +590,7 @@ impl ObjectRest {
                                         },
                                     );
                                     index += 1;
-                                    Some(Pat::Ident(var_ident.clone().into()))
+                                    Some(var_ident.clone().into())
                                 }
                                 _ => elem,
                             })
@@ -620,7 +620,7 @@ impl ObjectRest {
                             decorators: Default::default(),
                             pat: Pat::Assign(AssignPat {
                                 span,
-                                left: Box::new(Pat::Ident(var_ident.into())),
+                                left: var_ident.into(),
                                 right,
                                 ..n
                             }),
@@ -640,7 +640,7 @@ impl ObjectRest {
                         Param {
                             span: DUMMY_SP,
                             decorators: Default::default(),
-                            pat: Pat::Ident(var_ident.into()),
+                            pat: var_ident.into(),
                         }
                     }
                 }
@@ -807,7 +807,7 @@ impl ObjectRest {
                                 *index += 1;
                                 self.vars.push(VarDeclarator {
                                     span: DUMMY_SP,
-                                    name: Pat::Ident(ident.clone().into()),
+                                    name: ident.clone().into(),
                                     init: Some(c.expr),
                                     definite: false,
                                 });

--- a/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
@@ -86,7 +86,7 @@ macro_rules! impl_for_for_stmt {
                     VarDeclOrPat::VarDecl(VarDecl {
                         decls: vec![VarDeclarator {
                             span: DUMMY_SP,
-                            name: Pat::Ident(ref_ident.clone().into()),
+                            name: ref_ident.clone().into(),
                             init: None,
                             definite: false,
                         }],
@@ -132,7 +132,7 @@ macro_rules! impl_for_for_stmt {
                         kind: VarDeclKind::Var,
                         decls: vec![VarDeclarator {
                             span: DUMMY_SP,
-                            name: Pat::Ident(var_ident.clone().into()),
+                            name: var_ident.clone().into(),
                             init: None,
                             definite: false,
                         }],

--- a/crates/swc_ecma_transforms_compat/src/es2020/nullish_coalescing/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2020/nullish_coalescing/mod.rs
@@ -95,7 +95,7 @@ impl VisitMut for NullishCoalescing {
                 if aliased {
                     self.vars.push(VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(l.clone().into()),
+                        name: l.clone().into(),
                         init: None,
                         definite: false,
                     });
@@ -105,7 +105,7 @@ impl VisitMut for NullishCoalescing {
                     Expr::Assign(AssignExpr {
                         span: DUMMY_SP,
                         op: op!("="),
-                        left: PatOrExpr::Pat(Box::new(Pat::Ident(l.clone().into()))),
+                        left: PatOrExpr::Pat(l.clone().into()),
                         right: left.take(),
                     })
                 } else {
@@ -123,7 +123,7 @@ impl VisitMut for NullishCoalescing {
                         if aliased {
                             self.vars.push(VarDeclarator {
                                 span: DUMMY_SP,
-                                name: Pat::Ident(alias.clone().into()),
+                                name: alias.clone().into(),
                                 init: None,
                                 definite: false,
                             });
@@ -145,7 +145,7 @@ impl VisitMut for NullishCoalescing {
                             Expr::Assign(AssignExpr {
                                 span: DUMMY_SP,
                                 op: op!("="),
-                                left: PatOrExpr::Pat(Box::new(Pat::Ident(alias.clone().into()))),
+                                left: PatOrExpr::Pat(alias.clone().into()),
                                 right: left.take(),
                             })
                         } else {
@@ -155,7 +155,7 @@ impl VisitMut for NullishCoalescing {
                         *e = Expr::Assign(AssignExpr {
                             span: assign.span,
                             op: op!("="),
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(alias.clone().into()))),
+                            left: PatOrExpr::Pat(alias.clone().into()),
                             right: Box::new(make_cond(
                                 self.c,
                                 assign.span,
@@ -171,7 +171,7 @@ impl VisitMut for NullishCoalescing {
                             *e = Expr::Assign(AssignExpr {
                                 span: assign.span,
                                 op: op!("="),
-                                left: PatOrExpr::Pat(Box::new(Pat::Ident(i.clone()))),
+                                left: PatOrExpr::Pat(i.clone().into()),
                                 right: Box::new(make_cond(
                                     self.c,
                                     assign.span,

--- a/crates/swc_ecma_transforms_compat/src/es2020/opt_chaining.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2020/opt_chaining.rs
@@ -422,14 +422,14 @@ impl OptChaining {
                         self.vars_without_init.push(VarDeclarator {
                             span: obj_span,
                             definite: false,
-                            name: Pat::Ident(i.clone().into()),
+                            name: i.clone().into(),
                             init: None,
                         });
 
                         (
                             Box::new(Expr::Assign(AssignExpr {
                                 span: DUMMY_SP,
-                                left: PatOrExpr::Pat(Box::new(Pat::Ident(i.clone().into()))),
+                                left: PatOrExpr::Pat(i.clone().into()),
                                 op: op!("="),
                                 right: obj.take(),
                             })),
@@ -524,7 +524,7 @@ impl OptChaining {
                             self.vars_without_init.push(VarDeclarator {
                                 span: obj_span,
                                 definite: false,
-                                name: Pat::Ident(this_obj.clone().into()),
+                                name: this_obj.clone().into(),
                                 init: None,
                             });
 
@@ -534,9 +534,7 @@ impl OptChaining {
                                     obj: Expr::Assign(AssignExpr {
                                         span: DUMMY_SP,
                                         op: op!("="),
-                                        left: PatOrExpr::Pat(Box::new(Pat::Ident(
-                                            this_obj.clone().into(),
-                                        ))),
+                                        left: PatOrExpr::Pat(this_obj.clone().into()),
                                         right: obj.obj.take(),
                                     })
                                     .into(),
@@ -545,9 +543,7 @@ impl OptChaining {
                                 _ => Box::new(Expr::Assign(AssignExpr {
                                     span: DUMMY_SP,
                                     op: op!("="),
-                                    left: PatOrExpr::Pat(Box::new(Pat::Ident(
-                                        this_obj.clone().into(),
-                                    ))),
+                                    left: PatOrExpr::Pat(this_obj.clone().into()),
                                     right: obj.take(),
                                 })),
                             }
@@ -560,14 +556,14 @@ impl OptChaining {
                         self.vars_without_init.push(VarDeclarator {
                             span: obj_span,
                             definite: false,
-                            name: Pat::Ident(tmp.clone().into()),
+                            name: tmp.clone().into(),
                             init: None,
                         });
 
                         (
                             Box::new(Expr::Assign(AssignExpr {
                                 span: DUMMY_SP,
-                                left: PatOrExpr::Pat(Box::new(Pat::Ident(tmp.clone().into()))),
+                                left: PatOrExpr::Pat(tmp.clone().into()),
                                 op: op!("="),
                                 right: obj_expr,
                             })),

--- a/crates/swc_ecma_transforms_compat/src/es2021/logical_assignments.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2021/logical_assignments.rs
@@ -43,7 +43,7 @@ impl VisitMut for Operators {
                         let alias = alias_ident_for(&m.obj, "_ref");
                         self.vars.push(VarDeclarator {
                             span: DUMMY_SP,
-                            name: Pat::Ident(alias.clone().into()),
+                            name: alias.clone().into(),
                             init: None,
                             definite: false,
                         });
@@ -53,7 +53,7 @@ impl VisitMut for Operators {
                         let obj = Box::new(Expr::Assign(AssignExpr {
                             span: DUMMY_SP,
                             op: op!("="),
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(alias.clone().into()))),
+                            left: PatOrExpr::Pat(alias.clone().into()),
                             right: m.obj.take(),
                         }));
 

--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
@@ -396,7 +396,7 @@ impl ClassProperties {
                             // Handle computed property
                             vars.push(VarDeclarator {
                                 span: DUMMY_SP,
-                                name: Pat::Ident(ident.clone().into()),
+                                name: ident.clone().into(),
                                 init: Some(expr),
                                 definite: false,
                             });
@@ -456,7 +456,7 @@ impl ClassProperties {
                                 // Handle computed property
                                 vars.push(VarDeclarator {
                                     span: DUMMY_SP,
-                                    name: Pat::Ident(ident.clone().into()),
+                                    name: ident.clone().into(),
                                     init: Some(key.expr),
                                     definite: false,
                                 });
@@ -595,7 +595,7 @@ impl ClassProperties {
                         decls: vec![VarDeclarator {
                             span: DUMMY_SP,
                             definite: false,
-                            name: Pat::Ident(ident.clone().into()),
+                            name: ident.clone().into(),
                             init: Some(extra_init),
                         }],
                     })));
@@ -633,7 +633,7 @@ impl ClassProperties {
                         vars.push(VarDeclarator {
                             span: DUMMY_SP,
                             definite: false,
-                            name: Pat::Ident(weak_coll_var.clone().into()),
+                            name: weak_coll_var.clone().into(),
                             init: Some(Box::new(Expr::from(NewExpr {
                                 span: DUMMY_SP,
                                 callee: if should_use_map {
@@ -667,7 +667,7 @@ impl ClassProperties {
 
                             vars.push(VarDeclarator {
                                 span: DUMMY_SP,
-                                name: Pat::Ident(var_name.clone().into()),
+                                name: var_name.clone().into(),
                                 init: Some(Box::new(Expr::Object(obj))),
                                 definite: Default::default(),
                             });

--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/private_field.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/private_field.rs
@@ -179,7 +179,7 @@ impl<'a> VisitMut for FieldAccessFolder<'a> {
                     });
                     AssignExpr {
                         span: obj.span(),
-                        left: var.clone().into(),
+                        left: PatOrExpr::Pat(var.clone().into()),
                         op: op!("="),
                         right: obj,
                     }

--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/private_field.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/private_field.rs
@@ -173,13 +173,13 @@ impl<'a> VisitMut for FieldAccessFolder<'a> {
                 } else {
                     self.vars.push(VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(var.clone().into()),
+                        name: var.clone().into(),
                         init: None,
                         definite: false,
                     });
                     AssignExpr {
                         span: obj.span(),
-                        left: PatOrExpr::Pat(Box::new(Pat::Ident(var.clone().into()))),
+                        left: var.clone().into(),
                         op: op!("="),
                         right: obj,
                     }
@@ -195,7 +195,7 @@ impl<'a> VisitMut for FieldAccessFolder<'a> {
                 if !*prefix {
                     self.vars.push(VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(old_var.clone().into()),
+                        name: old_var.clone().into(),
                         init: None,
                         definite: false,
                     });
@@ -213,7 +213,7 @@ impl<'a> VisitMut for FieldAccessFolder<'a> {
                     } else {
                         Box::new(Expr::Assign(AssignExpr {
                             span: DUMMY_SP,
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(old_var.clone().into()))),
+                            left: PatOrExpr::Pat(old_var.clone().into()),
                             op: op!("="),
                             right: left,
                         }))
@@ -315,13 +315,13 @@ impl<'a> VisitMut for FieldAccessFolder<'a> {
                 } else {
                     self.vars.push(VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(var.clone().into()),
+                        name: var.clone().into(),
                         init: None,
                         definite: false,
                     });
                     AssignExpr {
                         span: obj.span(),
-                        left: PatOrExpr::Pat(Box::new(Pat::Ident(var.clone().into()))),
+                        left: PatOrExpr::Pat(var.clone().into()),
                         op: op!("="),
                         right: obj,
                     }
@@ -635,7 +635,7 @@ impl<'a> FieldAccessFolder<'a> {
                             aliased = true;
                             self.vars.push(VarDeclarator {
                                 span: DUMMY_SP,
-                                name: Pat::Ident(var.clone().into()),
+                                name: var.clone().into(),
                                 init: None,
                                 definite: false,
                             });
@@ -649,7 +649,7 @@ impl<'a> FieldAccessFolder<'a> {
                         if aliased {
                             AssignExpr {
                                 span: DUMMY_SP,
-                                left: PatOrExpr::Pat(Box::new(Pat::Ident(var.clone().into()))),
+                                left: PatOrExpr::Pat(var.clone().into()),
                                 op: op!("="),
                                 right: obj.take(),
                             }

--- a/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
@@ -45,7 +45,7 @@ impl Mode {
             Mode::ClassExpr { vars, init_exprs } => {
                 vars.push(VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(n.clone().into()),
+                    name: n.clone().into(),
                     init: None,
                     definite: Default::default(),
                 });
@@ -53,7 +53,7 @@ impl Mode {
                     init_exprs.push(Box::new(Expr::Assign(AssignExpr {
                         span: DUMMY_SP,
                         op: op!("="),
-                        left: PatOrExpr::Pat(Box::new(Pat::Ident(n.into()))),
+                        left: PatOrExpr::Pat(n.into()),
                         right: init,
                     })));
                 }
@@ -61,7 +61,7 @@ impl Mode {
             Mode::ClassDecl { vars } => {
                 vars.push(VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(n.into()),
+                    name: n.into(),
                     init,
                     definite: Default::default(),
                 });
@@ -421,7 +421,7 @@ impl VisitMut for PrivateInObject {
                     let assign = Box::new(Expr::Assign(AssignExpr {
                         span: DUMMY_SP,
                         op: op!("="),
-                        left: PatOrExpr::Pat(Box::new(Pat::Ident(tmp.clone().into()))),
+                        left: PatOrExpr::Pat(tmp.clone().into()),
                         right: init.take(),
                     }));
 

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -305,7 +305,7 @@ where
                                 kind: VarDeclKind::Var,
                                 decls: vec![VarDeclarator {
                                     span: DUMMY_SP,
-                                    name: Pat::Ident(ident.clone().into()),
+                                    name: ident.clone().into(),
                                     init: Some(expr.fold_with(self)),
                                     definite: false,
                                 }],
@@ -474,7 +474,7 @@ where
             factory_params.push(Param {
                 span: DUMMY_SP,
                 decorators: Default::default(),
-                pat: Pat::Ident(exports_ident.clone().into()),
+                pat: exports_ident.clone().into(),
             });
         }
 
@@ -487,7 +487,7 @@ where
                     kind: VarDeclKind::Var,
                     decls: vec![VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(exported_names.clone().into()),
+                        name: exported_names.clone().into(),
                         init: Some(Box::new(Expr::Object(ObjectLit {
                             span: DUMMY_SP,
                             props: exports
@@ -560,7 +560,7 @@ where
             factory_params.push(Param {
                 span: DUMMY_SP,
                 decorators: Default::default(),
-                pat: Pat::Ident(ident.clone().into()),
+                pat: ident.clone().into(),
             });
 
             {
@@ -583,7 +583,7 @@ where
                         import_stmts.push(
                             AssignExpr {
                                 span: DUMMY_SP,
-                                left: PatOrExpr::Pat(Box::new(Pat::Ident(ident.clone().into()))),
+                                left: PatOrExpr::Pat(ident.clone().into()),
                                 op: op!("="),
                                 right,
                             }
@@ -718,13 +718,13 @@ pub(super) fn handle_dynamic_import(span: Span, args: Vec<ExprOrSpread>) -> Expr
                     Param {
                         span: DUMMY_SP,
                         decorators: Default::default(),
-                        pat: Pat::Ident(quote_ident!("resolve").into()),
+                        pat: quote_ident!("resolve").into(),
                     },
                     // reject
                     Param {
                         span: DUMMY_SP,
                         decorators: Default::default(),
-                        pat: Pat::Ident(quote_ident!("reject").into()),
+                        pat: quote_ident!("reject").into(),
                     },
                 ],
 
@@ -765,7 +765,7 @@ pub(super) fn handle_dynamic_import(span: Span, args: Vec<ExprOrSpread>) -> Expr
                                             params: vec![Param {
                                                 span: DUMMY_SP,
                                                 decorators: Default::default(),
-                                                pat: Pat::Ident(quote_ident!("dep").into()),
+                                                pat: quote_ident!("dep").into(),
                                             }],
                                             body: Some(BlockStmt {
                                                 span: DUMMY_SP,
@@ -795,7 +795,7 @@ pub(super) fn handle_dynamic_import(span: Span, args: Vec<ExprOrSpread>) -> Expr
                                             params: vec![Param {
                                                 span: DUMMY_SP,
                                                 decorators: Default::default(),
-                                                pat: Pat::Ident(quote_ident!("err").into()),
+                                                pat: quote_ident!("err").into(),
                                             }],
                                             body: Some(BlockStmt {
                                                 span: DUMMY_SP,

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -295,7 +295,7 @@ where
                                     kind: VarDeclKind::Var,
                                     decls: vec![VarDeclarator {
                                         span: DUMMY_SP,
-                                        name: Pat::Ident(exported_names_ident.clone().into()),
+                                        name: exported_names_ident.clone().into(),
                                         init: Some(Box::new(Expr::Object(ObjectLit {
                                             span: DUMMY_SP,
                                             props: exports
@@ -520,7 +520,7 @@ where
                                 kind: VarDeclKind::Var,
                                 decls: vec![VarDeclarator {
                                     span: DUMMY_SP,
-                                    name: Pat::Ident(ident.clone().into()),
+                                    name: ident.clone().into(),
                                     init: Some(expr.expr.fold_with(self)),
                                     definite: false,
                                 }],
@@ -757,7 +757,7 @@ where
                                             kind: VarDeclKind::Const,
                                             decls: vec![VarDeclarator {
                                                 span: DUMMY_SP,
-                                                name: Pat::Ident(quote_ident!("data").into()),
+                                                name: quote_ident!("data").into(),
                                                 init: Some(rhs),
                                                 definite: false,
                                             }],
@@ -766,9 +766,7 @@ where
                                         // foo = function() { return data; };
                                         AssignExpr {
                                             span: DUMMY_SP,
-                                            left: PatOrExpr::Pat(Box::new(Pat::Ident(
-                                                ident.into(),
-                                            ))),
+                                            left: PatOrExpr::Pat(ident.into()),
                                             op: op!("="),
                                             right: Box::new(
                                                 FnExpr {
@@ -807,7 +805,7 @@ where
                             kind: VarDeclKind::Var,
                             decls: vec![VarDeclarator {
                                 span: DUMMY_SP,
-                                name: Pat::Ident(ident.into()),
+                                name: ident.into(),
                                 init: Some(rhs),
                                 definite: false,
                             }],

--- a/crates/swc_ecma_transforms_module/src/umd.rs
+++ b/crates/swc_ecma_transforms_module/src/umd.rs
@@ -308,7 +308,7 @@ where
                                 kind: VarDeclKind::Var,
                                 decls: vec![VarDeclarator {
                                     span: DUMMY_SP,
-                                    name: Pat::Ident(ident.clone().into()),
+                                    name: ident.clone().into(),
                                     init: Some(expr.expr.fold_with(self)),
                                     definite: false,
                                 }],
@@ -479,7 +479,7 @@ where
             factory_params.push(Param {
                 span: DUMMY_SP,
                 decorators: Default::default(),
-                pat: Pat::Ident(exports_ident.clone().into()),
+                pat: exports_ident.clone().into(),
             });
             factory_args.push(quote_ident!("exports").as_arg());
             global_factory_args.push(member_expr!(DUMMY_SP, mod.exports).as_arg());
@@ -494,7 +494,7 @@ where
                     kind: VarDeclKind::Var,
                     decls: vec![VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(exported_names.clone().into()),
+                        name: exported_names.clone().into(),
                         init: Some(Box::new(Expr::Object(ObjectLit {
                             span: DUMMY_SP,
                             props: exports
@@ -558,7 +558,7 @@ where
             factory_params.push(Param {
                 span: DUMMY_SP,
                 decorators: Default::default(),
-                pat: Pat::Ident(ident.clone().into()),
+                pat: ident.clone().into(),
             });
             factory_args
                 .push(make_require_call(&self.resolver, self.root_mark, src.clone()).as_arg());
@@ -586,7 +586,7 @@ where
                         import_stmts.push(
                             AssignExpr {
                                 span: DUMMY_SP,
-                                left: PatOrExpr::Pat(Box::new(Pat::Ident(ident.clone().into()))),
+                                left: PatOrExpr::Pat(ident.clone().into()),
                                 op: op!("="),
                                 right,
                             }
@@ -613,12 +613,12 @@ where
                 Param {
                     span: DUMMY_SP,
                     decorators: Default::default(),
-                    pat: Pat::Ident(quote_ident!("global").into()),
+                    pat: quote_ident!("global").into(),
                 },
                 Param {
                     span: DUMMY_SP,
                     decorators: Default::default(),
-                    pat: Pat::Ident(quote_ident!("factory").into()),
+                    pat: quote_ident!("factory").into(),
                 },
             ],
             body: Some(BlockStmt {
@@ -687,7 +687,7 @@ where
                                         kind: VarDeclKind::Var,
                                         decls: vec![VarDeclarator {
                                             span: DUMMY_SP,
-                                            name: Pat::Ident(quote_ident!("mod").into()),
+                                            name: quote_ident!("mod").into(),
                                             init: Some(Box::new(Expr::Object(ObjectLit {
                                                 span: DUMMY_SP,
                                                 props: vec![PropOrSpread::Prop(Box::new(

--- a/crates/swc_ecma_transforms_module/src/util.rs
+++ b/crates/swc_ecma_transforms_module/src/util.rs
@@ -169,7 +169,7 @@ impl Scope {
             params: vec![Param {
                 span: DUMMY_SP,
                 decorators: Default::default(),
-                pat: Pat::Ident(key_ident.clone().into()),
+                pat: key_ident.clone().into(),
             }],
             body: Some(BlockStmt {
                 span: DUMMY_SP,
@@ -595,7 +595,7 @@ impl Scope {
                             entry,
                             Box::new(Expr::Assign(AssignExpr {
                                 span: DUMMY_SP,
-                                left: PatOrExpr::Pat(Box::new(Pat::Ident(arg.clone().into()))),
+                                left: PatOrExpr::Pat(arg.clone().into()),
                                 op: op!("="),
                                 right: Box::new(Expr::Bin(BinExpr {
                                     span: DUMMY_SP,
@@ -722,7 +722,7 @@ impl Scope {
 
                 match expr.left {
                     PatOrExpr::Pat(pat) if pat.is_ident() => {
-                        let i = pat.ident().unwrap();
+                        let i = pat.expect_ident();
                         let mut scope = folder.scope_mut();
                         let entry = scope
                             .exported_bindings
@@ -731,7 +731,7 @@ impl Scope {
                         match entry {
                             Entry::Occupied(entry) => {
                                 let expr = Expr::Assign(AssignExpr {
-                                    left: PatOrExpr::Pat(Box::new(Pat::Ident(i))),
+                                    left: PatOrExpr::Pat(i.into()),
                                     ..expr
                                 });
                                 let e = chain_assign!(entry, Box::new(expr));
@@ -739,7 +739,7 @@ impl Scope {
                                 *e
                             }
                             _ => Expr::Assign(AssignExpr {
-                                left: PatOrExpr::Pat(Box::new(Pat::Ident(i))),
+                                left: PatOrExpr::Pat(i.into()),
                                 ..expr
                             }),
                         }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -651,7 +651,7 @@ impl VisitMut for Remover {
                                 .flat_map(|stmt| stmt.extract_var_ids())
                                 .map(|i| VarDeclarator {
                                     span: DUMMY_SP,
-                                    name: Pat::Ident(i.into()),
+                                    name: i.into(),
                                     init: None,
                                     definite: false,
                                 })
@@ -688,7 +688,7 @@ impl VisitMut for Remover {
                                         vars.extend(cons.extract_var_ids().into_iter().map(
                                             |name| VarDeclarator {
                                                 span: DUMMY_SP,
-                                                name: Pat::Ident(name.into()),
+                                                name: name.into(),
                                                 init: None,
                                                 definite: Default::default(),
                                             },
@@ -828,7 +828,7 @@ impl VisitMut for Remover {
                                 .chain(var_ids)
                                 .map(|i| VarDeclarator {
                                     span: i.span,
-                                    name: Pat::Ident(i.into()),
+                                    name: i.into(),
                                     init: None,
                                     definite: false,
                                 })
@@ -1037,7 +1037,7 @@ impl Remover {
                                         let ids = extract_var_ids(&t).into_iter().map(|i| {
                                             VarDeclarator {
                                                 span: i.span,
-                                                name: Pat::Ident(i.into()),
+                                                name: i.into(),
                                                 init: None,
                                                 definite: false,
                                             }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -231,20 +231,14 @@ impl SimplifyExpr {
                     let var_name = alias_ident_for(&v, "_v");
                     self.vars.push(VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(BindingIdent {
-                            id: var_name.clone(),
-                            type_ann: None,
-                        }),
+                        name: var_name.clone().into(),
                         init: None,
                         definite: false,
                     });
 
                     exprs.push(Box::new(Expr::Assign(AssignExpr {
                         span: v.span(),
-                        left: PatOrExpr::Pat(Box::new(Pat::Ident(BindingIdent {
-                            id: var_name.clone(),
-                            type_ann: None,
-                        }))),
+                        left: PatOrExpr::Pat(var_name.clone().into()),
                         op: op!("="),
                         right: v,
                     })));

--- a/crates/swc_ecma_transforms_proposal/src/decorators.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators.rs
@@ -112,7 +112,7 @@ impl Fold for Decorators {
                     declare: false,
                     decls: vec![VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(ident.into()),
+                        name: ident.into(),
                         definite: false,
                         init: Some(decorate_call),
                     }],
@@ -186,7 +186,7 @@ impl Fold for Decorators {
                         declare: false,
                         decls: vec![VarDeclarator {
                             span: DUMMY_SP,
-                            name: Pat::Ident(ident.clone().into()),
+                            name: ident.clone().into(),
                             init: Some(decorate_call),
                             definite: false,
                         }],
@@ -553,7 +553,7 @@ impl Decorators {
                         span: DUMMY_SP,
 
                         params: iter::once(Pat::Ident(initialize.into()))
-                            .chain(super_class_ident.map(BindingIdent::from).map(Pat::Ident))
+                            .chain(super_class_ident.map(Pat::from))
                             .map(|pat| Param {
                                 span: DUMMY_SP,
                                 decorators: vec![],

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/metadata.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/metadata.rs
@@ -75,12 +75,12 @@ impl ParamMetadata {
                         Param {
                             span: DUMMY_SP,
                             decorators: Default::default(),
-                            pat: Pat::Ident(quote_ident!("target").into()),
+                            pat: quote_ident!("target").into(),
                         },
                         Param {
                             span: DUMMY_SP,
                             decorators: Default::default(),
-                            pat: Pat::Ident(quote_ident!("key").into()),
+                            pat: quote_ident!("key").into(),
                         },
                     ],
                     body: Some(BlockStmt {

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
@@ -316,7 +316,7 @@ impl Legacy {
                     if aliased {
                         self.uninitialized_vars.push(VarDeclarator {
                             span: DUMMY_SP,
-                            name: Pat::Ident(i.clone().into()),
+                            name: i.clone().into(),
                             init: None,
                             definite: false,
                         });
@@ -344,7 +344,7 @@ impl Legacy {
                         dec_inits.push(Box::new(Expr::Assign(AssignExpr {
                             span: dec.span,
                             op: op!("="),
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(i.clone().into()))),
+                            left: PatOrExpr::Pat(i.clone().into()),
                             right,
                         })));
                     }
@@ -364,12 +364,12 @@ impl Legacy {
                             dec_init_exprs.push(Box::new(Expr::Assign(AssignExpr {
                                 span: DUMMY_SP,
                                 op: op!("="),
-                                left: PatOrExpr::Pat(Box::new(Pat::Ident(name.clone().into()))),
+                                left: PatOrExpr::Pat(name.clone().into()),
                                 right: init,
                             })));
                             self.uninitialized_vars.push(VarDeclarator {
                                 span: DUMMY_SP,
-                                name: Pat::Ident(name.clone().into()),
+                                name: name.clone().into(),
                                 init: None,
                                 definite: Default::default(),
                             })
@@ -467,7 +467,7 @@ impl Legacy {
                 if !p.is_static {
                     self.uninitialized_vars.push(VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(descriptor.clone().into()),
+                        name: descriptor.clone().into(),
                         init: None,
                         definite: false,
                     });
@@ -486,12 +486,12 @@ impl Legacy {
                         dec_init_exprs.push(Box::new(Expr::Assign(AssignExpr {
                             span: DUMMY_SP,
                             op: op!("="),
-                            left: PatOrExpr::Pat(Box::new(Pat::Ident(i.clone().into()))),
+                            left: PatOrExpr::Pat(i.clone().into()),
                             right: dec.expr,
                         })));
                         self.uninitialized_vars.push(VarDeclarator {
                             span: DUMMY_SP,
-                            name: Pat::Ident(i.clone().into()),
+                            name: i.clone().into(),
                             init: None,
                             definite: false,
                         });
@@ -516,7 +516,7 @@ impl Legacy {
                 if p.is_static {
                     self.uninitialized_vars.push(VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(init.clone().into()),
+                        name: init.clone().into(),
                         init: None,
                         definite: false,
                     });
@@ -595,7 +595,7 @@ impl Legacy {
                         exprs: vec![
                             Box::new(Expr::Assign(AssignExpr {
                                 span: DUMMY_SP,
-                                left: PatOrExpr::Pat(Box::new(Pat::Ident(init.clone().into()))),
+                                left: PatOrExpr::Pat(init.clone().into()),
                                 op: op!("="),
                                 // Object.getOwnPropertyDescriptor(_class, "enumconfwrite")
                                 right: Box::new(Expr::Call(CallExpr {
@@ -609,7 +609,7 @@ impl Legacy {
                             // _init = _init ? _init.value : void 0
                             Box::new(Expr::Assign(AssignExpr {
                                 span: DUMMY_SP,
-                                left: PatOrExpr::Pat(Box::new(Pat::Ident(init.clone().into()))),
+                                left: PatOrExpr::Pat(init.clone().into()),
                                 op: op!("="),
                                 right: Box::new(Expr::Cond(CondExpr {
                                     span: DUMMY_SP,
@@ -667,7 +667,7 @@ impl Legacy {
                     extra_exprs.push(Box::new(Expr::Assign(AssignExpr {
                         span: DUMMY_SP,
                         op: op!("="),
-                        left: PatOrExpr::Pat(Box::new(Pat::Ident(descriptor.clone().into()))),
+                        left: PatOrExpr::Pat(descriptor.clone().into()),
                         right: call_expr,
                     })));
                 } else {
@@ -777,7 +777,7 @@ impl Legacy {
         let cls_assign = Box::new(Expr::Assign(AssignExpr {
             span: DUMMY_SP,
             op: op!("="),
-            left: PatOrExpr::Pat(Box::new(Pat::Ident(cls_ident.clone().into()))),
+            left: PatOrExpr::Pat(cls_ident.clone().into()),
             right: Box::new(Expr::Class(ClassExpr {
                 ident: c.ident.clone(),
                 class: Class {
@@ -830,7 +830,7 @@ impl Legacy {
             if aliased {
                 self.initialized_vars.push(VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(i.clone().into()),
+                    name: i.clone().into(),
                     init: Some(dec.expr),
                     definite: false,
                 });
@@ -846,7 +846,7 @@ impl Legacy {
             // _class = dec(_class = function() {}) || _class
             let class_expr = Box::new(Expr::Assign(AssignExpr {
                 span: DUMMY_SP,
-                left: PatOrExpr::Pat(Box::new(Pat::Ident(class_ident.clone().into()))),
+                left: PatOrExpr::Pat(class_ident.clone().into()),
                 op: op!("="),
                 right: Box::new(Expr::Bin(BinExpr {
                     span: DUMMY_SP,

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
@@ -100,7 +100,7 @@ impl Fold for Legacy {
                 declare: false,
                 decls: vec![VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(c.ident.into()),
+                    name: c.ident.into(),
                     init: Some(expr),
                     definite: false,
                 }],
@@ -183,7 +183,7 @@ impl Fold for Legacy {
                 declare: false,
                 decls: vec![VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(export_ident.into()),
+                    name: export_ident.into(),
                     init: Some(expr),
                     definite: false,
                 }],
@@ -272,7 +272,7 @@ impl Legacy {
 
         self.uninitialized_vars.push(VarDeclarator {
             span: DUMMY_SP,
-            name: Pat::Ident(cls_ident.clone().into()),
+            name: cls_ident.clone().into(),
             init: None,
             definite: false,
         });

--- a/crates/swc_ecma_transforms_react/src/refresh/hook.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/hook.rs
@@ -62,7 +62,7 @@ impl<'a> HookRegister<'a> {
                 .into_iter()
                 .map(|id| VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(BindingIdent::from(id)),
+                    name: id.into(),
                     init: Some(Box::new(make_call_expr(quote_ident!(self
                         .options
                         .refresh_sig

--- a/crates/swc_ecma_transforms_react/src/refresh/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/mod.rs
@@ -452,7 +452,7 @@ impl<C: Comments> VisitMut for Refresh<C> {
                     .iter()
                     .map(|(handle, _)| VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(BindingIdent::from(handle.clone())),
+                        name: handle.clone().into(),
                         init: None,
                         definite: false,
                     })

--- a/crates/swc_ecma_transforms_react/src/refresh/util.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/util.rs
@@ -177,7 +177,7 @@ pub fn make_assign_stmt(handle: Ident, expr: Box<Expr>) -> Expr {
     Expr::Assign(AssignExpr {
         span: expr.span(),
         op: op!("="),
-        left: PatOrExpr::Pat(Box::new(Pat::Ident(BindingIdent::from(handle)))),
+        left: PatOrExpr::Pat(handle.into()),
         right: expr,
     })
 }

--- a/crates/swc_ecma_transforms_testing/src/lib.rs
+++ b/crates/swc_ecma_transforms_testing/src/lib.rs
@@ -226,7 +226,7 @@ impl VisitMut for RegeneratorHandler {
 
             let decl = VarDeclarator {
                 span: DUMMY_SP,
-                name: Pat::Ident(s.into()),
+                name: s.into(),
                 init: Some(init),
                 definite: Default::default(),
             };

--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -260,10 +260,7 @@ where
 
         Some(VarDeclarator {
             span,
-            name: Pat::Ident(BindingIdent {
-                id: Ident::new(name.0, DUMMY_SP.with_ctxt(name.1)),
-                type_ann: None,
-            }),
+            name: Ident::new(name.0, DUMMY_SP.with_ctxt(name.1)).into(),
             init: None,
             definite: false,
         })
@@ -432,7 +429,7 @@ where
                                     let ident = private_ident!("_key");
                                     self.uninitialized_vars.push(VarDeclarator {
                                         span: DUMMY_SP,
-                                        name: Pat::Ident(ident.clone().into()),
+                                        name: ident.clone().into(),
                                         init: None,
                                         definite: false,
                                     });
@@ -490,7 +487,7 @@ where
                                     let ident = private_ident!("_key");
                                     self.uninitialized_vars.push(VarDeclarator {
                                         span: DUMMY_SP,
-                                        name: Pat::Ident(ident.clone().into()),
+                                        name: ident.clone().into(),
                                         init: None,
                                         definite: false,
                                     });
@@ -705,14 +702,11 @@ where
             } else {
                 self.uninitialized_vars.push(VarDeclarator {
                     span: DUMMY_SP,
-                    name: Pat::Ident(ident.clone().into()),
+                    name: ident.clone().into(),
                     init: None,
                     definite: false,
                 });
-                let assign_lhs = PatOrExpr::Pat(Box::new(Pat::Ident(BindingIdent {
-                    id: ident.clone(),
-                    type_ann: None,
-                })));
+                let assign_lhs = PatOrExpr::Pat(ident.clone().into());
                 let assign_expr = Box::new(Expr::Assign(AssignExpr {
                     span: n.span(),
                     op: op!("="),
@@ -1014,7 +1008,7 @@ where
                     params: vec![Param {
                         span: id.span,
                         decorators: vec![],
-                        pat: Pat::Ident(id.clone().into()),
+                        pat: id.clone().into(),
                     }],
                     body: Some(BlockStmt {
                         span: DUMMY_SP,
@@ -1148,10 +1142,7 @@ where
         let var_id = Ident::new(decl.id.sym.clone(), DUMMY_SP.with_ctxt(decl.id.span.ctxt));
         let var = VarDeclarator {
             span: DUMMY_SP,
-            name: Pat::Ident(BindingIdent {
-                id: var_id,
-                type_ann: None,
-            }),
+            name: var_id.into(),
             init: None,
             definite: false,
         };

--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -1185,7 +1185,7 @@ where
                 params: vec![Param {
                     span: DUMMY_SP,
                     decorators: Default::default(),
-                    pat: Pat::Ident(private_name.clone().into()),
+                    pat: private_name.clone().into(),
                 }],
                 decorators: Default::default(),
                 span: DUMMY_SP,
@@ -1363,7 +1363,7 @@ where
                 })) => {
                     let default = VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(id.into()),
+                        name: id.into(),
                         init: Some(Box::new(Expr::Call(CallExpr {
                             span: DUMMY_SP,
                             callee: quote_ident!("require").as_callee(),
@@ -1457,7 +1457,7 @@ where
                             kind: VarDeclKind::Var,
                             decls: vec![VarDeclarator {
                                 span: DUMMY_SP,
-                                name: Pat::Ident(import.id.clone().into()),
+                                name: import.id.clone().into(),
                                 init: Some(Box::new(module_ref_to_expr(import.module_ref))),
                                 definite: false,
                             }],
@@ -1706,7 +1706,7 @@ where
             }));
             AssignExpr {
                 span: DUMMY_SP,
-                left: PatOrExpr::Pat(Pat::Ident(id.clone().into()).into()),
+                left: PatOrExpr::Pat(id.clone().into()),
                 op: op!("="),
                 right: Box::new(Expr::Bin(BinExpr {
                     span: DUMMY_SP,
@@ -1731,7 +1731,7 @@ where
                 op: op!("||"),
                 right: Box::new(Expr::Assign(AssignExpr {
                     span: DUMMY_SP,
-                    left: PatOrExpr::Pat(Pat::Ident(id.clone().into()).into()),
+                    left: PatOrExpr::Pat(id.clone().into()),
                     op: op!("="),
                     right: Box::new(Expr::Object(ObjectLit {
                         span: DUMMY_SP,
@@ -2069,7 +2069,7 @@ where
                                     decorators: Default::default(),
                                     pat: Pat::Assign(AssignPat {
                                         span,
-                                        left: Box::new(Pat::Ident(i)),
+                                        left: i.into(),
                                         right,
                                         type_ann: None,
                                     }),
@@ -2325,7 +2325,7 @@ where
                 })) => {
                     let default = VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Ident(id.into()),
+                        name: id.into(),
                         init: Some(Box::new(Expr::Call(CallExpr {
                             span: DUMMY_SP,
                             callee: quote_ident!("require").as_callee(),
@@ -2414,7 +2414,7 @@ where
                             kind: VarDeclKind::Var,
                             decls: vec![VarDeclarator {
                                 span: DUMMY_SP,
-                                name: Pat::Ident(import.id.into()),
+                                name: import.id.into(),
                                 init: Some(Box::new(module_ref_to_expr(import.module_ref))),
                                 definite: false,
                             }],
@@ -2539,7 +2539,7 @@ where
                 if let Expr::Paren(ParenExpr { expr, .. }) = &**expr {
                     if let Expr::TsAs(TsAsExpr { expr, .. }) = &**expr {
                         if let Expr::Ident(ident) = &**expr {
-                            *node = PatOrExpr::Pat(Box::new(Pat::Ident(ident.clone().into())));
+                            *node = PatOrExpr::Pat(ident.clone().into());
                         }
                     }
                 }


### PR DESCRIPTION

# ChangeLog

swc_ecma_ast:
 - Improve API for AST creation.


## Cleanup

This is required as plugin authors will look at core transforms to know what they can do.

 - [x] Pat::Ident
 - [x] Pat::from
 - [x] AssignOp
 - [x] BinaryOp
 - [x] UnaryIOp


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

 - Closes #3239