### PR TITLE
reface(ecma): add `visit_obj_and_computed` macro

### DIFF
--- a/crates/swc_bundler/src/bundler/chunk/cjs.rs
+++ b/crates/swc_bundler/src/bundler/chunk/cjs.rs
@@ -354,18 +354,4 @@ impl VisitMut for DefaultHandler {
             }
         }
     }
-
-    fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
-        e.obj.visit_mut_with(self);
-
-        if let MemberProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, e: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
 }

--- a/crates/swc_bundler/src/bundler/keywords.rs
+++ b/crates/swc_bundler/src/bundler/keywords.rs
@@ -77,20 +77,6 @@ impl VisitMut for KeywordRenamer {
         }
     }
 
-    fn visit_mut_member_expr(&mut self, n: &mut MemberExpr) {
-        n.obj.visit_mut_with(self);
-
-        if let MemberProp::Computed(c) = &mut n.prop {
-            c.visit_mut_with(self)
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, n: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut n.prop {
-            c.visit_mut_with(self)
-        }
-    }
-
     fn visit_mut_object_pat_prop(&mut self, n: &mut ObjectPatProp) {
         n.visit_mut_children_with(self);
 

--- a/crates/swc_bundler/src/inline.rs
+++ b/crates/swc_bundler/src/inline.rs
@@ -2,7 +2,8 @@ use crate::{id::Id, modules::Modules, util::Readonly};
 use swc_common::{collections::AHashMap, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{
-    noop_visit_mut_type, noop_visit_type, Visit, VisitMut, VisitMutWith, VisitWith,
+    noop_visit_mut_type, noop_visit_type, visit_mut_obj_and_computed, Visit, VisitMut,
+    VisitMutWith, VisitWith,
 };
 
 #[derive(Debug, Default)]
@@ -100,20 +101,7 @@ impl VisitMut for Inliner {
         }
     }
 
-    /// General logic for member expression.s
-    fn visit_mut_member_expr(&mut self, n: &mut MemberExpr) {
-        n.obj.visit_mut_with(self);
-
-        if let MemberProp::Computed(c) = &mut n.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, n: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut n.prop {
-            c.visit_mut_with(self);
-        }
-    }
+    visit_mut_obj_and_computed!();
 
     fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
         n.visit_mut_children_with(self);

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -251,20 +251,6 @@ impl VisitMut for ExprReplacer {
         }
     }
 
-    fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
-        e.obj.visit_mut_with(self);
-
-        if let MemberProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, e: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
     fn visit_mut_prop(&mut self, p: &mut Prop) {
         p.visit_mut_children_with(self);
 

--- a/crates/swc_ecma_minifier/src/compress/util/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/util/mod.rs
@@ -560,20 +560,6 @@ where
 
         (self.op)(e);
     }
-
-    fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
-        e.obj.visit_mut_with(self);
-
-        if let MemberProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, e: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
 }
 
 pub fn replace_expr<N, F>(node: &mut N, op: F)

--- a/crates/swc_ecma_minifier/src/metadata/mod.rs
+++ b/crates/swc_ecma_minifier/src/metadata/mod.rs
@@ -390,19 +390,6 @@ impl VisitMut for IdentCollector {
         s.body.visit_mut_with(self);
     }
 
-    fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
-        e.obj.visit_mut_with(self);
-        if let MemberProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, e: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
     fn visit_mut_param(&mut self, p: &mut Param) {
         let old = self.is_pat_decl;
         self.is_pat_decl = true;

--- a/crates/swc_ecma_minifier/src/pass/hygiene/vars.rs
+++ b/crates/swc_ecma_minifier/src/pass/hygiene/vars.rs
@@ -104,22 +104,4 @@ impl Visit for VarAnalyzer<'_> {
 
         self.cur.add(i);
     }
-
-    fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with(self);
-
-        if n.computed {
-            n.prop.visit_with(self);
-        }
-    }
-
-    fn visit_prop_name(&mut self, n: &PropName) {
-        match n {
-            PropName::Computed(_) => {
-                n.visit_children_with(self);
-            }
-
-            _ => {}
-        }
-    }
 }

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
@@ -93,19 +93,6 @@ impl Visit for Preserver {
         }
     }
 
-    fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with(self);
-        if let MemberProp::Computed(c) = &n.prop {
-            c.visit_with(self);
-        }
-    }
-
-    fn visit_super_prop_expr(&mut self, n: &SuperPropExpr) {
-        if let SuperProp::Computed(c) = &n.prop {
-            c.visit_with(self);
-        }
-    }
-
     fn visit_module_items(&mut self, n: &[ModuleItem]) {
         for n in n {
             self.in_top_level = true;

--- a/crates/swc_ecma_minifier/src/util/mod.rs
+++ b/crates/swc_ecma_minifier/src/util/mod.rs
@@ -7,7 +7,7 @@ use swc_common::{
 };
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ident::IdentLike, Id, ModuleItemLike, StmtLike, Value};
-use swc_ecma_visit::{noop_visit_type, Fold, FoldWith, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, visit_obj_and_computed, Fold, FoldWith, Visit, VisitWith};
 
 pub(crate) mod base54;
 pub(crate) mod sort;
@@ -387,19 +387,7 @@ impl Visit for IdentUsageCollector {
         self.ids.insert(n.to_id());
     }
 
-    fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with(self);
-
-        if let MemberProp::Computed(c) = &n.prop {
-            c.visit_with(self);
-        }
-    }
-
-    fn visit_super_prop_expr(&mut self, n: &SuperPropExpr) {
-        if let SuperProp::Computed(c) = &n.prop {
-            c.visit_with(self);
-        }
-    }
+    visit_obj_and_computed!();
 
     fn visit_prop_name(&mut self, n: &PropName) {
         if let PropName::Computed(..) = n {

--- a/crates/swc_ecma_transforms_base/src/helpers/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/helpers/mod.rs
@@ -5,9 +5,7 @@ use swc_common::{FileName, FilePathMapping, Mark, SourceMap, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput};
 use swc_ecma_utils::{prepend_stmts, quote_ident, quote_str, DropSpan};
-use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, visit_mut_obj_and_computed, Fold, VisitMut, VisitMutWith,
-};
+use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 
 #[macro_export]
 macro_rules! enable_helper {
@@ -323,7 +321,17 @@ impl VisitMut for Marker {
         i.span = i.span.apply_mark(self.0);
     }
 
-    visit_mut_obj_and_computed!();
+    fn visit_mut_member_prop(&mut self, p: &mut MemberProp) {
+        if let MemberProp::Computed(p) = p {
+            p.visit_mut_with(self);
+        }
+    }
+
+    fn visit_mut_super_prop(&mut self, p: &mut SuperProp) {
+        if let SuperProp::Computed(p) = p {
+            p.visit_mut_with(self);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/swc_ecma_transforms_base/src/helpers/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/helpers/mod.rs
@@ -5,7 +5,9 @@ use swc_common::{FileName, FilePathMapping, Mark, SourceMap, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput};
 use swc_ecma_utils::{prepend_stmts, quote_ident, quote_str, DropSpan};
-use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
+use swc_ecma_visit::{
+    as_folder, noop_visit_mut_type, visit_mut_obj_and_computed, Fold, VisitMut, VisitMutWith,
+};
 
 #[macro_export]
 macro_rules! enable_helper {
@@ -321,17 +323,7 @@ impl VisitMut for Marker {
         i.span = i.span.apply_mark(self.0);
     }
 
-    fn visit_mut_member_prop(&mut self, p: &mut MemberProp) {
-        if let MemberProp::Computed(p) = p {
-            p.visit_mut_with(self);
-        }
-    }
-
-    fn visit_mut_super_prop(&mut self, p: &mut SuperProp) {
-        if let SuperProp::Computed(p) = p {
-            p.visit_mut_with(self);
-        }
-    }
+    visit_mut_obj_and_computed!();
 }
 
 #[cfg(test)]

--- a/crates/swc_ecma_transforms_base/src/hygiene/usage_analyzer.rs
+++ b/crates/swc_ecma_transforms_base/src/hygiene/usage_analyzer.rs
@@ -545,14 +545,6 @@ impl Visit for UsageAnalyzer<'_> {
         self.add_decl(s.local.to_id());
     }
 
-    fn visit_member_expr(&mut self, e: &MemberExpr) {
-        e.obj.visit_with(self);
-
-        if let MemberProp::Computed(c) = &e.prop {
-            c.visit_with(self)
-        }
-    }
-
     fn visit_method_prop(&mut self, f: &MethodProp) {
         f.key.visit_with(self);
 
@@ -620,12 +612,6 @@ impl Visit for UsageAnalyzer<'_> {
 
     fn visit_stmts(&mut self, stmts: &[Stmt]) {
         self.visit_stmt_likes(stmts);
-    }
-
-    fn visit_super_prop_expr(&mut self, e: &SuperPropExpr) {
-        if let SuperProp::Computed(c) = &e.prop {
-            c.visit_with(self);
-        }
     }
 
     fn visit_var_declarator(&mut self, v: &VarDeclarator) {

--- a/crates/swc_ecma_transforms_base/tests/fixture.rs
+++ b/crates/swc_ecma_transforms_base/tests/fixture.rs
@@ -7,7 +7,9 @@ use swc_ecma_transforms_base::{
     fixer::fixer,
     resolver::{resolver_with_mark, ts_resolver},
 };
-use swc_ecma_visit::{as_folder, Fold, FoldWith, VisitMut, VisitMutWith};
+use swc_ecma_visit::{
+    as_folder, visit_mut_obj_and_computed, Fold, FoldWith, VisitMut, VisitMutWith,
+};
 use testing::{fixture, run_test2, NormalizedOutput};
 
 pub fn print(cm: Lrc<SourceMap>, module: &Module) -> String {
@@ -114,22 +116,11 @@ impl VisitMut for TsHygiene {
         i.span = i.span.with_ctxt(SyntaxContext::empty());
     }
 
-    fn visit_mut_member_expr(&mut self, n: &mut MemberExpr) {
-        n.obj.visit_mut_with(self);
-        if let MemberProp::Computed(c) = &mut n.prop {
-            c.visit_mut_with(self);
-        }
-    }
+    visit_mut_obj_and_computed!();
 
     fn visit_mut_prop_name(&mut self, n: &mut PropName) {
         if let PropName::Computed(n) = n {
             n.visit_mut_with(self);
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, n: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut n.prop {
-            c.visit_mut_with(self);
         }
     }
 

--- a/crates/swc_ecma_transforms_base/tests/ts_resolver.rs
+++ b/crates/swc_ecma_transforms_base/tests/ts_resolver.rs
@@ -45,16 +45,6 @@ fn no_empty(input: PathBuf) {
 struct AssertNoEmptyCtxt;
 
 impl Visit for AssertNoEmptyCtxt {
-    fn visit_class_prop(&mut self, n: &ClassProp) {
-        if let PropName::Computed(key) = &n.key {
-            key.expr.visit_with(self);
-        }
-
-        n.value.visit_with(self);
-        n.type_ann.visit_with(self);
-        n.decorators.visit_with(self);
-    }
-
     fn visit_expr(&mut self, n: &Expr) {
         n.visit_children_with(self);
 
@@ -65,13 +55,6 @@ impl Visit for AssertNoEmptyCtxt {
         }
     }
 
-    fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with(self);
-        if let MemberProp::Computed(c) = &n.prop {
-            c.visit_with(self);
-        }
-    }
-
     fn visit_pat(&mut self, n: &Pat) {
         n.visit_children_with(self);
 
@@ -79,12 +62,6 @@ impl Visit for AssertNoEmptyCtxt {
             if i.id.span.ctxt == SyntaxContext::empty() {
                 unreachable!("ts_resolver has a bug")
             }
-        }
-    }
-
-    fn visit_super_prop_expr(&mut self, n: &SuperPropExpr) {
-        if let SuperProp::Computed(c) = &n.prop {
-            c.visit_with(self);
         }
     }
 

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping.rs
@@ -9,7 +9,8 @@ use swc_ecma_utils::{
     quote_ident, quote_str, undefined, var::VarCollector, ExprFactory, Id, StmtLike,
 };
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith, VisitWith,
+    as_folder, noop_visit_mut_type, noop_visit_type, visit_mut_obj_and_computed, Fold, Visit,
+    VisitMut, VisitMutWith, VisitWith,
 };
 
 ///
@@ -970,19 +971,7 @@ impl VisitMut for MutationHandler<'_> {
         n.arg = Some(Box::new(self.make_reassignment(val)))
     }
 
-    /// Don't recurse into member expression prop if not computed
-    fn visit_mut_member_expr(&mut self, m: &mut MemberExpr) {
-        m.obj.visit_mut_with(self);
-        if let MemberProp::Computed(c) = &mut m.prop {
-            c.visit_mut_with(self)
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, m: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut m.prop {
-            c.visit_mut_with(self)
-        }
-    }
+    visit_mut_obj_and_computed!();
 }
 
 #[derive(Debug)]

--- a/crates/swc_ecma_transforms_compat/src/es2015/regenerator/hoist.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/regenerator/hoist.rs
@@ -101,21 +101,6 @@ impl VisitMut for Hoister {
         }
     }
 
-    // TODO: move this to utils
-    fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
-        e.obj.visit_mut_with(self);
-
-        if let MemberProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, e: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
     fn visit_mut_module_decl(&mut self, decl: &mut ModuleDecl) {
         if let ModuleDecl::ExportDecl(ExportDecl {
             span,

--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/private_field.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/private_field.rs
@@ -454,19 +454,6 @@ impl<'a> VisitMut for FieldAccessFolder<'a> {
         };
     }
 
-    fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
-        e.obj.visit_mut_with(self);
-        if let MemberProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, e: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
     fn visit_mut_pat(&mut self, p: &mut Pat) {
         if let Pat::Expr(expr) = &p {
             if let Expr::Member(me) = &**expr {

--- a/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
@@ -445,16 +445,6 @@ impl VisitMut for PrivateInObject {
         }
     }
 
-    fn visit_mut_prop_name(&mut self, n: &mut PropName) {
-        match n {
-            PropName::Computed(_) => {
-                n.visit_mut_children_with(self);
-            }
-
-            _ => {}
-        }
-    }
-
     fn visit_mut_stmts(&mut self, s: &mut Vec<Stmt>) {
         s.visit_mut_children_with(self);
 

--- a/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/private_in_object.rs
@@ -374,20 +374,6 @@ impl VisitMut for PrivateInObject {
         }
     }
 
-    fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
-        e.obj.visit_mut_with(self);
-
-        if let MemberProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, e: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
     fn visit_mut_module_items(&mut self, ns: &mut Vec<ModuleItem>) {
         ns.visit_mut_children_with(self);
 

--- a/crates/swc_ecma_transforms_compat/src/reserved_words.rs
+++ b/crates/swc_ecma_transforms_compat/src/reserved_words.rs
@@ -2,7 +2,9 @@ use swc_atoms::{js_word, JsWord};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::perf::Parallel;
 use swc_ecma_transforms_macros::parallel;
-use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
+use swc_ecma_visit::{
+    as_folder, noop_visit_mut_type, visit_mut_obj_and_computed, Fold, VisitMut, VisitMutWith,
+};
 
 pub fn reserved_words() -> impl 'static + Fold + VisitMut {
     as_folder(EsReservedWord)
@@ -33,21 +35,7 @@ impl VisitMut for EsReservedWord {
         s.local.visit_mut_with(self);
     }
 
-    fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
-        e.obj.visit_mut_with(self);
-
-        if let MemberProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, e: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
-    fn visit_mut_meta_prop_expr(&mut self, _n: &mut MetaPropExpr) {}
+    visit_mut_obj_and_computed!();
 
     fn visit_mut_prop_name(&mut self, _n: &mut PropName) {}
 }

--- a/crates/swc_ecma_transforms_optimization/src/inline_globals.rs
+++ b/crates/swc_ecma_transforms_optimization/src/inline_globals.rs
@@ -180,14 +180,6 @@ impl VisitMut for InlineGlobals {
         }
     }
 
-    fn visit_mut_member_expr(&mut self, expr: &mut MemberExpr) {
-        expr.obj.visit_mut_with(self);
-
-        if let MemberProp::Computed(c) = &mut expr.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
     fn visit_mut_module(&mut self, module: &mut Module) {
         self.bindings = Lrc::new(collect_decls(&*module));
 
@@ -217,12 +209,6 @@ impl VisitMut for InlineGlobals {
         self.bindings = Lrc::new(collect_decls(&*script));
 
         script.visit_mut_children_with(self);
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, expr: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut expr.prop {
-            c.visit_mut_with(self);
-        }
     }
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/const_propgation.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/const_propgation.rs
@@ -3,9 +3,7 @@
 use swc_common::{collections::AHashMap, util::take::Take};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ident::IdentLike, Id};
-use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, visit_mut_obj_and_computed, Fold, VisitMut, VisitMutWith,
-};
+use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 
 /// This pass is kind of inliner, but it's far faster.
 pub fn constant_propagation() -> impl 'static + Fold + VisitMut {
@@ -98,8 +96,6 @@ impl VisitMut for ConstPropagation<'_> {
         let mut v = ConstPropagation { scope };
         n.visit_mut_children_with(&mut v);
     }
-
-    visit_mut_obj_and_computed!();
 
     fn visit_mut_prop(&mut self, p: &mut Prop) {
         p.visit_mut_children_with(self);

--- a/crates/swc_ecma_transforms_optimization/src/simplify/const_propgation.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/const_propgation.rs
@@ -3,7 +3,9 @@
 use swc_common::{collections::AHashMap, util::take::Take};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ident::IdentLike, Id};
-use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
+use swc_ecma_visit::{
+    as_folder, noop_visit_mut_type, visit_mut_obj_and_computed, Fold, VisitMut, VisitMutWith,
+};
 
 /// This pass is kind of inliner, but it's far faster.
 pub fn constant_propagation() -> impl 'static + Fold + VisitMut {
@@ -97,13 +99,7 @@ impl VisitMut for ConstPropagation<'_> {
         n.visit_mut_children_with(&mut v);
     }
 
-    fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
-        e.obj.visit_mut_with(self);
-
-        if let MemberProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
+    visit_mut_obj_and_computed!();
 
     fn visit_mut_prop(&mut self, p: &mut Prop) {
         p.visit_mut_children_with(self);
@@ -115,12 +111,6 @@ impl VisitMut for ConstPropagation<'_> {
                     value: expr.clone(),
                 });
             }
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, e: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
         }
     }
 

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -1027,19 +1027,6 @@ where
         self.top_level_node = top_level_node;
     }
 
-    fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
-        e.obj.visit_mut_with(self);
-        if let MemberProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
-    fn visit_mut_super_prop_expr(&mut self, e: &mut SuperPropExpr) {
-        if let SuperProp::Computed(c) = &mut e.prop {
-            c.visit_mut_with(self);
-        }
-    }
-
     fn visit_mut_module(&mut self, module: &mut Module) {
         self.parse_directives(module.span);
 

--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -16,7 +16,8 @@ use swc_ecma_utils::{
     StmtLike,
 };
 use swc_ecma_visit::{
-    as_folder, noop_visit_mut_type, Fold, Visit, VisitMut, VisitMutWith, VisitWith,
+    as_folder, noop_visit_mut_type, visit_obj_and_computed, Fold, Visit, VisitMut, VisitMutWith,
+    VisitWith,
 };
 
 /// Value does not contain TsLit::Bool
@@ -1874,12 +1875,7 @@ where
         }
     }
 
-    fn visit_member_expr(&mut self, n: &MemberExpr) {
-        n.obj.visit_with(self);
-        if let MemberProp::Computed(c) = &n.prop {
-            c.visit_with(self);
-        }
-    }
+    visit_obj_and_computed!();
 
     fn visit_module_items(&mut self, n: &[ModuleItem]) {
         let old = self.non_top_level;
@@ -1908,12 +1904,6 @@ where
         self.non_top_level = true;
         n.iter().for_each(|n| n.visit_with(self));
         self.non_top_level = old;
-    }
-
-    fn visit_super_prop_expr(&mut self, n: &SuperPropExpr) {
-        if let SuperProp::Computed(c) = &n.prop {
-            c.visit_with(self);
-        }
     }
 
     fn visit_ts_entity_name(&mut self, name: &TsEntityName) {

--- a/crates/swc_ecma_utils/src/function/fn_env_hoister.rs
+++ b/crates/swc_ecma_utils/src/function/fn_env_hoister.rs
@@ -508,22 +508,6 @@ impl VisitMut for FnEnvHoister {
         }
     }
 
-    /// Don't recurse into prop of member expression unless computed
-    fn visit_mut_member_expr(&mut self, m: &mut MemberExpr) {
-        if let MemberProp::Computed(computed) = &mut m.prop {
-            computed.visit_mut_with(self);
-        }
-
-        m.obj.visit_mut_with(self);
-    }
-
-    /// Don't recurse into prop of super expression unless computed
-    fn visit_mut_super_prop_expr(&mut self, m: &mut SuperPropExpr) {
-        if let SuperProp::Computed(computed) = &mut m.prop {
-            computed.visit_mut_with(self);
-        }
-    }
-
     /// Don't recurse into constructor
     fn visit_mut_class(&mut self, _: &mut Class) {}
 

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -1782,3 +1782,39 @@ define!({
         pub expr: Box<Expr>,
     }
 });
+
+#[macro_export]
+macro_rules! visit_obj_and_computed {
+    () => {
+        fn visit_member_expr(&mut self, n: &$crate::swc_ecma_ast::MemberExpr) {
+            n.obj.visit_with(self);
+            if let $crate::swc_ecma_ast::MemberProp::Computed(c) = &n.prop {
+                c.visit_with(self);
+            }
+        }
+
+        fn visit_super_prop_expr(&mut self, n: &$crate::swc_ecma_ast::SuperPropExpr) {
+            if let $crate::swc_ecma_ast::SuperProp::Computed(c) = &n.prop {
+                c.visit_with(self);
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! visit_mut_obj_and_computed {
+    () => {
+        fn visit_mut_member_expr(&mut self, n: &mut $crate::swc_ecma_ast::MemberExpr) {
+            n.obj.visit_mut_with(self);
+            if let $crate::swc_ecma_ast::MemberProp::Computed(c) = &mut n.prop {
+                c.visit_mut_with(self);
+            }
+        }
+
+        fn visit_mut_super_prop_expr(&mut self, n: &mut $crate::swc_ecma_ast::SuperPropExpr) {
+            if let $crate::swc_ecma_ast::SuperProp::Computed(c) = &mut n.prop {
+                c.visit_mut_with(self);
+            }
+        }
+    };
+}

--- a/crates/swc_webpack_ast/src/reducer/mod.rs
+++ b/crates/swc_webpack_ast/src/reducer/mod.rs
@@ -137,14 +137,6 @@ impl Visit for Analyzer {
         }
     }
 
-    fn visit_member_expr(&mut self, e: &MemberExpr) {
-        e.obj.visit_with(self);
-
-        if let MemberProp::Computed(c) = &e.prop {
-            c.visit_with(self);
-        }
-    }
-
     fn visit_pat(&mut self, p: &Pat) {
         p.visit_children_with(self);
 
@@ -158,12 +150,6 @@ impl Visit for Analyzer {
 
         if let Prop::Shorthand(s) = p {
             self.used_refs.entry(s.to_id()).or_default().used_as_var = true;
-        }
-    }
-
-    fn visit_super_prop_expr(&mut self, e: &SuperPropExpr) {
-        if let SuperProp::Computed(c) = &e.prop {
-            c.visit_with(self);
         }
     }
 


### PR DESCRIPTION
**Description:**

There're lots of code like this in swc
```rust
visit_member_prop() {
   obj.visit_with(self);
   if let MemeberProp::Computed(c) = &e.prop {
      c.visit_with(self)
   }
}
```
this pr add a macro to simplify it

