### PR TITLE
Refactor namespace at rule

### DIFF
--- a/crates/swc_css_ast/src/at_rule/import.rs
+++ b/crates/swc_css_ast/src/at_rule/import.rs
@@ -1,13 +1,10 @@
-use crate::{Declaration, Function, Ident, MediaQueryList, Str, SupportsCondition, UrlValue};
+use crate::{Declaration, Function, Ident, MediaQueryList, Str, SupportsCondition, Url};
 use swc_common::{ast_node, Span};
 
 #[ast_node]
 pub enum ImportHref {
-    #[tag("Function")]
-    Function(Function),
-
-    #[tag("UrlValue")]
-    Url(UrlValue),
+    #[tag("Url")]
+    Url(Url),
 
     #[tag("Str")]
     Str(Str),

--- a/crates/swc_css_ast/src/at_rule/mod.rs
+++ b/crates/swc_css_ast/src/at_rule/mod.rs
@@ -1,7 +1,7 @@
 pub use self::{
     charset::*, document::*, import::*, keyframe::*, layer::*, media::*, page::*, support::*,
 };
-use crate::{Block, Ident, SimpleBlock, Str, UrlValue, Value};
+use crate::{Block, Function, Ident, SimpleBlock, Str, UrlValue, Value};
 use is_macro::Is;
 use swc_common::{ast_node, Span};
 
@@ -64,6 +64,9 @@ pub struct FontFaceRule {
 pub enum NamespaceUri {
     #[tag("UrlValue")]
     Url(UrlValue),
+
+    #[tag("Function")]
+    Function(Function),
 
     #[tag("Str")]
     Str(Str),

--- a/crates/swc_css_ast/src/at_rule/mod.rs
+++ b/crates/swc_css_ast/src/at_rule/mod.rs
@@ -1,7 +1,7 @@
 pub use self::{
     charset::*, document::*, import::*, keyframe::*, layer::*, media::*, page::*, support::*,
 };
-use crate::{Block, Function, Ident, SimpleBlock, Str, UrlValue, Value};
+use crate::{Block, Ident, SimpleBlock, Str, Url, Value};
 use is_macro::Is;
 use swc_common::{ast_node, Span};
 
@@ -62,11 +62,8 @@ pub struct FontFaceRule {
 
 #[ast_node]
 pub enum NamespaceUri {
-    #[tag("UrlValue")]
-    Url(UrlValue),
-
-    #[tag("Function")]
-    Function(Function),
+    #[tag("Url")]
+    Url(Url),
 
     #[tag("Str")]
     Str(Str),

--- a/crates/swc_css_ast/src/token.rs
+++ b/crates/swc_css_ast/src/token.rs
@@ -60,13 +60,17 @@ pub enum Token {
 
     /// `url(value)`
     Url {
+        name: JsWord,
+        raw_name: JsWord,
         value: JsWord,
-        raw: JsWord,
+        raw_value: JsWord,
     },
 
     BadUrl {
+        name: JsWord,
+        raw_name: JsWord,
         value: JsWord,
-        raw: JsWord,
+        raw_value: JsWord,
     },
 
     Delim {

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -161,8 +161,8 @@ pub struct SimpleBlock {
 pub struct Url {
     pub span: Span,
     pub name: Ident,
-    pub value: UrlValue,
-    pub modifiers: Option<Vec<Value>>,
+    pub value: Option<UrlValue>,
+    pub modifiers: Option<Vec<UrlModifier>>,
 }
 
 #[ast_node]

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -150,13 +150,6 @@ pub struct AtTextValue {
     pub block: Option<SimpleBlock>,
 }
 
-#[ast_node("SimpleBlock")]
-pub struct SimpleBlock {
-    pub span: Span,
-    pub name: char,
-    pub value: Vec<Value>,
-}
-
 #[ast_node("Url")]
 pub struct Url {
     pub span: Span,

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -47,8 +47,8 @@ pub enum Value {
     #[tag("AtTextValue")]
     AtText(AtTextValue),
 
-    #[tag("UrlValue")]
-    Url(UrlValue),
+    #[tag("Url")]
+    Url(Url),
 }
 
 /// List of values separated by a space.
@@ -150,13 +150,6 @@ pub struct AtTextValue {
     pub block: Option<SimpleBlock>,
 }
 
-#[ast_node("UrlValue")]
-pub struct UrlValue {
-    pub span: Span,
-    pub url: JsWord,
-    pub raw: JsWord,
-}
-
 #[ast_node("SimpleBlock")]
 pub struct SimpleBlock {
     pub span: Span,
@@ -168,13 +161,12 @@ pub struct SimpleBlock {
 pub struct Url {
     pub span: Span,
     pub name: Ident,
-    pub value: UrlValueType,
+    pub value: UrlValue,
     pub modifiers: Option<Vec<Value>>,
 }
 
-// TODO rename me to `UrlValue` and remove `UrlValue` in favor `Url`
 #[ast_node]
-pub enum UrlValueType {
+pub enum UrlValue {
     #[tag("Str")]
     Str(Str),
     #[tag("UrlValueRaw")]

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -156,3 +156,42 @@ pub struct UrlValue {
     pub url: JsWord,
     pub raw: JsWord,
 }
+
+#[ast_node("SimpleBlock")]
+pub struct SimpleBlock {
+    pub span: Span,
+    pub name: char,
+    pub value: Vec<Value>,
+}
+
+#[ast_node("Url")]
+pub struct Url {
+    pub span: Span,
+    pub name: Ident,
+    pub value: UrlValueType,
+    pub modifiers: Option<Vec<Value>>,
+}
+
+// TODO rename me to `UrlValue` and remove `UrlValue` in favor `Url`
+#[ast_node]
+pub enum UrlValueType {
+    #[tag("Str")]
+    Str(Str),
+    #[tag("UrlValueRaw")]
+    Raw(UrlValueRaw),
+}
+
+#[ast_node("UrlValueRaw")]
+pub struct UrlValueRaw {
+    pub span: Span,
+    pub value: JsWord,
+    pub raw: JsWord,
+}
+
+#[ast_node]
+pub enum UrlModifier {
+    #[tag("Ident")]
+    Ident(Ident),
+    #[tag("Function")]
+    Function(Function),
+}

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -885,7 +885,15 @@ where
     fn emit_url(&mut self, n: &Url) -> Result {
         emit!(self, n.name);
         punct!(self, "(");
-        emit!(self, n.value);
+
+        if let Some(value) = &n.value {
+            emit!(self, value);
+        }
+
+        if let Some(modifiers) = &n.modifiers {
+            self.emit_list(&modifiers, ListFormat::SpaceDelimited)?;
+        }
+
         punct!(self, ")");
     }
 
@@ -900,6 +908,14 @@ where
     #[emitter]
     fn emit_url_value_raw(&mut self, n: &UrlValueRaw) -> Result {
         self.wr.write_raw(Some(n.span), &n.raw)?;
+    }
+
+    #[emitter]
+    fn emit_url_modifier(&mut self, n: &UrlModifier) -> Result {
+        match n {
+            UrlModifier::Ident(n) => emit!(self, n),
+            UrlModifier::Function(n) => emit!(self, n),
+        }
     }
 
     #[emitter]

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -899,7 +899,7 @@ where
         }
 
         if let Some(modifiers) = &n.modifiers {
-            self.emit_list(&modifiers, ListFormat::SpaceDelimited)?;
+            self.emit_list(modifiers, ListFormat::SpaceDelimited)?;
         }
 
         punct!(self, ")");

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -828,16 +828,24 @@ where
                 Token::Str { raw, .. } => {
                     self.wr.write_raw(Some(span), raw)?;
                 }
-                Token::Url { raw, .. } => {
-                    self.wr.write_raw(Some(span), "url")?;
+                Token::Url {
+                    raw_name,
+                    raw_value,
+                    ..
+                } => {
+                    self.wr.write_raw(None, raw_name)?;
                     punct!(self, "(");
-                    self.wr.write_raw(None, raw)?;
+                    self.wr.write_raw(None, raw_value)?;
                     punct!(self, ")");
                 }
-                Token::BadUrl { raw, .. } => {
-                    self.wr.write_raw(Some(span), "url")?;
+                Token::BadUrl {
+                    raw_name,
+                    raw_value,
+                    ..
+                } => {
+                    self.wr.write_raw(Some(span), raw_name)?;
                     punct!(self, "(");
-                    self.wr.write_raw(None, raw)?;
+                    self.wr.write_raw(None, raw_value)?;
                     punct!(self, ")");
                 }
                 Token::Comma => {

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -134,7 +134,6 @@ where
     #[emitter]
     fn emit_import_href(&mut self, n: &ImportHref) -> Result {
         match n {
-            ImportHref::Function(n) => emit!(self, n),
             ImportHref::Url(n) => emit!(self, n),
             ImportHref::Str(n) => emit!(self, n),
         }
@@ -891,24 +890,16 @@ where
     }
 
     #[emitter]
-    fn emit_url_value_type(&mut self, n: &UrlValueType) -> Result {
+    fn emit_url_value(&mut self, n: &UrlValue) -> Result {
         match n {
-            UrlValueType::Raw(n) => emit!(self, n),
-            UrlValueType::Str(n) => emit!(self, n),
+            UrlValue::Raw(n) => emit!(self, n),
+            UrlValue::Str(n) => emit!(self, n),
         }
     }
 
     #[emitter]
     fn emit_url_value_raw(&mut self, n: &UrlValueRaw) -> Result {
         self.wr.write_raw(Some(n.span), &n.raw)?;
-    }
-
-    #[emitter]
-    fn emit_url_value(&mut self, n: &UrlValue) -> Result {
-        keyword!(self, "url");
-        punct!(self, "(");
-        self.wr.write_raw(Some(n.span), &n.raw)?;
-        punct!(self, ")");
     }
 
     #[emitter]

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -883,6 +883,27 @@ where
     }
 
     #[emitter]
+    fn emit_url(&mut self, n: &Url) -> Result {
+        emit!(self, n.name);
+        punct!(self, "(");
+        emit!(self, n.value);
+        punct!(self, ")");
+    }
+
+    #[emitter]
+    fn emit_url_value_type(&mut self, n: &UrlValueType) -> Result {
+        match n {
+            UrlValueType::Raw(n) => emit!(self, n),
+            UrlValueType::Str(n) => emit!(self, n),
+        }
+    }
+
+    #[emitter]
+    fn emit_url_value_raw(&mut self, n: &UrlValueRaw) -> Result {
+        self.wr.write_raw(Some(n.span), &n.raw)?;
+    }
+
+    #[emitter]
     fn emit_url_value(&mut self, n: &UrlValue) -> Result {
         keyword!(self, "url");
         punct!(self, "(");

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -549,16 +549,16 @@ where
                                 raw_name: ref mut raw_url_name,
                                 ..
                             } => {
-                                *url_name = name.0.into();
-                                *raw_url_name = name.1.into();
+                                *url_name = name.0;
+                                *raw_url_name = name.1;
                             }
                             Token::BadUrl {
                                 name: ref mut url_name,
                                 raw_name: ref mut raw_url_name,
                                 ..
                             } => {
-                                *url_name = name.0.into();
-                                *raw_url_name = name.1.into();
+                                *url_name = name.0;
+                                *raw_url_name = name.1;
                             }
                             _ => {}
                         }
@@ -1243,7 +1243,7 @@ where
             }
         }
 
-        return Ok((value, raw));
+        Ok((value, raw))
     }
 }
 

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -542,29 +542,7 @@ where
                 }
                 // Otherwise, consume a url token, and return it.
                 _ => {
-                    return self.read_url().map(|mut token| {
-                        match token {
-                            Token::Url {
-                                name: ref mut url_name,
-                                raw_name: ref mut raw_url_name,
-                                ..
-                            } => {
-                                *url_name = name.0;
-                                *raw_url_name = name.1;
-                            }
-                            Token::BadUrl {
-                                name: ref mut url_name,
-                                raw_name: ref mut raw_url_name,
-                                ..
-                            } => {
-                                *url_name = name.0;
-                                *raw_url_name = name.1;
-                            }
-                            _ => {}
-                        }
-
-                        token
-                    });
+                    return self.read_url(name);
                 }
             }
         }
@@ -679,7 +657,7 @@ where
 
     // This section describes how to consume a url token from a stream of code
     // points. It returns either a <url-token> or a <bad-url-token>.
-    fn read_url(&mut self) -> LexResult<Token> {
+    fn read_url(&mut self, name: (JsWord, JsWord)) -> LexResult<Token> {
         // Initially create a <url-token> with its value set to the empty string.
         let mut value = String::new();
         let mut raw = String::new();
@@ -702,8 +680,8 @@ where
                 // Return the <url-token>.
                 Some(')') => {
                     return Ok(Token::Url {
-                        name: Default::default(),
-                        raw_name: Default::default(),
+                        name: name.0,
+                        raw_name: name.1,
                         value: value.into(),
                         raw_value: raw.into(),
                     });
@@ -713,8 +691,8 @@ where
                 // This is a parse error. Return the <url-token>.
                 None => {
                     return Ok(Token::Url {
-                        name: Default::default(),
-                        raw_name: Default::default(),
+                        name: name.0,
+                        raw_name: name.1,
                         value: value.into(),
                         raw_value: raw.into(),
                     });
@@ -747,16 +725,16 @@ where
                             self.consume();
 
                             return Ok(Token::Url {
-                                name: Default::default(),
-                                raw_name: Default::default(),
+                                name: name.0,
+                                raw_name: name.1,
                                 value: value.into(),
                                 raw_value: raw.into(),
                             });
                         }
                         None => {
                             return Ok(Token::Url {
-                                name: Default::default(),
-                                raw_name: Default::default(),
+                                name: name.0,
+                                raw_name: name.1,
                                 value: value.into(),
                                 raw_value: raw.into(),
                             });
@@ -773,8 +751,8 @@ where
 
                     // TODO check me
                     return Ok(Token::BadUrl {
-                        name: Default::default(),
-                        raw_name: Default::default(),
+                        name: name.0,
+                        raw_name: name.1,
                         value: value.into(),
                         raw_value: raw.into(),
                     });
@@ -795,8 +773,8 @@ where
                     raw.push_str(&remnants.1);
 
                     return Ok(Token::BadUrl {
-                        name: Default::default(),
-                        raw_name: Default::default(),
+                        name: name.0,
+                        raw_name: name.1,
                         value: value.into(),
                         raw_value: raw.into(),
                     });
@@ -824,8 +802,8 @@ where
                         raw.push_str(&remnants.1);
 
                         return Ok(Token::BadUrl {
-                            name: Default::default(),
-                            raw_name: Default::default(),
+                            name: name.0,
+                            raw_name: name.1,
                             value: value.into(),
                             raw_value: raw.into(),
                         });

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -542,7 +542,7 @@ where
                 }
                 // Otherwise, consume a url token, and return it.
                 _ => {
-                    return self.read_url();
+                    return self.read_url(name);
                 }
             }
         }
@@ -657,7 +657,7 @@ where
 
     // This section describes how to consume a url token from a stream of code
     // points. It returns either a <url-token> or a <bad-url-token>.
-    fn read_url(&mut self) -> LexResult<Token> {
+    fn read_url(&mut self, name: (JsWord, JsWord)) -> LexResult<Token> {
         // Initially create a <url-token> with its value set to the empty string.
         let mut value = String::new();
         let mut raw = String::new();
@@ -680,8 +680,10 @@ where
                 // Return the <url-token>.
                 Some(')') => {
                     return Ok(Token::Url {
+                        name: name.0,
+                        raw_name: name.1,
                         value: value.into(),
-                        raw: raw.into(),
+                        raw_value: raw.into(),
                     });
                 }
 
@@ -689,8 +691,10 @@ where
                 // This is a parse error. Return the <url-token>.
                 None => {
                     return Ok(Token::Url {
+                        name: name.0,
+                        raw_name: name.1,
                         value: value.into(),
-                        raw: raw.into(),
+                        raw_value: raw.into(),
                     });
                 }
 
@@ -721,14 +725,18 @@ where
                             self.consume();
 
                             return Ok(Token::Url {
+                                name: name.0,
+                                raw_name: name.1,
                                 value: value.into(),
-                                raw: raw.into(),
+                                raw_value: raw.into(),
                             });
                         }
                         None => {
                             return Ok(Token::Url {
+                                name: name.0,
+                                raw_name: name.1,
                                 value: value.into(),
-                                raw: raw.into(),
+                                raw_value: raw.into(),
                             });
                         }
                         _ => {}
@@ -743,8 +751,10 @@ where
 
                     // TODO check me
                     return Ok(Token::BadUrl {
+                        name: name.0,
+                        raw_name: name.1,
                         value: value.into(),
-                        raw: raw.into(),
+                        raw_value: raw.into(),
                     });
                 }
 
@@ -763,8 +773,10 @@ where
                     raw.push_str(&remnants.1);
 
                     return Ok(Token::BadUrl {
+                        name: name.0,
+                        raw_name: name.1,
                         value: value.into(),
-                        raw: raw.into(),
+                        raw_value: raw.into(),
                     });
                 }
 
@@ -790,8 +802,10 @@ where
                         raw.push_str(&remnants.1);
 
                         return Ok(Token::BadUrl {
+                            name: name.0,
+                            raw_name: name.1,
                             value: value.into(),
-                            raw: raw.into(),
+                            raw_value: raw.into(),
                         });
                     }
                 }

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -542,7 +542,29 @@ where
                 }
                 // Otherwise, consume a url token, and return it.
                 _ => {
-                    return self.read_url(name);
+                    return self.read_url().map(|mut token| {
+                        match token {
+                            Token::Url {
+                                name: ref mut url_name,
+                                raw_name: ref mut raw_url_name,
+                                ..
+                            } => {
+                                *url_name = name.0.into();
+                                *raw_url_name = name.1.into();
+                            }
+                            Token::BadUrl {
+                                name: ref mut url_name,
+                                raw_name: ref mut raw_url_name,
+                                ..
+                            } => {
+                                *url_name = name.0.into();
+                                *raw_url_name = name.1.into();
+                            }
+                            _ => {}
+                        }
+
+                        token
+                    });
                 }
             }
         }
@@ -657,7 +679,7 @@ where
 
     // This section describes how to consume a url token from a stream of code
     // points. It returns either a <url-token> or a <bad-url-token>.
-    fn read_url(&mut self, name: (JsWord, JsWord)) -> LexResult<Token> {
+    fn read_url(&mut self) -> LexResult<Token> {
         // Initially create a <url-token> with its value set to the empty string.
         let mut value = String::new();
         let mut raw = String::new();
@@ -680,8 +702,8 @@ where
                 // Return the <url-token>.
                 Some(')') => {
                     return Ok(Token::Url {
-                        name: name.0,
-                        raw_name: name.1,
+                        name: Default::default(),
+                        raw_name: Default::default(),
                         value: value.into(),
                         raw_value: raw.into(),
                     });
@@ -691,8 +713,8 @@ where
                 // This is a parse error. Return the <url-token>.
                 None => {
                     return Ok(Token::Url {
-                        name: name.0,
-                        raw_name: name.1,
+                        name: Default::default(),
+                        raw_name: Default::default(),
                         value: value.into(),
                         raw_value: raw.into(),
                     });
@@ -725,16 +747,16 @@ where
                             self.consume();
 
                             return Ok(Token::Url {
-                                name: name.0,
-                                raw_name: name.1,
+                                name: Default::default(),
+                                raw_name: Default::default(),
                                 value: value.into(),
                                 raw_value: raw.into(),
                             });
                         }
                         None => {
                             return Ok(Token::Url {
-                                name: name.0,
-                                raw_name: name.1,
+                                name: Default::default(),
+                                raw_name: Default::default(),
                                 value: value.into(),
                                 raw_value: raw.into(),
                             });
@@ -751,8 +773,8 @@ where
 
                     // TODO check me
                     return Ok(Token::BadUrl {
-                        name: name.0,
-                        raw_name: name.1,
+                        name: Default::default(),
+                        raw_name: Default::default(),
                         value: value.into(),
                         raw_value: raw.into(),
                     });
@@ -773,8 +795,8 @@ where
                     raw.push_str(&remnants.1);
 
                     return Ok(Token::BadUrl {
-                        name: name.0,
-                        raw_name: name.1,
+                        name: Default::default(),
+                        raw_name: Default::default(),
                         value: value.into(),
                         raw_value: raw.into(),
                     });
@@ -802,8 +824,8 @@ where
                         raw.push_str(&remnants.1);
 
                         return Ok(Token::BadUrl {
-                            name: name.0,
-                            raw_name: name.1,
+                            name: Default::default(),
+                            raw_name: Default::default(),
                             value: value.into(),
                             raw_value: raw.into(),
                         });

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -435,7 +435,7 @@ where
         let uri = match cur!(self) {
             tok!("str") => NamespaceUri::Str(self.parse()?),
             tok!("url") => NamespaceUri::Url(self.parse()?),
-            tok!("function") => NamespaceUri::Function(self.parse()?),
+            tok!("function") => NamespaceUri::Url(self.parse()?),
             _ => {
                 return Err(Error::new(
                     span,

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -1260,9 +1260,7 @@ where
                     right,
                 }))
             }
-            _ => {
-                return Err(Error::new(span, ErrorKind::Expected("identifier value")));
-            }
+            _ => Err(Error::new(span, ErrorKind::Expected("identifier value"))),
         }
     }
 }
@@ -1292,16 +1290,14 @@ where
                     }));
                 }
 
-                return Ok(MediaFeatureValue::Number(left));
+                Ok(MediaFeatureValue::Number(left))
             }
             Token::Ident { .. } => Ok(MediaFeatureValue::Ident(self.parse()?)),
             Token::Dimension { .. } => Ok(MediaFeatureValue::Dimension(self.parse()?)),
-            _ => {
-                return Err(Error::new(
-                    span,
-                    ErrorKind::Expected("number, dimension, identifier or ration value"),
-                ));
-            }
+            _ => Err(Error::new(
+                span,
+                ErrorKind::Expected("number, dimension, identifier or ration value"),
+            )),
         }
     }
 }

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -4,7 +4,6 @@ use crate::{
     parser::{Ctx, RuleContext},
     Parse,
 };
-use swc_atoms::js_word;
 use swc_common::Span;
 use swc_css_ast::*;
 
@@ -282,15 +281,13 @@ where
     fn parse(&mut self) -> PResult<ImportRule> {
         let span = self.input.cur_span()?;
         let href = match cur!(self) {
-            Token::Str { .. } => ImportHref::Str(self.parse()?),
-            Token::Function { value, .. } if *value.to_ascii_lowercase() == js_word!("url") => {
-                ImportHref::Function(self.parse()?)
-            }
-            Token::Url { .. } => ImportHref::Url(self.parse()?),
+            tok!("str") => ImportHref::Str(self.parse()?),
+            tok!("url") => ImportHref::Url(self.parse()?),
+            tok!("function") => ImportHref::Url(self.parse()?),
             _ => {
                 return Err(Error::new(
                     span,
-                    ErrorKind::Expected("url('https://example.com') or 'https://example.com'"),
+                    ErrorKind::Expected("string, url or function"),
                 ))
             }
         };
@@ -439,7 +436,7 @@ where
             _ => {
                 return Err(Error::new(
                     span,
-                    ErrorKind::Expected("string, function or url"),
+                    ErrorKind::Expected("string, url or function"),
                 ))
             }
         };

--- a/crates/swc_css_parser/src/parser/selector/mod.rs
+++ b/crates/swc_css_parser/src/parser/selector/mod.rs
@@ -507,8 +507,8 @@ where
                             }
                         };
 
-                        let has_minus_sign = ident_value.chars().nth(0) == Some('-');
-                        let n_char = if has_minus_sign { ident_value.chars().nth(1) } else { ident_value.chars().nth(0) };
+                        let has_minus_sign = ident_value.chars().next() == Some('-');
+                        let n_char = if has_minus_sign { ident_value.chars().nth(1) } else { ident_value.chars().next() };
 
                         if n_char != Some('n') && n_char != Some('N') {
                             return Err(Error::new(
@@ -530,7 +530,7 @@ where
                             }
                         };
 
-                        let n_char = dimension.2.chars().nth(0);
+                        let n_char = dimension.2.chars().next();
 
                         if n_char != Some('n') && n_char != Some('N') {
                             return Err(Error::new(
@@ -540,7 +540,7 @@ where
                         }
 
                         a = Some(dimension.0 as i32);
-                        a_raw = Some(dimension.1.into());
+                        a_raw = Some(dimension.1);
 
                         n_value =  (*dimension.2).to_string();
                     }
@@ -582,7 +582,7 @@ where
                             }
                         };
 
-                        b = Some(-1 * num.0 as i32);
+                        b = Some(-num.0 as i32);
 
                         let mut b_raw_str = String::new();
 
@@ -632,7 +632,7 @@ where
                             )
                         });
 
-                        b = Some(-1 * parsed);
+                        b = Some(-parsed);
 
                         let mut b_raw_str = String::new();
 
@@ -890,7 +890,7 @@ where
 
         let span = span!(self, start_pos);
 
-        if nesting_selector.is_none() && type_selector.is_none() && subclass_selectors.len() == 0 {
+        if nesting_selector.is_none() && type_selector.is_none() && subclass_selectors.is_empty() {
             return Err(Error::new(span, ErrorKind::InvalidSelector));
         }
 

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -794,12 +794,17 @@ where
         }
 
         match bump!(self) {
-            Token::Url { value, raw } => {
+            Token::Url {
+                name,
+                raw_name,
+                value,
+                raw_value,
+            } => {
                 let name = Ident {
+                    // TODO add additional fields in lexer to keep original spaces and fix span
                     span: swc_common::Span::new(span.lo, span.lo + BytePos(3), Default::default()),
-                    // TODO add additional fields in lexer to keep original name of url and spaces
-                    value: "url".into(),
-                    raw: "url".into(),
+                    value: name,
+                    raw: raw_name,
                 };
 
                 let value = Some(UrlValue::Raw(UrlValueRaw {
@@ -809,7 +814,7 @@ where
                         Default::default(),
                     ),
                     value,
-                    raw,
+                    raw: raw_value,
                 }));
 
                 Ok(Url {

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -281,6 +281,15 @@ where
             tok!("num") => return self.parse_numeric_value(),
 
             tok!("function") => return Ok(Value::Function(self.parse()?)),
+            Token::Url { .. } => return Ok(Value::Url(self.parse()?)),
+
+            Token::Function { value, .. } => {
+                if &*value.to_ascii_lowercase() == "url" || &*value.to_ascii_lowercase() == "src" {
+                    return Ok(Value::Url(self.parse()?));
+                }
+
+                return Ok(Value::Function(self.parse()?));
+            }
 
             tok!("percent") => return self.parse_numeric_value(),
 

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -774,30 +774,6 @@ where
     }
 }
 
-impl<I> Parse<UrlValue> for Parser<I>
-where
-    I: ParserInput,
-{
-    fn parse(&mut self) -> PResult<UrlValue> {
-        let span = self.input.cur_span()?;
-
-        if !is!(self, Url) {
-            return Err(Error::new(span, ErrorKind::Expected("Url")));
-        }
-
-        match bump!(self) {
-            Token::Url { value, raw } => Ok(UrlValue {
-                span,
-                url: value,
-                raw,
-            }),
-            _ => {
-                unreachable!()
-            }
-        }
-    }
-}
-
 impl<I> Parse<Url> for Parser<I>
 where
     I: ParserInput,
@@ -818,7 +794,7 @@ where
                     raw: "url".into(),
                 };
 
-                let value = UrlValueType::Raw(UrlValueRaw {
+                let value = UrlValue::Raw(UrlValueRaw {
                     span: swc_common::Span::new(
                         span.lo + BytePos(4),
                         span.hi - BytePos(1),
@@ -854,7 +830,7 @@ where
                 self.input.skip_ws()?;
 
                 let value = match cur!(self) {
-                    tok!("str") => UrlValueType::Str(self.parse()?),
+                    tok!("str") => UrlValue::Str(self.parse()?),
                     _ => {
                         return Err(Error::new(span, ErrorKind::Expected("string")));
                     }

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -5,7 +5,6 @@ use crate::{
     error::{Error, ErrorKind},
     Parse,
 };
-use swc_atoms::js_word;
 use swc_common::{BytePos, Spanned};
 use swc_css_ast::*;
 
@@ -902,10 +901,9 @@ where
             value: name.0,
             raw: name.1,
         };
-        let is_url = name.value.to_ascii_lowercase() == js_word!("url");
         let ctx = Ctx {
-            allow_operation_in_value: !is_url,
-            allow_separating_value_with_space: !is_url,
+            allow_operation_in_value: true,
+            allow_separating_value_with_space: true,
             allow_separating_value_with_comma: false,
             ..self.ctx
         };

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -279,8 +279,7 @@ where
 
             tok!("num") => return self.parse_numeric_value(),
 
-            tok!("function") => return Ok(Value::Function(self.parse()?)),
-            Token::Url { .. } => return Ok(Value::Url(self.parse()?)),
+            tok!("url") => return Ok(Value::Url(self.parse()?)),
 
             Token::Function { value, .. } => {
                 if &*value.to_ascii_lowercase() == "url" || &*value.to_ascii_lowercase() == "src" {
@@ -338,8 +337,6 @@ where
                     block,
                 }));
             }
-
-            tok!("url") => return Ok(Value::Url(self.parse()?)),
 
             _ => {}
         }

--- a/crates/swc_css_parser/tests/fixture.rs
+++ b/crates/swc_css_parser/tests/fixture.rs
@@ -316,9 +316,8 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(Tokens, visit_tokens);
     mtd!(Unit, visit_unit);
     mtd!(UnitValue, visit_unit_value);
-    mtd!(UrlValue, visit_url_value);
     mtd!(Url, visit_url);
-    mtd!(UrlValueType, visit_url_value_type);
+    mtd!(UrlValue, visit_url_value);
     mtd!(UrlValueRaw, visit_url_value_raw);
     mtd!(Value, visit_value);
 

--- a/crates/swc_css_parser/tests/fixture.rs
+++ b/crates/swc_css_parser/tests/fixture.rs
@@ -319,6 +319,7 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(Url, visit_url);
     mtd!(UrlValue, visit_url_value);
     mtd!(UrlValueRaw, visit_url_value_raw);
+    mtd!(UrlModifier, visit_url_modifier);
     mtd!(Value, visit_value);
 
     mtd!(CharsetRule, visit_charset_rule);

--- a/crates/swc_css_parser/tests/fixture.rs
+++ b/crates/swc_css_parser/tests/fixture.rs
@@ -317,6 +317,9 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(Unit, visit_unit);
     mtd!(UnitValue, visit_unit_value);
     mtd!(UrlValue, visit_url_value);
+    mtd!(Url, visit_url);
+    mtd!(UrlValueType, visit_url_value_type);
+    mtd!(UrlValueRaw, visit_url_value_raw);
     mtd!(Value, visit_value);
 
     mtd!(CharsetRule, visit_charset_rule);

--- a/crates/swc_css_parser/tests/fixture/at-rule/font-face/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/font-face/output.json
@@ -97,7 +97,7 @@
                   "value": "/fonts/OpenSans-Regular-webfont.woff2",
                   "raw": "\"/fonts/OpenSans-Regular-webfont.woff2\""
                 },
-                "modifiers": null
+                "modifiers": []
               },
               {
                 "type": "CommaValues",
@@ -164,7 +164,7 @@
                       "value": "/fonts/OpenSans-Regular-webfont.woff",
                       "raw": "\"/fonts/OpenSans-Regular-webfont.woff\""
                     },
-                    "modifiers": null
+                    "modifiers": []
                   }
                 ]
               },

--- a/crates/swc_css_parser/tests/fixture/at-rule/font-face/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/font-face/output.json
@@ -71,7 +71,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 52,
                   "end": 96,
@@ -87,18 +87,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 56,
-                      "end": 95,
-                      "ctxt": 0
-                    },
-                    "value": "/fonts/OpenSans-Regular-webfont.woff2",
-                    "raw": "\"/fonts/OpenSans-Regular-webfont.woff2\""
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 56,
+                    "end": 95,
+                    "ctxt": 0
+                  },
+                  "value": "/fonts/OpenSans-Regular-webfont.woff2",
+                  "raw": "\"/fonts/OpenSans-Regular-webfont.woff2\""
+                },
+                "modifiers": null
               },
               {
                 "type": "CommaValues",
@@ -139,7 +138,7 @@
                     ]
                   },
                   {
-                    "type": "Function",
+                    "type": "Url",
                     "span": {
                       "start": 118,
                       "end": 161,
@@ -155,18 +154,17 @@
                       "value": "url",
                       "raw": "url"
                     },
-                    "value": [
-                      {
-                        "type": "String",
-                        "span": {
-                          "start": 122,
-                          "end": 160,
-                          "ctxt": 0
-                        },
-                        "value": "/fonts/OpenSans-Regular-webfont.woff",
-                        "raw": "\"/fonts/OpenSans-Regular-webfont.woff\""
-                      }
-                    ]
+                    "value": {
+                      "type": "String",
+                      "span": {
+                        "start": 122,
+                        "end": 160,
+                        "ctxt": 0
+                      },
+                      "value": "/fonts/OpenSans-Regular-webfont.woff",
+                      "raw": "\"/fonts/OpenSans-Regular-webfont.woff\""
+                    },
+                    "modifiers": null
                   }
                 ]
               },

--- a/crates/swc_css_parser/tests/fixture/at-rule/font-face/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/font-face/span.rust-debug
@@ -92,7 +92,7 @@ error: Value
 3 |     src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/at-rule/font-face/input.css:3:10
   |
 3 |     src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
@@ -104,7 +104,7 @@ error: Ident
 3 |     src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
   |          ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/at-rule/font-face/input.css:3:14
   |
 3 |     src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
@@ -160,7 +160,7 @@ error: Value
 4 |     url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/at-rule/font-face/input.css:4:5
   |
 4 |     url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
@@ -172,7 +172,7 @@ error: Ident
 4 |     url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
   |     ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/at-rule/font-face/input.css:4:9
   |
 4 |     url("/fonts/OpenSans-Regular-webfont.woff") format("woff");

--- a/crates/swc_css_parser/tests/fixture/at-rule/import/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/import/output.json
@@ -229,8 +229,8 @@
             "end": 167,
             "ctxt": 0
           },
-          "value": "url",
-          "raw": "url"
+          "value": "URL",
+          "raw": "URL"
         },
         "value": {
           "type": "UrlValueRaw",
@@ -1383,8 +1383,8 @@
             "end": 936,
             "ctxt": 0
           },
-          "value": "url",
-          "raw": "url"
+          "value": "URL",
+          "raw": "URL"
         },
         "value": {
           "type": "UrlValueRaw",

--- a/crates/swc_css_parser/tests/fixture/at-rule/import/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/import/output.json
@@ -40,7 +40,7 @@
           "value": "./style.css",
           "raw": "\"./style.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -80,7 +80,7 @@
           "value": "./style.css",
           "raw": "'./style.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -202,7 +202,7 @@
           "value": "./style.css",
           "raw": "\"./style.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -282,7 +282,7 @@
           "value": "./style.css",
           "raw": "\"./style.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -393,7 +393,7 @@
           "value": "landscape.css",
           "raw": "'landscape.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -499,7 +499,7 @@
           "value": "theme.css",
           "raw": "\"theme.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Identifier",
@@ -548,7 +548,7 @@
           "value": "theme.css",
           "raw": "\"theme.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Identifier",
@@ -597,7 +597,7 @@
           "value": "theme.css",
           "raw": "\"theme.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Identifier",
@@ -646,7 +646,7 @@
           "value": "theme.css",
           "raw": "\"theme.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Function",
@@ -715,7 +715,7 @@
           "value": "theme.css",
           "raw": "\"theme.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Function",
@@ -784,7 +784,7 @@
           "value": "override.css",
           "raw": "\"override.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Function",
@@ -842,7 +842,7 @@
           "value": "narrow.css",
           "raw": "\"narrow.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": {
@@ -995,7 +995,7 @@
           "value": "narrow.css",
           "raw": "\"narrow.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": {
@@ -1148,7 +1148,7 @@
           "value": "fallback-layout.css",
           "raw": "\"fallback-layout.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": {
@@ -1276,7 +1276,7 @@
           "value": "test.css",
           "raw": "'test.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -1316,7 +1316,7 @@
           "value": "test.css",
           "raw": "\"test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -1636,7 +1636,7 @@
           "value": "",
           "raw": "''"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -1676,7 +1676,7 @@
           "value": "",
           "raw": "\"\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -1882,7 +1882,7 @@
           "value": "",
           "raw": "''"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -1922,7 +1922,7 @@
           "value": "",
           "raw": "\"\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -2386,7 +2386,7 @@
           "value": "//example.com/style.css",
           "raw": "\"//example.com/style.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -2466,7 +2466,7 @@
           "value": "https://fonts.googleapis.com/css?family=Roboto",
           "raw": "'https://fonts.googleapis.com/css?family=Roboto'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -2506,7 +2506,7 @@
           "value": "https://fonts.googleapis.com/css?family=Noto+Sans+TC",
           "raw": "'https://fonts.googleapis.com/css?family=Noto+Sans+TC'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -2546,7 +2546,7 @@
           "value": "https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto",
           "raw": "'https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -2586,7 +2586,7 @@
           "value": "./relative.css",
           "raw": "'./relative.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -2626,7 +2626,7 @@
           "value": "../import/top-relative.css",
           "raw": "'../import/top-relative.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -2746,7 +2746,7 @@
           "value": "./url.css",
           "raw": "'./url.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -2868,7 +2868,7 @@
           "value": "./test.css",
           "raw": "'./te\\\nst.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -2908,7 +2908,7 @@
           "value": "./test.css",
           "raw": "'./te\\\n\\\n\\\nst.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -2969,7 +2969,7 @@
           "value": "./te'st.css",
           "raw": "\"./te'st.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -3030,7 +3030,7 @@
           "value": "./te'st.css",
           "raw": "'./te\\'st.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -3091,7 +3091,7 @@
           "value": "./test test.css",
           "raw": "'./test test.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -3152,7 +3152,7 @@
           "value": "./test test.css",
           "raw": "'./test\\ test.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -3213,7 +3213,7 @@
           "value": "./test%20test.css",
           "raw": "'./test%20test.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -3274,7 +3274,7 @@
           "value": "./test.css",
           "raw": "'./\\74\\65\\73\\74.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -3335,7 +3335,7 @@
           "value": "./test.css",
           "raw": "'./t\\65\\73\\74.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -3455,7 +3455,7 @@
           "value": "./test%20test.css",
           "raw": "'./t\\65st%20test.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -3495,7 +3495,7 @@
           "value": "./test%20test.css",
           "raw": "\"./t\\65st%20test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -3638,7 +3638,7 @@
           "value": "!!../../helpers/string-loader.js?esModule=false!~package/tilde.css",
           "raw": "'!!../../helpers/string-loader.js?esModule=false!~package/tilde.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -4104,7 +4104,7 @@
           "value": "   ./test.css   ",
           "raw": "'   ./test.css   '"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -4205,7 +4205,7 @@
           "value": "   https://fonts.googleapis.com/css?family=Roboto   ",
           "raw": "'   https://fonts.googleapis.com/css?family=Roboto   '"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -4245,7 +4245,7 @@
           "value": "!!../../helpers/string-loader.js?esModule=false!",
           "raw": "'!!../../helpers/string-loader.js?esModule=false!'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -4285,7 +4285,7 @@
           "value": "   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   ",
           "raw": "'   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   '"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -4445,7 +4445,7 @@
           "value": "./test.css",
           "raw": "\"./test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": {
@@ -4515,7 +4515,7 @@
           "value": "./test.css",
           "raw": "\"./test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": {
@@ -4589,7 +4589,7 @@
           "value": "./test.css",
           "raw": "\"./test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": {
@@ -4742,7 +4742,7 @@
           "value": "./test.css",
           "raw": "\"./test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Identifier",
@@ -4791,7 +4791,7 @@
           "value": "./test.css",
           "raw": "\"./test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Function",
@@ -4860,7 +4860,7 @@
           "value": "./test.css",
           "raw": "\"./test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Function",
@@ -5042,7 +5042,7 @@
           "value": "./test.css",
           "raw": "\"./test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Identifier",
@@ -5204,7 +5204,7 @@
           "value": "./test.css",
           "raw": "\"./test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Function",
@@ -5375,7 +5375,7 @@
           "value": "./test.css",
           "raw": "\"./test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Function",
@@ -5433,7 +5433,7 @@
           "value": "http://example.com/style.css",
           "raw": "\"http://example.com/style.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": {
@@ -5586,7 +5586,7 @@
           "value": "./test.css",
           "raw": "\"./test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Function",
@@ -5768,7 +5768,7 @@
           "value": "./test.css",
           "raw": "\"./test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -5891,7 +5891,7 @@
           "value": "./test.css",
           "raw": "\"./test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Function",
@@ -6365,7 +6365,7 @@
           "value": "./deep-import-with-media.css",
           "raw": "\"./deep-import-with-media.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,
@@ -6462,7 +6462,7 @@
           "value": "./import-with-supports.css",
           "raw": "\"./import-with-supports.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": {
@@ -6532,7 +6532,7 @@
           "value": "./import-with-supports.css",
           "raw": "\"./import-with-supports.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": {
@@ -6622,7 +6622,7 @@
           "value": "./deep-import-with-supports.css",
           "raw": "\"./deep-import-with-supports.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": {
@@ -6692,7 +6692,7 @@
           "value": "./test.css",
           "raw": "'./test.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": {
@@ -6762,7 +6762,7 @@
           "value": "./test.css",
           "raw": "'./test.css'"
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": {
@@ -6832,7 +6832,7 @@
           "value": "./import-with-supports-and-media.css",
           "raw": "\"./import-with-supports-and-media.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": {
@@ -6985,7 +6985,7 @@
           "value": "./test.css",
           "raw": "\"./test.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Function",
@@ -7054,7 +7054,7 @@
           "value": "./import-multiple-with-layer.css",
           "raw": "\"./import-multiple-with-layer.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Function",
@@ -7123,7 +7123,7 @@
           "value": "./import-unnamed-layer.css",
           "raw": "\"./import-unnamed-layer.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Function",
@@ -7192,7 +7192,7 @@
           "value": "./import-with-layer-and-supports.css",
           "raw": "\"./import-with-layer-and-supports.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": {
         "type": "Function",

--- a/crates/swc_css_parser/tests/fixture/at-rule/import/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/import/output.json
@@ -14,7 +14,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 8,
           "end": 26,
@@ -30,18 +30,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 12,
-              "end": 25,
-              "ctxt": 0
-            },
-            "value": "./style.css",
-            "raw": "\"./style.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 12,
+            "end": 25,
+            "ctxt": 0
+          },
+          "value": "./style.css",
+          "raw": "\"./style.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -55,7 +54,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 36,
           "end": 54,
@@ -71,18 +70,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 40,
-              "end": 53,
-              "ctxt": 0
-            },
-            "value": "./style.css",
-            "raw": "'./style.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 40,
+            "end": 53,
+            "ctxt": 0
+          },
+          "value": "./style.css",
+          "raw": "'./style.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -96,14 +94,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 64,
           "end": 80,
           "ctxt": 0
         },
-        "url": "./style.css",
-        "raw": "./style.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 64,
+            "end": 67,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 68,
+            "end": 79,
+            "ctxt": 0
+          },
+          "value": "./style.css",
+          "raw": "./style.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -159,7 +176,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 136,
           "end": 154,
@@ -175,18 +192,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 140,
-              "end": 153,
-              "ctxt": 0
-            },
-            "value": "./style.css",
-            "raw": "\"./style.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 140,
+            "end": 153,
+            "ctxt": 0
+          },
+          "value": "./style.css",
+          "raw": "\"./style.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -200,14 +216,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 164,
           "end": 180,
           "ctxt": 0
         },
-        "url": "./style.css",
-        "raw": "./style.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 164,
+            "end": 167,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 168,
+            "end": 179,
+            "ctxt": 0
+          },
+          "value": "./style.css",
+          "raw": "./style.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -221,7 +256,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 190,
           "end": 208,
@@ -237,18 +272,17 @@
           "value": "URL",
           "raw": "URL"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 194,
-              "end": 207,
-              "ctxt": 0
-            },
-            "value": "./style.css",
-            "raw": "\"./style.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 194,
+            "end": 207,
+            "ctxt": 0
+          },
+          "value": "./style.css",
+          "raw": "\"./style.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -333,7 +367,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 266,
           "end": 286,
@@ -349,18 +383,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 270,
-              "end": 285,
-              "ctxt": 0
-            },
-            "value": "landscape.css",
-            "raw": "'landscape.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 270,
+            "end": 285,
+            "ctxt": 0
+          },
+          "value": "landscape.css",
+          "raw": "'landscape.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -440,7 +473,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 331,
           "end": 347,
@@ -456,18 +489,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 335,
-              "end": 346,
-              "ctxt": 0
-            },
-            "value": "theme.css",
-            "raw": "\"theme.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 335,
+            "end": 346,
+            "ctxt": 0
+          },
+          "value": "theme.css",
+          "raw": "\"theme.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Identifier",
@@ -490,7 +522,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 363,
           "end": 379,
@@ -506,18 +538,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 367,
-              "end": 378,
-              "ctxt": 0
-            },
-            "value": "theme.css",
-            "raw": "\"theme.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 367,
+            "end": 378,
+            "ctxt": 0
+          },
+          "value": "theme.css",
+          "raw": "\"theme.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Identifier",
@@ -540,7 +571,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 398,
           "end": 414,
@@ -556,18 +587,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 402,
-              "end": 413,
-              "ctxt": 0
-            },
-            "value": "theme.css",
-            "raw": "\"theme.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 402,
+            "end": 413,
+            "ctxt": 0
+          },
+          "value": "theme.css",
+          "raw": "\"theme.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Identifier",
@@ -590,7 +620,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 430,
           "end": 446,
@@ -606,18 +636,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 434,
-              "end": 445,
-              "ctxt": 0
-            },
-            "value": "theme.css",
-            "raw": "\"theme.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 434,
+            "end": 445,
+            "ctxt": 0
+          },
+          "value": "theme.css",
+          "raw": "\"theme.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Function",
@@ -660,7 +689,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 471,
           "end": 487,
@@ -676,18 +705,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 475,
-              "end": 486,
-              "ctxt": 0
-            },
-            "value": "theme.css",
-            "raw": "\"theme.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 475,
+            "end": 486,
+            "ctxt": 0
+          },
+          "value": "theme.css",
+          "raw": "\"theme.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Function",
@@ -730,7 +758,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 568,
           "end": 587,
@@ -746,18 +774,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 572,
-              "end": 586,
-              "ctxt": 0
-            },
-            "value": "override.css",
-            "raw": "\"override.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 572,
+            "end": 586,
+            "ctxt": 0
+          },
+          "value": "override.css",
+          "raw": "\"override.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Function",
@@ -789,7 +816,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 605,
           "end": 622,
@@ -805,18 +832,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 609,
-              "end": 621,
-              "ctxt": 0
-            },
-            "value": "narrow.css",
-            "raw": "\"narrow.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 609,
+            "end": 621,
+            "ctxt": 0
+          },
+          "value": "narrow.css",
+          "raw": "\"narrow.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": {
@@ -943,7 +969,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 688,
           "end": 705,
@@ -959,18 +985,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 692,
-              "end": 704,
-              "ctxt": 0
-            },
-            "value": "narrow.css",
-            "raw": "\"narrow.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 692,
+            "end": 704,
+            "ctxt": 0
+          },
+          "value": "narrow.css",
+          "raw": "\"narrow.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": {
@@ -1097,7 +1122,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 771,
           "end": 797,
@@ -1113,18 +1138,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 775,
-              "end": 796,
-              "ctxt": 0
-            },
-            "value": "fallback-layout.css",
-            "raw": "\"fallback-layout.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 775,
+            "end": 796,
+            "ctxt": 0
+          },
+          "value": "fallback-layout.css",
+          "raw": "\"fallback-layout.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": {
@@ -1186,14 +1210,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 837,
           "end": 850,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 837,
+            "end": 840,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 841,
+            "end": 849,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1207,7 +1250,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 860,
           "end": 875,
@@ -1223,18 +1266,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 864,
-              "end": 874,
-              "ctxt": 0
-            },
-            "value": "test.css",
-            "raw": "'test.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 864,
+            "end": 874,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "'test.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1248,7 +1290,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 885,
           "end": 900,
@@ -1264,18 +1306,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 889,
-              "end": 899,
-              "ctxt": 0
-            },
-            "value": "test.css",
-            "raw": "\"test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 889,
+            "end": 899,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "\"test.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1289,14 +1330,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 910,
           "end": 923,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 910,
+            "end": 913,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 914,
+            "end": 922,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1310,14 +1370,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 933,
           "end": 946,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 933,
+            "end": 936,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 937,
+            "end": 945,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1331,14 +1410,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 956,
           "end": 970,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css "
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 956,
+            "end": 959,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 960,
+            "end": 969,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css "
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1352,14 +1450,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 980,
           "end": 994,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 980,
+            "end": 983,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 984,
+            "end": 993,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1373,14 +1490,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 1004,
           "end": 1019,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css "
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 1004,
+            "end": 1007,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 1008,
+            "end": 1018,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css "
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1394,14 +1530,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 1029,
           "end": 1044,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css\n"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 1029,
+            "end": 1032,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 1033,
+            "end": 1043,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css\n"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1415,14 +1570,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 1054,
           "end": 1059,
           "ctxt": 0
         },
-        "url": "",
-        "raw": ""
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 1054,
+            "end": 1057,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 1058,
+            "end": 1058,
+            "ctxt": 0
+          },
+          "value": "",
+          "raw": ""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1436,7 +1610,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 1069,
           "end": 1076,
@@ -1452,18 +1626,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 1073,
-              "end": 1075,
-              "ctxt": 0
-            },
-            "value": "",
-            "raw": "''"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 1073,
+            "end": 1075,
+            "ctxt": 0
+          },
+          "value": "",
+          "raw": "''"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1477,7 +1650,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 1086,
           "end": 1093,
@@ -1493,18 +1666,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 1090,
-              "end": 1092,
-              "ctxt": 0
-            },
-            "value": "",
-            "raw": "\"\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 1090,
+            "end": 1092,
+            "ctxt": 0
+          },
+          "value": "",
+          "raw": "\"\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1644,14 +1816,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 1196,
           "end": 1201,
           "ctxt": 0
         },
-        "url": "",
-        "raw": ""
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 1196,
+            "end": 1199,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 1200,
+            "end": 1200,
+            "ctxt": 0
+          },
+          "value": "",
+          "raw": ""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1665,7 +1856,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 1211,
           "end": 1218,
@@ -1681,18 +1872,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 1215,
-              "end": 1217,
-              "ctxt": 0
-            },
-            "value": "",
-            "raw": "''"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 1215,
+            "end": 1217,
+            "ctxt": 0
+          },
+          "value": "",
+          "raw": "''"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1706,7 +1896,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 1228,
           "end": 1235,
@@ -1722,18 +1912,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 1232,
-              "end": 1234,
-              "ctxt": 0
-            },
-            "value": "",
-            "raw": "\"\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 1232,
+            "end": 1234,
+            "ctxt": 0
+          },
+          "value": "",
+          "raw": "\"\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1747,14 +1936,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 1245,
           "end": 1258,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 1245,
+            "end": 1248,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 1249,
+            "end": 1257,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1834,14 +2042,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 1366,
           "end": 1379,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 1366,
+            "end": 1369,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 1370,
+            "end": 1378,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -1921,14 +2148,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 1423,
           "end": 1436,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 1423,
+            "end": 1426,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 1427,
+            "end": 1435,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2008,14 +2254,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 1502,
           "end": 1515,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 1502,
+            "end": 1505,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 1506,
+            "end": 1514,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2095,7 +2360,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 1560,
           "end": 1590,
@@ -2111,18 +2376,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 1564,
-              "end": 1589,
-              "ctxt": 0
-            },
-            "value": "//example.com/style.css",
-            "raw": "\"//example.com/style.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 1564,
+            "end": 1589,
+            "ctxt": 0
+          },
+          "value": "//example.com/style.css",
+          "raw": "\"//example.com/style.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2136,14 +2400,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 1600,
           "end": 1622,
           "ctxt": 0
         },
-        "url": "~package/test.css",
-        "raw": "~package/test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 1600,
+            "end": 1603,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 1604,
+            "end": 1621,
+            "ctxt": 0
+          },
+          "value": "~package/test.css",
+          "raw": "~package/test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2157,7 +2440,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 1632,
           "end": 1685,
@@ -2173,18 +2456,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 1636,
-              "end": 1684,
-              "ctxt": 0
-            },
-            "value": "https://fonts.googleapis.com/css?family=Roboto",
-            "raw": "'https://fonts.googleapis.com/css?family=Roboto'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 1636,
+            "end": 1684,
+            "ctxt": 0
+          },
+          "value": "https://fonts.googleapis.com/css?family=Roboto",
+          "raw": "'https://fonts.googleapis.com/css?family=Roboto'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2198,7 +2480,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 1695,
           "end": 1754,
@@ -2214,18 +2496,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 1699,
-              "end": 1753,
-              "ctxt": 0
-            },
-            "value": "https://fonts.googleapis.com/css?family=Noto+Sans+TC",
-            "raw": "'https://fonts.googleapis.com/css?family=Noto+Sans+TC'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 1699,
+            "end": 1753,
+            "ctxt": 0
+          },
+          "value": "https://fonts.googleapis.com/css?family=Noto+Sans+TC",
+          "raw": "'https://fonts.googleapis.com/css?family=Noto+Sans+TC'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2239,7 +2520,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 1764,
           "end": 1830,
@@ -2255,18 +2536,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 1768,
-              "end": 1829,
-              "ctxt": 0
-            },
-            "value": "https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto",
-            "raw": "'https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 1768,
+            "end": 1829,
+            "ctxt": 0
+          },
+          "value": "https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto",
+          "raw": "'https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2280,7 +2560,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 1840,
           "end": 1861,
@@ -2296,18 +2576,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 1844,
-              "end": 1860,
-              "ctxt": 0
-            },
-            "value": "./relative.css",
-            "raw": "'./relative.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 1844,
+            "end": 1860,
+            "ctxt": 0
+          },
+          "value": "./relative.css",
+          "raw": "'./relative.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2321,7 +2600,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 1871,
           "end": 1904,
@@ -2337,18 +2616,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 1875,
-              "end": 1903,
-              "ctxt": 0
-            },
-            "value": "../import/top-relative.css",
-            "raw": "'../import/top-relative.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 1875,
+            "end": 1903,
+            "ctxt": 0
+          },
+          "value": "../import/top-relative.css",
+          "raw": "'../import/top-relative.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2362,14 +2640,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 1914,
           "end": 1937,
           "ctxt": 0
         },
-        "url": "~package/tilde.css",
-        "raw": "~package/tilde.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 1914,
+            "end": 1917,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 1918,
+            "end": 1936,
+            "ctxt": 0
+          },
+          "value": "~package/tilde.css",
+          "raw": "~package/tilde.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2383,14 +2680,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 1947,
           "end": 1976,
           "ctxt": 0
         },
-        "url": "~aliasesImport/alias.css",
-        "raw": "~aliasesImport/alias.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 1947,
+            "end": 1950,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 1951,
+            "end": 1975,
+            "ctxt": 0
+          },
+          "value": "~aliasesImport/alias.css",
+          "raw": "~aliasesImport/alias.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2404,7 +2720,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 1986,
           "end": 2002,
@@ -2420,18 +2736,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 1990,
-              "end": 2001,
-              "ctxt": 0
-            },
-            "value": "./url.css",
-            "raw": "'./url.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 1990,
+            "end": 2001,
+            "ctxt": 0
+          },
+          "value": "./url.css",
+          "raw": "'./url.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2445,14 +2760,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 2013,
           "end": 2028,
           "ctxt": 0
         },
-        "url": "./test.css",
-        "raw": "./test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 2013,
+            "end": 2016,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 2017,
+            "end": 2027,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "./test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2508,7 +2842,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 2091,
           "end": 2110,
@@ -2524,18 +2858,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 2095,
-              "end": 2109,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "'./te\\\nst.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 2095,
+            "end": 2109,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "'./te\\\nst.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2549,7 +2882,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 2120,
           "end": 2143,
@@ -2565,18 +2898,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 2124,
-              "end": 2142,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "'./te\\\n\\\n\\\nst.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 2124,
+            "end": 2142,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "'./te\\\n\\\n\\\nst.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2611,7 +2943,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 2177,
           "end": 2195,
@@ -2627,18 +2959,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 2181,
-              "end": 2194,
-              "ctxt": 0
-            },
-            "value": "./te'st.css",
-            "raw": "\"./te'st.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 2181,
+            "end": 2194,
+            "ctxt": 0
+          },
+          "value": "./te'st.css",
+          "raw": "\"./te'st.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2673,7 +3004,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 2229,
           "end": 2248,
@@ -2689,18 +3020,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 2233,
-              "end": 2247,
-              "ctxt": 0
-            },
-            "value": "./te'st.css",
-            "raw": "'./te\\'st.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 2233,
+            "end": 2247,
+            "ctxt": 0
+          },
+          "value": "./te'st.css",
+          "raw": "'./te\\'st.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2735,7 +3065,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 2285,
           "end": 2307,
@@ -2751,18 +3081,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 2289,
-              "end": 2306,
-              "ctxt": 0
-            },
-            "value": "./test test.css",
-            "raw": "'./test test.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 2289,
+            "end": 2306,
+            "ctxt": 0
+          },
+          "value": "./test test.css",
+          "raw": "'./test test.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2797,7 +3126,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 2345,
           "end": 2368,
@@ -2813,18 +3142,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 2349,
-              "end": 2367,
-              "ctxt": 0
-            },
-            "value": "./test test.css",
-            "raw": "'./test\\ test.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 2349,
+            "end": 2367,
+            "ctxt": 0
+          },
+          "value": "./test test.css",
+          "raw": "'./test\\ test.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2859,7 +3187,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 2407,
           "end": 2431,
@@ -2875,18 +3203,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 2411,
-              "end": 2430,
-              "ctxt": 0
-            },
-            "value": "./test%20test.css",
-            "raw": "'./test%20test.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 2411,
+            "end": 2430,
+            "ctxt": 0
+          },
+          "value": "./test%20test.css",
+          "raw": "'./test%20test.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2921,7 +3248,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 2471,
           "end": 2496,
@@ -2937,18 +3264,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 2475,
-              "end": 2495,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "'./\\74\\65\\73\\74.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 2475,
+            "end": 2495,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "'./\\74\\65\\73\\74.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -2983,7 +3309,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 2534,
           "end": 2557,
@@ -2999,18 +3325,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 2538,
-              "end": 2556,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "'./t\\65\\73\\74.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 2538,
+            "end": 2556,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "'./t\\65\\73\\74.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3024,14 +3349,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 2567,
           "end": 2588,
           "ctxt": 0
         },
-        "url": "./test test.css",
-        "raw": "./test\\ test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 2567,
+            "end": 2570,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 2571,
+            "end": 2587,
+            "ctxt": 0
+          },
+          "value": "./test test.css",
+          "raw": "./test\\ test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3045,14 +3389,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 2598,
           "end": 2622,
           "ctxt": 0
         },
-        "url": "./test%20test.css",
-        "raw": "./t\\65st%20test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 2598,
+            "end": 2601,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 2602,
+            "end": 2621,
+            "ctxt": 0
+          },
+          "value": "./test%20test.css",
+          "raw": "./t\\65st%20test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3066,7 +3429,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 2632,
           "end": 2658,
@@ -3082,18 +3445,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 2636,
-              "end": 2657,
-              "ctxt": 0
-            },
-            "value": "./test%20test.css",
-            "raw": "'./t\\65st%20test.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 2636,
+            "end": 2657,
+            "ctxt": 0
+          },
+          "value": "./test%20test.css",
+          "raw": "'./t\\65st%20test.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3107,7 +3469,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 2668,
           "end": 2694,
@@ -3123,18 +3485,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 2672,
-              "end": 2693,
-              "ctxt": 0
-            },
-            "value": "./test%20test.css",
-            "raw": "\"./t\\65st%20test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 2672,
+            "end": 2693,
+            "ctxt": 0
+          },
+          "value": "./test%20test.css",
+          "raw": "\"./t\\65st%20test.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3190,14 +3551,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 2766,
           "end": 2818,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css                      "
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 2766,
+            "end": 2769,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 2770,
+            "end": 2817,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css                      "
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3232,7 +3612,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 2846,
           "end": 2919,
@@ -3248,18 +3628,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 2850,
-              "end": 2918,
-              "ctxt": 0
-            },
-            "value": "!!../../helpers/string-loader.js?esModule=false!~package/tilde.css",
-            "raw": "'!!../../helpers/string-loader.js?esModule=false!~package/tilde.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 2850,
+            "end": 2918,
+            "ctxt": 0
+          },
+          "value": "!!../../helpers/string-loader.js?esModule=false!~package/tilde.css",
+          "raw": "'!!../../helpers/string-loader.js?esModule=false!~package/tilde.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3273,14 +3652,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 2930,
           "end": 2951,
           "ctxt": 0
         },
-        "url": "test.css?foo=bar",
-        "raw": "test.css?foo=bar"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 2930,
+            "end": 2933,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 2934,
+            "end": 2950,
+            "ctxt": 0
+          },
+          "value": "test.css?foo=bar",
+          "raw": "test.css?foo=bar"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3294,14 +3692,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 2961,
           "end": 2987,
           "ctxt": 0
         },
-        "url": "test.css?foo=bar#hash",
-        "raw": "test.css?foo=bar#hash"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 2961,
+            "end": 2964,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 2965,
+            "end": 2986,
+            "ctxt": 0
+          },
+          "value": "test.css?foo=bar#hash",
+          "raw": "test.css?foo=bar#hash"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3315,14 +3732,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 2997,
           "end": 3016,
           "ctxt": 0
         },
-        "url": "test.css?#hash",
-        "raw": "test.css?#hash"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 2997,
+            "end": 3000,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 3001,
+            "end": 3015,
+            "ctxt": 0
+          },
+          "value": "test.css?#hash",
+          "raw": "test.css?#hash"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3642,7 +4078,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 3255,
           "end": 3278,
@@ -3658,18 +4094,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 3259,
-              "end": 3277,
-              "ctxt": 0
-            },
-            "value": "   ./test.css   ",
-            "raw": "'   ./test.css   '"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 3259,
+            "end": 3277,
+            "ctxt": 0
+          },
+          "value": "   ./test.css   ",
+          "raw": "'   ./test.css   '"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3683,14 +4118,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 3288,
           "end": 3309,
           "ctxt": 0
         },
-        "url": "./test.css",
-        "raw": "./test.css   "
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 3288,
+            "end": 3291,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 3292,
+            "end": 3308,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "./test.css   "
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3725,7 +4179,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 3342,
           "end": 3401,
@@ -3741,18 +4195,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 3346,
-              "end": 3400,
-              "ctxt": 0
-            },
-            "value": "   https://fonts.googleapis.com/css?family=Roboto   ",
-            "raw": "'   https://fonts.googleapis.com/css?family=Roboto   '"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 3346,
+            "end": 3400,
+            "ctxt": 0
+          },
+          "value": "   https://fonts.googleapis.com/css?family=Roboto   ",
+          "raw": "'   https://fonts.googleapis.com/css?family=Roboto   '"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3766,7 +4219,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 3411,
           "end": 3466,
@@ -3782,18 +4235,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 3415,
-              "end": 3465,
-              "ctxt": 0
-            },
-            "value": "!!../../helpers/string-loader.js?esModule=false!",
-            "raw": "'!!../../helpers/string-loader.js?esModule=false!'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 3415,
+            "end": 3465,
+            "ctxt": 0
+          },
+          "value": "!!../../helpers/string-loader.js?esModule=false!",
+          "raw": "'!!../../helpers/string-loader.js?esModule=false!'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3807,7 +4259,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 3476,
           "end": 3555,
@@ -3823,18 +4275,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 3480,
-              "end": 3554,
-              "ctxt": 0
-            },
-            "value": "   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   ",
-            "raw": "'   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   '"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 3480,
+            "end": 3554,
+            "ctxt": 0
+          },
+          "value": "   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   ",
+          "raw": "'   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   '"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3848,14 +4299,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 3565,
           "end": 3643,
           "ctxt": 0
         },
-        "url": "data:text/css;charset=utf-8,a%20%7B%0D%0A%20%20color%3A%20red%3B%0D%0A%7D",
-        "raw": "data:text/css;charset=utf-8,a%20%7B%0D%0A%20%20color%3A%20red%3B%0D%0A%7D"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 3565,
+            "end": 3568,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 3569,
+            "end": 3642,
+            "ctxt": 0
+          },
+          "value": "data:text/css;charset=utf-8,a%20%7B%0D%0A%20%20color%3A%20red%3B%0D%0A%7D",
+          "raw": "data:text/css;charset=utf-8,a%20%7B%0D%0A%20%20color%3A%20red%3B%0D%0A%7D"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3869,14 +4339,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 3654,
           "end": 3676,
           "ctxt": 0
         },
-        "url": "package/first.css",
-        "raw": "package/first.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 3654,
+            "end": 3657,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 3658,
+            "end": 3675,
+            "ctxt": 0
+          },
+          "value": "package/first.css",
+          "raw": "package/first.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3890,14 +4379,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 3686,
           "end": 3709,
           "ctxt": 0
         },
-        "url": "package/second.css",
-        "raw": "package/second.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 3686,
+            "end": 3689,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 3690,
+            "end": 3708,
+            "ctxt": 0
+          },
+          "value": "package/second.css",
+          "raw": "package/second.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -3911,7 +4419,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 3811,
           "end": 3828,
@@ -3927,18 +4435,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 3815,
-              "end": 3827,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "\"./test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 3815,
+            "end": 3827,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "\"./test.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": {
@@ -3982,7 +4489,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 3862,
           "end": 3879,
@@ -3998,18 +4505,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 3866,
-              "end": 3878,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "\"./test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 3866,
+            "end": 3878,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "\"./test.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": {
@@ -4057,7 +4563,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 3924,
           "end": 3941,
@@ -4073,18 +4579,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 3928,
-              "end": 3940,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "\"./test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 3928,
+            "end": 3940,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "\"./test.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": {
@@ -4211,7 +4716,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 4005,
           "end": 4022,
@@ -4227,18 +4732,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 4009,
-              "end": 4021,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "\"./test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 4009,
+            "end": 4021,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "\"./test.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Identifier",
@@ -4261,7 +4765,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 4038,
           "end": 4055,
@@ -4277,18 +4781,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 4042,
-              "end": 4054,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "\"./test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 4042,
+            "end": 4054,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "\"./test.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Function",
@@ -4331,7 +4834,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 4080,
           "end": 4097,
@@ -4347,18 +4850,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 4084,
-              "end": 4096,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "\"./test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 4084,
+            "end": 4096,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "\"./test.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Function",
@@ -4514,7 +5016,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 4176,
           "end": 4193,
@@ -4530,18 +5032,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 4180,
-              "end": 4192,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "\"./test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 4180,
+            "end": 4192,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "\"./test.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Identifier",
@@ -4677,7 +5178,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 4263,
           "end": 4280,
@@ -4693,18 +5194,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 4267,
-              "end": 4279,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "\"./test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 4267,
+            "end": 4279,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "\"./test.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Function",
@@ -4849,7 +5349,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 4352,
           "end": 4369,
@@ -4865,18 +5365,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 4356,
-              "end": 4368,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "\"./test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 4356,
+            "end": 4368,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "\"./test.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Function",
@@ -4908,7 +5407,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 4387,
           "end": 4422,
@@ -4924,18 +5423,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 4391,
-              "end": 4421,
-              "ctxt": 0
-            },
-            "value": "http://example.com/style.css",
-            "raw": "\"http://example.com/style.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 4391,
+            "end": 4421,
+            "ctxt": 0
+          },
+          "value": "http://example.com/style.css",
+          "raw": "\"http://example.com/style.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": {
@@ -5062,7 +5560,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 4486,
           "end": 4503,
@@ -5078,18 +5576,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 4490,
-              "end": 4502,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "\"./test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 4490,
+            "end": 4502,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "\"./test.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Function",
@@ -5245,7 +5742,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 4578,
           "end": 4595,
@@ -5261,18 +5758,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 4582,
-              "end": 4594,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "\"./test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 4582,
+            "end": 4594,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "\"./test.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -5369,7 +5865,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 4902,
           "end": 4919,
@@ -5385,18 +5881,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 4906,
-              "end": 4918,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "\"./test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 4906,
+            "end": 4918,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "\"./test.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Function",
@@ -5552,14 +6047,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 5195,
           "end": 5208,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 5195,
+            "end": 5198,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 5199,
+            "end": 5207,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -5573,14 +6087,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 5246,
           "end": 5259,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 5246,
+            "end": 5249,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 5250,
+            "end": 5258,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -5594,14 +6127,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 5283,
           "end": 5296,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 5283,
+            "end": 5286,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 5287,
+            "end": 5295,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -5681,14 +6233,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 5368,
           "end": 5381,
           "ctxt": 0
         },
-        "url": "test.css",
-        "raw": "test.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 5368,
+            "end": 5371,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 5372,
+            "end": 5380,
+            "ctxt": 0
+          },
+          "value": "test.css",
+          "raw": "test.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -5768,7 +6339,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 5440,
           "end": 5475,
@@ -5784,18 +6355,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 5444,
-              "end": 5474,
-              "ctxt": 0
-            },
-            "value": "./deep-import-with-media.css",
-            "raw": "\"./deep-import-with-media.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 5444,
+            "end": 5474,
+            "ctxt": 0
+          },
+          "value": "./deep-import-with-media.css",
+          "raw": "\"./deep-import-with-media.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,
@@ -5866,7 +6436,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 5514,
           "end": 5547,
@@ -5882,18 +6452,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 5518,
-              "end": 5546,
-              "ctxt": 0
-            },
-            "value": "./import-with-supports.css",
-            "raw": "\"./import-with-supports.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 5518,
+            "end": 5546,
+            "ctxt": 0
+          },
+          "value": "./import-with-supports.css",
+          "raw": "\"./import-with-supports.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": {
@@ -5937,7 +6506,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 5581,
           "end": 5614,
@@ -5953,18 +6522,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 5585,
-              "end": 5613,
-              "ctxt": 0
-            },
-            "value": "./import-with-supports.css",
-            "raw": "\"./import-with-supports.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 5585,
+            "end": 5613,
+            "ctxt": 0
+          },
+          "value": "./import-with-supports.css",
+          "raw": "\"./import-with-supports.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": {
@@ -6028,7 +6596,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 5652,
           "end": 5690,
@@ -6044,18 +6612,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 5656,
-              "end": 5689,
-              "ctxt": 0
-            },
-            "value": "./deep-import-with-supports.css",
-            "raw": "\"./deep-import-with-supports.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 5656,
+            "end": 5689,
+            "ctxt": 0
+          },
+          "value": "./deep-import-with-supports.css",
+          "raw": "\"./deep-import-with-supports.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": {
@@ -6099,7 +6666,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 5724,
           "end": 5741,
@@ -6115,18 +6682,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 5728,
-              "end": 5740,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "'./test.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 5728,
+            "end": 5740,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "'./test.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": {
@@ -6170,7 +6736,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 5775,
           "end": 5792,
@@ -6186,18 +6752,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 5779,
-              "end": 5791,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "'./test.css'"
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 5779,
+            "end": 5791,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "'./test.css'"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": {
@@ -6241,7 +6806,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 5838,
           "end": 5881,
@@ -6257,18 +6822,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 5842,
-              "end": 5880,
-              "ctxt": 0
-            },
-            "value": "./import-with-supports-and-media.css",
-            "raw": "\"./import-with-supports-and-media.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 5842,
+            "end": 5880,
+            "ctxt": 0
+          },
+          "value": "./import-with-supports-and-media.css",
+          "raw": "\"./import-with-supports-and-media.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": {
@@ -6395,7 +6959,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 5945,
           "end": 5962,
@@ -6411,18 +6975,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 5949,
-              "end": 5961,
-              "ctxt": 0
-            },
-            "value": "./test.css",
-            "raw": "\"./test.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 5949,
+            "end": 5961,
+            "ctxt": 0
+          },
+          "value": "./test.css",
+          "raw": "\"./test.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Function",
@@ -6465,7 +7028,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 5989,
           "end": 6028,
@@ -6481,18 +7044,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 5993,
-              "end": 6027,
-              "ctxt": 0
-            },
-            "value": "./import-multiple-with-layer.css",
-            "raw": "\"./import-multiple-with-layer.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 5993,
+            "end": 6027,
+            "ctxt": 0
+          },
+          "value": "./import-multiple-with-layer.css",
+          "raw": "\"./import-multiple-with-layer.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Function",
@@ -6535,7 +7097,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 6053,
           "end": 6086,
@@ -6551,18 +7113,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 6057,
-              "end": 6085,
-              "ctxt": 0
-            },
-            "value": "./import-unnamed-layer.css",
-            "raw": "\"./import-unnamed-layer.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 6057,
+            "end": 6085,
+            "ctxt": 0
+          },
+          "value": "./import-unnamed-layer.css",
+          "raw": "\"./import-unnamed-layer.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Function",
@@ -6605,7 +7166,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 6108,
           "end": 6151,
@@ -6621,18 +7182,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 6112,
-              "end": 6150,
-              "ctxt": 0
-            },
-            "value": "./import-with-layer-and-supports.css",
-            "raw": "\"./import-with-layer-and-supports.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 6112,
+            "end": 6150,
+            "ctxt": 0
+          },
+          "value": "./import-with-layer-and-supports.css",
+          "raw": "\"./import-with-layer-and-supports.css\""
+        },
+        "modifiers": null
       },
       "layerName": {
         "type": "Function",

--- a/crates/swc_css_parser/tests/fixture/at-rule/import/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/import/span.rust-debug
@@ -34,7 +34,7 @@ error: ImportHref
 1 | @import url("./style.css");
   |         ^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/at-rule/import/input.css:1:9
   |
 1 | @import url("./style.css");
@@ -45,96 +45,114 @@ error: Ident
   |
 1 | @import url("./style.css");
   |         ^^^
-
-error: Value
- --> $DIR/tests/fixture/at-rule/import/input.css:1:13
-  |
-1 | @import url("./style.css");
-  |             ^^^^^^^^^^^^^
-
-error: Str
- --> $DIR/tests/fixture/at-rule/import/input.css:1:13
-  |
-1 | @import url("./style.css");
-  |             ^^^^^^^^^^^^^
-
-error: Rule
- --> $DIR/tests/fixture/at-rule/import/input.css:2:1
-  |
-2 | @import url('./style.css');
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: AtRule
- --> $DIR/tests/fixture/at-rule/import/input.css:2:1
-  |
-2 | @import url('./style.css');
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: ImportRule
- --> $DIR/tests/fixture/at-rule/import/input.css:2:1
-  |
-2 | @import url('./style.css');
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: ImportHref
- --> $DIR/tests/fixture/at-rule/import/input.css:2:9
-  |
-2 | @import url('./style.css');
-  |         ^^^^^^^^^^^^^^^^^^
-
-error: Function
- --> $DIR/tests/fixture/at-rule/import/input.css:2:9
-  |
-2 | @import url('./style.css');
-  |         ^^^^^^^^^^^^^^^^^^
-
-error: Ident
- --> $DIR/tests/fixture/at-rule/import/input.css:2:9
-  |
-2 | @import url('./style.css');
-  |         ^^^
-
-error: Value
- --> $DIR/tests/fixture/at-rule/import/input.css:2:13
-  |
-2 | @import url('./style.css');
-  |             ^^^^^^^^^^^^^
-
-error: Str
- --> $DIR/tests/fixture/at-rule/import/input.css:2:13
-  |
-2 | @import url('./style.css');
-  |             ^^^^^^^^^^^^^
-
-error: Rule
- --> $DIR/tests/fixture/at-rule/import/input.css:3:1
-  |
-3 | @import url(./style.css);
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: AtRule
- --> $DIR/tests/fixture/at-rule/import/input.css:3:1
-  |
-3 | @import url(./style.css);
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: ImportRule
- --> $DIR/tests/fixture/at-rule/import/input.css:3:1
-  |
-3 | @import url(./style.css);
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: ImportHref
- --> $DIR/tests/fixture/at-rule/import/input.css:3:9
-  |
-3 | @import url(./style.css);
-  |         ^^^^^^^^^^^^^^^^
 
 error: UrlValue
+ --> $DIR/tests/fixture/at-rule/import/input.css:1:13
+  |
+1 | @import url("./style.css");
+  |             ^^^^^^^^^^^^^
+
+error: Str
+ --> $DIR/tests/fixture/at-rule/import/input.css:1:13
+  |
+1 | @import url("./style.css");
+  |             ^^^^^^^^^^^^^
+
+error: Rule
+ --> $DIR/tests/fixture/at-rule/import/input.css:2:1
+  |
+2 | @import url('./style.css');
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: AtRule
+ --> $DIR/tests/fixture/at-rule/import/input.css:2:1
+  |
+2 | @import url('./style.css');
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: ImportRule
+ --> $DIR/tests/fixture/at-rule/import/input.css:2:1
+  |
+2 | @import url('./style.css');
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: ImportHref
+ --> $DIR/tests/fixture/at-rule/import/input.css:2:9
+  |
+2 | @import url('./style.css');
+  |         ^^^^^^^^^^^^^^^^^^
+
+error: Url
+ --> $DIR/tests/fixture/at-rule/import/input.css:2:9
+  |
+2 | @import url('./style.css');
+  |         ^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/at-rule/import/input.css:2:9
+  |
+2 | @import url('./style.css');
+  |         ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/at-rule/import/input.css:2:13
+  |
+2 | @import url('./style.css');
+  |             ^^^^^^^^^^^^^
+
+error: Str
+ --> $DIR/tests/fixture/at-rule/import/input.css:2:13
+  |
+2 | @import url('./style.css');
+  |             ^^^^^^^^^^^^^
+
+error: Rule
+ --> $DIR/tests/fixture/at-rule/import/input.css:3:1
+  |
+3 | @import url(./style.css);
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: AtRule
+ --> $DIR/tests/fixture/at-rule/import/input.css:3:1
+  |
+3 | @import url(./style.css);
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: ImportRule
+ --> $DIR/tests/fixture/at-rule/import/input.css:3:1
+  |
+3 | @import url(./style.css);
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: ImportHref
  --> $DIR/tests/fixture/at-rule/import/input.css:3:9
   |
 3 | @import url(./style.css);
   |         ^^^^^^^^^^^^^^^^
+
+error: Url
+ --> $DIR/tests/fixture/at-rule/import/input.css:3:9
+  |
+3 | @import url(./style.css);
+  |         ^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/at-rule/import/input.css:3:9
+  |
+3 | @import url(./style.css);
+  |         ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/at-rule/import/input.css:3:13
+  |
+3 | @import url(./style.css);
+  |             ^^^^^^^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/at-rule/import/input.css:3:13
+  |
+3 | @import url(./style.css);
+  |             ^^^^^^^^^^^
 
 error: Rule
  --> $DIR/tests/fixture/at-rule/import/input.css:4:1
@@ -220,7 +238,7 @@ error: ImportHref
 6 | @IMPORT url("./style.css");
   |         ^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/at-rule/import/input.css:6:9
   |
 6 | @IMPORT url("./style.css");
@@ -232,7 +250,7 @@ error: Ident
 6 | @IMPORT url("./style.css");
   |         ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/at-rule/import/input.css:6:13
   |
 6 | @IMPORT url("./style.css");
@@ -268,11 +286,29 @@ error: ImportHref
 7 | @import URL(./style.css);
   |         ^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/at-rule/import/input.css:7:9
   |
 7 | @import URL(./style.css);
   |         ^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/at-rule/import/input.css:7:9
+  |
+7 | @import URL(./style.css);
+  |         ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/at-rule/import/input.css:7:13
+  |
+7 | @import URL(./style.css);
+  |             ^^^^^^^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/at-rule/import/input.css:7:13
+  |
+7 | @import URL(./style.css);
+  |             ^^^^^^^^^^^
 
 error: Rule
  --> $DIR/tests/fixture/at-rule/import/input.css:8:1
@@ -298,7 +334,7 @@ error: ImportHref
 8 | @import URL("./style.css");
   |         ^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/at-rule/import/input.css:8:9
   |
 8 | @import URL("./style.css");
@@ -310,7 +346,7 @@ error: Ident
 8 | @import URL("./style.css");
   |         ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/at-rule/import/input.css:8:13
   |
 8 | @import URL("./style.css");
@@ -424,7 +460,7 @@ error: ImportHref
 11 | @import url('landscape.css') screen and (orientation:landscape);
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:11:9
    |
 11 | @import url('landscape.css') screen and (orientation:landscape);
@@ -436,7 +472,7 @@ error: Ident
 11 | @import url('landscape.css') screen and (orientation:landscape);
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:11:13
    |
 11 | @import url('landscape.css') screen and (orientation:landscape);
@@ -544,7 +580,7 @@ error: ImportHref
 12 | @import url("theme.css") layer;
    |         ^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:12:9
    |
 12 | @import url("theme.css") layer;
@@ -556,7 +592,7 @@ error: Ident
 12 | @import url("theme.css") layer;
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:12:13
    |
 12 | @import url("theme.css") layer;
@@ -604,7 +640,7 @@ error: ImportHref
 13 | @import url("theme.css") layer   ;
    |         ^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:13:9
    |
 13 | @import url("theme.css") layer   ;
@@ -616,7 +652,7 @@ error: Ident
 13 | @import url("theme.css") layer   ;
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:13:13
    |
 13 | @import url("theme.css") layer   ;
@@ -664,7 +700,7 @@ error: ImportHref
 14 | @import url("theme.css") LAYER;
    |         ^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:14:9
    |
 14 | @import url("theme.css") LAYER;
@@ -676,7 +712,7 @@ error: Ident
 14 | @import url("theme.css") LAYER;
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:14:13
    |
 14 | @import url("theme.css") LAYER;
@@ -724,7 +760,7 @@ error: ImportHref
 15 | @import url("theme.css") layer(default);
    |         ^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:15:9
    |
 15 | @import url("theme.css") layer(default);
@@ -736,7 +772,7 @@ error: Ident
 15 | @import url("theme.css") layer(default);
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:15:13
    |
 15 | @import url("theme.css") layer(default);
@@ -802,7 +838,7 @@ error: ImportHref
 16 | @import url("theme.css") LAYER(default);
    |         ^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:16:9
    |
 16 | @import url("theme.css") LAYER(default);
@@ -814,7 +850,7 @@ error: Ident
 16 | @import url("theme.css") LAYER(default);
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:16:13
    |
 16 | @import url("theme.css") LAYER(default);
@@ -880,7 +916,7 @@ error: ImportHref
 18 | @import url("override.css") layer();
    |         ^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:18:9
    |
 18 | @import url("override.css") layer();
@@ -892,7 +928,7 @@ error: Ident
 18 | @import url("override.css") layer();
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:18:13
    |
 18 | @import url("override.css") layer();
@@ -946,7 +982,7 @@ error: ImportHref
 19 | @import url("narrow.css") supports(display: flex) handheld and (max-width: 400px);
    |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:19:9
    |
 19 | @import url("narrow.css") supports(display: flex) handheld and (max-width: 400px);
@@ -958,7 +994,7 @@ error: Ident
 19 | @import url("narrow.css") supports(display: flex) handheld and (max-width: 400px);
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:19:13
    |
 19 | @import url("narrow.css") supports(display: flex) handheld and (max-width: 400px);
@@ -1108,7 +1144,7 @@ error: ImportHref
 20 | @import url("narrow.css") SUPPORTS(display: flex) handheld and (max-width: 400px);
    |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:20:9
    |
 20 | @import url("narrow.css") SUPPORTS(display: flex) handheld and (max-width: 400px);
@@ -1120,7 +1156,7 @@ error: Ident
 20 | @import url("narrow.css") SUPPORTS(display: flex) handheld and (max-width: 400px);
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:20:13
    |
 20 | @import url("narrow.css") SUPPORTS(display: flex) handheld and (max-width: 400px);
@@ -1270,7 +1306,7 @@ error: ImportHref
 21 | @import url("fallback-layout.css") supports(not (display: flex));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:21:9
    |
 21 | @import url("fallback-layout.css") supports(not (display: flex));
@@ -1282,7 +1318,7 @@ error: Ident
 21 | @import url("fallback-layout.css") supports(not (display: flex));
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:21:13
    |
 21 | @import url("fallback-layout.css") supports(not (display: flex));
@@ -1378,12 +1414,30 @@ error: ImportHref
 22 | @import url(test.css);
    |         ^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:22:9
    |
 22 | @import url(test.css);
    |         ^^^^^^^^^^^^^
 
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:22:9
+   |
+22 | @import url(test.css);
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:22:13
+   |
+22 | @import url(test.css);
+   |             ^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:22:13
+   |
+22 | @import url(test.css);
+   |             ^^^^^^^^
+
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:23:1
    |
@@ -1408,7 +1462,7 @@ error: ImportHref
 23 | @import url('test.css');
    |         ^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:23:9
    |
 23 | @import url('test.css');
@@ -1420,7 +1474,7 @@ error: Ident
 23 | @import url('test.css');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:23:13
    |
 23 | @import url('test.css');
@@ -1456,7 +1510,7 @@ error: ImportHref
 24 | @import url("test.css");
    |         ^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:24:9
    |
 24 | @import url("test.css");
@@ -1468,7 +1522,7 @@ error: Ident
 24 | @import url("test.css");
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:24:13
    |
 24 | @import url("test.css");
@@ -1504,12 +1558,30 @@ error: ImportHref
 25 | @IMPORT url(test.css);
    |         ^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:25:9
    |
 25 | @IMPORT url(test.css);
    |         ^^^^^^^^^^^^^
 
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:25:9
+   |
+25 | @IMPORT url(test.css);
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:25:13
+   |
+25 | @IMPORT url(test.css);
+   |             ^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:25:13
+   |
+25 | @IMPORT url(test.css);
+   |             ^^^^^^^^
+
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:26:1
    |
@@ -1534,11 +1606,29 @@ error: ImportHref
 26 | @import URL(test.css);
    |         ^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:26:9
    |
 26 | @import URL(test.css);
    |         ^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:26:9
+   |
+26 | @import URL(test.css);
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:26:13
+   |
+26 | @import URL(test.css);
+   |             ^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:26:13
+   |
+26 | @import URL(test.css);
+   |             ^^^^^^^^
 
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:27:1
@@ -1564,12 +1654,30 @@ error: ImportHref
 27 | @import url(test.css );
    |         ^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:27:9
    |
 27 | @import url(test.css );
    |         ^^^^^^^^^^^^^^
 
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:27:9
+   |
+27 | @import url(test.css );
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:27:13
+   |
+27 | @import url(test.css );
+   |             ^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:27:13
+   |
+27 | @import url(test.css );
+   |             ^^^^^^^^^
+
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:28:1
    |
@@ -1594,11 +1702,29 @@ error: ImportHref
 28 | @import url( test.css);
    |         ^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:28:9
    |
 28 | @import url( test.css);
    |         ^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:28:9
+   |
+28 | @import url( test.css);
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:28:13
+   |
+28 | @import url( test.css);
+   |             ^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:28:13
+   |
+28 | @import url( test.css);
+   |             ^^^^^^^^^
 
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:29:1
@@ -1624,11 +1750,29 @@ error: ImportHref
 29 | @import url( test.css );
    |         ^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:29:9
    |
 29 | @import url( test.css );
    |         ^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:29:9
+   |
+29 | @import url( test.css );
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:29:13
+   |
+29 | @import url( test.css );
+   |             ^^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:29:13
+   |
+29 | @import url( test.css );
+   |             ^^^^^^^^^^
 
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:30:1
@@ -1663,7 +1807,7 @@ error: ImportHref
 32 | | );
    | |_^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:30:9
    |
 30 |   @import url(
@@ -1671,6 +1815,30 @@ error: UrlValue
 31 | | test.css
 32 | | );
    | |_^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:30:9
+   |
+30 | @import url(
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:30:13
+   |
+30 |   @import url(
+   |  _____________^
+31 | | test.css
+32 | | );
+   | |_
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:30:13
+   |
+30 |   @import url(
+   |  _____________^
+31 | | test.css
+32 | | );
+   | |_
 
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:33:1
@@ -1696,11 +1864,29 @@ error: ImportHref
 33 | @import url();
    |         ^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:33:9
    |
 33 | @import url();
    |         ^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:33:9
+   |
+33 | @import url();
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:33:13
+   |
+33 | @import url();
+   |             ^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:33:13
+   |
+33 | @import url();
+   |             ^
 
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:34:1
@@ -1726,7 +1912,7 @@ error: ImportHref
 34 | @import url('');
    |         ^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:34:9
    |
 34 | @import url('');
@@ -1738,7 +1924,7 @@ error: Ident
 34 | @import url('');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:34:13
    |
 34 | @import url('');
@@ -1774,7 +1960,7 @@ error: ImportHref
 35 | @import url("");
    |         ^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:35:9
    |
 35 | @import url("");
@@ -1786,7 +1972,7 @@ error: Ident
 35 | @import url("");
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:35:13
    |
 35 | @import url("");
@@ -2009,137 +2195,173 @@ error: ImportHref
 43 | @import url();
    |         ^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:43:9
    |
 43 | @import url();
    |         ^^^^^
 
-error: Rule
-  --> $DIR/tests/fixture/at-rule/import/input.css:44:1
-   |
-44 | @import url('');
-   | ^^^^^^^^^^^^^^^^
-
-error: AtRule
-  --> $DIR/tests/fixture/at-rule/import/input.css:44:1
-   |
-44 | @import url('');
-   | ^^^^^^^^^^^^^^^^
-
-error: ImportRule
-  --> $DIR/tests/fixture/at-rule/import/input.css:44:1
-   |
-44 | @import url('');
-   | ^^^^^^^^^^^^^^^^
-
-error: ImportHref
-  --> $DIR/tests/fixture/at-rule/import/input.css:44:9
-   |
-44 | @import url('');
-   |         ^^^^^^^
-
-error: Function
-  --> $DIR/tests/fixture/at-rule/import/input.css:44:9
-   |
-44 | @import url('');
-   |         ^^^^^^^
-
 error: Ident
-  --> $DIR/tests/fixture/at-rule/import/input.css:44:9
+  --> $DIR/tests/fixture/at-rule/import/input.css:43:9
    |
-44 | @import url('');
+43 | @import url();
    |         ^^^
-
-error: Value
-  --> $DIR/tests/fixture/at-rule/import/input.css:44:13
-   |
-44 | @import url('');
-   |             ^^
-
-error: Str
-  --> $DIR/tests/fixture/at-rule/import/input.css:44:13
-   |
-44 | @import url('');
-   |             ^^
-
-error: Rule
-  --> $DIR/tests/fixture/at-rule/import/input.css:45:1
-   |
-45 | @import url("");
-   | ^^^^^^^^^^^^^^^^
-
-error: AtRule
-  --> $DIR/tests/fixture/at-rule/import/input.css:45:1
-   |
-45 | @import url("");
-   | ^^^^^^^^^^^^^^^^
-
-error: ImportRule
-  --> $DIR/tests/fixture/at-rule/import/input.css:45:1
-   |
-45 | @import url("");
-   | ^^^^^^^^^^^^^^^^
-
-error: ImportHref
-  --> $DIR/tests/fixture/at-rule/import/input.css:45:9
-   |
-45 | @import url("");
-   |         ^^^^^^^
-
-error: Function
-  --> $DIR/tests/fixture/at-rule/import/input.css:45:9
-   |
-45 | @import url("");
-   |         ^^^^^^^
-
-error: Ident
-  --> $DIR/tests/fixture/at-rule/import/input.css:45:9
-   |
-45 | @import url("");
-   |         ^^^
-
-error: Value
-  --> $DIR/tests/fixture/at-rule/import/input.css:45:13
-   |
-45 | @import url("");
-   |             ^^
-
-error: Str
-  --> $DIR/tests/fixture/at-rule/import/input.css:45:13
-   |
-45 | @import url("");
-   |             ^^
-
-error: Rule
-  --> $DIR/tests/fixture/at-rule/import/input.css:46:1
-   |
-46 | @import url(test.css) screen and (orientation:landscape);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: AtRule
-  --> $DIR/tests/fixture/at-rule/import/input.css:46:1
-   |
-46 | @import url(test.css) screen and (orientation:landscape);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: ImportRule
-  --> $DIR/tests/fixture/at-rule/import/input.css:46:1
-   |
-46 | @import url(test.css) screen and (orientation:landscape);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: ImportHref
-  --> $DIR/tests/fixture/at-rule/import/input.css:46:9
-   |
-46 | @import url(test.css) screen and (orientation:landscape);
-   |         ^^^^^^^^^^^^^
 
 error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:43:13
+   |
+43 | @import url();
+   |             ^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:43:13
+   |
+43 | @import url();
+   |             ^
+
+error: Rule
+  --> $DIR/tests/fixture/at-rule/import/input.css:44:1
+   |
+44 | @import url('');
+   | ^^^^^^^^^^^^^^^^
+
+error: AtRule
+  --> $DIR/tests/fixture/at-rule/import/input.css:44:1
+   |
+44 | @import url('');
+   | ^^^^^^^^^^^^^^^^
+
+error: ImportRule
+  --> $DIR/tests/fixture/at-rule/import/input.css:44:1
+   |
+44 | @import url('');
+   | ^^^^^^^^^^^^^^^^
+
+error: ImportHref
+  --> $DIR/tests/fixture/at-rule/import/input.css:44:9
+   |
+44 | @import url('');
+   |         ^^^^^^^
+
+error: Url
+  --> $DIR/tests/fixture/at-rule/import/input.css:44:9
+   |
+44 | @import url('');
+   |         ^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:44:9
+   |
+44 | @import url('');
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:44:13
+   |
+44 | @import url('');
+   |             ^^
+
+error: Str
+  --> $DIR/tests/fixture/at-rule/import/input.css:44:13
+   |
+44 | @import url('');
+   |             ^^
+
+error: Rule
+  --> $DIR/tests/fixture/at-rule/import/input.css:45:1
+   |
+45 | @import url("");
+   | ^^^^^^^^^^^^^^^^
+
+error: AtRule
+  --> $DIR/tests/fixture/at-rule/import/input.css:45:1
+   |
+45 | @import url("");
+   | ^^^^^^^^^^^^^^^^
+
+error: ImportRule
+  --> $DIR/tests/fixture/at-rule/import/input.css:45:1
+   |
+45 | @import url("");
+   | ^^^^^^^^^^^^^^^^
+
+error: ImportHref
+  --> $DIR/tests/fixture/at-rule/import/input.css:45:9
+   |
+45 | @import url("");
+   |         ^^^^^^^
+
+error: Url
+  --> $DIR/tests/fixture/at-rule/import/input.css:45:9
+   |
+45 | @import url("");
+   |         ^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:45:9
+   |
+45 | @import url("");
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:45:13
+   |
+45 | @import url("");
+   |             ^^
+
+error: Str
+  --> $DIR/tests/fixture/at-rule/import/input.css:45:13
+   |
+45 | @import url("");
+   |             ^^
+
+error: Rule
+  --> $DIR/tests/fixture/at-rule/import/input.css:46:1
+   |
+46 | @import url(test.css) screen and (orientation:landscape);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: AtRule
+  --> $DIR/tests/fixture/at-rule/import/input.css:46:1
+   |
+46 | @import url(test.css) screen and (orientation:landscape);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: ImportRule
+  --> $DIR/tests/fixture/at-rule/import/input.css:46:1
+   |
+46 | @import url(test.css) screen and (orientation:landscape);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: ImportHref
   --> $DIR/tests/fixture/at-rule/import/input.css:46:9
    |
 46 | @import url(test.css) screen and (orientation:landscape);
    |         ^^^^^^^^^^^^^
+
+error: Url
+  --> $DIR/tests/fixture/at-rule/import/input.css:46:9
+   |
+46 | @import url(test.css) screen and (orientation:landscape);
+   |         ^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:46:9
+   |
+46 | @import url(test.css) screen and (orientation:landscape);
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:46:13
+   |
+46 | @import url(test.css) screen and (orientation:landscape);
+   |             ^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:46:13
+   |
+46 | @import url(test.css) screen and (orientation:landscape);
+   |             ^^^^^^^^
 
 error: MediaQueryList
   --> $DIR/tests/fixture/at-rule/import/input.css:46:23
@@ -2237,11 +2459,29 @@ error: ImportHref
 48 | @import url(test.css)screen and (orientation:landscape);
    |         ^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:48:9
    |
 48 | @import url(test.css)screen and (orientation:landscape);
    |         ^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:48:9
+   |
+48 | @import url(test.css)screen and (orientation:landscape);
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:48:13
+   |
+48 | @import url(test.css)screen and (orientation:landscape);
+   |             ^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:48:13
+   |
+48 | @import url(test.css)screen and (orientation:landscape);
+   |             ^^^^^^^^
 
 error: MediaQueryList
   --> $DIR/tests/fixture/at-rule/import/input.css:48:22
@@ -2339,11 +2579,29 @@ error: ImportHref
 49 | @import url(test.css)   screen   and   (   orientation   :   landscape   )   ;
    |         ^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:49:9
    |
 49 | @import url(test.css)   screen   and   (   orientation   :   landscape   )   ;
    |         ^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:49:9
+   |
+49 | @import url(test.css)   screen   and   (   orientation   :   landscape   )   ;
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:49:13
+   |
+49 | @import url(test.css)   screen   and   (   orientation   :   landscape   )   ;
+   |             ^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:49:13
+   |
+49 | @import url(test.css)   screen   and   (   orientation   :   landscape   )   ;
+   |             ^^^^^^^^
 
 error: MediaQueryList
   --> $DIR/tests/fixture/at-rule/import/input.css:49:25
@@ -2441,11 +2699,29 @@ error: ImportHref
 50 | @import url(test.css) screen and (orientation:landscape);
    |         ^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:50:9
    |
 50 | @import url(test.css) screen and (orientation:landscape);
    |         ^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:50:9
+   |
+50 | @import url(test.css) screen and (orientation:landscape);
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:50:13
+   |
+50 | @import url(test.css) screen and (orientation:landscape);
+   |             ^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:50:13
+   |
+50 | @import url(test.css) screen and (orientation:landscape);
+   |             ^^^^^^^^
 
 error: MediaQueryList
   --> $DIR/tests/fixture/at-rule/import/input.css:50:23
@@ -2543,7 +2819,7 @@ error: ImportHref
 51 | @import url("//example.com/style.css");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:51:9
    |
 51 | @import url("//example.com/style.css");
@@ -2555,7 +2831,7 @@ error: Ident
 51 | @import url("//example.com/style.css");
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:51:13
    |
 51 | @import url("//example.com/style.css");
@@ -2591,12 +2867,30 @@ error: ImportHref
 52 | @import url(~package/test.css);
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:52:9
    |
 52 | @import url(~package/test.css);
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:52:9
+   |
+52 | @import url(~package/test.css);
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:52:13
+   |
+52 | @import url(~package/test.css);
+   |             ^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:52:13
+   |
+52 | @import url(~package/test.css);
+   |             ^^^^^^^^^^^^^^^^^
+
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:53:1
    |
@@ -2621,7 +2915,7 @@ error: ImportHref
 53 | @import url('https://fonts.googleapis.com/css?family=Roboto');
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:53:9
    |
 53 | @import url('https://fonts.googleapis.com/css?family=Roboto');
@@ -2633,7 +2927,7 @@ error: Ident
 53 | @import url('https://fonts.googleapis.com/css?family=Roboto');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:53:13
    |
 53 | @import url('https://fonts.googleapis.com/css?family=Roboto');
@@ -2669,7 +2963,7 @@ error: ImportHref
 54 | @import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC');
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:54:9
    |
 54 | @import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC');
@@ -2681,7 +2975,7 @@ error: Ident
 54 | @import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:54:13
    |
 54 | @import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC');
@@ -2717,7 +3011,7 @@ error: ImportHref
 55 | @import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto');
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:55:9
    |
 55 | @import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto');
@@ -2729,7 +3023,7 @@ error: Ident
 55 | @import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:55:13
    |
 55 | @import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto');
@@ -2765,7 +3059,7 @@ error: ImportHref
 56 | @import url('./relative.css');
    |         ^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:56:9
    |
 56 | @import url('./relative.css');
@@ -2777,7 +3071,7 @@ error: Ident
 56 | @import url('./relative.css');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:56:13
    |
 56 | @import url('./relative.css');
@@ -2813,7 +3107,7 @@ error: ImportHref
 57 | @import url('../import/top-relative.css');
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:57:9
    |
 57 | @import url('../import/top-relative.css');
@@ -2825,7 +3119,7 @@ error: Ident
 57 | @import url('../import/top-relative.css');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:57:13
    |
 57 | @import url('../import/top-relative.css');
@@ -2861,11 +3155,29 @@ error: ImportHref
 58 | @import url(~package/tilde.css);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:58:9
    |
 58 | @import url(~package/tilde.css);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:58:9
+   |
+58 | @import url(~package/tilde.css);
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:58:13
+   |
+58 | @import url(~package/tilde.css);
+   |             ^^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:58:13
+   |
+58 | @import url(~package/tilde.css);
+   |             ^^^^^^^^^^^^^^^^^^
 
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:59:1
@@ -2891,11 +3203,29 @@ error: ImportHref
 59 | @import url(~aliasesImport/alias.css);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:59:9
    |
 59 | @import url(~aliasesImport/alias.css);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:59:9
+   |
+59 | @import url(~aliasesImport/alias.css);
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:59:13
+   |
+59 | @import url(~aliasesImport/alias.css);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:59:13
+   |
+59 | @import url(~aliasesImport/alias.css);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:60:1
@@ -2921,7 +3251,7 @@ error: ImportHref
 60 | @import url('./url.css');
    |         ^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:60:9
    |
 60 | @import url('./url.css');
@@ -2933,7 +3263,7 @@ error: Ident
 60 | @import url('./url.css');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:60:13
    |
 60 | @import url('./url.css');
@@ -2969,11 +3299,29 @@ error: ImportHref
 62 | @import url(./test.css);
    |         ^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:62:9
    |
 62 | @import url(./test.css);
    |         ^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:62:9
+   |
+62 | @import url(./test.css);
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:62:13
+   |
+62 | @import url(./test.css);
+   |             ^^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:62:13
+   |
+62 | @import url(./test.css);
+   |             ^^^^^^^^^^
 
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:64:1
@@ -3088,7 +3436,7 @@ error: ImportHref
 71 | | st.css');
    | |________^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:70:9
    |
 70 |   @import url('./te\
@@ -3102,7 +3450,7 @@ error: Ident
 70 | @import url('./te\
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:70:13
    |
 70 |   @import url('./te\
@@ -3155,7 +3503,7 @@ error: ImportHref
 75 | | st.css');
    | |________^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:72:9
    |
 72 |   @import url('./te\
@@ -3171,7 +3519,7 @@ error: Ident
 72 | @import url('./te\
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:72:13
    |
 72 |   @import url('./te\
@@ -3245,7 +3593,7 @@ error: ImportHref
 78 | @import url("./te'st.css");
    |         ^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:78:9
    |
 78 | @import url("./te'st.css");
@@ -3257,7 +3605,7 @@ error: Ident
 78 | @import url("./te'st.css");
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:78:13
    |
 78 | @import url("./te'st.css");
@@ -3323,7 +3671,7 @@ error: ImportHref
 80 | @import url('./te\'st.css');
    |         ^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:80:9
    |
 80 | @import url('./te\'st.css');
@@ -3335,7 +3683,7 @@ error: Ident
 80 | @import url('./te\'st.css');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:80:13
    |
 80 | @import url('./te\'st.css');
@@ -3401,7 +3749,7 @@ error: ImportHref
 82 | @import url('./test test.css');
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:82:9
    |
 82 | @import url('./test test.css');
@@ -3413,7 +3761,7 @@ error: Ident
 82 | @import url('./test test.css');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:82:13
    |
 82 | @import url('./test test.css');
@@ -3479,7 +3827,7 @@ error: ImportHref
 84 | @import url('./test\ test.css');
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:84:9
    |
 84 | @import url('./test\ test.css');
@@ -3491,7 +3839,7 @@ error: Ident
 84 | @import url('./test\ test.css');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:84:13
    |
 84 | @import url('./test\ test.css');
@@ -3557,7 +3905,7 @@ error: ImportHref
 86 | @import url('./test%20test.css');
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:86:9
    |
 86 | @import url('./test%20test.css');
@@ -3569,7 +3917,7 @@ error: Ident
 86 | @import url('./test%20test.css');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:86:13
    |
 86 | @import url('./test%20test.css');
@@ -3635,7 +3983,7 @@ error: ImportHref
 88 | @import url('./\74\65\73\74.css');
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:88:9
    |
 88 | @import url('./\74\65\73\74.css');
@@ -3647,7 +3995,7 @@ error: Ident
 88 | @import url('./\74\65\73\74.css');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:88:13
    |
 88 | @import url('./\74\65\73\74.css');
@@ -3713,7 +4061,7 @@ error: ImportHref
 90 | @import url('./t\65\73\74.css');
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:90:9
    |
 90 | @import url('./t\65\73\74.css');
@@ -3725,7 +4073,7 @@ error: Ident
 90 | @import url('./t\65\73\74.css');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:90:13
    |
 90 | @import url('./t\65\73\74.css');
@@ -3761,11 +4109,29 @@ error: ImportHref
 91 | @import url(./test\ test.css);
    |         ^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:91:9
    |
 91 | @import url(./test\ test.css);
    |         ^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:91:9
+   |
+91 | @import url(./test\ test.css);
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:91:13
+   |
+91 | @import url(./test\ test.css);
+   |             ^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:91:13
+   |
+91 | @import url(./test\ test.css);
+   |             ^^^^^^^^^^^^^^^^
 
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:92:1
@@ -3791,11 +4157,29 @@ error: ImportHref
 92 | @import url(./t\65st%20test.css);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:92:9
    |
 92 | @import url(./t\65st%20test.css);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:92:9
+   |
+92 | @import url(./t\65st%20test.css);
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:92:13
+   |
+92 | @import url(./t\65st%20test.css);
+   |             ^^^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:92:13
+   |
+92 | @import url(./t\65st%20test.css);
+   |             ^^^^^^^^^^^^^^^^^^^
 
 error: Rule
   --> $DIR/tests/fixture/at-rule/import/input.css:93:1
@@ -3821,7 +4205,7 @@ error: ImportHref
 93 | @import url('./t\65st%20test.css');
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:93:9
    |
 93 | @import url('./t\65st%20test.css');
@@ -3833,7 +4217,7 @@ error: Ident
 93 | @import url('./t\65st%20test.css');
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:93:13
    |
 93 | @import url('./t\65st%20test.css');
@@ -3869,7 +4253,7 @@ error: ImportHref
 94 | @import url("./t\65st%20test.css");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:94:9
    |
 94 | @import url("./t\65st%20test.css");
@@ -3881,7 +4265,7 @@ error: Ident
 94 | @import url("./t\65st%20test.css");
    |         ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/at-rule/import/input.css:94:13
    |
 94 | @import url("./t\65st%20test.css");
@@ -3977,11 +4361,29 @@ error: ImportHref
 97 | @import url(                 test.css                      );
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/at-rule/import/input.css:97:9
    |
 97 | @import url(                 test.css                      );
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/import/input.css:97:9
+   |
+97 | @import url(                 test.css                      );
+   |         ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/at-rule/import/input.css:97:13
+   |
+97 | @import url(                 test.css                      );
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/at-rule/import/input.css:97:13
+   |
+97 | @import url(                 test.css                      );
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Rule
    --> $DIR/tests/fixture/at-rule/import/input.css:98:1
@@ -4054,7 +4456,7 @@ error: ImportHref
 102 | @import url('!!../../helpers/string-loader.js?esModule=false!~package/tilde.css');
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:102:9
     |
 102 | @import url('!!../../helpers/string-loader.js?esModule=false!~package/tilde.css');
@@ -4066,7 +4468,7 @@ error: Ident
 102 | @import url('!!../../helpers/string-loader.js?esModule=false!~package/tilde.css');
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:102:13
     |
 102 | @import url('!!../../helpers/string-loader.js?esModule=false!~package/tilde.css');
@@ -4102,12 +4504,30 @@ error: ImportHref
 104 | @import url(test.css?foo=bar);
     |         ^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:104:9
     |
 104 | @import url(test.css?foo=bar);
     |         ^^^^^^^^^^^^^^^^^^^^^
 
+error: Ident
+   --> $DIR/tests/fixture/at-rule/import/input.css:104:9
+    |
+104 | @import url(test.css?foo=bar);
+    |         ^^^
+
+error: UrlValue
+   --> $DIR/tests/fixture/at-rule/import/input.css:104:13
+    |
+104 | @import url(test.css?foo=bar);
+    |             ^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+   --> $DIR/tests/fixture/at-rule/import/input.css:104:13
+    |
+104 | @import url(test.css?foo=bar);
+    |             ^^^^^^^^^^^^^^^^
+
 error: Rule
    --> $DIR/tests/fixture/at-rule/import/input.css:105:1
     |
@@ -4132,11 +4552,29 @@ error: ImportHref
 105 | @import url(test.css?foo=bar#hash);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:105:9
     |
 105 | @import url(test.css?foo=bar#hash);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+   --> $DIR/tests/fixture/at-rule/import/input.css:105:9
+    |
+105 | @import url(test.css?foo=bar#hash);
+    |         ^^^
+
+error: UrlValue
+   --> $DIR/tests/fixture/at-rule/import/input.css:105:13
+    |
+105 | @import url(test.css?foo=bar#hash);
+    |             ^^^^^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+   --> $DIR/tests/fixture/at-rule/import/input.css:105:13
+    |
+105 | @import url(test.css?foo=bar#hash);
+    |             ^^^^^^^^^^^^^^^^^^^^^
 
 error: Rule
    --> $DIR/tests/fixture/at-rule/import/input.css:106:1
@@ -4162,11 +4600,29 @@ error: ImportHref
 106 | @import url(test.css?#hash);
     |         ^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:106:9
     |
 106 | @import url(test.css?#hash);
     |         ^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+   --> $DIR/tests/fixture/at-rule/import/input.css:106:9
+    |
+106 | @import url(test.css?#hash);
+    |         ^^^
+
+error: UrlValue
+   --> $DIR/tests/fixture/at-rule/import/input.css:106:13
+    |
+106 | @import url(test.css?#hash);
+    |             ^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+   --> $DIR/tests/fixture/at-rule/import/input.css:106:13
+    |
+106 | @import url(test.css?#hash);
+    |             ^^^^^^^^^^^^^^
 
 error: Rule
    --> $DIR/tests/fixture/at-rule/import/input.css:108:1
@@ -4546,7 +5002,7 @@ error: ImportHref
 113 | @import url('   ./test.css   ');
     |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:113:9
     |
 113 | @import url('   ./test.css   ');
@@ -4558,7 +5014,7 @@ error: Ident
 113 | @import url('   ./test.css   ');
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:113:13
     |
 113 | @import url('   ./test.css   ');
@@ -4594,11 +5050,29 @@ error: ImportHref
 114 | @import url(   ./test.css   );
     |         ^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:114:9
     |
 114 | @import url(   ./test.css   );
     |         ^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+   --> $DIR/tests/fixture/at-rule/import/input.css:114:9
+    |
+114 | @import url(   ./test.css   );
+    |         ^^^
+
+error: UrlValue
+   --> $DIR/tests/fixture/at-rule/import/input.css:114:13
+    |
+114 | @import url(   ./test.css   );
+    |             ^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+   --> $DIR/tests/fixture/at-rule/import/input.css:114:13
+    |
+114 | @import url(   ./test.css   );
+    |             ^^^^^^^^^^^^^^^^
 
 error: Rule
    --> $DIR/tests/fixture/at-rule/import/input.css:116:1
@@ -4654,7 +5128,7 @@ error: ImportHref
 118 | @import url('   https://fonts.googleapis.com/css?family=Roboto   ');
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:118:9
     |
 118 | @import url('   https://fonts.googleapis.com/css?family=Roboto   ');
@@ -4666,7 +5140,7 @@ error: Ident
 118 | @import url('   https://fonts.googleapis.com/css?family=Roboto   ');
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:118:13
     |
 118 | @import url('   https://fonts.googleapis.com/css?family=Roboto   ');
@@ -4702,7 +5176,7 @@ error: ImportHref
 119 | @import url('!!../../helpers/string-loader.js?esModule=false!');
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:119:9
     |
 119 | @import url('!!../../helpers/string-loader.js?esModule=false!');
@@ -4714,7 +5188,7 @@ error: Ident
 119 | @import url('!!../../helpers/string-loader.js?esModule=false!');
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:119:13
     |
 119 | @import url('!!../../helpers/string-loader.js?esModule=false!');
@@ -4750,7 +5224,7 @@ error: ImportHref
 120 | @import url('   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   ');
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:120:9
     |
 120 | @import url('   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   ');
@@ -4762,7 +5236,7 @@ error: Ident
 120 | @import url('   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   ');
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:120:13
     |
 120 | @import url('   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   ');
@@ -4798,12 +5272,30 @@ error: ImportHref
 121 | @import url(data:text/css;charset=utf-8,a%20%7B%0D%0A%20%20color%3A%20red%3B%0D%0A%7D);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:121:9
     |
 121 | @import url(data:text/css;charset=utf-8,a%20%7B%0D%0A%20%20color%3A%20red%3B%0D%0A%7D);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: Ident
+   --> $DIR/tests/fixture/at-rule/import/input.css:121:9
+    |
+121 | @import url(data:text/css;charset=utf-8,a%20%7B%0D%0A%20%20color%3A%20red%3B%0D%0A%7D);
+    |         ^^^
+
+error: UrlValue
+   --> $DIR/tests/fixture/at-rule/import/input.css:121:13
+    |
+121 | @import url(data:text/css;charset=utf-8,a%20%7B%0D%0A%20%20color%3A%20red%3B%0D%0A%7D);
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+   --> $DIR/tests/fixture/at-rule/import/input.css:121:13
+    |
+121 | @import url(data:text/css;charset=utf-8,a%20%7B%0D%0A%20%20color%3A%20red%3B%0D%0A%7D);
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: Rule
    --> $DIR/tests/fixture/at-rule/import/input.css:123:1
     |
@@ -4828,11 +5320,29 @@ error: ImportHref
 123 | @import url(package/first.css);
     |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:123:9
     |
 123 | @import url(package/first.css);
     |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+   --> $DIR/tests/fixture/at-rule/import/input.css:123:9
+    |
+123 | @import url(package/first.css);
+    |         ^^^
+
+error: UrlValue
+   --> $DIR/tests/fixture/at-rule/import/input.css:123:13
+    |
+123 | @import url(package/first.css);
+    |             ^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+   --> $DIR/tests/fixture/at-rule/import/input.css:123:13
+    |
+123 | @import url(package/first.css);
+    |             ^^^^^^^^^^^^^^^^^
 
 error: Rule
    --> $DIR/tests/fixture/at-rule/import/input.css:124:1
@@ -4858,11 +5368,29 @@ error: ImportHref
 124 | @import url(package/second.css);
     |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:124:9
     |
 124 | @import url(package/second.css);
     |         ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+   --> $DIR/tests/fixture/at-rule/import/input.css:124:9
+    |
+124 | @import url(package/second.css);
+    |         ^^^
+
+error: UrlValue
+   --> $DIR/tests/fixture/at-rule/import/input.css:124:13
+    |
+124 | @import url(package/second.css);
+    |             ^^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+   --> $DIR/tests/fixture/at-rule/import/input.css:124:13
+    |
+124 | @import url(package/second.css);
+    |             ^^^^^^^^^^^^^^^^^^
 
 error: Rule
    --> $DIR/tests/fixture/at-rule/import/input.css:128:1
@@ -4888,7 +5416,7 @@ error: ImportHref
 128 | @import url("./test.css") supports(display: flex);
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:128:9
     |
 128 | @import url("./test.css") supports(display: flex);
@@ -4900,7 +5428,7 @@ error: Ident
 128 | @import url("./test.css") supports(display: flex);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:128:13
     |
 128 | @import url("./test.css") supports(display: flex);
@@ -4966,7 +5494,7 @@ error: ImportHref
 129 | @import url("./test.css") supports(display: flex !important);
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:129:9
     |
 129 | @import url("./test.css") supports(display: flex !important);
@@ -4978,7 +5506,7 @@ error: Ident
 129 | @import url("./test.css") supports(display: flex !important);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:129:13
     |
 129 | @import url("./test.css") supports(display: flex !important);
@@ -5044,7 +5572,7 @@ error: ImportHref
 130 | @import url("./test.css") supports(display: flex) screen and (min-width: 400px);
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:130:9
     |
 130 | @import url("./test.css") supports(display: flex) screen and (min-width: 400px);
@@ -5056,7 +5584,7 @@ error: Ident
 130 | @import url("./test.css") supports(display: flex) screen and (min-width: 400px);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:130:13
     |
 130 | @import url("./test.css") supports(display: flex) screen and (min-width: 400px);
@@ -5206,7 +5734,7 @@ error: ImportHref
 131 | @import url("./test.css") layer;
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:131:9
     |
 131 | @import url("./test.css") layer;
@@ -5218,7 +5746,7 @@ error: Ident
 131 | @import url("./test.css") layer;
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:131:13
     |
 131 | @import url("./test.css") layer;
@@ -5266,7 +5794,7 @@ error: ImportHref
 132 | @import url("./test.css") layer(default);
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:132:9
     |
 132 | @import url("./test.css") layer(default);
@@ -5278,7 +5806,7 @@ error: Ident
 132 | @import url("./test.css") layer(default);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:132:13
     |
 132 | @import url("./test.css") layer(default);
@@ -5344,7 +5872,7 @@ error: ImportHref
 133 | @import url("./test.css") layer(default) supports(display: flex) screen and (min-width: 400px);
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:133:9
     |
 133 | @import url("./test.css") layer(default) supports(display: flex) screen and (min-width: 400px);
@@ -5356,7 +5884,7 @@ error: Ident
 133 | @import url("./test.css") layer(default) supports(display: flex) screen and (min-width: 400px);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:133:13
     |
 133 | @import url("./test.css") layer(default) supports(display: flex) screen and (min-width: 400px);
@@ -5536,7 +6064,7 @@ error: ImportHref
 134 | @import url("./test.css") layer supports(display: flex) screen and (min-width: 400px);
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:134:9
     |
 134 | @import url("./test.css") layer supports(display: flex) screen and (min-width: 400px);
@@ -5548,7 +6076,7 @@ error: Ident
 134 | @import url("./test.css") layer supports(display: flex) screen and (min-width: 400px);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:134:13
     |
 134 | @import url("./test.css") layer supports(display: flex) screen and (min-width: 400px);
@@ -5710,7 +6238,7 @@ error: ImportHref
 135 | @import url("./test.css") layer() supports(display: flex) screen and (min-width: 400px);
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:135:9
     |
 135 | @import url("./test.css") layer() supports(display: flex) screen and (min-width: 400px);
@@ -5722,7 +6250,7 @@ error: Ident
 135 | @import url("./test.css") layer() supports(display: flex) screen and (min-width: 400px);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:135:13
     |
 135 | @import url("./test.css") layer() supports(display: flex) screen and (min-width: 400px);
@@ -5890,7 +6418,7 @@ error: ImportHref
 136 | @import url("./test.css") layer();
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:136:9
     |
 136 | @import url("./test.css") layer();
@@ -5902,7 +6430,7 @@ error: Ident
 136 | @import url("./test.css") layer();
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:136:13
     |
 136 | @import url("./test.css") layer();
@@ -5956,7 +6484,7 @@ error: ImportHref
 137 | @import url("http://example.com/style.css") supports(display: flex) screen and (min-width: 400px);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:137:9
     |
 137 | @import url("http://example.com/style.css") supports(display: flex) screen and (min-width: 400px);
@@ -5968,7 +6496,7 @@ error: Ident
 137 | @import url("http://example.com/style.css") supports(display: flex) screen and (min-width: 400px);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:137:13
     |
 137 | @import url("http://example.com/style.css") supports(display: flex) screen and (min-width: 400px);
@@ -6118,7 +6646,7 @@ error: ImportHref
 138 | @import url("./test.css")layer(default)supports(display: flex)screen and (min-width:400px);
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:138:9
     |
 138 | @import url("./test.css")layer(default)supports(display: flex)screen and (min-width:400px);
@@ -6130,7 +6658,7 @@ error: Ident
 138 | @import url("./test.css")layer(default)supports(display: flex)screen and (min-width:400px);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:138:13
     |
 138 | @import url("./test.css")layer(default)supports(display: flex)screen and (min-width:400px);
@@ -6310,7 +6838,7 @@ error: ImportHref
 139 | @import url("./test.css")screen and (min-width: 400px);
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:139:9
     |
 139 | @import url("./test.css")screen and (min-width: 400px);
@@ -6322,7 +6850,7 @@ error: Ident
 139 | @import url("./test.css")screen and (min-width: 400px);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:139:13
     |
 139 | @import url("./test.css")screen and (min-width: 400px);
@@ -6442,7 +6970,7 @@ error: ImportHref
 142 | @import url("./test.css") /* Comment */ layer(/* Comment */default/* Comment */) /* Comment */ supports(/* Comment */display/* Comment */:/* Comment */ flex/* Comment */)/* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */);
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:142:9
     |
 142 | @import url("./test.css") /* Comment */ layer(/* Comment */default/* Comment */) /* Comment */ supports(/* Comment */display/* Comment */:/* Comment */ flex/* Comment */)/* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */);
@@ -6454,7 +6982,7 @@ error: Ident
 142 | @import url("./test.css") /* Comment */ layer(/* Comment */default/* Comment */) /* Comment */ supports(/* Comment */display/* Comment */:/* Comment */ flex/* Comment */)/* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:142:13
     |
 142 | @import url("./test.css") /* Comment */ layer(/* Comment */default/* Comment */) /* Comment */ supports(/* Comment */display/* Comment */:/* Comment */ flex/* Comment */)/* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */);
@@ -6634,12 +7162,30 @@ error: ImportHref
 143 | @import url(test.css) /* Comment */;
     |         ^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:143:9
     |
 143 | @import url(test.css) /* Comment */;
     |         ^^^^^^^^^^^^^
 
+error: Ident
+   --> $DIR/tests/fixture/at-rule/import/input.css:143:9
+    |
+143 | @import url(test.css) /* Comment */;
+    |         ^^^
+
+error: UrlValue
+   --> $DIR/tests/fixture/at-rule/import/input.css:143:13
+    |
+143 | @import url(test.css) /* Comment */;
+    |             ^^^^^^^^
+
+error: UrlValueRaw
+   --> $DIR/tests/fixture/at-rule/import/input.css:143:13
+    |
+143 | @import url(test.css) /* Comment */;
+    |             ^^^^^^^^
+
 error: Rule
    --> $DIR/tests/fixture/at-rule/import/input.css:144:1
     |
@@ -6664,11 +7210,29 @@ error: ImportHref
 144 | @import /* Comment */ url(test.css) /* Comment */;
     |                       ^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:144:23
     |
 144 | @import /* Comment */ url(test.css) /* Comment */;
     |                       ^^^^^^^^^^^^^
+
+error: Ident
+   --> $DIR/tests/fixture/at-rule/import/input.css:144:23
+    |
+144 | @import /* Comment */ url(test.css) /* Comment */;
+    |                       ^^^
+
+error: UrlValue
+   --> $DIR/tests/fixture/at-rule/import/input.css:144:27
+    |
+144 | @import /* Comment */ url(test.css) /* Comment */;
+    |                           ^^^^^^^^
+
+error: UrlValueRaw
+   --> $DIR/tests/fixture/at-rule/import/input.css:144:27
+    |
+144 | @import /* Comment */ url(test.css) /* Comment */;
+    |                           ^^^^^^^^
 
 error: Rule
    --> $DIR/tests/fixture/at-rule/import/input.css:145:1
@@ -6694,11 +7258,29 @@ error: ImportHref
 145 | @import url(test.css) /* Comment */ print and (orientation:landscape);
     |         ^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:145:9
     |
 145 | @import url(test.css) /* Comment */ print and (orientation:landscape);
     |         ^^^^^^^^^^^^^
+
+error: Ident
+   --> $DIR/tests/fixture/at-rule/import/input.css:145:9
+    |
+145 | @import url(test.css) /* Comment */ print and (orientation:landscape);
+    |         ^^^
+
+error: UrlValue
+   --> $DIR/tests/fixture/at-rule/import/input.css:145:13
+    |
+145 | @import url(test.css) /* Comment */ print and (orientation:landscape);
+    |             ^^^^^^^^
+
+error: UrlValueRaw
+   --> $DIR/tests/fixture/at-rule/import/input.css:145:13
+    |
+145 | @import url(test.css) /* Comment */ print and (orientation:landscape);
+    |             ^^^^^^^^
 
 error: MediaQueryList
    --> $DIR/tests/fixture/at-rule/import/input.css:145:37
@@ -6796,11 +7378,29 @@ error: ImportHref
 146 | @import /* Comment */ url(test.css) /* Comment */ print and (orientation:landscape);
     |                       ^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:146:23
     |
 146 | @import /* Comment */ url(test.css) /* Comment */ print and (orientation:landscape);
     |                       ^^^^^^^^^^^^^
+
+error: Ident
+   --> $DIR/tests/fixture/at-rule/import/input.css:146:23
+    |
+146 | @import /* Comment */ url(test.css) /* Comment */ print and (orientation:landscape);
+    |                       ^^^
+
+error: UrlValue
+   --> $DIR/tests/fixture/at-rule/import/input.css:146:27
+    |
+146 | @import /* Comment */ url(test.css) /* Comment */ print and (orientation:landscape);
+    |                           ^^^^^^^^
+
+error: UrlValueRaw
+   --> $DIR/tests/fixture/at-rule/import/input.css:146:27
+    |
+146 | @import /* Comment */ url(test.css) /* Comment */ print and (orientation:landscape);
+    |                           ^^^^^^^^
 
 error: MediaQueryList
    --> $DIR/tests/fixture/at-rule/import/input.css:146:51
@@ -6898,7 +7498,7 @@ error: ImportHref
 148 | @import url("./deep-import-with-media.css") (prefers-color-scheme: dark);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:148:9
     |
 148 | @import url("./deep-import-with-media.css") (prefers-color-scheme: dark);
@@ -6910,7 +7510,7 @@ error: Ident
 148 | @import url("./deep-import-with-media.css") (prefers-color-scheme: dark);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:148:13
     |
 148 | @import url("./deep-import-with-media.css") (prefers-color-scheme: dark);
@@ -7012,7 +7612,7 @@ error: ImportHref
 149 | @import url("./import-with-supports.css") supports(display: flex);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:149:9
     |
 149 | @import url("./import-with-supports.css") supports(display: flex);
@@ -7024,7 +7624,7 @@ error: Ident
 149 | @import url("./import-with-supports.css") supports(display: flex);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:149:13
     |
 149 | @import url("./import-with-supports.css") supports(display: flex);
@@ -7090,7 +7690,7 @@ error: ImportHref
 150 | @import url("./import-with-supports.css") supports(((display: flex)));
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:150:9
     |
 150 | @import url("./import-with-supports.css") supports(((display: flex)));
@@ -7102,7 +7702,7 @@ error: Ident
 150 | @import url("./import-with-supports.css") supports(((display: flex)));
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:150:13
     |
 150 | @import url("./import-with-supports.css") supports(((display: flex)));
@@ -7210,7 +7810,7 @@ error: ImportHref
 151 | @import url("./deep-import-with-supports.css") supports(display: flex);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:151:9
     |
 151 | @import url("./deep-import-with-supports.css") supports(display: flex);
@@ -7222,7 +7822,7 @@ error: Ident
 151 | @import url("./deep-import-with-supports.css") supports(display: flex);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:151:13
     |
 151 | @import url("./deep-import-with-supports.css") supports(display: flex);
@@ -7288,7 +7888,7 @@ error: ImportHref
 152 | @import url('./test.css') supports(display: grid);
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:152:9
     |
 152 | @import url('./test.css') supports(display: grid);
@@ -7300,7 +7900,7 @@ error: Ident
 152 | @import url('./test.css') supports(display: grid);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:152:13
     |
 152 | @import url('./test.css') supports(display: grid);
@@ -7366,7 +7966,7 @@ error: ImportHref
 153 | @import url('./test.css') supports(   display   :    grid   );
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:153:9
     |
 153 | @import url('./test.css') supports(   display   :    grid   );
@@ -7378,7 +7978,7 @@ error: Ident
 153 | @import url('./test.css') supports(   display   :    grid   );
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:153:13
     |
 153 | @import url('./test.css') supports(   display   :    grid   );
@@ -7444,7 +8044,7 @@ error: ImportHref
 154 | @import url("./import-with-supports-and-media.css") supports(display: flex) screen and (min-width: 400px);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:154:9
     |
 154 | @import url("./import-with-supports-and-media.css") supports(display: flex) screen and (min-width: 400px);
@@ -7456,7 +8056,7 @@ error: Ident
 154 | @import url("./import-with-supports-and-media.css") supports(display: flex) screen and (min-width: 400px);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:154:13
     |
 154 | @import url("./import-with-supports-and-media.css") supports(display: flex) screen and (min-width: 400px);
@@ -7606,7 +8206,7 @@ error: ImportHref
 155 | @import url("./test.css") layer(framework);
     |         ^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:155:9
     |
 155 | @import url("./test.css") layer(framework);
@@ -7618,7 +8218,7 @@ error: Ident
 155 | @import url("./test.css") layer(framework);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:155:13
     |
 155 | @import url("./test.css") layer(framework);
@@ -7684,7 +8284,7 @@ error: ImportHref
 156 | @import url("./import-multiple-with-layer.css") layer(default);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:156:9
     |
 156 | @import url("./import-multiple-with-layer.css") layer(default);
@@ -7696,7 +8296,7 @@ error: Ident
 156 | @import url("./import-multiple-with-layer.css") layer(default);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:156:13
     |
 156 | @import url("./import-multiple-with-layer.css") layer(default);
@@ -7762,7 +8362,7 @@ error: ImportHref
 157 | @import url("./import-unnamed-layer.css") layer(base);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:157:9
     |
 157 | @import url("./import-unnamed-layer.css") layer(base);
@@ -7774,7 +8374,7 @@ error: Ident
 157 | @import url("./import-unnamed-layer.css") layer(base);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:157:13
     |
 157 | @import url("./import-unnamed-layer.css") layer(base);
@@ -7840,7 +8440,7 @@ error: ImportHref
 158 | @import url("./import-with-layer-and-supports.css") layer(default) supports(display: flex);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
    --> $DIR/tests/fixture/at-rule/import/input.css:158:9
     |
 158 | @import url("./import-with-layer-and-supports.css") layer(default) supports(display: flex);
@@ -7852,7 +8452,7 @@ error: Ident
 158 | @import url("./import-with-layer-and-supports.css") layer(default) supports(display: flex);
     |         ^^^
 
-error: Value
+error: UrlValue
    --> $DIR/tests/fixture/at-rule/import/input.css:158:13
     |
 158 | @import url("./import-with-layer-and-supports.css") layer(default) supports(display: flex);

--- a/crates/swc_css_parser/tests/fixture/at-rule/namespace/input.css
+++ b/crates/swc_css_parser/tests/fixture/at-rule/namespace/input.css
@@ -1,6 +1,8 @@
 @namespace empty "";
 @namespace "";
 @namespace url(http://www.w3.org/1999/xhtml);
+@namespace url("http://www.w3.org/1999/xhtml");
 @namespace svg url(http://www.w3.org/2000/svg);
+@namespace svg url("http://www.w3.org/2000/svg");
 @namespace "http://www.w3.org/1999/xhtml";
 @namespace svg "http://www.w3.org/2000/svg";

--- a/crates/swc_css_parser/tests/fixture/at-rule/namespace/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/namespace/output.json
@@ -62,14 +62,33 @@
       },
       "prefix": null,
       "uri": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 47,
           "end": 80,
           "ctxt": 0
         },
-        "url": "http://www.w3.org/1999/xhtml",
-        "raw": "http://www.w3.org/1999/xhtml"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 47,
+            "end": 50,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 51,
+            "end": 79,
+            "ctxt": 0
+          },
+          "value": "http://www.w3.org/1999/xhtml",
+          "raw": "http://www.w3.org/1999/xhtml"
+        },
+        "modifiers": null
       }
     },
     {
@@ -81,7 +100,7 @@
       },
       "prefix": null,
       "uri": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 93,
           "end": 128,
@@ -97,18 +116,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 97,
-              "end": 127,
-              "ctxt": 0
-            },
-            "value": "http://www.w3.org/1999/xhtml",
-            "raw": "\"http://www.w3.org/1999/xhtml\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 97,
+            "end": 127,
+            "ctxt": 0
+          },
+          "value": "http://www.w3.org/1999/xhtml",
+          "raw": "\"http://www.w3.org/1999/xhtml\""
+        },
+        "modifiers": null
       }
     },
     {
@@ -129,14 +147,33 @@
         "raw": "svg"
       },
       "uri": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 145,
           "end": 176,
           "ctxt": 0
         },
-        "url": "http://www.w3.org/2000/svg",
-        "raw": "http://www.w3.org/2000/svg"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 145,
+            "end": 148,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 149,
+            "end": 175,
+            "ctxt": 0
+          },
+          "value": "http://www.w3.org/2000/svg",
+          "raw": "http://www.w3.org/2000/svg"
+        },
+        "modifiers": null
       }
     },
     {
@@ -157,7 +194,7 @@
         "raw": "svg"
       },
       "uri": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 193,
           "end": 226,
@@ -173,18 +210,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 197,
-              "end": 225,
-              "ctxt": 0
-            },
-            "value": "http://www.w3.org/2000/svg",
-            "raw": "\"http://www.w3.org/2000/svg\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 197,
+            "end": 225,
+            "ctxt": 0
+          },
+          "value": "http://www.w3.org/2000/svg",
+          "raw": "\"http://www.w3.org/2000/svg\""
+        },
+        "modifiers": null
       }
     },
     {

--- a/crates/swc_css_parser/tests/fixture/at-rule/namespace/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/namespace/output.json
@@ -2,7 +2,7 @@
   "type": "Stylesheet",
   "span": {
     "start": 0,
-    "end": 218,
+    "end": 316,
     "ctxt": 0
   },
   "rules": [
@@ -79,11 +79,50 @@
         "end": 129,
         "ctxt": 0
       },
+      "prefix": null,
+      "uri": {
+        "type": "Function",
+        "span": {
+          "start": 93,
+          "end": 128,
+          "ctxt": 0
+        },
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 93,
+            "end": 96,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": [
+          {
+            "type": "String",
+            "span": {
+              "start": 97,
+              "end": 127,
+              "ctxt": 0
+            },
+            "value": "http://www.w3.org/1999/xhtml",
+            "raw": "\"http://www.w3.org/1999/xhtml\""
+          }
+        ]
+      }
+    },
+    {
+      "type": "NamespaceRule",
+      "span": {
+        "start": 130,
+        "end": 177,
+        "ctxt": 0
+      },
       "prefix": {
         "type": "Identifier",
         "span": {
-          "start": 93,
-          "end": 96,
+          "start": 141,
+          "end": 144,
           "ctxt": 0
         },
         "value": "svg",
@@ -92,8 +131,8 @@
       "uri": {
         "type": "UrlValue",
         "span": {
-          "start": 97,
-          "end": 128,
+          "start": 145,
+          "end": 176,
           "ctxt": 0
         },
         "url": "http://www.w3.org/2000/svg",
@@ -103,16 +142,64 @@
     {
       "type": "NamespaceRule",
       "span": {
-        "start": 130,
-        "end": 172,
+        "start": 178,
+        "end": 227,
+        "ctxt": 0
+      },
+      "prefix": {
+        "type": "Identifier",
+        "span": {
+          "start": 189,
+          "end": 192,
+          "ctxt": 0
+        },
+        "value": "svg",
+        "raw": "svg"
+      },
+      "uri": {
+        "type": "Function",
+        "span": {
+          "start": 193,
+          "end": 226,
+          "ctxt": 0
+        },
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 193,
+            "end": 196,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": [
+          {
+            "type": "String",
+            "span": {
+              "start": 197,
+              "end": 225,
+              "ctxt": 0
+            },
+            "value": "http://www.w3.org/2000/svg",
+            "raw": "\"http://www.w3.org/2000/svg\""
+          }
+        ]
+      }
+    },
+    {
+      "type": "NamespaceRule",
+      "span": {
+        "start": 228,
+        "end": 270,
         "ctxt": 0
       },
       "prefix": null,
       "uri": {
         "type": "String",
         "span": {
-          "start": 141,
-          "end": 171,
+          "start": 239,
+          "end": 269,
           "ctxt": 0
         },
         "value": "http://www.w3.org/1999/xhtml",
@@ -122,15 +209,15 @@
     {
       "type": "NamespaceRule",
       "span": {
-        "start": 173,
-        "end": 217,
+        "start": 271,
+        "end": 315,
         "ctxt": 0
       },
       "prefix": {
         "type": "Identifier",
         "span": {
-          "start": 184,
-          "end": 187,
+          "start": 282,
+          "end": 285,
           "ctxt": 0
         },
         "value": "svg",
@@ -139,8 +226,8 @@
       "uri": {
         "type": "String",
         "span": {
-          "start": 188,
-          "end": 216,
+          "start": 286,
+          "end": 314,
           "ctxt": 0
         },
         "value": "http://www.w3.org/2000/svg",

--- a/crates/swc_css_parser/tests/fixture/at-rule/namespace/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/namespace/output.json
@@ -126,7 +126,7 @@
           "value": "http://www.w3.org/1999/xhtml",
           "raw": "\"http://www.w3.org/1999/xhtml\""
         },
-        "modifiers": null
+        "modifiers": []
       }
     },
     {
@@ -220,7 +220,7 @@
           "value": "http://www.w3.org/2000/svg",
           "raw": "\"http://www.w3.org/2000/svg\""
         },
-        "modifiers": null
+        "modifiers": []
       }
     },
     {

--- a/crates/swc_css_parser/tests/fixture/at-rule/namespace/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/namespace/span.rust-debug
@@ -100,11 +100,29 @@ error: NamespaceUri
 3 | @namespace url(http://www.w3.org/1999/xhtml);
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/at-rule/namespace/input.css:3:12
   |
 3 | @namespace url(http://www.w3.org/1999/xhtml);
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:3:12
+  |
+3 | @namespace url(http://www.w3.org/1999/xhtml);
+  |            ^^^
+
+error: UrlValueType
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:3:16
+  |
+3 | @namespace url(http://www.w3.org/1999/xhtml);
+  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:3:16
+  |
+3 | @namespace url(http://www.w3.org/1999/xhtml);
+  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Rule
  --> $DIR/tests/fixture/at-rule/namespace/input.css:4:1
@@ -130,7 +148,7 @@ error: NamespaceUri
 4 | @namespace url("http://www.w3.org/1999/xhtml");
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/at-rule/namespace/input.css:4:12
   |
 4 | @namespace url("http://www.w3.org/1999/xhtml");
@@ -142,7 +160,7 @@ error: Ident
 4 | @namespace url("http://www.w3.org/1999/xhtml");
   |            ^^^
 
-error: Value
+error: UrlValueType
  --> $DIR/tests/fixture/at-rule/namespace/input.css:4:16
   |
 4 | @namespace url("http://www.w3.org/1999/xhtml");
@@ -184,11 +202,29 @@ error: NamespaceUri
 5 | @namespace svg url(http://www.w3.org/2000/svg);
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/at-rule/namespace/input.css:5:16
   |
 5 | @namespace svg url(http://www.w3.org/2000/svg);
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:5:16
+  |
+5 | @namespace svg url(http://www.w3.org/2000/svg);
+  |                ^^^
+
+error: UrlValueType
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:5:20
+  |
+5 | @namespace svg url(http://www.w3.org/2000/svg);
+  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:5:20
+  |
+5 | @namespace svg url(http://www.w3.org/2000/svg);
+  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Rule
  --> $DIR/tests/fixture/at-rule/namespace/input.css:6:1
@@ -220,7 +256,7 @@ error: NamespaceUri
 6 | @namespace svg url("http://www.w3.org/2000/svg");
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/at-rule/namespace/input.css:6:16
   |
 6 | @namespace svg url("http://www.w3.org/2000/svg");
@@ -232,7 +268,7 @@ error: Ident
 6 | @namespace svg url("http://www.w3.org/2000/svg");
   |                ^^^
 
-error: Value
+error: UrlValueType
  --> $DIR/tests/fixture/at-rule/namespace/input.css:6:20
   |
 6 | @namespace svg url("http://www.w3.org/2000/svg");

--- a/crates/swc_css_parser/tests/fixture/at-rule/namespace/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/namespace/span.rust-debug
@@ -4,9 +4,10 @@ error: Stylesheet
 1 | / @namespace empty "";
 2 | | @namespace "";
 3 | | @namespace url(http://www.w3.org/1999/xhtml);
-4 | | @namespace svg url(http://www.w3.org/2000/svg);
-5 | | @namespace "http://www.w3.org/1999/xhtml";
-6 | | @namespace svg "http://www.w3.org/2000/svg";
+4 | | @namespace url("http://www.w3.org/1999/xhtml");
+... |
+7 | | @namespace "http://www.w3.org/1999/xhtml";
+8 | | @namespace svg "http://www.w3.org/2000/svg";
   | |_____________________________________________^
 
 error: Rule
@@ -108,102 +109,204 @@ error: UrlValue
 error: Rule
  --> $DIR/tests/fixture/at-rule/namespace/input.css:4:1
   |
-4 | @namespace svg url(http://www.w3.org/2000/svg);
+4 | @namespace url("http://www.w3.org/1999/xhtml");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: AtRule
  --> $DIR/tests/fixture/at-rule/namespace/input.css:4:1
   |
-4 | @namespace svg url(http://www.w3.org/2000/svg);
+4 | @namespace url("http://www.w3.org/1999/xhtml");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: NamespaceRule
  --> $DIR/tests/fixture/at-rule/namespace/input.css:4:1
   |
-4 | @namespace svg url(http://www.w3.org/2000/svg);
+4 | @namespace url("http://www.w3.org/1999/xhtml");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: NamespaceUri
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:4:12
+  |
+4 | @namespace url("http://www.w3.org/1999/xhtml");
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Function
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:4:12
+  |
+4 | @namespace url("http://www.w3.org/1999/xhtml");
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
  --> $DIR/tests/fixture/at-rule/namespace/input.css:4:12
   |
-4 | @namespace svg url(http://www.w3.org/2000/svg);
+4 | @namespace url("http://www.w3.org/1999/xhtml");
+  |            ^^^
+
+error: Value
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:4:16
+  |
+4 | @namespace url("http://www.w3.org/1999/xhtml");
+  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Str
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:4:16
+  |
+4 | @namespace url("http://www.w3.org/1999/xhtml");
+  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Rule
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:5:1
+  |
+5 | @namespace svg url(http://www.w3.org/2000/svg);
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: AtRule
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:5:1
+  |
+5 | @namespace svg url(http://www.w3.org/2000/svg);
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: NamespaceRule
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:5:1
+  |
+5 | @namespace svg url(http://www.w3.org/2000/svg);
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:5:12
+  |
+5 | @namespace svg url(http://www.w3.org/2000/svg);
   |            ^^^
 
 error: NamespaceUri
- --> $DIR/tests/fixture/at-rule/namespace/input.css:4:16
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:5:16
   |
-4 | @namespace svg url(http://www.w3.org/2000/svg);
+5 | @namespace svg url(http://www.w3.org/2000/svg);
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: UrlValue
- --> $DIR/tests/fixture/at-rule/namespace/input.css:4:16
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:5:16
   |
-4 | @namespace svg url(http://www.w3.org/2000/svg);
+5 | @namespace svg url(http://www.w3.org/2000/svg);
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Rule
- --> $DIR/tests/fixture/at-rule/namespace/input.css:5:1
-  |
-5 | @namespace "http://www.w3.org/1999/xhtml";
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: AtRule
- --> $DIR/tests/fixture/at-rule/namespace/input.css:5:1
-  |
-5 | @namespace "http://www.w3.org/1999/xhtml";
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: NamespaceRule
- --> $DIR/tests/fixture/at-rule/namespace/input.css:5:1
-  |
-5 | @namespace "http://www.w3.org/1999/xhtml";
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: NamespaceUri
- --> $DIR/tests/fixture/at-rule/namespace/input.css:5:12
-  |
-5 | @namespace "http://www.w3.org/1999/xhtml";
-  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Str
- --> $DIR/tests/fixture/at-rule/namespace/input.css:5:12
-  |
-5 | @namespace "http://www.w3.org/1999/xhtml";
-  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Rule
  --> $DIR/tests/fixture/at-rule/namespace/input.css:6:1
   |
-6 | @namespace svg "http://www.w3.org/2000/svg";
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6 | @namespace svg url("http://www.w3.org/2000/svg");
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: AtRule
  --> $DIR/tests/fixture/at-rule/namespace/input.css:6:1
   |
-6 | @namespace svg "http://www.w3.org/2000/svg";
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6 | @namespace svg url("http://www.w3.org/2000/svg");
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: NamespaceRule
  --> $DIR/tests/fixture/at-rule/namespace/input.css:6:1
   |
-6 | @namespace svg "http://www.w3.org/2000/svg";
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6 | @namespace svg url("http://www.w3.org/2000/svg");
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
  --> $DIR/tests/fixture/at-rule/namespace/input.css:6:12
   |
-6 | @namespace svg "http://www.w3.org/2000/svg";
+6 | @namespace svg url("http://www.w3.org/2000/svg");
   |            ^^^
 
 error: NamespaceUri
  --> $DIR/tests/fixture/at-rule/namespace/input.css:6:16
   |
-6 | @namespace svg "http://www.w3.org/2000/svg";
+6 | @namespace svg url("http://www.w3.org/2000/svg");
+  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Function
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:6:16
+  |
+6 | @namespace svg url("http://www.w3.org/2000/svg");
+  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:6:16
+  |
+6 | @namespace svg url("http://www.w3.org/2000/svg");
+  |                ^^^
+
+error: Value
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:6:20
+  |
+6 | @namespace svg url("http://www.w3.org/2000/svg");
+  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Str
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:6:20
+  |
+6 | @namespace svg url("http://www.w3.org/2000/svg");
+  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Rule
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:7:1
+  |
+7 | @namespace "http://www.w3.org/1999/xhtml";
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: AtRule
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:7:1
+  |
+7 | @namespace "http://www.w3.org/1999/xhtml";
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: NamespaceRule
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:7:1
+  |
+7 | @namespace "http://www.w3.org/1999/xhtml";
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: NamespaceUri
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:7:12
+  |
+7 | @namespace "http://www.w3.org/1999/xhtml";
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Str
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:7:12
+  |
+7 | @namespace "http://www.w3.org/1999/xhtml";
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Rule
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:8:1
+  |
+8 | @namespace svg "http://www.w3.org/2000/svg";
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: AtRule
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:8:1
+  |
+8 | @namespace svg "http://www.w3.org/2000/svg";
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: NamespaceRule
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:8:1
+  |
+8 | @namespace svg "http://www.w3.org/2000/svg";
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:8:12
+  |
+8 | @namespace svg "http://www.w3.org/2000/svg";
+  |            ^^^
+
+error: NamespaceUri
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:8:16
+  |
+8 | @namespace svg "http://www.w3.org/2000/svg";
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Str
- --> $DIR/tests/fixture/at-rule/namespace/input.css:6:16
+ --> $DIR/tests/fixture/at-rule/namespace/input.css:8:16
   |
-6 | @namespace svg "http://www.w3.org/2000/svg";
+8 | @namespace svg "http://www.w3.org/2000/svg";
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/crates/swc_css_parser/tests/fixture/at-rule/namespace/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/namespace/span.rust-debug
@@ -112,7 +112,7 @@ error: Ident
 3 | @namespace url(http://www.w3.org/1999/xhtml);
   |            ^^^
 
-error: UrlValueType
+error: UrlValue
  --> $DIR/tests/fixture/at-rule/namespace/input.css:3:16
   |
 3 | @namespace url(http://www.w3.org/1999/xhtml);
@@ -160,7 +160,7 @@ error: Ident
 4 | @namespace url("http://www.w3.org/1999/xhtml");
   |            ^^^
 
-error: UrlValueType
+error: UrlValue
  --> $DIR/tests/fixture/at-rule/namespace/input.css:4:16
   |
 4 | @namespace url("http://www.w3.org/1999/xhtml");
@@ -214,7 +214,7 @@ error: Ident
 5 | @namespace svg url(http://www.w3.org/2000/svg);
   |                ^^^
 
-error: UrlValueType
+error: UrlValue
  --> $DIR/tests/fixture/at-rule/namespace/input.css:5:20
   |
 5 | @namespace svg url(http://www.w3.org/2000/svg);
@@ -268,7 +268,7 @@ error: Ident
 6 | @namespace svg url("http://www.w3.org/2000/svg");
   |                ^^^
 
-error: UrlValueType
+error: UrlValue
  --> $DIR/tests/fixture/at-rule/namespace/input.css:6:20
   |
 6 | @namespace svg url("http://www.w3.org/2000/svg");

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/output.json
@@ -89,14 +89,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 11,
                   "end": 21,
                   "ctxt": 0
                 },
-                "url": "aج",
-                "raw": "a\\62c"
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 11,
+                    "end": 14,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 15,
+                    "end": 20,
+                    "ctxt": 0
+                  },
+                  "value": "aج",
+                  "raw": "a\\62c"
+                },
+                "modifiers": null
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/span.rust-debug
@@ -70,9 +70,27 @@ error: Value
 1 | a { value: url(a\62c) }
   |            ^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/input.css:1:12
   |
 1 | a { value: url(a\62c) }
   |            ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/input.css:1:12
+  |
+1 | a { value: url(a\62c) }
+  |            ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/input.css:1:16
+  |
+1 | a { value: url(a\62c) }
+  |                ^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/esbuild/misc/8Gs_Q4kYqijbgIQ6xIW8qw/input.css:1:16
+  |
+1 | a { value: url(a\62c) }
+  |                ^^^^^
 

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/BIDuS3X-CUq54w1iGLX2ig/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/BIDuS3X-CUq54w1iGLX2ig/output.json
@@ -40,7 +40,7 @@
           "value": "foo.css",
           "raw": "\"foo.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/BIDuS3X-CUq54w1iGLX2ig/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/BIDuS3X-CUq54w1iGLX2ig/output.json
@@ -14,7 +14,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 8,
           "end": 22,
@@ -30,18 +30,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 12,
-              "end": 21,
-              "ctxt": 0
-            },
-            "value": "foo.css",
-            "raw": "\"foo.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 12,
+            "end": 21,
+            "ctxt": 0
+          },
+          "value": "foo.css",
+          "raw": "\"foo.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/BIDuS3X-CUq54w1iGLX2ig/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/BIDuS3X-CUq54w1iGLX2ig/span.rust-debug
@@ -28,7 +28,7 @@ error: ImportHref
 1 | @import url("foo.css") print;
   |         ^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/esbuild/misc/BIDuS3X-CUq54w1iGLX2ig/input.css:1:9
   |
 1 | @import url("foo.css") print;
@@ -40,7 +40,7 @@ error: Ident
 1 | @import url("foo.css") print;
   |         ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/esbuild/misc/BIDuS3X-CUq54w1iGLX2ig/input.css:1:13
   |
 1 | @import url("foo.css") print;

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/FU0reCXb694XEXwdM2wqsQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/FU0reCXb694XEXwdM2wqsQ/output.json
@@ -14,14 +14,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 8,
           "end": 20,
           "ctxt": 0
         },
-        "url": "foo.css",
-        "raw": "foo.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 8,
+            "end": 11,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 12,
+            "end": 19,
+            "ctxt": 0
+          },
+          "value": "foo.css",
+          "raw": "foo.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/FU0reCXb694XEXwdM2wqsQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/FU0reCXb694XEXwdM2wqsQ/span.rust-debug
@@ -28,9 +28,27 @@ error: ImportHref
 1 | @import url(foo.css) ;
   |         ^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/esbuild/misc/FU0reCXb694XEXwdM2wqsQ/input.css:1:9
   |
 1 | @import url(foo.css) ;
   |         ^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/esbuild/misc/FU0reCXb694XEXwdM2wqsQ/input.css:1:9
+  |
+1 | @import url(foo.css) ;
+  |         ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/esbuild/misc/FU0reCXb694XEXwdM2wqsQ/input.css:1:13
+  |
+1 | @import url(foo.css) ;
+  |             ^^^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/esbuild/misc/FU0reCXb694XEXwdM2wqsQ/input.css:1:13
+  |
+1 | @import url(foo.css) ;
+  |             ^^^^^^^
 

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/OEG8DCXSJeDTU7pt4fTE-g/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/OEG8DCXSJeDTU7pt4fTE-g/output.json
@@ -40,7 +40,7 @@
           "value": "foo.css",
           "raw": "\"foo.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/OEG8DCXSJeDTU7pt4fTE-g/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/OEG8DCXSJeDTU7pt4fTE-g/output.json
@@ -14,7 +14,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 8,
           "end": 22,
@@ -30,18 +30,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 12,
-              "end": 21,
-              "ctxt": 0
-            },
-            "value": "foo.css",
-            "raw": "\"foo.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 12,
+            "end": 21,
+            "ctxt": 0
+          },
+          "value": "foo.css",
+          "raw": "\"foo.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/OEG8DCXSJeDTU7pt4fTE-g/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/OEG8DCXSJeDTU7pt4fTE-g/span.rust-debug
@@ -28,7 +28,7 @@ error: ImportHref
 1 | @import url("foo.css") screen and (orientation:landscape);
   |         ^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/esbuild/misc/OEG8DCXSJeDTU7pt4fTE-g/input.css:1:9
   |
 1 | @import url("foo.css") screen and (orientation:landscape);
@@ -40,7 +40,7 @@ error: Ident
 1 | @import url("foo.css") screen and (orientation:landscape);
   |         ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/esbuild/misc/OEG8DCXSJeDTU7pt4fTE-g/input.css:1:13
   |
 1 | @import url("foo.css") screen and (orientation:landscape);

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/output.json
@@ -89,14 +89,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 11,
                   "end": 22,
                   "ctxt": 0
                 },
-                "url": "abc",
-                "raw": "a\\62 c"
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 11,
+                    "end": 14,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 15,
+                    "end": 21,
+                    "ctxt": 0
+                  },
+                  "value": "abc",
+                  "raw": "a\\62 c"
+                },
+                "modifiers": null
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/span.rust-debug
@@ -70,9 +70,27 @@ error: Value
 1 | a { value: url(a\62 c) }
   |            ^^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/input.css:1:12
   |
 1 | a { value: url(a\62 c) }
   |            ^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/input.css:1:12
+  |
+1 | a { value: url(a\62 c) }
+  |            ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/input.css:1:16
+  |
+1 | a { value: url(a\62 c) }
+  |                ^^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/esbuild/misc/Uuvi9sS4YR_ILpKl0xpfOg/input.css:1:16
+  |
+1 | a { value: url(a\62 c) }
+  |                ^^^^^^
 

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/output.json
@@ -89,14 +89,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 11,
                   "end": 18,
                   "ctxt": 0
                 },
-                "url": ",",
-                "raw": "\\,"
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 11,
+                    "end": 14,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 15,
+                    "end": 17,
+                    "ctxt": 0
+                  },
+                  "value": ",",
+                  "raw": "\\,"
+                },
+                "modifiers": null
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/span.rust-debug
@@ -70,9 +70,27 @@ error: Value
 1 | a { value: url(\,) }
   |            ^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/input.css:1:12
   |
 1 | a { value: url(\,) }
   |            ^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/input.css:1:12
+  |
+1 | a { value: url(\,) }
+  |            ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/input.css:1:16
+  |
+1 | a { value: url(\,) }
+  |                ^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/esbuild/misc/dCIAD8Ab98J4V9rGaJvZlw/input.css:1:16
+  |
+1 | a { value: url(\,) }
+  |                ^^
 

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/eqYc139qNzkqXqBaJaQm6A/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/eqYc139qNzkqXqBaJaQm6A/output.json
@@ -14,14 +14,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 8,
           "end": 20,
           "ctxt": 0
         },
-        "url": "foo.css",
-        "raw": "foo.css"
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 8,
+            "end": 11,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 12,
+            "end": 19,
+            "ctxt": 0
+          },
+          "value": "foo.css",
+          "raw": "foo.css"
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/eqYc139qNzkqXqBaJaQm6A/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/eqYc139qNzkqXqBaJaQm6A/span.rust-debug
@@ -28,9 +28,27 @@ error: ImportHref
 1 | @import url(foo.css);
   |         ^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/esbuild/misc/eqYc139qNzkqXqBaJaQm6A/input.css:1:9
   |
 1 | @import url(foo.css);
   |         ^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/esbuild/misc/eqYc139qNzkqXqBaJaQm6A/input.css:1:9
+  |
+1 | @import url(foo.css);
+  |         ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/esbuild/misc/eqYc139qNzkqXqBaJaQm6A/input.css:1:13
+  |
+1 | @import url(foo.css);
+  |             ^^^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/esbuild/misc/eqYc139qNzkqXqBaJaQm6A/input.css:1:13
+  |
+1 | @import url(foo.css);
+  |             ^^^^^^^
 

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/output.json
@@ -89,14 +89,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 11,
                   "end": 19,
                   "ctxt": 0
                 },
-                "url": ",",
-                "raw": "\\2c"
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 11,
+                    "end": 14,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 15,
+                    "end": 18,
+                    "ctxt": 0
+                  },
+                  "value": ",",
+                  "raw": "\\2c"
+                },
+                "modifiers": null
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/span.rust-debug
@@ -70,9 +70,27 @@ error: Value
 1 | a { value: url(\2c) }
   |            ^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/input.css:1:12
   |
 1 | a { value: url(\2c) }
   |            ^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/input.css:1:12
+  |
+1 | a { value: url(\2c) }
+  |            ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/input.css:1:16
+  |
+1 | a { value: url(\2c) }
+  |                ^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/esbuild/misc/fmt94qCRfRXbpej5kzLZUw/input.css:1:16
+  |
+1 | a { value: url(\2c) }
+  |                ^^^
 

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/output.json
@@ -89,14 +89,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 11,
                   "end": 22,
                   "ctxt": 0
                 },
-                "url": "abc",
-                "raw": "\\61 bc"
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 11,
+                    "end": 14,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 15,
+                    "end": 21,
+                    "ctxt": 0
+                  },
+                  "value": "abc",
+                  "raw": "\\61 bc"
+                },
+                "modifiers": null
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/span.rust-debug
@@ -70,9 +70,27 @@ error: Value
 1 | a { value: url(\61 bc) }
   |            ^^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/input.css:1:12
   |
 1 | a { value: url(\61 bc) }
   |            ^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/input.css:1:12
+  |
+1 | a { value: url(\61 bc) }
+  |            ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/input.css:1:16
+  |
+1 | a { value: url(\61 bc) }
+  |                ^^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/esbuild/misc/gPpnAqOuxEdLAEJjFaUEkg/input.css:1:16
+  |
+1 | a { value: url(\61 bc) }
+  |                ^^^^^^
 

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/i3YGyP16CjaKe5cnWygVeQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/i3YGyP16CjaKe5cnWygVeQ/output.json
@@ -14,14 +14,33 @@
         "ctxt": 0
       },
       "href": {
-        "type": "UrlValue",
+        "type": "Url",
         "span": {
           "start": 8,
           "end": 13,
           "ctxt": 0
         },
-        "url": "",
-        "raw": ""
+        "name": {
+          "type": "Identifier",
+          "span": {
+            "start": 8,
+            "end": 11,
+            "ctxt": 0
+          },
+          "value": "url",
+          "raw": "url"
+        },
+        "value": {
+          "type": "UrlValueRaw",
+          "span": {
+            "start": 12,
+            "end": 12,
+            "ctxt": 0
+          },
+          "value": "",
+          "raw": ""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/i3YGyP16CjaKe5cnWygVeQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/i3YGyP16CjaKe5cnWygVeQ/span.rust-debug
@@ -28,9 +28,27 @@ error: ImportHref
 1 | @import url();
   |         ^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/esbuild/misc/i3YGyP16CjaKe5cnWygVeQ/input.css:1:9
   |
 1 | @import url();
   |         ^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/esbuild/misc/i3YGyP16CjaKe5cnWygVeQ/input.css:1:9
+  |
+1 | @import url();
+  |         ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/esbuild/misc/i3YGyP16CjaKe5cnWygVeQ/input.css:1:13
+  |
+1 | @import url();
+  |             ^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/esbuild/misc/i3YGyP16CjaKe5cnWygVeQ/input.css:1:13
+  |
+1 | @import url();
+  |             ^
 

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/lJZ-deFRPQReFbr84abctQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/lJZ-deFRPQReFbr84abctQ/output.json
@@ -40,7 +40,7 @@
           "value": "foo.css",
           "raw": "\"foo.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/lJZ-deFRPQReFbr84abctQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/lJZ-deFRPQReFbr84abctQ/output.json
@@ -14,7 +14,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 8,
           "end": 22,
@@ -30,18 +30,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 12,
-              "end": 21,
-              "ctxt": 0
-            },
-            "value": "foo.css",
-            "raw": "\"foo.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 12,
+            "end": 21,
+            "ctxt": 0
+          },
+          "value": "foo.css",
+          "raw": "\"foo.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/lJZ-deFRPQReFbr84abctQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/lJZ-deFRPQReFbr84abctQ/span.rust-debug
@@ -28,7 +28,7 @@ error: ImportHref
 1 | @import url("foo.css") ;
   |         ^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/esbuild/misc/lJZ-deFRPQReFbr84abctQ/input.css:1:9
   |
 1 | @import url("foo.css") ;
@@ -40,7 +40,7 @@ error: Ident
 1 | @import url("foo.css") ;
   |         ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/esbuild/misc/lJZ-deFRPQReFbr84abctQ/input.css:1:13
   |
 1 | @import url("foo.css") ;

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/output.json
@@ -89,14 +89,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 11,
                   "end": 21,
                   "ctxt": 0
                 },
-                "url": "憼",
-                "raw": "\\61bc"
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 11,
+                    "end": 14,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 15,
+                    "end": 20,
+                    "ctxt": 0
+                  },
+                  "value": "憼",
+                  "raw": "\\61bc"
+                },
+                "modifiers": null
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/span.rust-debug
@@ -70,9 +70,27 @@ error: Value
 1 | a { value: url(\61bc) }
   |            ^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/input.css:1:12
   |
 1 | a { value: url(\61bc) }
   |            ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/input.css:1:12
+  |
+1 | a { value: url(\61bc) }
+  |            ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/input.css:1:16
+  |
+1 | a { value: url(\61bc) }
+  |                ^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/esbuild/misc/mx296i8q4HfA0IzZ055Xpw/input.css:1:16
+  |
+1 | a { value: url(\61bc) }
+  |                ^^^^^
 

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/o97ukh94L8_Su32XfrkoKA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/o97ukh94L8_Su32XfrkoKA/output.json
@@ -40,7 +40,7 @@
           "value": "foo.css",
           "raw": "\"foo.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/o97ukh94L8_Su32XfrkoKA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/o97ukh94L8_Su32XfrkoKA/output.json
@@ -14,7 +14,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 8,
           "end": 22,
@@ -30,18 +30,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 12,
-              "end": 21,
-              "ctxt": 0
-            },
-            "value": "foo.css",
-            "raw": "\"foo.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 12,
+            "end": 21,
+            "ctxt": 0
+          },
+          "value": "foo.css",
+          "raw": "\"foo.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/o97ukh94L8_Su32XfrkoKA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/o97ukh94L8_Su32XfrkoKA/span.rust-debug
@@ -28,7 +28,7 @@ error: ImportHref
 1 | @import url("foo.css");
   |         ^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/esbuild/misc/o97ukh94L8_Su32XfrkoKA/input.css:1:9
   |
 1 | @import url("foo.css");
@@ -40,7 +40,7 @@ error: Ident
 1 | @import url("foo.css");
   |         ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/esbuild/misc/o97ukh94L8_Su32XfrkoKA/input.css:1:13
   |
 1 | @import url("foo.css");

--- a/crates/swc_css_parser/tests/fixture/function/url/output.json
+++ b/crates/swc_css_parser/tests/fixture/function/url/output.json
@@ -139,7 +139,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 133,
                   "end": 155,
@@ -155,18 +155,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 137,
-                      "end": 154,
-                      "ctxt": 0
-                    },
-                    "value": "./image (1).jpg",
-                    "raw": "\"./image (1).jpg\""
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 137,
+                    "end": 154,
+                    "ctxt": 0
+                  },
+                  "value": "./image (1).jpg",
+                  "raw": "\"./image (1).jpg\""
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -190,7 +189,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 179,
                   "end": 201,
@@ -206,18 +205,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 183,
-                      "end": 200,
-                      "ctxt": 0
-                    },
-                    "value": "./image (1).jpg",
-                    "raw": "'./image (1).jpg'"
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 183,
+                    "end": 200,
+                    "ctxt": 0
+                  },
+                  "value": "./image (1).jpg",
+                  "raw": "'./image (1).jpg'"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -241,7 +239,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 225,
                   "end": 247,
@@ -257,18 +255,17 @@
                   "value": "URL",
                   "raw": "URL"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 229,
-                      "end": 246,
-                      "ctxt": 0
-                    },
-                    "value": "./image (1).jpg",
-                    "raw": "'./image (1).jpg'"
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 229,
+                    "end": 246,
+                    "ctxt": 0
+                  },
+                  "value": "./image (1).jpg",
+                  "raw": "'./image (1).jpg'"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -292,7 +289,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 271,
                   "end": 296,
@@ -308,18 +305,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 278,
-                      "end": 295,
-                      "ctxt": 0
-                    },
-                    "value": "./image (1).jpg",
-                    "raw": "'./image (1).jpg'"
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 278,
+                    "end": 295,
+                    "ctxt": 0
+                  },
+                  "value": "./image (1).jpg",
+                  "raw": "'./image (1).jpg'"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -343,7 +339,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 320,
                   "end": 345,
@@ -359,18 +355,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 324,
-                      "end": 341,
-                      "ctxt": 0
-                    },
-                    "value": "./image (1).jpg",
-                    "raw": "'./image (1).jpg'"
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 324,
+                    "end": 341,
+                    "ctxt": 0
+                  },
+                  "value": "./image (1).jpg",
+                  "raw": "'./image (1).jpg'"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -394,7 +389,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 369,
                   "end": 397,
@@ -410,18 +405,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 376,
-                      "end": 393,
-                      "ctxt": 0
-                    },
-                    "value": "./image (1).jpg",
-                    "raw": "'./image (1).jpg'"
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 376,
+                    "end": 393,
+                    "ctxt": 0
+                  },
+                  "value": "./image (1).jpg",
+                  "raw": "'./image (1).jpg'"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -445,7 +439,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 421,
                   "end": 459,
@@ -461,18 +455,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 433,
-                      "end": 450,
-                      "ctxt": 0
-                    },
-                    "value": "./image (1).jpg",
-                    "raw": "'./image (1).jpg'"
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 433,
+                    "end": 450,
+                    "ctxt": 0
+                  },
+                  "value": "./image (1).jpg",
+                  "raw": "'./image (1).jpg'"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -596,7 +589,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 544,
                   "end": 551,
@@ -612,18 +605,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 548,
-                      "end": 550,
-                      "ctxt": 0
-                    },
-                    "value": "",
-                    "raw": "\"\""
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 548,
+                    "end": 550,
+                    "ctxt": 0
+                  },
+                  "value": "",
+                  "raw": "\"\""
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -647,7 +639,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 575,
                   "end": 588,
@@ -663,18 +655,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 582,
-                      "end": 584,
-                      "ctxt": 0
-                    },
-                    "value": "",
-                    "raw": "\"\""
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 582,
+                    "end": 584,
+                    "ctxt": 0
+                  },
+                  "value": "",
+                  "raw": "\"\""
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -698,7 +689,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 612,
                   "end": 619,
@@ -714,18 +705,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 616,
-                      "end": 618,
-                      "ctxt": 0
-                    },
-                    "value": "",
-                    "raw": "''"
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 616,
+                    "end": 618,
+                    "ctxt": 0
+                  },
+                  "value": "",
+                  "raw": "''"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -749,7 +739,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 643,
                   "end": 656,
@@ -765,18 +755,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 650,
-                      "end": 652,
-                      "ctxt": 0
-                    },
-                    "value": "",
-                    "raw": "''"
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 650,
+                    "end": 652,
+                    "ctxt": 0
+                  },
+                  "value": "",
+                  "raw": "''"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -800,7 +789,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 680,
                   "end": 694,
@@ -816,18 +805,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 687,
-                      "end": 690,
-                      "ctxt": 0
-                    },
-                    "value": " ",
-                    "raw": "' '"
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 687,
+                    "end": 690,
+                    "ctxt": 0
+                  },
+                  "value": " ",
+                  "raw": "' '"
+                },
+                "modifiers": null
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/function/url/output.json
+++ b/crates/swc_css_parser/tests/fixture/function/url/output.json
@@ -89,14 +89,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 26,
                   "end": 109,
                   "ctxt": 0
                 },
-                "url": "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
-                "raw": "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 26,
+                    "end": 29,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 30,
+                    "end": 108,
+                    "ctxt": 0
+                  },
+                  "value": "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+                  "raw": "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -477,14 +496,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 483,
                   "end": 488,
                   "ctxt": 0
                 },
-                "url": "",
-                "raw": ""
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 483,
+                    "end": 486,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 487,
+                    "end": 487,
+                    "ctxt": 0
+                  },
+                  "value": "",
+                  "raw": ""
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -508,14 +546,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 512,
                   "end": 520,
                   "ctxt": 0
                 },
-                "url": "",
-                "raw": ""
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 512,
+                    "end": 515,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 516,
+                    "end": 519,
+                    "ctxt": 0
+                  },
+                  "value": "",
+                  "raw": ""
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -794,14 +851,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 718,
                   "end": 734,
                   "ctxt": 0
                 },
-                "url": "./image.png",
-                "raw": "./image.png"
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 718,
+                    "end": 721,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 722,
+                    "end": 733,
+                    "ctxt": 0
+                  },
+                  "value": "./image.png",
+                  "raw": "./image.png"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -825,14 +901,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 758,
                   "end": 780,
                   "ctxt": 0
                 },
-                "url": "./image.png",
-                "raw": "./image.png   "
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 758,
+                    "end": 761,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 762,
+                    "end": 779,
+                    "ctxt": 0
+                  },
+                  "value": "./image.png",
+                  "raw": "./image.png   "
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -856,14 +951,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 804,
                   "end": 829,
                   "ctxt": 0
                 },
-                "url": "./image2.png",
-                "raw": "./image\\32.png   "
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 804,
+                    "end": 807,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 808,
+                    "end": 828,
+                    "ctxt": 0
+                  },
+                  "value": "./image2.png",
+                  "raw": "./image\\32.png   "
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -887,14 +1001,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 853,
                   "end": 888,
                   "ctxt": 0
                 },
-                "url": "./image2.png",
-                "raw": "./image\\32.png   \n    "
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 853,
+                    "end": 856,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 857,
+                    "end": 887,
+                    "ctxt": 0
+                  },
+                  "value": "./image2.png",
+                  "raw": "./image\\32.png   \n    "
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -918,14 +1051,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 912,
                   "end": 974,
                   "ctxt": 0
                 },
-                "url": "./image2.png",
-                "raw": "./image\\32.png\n    \n    \n    \n    "
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 912,
+                    "end": 915,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 916,
+                    "end": 973,
+                    "ctxt": 0
+                  },
+                  "value": "./image2.png",
+                  "raw": "./image\\32.png\n    \n    \n    \n    "
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -949,14 +1101,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 998,
                   "end": 1039,
                   "ctxt": 0
                 },
-                "url": "./image2.png",
-                "raw": "./image\\32.png\n\n\n\n       "
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 998,
+                    "end": 1001,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 1002,
+                    "end": 1038,
+                    "ctxt": 0
+                  },
+                  "value": "./image2.png",
+                  "raw": "./image\\32.png\n\n\n\n       "
+                },
+                "modifiers": null
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/function/url/output.json
+++ b/crates/swc_css_parser/tests/fixture/function/url/output.json
@@ -165,7 +165,7 @@
                   "value": "./image (1).jpg",
                   "raw": "\"./image (1).jpg\""
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -215,7 +215,7 @@
                   "value": "./image (1).jpg",
                   "raw": "'./image (1).jpg'"
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -265,7 +265,7 @@
                   "value": "./image (1).jpg",
                   "raw": "'./image (1).jpg'"
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -315,7 +315,7 @@
                   "value": "./image (1).jpg",
                   "raw": "'./image (1).jpg'"
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -365,7 +365,7 @@
                   "value": "./image (1).jpg",
                   "raw": "'./image (1).jpg'"
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -415,7 +415,7 @@
                   "value": "./image (1).jpg",
                   "raw": "'./image (1).jpg'"
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -465,7 +465,7 @@
                   "value": "./image (1).jpg",
                   "raw": "'./image (1).jpg'"
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -615,7 +615,7 @@
                   "value": "",
                   "raw": "\"\""
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -665,7 +665,7 @@
                   "value": "",
                   "raw": "\"\""
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -715,7 +715,7 @@
                   "value": "",
                   "raw": "''"
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -765,7 +765,7 @@
                   "value": "",
                   "raw": "''"
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -815,7 +815,7 @@
                   "value": " ",
                   "raw": "' '"
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/function/url/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/function/url/span.rust-debug
@@ -95,11 +95,29 @@ error: Value
 2 |     background-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/function/url/input.css:2:23
   |
 2 |     background-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/function/url/input.css:2:23
+  |
+2 |     background-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
+  |                       ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/function/url/input.css:2:27
+  |
+2 |     background-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
+  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/function/url/input.css:2:27
+  |
+2 |     background-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
+  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
  --> $DIR/tests/fixture/function/url/input.css:3:5
@@ -421,11 +439,29 @@ error: Value
 12 |     background-image: url();
    |                       ^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:12:23
    |
 12 |     background-image: url();
    |                       ^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/function/url/input.css:12:23
+   |
+12 |     background-image: url();
+   |                       ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/function/url/input.css:12:27
+   |
+12 |     background-image: url();
+   |                           ^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/function/url/input.css:12:27
+   |
+12 |     background-image: url();
+   |                           ^
 
 error: Declaration
   --> $DIR/tests/fixture/function/url/input.css:13:5
@@ -445,11 +481,29 @@ error: Value
 13 |     background-image: url(   );
    |                       ^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:13:23
    |
 13 |     background-image: url(   );
    |                       ^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/function/url/input.css:13:23
+   |
+13 |     background-image: url(   );
+   |                       ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/function/url/input.css:13:27
+   |
+13 |     background-image: url(   );
+   |                           ^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/function/url/input.css:13:27
+   |
+13 |     background-image: url(   );
+   |                           ^^^
 
 error: Declaration
   --> $DIR/tests/fixture/function/url/input.css:14:5
@@ -679,11 +733,29 @@ error: Value
 19 |     background-image: url(./image.png);
    |                       ^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:19:23
    |
 19 |     background-image: url(./image.png);
    |                       ^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/function/url/input.css:19:23
+   |
+19 |     background-image: url(./image.png);
+   |                       ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/function/url/input.css:19:27
+   |
+19 |     background-image: url(./image.png);
+   |                           ^^^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/function/url/input.css:19:27
+   |
+19 |     background-image: url(./image.png);
+   |                           ^^^^^^^^^^^
 
 error: Declaration
   --> $DIR/tests/fixture/function/url/input.css:20:5
@@ -703,11 +775,29 @@ error: Value
 20 |     background-image: url(   ./image.png   );
    |                       ^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:20:23
    |
 20 |     background-image: url(   ./image.png   );
    |                       ^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/function/url/input.css:20:23
+   |
+20 |     background-image: url(   ./image.png   );
+   |                       ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/function/url/input.css:20:27
+   |
+20 |     background-image: url(   ./image.png   );
+   |                           ^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/function/url/input.css:20:27
+   |
+20 |     background-image: url(   ./image.png   );
+   |                           ^^^^^^^^^^^^^^^^^
 
 error: Declaration
   --> $DIR/tests/fixture/function/url/input.css:21:5
@@ -727,11 +817,29 @@ error: Value
 21 |     background-image: url(   ./image\32.png   );
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:21:23
    |
 21 |     background-image: url(   ./image\32.png   );
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/function/url/input.css:21:23
+   |
+21 |     background-image: url(   ./image\32.png   );
+   |                       ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/function/url/input.css:21:27
+   |
+21 |     background-image: url(   ./image\32.png   );
+   |                           ^^^^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/function/url/input.css:21:27
+   |
+21 |     background-image: url(   ./image\32.png   );
+   |                           ^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
   --> $DIR/tests/fixture/function/url/input.css:22:5
@@ -756,7 +864,7 @@ error: Value
 24 | |     );
    | |_____^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:22:23
    |
 22 |       background-image: url(   
@@ -764,6 +872,30 @@ error: UrlValue
 23 | |     ./image\32.png   
 24 | |     );
    | |_____^
+
+error: Ident
+  --> $DIR/tests/fixture/function/url/input.css:22:23
+   |
+22 |     background-image: url(   
+   |                       ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/function/url/input.css:22:27
+   |
+22 |       background-image: url(   
+   |  ___________________________^
+23 | |     ./image\32.png   
+24 | |     );
+   | |____^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/function/url/input.css:22:27
+   |
+22 |       background-image: url(   
+   |  ___________________________^
+23 | |     ./image\32.png   
+24 | |     );
+   | |____^
 
 error: Declaration
   --> $DIR/tests/fixture/function/url/input.css:25:5
@@ -796,7 +928,7 @@ error: Value
 33 | |     );
    | |_____^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:25:23
    |
 25 |       background-image: url(
@@ -808,6 +940,38 @@ error: UrlValue
 32 | |     
 33 | |     );
    | |_____^
+
+error: Ident
+  --> $DIR/tests/fixture/function/url/input.css:25:23
+   |
+25 |     background-image: url(
+   |                       ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/function/url/input.css:25:27
+   |
+25 |       background-image: url(
+   |  ___________________________^
+26 | |     
+27 | |     
+28 | |     
+...  |
+32 | |     
+33 | |     );
+   | |____^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/function/url/input.css:25:27
+   |
+25 |       background-image: url(
+   |  ___________________________^
+26 | |     
+27 | |     
+28 | |     
+...  |
+32 | |     
+33 | |     );
+   | |____^
 
 error: Declaration
   --> $DIR/tests/fixture/function/url/input.css:34:5
@@ -840,7 +1004,7 @@ error: Value
 42 | |        );
    | |________^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:34:23
    |
 34 |       background-image: url(   
@@ -852,4 +1016,36 @@ error: UrlValue
 41 | |
 42 | |        );
    | |________^
+
+error: Ident
+  --> $DIR/tests/fixture/function/url/input.css:34:23
+   |
+34 |     background-image: url(   
+   |                       ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/function/url/input.css:34:27
+   |
+34 |       background-image: url(   
+   |  ___________________________^
+35 | |
+36 | |
+37 | |
+...  |
+41 | |
+42 | |        );
+   | |_______^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/function/url/input.css:34:27
+   |
+34 |       background-image: url(   
+   |  ___________________________^
+35 | |
+36 | |
+37 | |
+...  |
+41 | |
+42 | |        );
+   | |_______^
 

--- a/crates/swc_css_parser/tests/fixture/function/url/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/function/url/span.rust-debug
@@ -137,7 +137,7 @@ error: Value
 3 |     background-image: url("./image (1).jpg");
   |                       ^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/function/url/input.css:3:23
   |
 3 |     background-image: url("./image (1).jpg");
@@ -149,7 +149,7 @@ error: Ident
 3 |     background-image: url("./image (1).jpg");
   |                       ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/function/url/input.css:3:27
   |
 3 |     background-image: url("./image (1).jpg");
@@ -179,7 +179,7 @@ error: Value
 4 |     background-image: url('./image (1).jpg');
   |                       ^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/function/url/input.css:4:23
   |
 4 |     background-image: url('./image (1).jpg');
@@ -191,7 +191,7 @@ error: Ident
 4 |     background-image: url('./image (1).jpg');
   |                       ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/function/url/input.css:4:27
   |
 4 |     background-image: url('./image (1).jpg');
@@ -221,7 +221,7 @@ error: Value
 5 |     background-image: URL('./image (1).jpg');
   |                       ^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/function/url/input.css:5:23
   |
 5 |     background-image: URL('./image (1).jpg');
@@ -233,7 +233,7 @@ error: Ident
 5 |     background-image: URL('./image (1).jpg');
   |                       ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/function/url/input.css:5:27
   |
 5 |     background-image: URL('./image (1).jpg');
@@ -263,7 +263,7 @@ error: Value
 6 |     background-image: url(   './image (1).jpg');
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/function/url/input.css:6:23
   |
 6 |     background-image: url(   './image (1).jpg');
@@ -275,7 +275,7 @@ error: Ident
 6 |     background-image: url(   './image (1).jpg');
   |                       ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/function/url/input.css:6:30
   |
 6 |     background-image: url(   './image (1).jpg');
@@ -305,7 +305,7 @@ error: Value
 7 |     background-image: url('./image (1).jpg'   );
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/function/url/input.css:7:23
   |
 7 |     background-image: url('./image (1).jpg'   );
@@ -317,7 +317,7 @@ error: Ident
 7 |     background-image: url('./image (1).jpg'   );
   |                       ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/function/url/input.css:7:27
   |
 7 |     background-image: url('./image (1).jpg'   );
@@ -347,7 +347,7 @@ error: Value
 8 |     background-image: url(   './image (1).jpg'   );
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/function/url/input.css:8:23
   |
 8 |     background-image: url(   './image (1).jpg'   );
@@ -359,7 +359,7 @@ error: Ident
 8 |     background-image: url(   './image (1).jpg'   );
   |                       ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/function/url/input.css:8:30
   |
 8 |     background-image: url(   './image (1).jpg'   );
@@ -394,7 +394,7 @@ error: Value
 11 | |     );
    | |_____^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:9:23
    |
 9  |       background-image: url(   
@@ -409,7 +409,7 @@ error: Ident
 9 |     background-image: url(   
   |                       ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/function/url/input.css:10:5
    |
 10 |     './image (1).jpg'   
@@ -523,7 +523,7 @@ error: Value
 14 |     background-image: url("");
    |                       ^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:14:23
    |
 14 |     background-image: url("");
@@ -535,7 +535,7 @@ error: Ident
 14 |     background-image: url("");
    |                       ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/function/url/input.css:14:27
    |
 14 |     background-image: url("");
@@ -565,7 +565,7 @@ error: Value
 15 |     background-image: url(   ""   );
    |                       ^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:15:23
    |
 15 |     background-image: url(   ""   );
@@ -577,7 +577,7 @@ error: Ident
 15 |     background-image: url(   ""   );
    |                       ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/function/url/input.css:15:30
    |
 15 |     background-image: url(   ""   );
@@ -607,7 +607,7 @@ error: Value
 16 |     background-image: url('');
    |                       ^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:16:23
    |
 16 |     background-image: url('');
@@ -619,7 +619,7 @@ error: Ident
 16 |     background-image: url('');
    |                       ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/function/url/input.css:16:27
    |
 16 |     background-image: url('');
@@ -649,7 +649,7 @@ error: Value
 17 |     background-image: url(   ''   );
    |                       ^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:17:23
    |
 17 |     background-image: url(   ''   );
@@ -661,7 +661,7 @@ error: Ident
 17 |     background-image: url(   ''   );
    |                       ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/function/url/input.css:17:30
    |
 17 |     background-image: url(   ''   );
@@ -691,7 +691,7 @@ error: Value
 18 |     background-image: url(   ' '   );
    |                       ^^^^^^^^^^^^^^
 
-error: Function
+error: Url
   --> $DIR/tests/fixture/function/url/input.css:18:23
    |
 18 |     background-image: url(   ' '   );
@@ -703,7 +703,7 @@ error: Ident
 18 |     background-image: url(   ' '   );
    |                       ^^^
 
-error: Value
+error: UrlValue
   --> $DIR/tests/fixture/function/url/input.css:18:30
    |
 18 |     background-image: url(   ' '   );

--- a/crates/swc_css_parser/tests/fixture/rome/font/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/font/output.json
@@ -40,7 +40,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 19,
                   "end": 26,
@@ -56,18 +56,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 23,
-                      "end": 25,
-                      "ctxt": 0
-                    },
-                    "value": "",
-                    "raw": "\"\""
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 23,
+                    "end": 25,
+                    "ctxt": 0
+                  },
+                  "value": "",
+                  "raw": "\"\""
+                },
+                "modifiers": null
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/rome/font/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/font/output.json
@@ -66,7 +66,7 @@
                   "value": "",
                   "raw": "\"\""
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/rome/font/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/font/span.rust-debug
@@ -57,7 +57,7 @@ error: Value
 2 |     src: url("");
   |          ^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/rome/font/input.css:2:7
   |
 2 |     src: url("");
@@ -69,7 +69,7 @@ error: Ident
 2 |     src: url("");
   |          ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/rome/font/input.css:2:11
   |
 2 |     src: url("");

--- a/crates/swc_css_parser/tests/fixture/rome/functions/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/functions/output.json
@@ -330,7 +330,7 @@
                   "value": "",
                   "raw": "\"\""
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -380,7 +380,7 @@
                   "value": "something",
                   "raw": "\"something\""
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -430,7 +430,7 @@
                   "value": "./something",
                   "raw": "\"./something\""
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/rome/functions/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/functions/output.json
@@ -304,7 +304,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 91,
                   "end": 98,
@@ -320,18 +320,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 95,
-                      "end": 97,
-                      "ctxt": 0
-                    },
-                    "value": "",
-                    "raw": "\"\""
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 95,
+                    "end": 97,
+                    "ctxt": 0
+                  },
+                  "value": "",
+                  "raw": "\"\""
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -355,7 +354,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 113,
                   "end": 129,
@@ -371,18 +370,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 117,
-                      "end": 128,
-                      "ctxt": 0
-                    },
-                    "value": "something",
-                    "raw": "\"something\""
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 117,
+                    "end": 128,
+                    "ctxt": 0
+                  },
+                  "value": "something",
+                  "raw": "\"something\""
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -406,7 +404,7 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 144,
                   "end": 162,
@@ -422,18 +420,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 148,
-                      "end": 161,
-                      "ctxt": 0
-                    },
-                    "value": "./something",
-                    "raw": "\"./something\""
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 148,
+                    "end": 161,
+                    "ctxt": 0
+                  },
+                  "value": "./something",
+                  "raw": "\"./something\""
+                },
+                "modifiers": null
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/rome/functions/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/functions/span.rust-debug
@@ -269,7 +269,7 @@ error: Value
 5 |     background: url("");
   |                 ^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/rome/functions/input.css:5:14
   |
 5 |     background: url("");
@@ -281,7 +281,7 @@ error: Ident
 5 |     background: url("");
   |                 ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/rome/functions/input.css:5:18
   |
 5 |     background: url("");
@@ -311,7 +311,7 @@ error: Value
 6 |     background: url("something");
   |                 ^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/rome/functions/input.css:6:14
   |
 6 |     background: url("something");
@@ -323,7 +323,7 @@ error: Ident
 6 |     background: url("something");
   |                 ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/rome/functions/input.css:6:18
   |
 6 |     background: url("something");
@@ -353,7 +353,7 @@ error: Value
 7 |     background: url("./something");
   |                 ^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/rome/functions/input.css:7:14
   |
 7 |     background: url("./something");
@@ -365,7 +365,7 @@ error: Ident
 7 |     background: url("./something");
   |                 ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/rome/functions/input.css:7:18
   |
 7 |     background: url("./something");

--- a/crates/swc_css_parser/tests/fixture/rome/import/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/import/output.json
@@ -61,7 +61,7 @@
           "value": "something.css",
           "raw": "\"something.css\""
         },
-        "modifiers": null
+        "modifiers": []
       },
       "layerName": null,
       "supports": null,

--- a/crates/swc_css_parser/tests/fixture/rome/import/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/import/output.json
@@ -35,7 +35,7 @@
         "ctxt": 0
       },
       "href": {
-        "type": "Function",
+        "type": "Url",
         "span": {
           "start": 33,
           "end": 53,
@@ -51,18 +51,17 @@
           "value": "url",
           "raw": "url"
         },
-        "value": [
-          {
-            "type": "String",
-            "span": {
-              "start": 37,
-              "end": 52,
-              "ctxt": 0
-            },
-            "value": "something.css",
-            "raw": "\"something.css\""
-          }
-        ]
+        "value": {
+          "type": "String",
+          "span": {
+            "start": 37,
+            "end": 52,
+            "ctxt": 0
+          },
+          "value": "something.css",
+          "raw": "\"something.css\""
+        },
+        "modifiers": null
       },
       "layerName": null,
       "supports": null,

--- a/crates/swc_css_parser/tests/fixture/rome/import/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/import/span.rust-debug
@@ -59,7 +59,7 @@ error: ImportHref
 2 | @import url("something.css");
   |         ^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/rome/import/input.css:2:9
   |
 2 | @import url("something.css");
@@ -71,7 +71,7 @@ error: Ident
 2 | @import url("something.css");
   |         ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/rome/import/input.css:2:13
   |
 2 | @import url("something.css");

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-class/unknown/output.json
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-class/unknown/output.json
@@ -1701,8 +1701,10 @@
                           },
                           "token": {
                             "Url": {
+                              "name": "url",
+                              "raw_name": "url",
                               "value": "foo.png",
-                              "raw": "foo.png"
+                              "raw_value": "foo.png"
                             }
                           }
                         }

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-class/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-class/unknown/span.rust-debug
@@ -1210,7 +1210,7 @@ error: Tokens
 15 | :unknown(url(foo.png)) {}
    |          ^^^^^^^^^^^^
 
-error: Url { value: Atom('foo.png' type=inline), raw: Atom('foo.png' type=inline) }
+error: Url { name: Atom('url' type=static), raw_name: Atom('url' type=static), value: Atom('foo.png' type=inline), raw_value: Atom('foo.png' type=inline) }
   --> $DIR/tests/fixture/selector/pseudo-class/unknown/input.css:15:10
    |
 15 | :unknown(url(foo.png)) {}

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-element/unknown/output.json
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-element/unknown/output.json
@@ -1701,8 +1701,10 @@
                           },
                           "token": {
                             "Url": {
+                              "name": "url",
+                              "raw_name": "url",
                               "value": "foo.png",
-                              "raw": "foo.png"
+                              "raw_value": "foo.png"
                             }
                           }
                         }

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-element/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-element/unknown/span.rust-debug
@@ -1210,7 +1210,7 @@ error: Tokens
 15 | ::unknown(url(foo.png)) {}
    |           ^^^^^^^^^^^^
 
-error: Url { value: Atom('foo.png' type=inline), raw: Atom('foo.png' type=inline) }
+error: Url { name: Atom('url' type=static), raw_name: Atom('url' type=static), value: Atom('foo.png' type=inline), raw_value: Atom('foo.png' type=inline) }
   --> $DIR/tests/fixture/selector/pseudo-element/unknown/input.css:15:11
    |
 15 | ::unknown(url(foo.png)) {}

--- a/crates/swc_css_parser/tests/fixture/stylis/comma/01/output.json
+++ b/crates/swc_css_parser/tests/fixture/stylis/comma/01/output.json
@@ -123,14 +123,33 @@
                         },
                         "values": [
                           {
-                            "type": "UrlValue",
+                            "type": "Url",
                             "span": {
                               "start": 26,
                               "end": 38,
                               "ctxt": 0
                             },
-                            "url": "foo.jpg",
-                            "raw": "foo.jpg"
+                            "name": {
+                              "type": "Identifier",
+                              "span": {
+                                "start": 26,
+                                "end": 29,
+                                "ctxt": 0
+                              },
+                              "value": "url",
+                              "raw": "url"
+                            },
+                            "value": {
+                              "type": "UrlValueRaw",
+                              "span": {
+                                "start": 30,
+                                "end": 37,
+                                "ctxt": 0
+                              },
+                              "value": "foo.jpg",
+                              "raw": "foo.jpg"
+                            },
+                            "modifiers": null
                           },
                           {
                             "type": "UnitValue",

--- a/crates/swc_css_parser/tests/fixture/stylis/comma/01/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/stylis/comma/01/span.rust-debug
@@ -115,11 +115,29 @@ error: Value
 2 |     cursor: image-set(url(foo.jpg) 2x), pointer;
   |                       ^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/stylis/comma/01/input.css:2:23
   |
 2 |     cursor: image-set(url(foo.jpg) 2x), pointer;
   |                       ^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/stylis/comma/01/input.css:2:23
+  |
+2 |     cursor: image-set(url(foo.jpg) 2x), pointer;
+  |                       ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/stylis/comma/01/input.css:2:27
+  |
+2 |     cursor: image-set(url(foo.jpg) 2x), pointer;
+  |                           ^^^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/stylis/comma/01/input.css:2:27
+  |
+2 |     cursor: image-set(url(foo.jpg) 2x), pointer;
+  |                           ^^^^^^^
 
 error: Value
  --> $DIR/tests/fixture/stylis/comma/01/input.css:2:36

--- a/crates/swc_css_parser/tests/fixture/value/url/input.css
+++ b/crates/swc_css_parser/tests/fixture/value/url/input.css
@@ -1,7 +1,9 @@
 div {
     background: url(https://example.com/image.png);
+    background: URL(https://example.com/image.png);
     background: url("https://example.com/image.png");
     background: url('https://example.com/image.png');
+    background: URL('https://example.com/image.png');
     background: url(data:image/png;base64,iRxVB0);
     background: url(#IDofSVGpath);
 
@@ -16,5 +18,6 @@ div {
     --foo: "http://www.example.com/pinkish.gif";
 
     background: src("http://www.example.com/pinkish.gif");
-    background: src(var(--foo));
+    background: SRC("http://www.example.com/pinkish.gif");
+    /*background: src(var(--foo));*/
 }

--- a/crates/swc_css_parser/tests/fixture/value/url/input.css
+++ b/crates/swc_css_parser/tests/fixture/value/url/input.css
@@ -1,9 +1,11 @@
 div {
     background: url(https://example.com/image.png);
     background: URL(https://example.com/image.png);
+    background: \URL(https://example.com/image.png);
     background: url("https://example.com/image.png");
     background: url('https://example.com/image.png');
     background: URL('https://example.com/image.png');
+    background: \URL('https://example.com/image.png');
     background: url(data:image/png;base64,iRxVB0);
     background: url(#IDofSVGpath);
 

--- a/crates/swc_css_parser/tests/fixture/value/url/input.css
+++ b/crates/swc_css_parser/tests/fixture/value/url/input.css
@@ -8,8 +8,9 @@ div {
     background: url(#IDofSVGpath);
 
     /* A <url-modifier> is either an <ident> or a functional notation. */
-    /*background: url("//aa.com/img.svg" prefetch);*/
-    /*background: url("http://example.com/image.svg" param(--color var(--primary-color)));*/
+    background: url("//aa.com/img.svg" prefetch);
+    background: url("//aa.com/img.svg" foo bar baz func(test));
+    background: url("http://example.com/image.svg" param(--color var(--primary-color)));
 
     background: url();
     background: url("");
@@ -19,5 +20,5 @@ div {
 
     background: src("http://www.example.com/pinkish.gif");
     background: SRC("http://www.example.com/pinkish.gif");
-    /*background: src(var(--foo));*/
+    background: src(var(--foo));
 }

--- a/crates/swc_css_parser/tests/fixture/value/url/input.css
+++ b/crates/swc_css_parser/tests/fixture/value/url/input.css
@@ -1,0 +1,20 @@
+div {
+    background: url(https://example.com/image.png);
+    background: url("https://example.com/image.png");
+    background: url('https://example.com/image.png');
+    background: url(data:image/png;base64,iRxVB0);
+    background: url(#IDofSVGpath);
+
+    /* A <url-modifier> is either an <ident> or a functional notation. */
+    /*background: url("//aa.com/img.svg" prefetch);*/
+    /*background: url("http://example.com/image.svg" param(--color var(--primary-color)));*/
+
+    background: url();
+    background: url("");
+    background: url('');
+
+    --foo: "http://www.example.com/pinkish.gif";
+
+    background: src("http://www.example.com/pinkish.gif");
+    background: src(var(--foo));
+}

--- a/crates/swc_css_parser/tests/fixture/value/url/output.json
+++ b/crates/swc_css_parser/tests/fixture/value/url/output.json
@@ -2,7 +2,7 @@
   "type": "Stylesheet",
   "span": {
     "start": 0,
-    "end": 693,
+    "end": 862,
     "ctxt": 0
   },
   "rules": [
@@ -10,7 +10,7 @@
       "type": "QualifiedRule",
       "span": {
         "start": 0,
-        "end": 692,
+        "end": 861,
         "ctxt": 0
       },
       "prelude": {
@@ -66,7 +66,7 @@
         "type": "Block",
         "span": {
           "start": 4,
-          "end": 692,
+          "end": 861,
           "ctxt": 0
         },
         "value": [
@@ -124,7 +124,7 @@
             "type": "Declaration",
             "span": {
               "start": 62,
-              "end": 110,
+              "end": 108,
               "ctxt": 0
             },
             "property": {
@@ -139,10 +139,10 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
                   "start": 74,
-                  "end": 110,
+                  "end": 108,
                   "ctxt": 0
                 },
                 "name": {
@@ -155,69 +155,17 @@
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 78,
-                      "end": 109,
-                      "ctxt": 0
-                    },
-                    "value": "https://example.com/image.png",
-                    "raw": "\"https://example.com/image.png\""
-                  }
-                ]
-              }
-            ],
-            "important": null
-          },
-          {
-            "type": "Declaration",
-            "span": {
-              "start": 116,
-              "end": 164,
-              "ctxt": 0
-            },
-            "property": {
-              "type": "Identifier",
-              "span": {
-                "start": 116,
-                "end": 126,
-                "ctxt": 0
-              },
-              "value": "background",
-              "raw": "background"
-            },
-            "value": [
-              {
-                "type": "Function",
-                "span": {
-                  "start": 128,
-                  "end": 164,
-                  "ctxt": 0
-                },
-                "name": {
-                  "type": "Identifier",
+                "value": {
+                  "type": "UrlValueRaw",
                   "span": {
-                    "start": 128,
-                    "end": 131,
+                    "start": 78,
+                    "end": 107,
                     "ctxt": 0
                   },
-                  "value": "url",
-                  "raw": "url"
+                  "value": "https://example.com/image.png",
+                  "raw": "https://example.com/image.png"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 132,
-                      "end": 163,
-                      "ctxt": 0
-                    },
-                    "value": "https://example.com/image.png",
-                    "raw": "'https://example.com/image.png'"
-                  }
-                ]
+                "modifiers": null
               }
             ],
             "important": null
@@ -225,15 +173,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 170,
-              "end": 215,
+              "start": 114,
+              "end": 162,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 170,
-                "end": 180,
+                "start": 114,
+                "end": 124,
                 "ctxt": 0
               },
               "value": "background",
@@ -243,15 +191,165 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 182,
-                  "end": 215,
+                  "start": 126,
+                  "end": 162,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 182,
-                    "end": 185,
+                    "start": 126,
+                    "end": 129,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 130,
+                    "end": 161,
+                    "ctxt": 0
+                  },
+                  "value": "https://example.com/image.png",
+                  "raw": "\"https://example.com/image.png\""
+                },
+                "modifiers": null
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 168,
+              "end": 216,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 168,
+                "end": 178,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Url",
+                "span": {
+                  "start": 180,
+                  "end": 216,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 180,
+                    "end": 183,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 184,
+                    "end": 215,
+                    "ctxt": 0
+                  },
+                  "value": "https://example.com/image.png",
+                  "raw": "'https://example.com/image.png'"
+                },
+                "modifiers": null
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 222,
+              "end": 270,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 222,
+                "end": 232,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Url",
+                "span": {
+                  "start": 234,
+                  "end": 270,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 234,
+                    "end": 237,
+                    "ctxt": 0
+                  },
+                  "value": "URL",
+                  "raw": "URL"
+                },
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 238,
+                    "end": 269,
+                    "ctxt": 0
+                  },
+                  "value": "https://example.com/image.png",
+                  "raw": "'https://example.com/image.png'"
+                },
+                "modifiers": null
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 276,
+              "end": 321,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 276,
+                "end": 286,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Url",
+                "span": {
+                  "start": 288,
+                  "end": 321,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 288,
+                    "end": 291,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -260,8 +358,8 @@
                 "value": {
                   "type": "UrlValueRaw",
                   "span": {
-                    "start": 186,
-                    "end": 214,
+                    "start": 292,
+                    "end": 320,
                     "ctxt": 0
                   },
                   "value": "data:image/png;base64,iRxVB0",
@@ -275,15 +373,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 221,
-              "end": 250,
+              "start": 327,
+              "end": 356,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 221,
-                "end": 231,
+                "start": 327,
+                "end": 337,
                 "ctxt": 0
               },
               "value": "background",
@@ -293,15 +391,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 233,
-                  "end": 250,
+                  "start": 339,
+                  "end": 356,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 233,
-                    "end": 236,
+                    "start": 339,
+                    "end": 342,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -310,8 +408,8 @@
                 "value": {
                   "type": "UrlValueRaw",
                   "span": {
-                    "start": 237,
-                    "end": 249,
+                    "start": 343,
+                    "end": 355,
                     "ctxt": 0
                   },
                   "value": "#IDofSVGpath",
@@ -325,15 +423,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 479,
-              "end": 496,
+              "start": 585,
+              "end": 602,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 479,
-                "end": 489,
+                "start": 585,
+                "end": 595,
                 "ctxt": 0
               },
               "value": "background",
@@ -343,15 +441,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 491,
-                  "end": 496,
+                  "start": 597,
+                  "end": 602,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 491,
-                    "end": 494,
+                    "start": 597,
+                    "end": 600,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -360,8 +458,8 @@
                 "value": {
                   "type": "UrlValueRaw",
                   "span": {
-                    "start": 495,
-                    "end": 495,
+                    "start": 601,
+                    "end": 601,
                     "ctxt": 0
                   },
                   "value": "",
@@ -375,15 +473,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 502,
-              "end": 521,
+              "start": 608,
+              "end": 627,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 502,
-                "end": 512,
+                "start": 608,
+                "end": 618,
                 "ctxt": 0
               },
               "value": "background",
@@ -391,34 +489,33 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
-                  "start": 514,
-                  "end": 521,
+                  "start": 620,
+                  "end": 627,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 514,
-                    "end": 517,
+                    "start": 620,
+                    "end": 623,
                     "ctxt": 0
                   },
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 518,
-                      "end": 520,
-                      "ctxt": 0
-                    },
-                    "value": "",
-                    "raw": "\"\""
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 624,
+                    "end": 626,
+                    "ctxt": 0
+                  },
+                  "value": "",
+                  "raw": "\"\""
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -426,15 +523,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 527,
-              "end": 546,
+              "start": 633,
+              "end": 652,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 527,
-                "end": 537,
+                "start": 633,
+                "end": 643,
                 "ctxt": 0
               },
               "value": "background",
@@ -442,34 +539,33 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
-                  "start": 539,
-                  "end": 546,
+                  "start": 645,
+                  "end": 652,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 539,
-                    "end": 542,
+                    "start": 645,
+                    "end": 648,
                     "ctxt": 0
                   },
                   "value": "url",
                   "raw": "url"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 543,
-                      "end": 545,
-                      "ctxt": 0
-                    },
-                    "value": "",
-                    "raw": "''"
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 649,
+                    "end": 651,
+                    "ctxt": 0
+                  },
+                  "value": "",
+                  "raw": "''"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -477,15 +573,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 553,
-              "end": 560,
+              "start": 659,
+              "end": 666,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 553,
-                "end": 558,
+                "start": 659,
+                "end": 664,
                 "ctxt": 0
               },
               "value": "--foo",
@@ -495,15 +591,15 @@
               {
                 "type": "Tokens",
                 "span": {
-                  "start": 559,
-                  "end": 596,
+                  "start": 665,
+                  "end": 702,
                   "ctxt": 0
                 },
                 "tokens": [
                   {
                     "span": {
-                      "start": 559,
-                      "end": 560,
+                      "start": 665,
+                      "end": 666,
                       "ctxt": 0
                     },
                     "token": {
@@ -514,8 +610,8 @@
                   },
                   {
                     "span": {
-                      "start": 560,
-                      "end": 596,
+                      "start": 666,
+                      "end": 702,
                       "ctxt": 0
                     },
                     "token": {
@@ -533,15 +629,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 603,
-              "end": 656,
+              "start": 709,
+              "end": 762,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 603,
-                "end": 613,
+                "start": 709,
+                "end": 719,
                 "ctxt": 0
               },
               "value": "background",
@@ -549,34 +645,33 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
-                  "start": 615,
-                  "end": 656,
+                  "start": 721,
+                  "end": 762,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 615,
-                    "end": 618,
+                    "start": 721,
+                    "end": 724,
                     "ctxt": 0
                   },
                   "value": "src",
                   "raw": "src"
                 },
-                "value": [
-                  {
-                    "type": "String",
-                    "span": {
-                      "start": 619,
-                      "end": 655,
-                      "ctxt": 0
-                    },
-                    "value": "http://www.example.com/pinkish.gif",
-                    "raw": "\"http://www.example.com/pinkish.gif\""
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 725,
+                    "end": 761,
+                    "ctxt": 0
+                  },
+                  "value": "http://www.example.com/pinkish.gif",
+                  "raw": "\"http://www.example.com/pinkish.gif\""
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -584,15 +679,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 662,
-              "end": 689,
+              "start": 768,
+              "end": 821,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 662,
-                "end": 672,
+                "start": 768,
+                "end": 778,
                 "ctxt": 0
               },
               "value": "background",
@@ -600,54 +695,33 @@
             },
             "value": [
               {
-                "type": "Function",
+                "type": "Url",
                 "span": {
-                  "start": 674,
-                  "end": 689,
+                  "start": 780,
+                  "end": 821,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 674,
-                    "end": 677,
+                    "start": 780,
+                    "end": 783,
                     "ctxt": 0
                   },
-                  "value": "src",
-                  "raw": "src"
+                  "value": "SRC",
+                  "raw": "SRC"
                 },
-                "value": [
-                  {
-                    "type": "Function",
-                    "span": {
-                      "start": 678,
-                      "end": 688,
-                      "ctxt": 0
-                    },
-                    "name": {
-                      "type": "Identifier",
-                      "span": {
-                        "start": 678,
-                        "end": 681,
-                        "ctxt": 0
-                      },
-                      "value": "var",
-                      "raw": "var"
-                    },
-                    "value": [
-                      {
-                        "type": "Identifier",
-                        "span": {
-                          "start": 682,
-                          "end": 687,
-                          "ctxt": 0
-                        },
-                        "value": "--foo",
-                        "raw": "--foo"
-                      }
-                    ]
-                  }
-                ]
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 784,
+                    "end": 820,
+                    "ctxt": 0
+                  },
+                  "value": "http://www.example.com/pinkish.gif",
+                  "raw": "\"http://www.example.com/pinkish.gif\""
+                },
+                "modifiers": null
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/value/url/output.json
+++ b/crates/swc_css_parser/tests/fixture/value/url/output.json
@@ -2,7 +2,7 @@
   "type": "Stylesheet",
   "span": {
     "start": 0,
-    "end": 862,
+    "end": 914,
     "ctxt": 0
   },
   "rules": [
@@ -10,7 +10,7 @@
       "type": "QualifiedRule",
       "span": {
         "start": 0,
-        "end": 861,
+        "end": 913,
         "ctxt": 0
       },
       "prelude": {
@@ -66,7 +66,7 @@
         "type": "Block",
         "span": {
           "start": 4,
-          "end": 861,
+          "end": 913,
           "ctxt": 0
         },
         "value": [
@@ -215,7 +215,7 @@
                   "value": "https://example.com/image.png",
                   "raw": "\"https://example.com/image.png\""
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -265,7 +265,7 @@
                   "value": "https://example.com/image.png",
                   "raw": "'https://example.com/image.png'"
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -315,7 +315,7 @@
                   "value": "https://example.com/image.png",
                   "raw": "'https://example.com/image.png'"
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -423,15 +423,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 585,
-              "end": 602,
+              "start": 437,
+              "end": 481,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 585,
-                "end": 595,
+                "start": 437,
+                "end": 447,
                 "ctxt": 0
               },
               "value": "background",
@@ -441,15 +441,308 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 597,
-                  "end": 602,
+                  "start": 449,
+                  "end": 481,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 597,
-                    "end": 600,
+                    "start": 449,
+                    "end": 452,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 453,
+                    "end": 471,
+                    "ctxt": 0
+                  },
+                  "value": "//aa.com/img.svg",
+                  "raw": "\"//aa.com/img.svg\""
+                },
+                "modifiers": [
+                  {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 472,
+                      "end": 480,
+                      "ctxt": 0
+                    },
+                    "value": "prefetch",
+                    "raw": "prefetch"
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 487,
+              "end": 545,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 487,
+                "end": 497,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Url",
+                "span": {
+                  "start": 499,
+                  "end": 545,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 499,
+                    "end": 502,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 503,
+                    "end": 521,
+                    "ctxt": 0
+                  },
+                  "value": "//aa.com/img.svg",
+                  "raw": "\"//aa.com/img.svg\""
+                },
+                "modifiers": [
+                  {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 522,
+                      "end": 525,
+                      "ctxt": 0
+                    },
+                    "value": "foo",
+                    "raw": "foo"
+                  },
+                  {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 526,
+                      "end": 529,
+                      "ctxt": 0
+                    },
+                    "value": "bar",
+                    "raw": "bar"
+                  },
+                  {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 530,
+                      "end": 533,
+                      "ctxt": 0
+                    },
+                    "value": "baz",
+                    "raw": "baz"
+                  },
+                  {
+                    "type": "Function",
+                    "span": {
+                      "start": 534,
+                      "end": 544,
+                      "ctxt": 0
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 534,
+                        "end": 538,
+                        "ctxt": 0
+                      },
+                      "value": "func",
+                      "raw": "func"
+                    },
+                    "value": [
+                      {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 539,
+                          "end": 543,
+                          "ctxt": 0
+                        },
+                        "value": "test",
+                        "raw": "test"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 551,
+              "end": 634,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 551,
+                "end": 561,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Url",
+                "span": {
+                  "start": 563,
+                  "end": 634,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 563,
+                    "end": 566,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 567,
+                    "end": 597,
+                    "ctxt": 0
+                  },
+                  "value": "http://example.com/image.svg",
+                  "raw": "\"http://example.com/image.svg\""
+                },
+                "modifiers": [
+                  {
+                    "type": "Function",
+                    "span": {
+                      "start": 598,
+                      "end": 633,
+                      "ctxt": 0
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 598,
+                        "end": 603,
+                        "ctxt": 0
+                      },
+                      "value": "param",
+                      "raw": "param"
+                    },
+                    "value": [
+                      {
+                        "type": "SpaceValues",
+                        "span": {
+                          "start": 604,
+                          "end": 632,
+                          "ctxt": 0
+                        },
+                        "values": [
+                          {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 604,
+                              "end": 611,
+                              "ctxt": 0
+                            },
+                            "value": "--color",
+                            "raw": "--color"
+                          },
+                          {
+                            "type": "Function",
+                            "span": {
+                              "start": 612,
+                              "end": 632,
+                              "ctxt": 0
+                            },
+                            "name": {
+                              "type": "Identifier",
+                              "span": {
+                                "start": 612,
+                                "end": 615,
+                                "ctxt": 0
+                              },
+                              "value": "var",
+                              "raw": "var"
+                            },
+                            "value": [
+                              {
+                                "type": "Identifier",
+                                "span": {
+                                  "start": 616,
+                                  "end": 631,
+                                  "ctxt": 0
+                                },
+                                "value": "--primary-color",
+                                "raw": "--primary-color"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 641,
+              "end": 658,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 641,
+                "end": 651,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Url",
+                "span": {
+                  "start": 653,
+                  "end": 658,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 653,
+                    "end": 656,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -458,8 +751,8 @@
                 "value": {
                   "type": "UrlValueRaw",
                   "span": {
-                    "start": 601,
-                    "end": 601,
+                    "start": 657,
+                    "end": 657,
                     "ctxt": 0
                   },
                   "value": "",
@@ -473,15 +766,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 608,
-              "end": 627,
+              "start": 664,
+              "end": 683,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 608,
-                "end": 618,
+                "start": 664,
+                "end": 674,
                 "ctxt": 0
               },
               "value": "background",
@@ -491,15 +784,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 620,
-                  "end": 627,
+                  "start": 676,
+                  "end": 683,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 620,
-                    "end": 623,
+                    "start": 676,
+                    "end": 679,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -508,14 +801,14 @@
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 624,
-                    "end": 626,
+                    "start": 680,
+                    "end": 682,
                     "ctxt": 0
                   },
                   "value": "",
                   "raw": "\"\""
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -523,15 +816,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 633,
-              "end": 652,
+              "start": 689,
+              "end": 708,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 633,
-                "end": 643,
+                "start": 689,
+                "end": 699,
                 "ctxt": 0
               },
               "value": "background",
@@ -541,15 +834,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 645,
-                  "end": 652,
+                  "start": 701,
+                  "end": 708,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 645,
-                    "end": 648,
+                    "start": 701,
+                    "end": 704,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -558,14 +851,14 @@
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 649,
-                    "end": 651,
+                    "start": 705,
+                    "end": 707,
                     "ctxt": 0
                   },
                   "value": "",
                   "raw": "''"
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -573,15 +866,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 659,
-              "end": 666,
+              "start": 715,
+              "end": 722,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 659,
-                "end": 664,
+                "start": 715,
+                "end": 720,
                 "ctxt": 0
               },
               "value": "--foo",
@@ -591,15 +884,15 @@
               {
                 "type": "Tokens",
                 "span": {
-                  "start": 665,
-                  "end": 702,
+                  "start": 721,
+                  "end": 758,
                   "ctxt": 0
                 },
                 "tokens": [
                   {
                     "span": {
-                      "start": 665,
-                      "end": 666,
+                      "start": 721,
+                      "end": 722,
                       "ctxt": 0
                     },
                     "token": {
@@ -610,8 +903,8 @@
                   },
                   {
                     "span": {
-                      "start": 666,
-                      "end": 702,
+                      "start": 722,
+                      "end": 758,
                       "ctxt": 0
                     },
                     "token": {
@@ -629,15 +922,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 709,
-              "end": 762,
+              "start": 765,
+              "end": 818,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 709,
-                "end": 719,
+                "start": 765,
+                "end": 775,
                 "ctxt": 0
               },
               "value": "background",
@@ -647,15 +940,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 721,
-                  "end": 762,
+                  "start": 777,
+                  "end": 818,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 721,
-                    "end": 724,
+                    "start": 777,
+                    "end": 780,
                     "ctxt": 0
                   },
                   "value": "src",
@@ -664,14 +957,14 @@
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 725,
-                    "end": 761,
+                    "start": 781,
+                    "end": 817,
                     "ctxt": 0
                   },
                   "value": "http://www.example.com/pinkish.gif",
                   "raw": "\"http://www.example.com/pinkish.gif\""
                 },
-                "modifiers": null
+                "modifiers": []
               }
             ],
             "important": null
@@ -679,15 +972,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 768,
-              "end": 821,
+              "start": 824,
+              "end": 877,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 768,
-                "end": 778,
+                "start": 824,
+                "end": 834,
                 "ctxt": 0
               },
               "value": "background",
@@ -697,15 +990,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 780,
-                  "end": 821,
+                  "start": 836,
+                  "end": 877,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 780,
-                    "end": 783,
+                    "start": 836,
+                    "end": 839,
                     "ctxt": 0
                   },
                   "value": "SRC",
@@ -714,14 +1007,86 @@
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 784,
-                    "end": 820,
+                    "start": 840,
+                    "end": 876,
                     "ctxt": 0
                   },
                   "value": "http://www.example.com/pinkish.gif",
                   "raw": "\"http://www.example.com/pinkish.gif\""
                 },
-                "modifiers": null
+                "modifiers": []
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 883,
+              "end": 910,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 883,
+                "end": 893,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Url",
+                "span": {
+                  "start": 895,
+                  "end": 910,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 895,
+                    "end": 898,
+                    "ctxt": 0
+                  },
+                  "value": "src",
+                  "raw": "src"
+                },
+                "value": null,
+                "modifiers": [
+                  {
+                    "type": "Function",
+                    "span": {
+                      "start": 899,
+                      "end": 909,
+                      "ctxt": 0
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 899,
+                        "end": 902,
+                        "ctxt": 0
+                      },
+                      "value": "var",
+                      "raw": "var"
+                    },
+                    "value": [
+                      {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 903,
+                          "end": 908,
+                          "ctxt": 0
+                        },
+                        "value": "--foo",
+                        "raw": "--foo"
+                      }
+                    ]
+                  }
+                ]
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/value/url/output.json
+++ b/crates/swc_css_parser/tests/fixture/value/url/output.json
@@ -89,14 +89,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 22,
                   "end": 56,
                   "ctxt": 0
                 },
-                "url": "https://example.com/image.png",
-                "raw": "https://example.com/image.png"
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 22,
+                    "end": 25,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 26,
+                    "end": 55,
+                    "ctxt": 0
+                  },
+                  "value": "https://example.com/image.png",
+                  "raw": "https://example.com/image.png"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -222,14 +241,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 182,
                   "end": 215,
                   "ctxt": 0
                 },
-                "url": "data:image/png;base64,iRxVB0",
-                "raw": "data:image/png;base64,iRxVB0"
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 182,
+                    "end": 185,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 186,
+                    "end": 214,
+                    "ctxt": 0
+                  },
+                  "value": "data:image/png;base64,iRxVB0",
+                  "raw": "data:image/png;base64,iRxVB0"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -253,14 +291,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 233,
                   "end": 250,
                   "ctxt": 0
                 },
-                "url": "#IDofSVGpath",
-                "raw": "#IDofSVGpath"
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 233,
+                    "end": 236,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 237,
+                    "end": 249,
+                    "ctxt": 0
+                  },
+                  "value": "#IDofSVGpath",
+                  "raw": "#IDofSVGpath"
+                },
+                "modifiers": null
               }
             ],
             "important": null
@@ -284,14 +341,33 @@
             },
             "value": [
               {
-                "type": "UrlValue",
+                "type": "Url",
                 "span": {
                   "start": 491,
                   "end": 496,
                   "ctxt": 0
                 },
-                "url": "",
-                "raw": ""
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 491,
+                    "end": 494,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 495,
+                    "end": 495,
+                    "ctxt": 0
+                  },
+                  "value": "",
+                  "raw": ""
+                },
+                "modifiers": null
               }
             ],
             "important": null

--- a/crates/swc_css_parser/tests/fixture/value/url/output.json
+++ b/crates/swc_css_parser/tests/fixture/value/url/output.json
@@ -2,7 +2,7 @@
   "type": "Stylesheet",
   "span": {
     "start": 0,
-    "end": 914,
+    "end": 1022,
     "ctxt": 0
   },
   "rules": [
@@ -10,7 +10,7 @@
       "type": "QualifiedRule",
       "span": {
         "start": 0,
-        "end": 913,
+        "end": 1021,
         "ctxt": 0
       },
       "prelude": {
@@ -66,7 +66,7 @@
         "type": "Block",
         "span": {
           "start": 4,
-          "end": 913,
+          "end": 1021,
           "ctxt": 0
         },
         "value": [
@@ -152,8 +152,8 @@
                     "end": 77,
                     "ctxt": 0
                   },
-                  "value": "url",
-                  "raw": "url"
+                  "value": "URL",
+                  "raw": "URL"
                 },
                 "value": {
                   "type": "UrlValueRaw",
@@ -174,7 +174,7 @@
             "type": "Declaration",
             "span": {
               "start": 114,
-              "end": 162,
+              "end": 161,
               "ctxt": 0
             },
             "property": {
@@ -192,7 +192,7 @@
                 "type": "Url",
                 "span": {
                   "start": 126,
-                  "end": 162,
+                  "end": 161,
                   "ctxt": 0
                 },
                 "name": {
@@ -202,14 +202,64 @@
                     "end": 129,
                     "ctxt": 0
                   },
+                  "value": "URL",
+                  "raw": "\\URL"
+                },
+                "value": {
+                  "type": "UrlValueRaw",
+                  "span": {
+                    "start": 130,
+                    "end": 160,
+                    "ctxt": 0
+                  },
+                  "value": "https://example.com/image.png",
+                  "raw": "https://example.com/image.png"
+                },
+                "modifiers": null
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 167,
+              "end": 215,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 167,
+                "end": 177,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Url",
+                "span": {
+                  "start": 179,
+                  "end": 215,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 179,
+                    "end": 182,
+                    "ctxt": 0
+                  },
                   "value": "url",
                   "raw": "url"
                 },
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 130,
-                    "end": 161,
+                    "start": 183,
+                    "end": 214,
                     "ctxt": 0
                   },
                   "value": "https://example.com/image.png",
@@ -223,15 +273,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 168,
-              "end": 216,
+              "start": 221,
+              "end": 269,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 168,
-                "end": 178,
+                "start": 221,
+                "end": 231,
                 "ctxt": 0
               },
               "value": "background",
@@ -241,15 +291,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 180,
-                  "end": 216,
+                  "start": 233,
+                  "end": 269,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 180,
-                    "end": 183,
+                    "start": 233,
+                    "end": 236,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -258,8 +308,8 @@
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 184,
-                    "end": 215,
+                    "start": 237,
+                    "end": 268,
                     "ctxt": 0
                   },
                   "value": "https://example.com/image.png",
@@ -273,15 +323,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 222,
-              "end": 270,
+              "start": 275,
+              "end": 323,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 222,
-                "end": 232,
+                "start": 275,
+                "end": 285,
                 "ctxt": 0
               },
               "value": "background",
@@ -291,15 +341,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 234,
-                  "end": 270,
+                  "start": 287,
+                  "end": 323,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 234,
-                    "end": 237,
+                    "start": 287,
+                    "end": 290,
                     "ctxt": 0
                   },
                   "value": "URL",
@@ -308,8 +358,8 @@
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 238,
-                    "end": 269,
+                    "start": 291,
+                    "end": 322,
                     "ctxt": 0
                   },
                   "value": "https://example.com/image.png",
@@ -323,15 +373,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 276,
-              "end": 321,
+              "start": 329,
+              "end": 378,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 276,
-                "end": 286,
+                "start": 329,
+                "end": 339,
                 "ctxt": 0
               },
               "value": "background",
@@ -341,15 +391,65 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 288,
-                  "end": 321,
+                  "start": 341,
+                  "end": 378,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 288,
-                    "end": 291,
+                    "start": 341,
+                    "end": 345,
+                    "ctxt": 0
+                  },
+                  "value": "URL",
+                  "raw": "\\URL"
+                },
+                "value": {
+                  "type": "String",
+                  "span": {
+                    "start": 346,
+                    "end": 377,
+                    "ctxt": 0
+                  },
+                  "value": "https://example.com/image.png",
+                  "raw": "'https://example.com/image.png'"
+                },
+                "modifiers": []
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 384,
+              "end": 429,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 384,
+                "end": 394,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Url",
+                "span": {
+                  "start": 396,
+                  "end": 429,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 396,
+                    "end": 399,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -358,8 +458,8 @@
                 "value": {
                   "type": "UrlValueRaw",
                   "span": {
-                    "start": 292,
-                    "end": 320,
+                    "start": 400,
+                    "end": 428,
                     "ctxt": 0
                   },
                   "value": "data:image/png;base64,iRxVB0",
@@ -373,15 +473,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 327,
-              "end": 356,
+              "start": 435,
+              "end": 464,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 327,
-                "end": 337,
+                "start": 435,
+                "end": 445,
                 "ctxt": 0
               },
               "value": "background",
@@ -391,15 +491,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 339,
-                  "end": 356,
+                  "start": 447,
+                  "end": 464,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 339,
-                    "end": 342,
+                    "start": 447,
+                    "end": 450,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -408,8 +508,8 @@
                 "value": {
                   "type": "UrlValueRaw",
                   "span": {
-                    "start": 343,
-                    "end": 355,
+                    "start": 451,
+                    "end": 463,
                     "ctxt": 0
                   },
                   "value": "#IDofSVGpath",
@@ -423,15 +523,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 437,
-              "end": 481,
+              "start": 545,
+              "end": 589,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 437,
-                "end": 447,
+                "start": 545,
+                "end": 555,
                 "ctxt": 0
               },
               "value": "background",
@@ -441,15 +541,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 449,
-                  "end": 481,
+                  "start": 557,
+                  "end": 589,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 449,
-                    "end": 452,
+                    "start": 557,
+                    "end": 560,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -458,8 +558,8 @@
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 453,
-                    "end": 471,
+                    "start": 561,
+                    "end": 579,
                     "ctxt": 0
                   },
                   "value": "//aa.com/img.svg",
@@ -469,8 +569,8 @@
                   {
                     "type": "Identifier",
                     "span": {
-                      "start": 472,
-                      "end": 480,
+                      "start": 580,
+                      "end": 588,
                       "ctxt": 0
                     },
                     "value": "prefetch",
@@ -484,15 +584,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 487,
-              "end": 545,
+              "start": 595,
+              "end": 653,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 487,
-                "end": 497,
+                "start": 595,
+                "end": 605,
                 "ctxt": 0
               },
               "value": "background",
@@ -502,15 +602,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 499,
-                  "end": 545,
+                  "start": 607,
+                  "end": 653,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 499,
-                    "end": 502,
+                    "start": 607,
+                    "end": 610,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -519,8 +619,8 @@
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 503,
-                    "end": 521,
+                    "start": 611,
+                    "end": 629,
                     "ctxt": 0
                   },
                   "value": "//aa.com/img.svg",
@@ -530,8 +630,8 @@
                   {
                     "type": "Identifier",
                     "span": {
-                      "start": 522,
-                      "end": 525,
+                      "start": 630,
+                      "end": 633,
                       "ctxt": 0
                     },
                     "value": "foo",
@@ -540,8 +640,8 @@
                   {
                     "type": "Identifier",
                     "span": {
-                      "start": 526,
-                      "end": 529,
+                      "start": 634,
+                      "end": 637,
                       "ctxt": 0
                     },
                     "value": "bar",
@@ -550,8 +650,8 @@
                   {
                     "type": "Identifier",
                     "span": {
-                      "start": 530,
-                      "end": 533,
+                      "start": 638,
+                      "end": 641,
                       "ctxt": 0
                     },
                     "value": "baz",
@@ -560,15 +660,15 @@
                   {
                     "type": "Function",
                     "span": {
-                      "start": 534,
-                      "end": 544,
+                      "start": 642,
+                      "end": 652,
                       "ctxt": 0
                     },
                     "name": {
                       "type": "Identifier",
                       "span": {
-                        "start": 534,
-                        "end": 538,
+                        "start": 642,
+                        "end": 646,
                         "ctxt": 0
                       },
                       "value": "func",
@@ -578,8 +678,8 @@
                       {
                         "type": "Identifier",
                         "span": {
-                          "start": 539,
-                          "end": 543,
+                          "start": 647,
+                          "end": 651,
                           "ctxt": 0
                         },
                         "value": "test",
@@ -595,15 +695,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 551,
-              "end": 634,
+              "start": 659,
+              "end": 742,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 551,
-                "end": 561,
+                "start": 659,
+                "end": 669,
                 "ctxt": 0
               },
               "value": "background",
@@ -613,15 +713,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 563,
-                  "end": 634,
+                  "start": 671,
+                  "end": 742,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 563,
-                    "end": 566,
+                    "start": 671,
+                    "end": 674,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -630,8 +730,8 @@
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 567,
-                    "end": 597,
+                    "start": 675,
+                    "end": 705,
                     "ctxt": 0
                   },
                   "value": "http://example.com/image.svg",
@@ -641,15 +741,15 @@
                   {
                     "type": "Function",
                     "span": {
-                      "start": 598,
-                      "end": 633,
+                      "start": 706,
+                      "end": 741,
                       "ctxt": 0
                     },
                     "name": {
                       "type": "Identifier",
                       "span": {
-                        "start": 598,
-                        "end": 603,
+                        "start": 706,
+                        "end": 711,
                         "ctxt": 0
                       },
                       "value": "param",
@@ -659,16 +759,16 @@
                       {
                         "type": "SpaceValues",
                         "span": {
-                          "start": 604,
-                          "end": 632,
+                          "start": 712,
+                          "end": 740,
                           "ctxt": 0
                         },
                         "values": [
                           {
                             "type": "Identifier",
                             "span": {
-                              "start": 604,
-                              "end": 611,
+                              "start": 712,
+                              "end": 719,
                               "ctxt": 0
                             },
                             "value": "--color",
@@ -677,15 +777,15 @@
                           {
                             "type": "Function",
                             "span": {
-                              "start": 612,
-                              "end": 632,
+                              "start": 720,
+                              "end": 740,
                               "ctxt": 0
                             },
                             "name": {
                               "type": "Identifier",
                               "span": {
-                                "start": 612,
-                                "end": 615,
+                                "start": 720,
+                                "end": 723,
                                 "ctxt": 0
                               },
                               "value": "var",
@@ -695,8 +795,8 @@
                               {
                                 "type": "Identifier",
                                 "span": {
-                                  "start": 616,
-                                  "end": 631,
+                                  "start": 724,
+                                  "end": 739,
                                   "ctxt": 0
                                 },
                                 "value": "--primary-color",
@@ -716,15 +816,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 641,
-              "end": 658,
+              "start": 749,
+              "end": 766,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 641,
-                "end": 651,
+                "start": 749,
+                "end": 759,
                 "ctxt": 0
               },
               "value": "background",
@@ -734,15 +834,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 653,
-                  "end": 658,
+                  "start": 761,
+                  "end": 766,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 653,
-                    "end": 656,
+                    "start": 761,
+                    "end": 764,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -751,8 +851,8 @@
                 "value": {
                   "type": "UrlValueRaw",
                   "span": {
-                    "start": 657,
-                    "end": 657,
+                    "start": 765,
+                    "end": 765,
                     "ctxt": 0
                   },
                   "value": "",
@@ -766,15 +866,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 664,
-              "end": 683,
+              "start": 772,
+              "end": 791,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 664,
-                "end": 674,
+                "start": 772,
+                "end": 782,
                 "ctxt": 0
               },
               "value": "background",
@@ -784,15 +884,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 676,
-                  "end": 683,
+                  "start": 784,
+                  "end": 791,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 676,
-                    "end": 679,
+                    "start": 784,
+                    "end": 787,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -801,8 +901,8 @@
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 680,
-                    "end": 682,
+                    "start": 788,
+                    "end": 790,
                     "ctxt": 0
                   },
                   "value": "",
@@ -816,15 +916,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 689,
-              "end": 708,
+              "start": 797,
+              "end": 816,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 689,
-                "end": 699,
+                "start": 797,
+                "end": 807,
                 "ctxt": 0
               },
               "value": "background",
@@ -834,15 +934,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 701,
-                  "end": 708,
+                  "start": 809,
+                  "end": 816,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 701,
-                    "end": 704,
+                    "start": 809,
+                    "end": 812,
                     "ctxt": 0
                   },
                   "value": "url",
@@ -851,8 +951,8 @@
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 705,
-                    "end": 707,
+                    "start": 813,
+                    "end": 815,
                     "ctxt": 0
                   },
                   "value": "",
@@ -866,15 +966,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 715,
-              "end": 722,
+              "start": 823,
+              "end": 830,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 715,
-                "end": 720,
+                "start": 823,
+                "end": 828,
                 "ctxt": 0
               },
               "value": "--foo",
@@ -884,15 +984,15 @@
               {
                 "type": "Tokens",
                 "span": {
-                  "start": 721,
-                  "end": 758,
+                  "start": 829,
+                  "end": 866,
                   "ctxt": 0
                 },
                 "tokens": [
                   {
                     "span": {
-                      "start": 721,
-                      "end": 722,
+                      "start": 829,
+                      "end": 830,
                       "ctxt": 0
                     },
                     "token": {
@@ -903,8 +1003,8 @@
                   },
                   {
                     "span": {
-                      "start": 722,
-                      "end": 758,
+                      "start": 830,
+                      "end": 866,
                       "ctxt": 0
                     },
                     "token": {
@@ -922,15 +1022,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 765,
-              "end": 818,
+              "start": 873,
+              "end": 926,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 765,
-                "end": 775,
+                "start": 873,
+                "end": 883,
                 "ctxt": 0
               },
               "value": "background",
@@ -940,15 +1040,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 777,
-                  "end": 818,
+                  "start": 885,
+                  "end": 926,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 777,
-                    "end": 780,
+                    "start": 885,
+                    "end": 888,
                     "ctxt": 0
                   },
                   "value": "src",
@@ -957,8 +1057,8 @@
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 781,
-                    "end": 817,
+                    "start": 889,
+                    "end": 925,
                     "ctxt": 0
                   },
                   "value": "http://www.example.com/pinkish.gif",
@@ -972,15 +1072,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 824,
-              "end": 877,
+              "start": 932,
+              "end": 985,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 824,
-                "end": 834,
+                "start": 932,
+                "end": 942,
                 "ctxt": 0
               },
               "value": "background",
@@ -990,15 +1090,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 836,
-                  "end": 877,
+                  "start": 944,
+                  "end": 985,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 836,
-                    "end": 839,
+                    "start": 944,
+                    "end": 947,
                     "ctxt": 0
                   },
                   "value": "SRC",
@@ -1007,8 +1107,8 @@
                 "value": {
                   "type": "String",
                   "span": {
-                    "start": 840,
-                    "end": 876,
+                    "start": 948,
+                    "end": 984,
                     "ctxt": 0
                   },
                   "value": "http://www.example.com/pinkish.gif",
@@ -1022,15 +1122,15 @@
           {
             "type": "Declaration",
             "span": {
-              "start": 883,
-              "end": 910,
+              "start": 991,
+              "end": 1018,
               "ctxt": 0
             },
             "property": {
               "type": "Identifier",
               "span": {
-                "start": 883,
-                "end": 893,
+                "start": 991,
+                "end": 1001,
                 "ctxt": 0
               },
               "value": "background",
@@ -1040,15 +1140,15 @@
               {
                 "type": "Url",
                 "span": {
-                  "start": 895,
-                  "end": 910,
+                  "start": 1003,
+                  "end": 1018,
                   "ctxt": 0
                 },
                 "name": {
                   "type": "Identifier",
                   "span": {
-                    "start": 895,
-                    "end": 898,
+                    "start": 1003,
+                    "end": 1006,
                     "ctxt": 0
                   },
                   "value": "src",
@@ -1059,15 +1159,15 @@
                   {
                     "type": "Function",
                     "span": {
-                      "start": 899,
-                      "end": 909,
+                      "start": 1007,
+                      "end": 1017,
                       "ctxt": 0
                     },
                     "name": {
                       "type": "Identifier",
                       "span": {
-                        "start": 899,
-                        "end": 902,
+                        "start": 1007,
+                        "end": 1010,
                         "ctxt": 0
                       },
                       "value": "var",
@@ -1077,8 +1177,8 @@
                       {
                         "type": "Identifier",
                         "span": {
-                          "start": 903,
-                          "end": 908,
+                          "start": 1011,
+                          "end": 1016,
                           "ctxt": 0
                         },
                         "value": "--foo",

--- a/crates/swc_css_parser/tests/fixture/value/url/output.json
+++ b/crates/swc_css_parser/tests/fixture/value/url/output.json
@@ -1,0 +1,583 @@
+{
+  "type": "Stylesheet",
+  "span": {
+    "start": 0,
+    "end": 693,
+    "ctxt": 0
+  },
+  "rules": [
+    {
+      "type": "QualifiedRule",
+      "span": {
+        "start": 0,
+        "end": 692,
+        "ctxt": 0
+      },
+      "prelude": {
+        "type": "SelectorList",
+        "span": {
+          "start": 0,
+          "end": 3,
+          "ctxt": 0
+        },
+        "children": [
+          {
+            "type": "ComplexSelector",
+            "span": {
+              "start": 0,
+              "end": 3,
+              "ctxt": 0
+            },
+            "children": [
+              {
+                "type": "CompoundSelector",
+                "span": {
+                  "start": 0,
+                  "end": 3,
+                  "ctxt": 0
+                },
+                "nestingSelector": null,
+                "typeSelector": {
+                  "type": "TypeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 3,
+                    "ctxt": 0
+                  },
+                  "prefix": null,
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 0,
+                      "end": 3,
+                      "ctxt": 0
+                    },
+                    "value": "div",
+                    "raw": "div"
+                  }
+                },
+                "subclassSelectors": []
+              }
+            ]
+          }
+        ]
+      },
+      "block": {
+        "type": "Block",
+        "span": {
+          "start": 4,
+          "end": 692,
+          "ctxt": 0
+        },
+        "value": [
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 10,
+              "end": 56,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 10,
+                "end": 20,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "UrlValue",
+                "span": {
+                  "start": 22,
+                  "end": 56,
+                  "ctxt": 0
+                },
+                "url": "https://example.com/image.png",
+                "raw": "https://example.com/image.png"
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 62,
+              "end": 110,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 62,
+                "end": 72,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Function",
+                "span": {
+                  "start": 74,
+                  "end": 110,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 74,
+                    "end": 77,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": [
+                  {
+                    "type": "String",
+                    "span": {
+                      "start": 78,
+                      "end": 109,
+                      "ctxt": 0
+                    },
+                    "value": "https://example.com/image.png",
+                    "raw": "\"https://example.com/image.png\""
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 116,
+              "end": 164,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 116,
+                "end": 126,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Function",
+                "span": {
+                  "start": 128,
+                  "end": 164,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 128,
+                    "end": 131,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": [
+                  {
+                    "type": "String",
+                    "span": {
+                      "start": 132,
+                      "end": 163,
+                      "ctxt": 0
+                    },
+                    "value": "https://example.com/image.png",
+                    "raw": "'https://example.com/image.png'"
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 170,
+              "end": 215,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 170,
+                "end": 180,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "UrlValue",
+                "span": {
+                  "start": 182,
+                  "end": 215,
+                  "ctxt": 0
+                },
+                "url": "data:image/png;base64,iRxVB0",
+                "raw": "data:image/png;base64,iRxVB0"
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 221,
+              "end": 250,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 221,
+                "end": 231,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "UrlValue",
+                "span": {
+                  "start": 233,
+                  "end": 250,
+                  "ctxt": 0
+                },
+                "url": "#IDofSVGpath",
+                "raw": "#IDofSVGpath"
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 479,
+              "end": 496,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 479,
+                "end": 489,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "UrlValue",
+                "span": {
+                  "start": 491,
+                  "end": 496,
+                  "ctxt": 0
+                },
+                "url": "",
+                "raw": ""
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 502,
+              "end": 521,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 502,
+                "end": 512,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Function",
+                "span": {
+                  "start": 514,
+                  "end": 521,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 514,
+                    "end": 517,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": [
+                  {
+                    "type": "String",
+                    "span": {
+                      "start": 518,
+                      "end": 520,
+                      "ctxt": 0
+                    },
+                    "value": "",
+                    "raw": "\"\""
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 527,
+              "end": 546,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 527,
+                "end": 537,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Function",
+                "span": {
+                  "start": 539,
+                  "end": 546,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 539,
+                    "end": 542,
+                    "ctxt": 0
+                  },
+                  "value": "url",
+                  "raw": "url"
+                },
+                "value": [
+                  {
+                    "type": "String",
+                    "span": {
+                      "start": 543,
+                      "end": 545,
+                      "ctxt": 0
+                    },
+                    "value": "",
+                    "raw": "''"
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 553,
+              "end": 560,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 553,
+                "end": 558,
+                "ctxt": 0
+              },
+              "value": "--foo",
+              "raw": "--foo"
+            },
+            "value": [
+              {
+                "type": "Tokens",
+                "span": {
+                  "start": 559,
+                  "end": 596,
+                  "ctxt": 0
+                },
+                "tokens": [
+                  {
+                    "span": {
+                      "start": 559,
+                      "end": 560,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "WhiteSpace": {
+                        "value": " "
+                      }
+                    }
+                  },
+                  {
+                    "span": {
+                      "start": 560,
+                      "end": 596,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "Str": {
+                        "value": "http://www.example.com/pinkish.gif",
+                        "raw": "\"http://www.example.com/pinkish.gif\""
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 603,
+              "end": 656,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 603,
+                "end": 613,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Function",
+                "span": {
+                  "start": 615,
+                  "end": 656,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 615,
+                    "end": 618,
+                    "ctxt": 0
+                  },
+                  "value": "src",
+                  "raw": "src"
+                },
+                "value": [
+                  {
+                    "type": "String",
+                    "span": {
+                      "start": 619,
+                      "end": 655,
+                      "ctxt": 0
+                    },
+                    "value": "http://www.example.com/pinkish.gif",
+                    "raw": "\"http://www.example.com/pinkish.gif\""
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 662,
+              "end": 689,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 662,
+                "end": 672,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Function",
+                "span": {
+                  "start": 674,
+                  "end": 689,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 674,
+                    "end": 677,
+                    "ctxt": 0
+                  },
+                  "value": "src",
+                  "raw": "src"
+                },
+                "value": [
+                  {
+                    "type": "Function",
+                    "span": {
+                      "start": 678,
+                      "end": 688,
+                      "ctxt": 0
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 678,
+                        "end": 681,
+                        "ctxt": 0
+                      },
+                      "value": "var",
+                      "raw": "var"
+                    },
+                    "value": [
+                      {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 682,
+                          "end": 687,
+                          "ctxt": 0
+                        },
+                        "value": "--foo",
+                        "raw": "--foo"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "important": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/crates/swc_css_parser/tests/fixture/value/url/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/url/span.rust-debug
@@ -1,0 +1,481 @@
+error: Stylesheet
+  --> $DIR/tests/fixture/value/url/input.css:1:1
+   |
+1  | / div {
+2  | |     background: url(https://example.com/image.png);
+3  | |     background: url("https://example.com/image.png");
+4  | |     background: url('https://example.com/image.png');
+...  |
+19 | |     background: src(var(--foo));
+20 | | }
+   | |__^
+
+error: Rule
+  --> $DIR/tests/fixture/value/url/input.css:1:1
+   |
+1  | / div {
+2  | |     background: url(https://example.com/image.png);
+3  | |     background: url("https://example.com/image.png");
+4  | |     background: url('https://example.com/image.png');
+...  |
+19 | |     background: src(var(--foo));
+20 | | }
+   | |_^
+
+error: QualifiedRule
+  --> $DIR/tests/fixture/value/url/input.css:1:1
+   |
+1  | / div {
+2  | |     background: url(https://example.com/image.png);
+3  | |     background: url("https://example.com/image.png");
+4  | |     background: url('https://example.com/image.png');
+...  |
+19 | |     background: src(var(--foo));
+20 | | }
+   | |_^
+
+error: SelectorList
+ --> $DIR/tests/fixture/value/url/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: ComplexSelector
+ --> $DIR/tests/fixture/value/url/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: CompoundSelector
+ --> $DIR/tests/fixture/value/url/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: TypeSelector
+ --> $DIR/tests/fixture/value/url/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: Block
+  --> $DIR/tests/fixture/value/url/input.css:1:5
+   |
+1  |   div {
+   |  _____^
+2  | |     background: url(https://example.com/image.png);
+3  | |     background: url("https://example.com/image.png");
+4  | |     background: url('https://example.com/image.png');
+...  |
+19 | |     background: src(var(--foo));
+20 | | }
+   | |_^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/url/input.css:2:5
+  |
+2 |     background: url(https://example.com/image.png);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:2:5
+  |
+2 |     background: url(https://example.com/image.png);
+  |     ^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/url/input.css:2:17
+  |
+2 |     background: url(https://example.com/image.png);
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/value/url/input.css:2:17
+  |
+2 |     background: url(https://example.com/image.png);
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/url/input.css:3:5
+  |
+3 |     background: url("https://example.com/image.png");
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:3:5
+  |
+3 |     background: url("https://example.com/image.png");
+  |     ^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/url/input.css:3:17
+  |
+3 |     background: url("https://example.com/image.png");
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Function
+ --> $DIR/tests/fixture/value/url/input.css:3:17
+  |
+3 |     background: url("https://example.com/image.png");
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:3:17
+  |
+3 |     background: url("https://example.com/image.png");
+  |                 ^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/url/input.css:3:21
+  |
+3 |     background: url("https://example.com/image.png");
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Str
+ --> $DIR/tests/fixture/value/url/input.css:3:21
+  |
+3 |     background: url("https://example.com/image.png");
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/url/input.css:4:5
+  |
+4 |     background: url('https://example.com/image.png');
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:4:5
+  |
+4 |     background: url('https://example.com/image.png');
+  |     ^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/url/input.css:4:17
+  |
+4 |     background: url('https://example.com/image.png');
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Function
+ --> $DIR/tests/fixture/value/url/input.css:4:17
+  |
+4 |     background: url('https://example.com/image.png');
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:4:17
+  |
+4 |     background: url('https://example.com/image.png');
+  |                 ^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/url/input.css:4:21
+  |
+4 |     background: url('https://example.com/image.png');
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Str
+ --> $DIR/tests/fixture/value/url/input.css:4:21
+  |
+4 |     background: url('https://example.com/image.png');
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/url/input.css:5:5
+  |
+5 |     background: url(data:image/png;base64,iRxVB0);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:5:5
+  |
+5 |     background: url(data:image/png;base64,iRxVB0);
+  |     ^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/url/input.css:5:17
+  |
+5 |     background: url(data:image/png;base64,iRxVB0);
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/value/url/input.css:5:17
+  |
+5 |     background: url(data:image/png;base64,iRxVB0);
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/url/input.css:6:5
+  |
+6 |     background: url(#IDofSVGpath);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:6:5
+  |
+6 |     background: url(#IDofSVGpath);
+  |     ^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/url/input.css:6:17
+  |
+6 |     background: url(#IDofSVGpath);
+  |                 ^^^^^^^^^^^^^^^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/value/url/input.css:6:17
+  |
+6 |     background: url(#IDofSVGpath);
+  |                 ^^^^^^^^^^^^^^^^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:12:5
+   |
+12 |     background: url();
+   |     ^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:12:5
+   |
+12 |     background: url();
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:12:17
+   |
+12 |     background: url();
+   |                 ^^^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:12:17
+   |
+12 |     background: url();
+   |                 ^^^^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:13:5
+   |
+13 |     background: url("");
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:13:5
+   |
+13 |     background: url("");
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:13:17
+   |
+13 |     background: url("");
+   |                 ^^^^^^^
+
+error: Function
+  --> $DIR/tests/fixture/value/url/input.css:13:17
+   |
+13 |     background: url("");
+   |                 ^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:13:17
+   |
+13 |     background: url("");
+   |                 ^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:13:21
+   |
+13 |     background: url("");
+   |                     ^^
+
+error: Str
+  --> $DIR/tests/fixture/value/url/input.css:13:21
+   |
+13 |     background: url("");
+   |                     ^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:14:5
+   |
+14 |     background: url('');
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:14:5
+   |
+14 |     background: url('');
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:14:17
+   |
+14 |     background: url('');
+   |                 ^^^^^^^
+
+error: Function
+  --> $DIR/tests/fixture/value/url/input.css:14:17
+   |
+14 |     background: url('');
+   |                 ^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:14:17
+   |
+14 |     background: url('');
+   |                 ^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:14:21
+   |
+14 |     background: url('');
+   |                     ^^
+
+error: Str
+  --> $DIR/tests/fixture/value/url/input.css:14:21
+   |
+14 |     background: url('');
+   |                     ^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:16:5
+   |
+16 |     --foo: "http://www.example.com/pinkish.gif";
+   |     ^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:16:5
+   |
+16 |     --foo: "http://www.example.com/pinkish.gif";
+   |     ^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:16:11
+   |
+16 |     --foo: "http://www.example.com/pinkish.gif";
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Tokens
+  --> $DIR/tests/fixture/value/url/input.css:16:11
+   |
+16 |     --foo: "http://www.example.com/pinkish.gif";
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: WhiteSpace { value: Atom(' ' type=inline) }
+  --> $DIR/tests/fixture/value/url/input.css:16:11
+   |
+16 |     --foo: "http://www.example.com/pinkish.gif";
+   |           ^
+
+error: Str { value: Atom('http://www.example.com/pinkish.gif' type=dynamic), raw: Atom('"http://www.example.com/pinkish.gif"' type=dynamic) }
+  --> $DIR/tests/fixture/value/url/input.css:16:12
+   |
+16 |     --foo: "http://www.example.com/pinkish.gif";
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:18:5
+   |
+18 |     background: src("http://www.example.com/pinkish.gif");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:18:5
+   |
+18 |     background: src("http://www.example.com/pinkish.gif");
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:18:17
+   |
+18 |     background: src("http://www.example.com/pinkish.gif");
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Function
+  --> $DIR/tests/fixture/value/url/input.css:18:17
+   |
+18 |     background: src("http://www.example.com/pinkish.gif");
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:18:17
+   |
+18 |     background: src("http://www.example.com/pinkish.gif");
+   |                 ^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:18:21
+   |
+18 |     background: src("http://www.example.com/pinkish.gif");
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Str
+  --> $DIR/tests/fixture/value/url/input.css:18:21
+   |
+18 |     background: src("http://www.example.com/pinkish.gif");
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:19:5
+   |
+19 |     background: src(var(--foo));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:19:5
+   |
+19 |     background: src(var(--foo));
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:19:17
+   |
+19 |     background: src(var(--foo));
+   |                 ^^^^^^^^^^^^^^^
+
+error: Function
+  --> $DIR/tests/fixture/value/url/input.css:19:17
+   |
+19 |     background: src(var(--foo));
+   |                 ^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:19:17
+   |
+19 |     background: src(var(--foo));
+   |                 ^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:19:21
+   |
+19 |     background: src(var(--foo));
+   |                     ^^^^^^^^^^
+
+error: Function
+  --> $DIR/tests/fixture/value/url/input.css:19:21
+   |
+19 |     background: src(var(--foo));
+   |                     ^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:19:21
+   |
+19 |     background: src(var(--foo));
+   |                     ^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:19:25
+   |
+19 |     background: src(var(--foo));
+   |                         ^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:19:25
+   |
+19 |     background: src(var(--foo));
+   |                         ^^^^^
+

--- a/crates/swc_css_parser/tests/fixture/value/url/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/url/span.rust-debug
@@ -6,8 +6,8 @@ error: Stylesheet
 3  | |     background: URL(https://example.com/image.png);
 4  | |     background: url("https://example.com/image.png");
 ...  |
-22 | |     /*background: src(var(--foo));*/
-23 | | }
+23 | |     background: src(var(--foo));
+24 | | }
    | |__^
 
 error: Rule
@@ -18,8 +18,8 @@ error: Rule
 3  | |     background: URL(https://example.com/image.png);
 4  | |     background: url("https://example.com/image.png");
 ...  |
-22 | |     /*background: src(var(--foo));*/
-23 | | }
+23 | |     background: src(var(--foo));
+24 | | }
    | |_^
 
 error: QualifiedRule
@@ -30,8 +30,8 @@ error: QualifiedRule
 3  | |     background: URL(https://example.com/image.png);
 4  | |     background: url("https://example.com/image.png");
 ...  |
-22 | |     /*background: src(var(--foo));*/
-23 | | }
+23 | |     background: src(var(--foo));
+24 | | }
    | |_^
 
 error: SelectorList
@@ -73,8 +73,8 @@ error: Block
 3  | |     background: URL(https://example.com/image.png);
 4  | |     background: url("https://example.com/image.png");
 ...  |
-22 | |     /*background: src(var(--foo));*/
-23 | | }
+23 | |     background: src(var(--foo));
+24 | | }
    | |_^
 
 error: Declaration
@@ -372,248 +372,584 @@ error: UrlValueRaw
   |                     ^^^^^^^^^^^^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:14:5
+  --> $DIR/tests/fixture/value/url/input.css:11:5
    |
-14 |     background: url();
+11 |     background: url("//aa.com/img.svg" prefetch);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:11:5
+   |
+11 |     background: url("//aa.com/img.svg" prefetch);
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:11:17
+   |
+11 |     background: url("//aa.com/img.svg" prefetch);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Url
+  --> $DIR/tests/fixture/value/url/input.css:11:17
+   |
+11 |     background: url("//aa.com/img.svg" prefetch);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:11:17
+   |
+11 |     background: url("//aa.com/img.svg" prefetch);
+   |                 ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:11:21
+   |
+11 |     background: url("//aa.com/img.svg" prefetch);
+   |                     ^^^^^^^^^^^^^^^^^^
+
+error: Str
+  --> $DIR/tests/fixture/value/url/input.css:11:21
+   |
+11 |     background: url("//aa.com/img.svg" prefetch);
+   |                     ^^^^^^^^^^^^^^^^^^
+
+error: UrlModifier
+  --> $DIR/tests/fixture/value/url/input.css:11:40
+   |
+11 |     background: url("//aa.com/img.svg" prefetch);
+   |                                        ^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:11:40
+   |
+11 |     background: url("//aa.com/img.svg" prefetch);
+   |                                        ^^^^^^^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:12:5
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:12:5
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:12:17
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Url
+  --> $DIR/tests/fixture/value/url/input.css:12:17
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:12:17
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                 ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:12:21
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                     ^^^^^^^^^^^^^^^^^^
+
+error: Str
+  --> $DIR/tests/fixture/value/url/input.css:12:21
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                     ^^^^^^^^^^^^^^^^^^
+
+error: UrlModifier
+  --> $DIR/tests/fixture/value/url/input.css:12:40
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                                        ^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:12:40
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                                        ^^^
+
+error: UrlModifier
+  --> $DIR/tests/fixture/value/url/input.css:12:44
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                                            ^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:12:44
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                                            ^^^
+
+error: UrlModifier
+  --> $DIR/tests/fixture/value/url/input.css:12:48
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                                                ^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:12:48
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                                                ^^^
+
+error: UrlModifier
+  --> $DIR/tests/fixture/value/url/input.css:12:52
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                                                    ^^^^^^^^^^
+
+error: Function
+  --> $DIR/tests/fixture/value/url/input.css:12:52
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                                                    ^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:12:52
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                                                    ^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:12:57
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                                                         ^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:12:57
+   |
+12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+   |                                                         ^^^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:13:5
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:13:5
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:13:17
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Url
+  --> $DIR/tests/fixture/value/url/input.css:13:17
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:13:17
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                 ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:13:21
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Str
+  --> $DIR/tests/fixture/value/url/input.css:13:21
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: UrlModifier
+  --> $DIR/tests/fixture/value/url/input.css:13:52
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Function
+  --> $DIR/tests/fixture/value/url/input.css:13:52
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:13:52
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                                                    ^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:13:58
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: SpaceValues
+  --> $DIR/tests/fixture/value/url/input.css:13:58
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:13:58
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                                                          ^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:13:58
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                                                          ^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:13:66
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                                                                  ^^^^^^^^^^^^^^^^^^^^
+
+error: Function
+  --> $DIR/tests/fixture/value/url/input.css:13:66
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                                                                  ^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:13:66
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                                                                  ^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:13:70
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                                                                      ^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:13:70
+   |
+13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+   |                                                                      ^^^^^^^^^^^^^^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:15:5
+   |
+15 |     background: url();
    |     ^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:14:5
+  --> $DIR/tests/fixture/value/url/input.css:15:5
    |
-14 |     background: url();
+15 |     background: url();
    |     ^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:14:17
+  --> $DIR/tests/fixture/value/url/input.css:15:17
    |
-14 |     background: url();
+15 |     background: url();
    |                 ^^^^^
 
 error: Url
-  --> $DIR/tests/fixture/value/url/input.css:14:17
+  --> $DIR/tests/fixture/value/url/input.css:15:17
    |
-14 |     background: url();
+15 |     background: url();
    |                 ^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:14:17
+  --> $DIR/tests/fixture/value/url/input.css:15:17
    |
-14 |     background: url();
+15 |     background: url();
    |                 ^^^
 
 error: UrlValue
-  --> $DIR/tests/fixture/value/url/input.css:14:21
+  --> $DIR/tests/fixture/value/url/input.css:15:21
    |
-14 |     background: url();
+15 |     background: url();
    |                     ^
 
 error: UrlValueRaw
-  --> $DIR/tests/fixture/value/url/input.css:14:21
+  --> $DIR/tests/fixture/value/url/input.css:15:21
    |
-14 |     background: url();
+15 |     background: url();
    |                     ^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:15:5
-   |
-15 |     background: url("");
-   |     ^^^^^^^^^^^^^^^^^^^
-
-error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:15:5
-   |
-15 |     background: url("");
-   |     ^^^^^^^^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/url/input.css:15:17
-   |
-15 |     background: url("");
-   |                 ^^^^^^^
-
-error: Url
-  --> $DIR/tests/fixture/value/url/input.css:15:17
-   |
-15 |     background: url("");
-   |                 ^^^^^^^
-
-error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:15:17
-   |
-15 |     background: url("");
-   |                 ^^^
-
-error: UrlValue
-  --> $DIR/tests/fixture/value/url/input.css:15:21
-   |
-15 |     background: url("");
-   |                     ^^
-
-error: Str
-  --> $DIR/tests/fixture/value/url/input.css:15:21
-   |
-15 |     background: url("");
-   |                     ^^
-
-error: Declaration
   --> $DIR/tests/fixture/value/url/input.css:16:5
    |
-16 |     background: url('');
+16 |     background: url("");
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: Ident
   --> $DIR/tests/fixture/value/url/input.css:16:5
    |
-16 |     background: url('');
+16 |     background: url("");
    |     ^^^^^^^^^^
 
 error: Value
   --> $DIR/tests/fixture/value/url/input.css:16:17
    |
-16 |     background: url('');
+16 |     background: url("");
    |                 ^^^^^^^
 
 error: Url
   --> $DIR/tests/fixture/value/url/input.css:16:17
    |
-16 |     background: url('');
+16 |     background: url("");
    |                 ^^^^^^^
 
 error: Ident
   --> $DIR/tests/fixture/value/url/input.css:16:17
    |
-16 |     background: url('');
+16 |     background: url("");
    |                 ^^^
 
 error: UrlValue
   --> $DIR/tests/fixture/value/url/input.css:16:21
    |
-16 |     background: url('');
+16 |     background: url("");
    |                     ^^
 
 error: Str
   --> $DIR/tests/fixture/value/url/input.css:16:21
    |
-16 |     background: url('');
+16 |     background: url("");
    |                     ^^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:18:5
+  --> $DIR/tests/fixture/value/url/input.css:17:5
    |
-18 |     --foo: "http://www.example.com/pinkish.gif";
+17 |     background: url('');
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:17:5
+   |
+17 |     background: url('');
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:17:17
+   |
+17 |     background: url('');
+   |                 ^^^^^^^
+
+error: Url
+  --> $DIR/tests/fixture/value/url/input.css:17:17
+   |
+17 |     background: url('');
+   |                 ^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:17:17
+   |
+17 |     background: url('');
+   |                 ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:17:21
+   |
+17 |     background: url('');
+   |                     ^^
+
+error: Str
+  --> $DIR/tests/fixture/value/url/input.css:17:21
+   |
+17 |     background: url('');
+   |                     ^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:19:5
+   |
+19 |     --foo: "http://www.example.com/pinkish.gif";
    |     ^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:18:5
+  --> $DIR/tests/fixture/value/url/input.css:19:5
    |
-18 |     --foo: "http://www.example.com/pinkish.gif";
+19 |     --foo: "http://www.example.com/pinkish.gif";
    |     ^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:18:11
+  --> $DIR/tests/fixture/value/url/input.css:19:11
    |
-18 |     --foo: "http://www.example.com/pinkish.gif";
+19 |     --foo: "http://www.example.com/pinkish.gif";
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Tokens
-  --> $DIR/tests/fixture/value/url/input.css:18:11
+  --> $DIR/tests/fixture/value/url/input.css:19:11
    |
-18 |     --foo: "http://www.example.com/pinkish.gif";
+19 |     --foo: "http://www.example.com/pinkish.gif";
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: WhiteSpace { value: Atom(' ' type=inline) }
-  --> $DIR/tests/fixture/value/url/input.css:18:11
+  --> $DIR/tests/fixture/value/url/input.css:19:11
    |
-18 |     --foo: "http://www.example.com/pinkish.gif";
+19 |     --foo: "http://www.example.com/pinkish.gif";
    |           ^
 
 error: Str { value: Atom('http://www.example.com/pinkish.gif' type=dynamic), raw: Atom('"http://www.example.com/pinkish.gif"' type=dynamic) }
-  --> $DIR/tests/fixture/value/url/input.css:18:12
+  --> $DIR/tests/fixture/value/url/input.css:19:12
    |
-18 |     --foo: "http://www.example.com/pinkish.gif";
+19 |     --foo: "http://www.example.com/pinkish.gif";
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:20:5
+  --> $DIR/tests/fixture/value/url/input.css:21:5
    |
-20 |     background: src("http://www.example.com/pinkish.gif");
+21 |     background: src("http://www.example.com/pinkish.gif");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:20:5
+  --> $DIR/tests/fixture/value/url/input.css:21:5
    |
-20 |     background: src("http://www.example.com/pinkish.gif");
+21 |     background: src("http://www.example.com/pinkish.gif");
    |     ^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:20:17
+  --> $DIR/tests/fixture/value/url/input.css:21:17
    |
-20 |     background: src("http://www.example.com/pinkish.gif");
+21 |     background: src("http://www.example.com/pinkish.gif");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Url
-  --> $DIR/tests/fixture/value/url/input.css:20:17
+  --> $DIR/tests/fixture/value/url/input.css:21:17
    |
-20 |     background: src("http://www.example.com/pinkish.gif");
+21 |     background: src("http://www.example.com/pinkish.gif");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:20:17
+  --> $DIR/tests/fixture/value/url/input.css:21:17
    |
-20 |     background: src("http://www.example.com/pinkish.gif");
+21 |     background: src("http://www.example.com/pinkish.gif");
    |                 ^^^
 
 error: UrlValue
-  --> $DIR/tests/fixture/value/url/input.css:20:21
+  --> $DIR/tests/fixture/value/url/input.css:21:21
    |
-20 |     background: src("http://www.example.com/pinkish.gif");
+21 |     background: src("http://www.example.com/pinkish.gif");
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Str
-  --> $DIR/tests/fixture/value/url/input.css:20:21
+  --> $DIR/tests/fixture/value/url/input.css:21:21
    |
-20 |     background: src("http://www.example.com/pinkish.gif");
+21 |     background: src("http://www.example.com/pinkish.gif");
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:21:5
+  --> $DIR/tests/fixture/value/url/input.css:22:5
    |
-21 |     background: SRC("http://www.example.com/pinkish.gif");
+22 |     background: SRC("http://www.example.com/pinkish.gif");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:21:5
+  --> $DIR/tests/fixture/value/url/input.css:22:5
    |
-21 |     background: SRC("http://www.example.com/pinkish.gif");
+22 |     background: SRC("http://www.example.com/pinkish.gif");
    |     ^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:21:17
+  --> $DIR/tests/fixture/value/url/input.css:22:17
    |
-21 |     background: SRC("http://www.example.com/pinkish.gif");
+22 |     background: SRC("http://www.example.com/pinkish.gif");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Url
-  --> $DIR/tests/fixture/value/url/input.css:21:17
+  --> $DIR/tests/fixture/value/url/input.css:22:17
    |
-21 |     background: SRC("http://www.example.com/pinkish.gif");
+22 |     background: SRC("http://www.example.com/pinkish.gif");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:21:17
+  --> $DIR/tests/fixture/value/url/input.css:22:17
    |
-21 |     background: SRC("http://www.example.com/pinkish.gif");
+22 |     background: SRC("http://www.example.com/pinkish.gif");
    |                 ^^^
 
 error: UrlValue
-  --> $DIR/tests/fixture/value/url/input.css:21:21
+  --> $DIR/tests/fixture/value/url/input.css:22:21
    |
-21 |     background: SRC("http://www.example.com/pinkish.gif");
+22 |     background: SRC("http://www.example.com/pinkish.gif");
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Str
-  --> $DIR/tests/fixture/value/url/input.css:21:21
+  --> $DIR/tests/fixture/value/url/input.css:22:21
    |
-21 |     background: SRC("http://www.example.com/pinkish.gif");
+22 |     background: SRC("http://www.example.com/pinkish.gif");
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:23:5
+   |
+23 |     background: src(var(--foo));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:23:5
+   |
+23 |     background: src(var(--foo));
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:23:17
+   |
+23 |     background: src(var(--foo));
+   |                 ^^^^^^^^^^^^^^^
+
+error: Url
+  --> $DIR/tests/fixture/value/url/input.css:23:17
+   |
+23 |     background: src(var(--foo));
+   |                 ^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:23:17
+   |
+23 |     background: src(var(--foo));
+   |                 ^^^
+
+error: UrlModifier
+  --> $DIR/tests/fixture/value/url/input.css:23:21
+   |
+23 |     background: src(var(--foo));
+   |                     ^^^^^^^^^^
+
+error: Function
+  --> $DIR/tests/fixture/value/url/input.css:23:21
+   |
+23 |     background: src(var(--foo));
+   |                     ^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:23:21
+   |
+23 |     background: src(var(--foo));
+   |                     ^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:23:25
+   |
+23 |     background: src(var(--foo));
+   |                         ^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:23:25
+   |
+23 |     background: src(var(--foo));
+   |                         ^^^^^
 

--- a/crates/swc_css_parser/tests/fixture/value/url/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/url/span.rust-debug
@@ -3,11 +3,11 @@ error: Stylesheet
    |
 1  | / div {
 2  | |     background: url(https://example.com/image.png);
-3  | |     background: url("https://example.com/image.png");
-4  | |     background: url('https://example.com/image.png');
+3  | |     background: URL(https://example.com/image.png);
+4  | |     background: url("https://example.com/image.png");
 ...  |
-19 | |     background: src(var(--foo));
-20 | | }
+22 | |     /*background: src(var(--foo));*/
+23 | | }
    | |__^
 
 error: Rule
@@ -15,11 +15,11 @@ error: Rule
    |
 1  | / div {
 2  | |     background: url(https://example.com/image.png);
-3  | |     background: url("https://example.com/image.png");
-4  | |     background: url('https://example.com/image.png');
+3  | |     background: URL(https://example.com/image.png);
+4  | |     background: url("https://example.com/image.png");
 ...  |
-19 | |     background: src(var(--foo));
-20 | | }
+22 | |     /*background: src(var(--foo));*/
+23 | | }
    | |_^
 
 error: QualifiedRule
@@ -27,11 +27,11 @@ error: QualifiedRule
    |
 1  | / div {
 2  | |     background: url(https://example.com/image.png);
-3  | |     background: url("https://example.com/image.png");
-4  | |     background: url('https://example.com/image.png');
+3  | |     background: URL(https://example.com/image.png);
+4  | |     background: url("https://example.com/image.png");
 ...  |
-19 | |     background: src(var(--foo));
-20 | | }
+22 | |     /*background: src(var(--foo));*/
+23 | | }
    | |_^
 
 error: SelectorList
@@ -70,11 +70,11 @@ error: Block
 1  |   div {
    |  _____^
 2  | |     background: url(https://example.com/image.png);
-3  | |     background: url("https://example.com/image.png");
-4  | |     background: url('https://example.com/image.png');
+3  | |     background: URL(https://example.com/image.png);
+4  | |     background: url("https://example.com/image.png");
 ...  |
-19 | |     background: src(var(--foo));
-20 | | }
+22 | |     /*background: src(var(--foo));*/
+23 | | }
    | |_^
 
 error: Declaration
@@ -122,432 +122,498 @@ error: UrlValueRaw
 error: Declaration
  --> $DIR/tests/fixture/value/url/input.css:3:5
   |
-3 |     background: url("https://example.com/image.png");
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3 |     background: URL(https://example.com/image.png);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
  --> $DIR/tests/fixture/value/url/input.css:3:5
   |
-3 |     background: url("https://example.com/image.png");
+3 |     background: URL(https://example.com/image.png);
   |     ^^^^^^^^^^
 
 error: Value
  --> $DIR/tests/fixture/value/url/input.css:3:17
   |
-3 |     background: url("https://example.com/image.png");
-  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3 |     background: URL(https://example.com/image.png);
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/value/url/input.css:3:17
   |
-3 |     background: url("https://example.com/image.png");
-  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3 |     background: URL(https://example.com/image.png);
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
  --> $DIR/tests/fixture/value/url/input.css:3:17
   |
-3 |     background: url("https://example.com/image.png");
+3 |     background: URL(https://example.com/image.png);
   |                 ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/value/url/input.css:3:21
   |
-3 |     background: url("https://example.com/image.png");
-  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3 |     background: URL(https://example.com/image.png);
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Str
+error: UrlValueRaw
  --> $DIR/tests/fixture/value/url/input.css:3:21
   |
-3 |     background: url("https://example.com/image.png");
-  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3 |     background: URL(https://example.com/image.png);
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
  --> $DIR/tests/fixture/value/url/input.css:4:5
   |
-4 |     background: url('https://example.com/image.png');
+4 |     background: url("https://example.com/image.png");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
  --> $DIR/tests/fixture/value/url/input.css:4:5
   |
-4 |     background: url('https://example.com/image.png');
+4 |     background: url("https://example.com/image.png");
   |     ^^^^^^^^^^
 
 error: Value
  --> $DIR/tests/fixture/value/url/input.css:4:17
   |
-4 |     background: url('https://example.com/image.png');
+4 |     background: url("https://example.com/image.png");
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
+error: Url
  --> $DIR/tests/fixture/value/url/input.css:4:17
   |
-4 |     background: url('https://example.com/image.png');
+4 |     background: url("https://example.com/image.png");
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
  --> $DIR/tests/fixture/value/url/input.css:4:17
   |
-4 |     background: url('https://example.com/image.png');
+4 |     background: url("https://example.com/image.png");
   |                 ^^^
 
-error: Value
+error: UrlValue
  --> $DIR/tests/fixture/value/url/input.css:4:21
   |
-4 |     background: url('https://example.com/image.png');
+4 |     background: url("https://example.com/image.png");
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Str
  --> $DIR/tests/fixture/value/url/input.css:4:21
   |
-4 |     background: url('https://example.com/image.png');
+4 |     background: url("https://example.com/image.png");
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
  --> $DIR/tests/fixture/value/url/input.css:5:5
   |
-5 |     background: url(data:image/png;base64,iRxVB0);
+5 |     background: url('https://example.com/image.png');
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:5:5
+  |
+5 |     background: url('https://example.com/image.png');
+  |     ^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/url/input.css:5:17
+  |
+5 |     background: url('https://example.com/image.png');
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Url
+ --> $DIR/tests/fixture/value/url/input.css:5:17
+  |
+5 |     background: url('https://example.com/image.png');
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:5:17
+  |
+5 |     background: url('https://example.com/image.png');
+  |                 ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/value/url/input.css:5:21
+  |
+5 |     background: url('https://example.com/image.png');
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Str
+ --> $DIR/tests/fixture/value/url/input.css:5:21
+  |
+5 |     background: url('https://example.com/image.png');
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/url/input.css:6:5
+  |
+6 |     background: URL('https://example.com/image.png');
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:6:5
+  |
+6 |     background: URL('https://example.com/image.png');
+  |     ^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/url/input.css:6:17
+  |
+6 |     background: URL('https://example.com/image.png');
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Url
+ --> $DIR/tests/fixture/value/url/input.css:6:17
+  |
+6 |     background: URL('https://example.com/image.png');
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:6:17
+  |
+6 |     background: URL('https://example.com/image.png');
+  |                 ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/value/url/input.css:6:21
+  |
+6 |     background: URL('https://example.com/image.png');
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Str
+ --> $DIR/tests/fixture/value/url/input.css:6:21
+  |
+6 |     background: URL('https://example.com/image.png');
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/url/input.css:7:5
+  |
+7 |     background: url(data:image/png;base64,iRxVB0);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
- --> $DIR/tests/fixture/value/url/input.css:5:5
+ --> $DIR/tests/fixture/value/url/input.css:7:5
   |
-5 |     background: url(data:image/png;base64,iRxVB0);
+7 |     background: url(data:image/png;base64,iRxVB0);
   |     ^^^^^^^^^^
 
 error: Value
- --> $DIR/tests/fixture/value/url/input.css:5:17
+ --> $DIR/tests/fixture/value/url/input.css:7:17
   |
-5 |     background: url(data:image/png;base64,iRxVB0);
+7 |     background: url(data:image/png;base64,iRxVB0);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Url
- --> $DIR/tests/fixture/value/url/input.css:5:17
+ --> $DIR/tests/fixture/value/url/input.css:7:17
   |
-5 |     background: url(data:image/png;base64,iRxVB0);
+7 |     background: url(data:image/png;base64,iRxVB0);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
- --> $DIR/tests/fixture/value/url/input.css:5:17
+ --> $DIR/tests/fixture/value/url/input.css:7:17
   |
-5 |     background: url(data:image/png;base64,iRxVB0);
+7 |     background: url(data:image/png;base64,iRxVB0);
   |                 ^^^
 
 error: UrlValue
- --> $DIR/tests/fixture/value/url/input.css:5:21
+ --> $DIR/tests/fixture/value/url/input.css:7:21
   |
-5 |     background: url(data:image/png;base64,iRxVB0);
+7 |     background: url(data:image/png;base64,iRxVB0);
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: UrlValueRaw
- --> $DIR/tests/fixture/value/url/input.css:5:21
+ --> $DIR/tests/fixture/value/url/input.css:7:21
   |
-5 |     background: url(data:image/png;base64,iRxVB0);
+7 |     background: url(data:image/png;base64,iRxVB0);
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
- --> $DIR/tests/fixture/value/url/input.css:6:5
+ --> $DIR/tests/fixture/value/url/input.css:8:5
   |
-6 |     background: url(#IDofSVGpath);
+8 |     background: url(#IDofSVGpath);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
- --> $DIR/tests/fixture/value/url/input.css:6:5
+ --> $DIR/tests/fixture/value/url/input.css:8:5
   |
-6 |     background: url(#IDofSVGpath);
+8 |     background: url(#IDofSVGpath);
   |     ^^^^^^^^^^
 
 error: Value
- --> $DIR/tests/fixture/value/url/input.css:6:17
+ --> $DIR/tests/fixture/value/url/input.css:8:17
   |
-6 |     background: url(#IDofSVGpath);
+8 |     background: url(#IDofSVGpath);
   |                 ^^^^^^^^^^^^^^^^^
 
 error: Url
- --> $DIR/tests/fixture/value/url/input.css:6:17
+ --> $DIR/tests/fixture/value/url/input.css:8:17
   |
-6 |     background: url(#IDofSVGpath);
+8 |     background: url(#IDofSVGpath);
   |                 ^^^^^^^^^^^^^^^^^
 
 error: Ident
- --> $DIR/tests/fixture/value/url/input.css:6:17
+ --> $DIR/tests/fixture/value/url/input.css:8:17
   |
-6 |     background: url(#IDofSVGpath);
+8 |     background: url(#IDofSVGpath);
   |                 ^^^
 
 error: UrlValue
- --> $DIR/tests/fixture/value/url/input.css:6:21
+ --> $DIR/tests/fixture/value/url/input.css:8:21
   |
-6 |     background: url(#IDofSVGpath);
+8 |     background: url(#IDofSVGpath);
   |                     ^^^^^^^^^^^^
 
 error: UrlValueRaw
- --> $DIR/tests/fixture/value/url/input.css:6:21
+ --> $DIR/tests/fixture/value/url/input.css:8:21
   |
-6 |     background: url(#IDofSVGpath);
+8 |     background: url(#IDofSVGpath);
   |                     ^^^^^^^^^^^^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:12:5
+  --> $DIR/tests/fixture/value/url/input.css:14:5
    |
-12 |     background: url();
+14 |     background: url();
    |     ^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:12:5
+  --> $DIR/tests/fixture/value/url/input.css:14:5
    |
-12 |     background: url();
+14 |     background: url();
    |     ^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:12:17
+  --> $DIR/tests/fixture/value/url/input.css:14:17
    |
-12 |     background: url();
+14 |     background: url();
    |                 ^^^^^
 
 error: Url
-  --> $DIR/tests/fixture/value/url/input.css:12:17
+  --> $DIR/tests/fixture/value/url/input.css:14:17
    |
-12 |     background: url();
+14 |     background: url();
    |                 ^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:12:17
+  --> $DIR/tests/fixture/value/url/input.css:14:17
    |
-12 |     background: url();
+14 |     background: url();
    |                 ^^^
 
 error: UrlValue
-  --> $DIR/tests/fixture/value/url/input.css:12:21
+  --> $DIR/tests/fixture/value/url/input.css:14:21
    |
-12 |     background: url();
+14 |     background: url();
    |                     ^
 
 error: UrlValueRaw
-  --> $DIR/tests/fixture/value/url/input.css:12:21
+  --> $DIR/tests/fixture/value/url/input.css:14:21
    |
-12 |     background: url();
+14 |     background: url();
    |                     ^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:13:5
+  --> $DIR/tests/fixture/value/url/input.css:15:5
    |
-13 |     background: url("");
+15 |     background: url("");
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:13:5
+  --> $DIR/tests/fixture/value/url/input.css:15:5
    |
-13 |     background: url("");
+15 |     background: url("");
    |     ^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:13:17
+  --> $DIR/tests/fixture/value/url/input.css:15:17
    |
-13 |     background: url("");
+15 |     background: url("");
    |                 ^^^^^^^
 
-error: Function
-  --> $DIR/tests/fixture/value/url/input.css:13:17
+error: Url
+  --> $DIR/tests/fixture/value/url/input.css:15:17
    |
-13 |     background: url("");
+15 |     background: url("");
    |                 ^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:13:17
+  --> $DIR/tests/fixture/value/url/input.css:15:17
    |
-13 |     background: url("");
+15 |     background: url("");
    |                 ^^^
 
-error: Value
-  --> $DIR/tests/fixture/value/url/input.css:13:21
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:15:21
    |
-13 |     background: url("");
+15 |     background: url("");
    |                     ^^
 
 error: Str
-  --> $DIR/tests/fixture/value/url/input.css:13:21
+  --> $DIR/tests/fixture/value/url/input.css:15:21
    |
-13 |     background: url("");
-   |                     ^^
-
-error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:14:5
-   |
-14 |     background: url('');
-   |     ^^^^^^^^^^^^^^^^^^^
-
-error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:14:5
-   |
-14 |     background: url('');
-   |     ^^^^^^^^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/url/input.css:14:17
-   |
-14 |     background: url('');
-   |                 ^^^^^^^
-
-error: Function
-  --> $DIR/tests/fixture/value/url/input.css:14:17
-   |
-14 |     background: url('');
-   |                 ^^^^^^^
-
-error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:14:17
-   |
-14 |     background: url('');
-   |                 ^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/url/input.css:14:21
-   |
-14 |     background: url('');
-   |                     ^^
-
-error: Str
-  --> $DIR/tests/fixture/value/url/input.css:14:21
-   |
-14 |     background: url('');
+15 |     background: url("");
    |                     ^^
 
 error: Declaration
   --> $DIR/tests/fixture/value/url/input.css:16:5
    |
-16 |     --foo: "http://www.example.com/pinkish.gif";
+16 |     background: url('');
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:16:5
+   |
+16 |     background: url('');
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:16:17
+   |
+16 |     background: url('');
+   |                 ^^^^^^^
+
+error: Url
+  --> $DIR/tests/fixture/value/url/input.css:16:17
+   |
+16 |     background: url('');
+   |                 ^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:16:17
+   |
+16 |     background: url('');
+   |                 ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:16:21
+   |
+16 |     background: url('');
+   |                     ^^
+
+error: Str
+  --> $DIR/tests/fixture/value/url/input.css:16:21
+   |
+16 |     background: url('');
+   |                     ^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:18:5
+   |
+18 |     --foo: "http://www.example.com/pinkish.gif";
    |     ^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:16:5
+  --> $DIR/tests/fixture/value/url/input.css:18:5
    |
-16 |     --foo: "http://www.example.com/pinkish.gif";
+18 |     --foo: "http://www.example.com/pinkish.gif";
    |     ^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:16:11
+  --> $DIR/tests/fixture/value/url/input.css:18:11
    |
-16 |     --foo: "http://www.example.com/pinkish.gif";
+18 |     --foo: "http://www.example.com/pinkish.gif";
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Tokens
-  --> $DIR/tests/fixture/value/url/input.css:16:11
+  --> $DIR/tests/fixture/value/url/input.css:18:11
    |
-16 |     --foo: "http://www.example.com/pinkish.gif";
+18 |     --foo: "http://www.example.com/pinkish.gif";
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: WhiteSpace { value: Atom(' ' type=inline) }
-  --> $DIR/tests/fixture/value/url/input.css:16:11
+  --> $DIR/tests/fixture/value/url/input.css:18:11
    |
-16 |     --foo: "http://www.example.com/pinkish.gif";
+18 |     --foo: "http://www.example.com/pinkish.gif";
    |           ^
 
 error: Str { value: Atom('http://www.example.com/pinkish.gif' type=dynamic), raw: Atom('"http://www.example.com/pinkish.gif"' type=dynamic) }
-  --> $DIR/tests/fixture/value/url/input.css:16:12
+  --> $DIR/tests/fixture/value/url/input.css:18:12
    |
-16 |     --foo: "http://www.example.com/pinkish.gif";
+18 |     --foo: "http://www.example.com/pinkish.gif";
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:18:5
+  --> $DIR/tests/fixture/value/url/input.css:20:5
    |
-18 |     background: src("http://www.example.com/pinkish.gif");
+20 |     background: src("http://www.example.com/pinkish.gif");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:18:5
+  --> $DIR/tests/fixture/value/url/input.css:20:5
    |
-18 |     background: src("http://www.example.com/pinkish.gif");
+20 |     background: src("http://www.example.com/pinkish.gif");
    |     ^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:18:17
+  --> $DIR/tests/fixture/value/url/input.css:20:17
    |
-18 |     background: src("http://www.example.com/pinkish.gif");
+20 |     background: src("http://www.example.com/pinkish.gif");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
-  --> $DIR/tests/fixture/value/url/input.css:18:17
+error: Url
+  --> $DIR/tests/fixture/value/url/input.css:20:17
    |
-18 |     background: src("http://www.example.com/pinkish.gif");
+20 |     background: src("http://www.example.com/pinkish.gif");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:18:17
+  --> $DIR/tests/fixture/value/url/input.css:20:17
    |
-18 |     background: src("http://www.example.com/pinkish.gif");
+20 |     background: src("http://www.example.com/pinkish.gif");
    |                 ^^^
 
-error: Value
-  --> $DIR/tests/fixture/value/url/input.css:18:21
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:20:21
    |
-18 |     background: src("http://www.example.com/pinkish.gif");
+20 |     background: src("http://www.example.com/pinkish.gif");
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Str
-  --> $DIR/tests/fixture/value/url/input.css:18:21
+  --> $DIR/tests/fixture/value/url/input.css:20:21
    |
-18 |     background: src("http://www.example.com/pinkish.gif");
+20 |     background: src("http://www.example.com/pinkish.gif");
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:19:5
+  --> $DIR/tests/fixture/value/url/input.css:21:5
    |
-19 |     background: src(var(--foo));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+21 |     background: SRC("http://www.example.com/pinkish.gif");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:19:5
+  --> $DIR/tests/fixture/value/url/input.css:21:5
    |
-19 |     background: src(var(--foo));
+21 |     background: SRC("http://www.example.com/pinkish.gif");
    |     ^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:19:17
+  --> $DIR/tests/fixture/value/url/input.css:21:17
    |
-19 |     background: src(var(--foo));
-   |                 ^^^^^^^^^^^^^^^
+21 |     background: SRC("http://www.example.com/pinkish.gif");
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
-  --> $DIR/tests/fixture/value/url/input.css:19:17
+error: Url
+  --> $DIR/tests/fixture/value/url/input.css:21:17
    |
-19 |     background: src(var(--foo));
-   |                 ^^^^^^^^^^^^^^^
+21 |     background: SRC("http://www.example.com/pinkish.gif");
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:19:17
+  --> $DIR/tests/fixture/value/url/input.css:21:17
    |
-19 |     background: src(var(--foo));
+21 |     background: SRC("http://www.example.com/pinkish.gif");
    |                 ^^^
 
-error: Value
-  --> $DIR/tests/fixture/value/url/input.css:19:21
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:21:21
    |
-19 |     background: src(var(--foo));
-   |                     ^^^^^^^^^^
+21 |     background: SRC("http://www.example.com/pinkish.gif");
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Function
-  --> $DIR/tests/fixture/value/url/input.css:19:21
+error: Str
+  --> $DIR/tests/fixture/value/url/input.css:21:21
    |
-19 |     background: src(var(--foo));
-   |                     ^^^^^^^^^^
-
-error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:19:21
-   |
-19 |     background: src(var(--foo));
-   |                     ^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/url/input.css:19:25
-   |
-19 |     background: src(var(--foo));
-   |                         ^^^^^
-
-error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:19:25
-   |
-19 |     background: src(var(--foo));
-   |                         ^^^^^
+21 |     background: SRC("http://www.example.com/pinkish.gif");
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/crates/swc_css_parser/tests/fixture/value/url/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/url/span.rust-debug
@@ -95,11 +95,29 @@ error: Value
 2 |     background: url(https://example.com/image.png);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/value/url/input.css:2:17
   |
 2 |     background: url(https://example.com/image.png);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:2:17
+  |
+2 |     background: url(https://example.com/image.png);
+  |                 ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/value/url/input.css:2:21
+  |
+2 |     background: url(https://example.com/image.png);
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/value/url/input.css:2:21
+  |
+2 |     background: url(https://example.com/image.png);
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
  --> $DIR/tests/fixture/value/url/input.css:3:5
@@ -203,11 +221,29 @@ error: Value
 5 |     background: url(data:image/png;base64,iRxVB0);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/value/url/input.css:5:17
   |
 5 |     background: url(data:image/png;base64,iRxVB0);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:5:17
+  |
+5 |     background: url(data:image/png;base64,iRxVB0);
+  |                 ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/value/url/input.css:5:21
+  |
+5 |     background: url(data:image/png;base64,iRxVB0);
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/value/url/input.css:5:21
+  |
+5 |     background: url(data:image/png;base64,iRxVB0);
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
  --> $DIR/tests/fixture/value/url/input.css:6:5
@@ -227,11 +263,29 @@ error: Value
 6 |     background: url(#IDofSVGpath);
   |                 ^^^^^^^^^^^^^^^^^
 
-error: UrlValue
+error: Url
  --> $DIR/tests/fixture/value/url/input.css:6:17
   |
 6 |     background: url(#IDofSVGpath);
   |                 ^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:6:17
+  |
+6 |     background: url(#IDofSVGpath);
+  |                 ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/value/url/input.css:6:21
+  |
+6 |     background: url(#IDofSVGpath);
+  |                     ^^^^^^^^^^^^
+
+error: UrlValueRaw
+ --> $DIR/tests/fixture/value/url/input.css:6:21
+  |
+6 |     background: url(#IDofSVGpath);
+  |                     ^^^^^^^^^^^^
 
 error: Declaration
   --> $DIR/tests/fixture/value/url/input.css:12:5
@@ -251,11 +305,29 @@ error: Value
 12 |     background: url();
    |                 ^^^^^
 
-error: UrlValue
+error: Url
   --> $DIR/tests/fixture/value/url/input.css:12:17
    |
 12 |     background: url();
    |                 ^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:12:17
+   |
+12 |     background: url();
+   |                 ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:12:21
+   |
+12 |     background: url();
+   |                     ^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/value/url/input.css:12:21
+   |
+12 |     background: url();
+   |                     ^
 
 error: Declaration
   --> $DIR/tests/fixture/value/url/input.css:13:5

--- a/crates/swc_css_parser/tests/fixture/value/url/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/url/span.rust-debug
@@ -4,10 +4,10 @@ error: Stylesheet
 1  | / div {
 2  | |     background: url(https://example.com/image.png);
 3  | |     background: URL(https://example.com/image.png);
-4  | |     background: url("https://example.com/image.png");
+4  | |     background: \URL(https://example.com/image.png);
 ...  |
-23 | |     background: src(var(--foo));
-24 | | }
+25 | |     background: src(var(--foo));
+26 | | }
    | |__^
 
 error: Rule
@@ -16,10 +16,10 @@ error: Rule
 1  | / div {
 2  | |     background: url(https://example.com/image.png);
 3  | |     background: URL(https://example.com/image.png);
-4  | |     background: url("https://example.com/image.png");
+4  | |     background: \URL(https://example.com/image.png);
 ...  |
-23 | |     background: src(var(--foo));
-24 | | }
+25 | |     background: src(var(--foo));
+26 | | }
    | |_^
 
 error: QualifiedRule
@@ -28,10 +28,10 @@ error: QualifiedRule
 1  | / div {
 2  | |     background: url(https://example.com/image.png);
 3  | |     background: URL(https://example.com/image.png);
-4  | |     background: url("https://example.com/image.png");
+4  | |     background: \URL(https://example.com/image.png);
 ...  |
-23 | |     background: src(var(--foo));
-24 | | }
+25 | |     background: src(var(--foo));
+26 | | }
    | |_^
 
 error: SelectorList
@@ -71,10 +71,10 @@ error: Block
    |  _____^
 2  | |     background: url(https://example.com/image.png);
 3  | |     background: URL(https://example.com/image.png);
-4  | |     background: url("https://example.com/image.png");
+4  | |     background: \URL(https://example.com/image.png);
 ...  |
-23 | |     background: src(var(--foo));
-24 | | }
+25 | |     background: src(var(--foo));
+26 | | }
    | |_^
 
 error: Declaration
@@ -164,792 +164,876 @@ error: UrlValueRaw
 error: Declaration
  --> $DIR/tests/fixture/value/url/input.css:4:5
   |
-4 |     background: url("https://example.com/image.png");
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+4 |     background: \URL(https://example.com/image.png);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
  --> $DIR/tests/fixture/value/url/input.css:4:5
   |
-4 |     background: url("https://example.com/image.png");
+4 |     background: \URL(https://example.com/image.png);
   |     ^^^^^^^^^^
 
 error: Value
  --> $DIR/tests/fixture/value/url/input.css:4:17
   |
-4 |     background: url("https://example.com/image.png");
-  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+4 |     background: \URL(https://example.com/image.png);
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Url
  --> $DIR/tests/fixture/value/url/input.css:4:17
   |
-4 |     background: url("https://example.com/image.png");
-  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+4 |     background: \URL(https://example.com/image.png);
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
  --> $DIR/tests/fixture/value/url/input.css:4:17
   |
-4 |     background: url("https://example.com/image.png");
+4 |     background: \URL(https://example.com/image.png);
   |                 ^^^
 
 error: UrlValue
  --> $DIR/tests/fixture/value/url/input.css:4:21
   |
-4 |     background: url("https://example.com/image.png");
-  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+4 |     background: \URL(https://example.com/image.png);
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Str
+error: UrlValueRaw
  --> $DIR/tests/fixture/value/url/input.css:4:21
   |
-4 |     background: url("https://example.com/image.png");
-  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+4 |     background: \URL(https://example.com/image.png);
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
  --> $DIR/tests/fixture/value/url/input.css:5:5
   |
-5 |     background: url('https://example.com/image.png');
+5 |     background: url("https://example.com/image.png");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
  --> $DIR/tests/fixture/value/url/input.css:5:5
   |
-5 |     background: url('https://example.com/image.png');
+5 |     background: url("https://example.com/image.png");
   |     ^^^^^^^^^^
 
 error: Value
  --> $DIR/tests/fixture/value/url/input.css:5:17
   |
-5 |     background: url('https://example.com/image.png');
+5 |     background: url("https://example.com/image.png");
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Url
  --> $DIR/tests/fixture/value/url/input.css:5:17
   |
-5 |     background: url('https://example.com/image.png');
+5 |     background: url("https://example.com/image.png");
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
  --> $DIR/tests/fixture/value/url/input.css:5:17
   |
-5 |     background: url('https://example.com/image.png');
+5 |     background: url("https://example.com/image.png");
   |                 ^^^
 
 error: UrlValue
  --> $DIR/tests/fixture/value/url/input.css:5:21
   |
-5 |     background: url('https://example.com/image.png');
+5 |     background: url("https://example.com/image.png");
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Str
  --> $DIR/tests/fixture/value/url/input.css:5:21
   |
-5 |     background: url('https://example.com/image.png');
+5 |     background: url("https://example.com/image.png");
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
  --> $DIR/tests/fixture/value/url/input.css:6:5
   |
-6 |     background: URL('https://example.com/image.png');
+6 |     background: url('https://example.com/image.png');
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
  --> $DIR/tests/fixture/value/url/input.css:6:5
   |
-6 |     background: URL('https://example.com/image.png');
+6 |     background: url('https://example.com/image.png');
   |     ^^^^^^^^^^
 
 error: Value
  --> $DIR/tests/fixture/value/url/input.css:6:17
   |
-6 |     background: URL('https://example.com/image.png');
+6 |     background: url('https://example.com/image.png');
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Url
  --> $DIR/tests/fixture/value/url/input.css:6:17
   |
-6 |     background: URL('https://example.com/image.png');
+6 |     background: url('https://example.com/image.png');
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
  --> $DIR/tests/fixture/value/url/input.css:6:17
   |
-6 |     background: URL('https://example.com/image.png');
+6 |     background: url('https://example.com/image.png');
   |                 ^^^
 
 error: UrlValue
  --> $DIR/tests/fixture/value/url/input.css:6:21
   |
-6 |     background: URL('https://example.com/image.png');
+6 |     background: url('https://example.com/image.png');
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Str
  --> $DIR/tests/fixture/value/url/input.css:6:21
   |
-6 |     background: URL('https://example.com/image.png');
+6 |     background: url('https://example.com/image.png');
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
  --> $DIR/tests/fixture/value/url/input.css:7:5
   |
-7 |     background: url(data:image/png;base64,iRxVB0);
+7 |     background: URL('https://example.com/image.png');
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:7:5
+  |
+7 |     background: URL('https://example.com/image.png');
+  |     ^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/url/input.css:7:17
+  |
+7 |     background: URL('https://example.com/image.png');
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Url
+ --> $DIR/tests/fixture/value/url/input.css:7:17
+  |
+7 |     background: URL('https://example.com/image.png');
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:7:17
+  |
+7 |     background: URL('https://example.com/image.png');
+  |                 ^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/value/url/input.css:7:21
+  |
+7 |     background: URL('https://example.com/image.png');
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Str
+ --> $DIR/tests/fixture/value/url/input.css:7:21
+  |
+7 |     background: URL('https://example.com/image.png');
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/url/input.css:8:5
+  |
+8 |     background: \URL('https://example.com/image.png');
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:8:5
+  |
+8 |     background: \URL('https://example.com/image.png');
+  |     ^^^^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/value/url/input.css:8:17
+  |
+8 |     background: \URL('https://example.com/image.png');
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Url
+ --> $DIR/tests/fixture/value/url/input.css:8:17
+  |
+8 |     background: \URL('https://example.com/image.png');
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/url/input.css:8:17
+  |
+8 |     background: \URL('https://example.com/image.png');
+  |                 ^^^^
+
+error: UrlValue
+ --> $DIR/tests/fixture/value/url/input.css:8:22
+  |
+8 |     background: \URL('https://example.com/image.png');
+  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Str
+ --> $DIR/tests/fixture/value/url/input.css:8:22
+  |
+8 |     background: \URL('https://example.com/image.png');
+  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Declaration
+ --> $DIR/tests/fixture/value/url/input.css:9:5
+  |
+9 |     background: url(data:image/png;base64,iRxVB0);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
- --> $DIR/tests/fixture/value/url/input.css:7:5
+ --> $DIR/tests/fixture/value/url/input.css:9:5
   |
-7 |     background: url(data:image/png;base64,iRxVB0);
+9 |     background: url(data:image/png;base64,iRxVB0);
   |     ^^^^^^^^^^
 
 error: Value
- --> $DIR/tests/fixture/value/url/input.css:7:17
+ --> $DIR/tests/fixture/value/url/input.css:9:17
   |
-7 |     background: url(data:image/png;base64,iRxVB0);
+9 |     background: url(data:image/png;base64,iRxVB0);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Url
- --> $DIR/tests/fixture/value/url/input.css:7:17
+ --> $DIR/tests/fixture/value/url/input.css:9:17
   |
-7 |     background: url(data:image/png;base64,iRxVB0);
+9 |     background: url(data:image/png;base64,iRxVB0);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
- --> $DIR/tests/fixture/value/url/input.css:7:17
+ --> $DIR/tests/fixture/value/url/input.css:9:17
   |
-7 |     background: url(data:image/png;base64,iRxVB0);
+9 |     background: url(data:image/png;base64,iRxVB0);
   |                 ^^^
 
 error: UrlValue
- --> $DIR/tests/fixture/value/url/input.css:7:21
+ --> $DIR/tests/fixture/value/url/input.css:9:21
   |
-7 |     background: url(data:image/png;base64,iRxVB0);
+9 |     background: url(data:image/png;base64,iRxVB0);
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: UrlValueRaw
- --> $DIR/tests/fixture/value/url/input.css:7:21
+ --> $DIR/tests/fixture/value/url/input.css:9:21
   |
-7 |     background: url(data:image/png;base64,iRxVB0);
+9 |     background: url(data:image/png;base64,iRxVB0);
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
- --> $DIR/tests/fixture/value/url/input.css:8:5
-  |
-8 |     background: url(#IDofSVGpath);
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Ident
- --> $DIR/tests/fixture/value/url/input.css:8:5
-  |
-8 |     background: url(#IDofSVGpath);
-  |     ^^^^^^^^^^
-
-error: Value
- --> $DIR/tests/fixture/value/url/input.css:8:17
-  |
-8 |     background: url(#IDofSVGpath);
-  |                 ^^^^^^^^^^^^^^^^^
-
-error: Url
- --> $DIR/tests/fixture/value/url/input.css:8:17
-  |
-8 |     background: url(#IDofSVGpath);
-  |                 ^^^^^^^^^^^^^^^^^
-
-error: Ident
- --> $DIR/tests/fixture/value/url/input.css:8:17
-  |
-8 |     background: url(#IDofSVGpath);
-  |                 ^^^
-
-error: UrlValue
- --> $DIR/tests/fixture/value/url/input.css:8:21
-  |
-8 |     background: url(#IDofSVGpath);
-  |                     ^^^^^^^^^^^^
-
-error: UrlValueRaw
- --> $DIR/tests/fixture/value/url/input.css:8:21
-  |
-8 |     background: url(#IDofSVGpath);
-  |                     ^^^^^^^^^^^^
-
-error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:11:5
+  --> $DIR/tests/fixture/value/url/input.css:10:5
    |
-11 |     background: url("//aa.com/img.svg" prefetch);
+10 |     background: url(#IDofSVGpath);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:10:5
+   |
+10 |     background: url(#IDofSVGpath);
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:10:17
+   |
+10 |     background: url(#IDofSVGpath);
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: Url
+  --> $DIR/tests/fixture/value/url/input.css:10:17
+   |
+10 |     background: url(#IDofSVGpath);
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:10:17
+   |
+10 |     background: url(#IDofSVGpath);
+   |                 ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:10:21
+   |
+10 |     background: url(#IDofSVGpath);
+   |                     ^^^^^^^^^^^^
+
+error: UrlValueRaw
+  --> $DIR/tests/fixture/value/url/input.css:10:21
+   |
+10 |     background: url(#IDofSVGpath);
+   |                     ^^^^^^^^^^^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:13:5
+   |
+13 |     background: url("//aa.com/img.svg" prefetch);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:11:5
+  --> $DIR/tests/fixture/value/url/input.css:13:5
    |
-11 |     background: url("//aa.com/img.svg" prefetch);
+13 |     background: url("//aa.com/img.svg" prefetch);
    |     ^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:11:17
+  --> $DIR/tests/fixture/value/url/input.css:13:17
    |
-11 |     background: url("//aa.com/img.svg" prefetch);
+13 |     background: url("//aa.com/img.svg" prefetch);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Url
-  --> $DIR/tests/fixture/value/url/input.css:11:17
+  --> $DIR/tests/fixture/value/url/input.css:13:17
    |
-11 |     background: url("//aa.com/img.svg" prefetch);
+13 |     background: url("//aa.com/img.svg" prefetch);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:11:17
+  --> $DIR/tests/fixture/value/url/input.css:13:17
    |
-11 |     background: url("//aa.com/img.svg" prefetch);
+13 |     background: url("//aa.com/img.svg" prefetch);
    |                 ^^^
 
 error: UrlValue
-  --> $DIR/tests/fixture/value/url/input.css:11:21
+  --> $DIR/tests/fixture/value/url/input.css:13:21
    |
-11 |     background: url("//aa.com/img.svg" prefetch);
+13 |     background: url("//aa.com/img.svg" prefetch);
    |                     ^^^^^^^^^^^^^^^^^^
 
 error: Str
-  --> $DIR/tests/fixture/value/url/input.css:11:21
+  --> $DIR/tests/fixture/value/url/input.css:13:21
    |
-11 |     background: url("//aa.com/img.svg" prefetch);
+13 |     background: url("//aa.com/img.svg" prefetch);
    |                     ^^^^^^^^^^^^^^^^^^
 
 error: UrlModifier
-  --> $DIR/tests/fixture/value/url/input.css:11:40
+  --> $DIR/tests/fixture/value/url/input.css:13:40
    |
-11 |     background: url("//aa.com/img.svg" prefetch);
+13 |     background: url("//aa.com/img.svg" prefetch);
    |                                        ^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:11:40
+  --> $DIR/tests/fixture/value/url/input.css:13:40
    |
-11 |     background: url("//aa.com/img.svg" prefetch);
+13 |     background: url("//aa.com/img.svg" prefetch);
    |                                        ^^^^^^^^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:12:5
+  --> $DIR/tests/fixture/value/url/input.css:14:5
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:12:5
+  --> $DIR/tests/fixture/value/url/input.css:14:5
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |     ^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:12:17
+  --> $DIR/tests/fixture/value/url/input.css:14:17
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Url
-  --> $DIR/tests/fixture/value/url/input.css:12:17
+  --> $DIR/tests/fixture/value/url/input.css:14:17
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:12:17
+  --> $DIR/tests/fixture/value/url/input.css:14:17
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                 ^^^
 
 error: UrlValue
-  --> $DIR/tests/fixture/value/url/input.css:12:21
+  --> $DIR/tests/fixture/value/url/input.css:14:21
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                     ^^^^^^^^^^^^^^^^^^
 
 error: Str
-  --> $DIR/tests/fixture/value/url/input.css:12:21
+  --> $DIR/tests/fixture/value/url/input.css:14:21
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                     ^^^^^^^^^^^^^^^^^^
 
 error: UrlModifier
-  --> $DIR/tests/fixture/value/url/input.css:12:40
+  --> $DIR/tests/fixture/value/url/input.css:14:40
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                                        ^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:12:40
+  --> $DIR/tests/fixture/value/url/input.css:14:40
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                                        ^^^
 
 error: UrlModifier
-  --> $DIR/tests/fixture/value/url/input.css:12:44
+  --> $DIR/tests/fixture/value/url/input.css:14:44
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                                            ^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:12:44
+  --> $DIR/tests/fixture/value/url/input.css:14:44
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                                            ^^^
 
 error: UrlModifier
-  --> $DIR/tests/fixture/value/url/input.css:12:48
+  --> $DIR/tests/fixture/value/url/input.css:14:48
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                                                ^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:12:48
+  --> $DIR/tests/fixture/value/url/input.css:14:48
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                                                ^^^
 
 error: UrlModifier
-  --> $DIR/tests/fixture/value/url/input.css:12:52
+  --> $DIR/tests/fixture/value/url/input.css:14:52
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                                                    ^^^^^^^^^^
 
 error: Function
-  --> $DIR/tests/fixture/value/url/input.css:12:52
+  --> $DIR/tests/fixture/value/url/input.css:14:52
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                                                    ^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:12:52
+  --> $DIR/tests/fixture/value/url/input.css:14:52
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                                                    ^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:12:57
+  --> $DIR/tests/fixture/value/url/input.css:14:57
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                                                         ^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:12:57
+  --> $DIR/tests/fixture/value/url/input.css:14:57
    |
-12 |     background: url("//aa.com/img.svg" foo bar baz func(test));
+14 |     background: url("//aa.com/img.svg" foo bar baz func(test));
    |                                                         ^^^^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:13:5
+  --> $DIR/tests/fixture/value/url/input.css:15:5
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:13:5
+  --> $DIR/tests/fixture/value/url/input.css:15:5
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |     ^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:13:17
+  --> $DIR/tests/fixture/value/url/input.css:15:17
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Url
-  --> $DIR/tests/fixture/value/url/input.css:13:17
+  --> $DIR/tests/fixture/value/url/input.css:15:17
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:13:17
+  --> $DIR/tests/fixture/value/url/input.css:15:17
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                 ^^^
 
 error: UrlValue
-  --> $DIR/tests/fixture/value/url/input.css:13:21
+  --> $DIR/tests/fixture/value/url/input.css:15:21
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Str
-  --> $DIR/tests/fixture/value/url/input.css:13:21
+  --> $DIR/tests/fixture/value/url/input.css:15:21
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: UrlModifier
-  --> $DIR/tests/fixture/value/url/input.css:13:52
+  --> $DIR/tests/fixture/value/url/input.css:15:52
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Function
-  --> $DIR/tests/fixture/value/url/input.css:13:52
+  --> $DIR/tests/fixture/value/url/input.css:15:52
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:13:52
+  --> $DIR/tests/fixture/value/url/input.css:15:52
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                                                    ^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:13:58
+  --> $DIR/tests/fixture/value/url/input.css:15:58
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: SpaceValues
-  --> $DIR/tests/fixture/value/url/input.css:13:58
+  --> $DIR/tests/fixture/value/url/input.css:15:58
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:13:58
+  --> $DIR/tests/fixture/value/url/input.css:15:58
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                                                          ^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:13:58
+  --> $DIR/tests/fixture/value/url/input.css:15:58
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                                                          ^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:13:66
+  --> $DIR/tests/fixture/value/url/input.css:15:66
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                                                                  ^^^^^^^^^^^^^^^^^^^^
 
 error: Function
-  --> $DIR/tests/fixture/value/url/input.css:13:66
+  --> $DIR/tests/fixture/value/url/input.css:15:66
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                                                                  ^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:13:66
+  --> $DIR/tests/fixture/value/url/input.css:15:66
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                                                                  ^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:13:70
+  --> $DIR/tests/fixture/value/url/input.css:15:70
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                                                                      ^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:13:70
+  --> $DIR/tests/fixture/value/url/input.css:15:70
    |
-13 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
+15 |     background: url("http://example.com/image.svg" param(--color var(--primary-color)));
    |                                                                      ^^^^^^^^^^^^^^^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:15:5
+  --> $DIR/tests/fixture/value/url/input.css:17:5
    |
-15 |     background: url();
+17 |     background: url();
    |     ^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:15:5
+  --> $DIR/tests/fixture/value/url/input.css:17:5
    |
-15 |     background: url();
+17 |     background: url();
    |     ^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:15:17
+  --> $DIR/tests/fixture/value/url/input.css:17:17
    |
-15 |     background: url();
+17 |     background: url();
    |                 ^^^^^
 
 error: Url
-  --> $DIR/tests/fixture/value/url/input.css:15:17
+  --> $DIR/tests/fixture/value/url/input.css:17:17
    |
-15 |     background: url();
+17 |     background: url();
    |                 ^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:15:17
+  --> $DIR/tests/fixture/value/url/input.css:17:17
    |
-15 |     background: url();
+17 |     background: url();
    |                 ^^^
 
 error: UrlValue
-  --> $DIR/tests/fixture/value/url/input.css:15:21
+  --> $DIR/tests/fixture/value/url/input.css:17:21
    |
-15 |     background: url();
+17 |     background: url();
    |                     ^
 
 error: UrlValueRaw
-  --> $DIR/tests/fixture/value/url/input.css:15:21
+  --> $DIR/tests/fixture/value/url/input.css:17:21
    |
-15 |     background: url();
+17 |     background: url();
    |                     ^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:16:5
+  --> $DIR/tests/fixture/value/url/input.css:18:5
    |
-16 |     background: url("");
+18 |     background: url("");
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:16:5
+  --> $DIR/tests/fixture/value/url/input.css:18:5
    |
-16 |     background: url("");
+18 |     background: url("");
    |     ^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:16:17
+  --> $DIR/tests/fixture/value/url/input.css:18:17
    |
-16 |     background: url("");
+18 |     background: url("");
    |                 ^^^^^^^
 
 error: Url
-  --> $DIR/tests/fixture/value/url/input.css:16:17
+  --> $DIR/tests/fixture/value/url/input.css:18:17
    |
-16 |     background: url("");
+18 |     background: url("");
    |                 ^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:16:17
+  --> $DIR/tests/fixture/value/url/input.css:18:17
    |
-16 |     background: url("");
+18 |     background: url("");
    |                 ^^^
 
 error: UrlValue
-  --> $DIR/tests/fixture/value/url/input.css:16:21
+  --> $DIR/tests/fixture/value/url/input.css:18:21
    |
-16 |     background: url("");
+18 |     background: url("");
    |                     ^^
 
 error: Str
-  --> $DIR/tests/fixture/value/url/input.css:16:21
+  --> $DIR/tests/fixture/value/url/input.css:18:21
    |
-16 |     background: url("");
-   |                     ^^
-
-error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:17:5
-   |
-17 |     background: url('');
-   |     ^^^^^^^^^^^^^^^^^^^
-
-error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:17:5
-   |
-17 |     background: url('');
-   |     ^^^^^^^^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/url/input.css:17:17
-   |
-17 |     background: url('');
-   |                 ^^^^^^^
-
-error: Url
-  --> $DIR/tests/fixture/value/url/input.css:17:17
-   |
-17 |     background: url('');
-   |                 ^^^^^^^
-
-error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:17:17
-   |
-17 |     background: url('');
-   |                 ^^^
-
-error: UrlValue
-  --> $DIR/tests/fixture/value/url/input.css:17:21
-   |
-17 |     background: url('');
-   |                     ^^
-
-error: Str
-  --> $DIR/tests/fixture/value/url/input.css:17:21
-   |
-17 |     background: url('');
+18 |     background: url("");
    |                     ^^
 
 error: Declaration
   --> $DIR/tests/fixture/value/url/input.css:19:5
    |
-19 |     --foo: "http://www.example.com/pinkish.gif";
+19 |     background: url('');
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:19:5
+   |
+19 |     background: url('');
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:19:17
+   |
+19 |     background: url('');
+   |                 ^^^^^^^
+
+error: Url
+  --> $DIR/tests/fixture/value/url/input.css:19:17
+   |
+19 |     background: url('');
+   |                 ^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:19:17
+   |
+19 |     background: url('');
+   |                 ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:19:21
+   |
+19 |     background: url('');
+   |                     ^^
+
+error: Str
+  --> $DIR/tests/fixture/value/url/input.css:19:21
+   |
+19 |     background: url('');
+   |                     ^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:21:5
+   |
+21 |     --foo: "http://www.example.com/pinkish.gif";
    |     ^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:19:5
+  --> $DIR/tests/fixture/value/url/input.css:21:5
    |
-19 |     --foo: "http://www.example.com/pinkish.gif";
+21 |     --foo: "http://www.example.com/pinkish.gif";
    |     ^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:19:11
+  --> $DIR/tests/fixture/value/url/input.css:21:11
    |
-19 |     --foo: "http://www.example.com/pinkish.gif";
+21 |     --foo: "http://www.example.com/pinkish.gif";
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Tokens
-  --> $DIR/tests/fixture/value/url/input.css:19:11
+  --> $DIR/tests/fixture/value/url/input.css:21:11
    |
-19 |     --foo: "http://www.example.com/pinkish.gif";
+21 |     --foo: "http://www.example.com/pinkish.gif";
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: WhiteSpace { value: Atom(' ' type=inline) }
-  --> $DIR/tests/fixture/value/url/input.css:19:11
+  --> $DIR/tests/fixture/value/url/input.css:21:11
    |
-19 |     --foo: "http://www.example.com/pinkish.gif";
+21 |     --foo: "http://www.example.com/pinkish.gif";
    |           ^
 
 error: Str { value: Atom('http://www.example.com/pinkish.gif' type=dynamic), raw: Atom('"http://www.example.com/pinkish.gif"' type=dynamic) }
-  --> $DIR/tests/fixture/value/url/input.css:19:12
+  --> $DIR/tests/fixture/value/url/input.css:21:12
    |
-19 |     --foo: "http://www.example.com/pinkish.gif";
+21 |     --foo: "http://www.example.com/pinkish.gif";
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:21:5
-   |
-21 |     background: src("http://www.example.com/pinkish.gif");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:21:5
-   |
-21 |     background: src("http://www.example.com/pinkish.gif");
-   |     ^^^^^^^^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/url/input.css:21:17
-   |
-21 |     background: src("http://www.example.com/pinkish.gif");
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Url
-  --> $DIR/tests/fixture/value/url/input.css:21:17
-   |
-21 |     background: src("http://www.example.com/pinkish.gif");
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:21:17
-   |
-21 |     background: src("http://www.example.com/pinkish.gif");
-   |                 ^^^
-
-error: UrlValue
-  --> $DIR/tests/fixture/value/url/input.css:21:21
-   |
-21 |     background: src("http://www.example.com/pinkish.gif");
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Str
-  --> $DIR/tests/fixture/value/url/input.css:21:21
-   |
-21 |     background: src("http://www.example.com/pinkish.gif");
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Declaration
-  --> $DIR/tests/fixture/value/url/input.css:22:5
-   |
-22 |     background: SRC("http://www.example.com/pinkish.gif");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:22:5
-   |
-22 |     background: SRC("http://www.example.com/pinkish.gif");
-   |     ^^^^^^^^^^
-
-error: Value
-  --> $DIR/tests/fixture/value/url/input.css:22:17
-   |
-22 |     background: SRC("http://www.example.com/pinkish.gif");
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Url
-  --> $DIR/tests/fixture/value/url/input.css:22:17
-   |
-22 |     background: SRC("http://www.example.com/pinkish.gif");
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:22:17
-   |
-22 |     background: SRC("http://www.example.com/pinkish.gif");
-   |                 ^^^
-
-error: UrlValue
-  --> $DIR/tests/fixture/value/url/input.css:22:21
-   |
-22 |     background: SRC("http://www.example.com/pinkish.gif");
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Str
-  --> $DIR/tests/fixture/value/url/input.css:22:21
-   |
-22 |     background: SRC("http://www.example.com/pinkish.gif");
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: Declaration
   --> $DIR/tests/fixture/value/url/input.css:23:5
    |
-23 |     background: src(var(--foo));
+23 |     background: src("http://www.example.com/pinkish.gif");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:23:5
+   |
+23 |     background: src("http://www.example.com/pinkish.gif");
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:23:17
+   |
+23 |     background: src("http://www.example.com/pinkish.gif");
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Url
+  --> $DIR/tests/fixture/value/url/input.css:23:17
+   |
+23 |     background: src("http://www.example.com/pinkish.gif");
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:23:17
+   |
+23 |     background: src("http://www.example.com/pinkish.gif");
+   |                 ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:23:21
+   |
+23 |     background: src("http://www.example.com/pinkish.gif");
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Str
+  --> $DIR/tests/fixture/value/url/input.css:23:21
+   |
+23 |     background: src("http://www.example.com/pinkish.gif");
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:24:5
+   |
+24 |     background: SRC("http://www.example.com/pinkish.gif");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:24:5
+   |
+24 |     background: SRC("http://www.example.com/pinkish.gif");
+   |     ^^^^^^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/value/url/input.css:24:17
+   |
+24 |     background: SRC("http://www.example.com/pinkish.gif");
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Url
+  --> $DIR/tests/fixture/value/url/input.css:24:17
+   |
+24 |     background: SRC("http://www.example.com/pinkish.gif");
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/url/input.css:24:17
+   |
+24 |     background: SRC("http://www.example.com/pinkish.gif");
+   |                 ^^^
+
+error: UrlValue
+  --> $DIR/tests/fixture/value/url/input.css:24:21
+   |
+24 |     background: SRC("http://www.example.com/pinkish.gif");
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Str
+  --> $DIR/tests/fixture/value/url/input.css:24:21
+   |
+24 |     background: SRC("http://www.example.com/pinkish.gif");
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Declaration
+  --> $DIR/tests/fixture/value/url/input.css:25:5
+   |
+25 |     background: src(var(--foo));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:23:5
+  --> $DIR/tests/fixture/value/url/input.css:25:5
    |
-23 |     background: src(var(--foo));
+25 |     background: src(var(--foo));
    |     ^^^^^^^^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:23:17
+  --> $DIR/tests/fixture/value/url/input.css:25:17
    |
-23 |     background: src(var(--foo));
+25 |     background: src(var(--foo));
    |                 ^^^^^^^^^^^^^^^
 
 error: Url
-  --> $DIR/tests/fixture/value/url/input.css:23:17
+  --> $DIR/tests/fixture/value/url/input.css:25:17
    |
-23 |     background: src(var(--foo));
+25 |     background: src(var(--foo));
    |                 ^^^^^^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:23:17
+  --> $DIR/tests/fixture/value/url/input.css:25:17
    |
-23 |     background: src(var(--foo));
+25 |     background: src(var(--foo));
    |                 ^^^
 
 error: UrlModifier
-  --> $DIR/tests/fixture/value/url/input.css:23:21
+  --> $DIR/tests/fixture/value/url/input.css:25:21
    |
-23 |     background: src(var(--foo));
+25 |     background: src(var(--foo));
    |                     ^^^^^^^^^^
 
 error: Function
-  --> $DIR/tests/fixture/value/url/input.css:23:21
+  --> $DIR/tests/fixture/value/url/input.css:25:21
    |
-23 |     background: src(var(--foo));
+25 |     background: src(var(--foo));
    |                     ^^^^^^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:23:21
+  --> $DIR/tests/fixture/value/url/input.css:25:21
    |
-23 |     background: src(var(--foo));
+25 |     background: src(var(--foo));
    |                     ^^^
 
 error: Value
-  --> $DIR/tests/fixture/value/url/input.css:23:25
+  --> $DIR/tests/fixture/value/url/input.css:25:25
    |
-23 |     background: src(var(--foo));
+25 |     background: src(var(--foo));
    |                         ^^^^^
 
 error: Ident
-  --> $DIR/tests/fixture/value/url/input.css:23:25
+  --> $DIR/tests/fixture/value/url/input.css:25:25
    |
-23 |     background: src(var(--foo));
+25 |     background: src(var(--foo));
    |                         ^^^^^
 

--- a/crates/swc_css_parser/tests/recovery/bad-url-token/double-quotes/output.json
+++ b/crates/swc_css_parser/tests/recovery/bad-url-token/double-quotes/output.json
@@ -119,8 +119,10 @@
                 },
                 "token": {
                   "BadUrl": {
+                    "name": "url",
+                    "raw_name": "url",
                     "value": "image\".png",
-                    "raw": "image\".png"
+                    "raw_value": "image\".png"
                   }
                 }
               }

--- a/crates/swc_css_parser/tests/recovery/bad-url-token/left-parenthesis/output.json
+++ b/crates/swc_css_parser/tests/recovery/bad-url-token/left-parenthesis/output.json
@@ -119,8 +119,10 @@
                 },
                 "token": {
                   "BadUrl": {
+                    "name": "url",
+                    "raw_name": "url",
                     "value": "image(.png",
-                    "raw": "image(.png"
+                    "raw_value": "image(.png"
                   }
                 }
               }

--- a/crates/swc_css_parser/tests/recovery/bad-url-token/single-quotes/output.json
+++ b/crates/swc_css_parser/tests/recovery/bad-url-token/single-quotes/output.json
@@ -119,8 +119,10 @@
                 },
                 "token": {
                   "BadUrl": {
+                    "name": "url",
+                    "raw_name": "url",
                     "value": "image'.png",
-                    "raw": "image'.png"
+                    "raw_value": "image'.png"
                   }
                 }
               }

--- a/crates/swc_css_parser/tests/recovery/bad-url-token/whitespace/output.json
+++ b/crates/swc_css_parser/tests/recovery/bad-url-token/whitespace/output.json
@@ -119,8 +119,10 @@
                 },
                 "token": {
                   "BadUrl": {
+                    "name": "url",
+                    "raw_name": "url",
                     "value": "image.png",
-                    "raw": "image.\n    png"
+                    "raw_value": "image.\n    png"
                   }
                 }
               }

--- a/crates/swc_css_parser/tests/recovery/value/url/input.css
+++ b/crates/swc_css_parser/tests/recovery/value/url/input.css
@@ -1,0 +1,4 @@
+div {
+    --foo: "http://www.example.com/pinkish.gif";
+    background: url(var(--foo));
+}

--- a/crates/swc_css_parser/tests/recovery/value/url/output.json
+++ b/crates/swc_css_parser/tests/recovery/value/url/output.json
@@ -175,8 +175,10 @@
                 },
                 "token": {
                   "BadUrl": {
+                    "name": "url",
+                    "raw_name": "url",
                     "value": "var(--foo",
-                    "raw": "var(--foo"
+                    "raw_value": "var(--foo"
                   }
                 }
               },

--- a/crates/swc_css_parser/tests/recovery/value/url/output.json
+++ b/crates/swc_css_parser/tests/recovery/value/url/output.json
@@ -1,0 +1,197 @@
+{
+  "type": "Stylesheet",
+  "span": {
+    "start": 0,
+    "end": 90,
+    "ctxt": 0
+  },
+  "rules": [
+    {
+      "type": "QualifiedRule",
+      "span": {
+        "start": 0,
+        "end": 89,
+        "ctxt": 0
+      },
+      "prelude": {
+        "type": "SelectorList",
+        "span": {
+          "start": 0,
+          "end": 3,
+          "ctxt": 0
+        },
+        "children": [
+          {
+            "type": "ComplexSelector",
+            "span": {
+              "start": 0,
+              "end": 3,
+              "ctxt": 0
+            },
+            "children": [
+              {
+                "type": "CompoundSelector",
+                "span": {
+                  "start": 0,
+                  "end": 3,
+                  "ctxt": 0
+                },
+                "nestingSelector": null,
+                "typeSelector": {
+                  "type": "TypeSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 3,
+                    "ctxt": 0
+                  },
+                  "prefix": null,
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 0,
+                      "end": 3,
+                      "ctxt": 0
+                    },
+                    "value": "div",
+                    "raw": "div"
+                  }
+                },
+                "subclassSelectors": []
+              }
+            ]
+          }
+        ]
+      },
+      "block": {
+        "type": "Block",
+        "span": {
+          "start": 4,
+          "end": 89,
+          "ctxt": 0
+        },
+        "value": [
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 10,
+              "end": 17,
+              "ctxt": 0
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 10,
+                "end": 15,
+                "ctxt": 0
+              },
+              "value": "--foo",
+              "raw": "--foo"
+            },
+            "value": [
+              {
+                "type": "Tokens",
+                "span": {
+                  "start": 16,
+                  "end": 53,
+                  "ctxt": 0
+                },
+                "tokens": [
+                  {
+                    "span": {
+                      "start": 16,
+                      "end": 17,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "WhiteSpace": {
+                        "value": " "
+                      }
+                    }
+                  },
+                  {
+                    "span": {
+                      "start": 17,
+                      "end": 53,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "Str": {
+                        "value": "http://www.example.com/pinkish.gif",
+                        "raw": "\"http://www.example.com/pinkish.gif\""
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Tokens",
+            "span": {
+              "start": 59,
+              "end": 86,
+              "ctxt": 0
+            },
+            "tokens": [
+              {
+                "span": {
+                  "start": 59,
+                  "end": 69,
+                  "ctxt": 0
+                },
+                "token": {
+                  "Ident": {
+                    "value": "background",
+                    "raw": "background"
+                  }
+                }
+              },
+              {
+                "span": {
+                  "start": 69,
+                  "end": 70,
+                  "ctxt": 0
+                },
+                "token": "Colon"
+              },
+              {
+                "span": {
+                  "start": 70,
+                  "end": 71,
+                  "ctxt": 0
+                },
+                "token": {
+                  "WhiteSpace": {
+                    "value": " "
+                  }
+                }
+              },
+              {
+                "span": {
+                  "start": 71,
+                  "end": 85,
+                  "ctxt": 0
+                },
+                "token": {
+                  "BadUrl": {
+                    "value": "var(--foo",
+                    "raw": "var(--foo"
+                  }
+                }
+              },
+              {
+                "span": {
+                  "start": 85,
+                  "end": 86,
+                  "ctxt": 0
+                },
+                "token": "RParen"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/crates/swc_css_parser/tests/recovery/value/url/output.swc-stderr
+++ b/crates/swc_css_parser/tests/recovery/value/url/output.swc-stderr
@@ -1,0 +1,6 @@
+error: Expected Declaration value
+ --> $DIR/tests/recovery/value/url/input.css:3:17
+  |
+3 |     background: url(var(--foo));
+  |                 ^^^^^^^^^^^^^^
+

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -110,7 +110,7 @@ define!({
 
         AtText(AtTextValue),
 
-        Url(UrlValue),
+        Url(Url),
     }
 
     pub struct SpaceValues {
@@ -168,20 +168,14 @@ define!({
         pub block: Option<SimpleBlock>,
     }
 
-    pub struct UrlValue {
-        pub span: Span,
-        pub url: JsWord,
-        pub raw: JsWord,
-    }
-
     pub struct Url {
         pub span: Span,
         pub name: Ident,
-        pub value: UrlValueType,
-        pub modifiers: Option<Vec<Value>>
+        pub value: UrlValue,
+        pub modifiers: Option<Vec<Value>>,
     }
 
-    pub enum UrlValueType {
+    pub enum UrlValue {
         Str(Str),
         Raw(UrlValueRaw),
     }
@@ -354,8 +348,7 @@ define!({
     }
 
     pub enum ImportHref {
-        Function(Function),
-        Url(UrlValue),
+        Url(Url),
         Str(Str),
     }
 

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -174,6 +174,29 @@ define!({
         pub raw: JsWord,
     }
 
+    pub struct Url {
+        pub span: Span,
+        pub name: Ident,
+        pub value: UrlValueType,
+        pub modifiers: Option<Vec<Value>>
+    }
+
+    pub enum UrlValueType {
+        Str(Str),
+        Raw(UrlValueRaw),
+    }
+
+    pub struct UrlValueRaw {
+        pub span: Span,
+        pub value: JsWord,
+        pub raw: JsWord,
+    }
+
+    pub enum UrlModifier {
+        Ident(Ident),
+        Function(Function),
+    }
+
     pub struct SelectorList {
         pub span: Span,
         pub children: Vec<ComplexSelector>,
@@ -360,8 +383,7 @@ define!({
     }
 
     pub enum NamespaceUri {
-        Url(UrlValue),
-        Function(Function),
+        Url(Url),
         Str(Str),
     }
 

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -361,6 +361,7 @@ define!({
 
     pub enum NamespaceUri {
         Url(UrlValue),
+        Function(Function),
         Str(Str),
     }
 

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -171,8 +171,8 @@ define!({
     pub struct Url {
         pub span: Span,
         pub name: Ident,
-        pub value: UrlValue,
-        pub modifiers: Option<Vec<Value>>,
+        pub value: Option<UrlValue>,
+        pub modifiers: Option<Vec<UrlModifier>>,
     }
 
     pub enum UrlValue {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Implement new `Url` type (spec https://www.w3.org/TR/css-values-4/#urls): 
1. Fix bugs with parsing around `url()`/`src()`
2. Supports modifiers
3. Keep original name `Url` token
4. Refactor `at-rules`, now they accept `Url` type according spec
5. Fix parsing `@namespace`
6. Fix some clippy warnings
7. Added `TODO` for future fixes

**BREAKING CHANGE:**

Yes, new type

**Related issue (if exists):**

No