### PR TITLE
feat(es/minifier): Handle array literals in `sequences`

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -895,6 +895,16 @@ where
                 false
             }
 
+            Expr::Array(e) => {
+                for elem in e.elems.iter().flatten() {
+                    if !self.is_skippable_for_seq(a, &elem.expr) {
+                        return false;
+                    }
+                }
+
+                true
+            }
+
             _ => false,
         }
     }
@@ -1059,12 +1069,9 @@ where
                                 return Ok(true);
                             }
 
-                            match &*elem.expr {
-                                Expr::Ident(..) => {}
-                                _ => {
-                                    // To preserve side-effects, we need to abort.
-                                    break;
-                                }
+                            if !self.is_skippable_for_seq(Some(a), &elem.expr) {
+                                // To preserve side-effects, we need to abort.
+                                break;
                             }
                         }
                         None => {}

--- a/crates/swc_ecma_minifier/tests/golden.txt
+++ b/crates/swc_ecma_minifier/tests/golden.txt
@@ -120,6 +120,7 @@ collapse_vars/collapse_rhs_this/input.js
 collapse_vars/collapse_rhs_undefined/input.js
 collapse_vars/collapse_rhs_var/input.js
 collapse_vars/collapse_rhs_vardef/input.js
+collapse_vars/collapse_vars_array/input.js
 collapse_vars/collapse_vars_closures/input.js
 collapse_vars/collapse_vars_issue_721/input.js
 collapse_vars/collapse_vars_properties/input.js

--- a/crates/swc_ecma_minifier/tests/golden.txt
+++ b/crates/swc_ecma_minifier/tests/golden.txt
@@ -127,6 +127,7 @@ collapse_vars/collapse_vars_regexp/input.js
 collapse_vars/collapse_vars_try/input.js
 collapse_vars/collapse_vars_unary_2/input.js
 collapse_vars/collapse_vars_while/input.js
+collapse_vars/compound_assignment/input.js
 collapse_vars/cond_branch_switch/input.js
 collapse_vars/conditional_1/input.js
 collapse_vars/conditional_2/input.js
@@ -159,6 +160,9 @@ collapse_vars/issue_2425_1/input.js
 collapse_vars/issue_2425_2/input.js
 collapse_vars/issue_2425_3/input.js
 collapse_vars/issue_2436_12/input.js
+collapse_vars/issue_2436_2/input.js
+collapse_vars/issue_2436_3/input.js
+collapse_vars/issue_2436_5/input.js
 collapse_vars/issue_2437_1/input.js
 collapse_vars/issue_2437_2/input.js
 collapse_vars/issue_2571_1/input.js
@@ -380,6 +384,7 @@ evaluate/issue_2231_3/input.js
 evaluate/issue_2535_3/input.js
 evaluate/issue_2822/input.js
 evaluate/issue_2916_1/input.js
+evaluate/issue_2916_2/input.js
 evaluate/issue_2926_2/input.js
 evaluate/issue_2968/input.js
 evaluate/negative_zero/input.js
@@ -614,6 +619,7 @@ issue_1447/else_with_empty_statement/input.js
 issue_1588/runtime_error/input.js
 issue_1588/support_ie8/input.js
 issue_1609/chained_evaluation_1/input.js
+issue_1609/chained_evaluation_2/input.js
 issue_1639/issue_1639_3/input.js
 issue_1656/f7/input.js
 issue_1673/side_effects_catch/input.js
@@ -978,6 +984,7 @@ reduce_vars/issue_2455/input.js
 reduce_vars/issue_2598/input.js
 reduce_vars/issue_2670/input.js
 reduce_vars/issue_2869/input.js
+reduce_vars/issue_2916/input.js
 reduce_vars/issue_2919/input.js
 reduce_vars/issue_2992/input.js
 reduce_vars/issue_3042_1/input.js

--- a/crates/swc_ecma_minifier/tests/ignored.txt
+++ b/crates/swc_ecma_minifier/tests/ignored.txt
@@ -26,7 +26,6 @@ collapse_vars/collapse_vars_side_effects_1/input.js
 collapse_vars/collapse_vars_side_effects_2/input.js
 collapse_vars/collapse_vars_switch/input.js
 collapse_vars/collapse_vars_unary/input.js
-collapse_vars/compound_assignment/input.js
 collapse_vars/double_def_1/input.js
 collapse_vars/double_def_2/input.js
 collapse_vars/issue_1537_destructuring_1/input.js
@@ -41,10 +40,7 @@ collapse_vars/issue_2364_5/input.js
 collapse_vars/issue_2436_1/input.js
 collapse_vars/issue_2436_10/input.js
 collapse_vars/issue_2436_11/input.js
-collapse_vars/issue_2436_2/input.js
-collapse_vars/issue_2436_3/input.js
 collapse_vars/issue_2436_4/input.js
-collapse_vars/issue_2436_5/input.js
 collapse_vars/issue_2436_6/input.js
 collapse_vars/issue_2436_7/input.js
 collapse_vars/issue_2436_8/input.js
@@ -129,7 +125,6 @@ drop_unused/variable_refs_outside_unused_class/input.js
 evaluate/delete_expr_1/input.js
 evaluate/delete_expr_2/input.js
 evaluate/issue_2535_1/input.js
-evaluate/issue_2916_2/input.js
 expansions/avoid_spread_getset_object/input.js
 expansions/avoid_spread_hole/input.js
 export/export_default_named_async_function/input.js
@@ -215,7 +210,6 @@ issue_1443/keep_fnames/input.js
 issue_1443/unsafe_undefined/input.js
 issue_1446/undefined_redefined_mangle/input.js
 issue_1569/inner_reference/input.js
-issue_1609/chained_evaluation_2/input.js
 issue_1673/side_effects_else/input.js
 issue_1733/function_catch_catch/input.js
 issue_1750/case_1/input.js
@@ -372,7 +366,6 @@ reduce_vars/defun_var_2/input.js
 reduce_vars/escaped_prop_1/input.js
 reduce_vars/escaped_prop_2/input.js
 reduce_vars/issue_1595_3/input.js
-reduce_vars/issue_2916/input.js
 reduce_vars/issue_294/input.js
 reduce_vars/issue_308/input.js
 reduce_vars/issue_432_1/input.js

--- a/crates/swc_ecma_minifier/tests/ignored.txt
+++ b/crates/swc_ecma_minifier/tests/ignored.txt
@@ -8,7 +8,6 @@ collapse_vars/cascade_conditional/input.js
 collapse_vars/cascade_statement/input.js
 collapse_vars/cascade_switch/input.js
 collapse_vars/collapse_vars_arguments/input.js
-collapse_vars/collapse_vars_array/input.js
 collapse_vars/collapse_vars_assignment/input.js
 collapse_vars/collapse_vars_constants/input.js
 collapse_vars/collapse_vars_do_while/input.js

--- a/crates/swc_ecma_minifier/tests/terser/compress/collapse_vars/collapse_vars_array/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/collapse_vars/collapse_vars_array/output.js
@@ -2,8 +2,7 @@ function f1(x, y) {
     return [x + y];
 }
 function f2(x, y) {
-    var z = x + y;
-    return [x, side_effect(), z];
+    return [x, side_effect(), x + y];
 }
 function f3(x, y) {
     return [[3], [f(x + y), x, y], [g()]];


### PR DESCRIPTION
**Description:**

swc_ecma_minifier:
 - `sequences`: Implement more rule for array literals.


**Related issue (if exists):**



# Bugs

<details>
    <summary>
        Bug 1 (fixed)
    </summary>

```

   INFO [SWC_RUN]
var a = {};
(function(global) {
    function fail(o) {
        var result = {};
        function inner() {
            return outer({
                one: o.one,
                two: o.two
            });
        }
        result.inner = function() {
            return inner();
        };
        return result;
    }
    function outer(o) {
        var ret;
        if (o) {
            ret = o.one;
        } else {
            ret = o.two;
        }
        return ret;
    }
    global.fail = fail;
})(a);
var b = a.fail({
    one: "PASS"
});
console.log(b.inner());

PASS

    at crates/swc_ecma_minifier/src/debug.rs:120
    in compress ast
    in minify

   INFO Done in 255.375µs, kind: "perf"
    at crates/swc_timer/src/lib.rs:32
    in analyze
    in optimize with , pass: 0
    in compress ast
    in minify

  DEBUG ===== Start =====
var a = {};
(function(global) {
    function fail(o) {
        var result = {};
        function inner() {
            return outer({
                one: o.one,
                two: o.two
            });
        }
        result.inner = function() {
            return inner();
        };
        return result;
    }
    function outer(o) {
        var ret;
        if (o) {
            ret = o.one;
        } else {
            ret = o.two;
        }
        return ret;
    }
    global.fail = fail;
})(a);
var b = a.fail({
    one: "PASS"
});
console.log(b.inner());

    at crates/swc_ecma_minifier/src/compress/mod.rs:275
    in optimize with , pass: 0
    in compress ast
    in minify

   INFO compress: Running expression simplifier (pass = 0)
    at crates/swc_ecma_minifier/src/compress/mod.rs:282
    in optimize with , pass: 0
    in compress ast
    in minify

   INFO compress: expr_simplifier took 155.683µs (pass = 0)
    at crates/swc_ecma_minifier/src/compress/mod.rs:304
    in optimize with , pass: 0
    in compress ast
    in minify

   INFO compress/pure: Running pure optimizer (pass = 0)
    at crates/swc_ecma_minifier/src/compress/mod.rs:325
    in optimize with , pass: 0
    in compress ast
    in minify

   INFO compress/pure: Pure optimizer took 419.355µs (pass = 0)
    at crates/swc_ecma_minifier/src/compress/mod.rs:339
    in optimize with , pass: 0
    in compress ast
    in minify

   INFO compress: Running optimizer (pass = 0)
    at crates/swc_ecma_minifier/src/compress/mod.rs:355
    in optimize with , pass: 0
    in compress ast
    in minify

  DEBUG inline: Decided to inline function `inner#3` as it's used only once
    at crates/swc_ecma_minifier/src/compress/optimize/inline.rs:529
    in optimize with , pass: 0
    in compress ast
    in minify

  DEBUG inline: Replacing 'inner#3' with an expression
    at crates/swc_ecma_minifier/src/compress/optimize/inline.rs:618
    in optimize with , pass: 0
    in compress ast
    in minify

  DEBUG inline: Inlining an iife
    at crates/swc_ecma_minifier/src/compress/optimize/iife.rs:600
    in optimize with , pass: 0
    in compress ast
    in minify

  DEBUG inline: Inlining a function call
    at crates/swc_ecma_minifier/src/compress/optimize/iife.rs:500
    in optimize with , pass: 0
    in compress ast
    in minify

  DEBUG sequences: Compressing statements as a sequences
    at crates/swc_ecma_minifier/src/compress/optimize/sequences.rs:136
    in optimize with , pass: 0
    in compress ast
    in minify

  DEBUG inline: Decided to inline function `fail#2` as it's used only once
    at crates/swc_ecma_minifier/src/compress/optimize/inline.rs:529
    in optimize with , pass: 0
    in compress ast
    in minify

  DEBUG Merging assignments in cons and alt of if statement
    at crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs:525
    in optimize with , pass: 0
    in compress ast
    in minify

  DEBUG sequences: Inlining sequential expressions (`ret#4`)
    at crates/swc_ecma_minifier/src/compress/optimize/sequences.rs:1421
    in merge_sequential_expr with , b: "ret#4"
    in merge_sequences_in_stmts
    in optimize with , pass: 0
    in compress ast
    in minify

  DEBUG sequences: [Changed] ret#4 = o#4 ? o#4.one : o#4.two
    at crates/swc_ecma_minifier/src/compress/optimize/sequences.rs:1435
    in merge_sequential_expr with , b: "ret#4"
    in merge_sequences_in_stmts
    in optimize with , pass: 0
    in compress ast
    in minify

  DEBUG inline: Replacing 'fail#2' with an expression
    at crates/swc_ecma_minifier/src/compress/optimize/inline.rs:618
    in optimize with , pass: 0
    in compress ast
    in minify

  DEBUG negate_iife: Negating iife
    at crates/swc_ecma_minifier/src/compress/optimize/iife.rs:39
    in optimize with , pass: 0
    in compress ast
    in minify

  DEBUG Dropping [(Atom('fail' type=inline), #2), (Atom('inner' type=inline), #3)]
    at crates/swc_ecma_minifier/src/compress/optimize/util.rs:199
    in optimize with , pass: 0
    in compress ast
    in minify

   INFO compress: Optimizer took 5.266288ms (pass = 0)
    at crates/swc_ecma_minifier/src/compress/mod.rs:375
    in optimize with , pass: 0
    in compress ast
    in minify

   INFO Done in 8.066734ms, kind: "perf"
    at crates/swc_timer/src/lib.rs:32
    in optimize with , pass: 0
    in compress ast
    in minify

   INFO [SWC_RUN]
var a = {};
!function(global) {
    function outer(o) {
        var ret;
        return ret = o ? o.one : o.two;
    }
    global.fail = function fail(o) {
        var result = {};
        return result.inner = function() {
            return outer({
                one: o.one,
                two: o.two
            });
        }, result;
    };
}(a);
var b = a.fail({
    one: "PASS"
});
console.log(b.inner());

PASS

    at crates/swc_ecma_minifier/src/debug.rs:120
    in compress ast
    in minify

   INFO Done in 214.034µs, kind: "perf"
    at crates/swc_timer/src/lib.rs:32
    in analyze
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG ===== Start =====
var a = {};
!function(global) {
    function outer(o) {
        var ret;
        return ret = o ? o.one : o.two;
    }
    global.fail = function fail(o) {
        var result = {};
        return result.inner = function() {
            return outer({
                one: o.one,
                two: o.two
            });
        }, result;
    };
}(a);
var b = a.fail({
    one: "PASS"
});
console.log(b.inner());

    at crates/swc_ecma_minifier/src/compress/mod.rs:275
    in optimize with , pass: 1
    in compress ast
    in minify

   INFO compress: Running expression simplifier (pass = 1)
    at crates/swc_ecma_minifier/src/compress/mod.rs:282
    in optimize with , pass: 1
    in compress ast
    in minify

   INFO compress: expr_simplifier took 54.487µs (pass = 1)
    at crates/swc_ecma_minifier/src/compress/mod.rs:304
    in optimize with , pass: 1
    in compress ast
    in minify

   INFO compress/pure: Running pure optimizer (pass = 1)
    at crates/swc_ecma_minifier/src/compress/mod.rs:325
    in optimize with , pass: 1
    in compress ast
    in minify

   INFO compress/pure: Pure optimizer took 384.27µs (pass = 1)
    at crates/swc_ecma_minifier/src/compress/mod.rs:339
    in optimize with , pass: 1
    in compress ast
    in minify

   INFO [SWC_RUN]
var a = {};
!function(global) {
    function outer(o) {
        var ret = o ? o.one : o.two;
        return ret;
    }
    global.fail = function fail(o) {
        var result = {};
        return result.inner = function() {
            return outer({
                one: o.one,
                two: o.two
            });
        }, result;
    };
}(a);
var b = a.fail({
    one: "PASS"
});
console.log(b.inner());

PASS

    at crates/swc_ecma_minifier/src/debug.rs:120
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG ===== After pure =====
var a = {};
!function(global) {
    function outer(o) {
        var ret = o ? o.one : o.two;
        return ret;
    }
    global.fail = function fail(o) {
        var result = {};
        return result.inner = function() {
            return outer({
                one: o.one,
                two: o.two
            });
        }, result;
    };
}(a);
var b = a.fail({
    one: "PASS"
});
console.log(b.inner());

    at crates/swc_ecma_minifier/src/compress/mod.rs:349
    in optimize with , pass: 1
    in compress ast
    in minify

   INFO compress: Running optimizer (pass = 1)
    at crates/swc_ecma_minifier/src/compress/mod.rs:355
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG inline: Decided to inline function `outer#2` as it's used only once
    at crates/swc_ecma_minifier/src/compress/optimize/inline.rs:529
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG Removing ident of an class / function expression
    at crates/swc_ecma_minifier/src/compress/optimize/unused.rs:479
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG inline: Replacing 'outer#2' with an expression
    at crates/swc_ecma_minifier/src/compress/optimize/inline.rs:618
    in visit_mut_seq_expr
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG inline: Inlining an iife
    at crates/swc_ecma_minifier/src/compress/optimize/iife.rs:600
    in visit_mut_seq_expr
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG inline: Inlining a function call
    at crates/swc_ecma_minifier/src/compress/optimize/iife.rs:500
    in visit_mut_seq_expr
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG join_vars: Joining variables
    at crates/swc_ecma_minifier/src/compress/optimize/join_vars.rs:56
    in visit_mut_seq_expr
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG unused: Dropping assignment to var 'ret#4', which is never used
    at crates/swc_ecma_minifier/src/compress/optimize/unused.rs:437
    in visit_mut_seq_expr
    in visit_mut_seq_expr
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG sequences: Inlining sequential expressions (`o#4`)
    at crates/swc_ecma_minifier/src/compress/optimize/sequences.rs:1421
    in merge_sequential_expr with , b: "o#4"
    in merge_sequential_expr with , b: "o#4 ? o#4.one : o#4.two"
    in merge_sequences_in_seq_expr with , seq_expr: "o#4 = {\n    one: o#3.one,\n    two: o#3.two\n}, o#4 ? o#4.one : o#4.two, ret#4"
    in visit_mut_seq_expr
    in visit_mut_seq_expr
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG sequences: [Changed] o#4 = {
    one: o#3.one,
    two: o#3.two
}
    at crates/swc_ecma_minifier/src/compress/optimize/sequences.rs:1435
    in merge_sequential_expr with , b: "o#4"
    in merge_sequential_expr with , b: "o#4 ? o#4.one : o#4.two"
    in merge_sequences_in_seq_expr with , seq_expr: "o#4 = {\n    one: o#3.one,\n    two: o#3.two\n}, o#4 ? o#4.one : o#4.two, ret#4"
    in visit_mut_seq_expr
    in visit_mut_seq_expr
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG inline: Inlining an iife
    at crates/swc_ecma_minifier/src/compress/optimize/iife.rs:600
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG inline: Inlining a function call
    at crates/swc_ecma_minifier/src/compress/optimize/iife.rs:500
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG ignore_return_value: Reducing unary (!)
    at crates/swc_ecma_minifier/src/compress/optimize/mod.rs:1053
    in ignore_return_value
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG ignore_return_value: Reducing unary (void)
    at crates/swc_ecma_minifier/src/compress/optimize/mod.rs:1053
    in ignore_return_value
    in ignore_return_value
    in ignore_return_value
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG join_vars: Joining variables
    at crates/swc_ecma_minifier/src/compress/optimize/join_vars.rs:56
    in optimize with , pass: 1
    in compress ast
    in minify

  DEBUG Dropping [(Atom('outer' type=inline), #2)]
    at crates/swc_ecma_minifier/src/compress/optimize/util.rs:199
    in optimize with , pass: 1
    in compress ast
    in minify

   INFO compress: Optimizer took 5.345692ms (pass = 1)
    at crates/swc_ecma_minifier/src/compress/mod.rs:375
    in optimize with , pass: 1
    in compress ast
    in minify

   INFO Done in 61.536331ms, kind: "perf"
    at crates/swc_timer/src/lib.rs:32
    in optimize with , pass: 1
    in compress ast
    in minify

   INFO [SWC_RUN]
var a = {}, global;
global = a, global.fail = function(o1) {
    var result = {};
    return result.inner = function() {
        var o, ret;
        return (o = {
            one: o1.one,
            two: o1.two
        }) ? o.one : o.two, ret;
    }, result;
};
var b = a.fail({
    one: "PASS"
});
console.log(b.inner());

undefined
```

</details>

```
```
