### PR TITLE
Refactor code

### DIFF
--- a/crates/swc_css_ast/src/at_rule/media.rs
+++ b/crates/swc_css_ast/src/at_rule/media.rs
@@ -1,4 +1,4 @@
-use crate::{BinValue, Ident, Num, Rule, UnitValue};
+use crate::{Ident, Number, Ratio, Rule, UnitValue};
 use string_enum::StringEnum;
 use swc_common::{ast_node, EqIgnoreSpan, Span};
 
@@ -123,7 +123,7 @@ pub enum MediaFeatureName {
 #[ast_node]
 pub enum MediaFeatureValue {
     #[tag("Number")]
-    Number(Num),
+    Number(Number),
 
     #[tag("UnitValue")]
     Dimension(UnitValue),
@@ -131,8 +131,8 @@ pub enum MediaFeatureValue {
     #[tag("Ident")]
     Ident(Ident),
 
-    #[tag("BinValue")]
-    Ratio(BinValue),
+    #[tag("Ratio")]
+    Ratio(Ratio),
 }
 
 #[ast_node("MediaFeaturePlain")]

--- a/crates/swc_css_ast/src/base.rs
+++ b/crates/swc_css_ast/src/base.rs
@@ -22,10 +22,3 @@ pub struct Str {
     pub value: JsWord,
     pub raw: JsWord,
 }
-
-#[ast_node("Number")]
-pub struct Num {
-    pub span: Span,
-    pub value: f64,
-    pub raw: JsWord,
-}

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -1,4 +1,5 @@
 use crate::{Ident, Num, SimpleBlock, Str, Tokens};
+use crate::{Ident, Str, Tokens};
 use string_enum::StringEnum;
 use swc_atoms::JsWord;
 use swc_common::{ast_node, EqIgnoreSpan, Span};
@@ -12,10 +13,13 @@ pub enum Value {
     Unit(UnitValue),
 
     #[tag("Number")]
-    Number(Num),
+    Number(Number),
 
     #[tag("PercentValue")]
     Percent(PercentValue),
+
+    #[tag("Ratio")]
+    Ratio(Ratio),
 
     #[tag("HashValue")]
     Hash(HashValue),
@@ -103,14 +107,28 @@ pub struct Unit {
 #[ast_node("UnitValue")]
 pub struct UnitValue {
     pub span: Span,
-    pub value: Num,
+    pub value: Number,
     pub unit: Unit,
 }
 
 #[ast_node("PercentValue")]
 pub struct PercentValue {
     pub span: Span,
-    pub value: Num,
+    pub value: Number,
+}
+
+#[ast_node("Number")]
+pub struct Number {
+    pub span: Span,
+    pub value: f64,
+    pub raw: JsWord,
+}
+
+#[ast_node("Ratio")]
+pub struct Ratio {
+    pub span: Span,
+    pub left: Number,
+    pub right: Option<Number>,
 }
 
 #[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan)]

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -1,5 +1,4 @@
-use crate::{Ident, Num, SimpleBlock, Str, Tokens};
-use crate::{Ident, Str, Tokens};
+use crate::{Ident, SimpleBlock, Str, Tokens};
 use string_enum::StringEnum;
 use swc_atoms::JsWord;
 use swc_common::{ast_node, EqIgnoreSpan, Span};

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -570,6 +570,7 @@ where
             Value::Unit(n) => emit!(self, n),
             Value::Number(n) => emit!(self, n),
             Value::Percent(n) => emit!(self, n),
+            Value::Ratio(n) => emit!(self, n),
             Value::Hash(n) => emit!(self, n),
             Value::Ident(n) => emit!(self, n),
             Value::Str(n) => emit!(self, n),
@@ -736,8 +737,18 @@ where
     }
 
     #[emitter]
-    fn emit_num(&mut self, n: &Num) -> Result {
+    fn emit_number(&mut self, n: &Number) -> Result {
         self.wr.write_raw(Some(n.span), &n.raw)?;
+    }
+
+    #[emitter]
+    fn emit_ration(&mut self, n: &Ratio) -> Result {
+        emit!(self, n.left);
+        punct!(self, "/");
+
+        if let Some(right) = &n.right {
+            emit!(self, right);
+        }
     }
 
     #[emitter]

--- a/crates/swc_css_parser/src/macros.rs
+++ b/crates/swc_css_parser/src/macros.rs
@@ -19,7 +19,7 @@ macro_rules! tok {
     ("percent") => {
         swc_css_ast::Token::Percent { .. }
     };
-    
+
     ("function") => {
         swc_css_ast::Token::Function { .. }
     };
@@ -34,6 +34,10 @@ macro_rules! tok {
 
     ("bad-string") => {
         swc_css_ast::Token::BadStr { .. }
+    };
+
+    ("url") => {
+        swc_css_ast::Token::Url { .. }
     };
 
     ("bad-url") => {

--- a/crates/swc_css_parser/src/macros.rs
+++ b/crates/swc_css_parser/src/macros.rs
@@ -8,6 +8,18 @@ macro_rules! ident_tok {
 }
 
 macro_rules! tok {
+    ("num") => {
+        swc_css_ast::Token::Num { .. }
+    };
+
+    ("dimension") => {
+        swc_css_ast::Token::Dimension { .. }
+    };
+
+    ("percent") => {
+        swc_css_ast::Token::Percent { .. }
+    };
+    
     ("function") => {
         swc_css_ast::Token::Function { .. }
     };

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -1294,13 +1294,12 @@ where
                 if eat!(self, "/") {
                     self.input.skip_ws()?;
 
-                    let right = self.parse()?;
+                    let right = Some(self.parse()?);
 
-                    return Ok(MediaFeatureValue::Ratio(BinValue {
+                    return Ok(MediaFeatureValue::Ratio(Ratio {
                         span: span!(self, span.lo),
-                        op: BinOp::Div,
-                        left: Box::new(Value::Number(left)),
-                        right: Box::new(Value::Number(right)),
+                        left,
+                        right,
                     }));
                 }
 

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -276,17 +276,17 @@ where
 
         let span = self.input.cur_span()?;
         match cur!(self) {
-            Token::Str { .. } => return Ok(Value::Str(self.parse()?)),
+            tok!("str") => return Ok(Value::Str(self.parse()?)),
 
-            Token::Num { .. } => return self.parse_numeric_value(),
+            tok!("num") => return self.parse_numeric_value(),
 
-            Token::Function { .. } => return Ok(Value::Function(self.parse()?)),
+            tok!("function") => return Ok(Value::Function(self.parse()?)),
 
-            Token::Percent { .. } => return self.parse_numeric_value(),
+            tok!("percent") => return self.parse_numeric_value(),
 
-            Token::Dimension { .. } => return self.parse_numeric_value(),
+            tok!("dimension") => return self.parse_numeric_value(),
 
-            Token::Ident { .. } => return Ok(Value::Ident(self.parse()?)),
+            tok!("ident") => return Ok(Value::Ident(self.parse()?)),
 
             tok!("[") => return self.parse_square_brackets_value().map(From::from),
 
@@ -331,7 +331,7 @@ where
                 }));
             }
 
-            Token::Url { .. } => return Ok(Value::Url(self.parse()?)),
+            tok!("url") => return Ok(Value::Url(self.parse()?)),
 
             _ => {}
         }

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -602,11 +602,11 @@ where
     }
 }
 
-impl<I> Parse<Num> for Parser<I>
+impl<I> Parse<Number> for Parser<I>
 where
     I: ParserInput,
 {
-    fn parse(&mut self) -> PResult<Num> {
+    fn parse(&mut self) -> PResult<Number> {
         let span = self.input.cur_span()?;
 
         if !is!(self, Num) {
@@ -616,7 +616,7 @@ where
         let value = bump!(self);
 
         match value {
-            Token::Num { value, raw, .. } => Ok(Num { span, value, raw }),
+            Token::Num { value, raw, .. } => Ok(Number { span, value, raw }),
             _ => {
                 unreachable!()
             }
@@ -699,7 +699,7 @@ where
 
                 Ok(UnitValue {
                     span,
-                    value: Num {
+                    value: Number {
                         value,
                         raw: raw_value,
                         span: swc_common::Span::new(
@@ -739,7 +739,7 @@ where
 
         match bump!(self) {
             Token::Percent { value, raw } => {
-                let value = Num {
+                let value = Number {
                     span: swc_common::Span::new(span.lo, span.hi - BytePos(1), Default::default()),
                     value,
                     raw,

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -439,50 +439,10 @@ where
     }
 
     fn parse_basical_numeric_value(&mut self) -> PResult<Value> {
-        let span = self.input.cur_span()?;
-
-        match bump!(self) {
-            Token::Percent { value, raw, .. } => {
-                let value = Num {
-                    span: swc_common::Span::new(span.lo, span.hi - BytePos(1), Default::default()),
-                    value,
-                    raw,
-                };
-
-                Ok(Value::Percent(PercentValue { span, value }))
-            }
-            Token::Dimension {
-                value,
-                raw_value,
-                unit,
-                raw_unit,
-                ..
-            } => {
-                let unit_len = raw_unit.len() as u32;
-
-                Ok(Value::Unit(UnitValue {
-                    span,
-                    value: Num {
-                        value,
-                        raw: raw_value,
-                        span: swc_common::Span::new(
-                            span.lo,
-                            span.hi - BytePos(unit_len),
-                            Default::default(),
-                        ),
-                    },
-                    unit: Unit {
-                        span: swc_common::Span::new(
-                            span.hi - BytePos(unit_len),
-                            span.hi,
-                            Default::default(),
-                        ),
-                        value: unit,
-                        raw: raw_unit,
-                    },
-                }))
-            }
-            Token::Num { value, raw, .. } => Ok(Value::Number(Num { span, value, raw })),
+        match cur!(self) {
+            tok!("percent") => Ok(Value::Percent(self.parse()?)),
+            tok!("dimension") => Ok(Value::Unit(self.parse()?)),
+            tok!("num") => Ok(Value::Number(self.parse()?)),
             _ => {
                 unreachable!()
             }

--- a/crates/swc_css_parser/tests/fixture.rs
+++ b/crates/swc_css_parser/tests/fixture.rs
@@ -296,7 +296,8 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(NestingSelector, visit_nesting_selector);
     mtd!(IdSelector, visit_id_selector);
     mtd!(TypeSelector, visit_type_selector);
-    mtd!(Num, visit_num);
+    mtd!(Number, visit_number);
+    mtd!(Ratio, visit_ratio);
     mtd!(PercentValue, visit_percent_value);
     mtd!(Declaration, visit_declaration);
     mtd!(Nth, visit_nth);

--- a/crates/swc_css_parser/tests/fixture/at-rule/import/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/import/span.rust-debug
@@ -1072,7 +1072,7 @@ error: UnitValue
 19 | @import url("narrow.css") supports(display: flex) handheld and (max-width: 400px);
    |                                                                            ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/import/input.css:19:76
    |
 19 | @import url("narrow.css") supports(display: flex) handheld and (max-width: 400px);
@@ -1234,7 +1234,7 @@ error: UnitValue
 20 | @import url("narrow.css") SUPPORTS(display: flex) handheld and (max-width: 400px);
    |                                                                            ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/import/input.css:20:76
    |
 20 | @import url("narrow.css") SUPPORTS(display: flex) handheld and (max-width: 400px);
@@ -5170,7 +5170,7 @@ error: UnitValue
 130 | @import url("./test.css") supports(display: flex) screen and (min-width: 400px);
     |                                                                          ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/import/input.css:130:74
     |
 130 | @import url("./test.css") supports(display: flex) screen and (min-width: 400px);
@@ -5500,7 +5500,7 @@ error: UnitValue
 133 | @import url("./test.css") layer(default) supports(display: flex) screen and (min-width: 400px);
     |                                                                                         ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/import/input.css:133:89
     |
 133 | @import url("./test.css") layer(default) supports(display: flex) screen and (min-width: 400px);
@@ -5674,7 +5674,7 @@ error: UnitValue
 134 | @import url("./test.css") layer supports(display: flex) screen and (min-width: 400px);
     |                                                                                ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/import/input.css:134:80
     |
 134 | @import url("./test.css") layer supports(display: flex) screen and (min-width: 400px);
@@ -5854,7 +5854,7 @@ error: UnitValue
 135 | @import url("./test.css") layer() supports(display: flex) screen and (min-width: 400px);
     |                                                                                  ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/import/input.css:135:82
     |
 135 | @import url("./test.css") layer() supports(display: flex) screen and (min-width: 400px);
@@ -6082,7 +6082,7 @@ error: UnitValue
 137 | @import url("http://example.com/style.css") supports(display: flex) screen and (min-width: 400px);
     |                                                                                            ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/import/input.css:137:92
     |
 137 | @import url("http://example.com/style.css") supports(display: flex) screen and (min-width: 400px);
@@ -6274,7 +6274,7 @@ error: UnitValue
 138 | @import url("./test.css")layer(default)supports(display: flex)screen and (min-width:400px);
     |                                                                                     ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/import/input.css:138:85
     |
 138 | @import url("./test.css")layer(default)supports(display: flex)screen and (min-width:400px);
@@ -6406,7 +6406,7 @@ error: UnitValue
 139 | @import url("./test.css")screen and (min-width: 400px);
     |                                                 ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/import/input.css:139:49
     |
 139 | @import url("./test.css")screen and (min-width: 400px);
@@ -6598,7 +6598,7 @@ error: UnitValue
 142 | @import url("./test.css") /* Comment */ layer(/* Comment */default/* Comment */) /* Comment */ supports(/* Comment */display/* Comment */:/* Comment */ flex/* Comment */)/* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */);
     |                                                                                                                                                                                                                                                                                 ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/import/input.css:142:273
     |
 142 | @import url("./test.css") /* Comment */ layer(/* Comment */default/* Comment */) /* Comment */ supports(/* Comment */display/* Comment */:/* Comment */ flex/* Comment */)/* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */);
@@ -7570,7 +7570,7 @@ error: UnitValue
 154 | @import url("./import-with-supports-and-media.css") supports(display: flex) screen and (min-width: 400px);
     |                                                                                                    ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/import/input.css:154:100
     |
 154 | @import url("./import-with-supports-and-media.css") supports(display: flex) screen and (min-width: 400px);

--- a/crates/swc_css_parser/tests/fixture/at-rule/keyframe/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/keyframe/span.rust-debug
@@ -204,7 +204,7 @@ error: PercentValue
 7 |         transform: translateX(0%);
   |                               ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/at-rule/keyframe/input.css:7:31
   |
 7 |         transform: translateX(0%);
@@ -290,7 +290,7 @@ error: PercentValue
 11 |         transform: translateX(100%);
    |                               ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:11:31
    |
 11 |         transform: translateX(100%);
@@ -353,7 +353,7 @@ error: PercentValue
 16 |     0% { top: 0; left: 0; }
    |     ^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:16:5
    |
 16 |     0% { top: 0; left: 0; }
@@ -389,7 +389,7 @@ error: Value
 16 |     0% { top: 0; left: 0; }
    |               ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:16:15
    |
 16 |     0% { top: 0; left: 0; }
@@ -413,7 +413,7 @@ error: Value
 16 |     0% { top: 0; left: 0; }
    |                        ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:16:24
    |
 16 |     0% { top: 0; left: 0; }
@@ -437,7 +437,7 @@ error: PercentValue
 17 |     30% { top: 50px; }
    |     ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:17:5
    |
 17 |     30% { top: 50px; }
@@ -479,7 +479,7 @@ error: UnitValue
 17 |     30% { top: 50px; }
    |                ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:17:16
    |
 17 |     30% { top: 50px; }
@@ -509,7 +509,7 @@ error: PercentValue
 18 |     68%, 72% { left: 50px; }
    |     ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:18:5
    |
 18 |     68%, 72% { left: 50px; }
@@ -527,7 +527,7 @@ error: PercentValue
 18 |     68%, 72% { left: 50px; }
    |          ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:18:10
    |
 18 |     68%, 72% { left: 50px; }
@@ -569,7 +569,7 @@ error: UnitValue
 18 |     68%, 72% { left: 50px; }
    |                      ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:18:22
    |
 18 |     68%, 72% { left: 50px; }
@@ -599,7 +599,7 @@ error: PercentValue
 19 |     100% { top: 100px; left: 100%; }
    |     ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:19:5
    |
 19 |     100% { top: 100px; left: 100%; }
@@ -641,7 +641,7 @@ error: UnitValue
 19 |     100% { top: 100px; left: 100%; }
    |                 ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:19:17
    |
 19 |     100% { top: 100px; left: 100%; }
@@ -677,7 +677,7 @@ error: PercentValue
 19 |     100% { top: 100px; left: 100%; }
    |                              ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:19:30
    |
 19 |     100% { top: 100px; left: 100%; }

--- a/crates/swc_css_parser/tests/fixture/at-rule/layer/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/layer/span.rust-debug
@@ -226,7 +226,7 @@ error: Value
 5 |         from { translate: 0; }
   |                           ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/at-rule/layer/input.css:5:27
   |
 5 |         from { translate: 0; }
@@ -286,7 +286,7 @@ error: PercentValue
 6 |         to { translate: -100% 0; }
   |                         ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/at-rule/layer/input.css:6:25
   |
 6 |         to { translate: -100% 0; }
@@ -298,7 +298,7 @@ error: Value
 6 |         to { translate: -100% 0; }
   |                               ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/at-rule/layer/input.css:6:31
   |
 6 |         to { translate: -100% 0; }
@@ -436,7 +436,7 @@ error: Value
 12 |         from { margin-left: 0; }
    |                             ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/layer/input.css:12:29
    |
 12 |         from { margin-left: 0; }
@@ -496,7 +496,7 @@ error: PercentValue
 13 |         to { margin-left: -100%; }
    |                           ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/layer/input.css:13:27
    |
 13 |         to { margin-left: -100%; }
@@ -592,7 +592,7 @@ error: UnitValue
 17 | .sidebar { animation: slide-left 300ms; }
    |                                  ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/layer/input.css:17:34
    |
 17 | .sidebar { animation: slide-left 300ms; }
@@ -886,7 +886,7 @@ error: Value
 27 |     .title { font-weight: 100; }
    |                           ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/layer/input.css:27:27
    |
 27 |     .title { font-weight: 100; }
@@ -1318,7 +1318,7 @@ error: UnitValue
 40 |         p { margin-block: 0.75em; }
    |                           ^^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/layer/input.css:40:27
    |
 40 |         p { margin-block: 0.75em; }

--- a/crates/swc_css_parser/tests/fixture/at-rule/media/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/media/output.json
@@ -1011,13 +1011,12 @@
                       "raw": "device-aspect-ratio"
                     },
                     "value": {
-                      "type": "BinValue",
+                      "type": "Ratio",
                       "span": {
                         "start": 513,
                         "end": 517,
                         "ctxt": 0
                       },
-                      "op": "/",
                       "left": {
                         "type": "Number",
                         "span": {
@@ -1105,13 +1104,12 @@
                       "raw": "device-aspect-ratio"
                     },
                     "value": {
-                      "type": "BinValue",
+                      "type": "Ratio",
                       "span": {
                         "start": 555,
                         "end": 561,
                         "ctxt": 0
                       },
-                      "op": "/",
                       "left": {
                         "type": "Number",
                         "span": {
@@ -1690,13 +1688,12 @@
                     "raw": "device-aspect-ratio"
                   },
                   "value": {
-                    "type": "BinValue",
+                    "type": "Ratio",
                     "span": {
                       "start": 821,
                       "end": 825,
                       "ctxt": 0
                     },
-                    "op": "/",
                     "left": {
                       "type": "Number",
                       "span": {
@@ -1776,13 +1773,12 @@
                     "raw": "device-aspect-ratio"
                   },
                   "value": {
-                    "type": "BinValue",
+                    "type": "Ratio",
                     "span": {
                       "start": 871,
                       "end": 881,
                       "ctxt": 0
                     },
-                    "op": "/",
                     "left": {
                       "type": "Number",
                       "span": {

--- a/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
@@ -622,7 +622,7 @@ error: UnitValue
 10 | @media print and (min-resolution: 118dpcm) {}
    |                                   ^^^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:10:35
    |
 10 | @media print and (min-resolution: 118dpcm) {}
@@ -1132,31 +1132,19 @@ error: MediaFeatureValue
 17 | @media not (device-aspect-ratio: 16/9) {}
    |                                  ^^^^
 
-error: BinValue
+error: Ratio
   --> $DIR/tests/fixture/at-rule/media/input.css:17:34
    |
 17 | @media not (device-aspect-ratio: 16/9) {}
    |                                  ^^^^
 
-error: Value
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:17:34
    |
 17 | @media not (device-aspect-ratio: 16/9) {}
    |                                  ^^
 
-error: Num
-  --> $DIR/tests/fixture/at-rule/media/input.css:17:34
-   |
-17 | @media not (device-aspect-ratio: 16/9) {}
-   |                                  ^^
-
-error: Value
-  --> $DIR/tests/fixture/at-rule/media/input.css:17:37
-   |
-17 | @media not (device-aspect-ratio: 16/9) {}
-   |                                     ^
-
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:17:37
    |
 17 | @media not (device-aspect-ratio: 16/9) {}
@@ -1246,31 +1234,19 @@ error: MediaFeatureValue
 18 | @media not (device-aspect-ratio: 16 / 9) {}
    |                                  ^^^^^^
 
-error: BinValue
+error: Ratio
   --> $DIR/tests/fixture/at-rule/media/input.css:18:34
    |
 18 | @media not (device-aspect-ratio: 16 / 9) {}
    |                                  ^^^^^^
 
-error: Value
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:18:34
    |
 18 | @media not (device-aspect-ratio: 16 / 9) {}
    |                                  ^^
 
-error: Num
-  --> $DIR/tests/fixture/at-rule/media/input.css:18:34
-   |
-18 | @media not (device-aspect-ratio: 16 / 9) {}
-   |                                  ^^
-
-error: Value
-  --> $DIR/tests/fixture/at-rule/media/input.css:18:39
-   |
-18 | @media not (device-aspect-ratio: 16 / 9) {}
-   |                                       ^
-
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:18:39
    |
 18 | @media not (device-aspect-ratio: 16 / 9) {}
@@ -1612,7 +1588,7 @@ error: UnitValue
 25 | @media (min-width: 20px) {}
    |                    ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:25:20
    |
 25 | @media (min-width: 20px) {}
@@ -1708,7 +1684,7 @@ error: UnitValue
 26 | @media(min-width: 20px){}
    |                   ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:26:19
    |
 26 | @media(min-width: 20px){}
@@ -1804,7 +1780,7 @@ error: UnitValue
 27 | @media   (   min-width   :   20px   )   {}
    |                              ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:27:30
    |
 27 | @media   (   min-width   :   20px   )   {}
@@ -1894,31 +1870,19 @@ error: MediaFeatureValue
 28 | @media (device-aspect-ratio: 16/9) {}
    |                              ^^^^
 
-error: BinValue
+error: Ratio
   --> $DIR/tests/fixture/at-rule/media/input.css:28:30
    |
 28 | @media (device-aspect-ratio: 16/9) {}
    |                              ^^^^
 
-error: Value
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:28:30
    |
 28 | @media (device-aspect-ratio: 16/9) {}
    |                              ^^
 
-error: Num
-  --> $DIR/tests/fixture/at-rule/media/input.css:28:30
-   |
-28 | @media (device-aspect-ratio: 16/9) {}
-   |                              ^^
-
-error: Value
-  --> $DIR/tests/fixture/at-rule/media/input.css:28:33
-   |
-28 | @media (device-aspect-ratio: 16/9) {}
-   |                                 ^
-
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:28:33
    |
 28 | @media (device-aspect-ratio: 16/9) {}
@@ -2002,31 +1966,19 @@ error: MediaFeatureValue
 29 | @media    (   device-aspect-ratio   :    16   /   9   )   {}
    |                                          ^^^^^^^^^^
 
-error: BinValue
+error: Ratio
   --> $DIR/tests/fixture/at-rule/media/input.css:29:42
    |
 29 | @media    (   device-aspect-ratio   :    16   /   9   )   {}
    |                                          ^^^^^^^^^^
 
-error: Value
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:29:42
    |
 29 | @media    (   device-aspect-ratio   :    16   /   9   )   {}
    |                                          ^^
 
-error: Num
-  --> $DIR/tests/fixture/at-rule/media/input.css:29:42
-   |
-29 | @media    (   device-aspect-ratio   :    16   /   9   )   {}
-   |                                          ^^
-
-error: Value
-  --> $DIR/tests/fixture/at-rule/media/input.css:29:51
-   |
-29 | @media    (   device-aspect-ratio   :    16   /   9   )   {}
-   |                                                   ^
-
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:29:51
    |
 29 | @media    (   device-aspect-ratio   :    16   /   9   )   {}
@@ -2158,7 +2110,7 @@ error: UnitValue
 30 | @media (grid) and (max-width: 15em) {}
    |                               ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:30:31
    |
 30 | @media (grid) and (max-width: 15em) {}
@@ -2326,7 +2278,7 @@ error: UnitValue
 33 | @media (min-width: 20em) and (min-width: 20em) {}
    |                    ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:33:20
    |
 33 | @media (min-width: 20em) and (min-width: 20em) {}
@@ -2392,7 +2344,7 @@ error: UnitValue
 33 | @media (min-width: 20em) and (min-width: 20em) {}
    |                                          ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:33:42
    |
 33 | @media (min-width: 20em) and (min-width: 20em) {}
@@ -2488,7 +2440,7 @@ error: UnitValue
 34 | @media   (min-width   :   20em   )   and   (   min-width   :   20em   )   {}
    |                           ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:34:27
    |
 34 | @media   (min-width   :   20em   )   and   (   min-width   :   20em   )   {}
@@ -2554,7 +2506,7 @@ error: UnitValue
 34 | @media   (min-width   :   20em   )   and   (   min-width   :   20em   )   {}
    |                                                                ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:34:64
    |
 34 | @media   (min-width   :   20em   )   and   (   min-width   :   20em   )   {}
@@ -2650,7 +2602,7 @@ error: UnitValue
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
    |                    ^^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:35:20
    |
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
@@ -2716,7 +2668,7 @@ error: UnitValue
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
    |                                            ^^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:35:44
    |
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
@@ -2782,7 +2734,7 @@ error: UnitValue
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
    |                                                                    ^^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:35:68
    |
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
@@ -2878,7 +2830,7 @@ error: UnitValue
 36 | @media(min-width:20em)and (min-width: 20em){}
    |                  ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:36:18
    |
 36 | @media(min-width:20em)and (min-width: 20em){}
@@ -2944,7 +2896,7 @@ error: UnitValue
 36 | @media(min-width:20em)and (min-width: 20em){}
    |                                       ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:36:39
    |
 36 | @media(min-width:20em)and (min-width: 20em){}
@@ -3040,7 +2992,7 @@ error: UnitValue
 37 | @media(min-width:20em)and (min-width:20em){}
    |                  ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:37:18
    |
 37 | @media(min-width:20em)and (min-width:20em){}
@@ -3106,7 +3058,7 @@ error: UnitValue
 37 | @media(min-width:20em)and (min-width:20em){}
    |                                      ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:37:38
    |
 37 | @media(min-width:20em)and (min-width:20em){}
@@ -3616,7 +3568,7 @@ error: UnitValue
 43 | @media (height < 600px) {}
    |                  ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:43:18
    |
 43 | @media (height < 600px) {}
@@ -3712,7 +3664,7 @@ error: UnitValue
 44 | @media (height <= 600px) {}
    |                   ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:44:19
    |
 44 | @media (height <= 600px) {}
@@ -3808,7 +3760,7 @@ error: UnitValue
 45 | @media (height > 600px) {}
    |                  ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:45:18
    |
 45 | @media (height > 600px) {}
@@ -3904,7 +3856,7 @@ error: UnitValue
 46 | @media (height >= 600px) {}
    |                   ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:46:19
    |
 46 | @media (height >= 600px) {}
@@ -4000,7 +3952,7 @@ error: UnitValue
 47 | @media (height = 600px) {}
    |                  ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:47:18
    |
 47 | @media (height = 600px) {}
@@ -4096,7 +4048,7 @@ error: UnitValue
 48 | @media   (   height   <   600px   )   {}
    |                           ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:48:27
    |
 48 | @media   (   height   <   600px   )   {}
@@ -4192,7 +4144,7 @@ error: UnitValue
 49 | @media   (   height   <=   600px   )   {}
    |                            ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:49:28
    |
 49 | @media   (   height   <=   600px   )   {}
@@ -4288,7 +4240,7 @@ error: UnitValue
 50 | @media   (   height   >   600px   )   {}
    |                           ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:50:27
    |
 50 | @media   (   height   >   600px   )   {}
@@ -4384,7 +4336,7 @@ error: UnitValue
 51 | @media   (   height   >=   600px   )   {}
    |                            ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:51:28
    |
 51 | @media   (   height   >=   600px   )   {}
@@ -4480,7 +4432,7 @@ error: UnitValue
 52 | @media   (   height   =   600px   )   {}
    |                           ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:52:27
    |
 52 | @media   (   height   =   600px   )   {}
@@ -4576,7 +4528,7 @@ error: UnitValue
 53 | @media(height=600px){}
    |               ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:53:15
    |
 53 | @media(height=600px){}
@@ -4672,7 +4624,7 @@ error: UnitValue
 54 | @media(height>=600px) {}
    |                ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:54:16
    |
 54 | @media(height>=600px) {}
@@ -4756,7 +4708,7 @@ error: UnitValue
 56 | @media (600px < height) {}
    |         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:56:9
    |
 56 | @media (600px < height) {}
@@ -4852,7 +4804,7 @@ error: UnitValue
 57 | @media (600px <= height) {}
    |         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:57:9
    |
 57 | @media (600px <= height) {}
@@ -4948,7 +4900,7 @@ error: UnitValue
 58 | @media (600px > height) {}
    |         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:58:9
    |
 58 | @media (600px > height) {}
@@ -5044,7 +4996,7 @@ error: UnitValue
 59 | @media (600px >= height) {}
    |         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:59:9
    |
 59 | @media (600px >= height) {}
@@ -5140,7 +5092,7 @@ error: UnitValue
 60 | @media (600px = height) {}
    |         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:60:9
    |
 60 | @media (600px = height) {}
@@ -5236,7 +5188,7 @@ error: UnitValue
 61 | @media   (   600px   <   height   )   {}
    |              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:61:14
    |
 61 | @media   (   600px   <   height   )   {}
@@ -5332,7 +5284,7 @@ error: UnitValue
 62 | @media   (   600px   <=   height   )   {}
    |              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:62:14
    |
 62 | @media   (   600px   <=   height   )   {}
@@ -5428,7 +5380,7 @@ error: UnitValue
 63 | @media   (   600px   >   height   )   {}
    |              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:63:14
    |
 63 | @media   (   600px   >   height   )   {}
@@ -5524,7 +5476,7 @@ error: UnitValue
 64 | @media   (   600px   >=   height   )   {}
    |              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:64:14
    |
 64 | @media   (   600px   >=   height   )   {}
@@ -5620,7 +5572,7 @@ error: UnitValue
 65 | @media   (   600px   =   height   )   {}
    |              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:65:14
    |
 65 | @media   (   600px   =   height   )   {}
@@ -5716,7 +5668,7 @@ error: UnitValue
 66 | @media(600px=height) {}
    |        ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:66:8
    |
 66 | @media(600px=height) {}
@@ -5812,7 +5764,7 @@ error: UnitValue
 67 | @media(600px>=height) {}
    |        ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:67:8
    |
 67 | @media(600px>=height) {}
@@ -5908,7 +5860,7 @@ error: UnitValue
 69 | @media (400px < width < 700px) {}
    |         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:69:9
    |
 69 | @media (400px < width < 700px) {}
@@ -5944,7 +5896,7 @@ error: UnitValue
 69 | @media (400px < width < 700px) {}
    |                         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:69:25
    |
 69 | @media (400px < width < 700px) {}
@@ -6028,7 +5980,7 @@ error: UnitValue
 70 | @media (400px <= width < 700px) {}
    |         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:70:9
    |
 70 | @media (400px <= width < 700px) {}
@@ -6064,7 +6016,7 @@ error: UnitValue
 70 | @media (400px <= width < 700px) {}
    |                          ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:70:26
    |
 70 | @media (400px <= width < 700px) {}
@@ -6148,7 +6100,7 @@ error: UnitValue
 71 | @media (400px < width <= 700px) {}
    |         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:71:9
    |
 71 | @media (400px < width <= 700px) {}
@@ -6184,7 +6136,7 @@ error: UnitValue
 71 | @media (400px < width <= 700px) {}
    |                          ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:71:26
    |
 71 | @media (400px < width <= 700px) {}
@@ -6268,7 +6220,7 @@ error: UnitValue
 72 | @media (400px <= width <= 700px) {}
    |         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:72:9
    |
 72 | @media (400px <= width <= 700px) {}
@@ -6304,7 +6256,7 @@ error: UnitValue
 72 | @media (400px <= width <= 700px) {}
    |                           ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:72:27
    |
 72 | @media (400px <= width <= 700px) {}
@@ -6388,7 +6340,7 @@ error: UnitValue
 73 | @media(400px<width<700px){}
    |        ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:73:8
    |
 73 | @media(400px<width<700px){}
@@ -6424,7 +6376,7 @@ error: UnitValue
 73 | @media(400px<width<700px){}
    |                    ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:73:20
    |
 73 | @media(400px<width<700px){}
@@ -6508,7 +6460,7 @@ error: UnitValue
 74 | @media(400px<=width<=700px){}
    |        ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:74:8
    |
 74 | @media(400px<=width<=700px){}
@@ -6544,7 +6496,7 @@ error: UnitValue
 74 | @media(400px<=width<=700px){}
    |                      ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:74:22
    |
 74 | @media(400px<=width<=700px){}
@@ -6628,7 +6580,7 @@ error: UnitValue
 75 | @media   (   400px   <   width   <   700px   )   {}
    |              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:75:14
    |
 75 | @media   (   400px   <   width   <   700px   )   {}
@@ -6664,7 +6616,7 @@ error: UnitValue
 75 | @media   (   400px   <   width   <   700px   )   {}
    |                                      ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:75:38
    |
 75 | @media   (   400px   <   width   <   700px   )   {}
@@ -6748,7 +6700,7 @@ error: UnitValue
 76 | @media   (   400px   <=   width   <   700px   )   {}
    |              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:76:14
    |
 76 | @media   (   400px   <=   width   <   700px   )   {}
@@ -6784,7 +6736,7 @@ error: UnitValue
 76 | @media   (   400px   <=   width   <   700px   )   {}
    |                                       ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:76:39
    |
 76 | @media   (   400px   <=   width   <   700px   )   {}
@@ -6868,7 +6820,7 @@ error: UnitValue
 77 | @media   (   400px   <   width   <=   700px   )   {}
    |              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:77:14
    |
 77 | @media   (   400px   <   width   <=   700px   )   {}
@@ -6904,7 +6856,7 @@ error: UnitValue
 77 | @media   (   400px   <   width   <=   700px   )   {}
    |                                       ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:77:39
    |
 77 | @media   (   400px   <   width   <=   700px   )   {}
@@ -6988,7 +6940,7 @@ error: UnitValue
 78 | @media   (   400px   <=   width   <=   700px   )   {}
    |              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:78:14
    |
 78 | @media   (   400px   <=   width   <=   700px   )   {}
@@ -7024,7 +6976,7 @@ error: UnitValue
 78 | @media   (   400px   <=   width   <=   700px   )   {}
    |                                        ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:78:40
    |
 78 | @media   (   400px   <=   width   <=   700px   )   {}
@@ -7108,7 +7060,7 @@ error: UnitValue
 79 | @media(400px<width<700px){}
    |        ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:79:8
    |
 79 | @media(400px<width<700px){}
@@ -7144,7 +7096,7 @@ error: UnitValue
 79 | @media(400px<width<700px){}
    |                    ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:79:20
    |
 79 | @media(400px<width<700px){}
@@ -7228,7 +7180,7 @@ error: UnitValue
 80 | @media(400px<=width<=700px){}
    |        ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:80:8
    |
 80 | @media(400px<=width<=700px){}
@@ -7264,7 +7216,7 @@ error: UnitValue
 80 | @media(400px<=width<=700px){}
    |                      ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:80:22
    |
 80 | @media(400px<=width<=700px){}
@@ -7348,7 +7300,7 @@ error: UnitValue
 82 | @media (400px > width > 700px) {}
    |         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:82:9
    |
 82 | @media (400px > width > 700px) {}
@@ -7384,7 +7336,7 @@ error: UnitValue
 82 | @media (400px > width > 700px) {}
    |                         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:82:25
    |
 82 | @media (400px > width > 700px) {}
@@ -7468,7 +7420,7 @@ error: UnitValue
 83 | @media (400px >= width > 700px) {}
    |         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:83:9
    |
 83 | @media (400px >= width > 700px) {}
@@ -7504,7 +7456,7 @@ error: UnitValue
 83 | @media (400px >= width > 700px) {}
    |                          ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:83:26
    |
 83 | @media (400px >= width > 700px) {}
@@ -7588,7 +7540,7 @@ error: UnitValue
 84 | @media (400px > width >= 700px) {}
    |         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:84:9
    |
 84 | @media (400px > width >= 700px) {}
@@ -7624,7 +7576,7 @@ error: UnitValue
 84 | @media (400px > width >= 700px) {}
    |                          ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:84:26
    |
 84 | @media (400px > width >= 700px) {}
@@ -7708,7 +7660,7 @@ error: UnitValue
 85 | @media (400px >= width >= 700px) {}
    |         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:85:9
    |
 85 | @media (400px >= width >= 700px) {}
@@ -7744,7 +7696,7 @@ error: UnitValue
 85 | @media (400px >= width >= 700px) {}
    |                           ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:85:27
    |
 85 | @media (400px >= width >= 700px) {}
@@ -7828,7 +7780,7 @@ error: UnitValue
 86 | @media(400px>width>700px){}
    |        ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:86:8
    |
 86 | @media(400px>width>700px){}
@@ -7864,7 +7816,7 @@ error: UnitValue
 86 | @media(400px>width>700px){}
    |                    ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:86:20
    |
 86 | @media(400px>width>700px){}
@@ -7948,7 +7900,7 @@ error: UnitValue
 87 | @media(400px>=width>=700px) {}
    |        ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:87:8
    |
 87 | @media(400px>=width>=700px) {}
@@ -7984,7 +7936,7 @@ error: UnitValue
 87 | @media(400px>=width>=700px) {}
    |                      ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:87:22
    |
 87 | @media(400px>=width>=700px) {}
@@ -8068,7 +8020,7 @@ error: UnitValue
 88 | @media   (   400px   >   width   >   700px   )   {}
    |              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:88:14
    |
 88 | @media   (   400px   >   width   >   700px   )   {}
@@ -8104,7 +8056,7 @@ error: UnitValue
 88 | @media   (   400px   >   width   >   700px   )   {}
    |                                      ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:88:38
    |
 88 | @media   (   400px   >   width   >   700px   )   {}
@@ -8188,7 +8140,7 @@ error: UnitValue
 89 | @media   (   400px   >=   width   >   700px   )   {}
    |              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:89:14
    |
 89 | @media   (   400px   >=   width   >   700px   )   {}
@@ -8224,7 +8176,7 @@ error: UnitValue
 89 | @media   (   400px   >=   width   >   700px   )   {}
    |                                       ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:89:39
    |
 89 | @media   (   400px   >=   width   >   700px   )   {}
@@ -8308,7 +8260,7 @@ error: UnitValue
 90 | @media   (   400px   >   width   >=   700px   )   {}
    |              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:90:14
    |
 90 | @media   (   400px   >   width   >=   700px   )   {}
@@ -8344,7 +8296,7 @@ error: UnitValue
 90 | @media   (   400px   >   width   >=   700px   )   {}
    |                                       ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:90:39
    |
 90 | @media   (   400px   >   width   >=   700px   )   {}
@@ -8428,7 +8380,7 @@ error: UnitValue
 91 | @media   (   400px   >=   width   >=   700px   )   {}
    |              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:91:14
    |
 91 | @media   (   400px   >=   width   >=   700px   )   {}
@@ -8464,7 +8416,7 @@ error: UnitValue
 91 | @media   (   400px   >=   width   >=   700px   )   {}
    |                                        ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:91:40
    |
 91 | @media   (   400px   >=   width   >=   700px   )   {}
@@ -8548,7 +8500,7 @@ error: UnitValue
 92 | @media(400px>width>700px){}
    |        ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:92:8
    |
 92 | @media(400px>width>700px){}
@@ -8584,7 +8536,7 @@ error: UnitValue
 92 | @media(400px>width>700px){}
    |                    ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:92:20
    |
 92 | @media(400px>width>700px){}
@@ -8668,7 +8620,7 @@ error: UnitValue
 93 | @media(400px>=width>=700px){}
    |        ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:93:8
    |
 93 | @media(400px>=width>=700px){}
@@ -8704,7 +8656,7 @@ error: UnitValue
 93 | @media(400px>=width>=700px){}
    |                      ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:93:22
    |
 93 | @media(400px>=width>=700px){}
@@ -8842,7 +8794,7 @@ error: UnitValue
 95 | @media (--modern) and (min-width: 1024px) {}
    |                                   ^^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:95:35
    |
 95 | @media (--modern) and (min-width: 1024px) {}
@@ -9304,7 +9256,7 @@ error: UnitValue
 99 | @media ((color) or (hover)) and (width > 1024px) {}
    |                                          ^^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/media/input.css:99:42
    |
 99 | @media ((color) or (hover)) and (width > 1024px) {}
@@ -9520,7 +9472,7 @@ error: UnitValue
 100 | @media (((color)) or ((hover))) and (width > 1024px) {}
     |                                              ^^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/media/input.css:100:46
     |
 100 | @media (((color)) or ((hover))) and (width > 1024px) {}
@@ -9772,7 +9724,7 @@ error: UnitValue
 101 | @media (((((color)) or ((hover))))) and (width > 1024px) {}
     |                                                  ^^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/media/input.css:101:50
     |
 101 | @media (((((color)) or ((hover))))) and (width > 1024px) {}
@@ -10024,7 +9976,7 @@ error: UnitValue
 102 | @media   (   (   (   (   (   color   )   )   or   (   (   hover   )   )   )   )   )   and   (   width   >   1024px   )   {}
     |                                                                                                             ^^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/media/input.css:102:109
     |
 102 | @media   (   (   (   (   (   color   )   )   or   (   (   hover   )   )   )   )   )   and   (   width   >   1024px   )   {}
@@ -10138,7 +10090,7 @@ error: UnitValue
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
     |                     ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/media/input.css:104:21
     |
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -10204,7 +10156,7 @@ error: UnitValue
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
     |                                            ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/media/input.css:104:44
     |
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -10270,7 +10222,7 @@ error: UnitValue
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
     |                                                                   ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/media/input.css:104:67
     |
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -10366,7 +10318,7 @@ error: UnitValue
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
     |                    ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/media/input.css:105:20
     |
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -10450,7 +10402,7 @@ error: UnitValue
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
     |                                            ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/media/input.css:105:44
     |
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -10516,7 +10468,7 @@ error: UnitValue
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
     |                                                                  ^^^^^
 
-error: Num
+error: Number
    --> $DIR/tests/fixture/at-rule/media/input.css:105:66
     |
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}

--- a/crates/swc_css_parser/tests/fixture/at-rule/page/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/page/span.rust-debug
@@ -112,7 +112,7 @@ error: UnitValue
 3 | @page{margin: 1cm}
   |               ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/at-rule/page/input.css:3:15
   |
 3 | @page{margin: 1cm}
@@ -178,7 +178,7 @@ error: UnitValue
 4 | @page {margin: 1cm}
   |                ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/at-rule/page/input.css:4:16
   |
 4 | @page {margin: 1cm}
@@ -244,7 +244,7 @@ error: UnitValue
 5 | @page {margin: 1cm;}
   |                ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/at-rule/page/input.css:5:16
   |
 5 | @page {margin: 1cm;}
@@ -322,7 +322,7 @@ error: UnitValue
 6 | @page :first {margin: 2cm}
   |                       ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/at-rule/page/input.css:6:23
   |
 6 | @page :first {margin: 2cm}
@@ -400,7 +400,7 @@ error: UnitValue
 7 | @page :first {margin: 2cm;}
   |                       ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/at-rule/page/input.css:7:23
   |
 7 | @page :first {margin: 2cm;}
@@ -478,7 +478,7 @@ error: UnitValue
 8 | @page :first{margin: 2cm;}
   |                      ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/at-rule/page/input.css:8:22
   |
 8 | @page :first{margin: 2cm;}

--- a/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
@@ -432,7 +432,7 @@ error: UnitValue
 12 |     @media screen and (min-width: 900px) {
    |                                   ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:12:35
    |
 12 |     @media screen and (min-width: 900px) {
@@ -793,7 +793,7 @@ error: Value
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                        ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:24
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -805,7 +805,7 @@ error: Value
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                          ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:26
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -823,7 +823,7 @@ error: UnitValue
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                            ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:28
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -901,7 +901,7 @@ error: Value
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                   ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:67
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -913,7 +913,7 @@ error: Value
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                     ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:69
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -931,7 +931,7 @@ error: UnitValue
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                       ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:71
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -1009,7 +1009,7 @@ error: Value
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                                                                 ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:113
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -1021,7 +1021,7 @@ error: Value
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                                                                   ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:115
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -1039,7 +1039,7 @@ error: UnitValue
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                                                                     ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:117
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -1117,7 +1117,7 @@ error: Value
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                                                                                                          ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:154
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -1129,7 +1129,7 @@ error: Value
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                                                                                                            ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:156
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -1147,7 +1147,7 @@ error: UnitValue
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                                                                                                              ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:158
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -1262,7 +1262,7 @@ error: Value
 22 | @supports ( box-shadow: 0 0 2px black inset ) or
    |                         ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:22:25
    |
 22 | @supports ( box-shadow: 0 0 2px black inset ) or
@@ -1274,7 +1274,7 @@ error: Value
 22 | @supports ( box-shadow: 0 0 2px black inset ) or
    |                           ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:22:27
    |
 22 | @supports ( box-shadow: 0 0 2px black inset ) or
@@ -1292,7 +1292,7 @@ error: UnitValue
 22 | @supports ( box-shadow: 0 0 2px black inset ) or
    |                             ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:22:29
    |
 22 | @supports ( box-shadow: 0 0 2px black inset ) or
@@ -1374,7 +1374,7 @@ error: Value
 23 |   ( -moz-box-shadow: 0 0 2px black inset ) or
    |                      ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:23:22
    |
 23 |   ( -moz-box-shadow: 0 0 2px black inset ) or
@@ -1386,7 +1386,7 @@ error: Value
 23 |   ( -moz-box-shadow: 0 0 2px black inset ) or
    |                        ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:23:24
    |
 23 |   ( -moz-box-shadow: 0 0 2px black inset ) or
@@ -1404,7 +1404,7 @@ error: UnitValue
 23 |   ( -moz-box-shadow: 0 0 2px black inset ) or
    |                          ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:23:26
    |
 23 |   ( -moz-box-shadow: 0 0 2px black inset ) or
@@ -1486,7 +1486,7 @@ error: Value
 24 |   ( -webkit-box-shadow: 0 0 2px black inset ) or
    |                         ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:24:25
    |
 24 |   ( -webkit-box-shadow: 0 0 2px black inset ) or
@@ -1498,7 +1498,7 @@ error: Value
 24 |   ( -webkit-box-shadow: 0 0 2px black inset ) or
    |                           ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:24:27
    |
 24 |   ( -webkit-box-shadow: 0 0 2px black inset ) or
@@ -1516,7 +1516,7 @@ error: UnitValue
 24 |   ( -webkit-box-shadow: 0 0 2px black inset ) or
    |                             ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:24:29
    |
 24 |   ( -webkit-box-shadow: 0 0 2px black inset ) or
@@ -1598,7 +1598,7 @@ error: Value
 25 |   ( -o-box-shadow: 0 0 2px black inset ) {
    |                    ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:25:20
    |
 25 |   ( -o-box-shadow: 0 0 2px black inset ) {
@@ -1610,7 +1610,7 @@ error: Value
 25 |   ( -o-box-shadow: 0 0 2px black inset ) {
    |                      ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:25:22
    |
 25 |   ( -o-box-shadow: 0 0 2px black inset ) {
@@ -1628,7 +1628,7 @@ error: UnitValue
 25 |   ( -o-box-shadow: 0 0 2px black inset ) {
    |                        ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:25:24
    |
 25 |   ( -o-box-shadow: 0 0 2px black inset ) {
@@ -1862,7 +1862,7 @@ error: UnitValue
 28 | @supports ((transition-property: color) or (animation-name: foo)) and (transform: rotate(10deg)) {}
    |                                                                                          ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:28:90
    |
 28 | @supports ((transition-property: color) or (animation-name: foo)) and (transform: rotate(10deg)) {}
@@ -2072,7 +2072,7 @@ error: UnitValue
 29 | @supports (transition-property: color) or ((animation-name: foo) and (transform: rotate(10deg))) {}
    |                                                                                         ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:29:89
    |
 29 | @supports (transition-property: color) or ((animation-name: foo) and (transform: rotate(10deg))) {}
@@ -2282,7 +2282,7 @@ error: UnitValue
 30 | @supports   (   transition-property   :   color   )   or   (   (   animation-name   :   foo   )   and   (   transform   :    rotate(10deg)   )   )   {}
    |                                                                                                                                     ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:30:133
    |
 30 | @supports   (   transition-property   :   color   )   or   (   (   animation-name   :   foo   )   and   (   transform   :    rotate(10deg)   )   )   {}
@@ -2492,7 +2492,7 @@ error: UnitValue
 31 | @supports(transition-property:color)or ((animation-name:foo)and (transform:rotate(10deg))){}
    |                                                                                   ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/at-rule/supports/input.css:31:83
    |
 31 | @supports(transition-property:color)or ((animation-name:foo)and (transform:rotate(10deg))){}

--- a/crates/swc_css_parser/tests/fixture/dimension/basic/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/dimension/basic/span.rust-debug
@@ -101,7 +101,7 @@ error: UnitValue
 2 |     prop: 10px;
   |           ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/dimension/basic/input.css:2:11
   |
 2 |     prop: 10px;
@@ -137,7 +137,7 @@ error: UnitValue
 3 |     prop: .10px;
   |           ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/dimension/basic/input.css:3:11
   |
 3 |     prop: .10px;
@@ -173,7 +173,7 @@ error: UnitValue
 4 |     prop: 12.34px;
   |           ^^^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/dimension/basic/input.css:4:11
   |
 4 |     prop: 12.34px;
@@ -209,7 +209,7 @@ error: UnitValue
 5 |     prop: 0000.000px;
   |           ^^^^^^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/dimension/basic/input.css:5:11
   |
 5 |     prop: 0000.000px;
@@ -245,7 +245,7 @@ error: UnitValue
 6 |     prop: 1px\\9;
   |           ^^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/dimension/basic/input.css:6:11
   |
 6 |     prop: 1px\\9;
@@ -281,7 +281,7 @@ error: UnitValue
 7 |     prop: 1e;
   |           ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/dimension/basic/input.css:7:11
   |
 7 |     prop: 1e;
@@ -317,7 +317,7 @@ error: UnitValue
 8 |     prop: 1unknown;
   |           ^^^^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/dimension/basic/input.css:8:11
   |
 8 |     prop: 1unknown;

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/-JoxoRcnA-zaaEC7RjXKvQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/-JoxoRcnA-zaaEC7RjXKvQ/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: +.10; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/-JoxoRcnA-zaaEC7RjXKvQ/input.css:1:12
   |
 1 | a { width: +.10; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: -.10%; }
   |            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/input.css:1:12
   |
 1 | a { width: -.10%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/span.rust-debug
@@ -88,7 +88,7 @@ error: Value
 1 | a { box-shadow: rgb(255, 0, 17) 0 0 1 inset }
   |                     ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/input.css:1:21
   |
 1 | a { box-shadow: rgb(255, 0, 17) 0 0 1 inset }
@@ -100,7 +100,7 @@ error: Value
 1 | a { box-shadow: rgb(255, 0, 17) 0 0 1 inset }
   |                          ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/input.css:1:26
   |
 1 | a { box-shadow: rgb(255, 0, 17) 0 0 1 inset }
@@ -112,7 +112,7 @@ error: Value
 1 | a { box-shadow: rgb(255, 0, 17) 0 0 1 inset }
   |                             ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/input.css:1:29
   |
 1 | a { box-shadow: rgb(255, 0, 17) 0 0 1 inset }
@@ -124,7 +124,7 @@ error: Value
 1 | a { box-shadow: rgb(255, 0, 17) 0 0 1 inset }
   |                                 ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/input.css:1:33
   |
 1 | a { box-shadow: rgb(255, 0, 17) 0 0 1 inset }
@@ -136,7 +136,7 @@ error: Value
 1 | a { box-shadow: rgb(255, 0, 17) 0 0 1 inset }
   |                                   ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/input.css:1:35
   |
 1 | a { box-shadow: rgb(255, 0, 17) 0 0 1 inset }
@@ -148,7 +148,7 @@ error: Value
 1 | a { box-shadow: rgb(255, 0, 17) 0 0 1 inset }
   |                                     ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/-gboAEi1zyjFW5mtEM24Rg/input.css:1:37
   |
 1 | a { box-shadow: rgb(255, 0, 17) 0 0 1 inset }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/07tvJxvZrgDeTmptOclErA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/07tvJxvZrgDeTmptOclErA/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { margin: 0 1 0 1 }
   |             ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/07tvJxvZrgDeTmptOclErA/input.css:1:13
   |
 1 | a { margin: 0 1 0 1 }
@@ -82,7 +82,7 @@ error: Value
 1 | a { margin: 0 1 0 1 }
   |               ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/07tvJxvZrgDeTmptOclErA/input.css:1:15
   |
 1 | a { margin: 0 1 0 1 }
@@ -94,7 +94,7 @@ error: Value
 1 | a { margin: 0 1 0 1 }
   |                 ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/07tvJxvZrgDeTmptOclErA/input.css:1:17
   |
 1 | a { margin: 0 1 0 1 }
@@ -106,7 +106,7 @@ error: Value
 1 | a { margin: 0 1 0 1 }
   |                   ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/07tvJxvZrgDeTmptOclErA/input.css:1:19
   |
 1 | a { margin: 0 1 0 1 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/span.rust-debug
@@ -76,7 +76,7 @@ error: UnitValue
 1 | a { value: 10p\32x }
   |            ^^^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/input.css:1:12
   |
 1 | a { value: 10p\32x }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5 6; }
   |                    ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/input.css:1:20
   |
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5 6; }
@@ -82,7 +82,7 @@ error: Value
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5 6; }
   |                      ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/input.css:1:22
   |
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5 6; }
@@ -94,7 +94,7 @@ error: Value
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5 6; }
   |                        ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/input.css:1:24
   |
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5 6; }
@@ -106,7 +106,7 @@ error: Value
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5 6; }
   |                          ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/input.css:1:26
   |
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5 6; }
@@ -130,7 +130,7 @@ error: Value
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5 6; }
   |                                                      ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/input.css:1:54
   |
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5 6; }
@@ -142,7 +142,7 @@ error: Value
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5 6; }
   |                                                        ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/12EwJCu6DsfOEJubQW9jLg/input.css:1:56
   |
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5 6; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: 0.1%; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/input.css:1:12
   |
 1 | a { width: 0.1%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/3a1KXFwtncypOUCwQI7IAw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/3a1KXFwtncypOUCwQI7IAw/span.rust-debug
@@ -46,7 +46,7 @@ error: PercentValue
 1 | @keyframes name { 100% { color: red } }
   |                   ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/3a1KXFwtncypOUCwQI7IAw/input.css:1:19
   |
 1 | @keyframes name { 100% { color: red } }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/4Tjjgepnha63E4UiXXDNEA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/4Tjjgepnha63E4UiXXDNEA/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: 0.0; }
   |            ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/4Tjjgepnha63E4UiXXDNEA/input.css:1:12
   |
 1 | a { width: 0.0; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { padding: 0 1 0px 1px }
   |              ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/input.css:1:14
   |
 1 | a { padding: 0 1 0px 1px }
@@ -82,7 +82,7 @@ error: Value
 1 | a { padding: 0 1 0px 1px }
   |                ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/input.css:1:16
   |
 1 | a { padding: 0 1 0px 1px }
@@ -100,7 +100,7 @@ error: UnitValue
 1 | a { padding: 0 1 0px 1px }
   |                  ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/input.css:1:18
   |
 1 | a { padding: 0 1 0px 1px }
@@ -124,7 +124,7 @@ error: UnitValue
 1 | a { padding: 0 1 0px 1px }
   |                      ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/input.css:1:22
   |
 1 | a { padding: 0 1 0px 1px }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/span.rust-debug
@@ -76,7 +76,7 @@ error: UnitValue
 1 | a { value: 10\2cx }
   |            ^^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/input.css:1:12
   |
 1 | a { value: 10\2cx }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/5al65IRQbw_x4yG3ke74fQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/5al65IRQbw_x4yG3ke74fQ/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: +0.1; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/5al65IRQbw_x4yG3ke74fQ/input.css:1:12
   |
 1 | a { width: +0.1; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: .0%; }
   |            ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/input.css:1:12
   |
 1 | a { width: .0%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: -.00%; }
   |            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/input.css:1:12
   |
 1 | a { width: -.00%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/span.rust-debug
@@ -76,7 +76,7 @@ error: UnitValue
 1 | a { value: 10x\2c }
   |            ^^^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/input.css:1:12
   |
 1 | a { value: 10x\2c }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: +0.1%; }
   |            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/input.css:1:12
   |
 1 | a { width: +0.1%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ACQUsGVQAmGzhMqBRmS6Mw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ACQUsGVQAmGzhMqBRmS6Mw/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: .10; }
   |            ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/ACQUsGVQAmGzhMqBRmS6Mw/input.css:1:12
   |
 1 | a { width: .10; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/span.rust-debug
@@ -46,7 +46,7 @@ error: PercentValue
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
   |                   ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/input.css:1:19
   |
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
@@ -64,7 +64,7 @@ error: PercentValue
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
   |                       ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/input.css:1:23
   |
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
@@ -124,7 +124,7 @@ error: PercentValue
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
   |                                          ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/input.css:1:42
   |
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
@@ -142,7 +142,7 @@ error: PercentValue
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
   |                                               ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/input.css:1:47
   |
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/GC0pcFQY1xSlq9QsgSvEVg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/GC0pcFQY1xSlq9QsgSvEVg/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: -.0; }
   |            ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/GC0pcFQY1xSlq9QsgSvEVg/input.css:1:12
   |
 1 | a { width: -.0; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: -0.1%; }
   |            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/input.css:1:12
   |
 1 | a { width: -0.1%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/span.rust-debug
@@ -76,7 +76,7 @@ error: UnitValue
 1 | a { value: 10\32x }
   |            ^^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/input.css:1:12
   |
 1 | a { value: 10\32x }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/span.rust-debug
@@ -76,7 +76,7 @@ error: UnitValue
 1 | a { value: 10\65m }
   |            ^^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/input.css:1:12
   |
 1 | a { value: 10\65m }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/MmOsa9XFdPMS9x4ITbWSzg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/MmOsa9XFdPMS9x4ITbWSzg/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: -.00; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/MmOsa9XFdPMS9x4ITbWSzg/input.css:1:12
   |
 1 | a { width: -.00; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: +.00%; }
   |            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/input.css:1:12
   |
 1 | a { width: +.00%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/OtM9lGhbFLqI-r3dvNTUjQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/OtM9lGhbFLqI-r3dvNTUjQ/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: -.10; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/OtM9lGhbFLqI-r3dvNTUjQ/input.css:1:12
   |
 1 | a { width: -.10; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/PSncmPJMuHC-CjpwiYtkDw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/PSncmPJMuHC-CjpwiYtkDw/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { border-top-left-radius: 0 0 }
   |                             ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/PSncmPJMuHC-CjpwiYtkDw/input.css:1:29
   |
 1 | a { border-top-left-radius: 0 0 }
@@ -82,7 +82,7 @@ error: Value
 1 | a { border-top-left-radius: 0 0 }
   |                               ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/PSncmPJMuHC-CjpwiYtkDw/input.css:1:31
   |
 1 | a { border-top-left-radius: 0 0 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/span.rust-debug
@@ -88,7 +88,7 @@ error: UnitValue
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
   |                       ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/input.css:1:23
   |
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
@@ -112,7 +112,7 @@ error: UnitValue
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
   |                           ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/input.css:1:27
   |
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
@@ -136,7 +136,7 @@ error: UnitValue
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
   |                               ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/input.css:1:31
   |
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
@@ -160,7 +160,7 @@ error: UnitValue
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
   |                                   ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/input.css:1:35
   |
 1 | a { box-shadow: inset 0px 0px 0px 0px black }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/VOQJsreB5pi_yJysozWgcA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/VOQJsreB5pi_yJysozWgcA/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 2 |         @page :first { margin: 0 }
   |                                ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/VOQJsreB5pi_yJysozWgcA/input.css:2:26
   |
 2 |         @page :first { margin: 0 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Wb-aVu7CEQfCy1QL2yUrEw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Wb-aVu7CEQfCy1QL2yUrEw/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5; }
   |                    ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Wb-aVu7CEQfCy1QL2yUrEw/input.css:1:20
   |
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5; }
@@ -82,7 +82,7 @@ error: Value
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5; }
   |                      ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Wb-aVu7CEQfCy1QL2yUrEw/input.css:1:22
   |
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5; }
@@ -94,7 +94,7 @@ error: Value
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5; }
   |                        ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Wb-aVu7CEQfCy1QL2yUrEw/input.css:1:24
   |
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5; }
@@ -106,7 +106,7 @@ error: Value
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5; }
   |                          ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Wb-aVu7CEQfCy1QL2yUrEw/input.css:1:26
   |
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5; }
@@ -130,7 +130,7 @@ error: Value
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5; }
   |                                                      ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Wb-aVu7CEQfCy1QL2yUrEw/input.css:1:54
   |
 1 | a { border-radius: 1 2 3 4; border-top-right-radius: 5; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/X-yuwO0x1B-l1Js4JkKJZg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/X-yuwO0x1B-l1Js4JkKJZg/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: +0.0; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/X-yuwO0x1B-l1Js4JkKJZg/input.css:1:12
   |
 1 | a { width: +0.0; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Z4J4sVA4UnGhTMiN5tdMMQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Z4J4sVA4UnGhTMiN5tdMMQ/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { padding: 0 1 0 1 }
   |              ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Z4J4sVA4UnGhTMiN5tdMMQ/input.css:1:14
   |
 1 | a { padding: 0 1 0 1 }
@@ -82,7 +82,7 @@ error: Value
 1 | a { padding: 0 1 0 1 }
   |                ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Z4J4sVA4UnGhTMiN5tdMMQ/input.css:1:16
   |
 1 | a { padding: 0 1 0 1 }
@@ -94,7 +94,7 @@ error: Value
 1 | a { padding: 0 1 0 1 }
   |                  ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Z4J4sVA4UnGhTMiN5tdMMQ/input.css:1:18
   |
 1 | a { padding: 0 1 0 1 }
@@ -106,7 +106,7 @@ error: Value
 1 | a { padding: 0 1 0 1 }
   |                    ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/Z4J4sVA4UnGhTMiN5tdMMQ/input.css:1:20
   |
 1 | a { padding: 0 1 0 1 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/aVoVLZHijXjMsJvx4rbJGQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/aVoVLZHijXjMsJvx4rbJGQ/span.rust-debug
@@ -52,7 +52,7 @@ error: UnitValue
 1 | @viewport { width: 100vw }
   |                    ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/aVoVLZHijXjMsJvx4rbJGQ/input.css:1:20
   |
 1 | @viewport { width: 100vw }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: +.0%; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/input.css:1:12
   |
 1 | a { width: +.0%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: +0.0%; }
   |            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/input.css:1:12
   |
 1 | a { width: +0.0%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: .00%; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/input.css:1:12
   |
 1 | a { width: .00%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/egyt9Hk9xnn2Xfbi3Ckfrg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/egyt9Hk9xnn2Xfbi3Ckfrg/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: +.0; }
   |            ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/egyt9Hk9xnn2Xfbi3Ckfrg/input.css:1:12
   |
 1 | a { width: +.0; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { margin: 0 1 0px 1px }
   |             ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/input.css:1:13
   |
 1 | a { margin: 0 1 0px 1px }
@@ -82,7 +82,7 @@ error: Value
 1 | a { margin: 0 1 0px 1px }
   |               ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/input.css:1:15
   |
 1 | a { margin: 0 1 0px 1px }
@@ -100,7 +100,7 @@ error: UnitValue
 1 | a { margin: 0 1 0px 1px }
   |                 ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/input.css:1:17
   |
 1 | a { margin: 0 1 0px 1px }
@@ -124,7 +124,7 @@ error: UnitValue
 1 | a { margin: 0 1 0px 1px }
   |                     ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/input.css:1:21
   |
 1 | a { margin: 0 1 0px 1px }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/jD_IvFQVk8LtCrictrWpxw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/jD_IvFQVk8LtCrictrWpxw/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: 0.1; }
   |            ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/jD_IvFQVk8LtCrictrWpxw/input.css:1:12
   |
 1 | a { width: 0.1; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: -0.0%; }
   |            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/input.css:1:12
   |
 1 | a { width: -0.0%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/pQWwEpWgxuUS6-uSAJR0nQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/pQWwEpWgxuUS6-uSAJR0nQ/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: +.00; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/pQWwEpWgxuUS6-uSAJR0nQ/input.css:1:12
   |
 1 | a { width: +.00; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: -.0%; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/input.css:1:12
   |
 1 | a { width: -.0%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: .10%; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/input.css:1:12
   |
 1 | a { width: .10%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/span.rust-debug
@@ -76,7 +76,7 @@ error: UnitValue
 1 | a { value: 10x\, }
   |            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/input.css:1:12
   |
 1 | a { value: 10x\, }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/tJNGkqEMVKFfOWjyOm5TSg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/tJNGkqEMVKFfOWjyOm5TSg/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: -0.1; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/tJNGkqEMVKFfOWjyOm5TSg/input.css:1:12
   |
 1 | a { width: -0.1; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/span.rust-debug
@@ -46,7 +46,7 @@ error: PercentValue
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
   |                 ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/input.css:1:17
   |
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
@@ -64,7 +64,7 @@ error: PercentValue
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
   |                    ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/input.css:1:20
   |
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
@@ -124,7 +124,7 @@ error: PercentValue
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
   |                                  ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/input.css:1:34
   |
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
@@ -142,7 +142,7 @@ error: PercentValue
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
   |                                      ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/input.css:1:38
   |
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ugX8SLCLRvWN-wDCK7ouyA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ugX8SLCLRvWN-wDCK7ouyA/span.rust-debug
@@ -52,7 +52,7 @@ error: UnitValue
 1 | @-ms-viewport { width: 100vw }
   |                        ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/ugX8SLCLRvWN-wDCK7ouyA/input.css:1:24
   |
 1 | @-ms-viewport { width: 100vw }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/span.rust-debug
@@ -76,7 +76,7 @@ error: UnitValue
 1 | a { value: 10\,x }
   |            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/input.css:1:12
   |
 1 | a { value: 10\,x }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: +.10%; }
   |            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/input.css:1:12
   |
 1 | a { width: +.10%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/span.rust-debug
@@ -76,7 +76,7 @@ error: PercentValue
 1 | a { width: 0.0%; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/input.css:1:12
   |
 1 | a { width: 0.0%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/wEB80kxMinK4EZaPb3My1A/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/wEB80kxMinK4EZaPb3My1A/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: .00; }
   |            ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/wEB80kxMinK4EZaPb3My1A/input.css:1:12
   |
 1 | a { width: .00; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/wwLEw52LUKMFH3Wp5CaBAQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/wwLEw52LUKMFH3Wp5CaBAQ/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: -0.0; }
   |            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/wwLEw52LUKMFH3Wp5CaBAQ/input.css:1:12
   |
 1 | a { width: -0.0; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/yVqdwpiB7OK23Te5mXKdFw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/yVqdwpiB7OK23Te5mXKdFw/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: .0; }
   |            ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/yVqdwpiB7OK23Te5mXKdFw/input.css:1:12
   |
 1 | a { width: .0; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/span.rust-debug
@@ -76,7 +76,7 @@ error: UnitValue
 1 | a { value: 10e\32x }
   |            ^^^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/input.css:1:12
   |
 1 | a { value: 10e\32x }

--- a/crates/swc_css_parser/tests/fixture/important/basic/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/important/basic/span.rust-debug
@@ -167,7 +167,7 @@ error: UnitValue
 4 |     width: 1px!important;
   |            ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/important/basic/input.css:4:12
   |
 4 |     width: 1px!important;
@@ -347,7 +347,7 @@ error: UnitValue
 11 |     margin: 10px      !      important;
    |             ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/important/basic/input.css:11:13
    |
 11 |     margin: 10px      !      important;
@@ -383,7 +383,7 @@ error: UnitValue
 12 |     padding: 20px     !  /* test */   important;
    |              ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/important/basic/input.css:12:14
    |
 12 |     padding: 20px     !  /* test */   important;
@@ -419,7 +419,7 @@ error: UnitValue
 13 |     width: 100px ! /*! test */ important;
    |            ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/important/basic/input.css:13:12
    |
 13 |     width: 100px ! /*! test */ important;
@@ -455,7 +455,7 @@ error: UnitValue
 14 |     height: 100px /*! test */ important;
    |             ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/important/basic/input.css:14:13
    |
 14 |     height: 100px /*! test */ important;
@@ -497,7 +497,7 @@ error: Value
 15 |     z-index: 1 ""! important;
    |              ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/important/basic/input.css:15:14
    |
 15 |     z-index: 1 ""! important;
@@ -539,7 +539,7 @@ error: UnitValue
 16 |     padding: 1px/* sep */!important;
    |              ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/important/basic/input.css:16:14
    |
 16 |     padding: 1px/* sep */!important;

--- a/crates/swc_css_parser/tests/fixture/number/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/number/span.rust-debug
@@ -95,7 +95,7 @@ error: Value
 2 |     property: 10;
   |               ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/number/input.css:2:15
   |
 2 |     property: 10;
@@ -119,7 +119,7 @@ error: Value
 3 |     property: +10;
   |               ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/number/input.css:3:15
   |
 3 |     property: +10;
@@ -143,7 +143,7 @@ error: Value
 4 |     property: -10;
   |               ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/number/input.css:4:15
   |
 4 |     property: -10;
@@ -167,7 +167,7 @@ error: Value
 5 |     property: 0.1;
   |               ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/number/input.css:5:15
   |
 5 |     property: 0.1;
@@ -191,7 +191,7 @@ error: Value
 6 |     property: +0.1;
   |               ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/number/input.css:6:15
   |
 6 |     property: +0.1;
@@ -215,7 +215,7 @@ error: Value
 7 |     property: -0.1;
   |               ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/number/input.css:7:15
   |
 7 |     property: -0.1;
@@ -239,7 +239,7 @@ error: Value
 8 |     property: -.1;
   |               ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/number/input.css:8:15
   |
 8 |     property: -.1;
@@ -263,7 +263,7 @@ error: Value
 9 |     property: +.1;
   |               ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/number/input.css:9:15
   |
 9 |     property: +.1;
@@ -287,7 +287,7 @@ error: Value
 10 |     property: 0;
    |               ^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:10:15
    |
 10 |     property: 0;
@@ -311,7 +311,7 @@ error: Value
 11 |     property: 10;
    |               ^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:11:15
    |
 11 |     property: 10;
@@ -335,7 +335,7 @@ error: Value
 12 |     property: .10;
    |               ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:12:15
    |
 12 |     property: .10;
@@ -359,7 +359,7 @@ error: Value
 13 |     property: 12.34;
    |               ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:13:15
    |
 13 |     property: 12.34;
@@ -383,7 +383,7 @@ error: Value
 14 |     property: 0.1;
    |               ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:14:15
    |
 14 |     property: 0.1;
@@ -407,7 +407,7 @@ error: Value
 15 |     property: 1.0;
    |               ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:15:15
    |
 15 |     property: 1.0;
@@ -431,7 +431,7 @@ error: Value
 16 |     property: 0.0;
    |               ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:16:15
    |
 16 |     property: 0.0;
@@ -455,7 +455,7 @@ error: Value
 17 |     property: +0.0;
    |               ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:17:15
    |
 17 |     property: +0.0;
@@ -479,7 +479,7 @@ error: Value
 18 |     property: -0.0;
    |               ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:18:15
    |
 18 |     property: -0.0;
@@ -503,7 +503,7 @@ error: Value
 19 |     property: .0;
    |               ^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:19:15
    |
 19 |     property: .0;
@@ -527,7 +527,7 @@ error: Value
 20 |     property: 1.200000;
    |               ^^^^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:20:15
    |
 20 |     property: 1.200000;
@@ -551,7 +551,7 @@ error: Value
 21 |     property: 1.2e2;
    |               ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:21:15
    |
 21 |     property: 1.2e2;
@@ -575,7 +575,7 @@ error: Value
 22 |     property: 1e2;
    |               ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:22:15
    |
 22 |     property: 1e2;
@@ -599,7 +599,7 @@ error: Value
 23 |     property: .2e2;
    |               ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:23:15
    |
 23 |     property: .2e2;
@@ -623,7 +623,7 @@ error: Value
 24 |     property: 1.2E2;
    |               ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:24:15
    |
 24 |     property: 1.2E2;
@@ -647,7 +647,7 @@ error: Value
 25 |     property: 1.2e+2;
    |               ^^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:25:15
    |
 25 |     property: 1.2e+2;
@@ -671,7 +671,7 @@ error: Value
 26 |     property: 1.2e-2;
    |               ^^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:26:15
    |
 26 |     property: 1.2e-2;
@@ -695,7 +695,7 @@ error: Value
 27 |     property: -1;
    |               ^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:27:15
    |
 27 |     property: -1;
@@ -719,7 +719,7 @@ error: Value
 28 |     property: -1.2;
    |               ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:28:15
    |
 28 |     property: -1.2;
@@ -743,7 +743,7 @@ error: Value
 29 |     property: -.2;
    |               ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:29:15
    |
 29 |     property: -.2;
@@ -767,7 +767,7 @@ error: Value
 30 |     property: -.2;
    |               ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:30:15
    |
 30 |     property: -.2;
@@ -791,7 +791,7 @@ error: Value
 31 |     property: +.2;
    |               ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:31:15
    |
 31 |     property: +.2;
@@ -815,7 +815,7 @@ error: Value
 32 |     property: -1.2e3;
    |               ^^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:32:15
    |
 32 |     property: -1.2e3;
@@ -839,7 +839,7 @@ error: Value
 33 |     property: 1.75;
    |               ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:33:15
    |
 33 |     property: 1.75;
@@ -863,7 +863,7 @@ error: Value
 34 |     property: +1.75;
    |               ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:34:15
    |
 34 |     property: +1.75;
@@ -893,7 +893,7 @@ error: UnitValue
 35 |     property: 1e;
    |               ^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/number/input.css:35:15
    |
 35 |     property: 1e;

--- a/crates/swc_css_parser/tests/fixture/rome/at-page/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/at-page/span.rust-debug
@@ -179,7 +179,7 @@ error: UnitValue
 3 |     margin-left: 4cm;
   |                  ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/at-page/input.css:3:15
   |
 3 |     margin-left: 4cm;
@@ -354,7 +354,7 @@ error: UnitValue
 8 |     margin-left: 4cm;
   |                  ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/at-page/input.css:8:15
   |
 8 |     margin-left: 4cm;
@@ -517,7 +517,7 @@ error: UnitValue
 13 |     margin-left: 4cm;
    |                  ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/at-page/input.css:13:15
    |
 13 |     margin-left: 4cm;
@@ -680,7 +680,7 @@ error: UnitValue
 18 |     MARGIN-LEFT: 4cm;
    |                  ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/at-page/input.css:18:15
    |
 18 |     MARGIN-LEFT: 4cm;

--- a/crates/swc_css_parser/tests/fixture/rome/calc/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/calc/span.rust-debug
@@ -125,7 +125,7 @@ error: UnitValue
 2 |     width: calc(2px);
   |                 ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:2:14
   |
 2 |     width: calc(2px);
@@ -191,7 +191,7 @@ error: UnitValue
 3 |     width: calc(2px + 1px);
   |                 ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:3:14
   |
 3 |     width: calc(2px + 1px);
@@ -215,7 +215,7 @@ error: UnitValue
 3 |     width: calc(2px + 1px);
   |                       ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:3:20
   |
 3 |     width: calc(2px + 1px);
@@ -281,7 +281,7 @@ error: UnitValue
 4 |     width: calc(2em + 1%);
   |                 ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:4:14
   |
 4 |     width: calc(2em + 1%);
@@ -305,7 +305,7 @@ error: PercentValue
 4 |     width: calc(2em + 1%);
   |                       ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:4:20
   |
 4 |     width: calc(2em + 1%);
@@ -377,7 +377,7 @@ error: UnitValue
 5 |     width: calc(2em * 2% * 3px);
   |                 ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:5:14
   |
 5 |     width: calc(2em * 2% * 3px);
@@ -413,7 +413,7 @@ error: PercentValue
 5 |     width: calc(2em * 2% * 3px);
   |                       ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:5:20
   |
 5 |     width: calc(2em * 2% * 3px);
@@ -431,7 +431,7 @@ error: UnitValue
 5 |     width: calc(2em * 2% * 3px);
   |                            ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:5:25
   |
 5 |     width: calc(2em * 2% * 3px);
@@ -509,7 +509,7 @@ error: UnitValue
 6 |     width: calc(2em / 2 / 3);
   |                 ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:6:14
   |
 6 |     width: calc(2em / 2 / 3);
@@ -539,7 +539,7 @@ error: Value
 6 |     width: calc(2em / 2 / 3);
   |                       ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:6:20
   |
 6 |     width: calc(2em / 2 / 3);
@@ -551,7 +551,7 @@ error: Value
 6 |     width: calc(2em / 2 / 3);
   |                           ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:6:24
   |
 6 |     width: calc(2em / 2 / 3);
@@ -623,7 +623,7 @@ error: UnitValue
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
   |                 ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:7:14
   |
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
@@ -677,7 +677,7 @@ error: Value
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
   |                        ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:7:21
   |
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
@@ -689,7 +689,7 @@ error: Value
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
   |                            ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:7:25
   |
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
@@ -725,7 +725,7 @@ error: Value
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
   |                                  ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:7:31
   |
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
@@ -737,7 +737,7 @@ error: Value
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
   |                                      ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:7:35
   |
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
@@ -809,7 +809,7 @@ error: UnitValue
 8 |     width: calc(2em * 2 + 3);
   |                 ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:8:14
   |
 8 |     width: calc(2em * 2 + 3);
@@ -839,7 +839,7 @@ error: Value
 8 |     width: calc(2em * 2 + 3);
   |                       ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:8:20
   |
 8 |     width: calc(2em * 2 + 3);
@@ -851,7 +851,7 @@ error: Value
 8 |     width: calc(2em * 2 + 3);
   |                           ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:8:24
   |
 8 |     width: calc(2em * 2 + 3);
@@ -947,7 +947,7 @@ error: UnitValue
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
   |                 ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:9:14
   |
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
@@ -977,7 +977,7 @@ error: Value
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
   |                       ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:9:20
   |
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
@@ -1001,7 +1001,7 @@ error: Value
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
   |                           ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:9:24
   |
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
@@ -1031,7 +1031,7 @@ error: UnitValue
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
   |                               ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:9:28
   |
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
@@ -1049,7 +1049,7 @@ error: Value
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
   |                                     ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/calc/input.css:9:34
   |
 9 |     width: calc(2em * 2 - 3 + 3em / 5);

--- a/crates/swc_css_parser/tests/fixture/rome/fit-content/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/fit-content/span.rust-debug
@@ -109,7 +109,7 @@ error: UnitValue
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
   |                                        ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/fit-content/input.css:2:37
   |
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
@@ -151,7 +151,7 @@ error: UnitValue
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
   |                                                         ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/fit-content/input.css:2:54
   |
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
@@ -175,7 +175,7 @@ error: UnitValue
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
   |                                                              ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/fit-content/input.css:2:59
   |
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;

--- a/crates/swc_css_parser/tests/fixture/rome/functions/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/functions/span.rust-debug
@@ -215,7 +215,7 @@ error: UnitValue
 4 |     font-size: calc(10px + 5rem);
   |                     ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/functions/input.css:4:18
   |
 4 |     font-size: calc(10px + 5rem);
@@ -239,7 +239,7 @@ error: UnitValue
 4 |     font-size: calc(10px + 5rem);
   |                            ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/functions/input.css:4:25
   |
 4 |     font-size: calc(10px + 5rem);

--- a/crates/swc_css_parser/tests/fixture/rome/grid/minmax/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/minmax/span.rust-debug
@@ -121,7 +121,7 @@ error: UnitValue
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
   |                                                ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/grid/minmax/input.css:2:45
   |
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
@@ -163,7 +163,7 @@ error: UnitValue
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
   |                                                              ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/grid/minmax/input.css:2:59
   |
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
@@ -187,7 +187,7 @@ error: UnitValue
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
   |                                                                     ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/grid/minmax/input.css:2:66
   |
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/fit-content/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/fit-content/span.rust-debug
@@ -103,7 +103,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, fit-content(300px));
   |                                   ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/grid/repeat/fit-content/input.css:2:32
   |
 2 |     grid-template-columns: repeat(4, fit-content(300px));
@@ -139,7 +139,7 @@ error: UnitValue
 2 |     grid-template-columns: repeat(4, fit-content(300px));
   |                                                  ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/grid/repeat/fit-content/input.css:2:47
   |
 2 |     grid-template-columns: repeat(4, fit-content(300px));

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/flex/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/flex/span.rust-debug
@@ -103,7 +103,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, 1fr);
   |                                   ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/grid/repeat/flex/input.css:2:32
   |
 2 |     grid-template-columns: repeat(4, 1fr);
@@ -121,7 +121,7 @@ error: UnitValue
 2 |     grid-template-columns: repeat(4, 1fr);
   |                                      ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/grid/repeat/flex/input.css:2:35
   |
 2 |     grid-template-columns: repeat(4, 1fr);

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/line-name/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/line-name/span.rust-debug
@@ -103,7 +103,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, [col-start]);
   |                                   ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/grid/repeat/line-name/input.css:2:32
   |
 2 |     grid-template-columns: repeat(4, [col-start]);

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/minmax/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/minmax/span.rust-debug
@@ -103,7 +103,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, minmax(min-content, 300px));
   |                                   ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/grid/repeat/minmax/input.css:2:32
   |
 2 |     grid-template-columns: repeat(4, minmax(min-content, 300px));
@@ -151,7 +151,7 @@ error: UnitValue
 2 |     grid-template-columns: repeat(4, minmax(min-content, 300px));
   |                                                          ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/grid/repeat/minmax/input.css:2:55
   |
 2 |     grid-template-columns: repeat(4, minmax(min-content, 300px));

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/multi-values/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/multi-values/span.rust-debug
@@ -103,7 +103,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);
   |                                   ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/grid/repeat/multi-values/input.css:2:32
   |
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);

--- a/crates/swc_css_parser/tests/fixture/rome/keyframe/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/keyframe/span.rust-debug
@@ -114,7 +114,7 @@ error: UnitValue
 3 |         margin-top: 50px !important;
   |                     ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/keyframe/input.css:3:21
   |
 3 |         margin-top: 50px !important;
@@ -188,7 +188,7 @@ error: UnitValue
 6 |         margin-top: 100px !important;
   |                     ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/keyframe/input.css:6:21
   |
 6 |         margin-top: 100px !important;
@@ -331,7 +331,7 @@ error: PercentValue
 15 |     15% {
    |     ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/keyframe/input.css:15:5
    |
 15 |     15% {
@@ -372,7 +372,7 @@ error: PercentValue
 17 |     0% {
    |     ^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/keyframe/input.css:17:5
    |
 17 |     0% {
@@ -413,7 +413,7 @@ error: PercentValue
 19 |     100% {
    |     ^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/keyframe/input.css:19:5
    |
 19 |     100% {

--- a/crates/swc_css_parser/tests/fixture/rome/media/condition/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/media/condition/span.rust-debug
@@ -94,7 +94,7 @@ error: UnitValue
 1 | @media (min-width: 800px) {}
   |                    ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:1:20
   |
 1 | @media (min-width: 800px) {}
@@ -190,7 +190,7 @@ error: UnitValue
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                    ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:2:20
   |
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -256,7 +256,7 @@ error: UnitValue
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                           ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:2:43
   |
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -322,7 +322,7 @@ error: UnitValue
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                                  ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:2:66
   |
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -418,7 +418,7 @@ error: UnitValue
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                    ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:3:20
   |
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -484,7 +484,7 @@ error: UnitValue
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                           ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:3:43
   |
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -550,7 +550,7 @@ error: UnitValue
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                                  ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:3:66
   |
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -616,7 +616,7 @@ error: UnitValue
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                                                         ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:3:89
   |
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -718,7 +718,7 @@ error: UnitValue
 4 | @media not (min-width: 800px) {}
   |                        ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:4:24
   |
 4 | @media not (min-width: 800px) {}
@@ -832,7 +832,7 @@ error: UnitValue
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
   |                     ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:5:21
   |
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -898,7 +898,7 @@ error: UnitValue
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
   |                                            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:5:44
   |
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -964,7 +964,7 @@ error: UnitValue
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
   |                                                                   ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:5:67
   |
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -1060,7 +1060,7 @@ error: UnitValue
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
   |                    ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:6:20
   |
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -1144,7 +1144,7 @@ error: UnitValue
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
   |                                            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:6:44
   |
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -1210,7 +1210,7 @@ error: UnitValue
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
   |                                                                  ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:6:66
   |
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -1342,7 +1342,7 @@ error: UnitValue
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
   |                     ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:7:21
   |
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
@@ -1408,7 +1408,7 @@ error: UnitValue
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
   |                                            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:7:44
   |
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
@@ -1474,7 +1474,7 @@ error: UnitValue
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
   |                                                                   ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/condition/input.css:7:67
   |
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
@@ -1708,7 +1708,7 @@ error: UnitValue
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
    |                    ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/media/condition/input.css:15:20
    |
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
@@ -1792,7 +1792,7 @@ error: UnitValue
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
    |                                            ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/media/condition/input.css:15:44
    |
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
@@ -1858,7 +1858,7 @@ error: UnitValue
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
    |                                                                  ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/media/condition/input.css:15:66
    |
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {

--- a/crates/swc_css_parser/tests/fixture/rome/media/feature/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/media/feature/span.rust-debug
@@ -268,7 +268,7 @@ error: UnitValue
 3 | @media only screen and (min-width: 800px) {}
   |                                    ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/feature/input.css:3:36
   |
 3 | @media only screen and (min-width: 800px) {}
@@ -370,7 +370,7 @@ error: UnitValue
 4 | @media screen and (min-width       :          800px        ) {}
   |                                               ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/feature/input.css:4:47
   |
 4 | @media screen and (min-width       :          800px        ) {}
@@ -472,7 +472,7 @@ error: UnitValue
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                               ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/feature/input.css:5:31
   |
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -538,7 +538,7 @@ error: UnitValue
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                      ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/feature/input.css:5:54
   |
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -604,7 +604,7 @@ error: UnitValue
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                                             ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/feature/input.css:5:77
   |
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -706,7 +706,7 @@ error: UnitValue
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
   |                               ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/feature/input.css:6:31
   |
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
@@ -772,7 +772,7 @@ error: UnitValue
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
   |                                                      ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/feature/input.css:6:54
   |
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
@@ -838,7 +838,7 @@ error: UnitValue
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
   |                                                                             ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/feature/input.css:6:77
   |
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
@@ -904,7 +904,7 @@ error: UnitValue
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
   |                                                                                                    ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/feature/input.css:6:100
   |
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}

--- a/crates/swc_css_parser/tests/fixture/rome/media/ratio/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/media/ratio/output.json
@@ -56,13 +56,12 @@
                     "raw": "aspect-ratio"
                   },
                   "value": {
-                    "type": "BinValue",
+                    "type": "Ratio",
                     "span": {
                       "start": 22,
                       "end": 26,
                       "ctxt": 0
                     },
-                    "op": "/",
                     "left": {
                       "type": "Number",
                       "span": {

--- a/crates/swc_css_parser/tests/fixture/rome/media/ratio/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/media/ratio/span.rust-debug
@@ -82,31 +82,19 @@ error: MediaFeatureValue
 1 | @media (aspect-ratio: 12/9) {}
   |                       ^^^^
 
-error: BinValue
+error: Ratio
  --> $DIR/tests/fixture/rome/media/ratio/input.css:1:23
   |
 1 | @media (aspect-ratio: 12/9) {}
   |                       ^^^^
 
-error: Value
+error: Number
  --> $DIR/tests/fixture/rome/media/ratio/input.css:1:23
   |
 1 | @media (aspect-ratio: 12/9) {}
   |                       ^^
 
-error: Num
- --> $DIR/tests/fixture/rome/media/ratio/input.css:1:23
-  |
-1 | @media (aspect-ratio: 12/9) {}
-  |                       ^^
-
-error: Value
- --> $DIR/tests/fixture/rome/media/ratio/input.css:1:26
-  |
-1 | @media (aspect-ratio: 12/9) {}
-  |                          ^
-
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/media/ratio/input.css:1:26
   |
 1 | @media (aspect-ratio: 12/9) {}

--- a/crates/swc_css_parser/tests/fixture/rome/min-and-max/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/min-and-max/span.rust-debug
@@ -125,7 +125,7 @@ error: UnitValue
 2 |     width: max(500px);
   |                ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:2:13
   |
 2 |     width: max(500px);
@@ -179,7 +179,7 @@ error: UnitValue
 3 |     width: max(500px, 6 / 4);
   |                ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:3:13
   |
 3 |     width: max(500px, 6 / 4);
@@ -209,7 +209,7 @@ error: Value
 3 |     width: max(500px, 6 / 4);
   |                       ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:3:20
   |
 3 |     width: max(500px, 6 / 4);
@@ -221,7 +221,7 @@ error: Value
 3 |     width: max(500px, 6 / 4);
   |                           ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:3:24
   |
 3 |     width: max(500px, 6 / 4);
@@ -269,7 +269,7 @@ error: UnitValue
 4 |     width: max(500px, 40px + 5%);
   |                ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:4:13
   |
 4 |     width: max(500px, 40px + 5%);
@@ -305,7 +305,7 @@ error: UnitValue
 4 |     width: max(500px, 40px + 5%);
   |                       ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:4:20
   |
 4 |     width: max(500px, 40px + 5%);
@@ -329,7 +329,7 @@ error: PercentValue
 4 |     width: max(500px, 40px + 5%);
   |                              ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:4:27
   |
 4 |     width: max(500px, 40px + 5%);
@@ -377,7 +377,7 @@ error: UnitValue
 5 |     width: max(500px, 5% * 400px + 2px);
   |                ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:5:13
   |
 5 |     width: max(500px, 5% * 400px + 2px);
@@ -425,7 +425,7 @@ error: PercentValue
 5 |     width: max(500px, 5% * 400px + 2px);
   |                       ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:5:20
   |
 5 |     width: max(500px, 5% * 400px + 2px);
@@ -455,7 +455,7 @@ error: UnitValue
 5 |     width: max(500px, 5% * 400px + 2px);
   |                            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:5:25
   |
 5 |     width: max(500px, 5% * 400px + 2px);
@@ -479,7 +479,7 @@ error: UnitValue
 5 |     width: max(500px, 5% * 400px + 2px);
   |                                    ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:5:33
   |
 5 |     width: max(500px, 5% * 400px + 2px);
@@ -533,7 +533,7 @@ error: UnitValue
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:13
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -581,7 +581,7 @@ error: PercentValue
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                       ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:20
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -611,7 +611,7 @@ error: UnitValue
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                            ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:25
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -635,7 +635,7 @@ error: UnitValue
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                    ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:33
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -683,7 +683,7 @@ error: PercentValue
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                         ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:38
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -713,7 +713,7 @@ error: UnitValue
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                              ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:43
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -737,7 +737,7 @@ error: UnitValue
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                                      ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:51
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -785,7 +785,7 @@ error: PercentValue
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                                           ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:56
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -815,7 +815,7 @@ error: UnitValue
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                                                ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:61
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -839,7 +839,7 @@ error: UnitValue
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                                                        ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:69
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -893,7 +893,7 @@ error: UnitValue
 7 |     width: min(500px);
   |                ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:7:13
   |
 7 |     width: min(500px);
@@ -947,7 +947,7 @@ error: UnitValue
 8 |     width: min(500px, 6 / 4);
   |                ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:8:13
   |
 8 |     width: min(500px, 6 / 4);
@@ -977,7 +977,7 @@ error: Value
 8 |     width: min(500px, 6 / 4);
   |                       ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:8:20
   |
 8 |     width: min(500px, 6 / 4);
@@ -989,7 +989,7 @@ error: Value
 8 |     width: min(500px, 6 / 4);
   |                           ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:8:24
   |
 8 |     width: min(500px, 6 / 4);
@@ -1037,7 +1037,7 @@ error: UnitValue
 9 |     width: min(500px, 40px + 5%);
   |                ^^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:9:13
   |
 9 |     width: min(500px, 40px + 5%);
@@ -1073,7 +1073,7 @@ error: UnitValue
 9 |     width: min(500px, 40px + 5%);
   |                       ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:9:20
   |
 9 |     width: min(500px, 40px + 5%);
@@ -1097,7 +1097,7 @@ error: PercentValue
 9 |     width: min(500px, 40px + 5%);
   |                              ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/min-and-max/input.css:9:27
   |
 9 |     width: min(500px, 40px + 5%);
@@ -1145,7 +1145,7 @@ error: UnitValue
 10 |     width: min(500px, 5% * 400px + 2px);
    |                ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:10:13
    |
 10 |     width: min(500px, 5% * 400px + 2px);
@@ -1193,7 +1193,7 @@ error: PercentValue
 10 |     width: min(500px, 5% * 400px + 2px);
    |                       ^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:10:20
    |
 10 |     width: min(500px, 5% * 400px + 2px);
@@ -1223,7 +1223,7 @@ error: UnitValue
 10 |     width: min(500px, 5% * 400px + 2px);
    |                            ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:10:25
    |
 10 |     width: min(500px, 5% * 400px + 2px);
@@ -1247,7 +1247,7 @@ error: UnitValue
 10 |     width: min(500px, 5% * 400px + 2px);
    |                                    ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:10:33
    |
 10 |     width: min(500px, 5% * 400px + 2px);
@@ -1301,7 +1301,7 @@ error: UnitValue
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:13
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1349,7 +1349,7 @@ error: PercentValue
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                       ^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:20
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1379,7 +1379,7 @@ error: UnitValue
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                            ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:25
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1403,7 +1403,7 @@ error: UnitValue
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                    ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:33
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1451,7 +1451,7 @@ error: PercentValue
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                         ^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:38
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1481,7 +1481,7 @@ error: UnitValue
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:43
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1505,7 +1505,7 @@ error: UnitValue
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                                      ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:51
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1553,7 +1553,7 @@ error: PercentValue
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                                           ^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:56
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1583,7 +1583,7 @@ error: UnitValue
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                                                ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:61
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1607,7 +1607,7 @@ error: UnitValue
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                                                        ^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:69
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);

--- a/crates/swc_css_parser/tests/fixture/rome/smoke/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/smoke/span.rust-debug
@@ -147,7 +147,7 @@ error: UnitValue
 4 |     width: calc(1px + 2%);
   |                 ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/smoke/input.css:4:17
   |
 4 |     width: calc(1px + 2%);
@@ -171,7 +171,7 @@ error: PercentValue
 4 |     width: calc(1px + 2%);
   |                       ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/smoke/input.css:4:23
   |
 4 |     width: calc(1px + 2%);

--- a/crates/swc_css_parser/tests/fixture/rome/supports/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/supports/span.rust-debug
@@ -158,7 +158,7 @@ error: Value
 4 | @supports ( box-shadow: 0 0 2px black inset ) or
   |                         ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/supports/input.css:4:25
   |
 4 | @supports ( box-shadow: 0 0 2px black inset ) or
@@ -170,7 +170,7 @@ error: Value
 4 | @supports ( box-shadow: 0 0 2px black inset ) or
   |                           ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/supports/input.css:4:27
   |
 4 | @supports ( box-shadow: 0 0 2px black inset ) or
@@ -188,7 +188,7 @@ error: UnitValue
 4 | @supports ( box-shadow: 0 0 2px black inset ) or
   |                             ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/supports/input.css:4:29
   |
 4 | @supports ( box-shadow: 0 0 2px black inset ) or
@@ -270,7 +270,7 @@ error: Value
 5 |           ( -moz-box-shadow: 0 0 2px black inset ) or
   |                              ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/supports/input.css:5:30
   |
 5 |           ( -moz-box-shadow: 0 0 2px black inset ) or
@@ -282,7 +282,7 @@ error: Value
 5 |           ( -moz-box-shadow: 0 0 2px black inset ) or
   |                                ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/supports/input.css:5:32
   |
 5 |           ( -moz-box-shadow: 0 0 2px black inset ) or
@@ -300,7 +300,7 @@ error: UnitValue
 5 |           ( -moz-box-shadow: 0 0 2px black inset ) or
   |                                  ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/supports/input.css:5:34
   |
 5 |           ( -moz-box-shadow: 0 0 2px black inset ) or
@@ -382,7 +382,7 @@ error: Value
 6 |           ( -webkit-box-shadow: 0 0 2px black inset ) or
   |                                 ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/supports/input.css:6:33
   |
 6 |           ( -webkit-box-shadow: 0 0 2px black inset ) or
@@ -394,7 +394,7 @@ error: Value
 6 |           ( -webkit-box-shadow: 0 0 2px black inset ) or
   |                                   ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/supports/input.css:6:35
   |
 6 |           ( -webkit-box-shadow: 0 0 2px black inset ) or
@@ -412,7 +412,7 @@ error: UnitValue
 6 |           ( -webkit-box-shadow: 0 0 2px black inset ) or
   |                                     ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/supports/input.css:6:37
   |
 6 |           ( -webkit-box-shadow: 0 0 2px black inset ) or
@@ -494,7 +494,7 @@ error: Value
 7 |           ( -o-box-shadow: 0 0 2px black inset ) {}
   |                            ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/supports/input.css:7:28
   |
 7 |           ( -o-box-shadow: 0 0 2px black inset ) {}
@@ -506,7 +506,7 @@ error: Value
 7 |           ( -o-box-shadow: 0 0 2px black inset ) {}
   |                              ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/supports/input.css:7:30
   |
 7 |           ( -o-box-shadow: 0 0 2px black inset ) {}
@@ -524,7 +524,7 @@ error: UnitValue
 7 |           ( -o-box-shadow: 0 0 2px black inset ) {}
   |                                ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/supports/input.css:7:32
   |
 7 |           ( -o-box-shadow: 0 0 2px black inset ) {}
@@ -781,7 +781,7 @@ error: UnitValue
 12 |           (transform: rotate(10deg)) {}
    |                              ^^^^^
 
-error: Num
+error: Number
   --> $DIR/tests/fixture/rome/supports/input.css:12:30
    |
 12 |           (transform: rotate(10deg)) {}

--- a/crates/swc_css_parser/tests/fixture/rome/values/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/values/span.rust-debug
@@ -195,7 +195,7 @@ error: Value
 6 |     opacity: 1e-3;
   |              ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/values/input.css:6:11
   |
 6 |     opacity: 1e-3;
@@ -219,7 +219,7 @@ error: Value
 7 |     line-height: 0.2;
   |                  ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/values/input.css:7:15
   |
 7 |     line-height: 0.2;
@@ -249,7 +249,7 @@ error: PercentValue
 8 |     width: 20%;
   |            ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/values/input.css:8:9
   |
 8 |     width: 20%;
@@ -279,7 +279,7 @@ error: PercentValue
 9 |     margin-top: -5%;
   |                 ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/rome/values/input.css:9:14
   |
 9 |     margin-top: -5%;

--- a/crates/swc_css_parser/tests/fixture/stylis/comma/01/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/stylis/comma/01/span.rust-debug
@@ -133,7 +133,7 @@ error: UnitValue
 2 |     cursor: image-set(url(foo.jpg) 2x), pointer;
   |                                    ^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/stylis/comma/01/input.css:2:36
   |
 2 |     cursor: image-set(url(foo.jpg) 2x), pointer;

--- a/crates/swc_css_parser/tests/fixture/value/square-brackets/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/square-brackets/span.rust-debug
@@ -257,7 +257,7 @@ error: UnitValue
 6 |     prop:  [red #fff 12px];
   |                      ^^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/value/square-brackets/input.css:6:22
   |
 6 |     prop:  [red #fff 12px];
@@ -317,7 +317,7 @@ error: PercentValue
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
   |                        ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/value/square-brackets/input.css:7:24
   |
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
@@ -371,7 +371,7 @@ error: PercentValue
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
   |                                                  ^^^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/value/square-brackets/input.css:7:50
   |
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];

--- a/crates/swc_css_parser/tests/fixture/vercel/001/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/vercel/001/span.rust-debug
@@ -97,7 +97,7 @@ error: Value
 2 |     margin-right: 0;
   |                   ^
 
-error: Num
+error: Number
  --> $DIR/tests/fixture/vercel/001/input.css:2:19
   |
 2 |     margin-right: 0;

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -45,7 +45,7 @@ define!({
         pub raw: JsWord,
     }
 
-    pub struct Num {
+    pub struct Number {
         pub span: Span,
         pub value: f64,
         pub raw: JsWord,
@@ -86,9 +86,11 @@ define!({
 
         Unit(UnitValue),
 
-        Number(Num),
+        Number(Number),
 
         Percent(PercentValue),
+
+        Ratio(Ratio),
 
         Hash(HashValue),
 
@@ -145,13 +147,19 @@ define!({
 
     pub struct UnitValue {
         pub span: Span,
-        pub value: Num,
+        pub value: Number,
         pub unit: Unit,
     }
 
     pub struct PercentValue {
         pub span: Span,
-        pub value: Num,
+        pub value: Number,
+    }
+
+    pub struct Ratio {
+        pub span: Span,
+        pub left: Number,
+        pub right: Option<Number>,
     }
 
     pub struct AtTextValue {
@@ -506,10 +514,10 @@ define!({
     }
 
     pub enum MediaFeatureValue {
-        Number(Num),
+        Number(Number),
         Dimension(UnitValue),
         Ident(Ident),
-        Ratio(BinValue),
+        Ratio(Ratio),
     }
 
     pub struct MediaFeaturePlain {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Refactor:
- move duplicate logic inside `Parse<T>` for values
- Rename `Num` to `Number` to be align with CSS types in spec - https://www.w3.org/TR/css-values-4/#numbers
- Implement `Ratio` type https://www.w3.org/TR/css-values-4/#ratios 

**BREAKING CHANGE:**

Yes, due rename and new Ratio type

**Related issue (if exists):**

No