### PR TITLE
fix(es/parser): Fix parsing of escapes

### DIFF
--- a/crates/swc_ecma_parser/tests/typescript/literals/octal/1/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript/literals/octal/1/input.ts
@@ -1,0 +1,6 @@
+const a = {
+    'nbsp': '\240'
+}
+
+
+export { }


### PR DESCRIPTION
**Description:**



**Related issue (if exists):**
 
 - https://github.com/vercel/next.js/discussions/30237#discussioncomment-1996016