### PR TITLE
Refactor block

### DIFF
--- a/crates/swc_css_ast/src/style_rule.rs
+++ b/crates/swc_css_ast/src/style_rule.rs
@@ -32,3 +32,10 @@ pub struct Declaration {
     /// The span includes `!`
     pub important: Option<Span>,
 }
+
+#[ast_node("SimpleBlock")]
+pub struct SimpleBlock {
+    pub span: Span,
+    pub name: char,
+    pub value: Vec<Value>,
+}

--- a/crates/swc_css_ast/src/style_rule.rs
+++ b/crates/swc_css_ast/src/style_rule.rs
@@ -1,6 +1,15 @@
 use crate::{AtRule, Ident, SelectorList, Tokens, Value};
 use swc_common::{ast_node, Span};
 
+#[ast_node("SimpleBlock")]
+pub struct SimpleBlock {
+    pub span: Span,
+    // TODO Create a simple block with its associated token set to the current input token and with
+    // its value initially set to an empty list.
+    pub name: char,
+    pub value: Vec<Value>,
+}
+
 #[ast_node("QualifiedRule")]
 pub struct QualifiedRule {
     pub span: Span,
@@ -31,11 +40,4 @@ pub struct Declaration {
     pub value: Vec<Value>,
     /// The span includes `!`
     pub important: Option<Span>,
-}
-
-#[ast_node("SimpleBlock")]
-pub struct SimpleBlock {
-    pub span: Span,
-    pub name: char,
-    pub value: Vec<Value>,
 }

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -38,11 +38,8 @@ pub enum Value {
     #[tag("CommaValues")]
     Comma(CommaValues),
 
-    #[tag("BraceValue")]
-    Brace(BraceValue),
-
     #[tag("Tokens")]
-    Lazy(Tokens),
+    Tokens(Tokens),
 
     #[tag("AtTextValue")]
     AtText(AtTextValue),
@@ -128,19 +125,12 @@ pub enum BinOp {
     Div,
 }
 
-/// Values starting with `{` and ending with `}`.
-#[ast_node("BraceValue")]
-pub struct BraceValue {
-    pub span: Span,
-    pub value: Box<Value>,
-}
-
 #[ast_node("AtTextValue")]
 pub struct AtTextValue {
     pub span: Span,
     /// Includes `@`.
     pub name: Ident,
-    pub block: Option<BraceValue>,
+    pub block: Option<SimpleBlock>,
 }
 
 #[ast_node("UrlValue")]

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -8,9 +8,6 @@ pub enum Value {
     #[tag("SimpleBlock")]
     SimpleBlock(SimpleBlock),
 
-    #[tag("RoundBracketBlock")]
-    RoundBracketBlock(RoundBracketBlock),
-
     #[tag("UnitValue")]
     Unit(UnitValue),
 
@@ -87,13 +84,6 @@ pub struct Function {
     pub span: Span,
     pub name: Ident,
     pub value: Vec<Value>,
-}
-
-#[ast_node("RoundBracketBlock")]
-pub struct RoundBracketBlock {
-    /// Includes `(` and `)`.
-    pub span: Span,
-    pub children: Option<Vec<Value>>,
 }
 
 #[ast_node("HashValue")]

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -1,4 +1,4 @@
-use crate::{Ident, Num, Str, Tokens};
+use crate::{Ident, Num, SimpleBlock, Str, Tokens};
 use string_enum::StringEnum;
 use swc_atoms::JsWord;
 use swc_common::{ast_node, EqIgnoreSpan, Span};
@@ -148,11 +148,4 @@ pub struct UrlValue {
     pub span: Span,
     pub url: JsWord,
     pub raw: JsWord,
-}
-
-#[ast_node("SimpleBlock")]
-pub struct SimpleBlock {
-    pub span: Span,
-    pub name: char,
-    pub value: Vec<Value>,
 }

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -8,9 +8,6 @@ pub enum Value {
     #[tag("SimpleBlock")]
     SimpleBlock(SimpleBlock),
 
-    #[tag("SquareBracketBlock")]
-    SquareBracketBlock(SquareBracketBlock),
-
     #[tag("RoundBracketBlock")]
     RoundBracketBlock(RoundBracketBlock),
 
@@ -95,13 +92,6 @@ pub struct Function {
 #[ast_node("RoundBracketBlock")]
 pub struct RoundBracketBlock {
     /// Includes `(` and `)`.
-    pub span: Span,
-    pub children: Option<Vec<Value>>,
-}
-
-#[ast_node("SquareBracketBlock")]
-pub struct SquareBracketBlock {
-    /// Includes `[` and `]`.
     pub span: Span,
     pub children: Option<Vec<Value>>,
 }

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -567,7 +567,6 @@ where
         match n {
             Value::Function(n) => emit!(self, n),
             Value::SimpleBlock(n) => emit!(self, n),
-            Value::RoundBracketBlock(n) => emit!(self, n),
             Value::Unit(n) => emit!(self, n),
             Value::Number(n) => emit!(self, n),
             Value::Percent(n) => emit!(self, n),
@@ -615,7 +614,14 @@ where
         };
 
         self.wr.write_raw_char(None, n.name)?;
-        self.emit_list(&n.value, ListFormat::NotDelimited)?;
+        self.emit_list(
+            &n.value,
+            if ending == ']' {
+                ListFormat::SpaceDelimited
+            } else {
+                ListFormat::NotDelimited
+            },
+        )?;
         self.wr.write_raw_char(None, ending)?;
     }
 
@@ -749,17 +755,6 @@ where
         punct!(self, n.op.as_str());
         space!(self);
         emit!(self, n.right);
-    }
-
-    #[emitter]
-    fn emit_round_bracket_block(&mut self, n: &RoundBracketBlock) -> Result {
-        punct!(self, "(");
-
-        if let Some(values) = &n.children {
-            self.emit_list(values, ListFormat::CommaDelimited)?;
-        }
-
-        punct!(self, ")");
     }
 
     #[emitter]

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -567,7 +567,6 @@ where
         match n {
             Value::Function(n) => emit!(self, n),
             Value::SimpleBlock(n) => emit!(self, n),
-            Value::SquareBracketBlock(n) => emit!(self, n),
             Value::RoundBracketBlock(n) => emit!(self, n),
             Value::Unit(n) => emit!(self, n),
             Value::Number(n) => emit!(self, n),
@@ -750,17 +749,6 @@ where
         punct!(self, n.op.as_str());
         space!(self);
         emit!(self, n.right);
-    }
-
-    #[emitter]
-    fn emit_square_bracket_block(&mut self, n: &SquareBracketBlock) -> Result {
-        punct!(self, "[");
-
-        if let Some(values) = &n.children {
-            self.emit_list(values, ListFormat::SpaceDelimited)?;
-        }
-
-        punct!(self, "]");
     }
 
     #[emitter]

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -574,9 +574,8 @@ where
             Value::Ident(n) => emit!(self, n),
             Value::Str(n) => emit!(self, n),
             Value::Bin(n) => emit!(self, n),
-            Value::Brace(n) => emit!(self, n),
             Value::Space(n) => emit!(self, n),
-            Value::Lazy(n) => emit!(self, n),
+            Value::Tokens(n) => emit!(self, n),
             Value::AtText(n) => emit!(self, n),
             Value::Url(n) => emit!(self, n),
             Value::Comma(n) => emit!(self, n),
@@ -765,13 +764,6 @@ where
     #[emitter]
     fn emit_space_values(&mut self, n: &SpaceValues) -> Result {
         self.emit_list(&n.values, ListFormat::SpaceDelimited)?;
-    }
-
-    #[emitter]
-    fn emit_brace_value(&mut self, n: &BraceValue) -> Result {
-        punct!(self, "{");
-        emit!(self, n.value);
-        punct!(self, "}");
     }
 
     #[emitter]

--- a/crates/swc_css_parser/src/parser/style_rule.rs
+++ b/crates/swc_css_parser/src/parser/style_rule.rs
@@ -219,7 +219,7 @@ where
         if !is!(self, EOF) {
             match &*property.value {
                 str if str.starts_with("--") => {
-                    let tokens = Value::Lazy(self.parse_declaration_value()?);
+                    let tokens = Value::Tokens(self.parse_declaration_value()?);
 
                     value.push(tokens);
                 }

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -508,7 +508,7 @@ where
         Ok(args)
     }
 
-    fn parse_square_brackets_value(&mut self) -> PResult<SquareBracketBlock> {
+    fn parse_square_brackets_value(&mut self) -> PResult<SimpleBlock> {
         let span = self.input.cur_span()?;
 
         expect!(self, "[");
@@ -520,15 +520,16 @@ where
             ..self.ctx
         };
 
-        let children = Some(self.with_ctx(ctx).parse_property_values()?.0);
+        let value = self.with_ctx(ctx).parse_property_values()?.0;
 
         self.input.skip_ws()?;
 
         expect!(self, "]");
 
-        Ok(SquareBracketBlock {
+        Ok(SimpleBlock {
             span: span!(self, span.lo),
-            children,
+            name: '[',
+            value,
         })
     }
 

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -533,29 +533,30 @@ where
         })
     }
 
-    fn parse_round_brackets_value(&mut self) -> PResult<RoundBracketBlock> {
+    fn parse_round_brackets_value(&mut self) -> PResult<SimpleBlock> {
         let span = self.input.cur_span()?;
 
         expect!(self, "(");
 
         self.input.skip_ws()?;
 
-        let children = if is!(self, ")") {
-            None
+        let value = if is!(self, ")") {
+            vec![]
         } else {
             let ctx = Ctx {
                 allow_operation_in_value: true,
                 ..self.ctx
             };
 
-            Some(self.with_ctx(ctx).parse_property_values()?.0)
+            self.with_ctx(ctx).parse_property_values()?.0
         };
 
         expect!(self, ")");
 
-        Ok(RoundBracketBlock {
+        Ok(SimpleBlock {
             span: span!(self, span.lo),
-            children,
+            name: '(',
+            value,
         })
     }
 

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -57,7 +57,7 @@ where
                     }
 
                     let span = span!(self, start_pos);
-                    let v = Value::Lazy(Tokens { span, tokens });
+                    let v = Value::Tokens(Tokens { span, tokens });
 
                     self.errors
                         .push(Error::new(span, ErrorKind::InvalidDeclarationValue));
@@ -338,7 +338,7 @@ where
 
         if is_one_of!(self, "<!--", "-->", "!", ";") {
             let token = self.input.bump()?.unwrap();
-            return Ok(Value::Lazy(Tokens {
+            return Ok(Value::Tokens(Tokens {
                 span,
                 tokens: vec![token],
             }));
@@ -397,7 +397,7 @@ where
         Ok(base)
     }
 
-    fn parse_brace_value(&mut self) -> PResult<BraceValue> {
+    fn parse_brace_value(&mut self) -> PResult<SimpleBlock> {
         let span = self.input.cur_span()?;
 
         expect!(self, "{");
@@ -427,12 +427,14 @@ where
         let brace_span = span!(self, brace_start);
         expect!(self, "}");
 
-        Ok(BraceValue {
+        Ok(SimpleBlock {
             span: span!(self, span.lo),
-            value: Box::new(Value::Lazy(Tokens {
+            name: '{',
+            // TODO refactor me
+            value: vec![Value::Tokens(Tokens {
                 span: brace_span,
                 tokens,
-            })),
+            })],
         })
     }
 
@@ -607,7 +609,7 @@ where
                     let span = self.input.cur_span()?;
                     let token = self.input.bump()?.unwrap();
 
-                    simple_block.value.push(Value::Lazy(Tokens {
+                    simple_block.value.push(Value::Tokens(Tokens {
                         span: span!(self, span.lo),
                         tokens: vec![token],
                     }));
@@ -627,7 +629,7 @@ where
                 let token = self.input.bump()?;
 
                 match token {
-                    Some(t) => Ok(Value::Lazy(Tokens {
+                    Some(t) => Ok(Value::Tokens(Tokens {
                         span: span!(self, span.lo),
                         tokens: vec![t],
                     })),

--- a/crates/swc_css_parser/tests/fixture.rs
+++ b/crates/swc_css_parser/tests/fixture.rs
@@ -292,7 +292,7 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(CompoundSelector, visit_compound_selector);
     mtd!(Block, visit_block);
     mtd!(RoundBracketBlock, visit_round_bracket_block);
-    mtd!(SquareBracketBlock, visit_square_bracket_block);
+    mtd!(SimpleBlock, visit_simple_block);
     mtd!(Function, visit_function);
     mtd!(HashValue, visit_hash_value);
     mtd!(NestingSelector, visit_nesting_selector);

--- a/crates/swc_css_parser/tests/fixture.rs
+++ b/crates/swc_css_parser/tests/fixture.rs
@@ -284,7 +284,6 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(AtTextValue, visit_at_text_value);
     mtd!(AttrSelector, visit_attr_selector);
     mtd!(BinValue, visit_bin_value);
-    mtd!(BraceValue, visit_brace_value);
     mtd!(ClassSelector, visit_class_selector);
     mtd!(SpaceValues, visit_space_values);
     mtd!(ComplexSelector, visit_complex_selector);

--- a/crates/swc_css_parser/tests/fixture.rs
+++ b/crates/swc_css_parser/tests/fixture.rs
@@ -291,7 +291,6 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(Combinator, visit_combinator);
     mtd!(CompoundSelector, visit_compound_selector);
     mtd!(Block, visit_block);
-    mtd!(RoundBracketBlock, visit_round_bracket_block);
     mtd!(SimpleBlock, visit_simple_block);
     mtd!(Function, visit_function);
     mtd!(HashValue, visit_hash_value);

--- a/crates/swc_css_parser/tests/fixture/at-rule/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/unknown/span.rust-debug
@@ -430,6 +430,12 @@ error: WhiteSpace { value: Atom(' ' type=inline) }
 10 | @unknown {}
    |         ^
 
+error: SimpleBlock
+  --> $DIR/tests/fixture/at-rule/unknown/input.css:10:10
+   |
+10 | @unknown {}
+   |          ^^
+
 error: Rule
   --> $DIR/tests/fixture/at-rule/unknown/input.css:11:1
    |
@@ -471,6 +477,12 @@ error: WhiteSpace { value: Atom(' ' type=inline) }
    |
 11 | @\unknown {}
    |          ^
+
+error: SimpleBlock
+  --> $DIR/tests/fixture/at-rule/unknown/input.css:11:11
+   |
+11 | @\unknown {}
+   |           ^^
 
 error: Rule
   --> $DIR/tests/fixture/at-rule/unknown/input.css:12:1
@@ -586,6 +598,12 @@ error: WhiteSpace { value: Atom(' ' type=inline) }
 12 | @unknown a b {}
    |             ^
 
+error: SimpleBlock
+  --> $DIR/tests/fixture/at-rule/unknown/input.css:12:14
+   |
+12 | @unknown a b {}
+   |              ^^
+
 error: Rule
   --> $DIR/tests/fixture/at-rule/unknown/input.css:13:1
    |
@@ -627,6 +645,12 @@ error: WhiteSpace { value: Atom(' ' type=inline) }
    |
 13 | @unknown {p:v}
    |         ^
+
+error: SimpleBlock
+  --> $DIR/tests/fixture/at-rule/unknown/input.css:13:10
+   |
+13 | @unknown {p:v}
+   |          ^^^^^
 
 error: Value
   --> $DIR/tests/fixture/at-rule/unknown/input.css:13:11
@@ -796,6 +820,12 @@ error: WhiteSpace { value: Atom(' ' type=inline) }
 14 | @unknown x y {p:v}
    |             ^
 
+error: SimpleBlock
+  --> $DIR/tests/fixture/at-rule/unknown/input.css:14:14
+   |
+14 | @unknown x y {p:v}
+   |              ^^^^^
+
 error: Value
   --> $DIR/tests/fixture/at-rule/unknown/input.css:14:15
    |
@@ -873,6 +903,12 @@ error: Ident
    |
 17 | @unknown/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}
    | ^^^^^^^^
+
+error: SimpleBlock
+  --> $DIR/tests/fixture/at-rule/unknown/input.css:17:17
+   |
+17 | @unknown/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Value
   --> $DIR/tests/fixture/at-rule/unknown/input.css:17:26
@@ -969,6 +1005,12 @@ error: WhiteSpace { value: Atom('  ' type=inline) }
    |
 20 | @unknown  {  p  :  v  }
    |         ^^
+
+error: SimpleBlock
+  --> $DIR/tests/fixture/at-rule/unknown/input.css:20:11
+   |
+20 | @unknown  {  p  :  v  }
+   |           ^^^^^^^^^^^^^
 
 error: Value
   --> $DIR/tests/fixture/at-rule/unknown/input.css:20:12
@@ -1210,6 +1252,12 @@ error: WhiteSpace { value: Atom('  ' type=inline) }
 21 | @unknown  x  y  {  p  :  v  }
    |               ^^
 
+error: SimpleBlock
+  --> $DIR/tests/fixture/at-rule/unknown/input.css:21:17
+   |
+21 | @unknown  x  y  {  p  :  v  }
+   |                 ^^^^^^^^^^^^^
+
 error: Value
   --> $DIR/tests/fixture/at-rule/unknown/input.css:21:18
    |
@@ -1377,6 +1425,12 @@ error: WhiteSpace { value: Atom(' ' type=inline) }
    |
 24 | @unknown {s{p:v}}
    |         ^
+
+error: SimpleBlock
+  --> $DIR/tests/fixture/at-rule/unknown/input.css:24:10
+   |
+24 | @unknown {s{p:v}}
+   |          ^^^^^^^
 
 error: Value
   --> $DIR/tests/fixture/at-rule/unknown/input.css:24:11

--- a/crates/swc_css_parser/tests/fixture/declaration/output.json
+++ b/crates/swc_css_parser/tests/fixture/declaration/output.json
@@ -213,13 +213,14 @@
             },
             "value": [
               {
-                "type": "SquareBracketBlock",
+                "type": "SimpleBlock",
                 "span": {
                   "start": 71,
                   "end": 78,
                   "ctxt": 0
                 },
-                "children": [
+                "name": "[",
+                "value": [
                   {
                     "type": "Identifier",
                     "span": {

--- a/crates/swc_css_parser/tests/fixture/declaration/output.json
+++ b/crates/swc_css_parser/tests/fixture/declaration/output.json
@@ -162,35 +162,38 @@
             },
             "value": [
               {
-                "type": "BraceValue",
+                "type": "SimpleBlock",
                 "span": {
                   "start": 52,
                   "end": 59,
                   "ctxt": 0
                 },
-                "value": {
-                  "type": "Tokens",
-                  "span": {
-                    "start": 53,
-                    "end": 58,
-                    "ctxt": 0
-                  },
-                  "tokens": [
-                    {
-                      "span": {
-                        "start": 53,
-                        "end": 58,
-                        "ctxt": 0
-                      },
-                      "token": {
-                        "Ident": {
-                          "value": "value",
-                          "raw": "value"
+                "name": "{",
+                "value": [
+                  {
+                    "type": "Tokens",
+                    "span": {
+                      "start": 53,
+                      "end": 58,
+                      "ctxt": 0
+                    },
+                    "tokens": [
+                      {
+                        "span": {
+                          "start": 53,
+                          "end": 58,
+                          "ctxt": 0
+                        },
+                        "token": {
+                          "Ident": {
+                            "value": "value",
+                            "raw": "value"
+                          }
                         }
                       }
-                    }
-                  ]
-                }
+                    ]
+                  }
+                ]
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/declaration/output.json
+++ b/crates/swc_css_parser/tests/fixture/declaration/output.json
@@ -120,13 +120,14 @@
             },
             "value": [
               {
-                "type": "RoundBracketBlock",
+                "type": "SimpleBlock",
                 "span": {
                   "start": 33,
                   "end": 40,
                   "ctxt": 0
                 },
-                "children": [
+                "name": "(",
+                "value": [
                   {
                     "type": "Identifier",
                     "span": {

--- a/crates/swc_css_parser/tests/fixture/declaration/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/declaration/span.rust-debug
@@ -119,7 +119,7 @@ error: Value
 3 |     prop: (value);
   |           ^^^^^^^
 
-error: RoundBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/declaration/input.css:3:11
   |
 3 |     prop: (value);

--- a/crates/swc_css_parser/tests/fixture/declaration/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/declaration/span.rust-debug
@@ -155,7 +155,7 @@ error: Value
 4 |     prop: {value};
   |           ^^^^^^^
 
-error: BraceValue
+error: SimpleBlock
  --> $DIR/tests/fixture/declaration/input.css:4:11
   |
 4 |     prop: {value};

--- a/crates/swc_css_parser/tests/fixture/declaration/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/declaration/span.rust-debug
@@ -197,7 +197,7 @@ error: Value
 5 |     prop: [value];
   |           ^^^^^^^
 
-error: SquareBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/declaration/input.css:5:11
   |
 5 |     prop: [value];

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/span.rust-debug
@@ -40,6 +40,16 @@ error: Ident
 1 | @unknown{
   | ^^^^^^^^
 
+error: SimpleBlock
+ --> $DIR/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/input.css:1:9
+  |
+1 |   @unknown{
+  |  _________^
+2 | | a: b;
+3 | | c: d;
+4 | | }
+  | |_^
+
 error: Value
  --> $DIR/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/input.css:1:10
   |

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/_-29x4xnx6IaJMmYrOsypA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/_-29x4xnx6IaJMmYrOsypA/span.rust-debug
@@ -28,3 +28,9 @@ error: Ident
 1 | @unknown{}
   | ^^^^^^^^
 
+error: SimpleBlock
+ --> $DIR/tests/fixture/esbuild/misc/_-29x4xnx6IaJMmYrOsypA/input.css:1:9
+  |
+1 | @unknown{}
+  |         ^^
+

--- a/crates/swc_css_parser/tests/fixture/rome/calc/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/calc/output.json
@@ -683,13 +683,14 @@
                         },
                         "values": [
                           {
-                            "type": "RoundBracketBlock",
+                            "type": "SimpleBlock",
                             "span": {
                               "start": 153,
                               "end": 160,
                               "ctxt": 0
                             },
-                            "children": [
+                            "name": "(",
+                            "value": [
                               {
                                 "type": "BinValue",
                                 "span": {
@@ -725,13 +726,14 @@
                       }
                     },
                     "right": {
-                      "type": "RoundBracketBlock",
+                      "type": "SimpleBlock",
                       "span": {
                         "start": 163,
                         "end": 170,
                         "ctxt": 0
                       },
-                      "children": [
+                      "name": "(",
+                      "value": [
                         {
                           "type": "BinValue",
                           "span": {

--- a/crates/swc_css_parser/tests/fixture/rome/calc/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/calc/span.rust-debug
@@ -653,7 +653,7 @@ error: Value
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
   |                       ^^^^^^^
 
-error: RoundBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/rome/calc/input.css:7:20
   |
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
@@ -701,7 +701,7 @@ error: Value
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
   |                                 ^^^^^^^
 
-error: RoundBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/rome/calc/input.css:7:30
   |
 7 |     width: calc(2em / (2 - 3) / (2 - 6));

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/line-name/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/line-name/output.json
@@ -118,13 +118,14 @@
                     "raw": "4"
                   },
                   {
-                    "type": "SquareBracketBlock",
+                    "type": "SimpleBlock",
                     "span": {
                       "start": 43,
                       "end": 54,
                       "ctxt": 0
                     },
-                    "children": [
+                    "name": "[",
+                    "value": [
                       {
                         "type": "Identifier",
                         "span": {

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/line-name/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/line-name/span.rust-debug
@@ -115,7 +115,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, [col-start]);
   |                                      ^^^^^^^^^^^
 
-error: SquareBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/rome/grid/repeat/line-name/input.css:2:35
   |
 2 |     grid-template-columns: repeat(4, [col-start]);

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/multi-values/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/multi-values/output.json
@@ -126,13 +126,14 @@
                     },
                     "values": [
                       {
-                        "type": "SquareBracketBlock",
+                        "type": "SimpleBlock",
                         "span": {
                           "start": 43,
                           "end": 54,
                           "ctxt": 0
                         },
-                        "children": [
+                        "name": "[",
+                        "value": [
                           {
                             "type": "Identifier",
                             "span": {
@@ -156,13 +157,14 @@
                         "raw": "min-content"
                       },
                       {
-                        "type": "SquareBracketBlock",
+                        "type": "SimpleBlock",
                         "span": {
                           "start": 67,
                           "end": 79,
                           "ctxt": 0
                         },
-                        "children": [
+                        "name": "[",
+                        "value": [
                           {
                             "type": "Identifier",
                             "span": {
@@ -186,13 +188,14 @@
                         "raw": "max-content"
                       },
                       {
-                        "type": "SquareBracketBlock",
+                        "type": "SimpleBlock",
                         "span": {
                           "start": 92,
                           "end": 101,
                           "ctxt": 0
                         },
-                        "children": [
+                        "name": "[",
+                        "value": [
                           {
                             "type": "Identifier",
                             "span": {

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/multi-values/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/multi-values/span.rust-debug
@@ -127,7 +127,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);
   |                                      ^^^^^^^^^^^
 
-error: SquareBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/rome/grid/repeat/multi-values/input.css:2:35
   |
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);
@@ -163,7 +163,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);
   |                                                              ^^^^^^^^^^^^
 
-error: SquareBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/rome/grid/repeat/multi-values/input.css:2:59
   |
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);
@@ -199,7 +199,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);
   |                                                                                       ^^^^^^^^^
 
-error: SquareBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/rome/grid/repeat/multi-values/input.css:2:84
   |
 2 |     grid-template-columns: repeat(4, [col-start] min-content [col-middle] max-content [col-end]);

--- a/crates/swc_css_parser/tests/fixture/value/square-brackets/output.json
+++ b/crates/swc_css_parser/tests/fixture/value/square-brackets/output.json
@@ -89,13 +89,14 @@
             },
             "value": [
               {
-                "type": "SquareBracketBlock",
+                "type": "SimpleBlock",
                 "span": {
                   "start": 17,
                   "end": 19,
                   "ctxt": 0
                 },
-                "children": []
+                "name": "[",
+                "value": []
               }
             ],
             "important": null
@@ -119,13 +120,14 @@
             },
             "value": [
               {
-                "type": "SquareBracketBlock",
+                "type": "SimpleBlock",
                 "span": {
                   "start": 32,
                   "end": 35,
                   "ctxt": 0
                 },
-                "children": []
+                "name": "[",
+                "value": []
               }
             ],
             "important": null
@@ -149,13 +151,14 @@
             },
             "value": [
               {
-                "type": "SquareBracketBlock",
+                "type": "SimpleBlock",
                 "span": {
                   "start": 48,
                   "end": 60,
                   "ctxt": 0
                 },
-                "children": [
+                "name": "[",
+                "value": [
                   {
                     "type": "Identifier",
                     "span": {
@@ -190,13 +193,14 @@
             },
             "value": [
               {
-                "type": "SquareBracketBlock",
+                "type": "SimpleBlock",
                 "span": {
                   "start": 73,
                   "end": 110,
                   "ctxt": 0
                 },
-                "children": [
+                "name": "[",
+                "value": [
                   {
                     "type": "Identifier",
                     "span": {
@@ -231,13 +235,14 @@
             },
             "value": [
               {
-                "type": "SquareBracketBlock",
+                "type": "SimpleBlock",
                 "span": {
                   "start": 123,
                   "end": 138,
                   "ctxt": 0
                 },
-                "children": [
+                "name": "[",
+                "value": [
                   {
                     "type": "Identifier",
                     "span": {
@@ -309,13 +314,14 @@
             },
             "value": [
               {
-                "type": "SquareBracketBlock",
+                "type": "SimpleBlock",
                 "span": {
                   "start": 150,
                   "end": 162,
                   "ctxt": 0
                 },
-                "children": [
+                "name": "[",
+                "value": [
                   {
                     "type": "Identifier",
                     "span": {
@@ -347,13 +353,14 @@
                 }
               },
               {
-                "type": "SquareBracketBlock",
+                "type": "SimpleBlock",
                 "span": {
                   "start": 167,
                   "end": 188,
                   "ctxt": 0
                 },
-                "children": [
+                "name": "[",
+                "value": [
                   {
                     "type": "Identifier",
                     "span": {
@@ -395,13 +402,14 @@
                 }
               },
               {
-                "type": "SquareBracketBlock",
+                "type": "SimpleBlock",
                 "span": {
                   "start": 193,
                   "end": 203,
                   "ctxt": 0
                 },
-                "children": [
+                "name": "[",
+                "value": [
                   {
                     "type": "Identifier",
                     "span": {

--- a/crates/swc_css_parser/tests/fixture/value/square-brackets/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/square-brackets/span.rust-debug
@@ -95,7 +95,7 @@ error: Value
 2 |     prop:  [];
   |            ^^
 
-error: SquareBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/value/square-brackets/input.css:2:12
   |
 2 |     prop:  [];
@@ -119,7 +119,7 @@ error: Value
 3 |     prop:  [ ];
   |            ^^^
 
-error: SquareBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/value/square-brackets/input.css:3:12
   |
 3 |     prop:  [ ];
@@ -143,7 +143,7 @@ error: Value
 4 |     prop:  [row1-start];
   |            ^^^^^^^^^^^^
 
-error: SquareBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/value/square-brackets/input.css:4:12
   |
 4 |     prop:  [row1-start];
@@ -179,7 +179,7 @@ error: Value
 5 |     prop:  [   row1-start-with-spaces-around   ];
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: SquareBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/value/square-brackets/input.css:5:12
   |
 5 |     prop:  [   row1-start-with-spaces-around   ];
@@ -215,7 +215,7 @@ error: Value
 6 |     prop:  [red #fff 12px];
   |            ^^^^^^^^^^^^^^^
 
-error: SquareBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/value/square-brackets/input.css:6:12
   |
 6 |     prop:  [red #fff 12px];
@@ -287,7 +287,7 @@ error: Value
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
   |           ^^^^^^^^^^^^
 
-error: SquareBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/value/square-brackets/input.css:7:11
   |
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
@@ -329,7 +329,7 @@ error: Value
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
   |                            ^^^^^^^^^^^^^^^^^^^^^
 
-error: SquareBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/value/square-brackets/input.css:7:28
   |
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
@@ -383,7 +383,7 @@ error: Value
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
   |                                                      ^^^^^^^^^^
 
-error: SquareBracketBlock
+error: SimpleBlock
  --> $DIR/tests/fixture/value/square-brackets/input.css:7:54
   |
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -84,8 +84,6 @@ define!({
     pub enum Value {
         SimpleBlock(SimpleBlock),
 
-        SquareBracketBlock(SquareBracketBlock),
-
         RoundBracketBlock(RoundBracketBlock),
 
         Unit(UnitValue),
@@ -144,11 +142,6 @@ define!({
     }
 
     pub struct RoundBracketBlock {
-        pub span: Span,
-        pub children: Option<Vec<Value>>,
-    }
-
-    pub struct SquareBracketBlock {
         pub span: Span,
         pub children: Option<Vec<Value>>,
     }

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -104,9 +104,7 @@ define!({
 
         Comma(CommaValues),
 
-        Brace(BraceValue),
-
-        Lazy(Tokens),
+        Tokens(Tokens),
 
         AtText(AtTextValue),
 
@@ -156,15 +154,10 @@ define!({
         pub value: Num,
     }
 
-    pub struct BraceValue {
-        pub span: Span,
-        pub value: Box<Value>,
-    }
-
     pub struct AtTextValue {
         pub span: Span,
         pub name: Ident,
-        pub block: Option<BraceValue>,
+        pub block: Option<SimpleBlock>,
     }
 
     pub struct UrlValue {

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -84,8 +84,6 @@ define!({
     pub enum Value {
         SimpleBlock(SimpleBlock),
 
-        RoundBracketBlock(RoundBracketBlock),
-
         Unit(UnitValue),
 
         Number(Num),
@@ -139,11 +137,6 @@ define!({
         pub span: Span,
         pub name: Ident,
         pub value: Vec<Value>,
-    }
-
-    pub struct RoundBracketBlock {
-        pub span: Span,
-        pub children: Option<Vec<Value>>,
     }
 
     pub struct HashValue {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Refactor from https://github.com/swc-project/swc/pull/2922/, start to union all blocks in `SimpleBlock` https://www.w3.org/TR/css-syntax-3/#consume-simple-block, i.e. all things in `{}`/`()`/`[]` is `SimpleBlock`.

Next things:
- Refactor `@page` at-rule, because we use `Block` here and it is invalid, there are bugs in parsing
- Union `Block` and `SimpleBlock`

**BREAKING CHANGE:**

Yes, we union all in `SimpleBlock`

**Related issue (if exists):**

No