### PR TITLE
fix(es/transforms): Remove unsafe `new String("...")` optimization

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/mod.rs
@@ -68,10 +68,7 @@ where
     chain!(
         console_remover,
         as_folder(compressor),
-        expr_simplifier(ExprSimplifierConfig {
-            preserve_string_call: true,
-            ..Default::default()
-        })
+        expr_simplifier(ExprSimplifierConfig {})
     )
 }
 
@@ -293,9 +290,7 @@ where
 
             let start_time = now();
 
-            let mut visitor = expr_simplifier(ExprSimplifierConfig {
-                preserve_string_call: true,
-            });
+            let mut visitor = expr_simplifier(ExprSimplifierConfig {});
             n.apply(&mut visitor);
             self.changed |= visitor.changed();
             if visitor.changed() {

--- a/crates/swc_ecma_minifier/src/eval.rs
+++ b/crates/swc_ecma_minifier/src/eval.rs
@@ -188,9 +188,7 @@ impl Evaluator {
                     prop: prop.clone(),
                 });
 
-                e.visit_mut_with(&mut expr_simplifier(ExprSimplifierConfig {
-                    preserve_string_call: true,
-                }));
+                e.visit_mut_with(&mut expr_simplifier(ExprSimplifierConfig {}));
                 return Some(Box::new(e));
             }
             _ => {}

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -29,9 +29,7 @@ macro_rules! try_val {
 
 /// All [bool] fields defaults to [false].
 #[derive(Debug, Clone, Copy, Default, Hash)]
-pub struct Config {
-    pub preserve_string_call: bool,
-}
+pub struct Config {}
 
 /// Not intended for general use. Use [simplifier] instead.
 ///
@@ -1333,31 +1331,6 @@ impl VisitMut for SimplifyExpr {
                         }
                     }
                     ObjectLit { span, props: ps }.into()
-                }
-
-                Expr::New(e) => {
-                    if !self.config.preserve_string_call
-                        && e.callee.is_ident_ref_to(js_word!("String"))
-                        && e.args.is_some()
-                        && e.args.as_ref().unwrap().len() == 1
-                        && e.args.as_ref().unwrap()[0].spread.is_none()
-                        && is_literal(&e.args.as_ref().unwrap()[0].expr)
-                    {
-                        let e = &*e.args.into_iter().next().unwrap().pop().unwrap().expr;
-                        if let Known(value) = e.as_string() {
-                            self.changed = true;
-
-                            return Expr::Lit(Lit::Str(Str {
-                                span: e.span(),
-                                value: value.into(),
-                                has_escape: false,
-                                kind: Default::default(),
-                            }));
-                        }
-                        unreachable!()
-                    }
-
-                    NewExpr { ..e }.into()
                 }
 
                 // be conservative.

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/tests.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/tests.rs
@@ -749,20 +749,6 @@ fn test_issue821() {
 }
 
 #[test]
-fn test_fold_constructor() {
-    fold("x = this[new String('a')]", "x = this['a']");
-    fold("x = ob[new String(12)]", "x = ob['12']");
-    fold("x = ob[new String(false)]", "x = ob['false']");
-    fold("x = ob[new String(null)]", "x = ob['null']");
-    fold("x = 'a' + new String('b')", "x = 'ab'");
-    fold("x = 'a' + new String(23)", "x = 'a23'");
-    fold("x = 2 + new String(1)", "x = '21'");
-    fold_same("x = ob[new String(a)]");
-    fold_same("x = 'a'");
-    fold_same("x = 'a'[3]");
-}
-
-#[test]
 fn test_fold_arithmetic() {
     fold("x = 10 + 20", "x = 30");
     fold("x = 2 / 4", "x = 0.5");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
After removing the `preserve_string_call` setting, `ExprSimplifierConfig` is actually empty now. Not sure if that should be removed as well or left as is

**BREAKING CHANGE:**
The API changed did change..

**Related issue (if exists):**
Closes https://github.com/swc-project/swc/issues/3283