### PR TITLE
refactor: rename `PercentValue` to `Percent`

### DIFF
--- a/crates/swc_css_ast/src/at_rule/keyframe.rs
+++ b/crates/swc_css_ast/src/at_rule/keyframe.rs
@@ -1,4 +1,4 @@
-use crate::{AtRule, Block, CustomIdent, Ident, PercentValue, Str};
+use crate::{AtRule, Block, CustomIdent, Ident, Percent, Str};
 use swc_common::{ast_node, Span};
 
 #[ast_node]
@@ -27,8 +27,8 @@ pub struct KeyframeBlock {
 pub enum KeyframeSelector {
     #[tag("Ident")]
     Ident(Ident),
-    #[tag("PercentValue")]
-    Percent(PercentValue),
+    #[tag("Percent")]
+    Percent(Percent),
 }
 
 #[ast_node]

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -14,8 +14,8 @@ pub enum Value {
     #[tag("Number")]
     Number(Number),
 
-    #[tag("PercentValue")]
-    Percent(PercentValue),
+    #[tag("Percent")]
+    Percent(Percent),
 
     #[tag("Ratio")]
     Ratio(Ratio),
@@ -110,8 +110,8 @@ pub struct UnitValue {
     pub unit: Unit,
 }
 
-#[ast_node("PercentValue")]
-pub struct PercentValue {
+#[ast_node("Percent")]
+pub struct Percent {
     pub span: Span,
     pub value: Number,
 }

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -694,7 +694,7 @@ where
     }
 
     #[emitter]
-    fn emit_percent_value(&mut self, n: &PercentValue) -> Result {
+    fn emit_percent(&mut self, n: &Percent) -> Result {
         emit!(self, n.value);
         punct!(self, "%");
     }

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -731,11 +731,11 @@ where
     }
 }
 
-impl<I> Parse<PercentValue> for Parser<I>
+impl<I> Parse<Percent> for Parser<I>
 where
     I: ParserInput,
 {
-    fn parse(&mut self) -> PResult<PercentValue> {
+    fn parse(&mut self) -> PResult<Percent> {
         let span = self.input.cur_span()?;
 
         if !is!(self, Percent) {
@@ -750,7 +750,7 @@ where
                     raw,
                 };
 
-                Ok(PercentValue { span, value })
+                Ok(Percent { span, value })
             }
             _ => {
                 unreachable!()

--- a/crates/swc_css_parser/tests/fixture.rs
+++ b/crates/swc_css_parser/tests/fixture.rs
@@ -298,7 +298,7 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(TypeSelector, visit_type_selector);
     mtd!(Number, visit_number);
     mtd!(Ratio, visit_ratio);
-    mtd!(PercentValue, visit_percent_value);
+    mtd!(Percent, visit_percent);
     mtd!(Declaration, visit_declaration);
     mtd!(Nth, visit_nth);
     mtd!(AnPlusB, visit_an_plus_b);

--- a/crates/swc_css_parser/tests/fixture/at-rule/keyframe/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/keyframe/output.json
@@ -144,7 +144,7 @@
                     },
                     "value": [
                       {
-                        "type": "PercentValue",
+                        "type": "Percent",
                         "span": {
                           "start": 158,
                           "end": 160,
@@ -232,7 +232,7 @@
                     },
                     "value": [
                       {
-                        "type": "PercentValue",
+                        "type": "Percent",
                         "span": {
                           "start": 209,
                           "end": 213,
@@ -285,7 +285,7 @@
           },
           "selector": [
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 253,
                 "end": 255,
@@ -384,7 +384,7 @@
           },
           "selector": [
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 281,
                 "end": 284,
@@ -469,7 +469,7 @@
           },
           "selector": [
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 304,
                 "end": 307,
@@ -487,7 +487,7 @@
               }
             },
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 309,
                 "end": 312,
@@ -572,7 +572,7 @@
           },
           "selector": [
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 333,
                 "end": 337,
@@ -665,7 +665,7 @@
                 },
                 "value": [
                   {
-                    "type": "PercentValue",
+                    "type": "Percent",
                     "span": {
                       "start": 358,
                       "end": 362,

--- a/crates/swc_css_parser/tests/fixture/at-rule/keyframe/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/keyframe/span.rust-debug
@@ -198,7 +198,7 @@ error: Value
 7 |         transform: translateX(0%);
   |                               ^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/at-rule/keyframe/input.css:7:31
   |
 7 |         transform: translateX(0%);
@@ -284,7 +284,7 @@ error: Value
 11 |         transform: translateX(100%);
    |                               ^^^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:11:31
    |
 11 |         transform: translateX(100%);
@@ -347,7 +347,7 @@ error: KeyframeSelector
 16 |     0% { top: 0; left: 0; }
    |     ^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:16:5
    |
 16 |     0% { top: 0; left: 0; }
@@ -431,7 +431,7 @@ error: KeyframeSelector
 17 |     30% { top: 50px; }
    |     ^^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:17:5
    |
 17 |     30% { top: 50px; }
@@ -503,7 +503,7 @@ error: KeyframeSelector
 18 |     68%, 72% { left: 50px; }
    |     ^^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:18:5
    |
 18 |     68%, 72% { left: 50px; }
@@ -521,7 +521,7 @@ error: KeyframeSelector
 18 |     68%, 72% { left: 50px; }
    |          ^^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:18:10
    |
 18 |     68%, 72% { left: 50px; }
@@ -593,7 +593,7 @@ error: KeyframeSelector
 19 |     100% { top: 100px; left: 100%; }
    |     ^^^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:19:5
    |
 19 |     100% { top: 100px; left: 100%; }
@@ -671,7 +671,7 @@ error: Value
 19 |     100% { top: 100px; left: 100%; }
    |                              ^^^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:19:30
    |
 19 |     100% { top: 100px; left: 100%; }

--- a/crates/swc_css_parser/tests/fixture/at-rule/layer/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/layer/output.json
@@ -266,7 +266,7 @@
                     },
                     "value": [
                       {
-                        "type": "PercentValue",
+                        "type": "Percent",
                         "span": {
                           "start": 155,
                           "end": 160,
@@ -454,7 +454,7 @@
                     },
                     "value": [
                       {
-                        "type": "PercentValue",
+                        "type": "Percent",
                         "span": {
                           "start": 281,
                           "end": 286,

--- a/crates/swc_css_parser/tests/fixture/at-rule/layer/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/layer/span.rust-debug
@@ -280,7 +280,7 @@ error: Value
 6 |         to { translate: -100% 0; }
   |                         ^^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/at-rule/layer/input.css:6:25
   |
 6 |         to { translate: -100% 0; }
@@ -490,7 +490,7 @@ error: Value
 13 |         to { margin-left: -100%; }
    |                           ^^^^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/at-rule/layer/input.css:13:27
    |
 13 |         to { margin-left: -100%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: -.10%; }
   |            ^^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/-edvtxlXMemv5jnGeyueBA/input.css:1:12
   |
 1 | a { width: -.10%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 15,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: 0.1%; }
   |            ^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/3OV2jH0hrt2_2jOv6t4wvA/input.css:1:12
   |
 1 | a { width: 0.1%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/3a1KXFwtncypOUCwQI7IAw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/3a1KXFwtncypOUCwQI7IAw/output.json
@@ -32,7 +32,7 @@
           },
           "selector": [
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 18,
                 "end": 22,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/3a1KXFwtncypOUCwQI7IAw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/3a1KXFwtncypOUCwQI7IAw/span.rust-debug
@@ -40,7 +40,7 @@ error: KeyframeSelector
 1 | @keyframes name { 100% { color: red } }
   |                   ^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/3a1KXFwtncypOUCwQI7IAw/input.css:1:19
   |
 1 | @keyframes name { 100% { color: red } }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 14,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: .0%; }
   |            ^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/6aNPFn_YOBL4koYvV-g8pQ/input.css:1:12
   |
 1 | a { width: .0%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: -.00%; }
   |            ^^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/7YGXOizztR38f8fGB1DRaQ/input.css:1:12
   |
 1 | a { width: -.00%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: +0.1%; }
   |            ^^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/A3jvzrmJH_MIf_Uilsy4sg/input.css:1:12
   |
 1 | a { width: +0.1%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/output.json
@@ -32,7 +32,7 @@
           },
           "selector": [
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 18,
                 "end": 20,
@@ -50,7 +50,7 @@
               }
             },
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 22,
                 "end": 25,
@@ -118,7 +118,7 @@
           },
           "selector": [
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 41,
                 "end": 44,
@@ -136,7 +136,7 @@
               }
             },
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 46,
                 "end": 49,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/span.rust-debug
@@ -40,7 +40,7 @@ error: KeyframeSelector
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
   |                   ^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/input.css:1:19
   |
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
@@ -58,7 +58,7 @@ error: KeyframeSelector
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
   |                       ^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/input.css:1:23
   |
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
@@ -118,7 +118,7 @@ error: KeyframeSelector
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
   |                                          ^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/input.css:1:42
   |
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
@@ -136,7 +136,7 @@ error: KeyframeSelector
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }
   |                                               ^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/ATZbhYBr7fOFJoZ4E2dwkA/input.css:1:47
   |
 1 | @keyframes name { 0%, 50% { color: red } 25%, 75% { color: blue } }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: -0.1%; }
   |            ^^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/HWU09nmB9oZX7WY8zUbrnA/input.css:1:12
   |
 1 | a { width: -0.1%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: +.00%; }
   |            ^^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/NGFFzFWLONNmgWPM_FpiZg/input.css:1:12
   |
 1 | a { width: +.00%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 15,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: +.0%; }
   |            ^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/cGdUJvMcb_06jPxvv8lGkg/input.css:1:12
   |
 1 | a { width: +.0%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: +0.0%; }
   |            ^^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/ccwWSeXA2f9cTFtUANZA8Q/input.css:1:12
   |
 1 | a { width: +0.0%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 15,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: .00%; }
   |            ^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/eHdhrm6W2iHKQegxH7uEgw/input.css:1:12
   |
 1 | a { width: .00%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: -0.0%; }
   |            ^^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/pO8ANIJaeZDUsUBCBMKErg/input.css:1:12
   |
 1 | a { width: -0.0%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 15,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: -.0%; }
   |            ^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/ptR_ezJzwIRsP3geOEZI5A/input.css:1:12
   |
 1 | a { width: -.0%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 15,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: .10%; }
   |            ^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/rPWYt0NoxD_TvsI8Xrhvyg/input.css:1:12
   |
 1 | a { width: .10%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/output.json
@@ -32,7 +32,7 @@
           },
           "selector": [
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 16,
                 "end": 18,
@@ -50,7 +50,7 @@
               }
             },
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 19,
                 "end": 22,
@@ -118,7 +118,7 @@
           },
           "selector": [
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 33,
                 "end": 36,
@@ -136,7 +136,7 @@
               }
             },
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 37,
                 "end": 40,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/span.rust-debug
@@ -40,7 +40,7 @@ error: KeyframeSelector
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
   |                 ^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/input.css:1:17
   |
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
@@ -58,7 +58,7 @@ error: KeyframeSelector
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
   |                    ^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/input.css:1:20
   |
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
@@ -118,7 +118,7 @@ error: KeyframeSelector
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
   |                                  ^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/input.css:1:34
   |
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
@@ -136,7 +136,7 @@ error: KeyframeSelector
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}
   |                                      ^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/uWMeE1AAowARdci8tkE-cg/input.css:1:38
   |
 1 | @keyframes name{0%,50%{color:red}25%,75%{color:blue}}

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: +.10%; }
   |            ^^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/vFNgwFW2EHA0WTOoSWhSTg/input.css:1:12
   |
 1 | a { width: +.10%; }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 11,
                   "end": 15,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/span.rust-debug
@@ -70,7 +70,7 @@ error: Value
 1 | a { width: 0.0%; }
   |            ^^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/esbuild/misc/vIco-E1oKlSzuggLOcviNg/input.css:1:12
   |
 1 | a { width: 0.0%; }

--- a/crates/swc_css_parser/tests/fixture/rome/calc/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/calc/output.json
@@ -315,7 +315,7 @@
                       }
                     },
                     "right": {
-                      "type": "PercentValue",
+                      "type": "Percent",
                       "span": {
                         "start": 72,
                         "end": 74,
@@ -426,7 +426,7 @@
                         },
                         "values": [
                           {
-                            "type": "PercentValue",
+                            "type": "Percent",
                             "span": {
                               "start": 96,
                               "end": 98,

--- a/crates/swc_css_parser/tests/fixture/rome/calc/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/calc/span.rust-debug
@@ -299,7 +299,7 @@ error: Value
 4 |     width: calc(2em + 1%);
   |                       ^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/rome/calc/input.css:4:20
   |
 4 |     width: calc(2em + 1%);
@@ -407,7 +407,7 @@ error: Value
 5 |     width: calc(2em * 2% * 3px);
   |                       ^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/rome/calc/input.css:5:20
   |
 5 |     width: calc(2em * 2% * 3px);

--- a/crates/swc_css_parser/tests/fixture/rome/keyframe/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/keyframe/output.json
@@ -270,7 +270,7 @@
           },
           "selector": [
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 187,
                 "end": 190,
@@ -306,7 +306,7 @@
           },
           "selector": [
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 203,
                 "end": 205,
@@ -342,7 +342,7 @@
           },
           "selector": [
             {
-              "type": "PercentValue",
+              "type": "Percent",
               "span": {
                 "start": 218,
                 "end": 222,

--- a/crates/swc_css_parser/tests/fixture/rome/keyframe/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/keyframe/span.rust-debug
@@ -325,7 +325,7 @@ error: KeyframeSelector
 15 |     15% {
    |     ^^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/rome/keyframe/input.css:15:5
    |
 15 |     15% {
@@ -366,7 +366,7 @@ error: KeyframeSelector
 17 |     0% {
    |     ^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/rome/keyframe/input.css:17:5
    |
 17 |     0% {
@@ -407,7 +407,7 @@ error: KeyframeSelector
 19 |     100% {
    |     ^^^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/rome/keyframe/input.css:19:5
    |
 19 |     100% {

--- a/crates/swc_css_parser/tests/fixture/rome/min-and-max/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/min-and-max/output.json
@@ -335,7 +335,7 @@
                       }
                     },
                     "right": {
-                      "type": "PercentValue",
+                      "type": "Percent",
                       "span": {
                         "start": 82,
                         "end": 84,
@@ -438,7 +438,7 @@
                       },
                       "op": "*",
                       "left": {
-                        "type": "PercentValue",
+                        "type": "Percent",
                         "span": {
                           "start": 106,
                           "end": 108,
@@ -606,7 +606,7 @@
                       },
                       "op": "*",
                       "left": {
-                        "type": "PercentValue",
+                        "type": "Percent",
                         "span": {
                           "start": 144,
                           "end": 146,
@@ -706,7 +706,7 @@
                       },
                       "op": "*",
                       "left": {
-                        "type": "PercentValue",
+                        "type": "Percent",
                         "span": {
                           "start": 162,
                           "end": 164,
@@ -806,7 +806,7 @@
                       },
                       "op": "*",
                       "left": {
-                        "type": "PercentValue",
+                        "type": "Percent",
                         "span": {
                           "start": 180,
                           "end": 182,
@@ -1158,7 +1158,7 @@
                       }
                     },
                     "right": {
-                      "type": "PercentValue",
+                      "type": "Percent",
                       "span": {
                         "start": 272,
                         "end": 274,
@@ -1261,7 +1261,7 @@
                       },
                       "op": "*",
                       "left": {
-                        "type": "PercentValue",
+                        "type": "Percent",
                         "span": {
                           "start": 296,
                           "end": 298,
@@ -1429,7 +1429,7 @@
                       },
                       "op": "*",
                       "left": {
-                        "type": "PercentValue",
+                        "type": "Percent",
                         "span": {
                           "start": 334,
                           "end": 336,
@@ -1529,7 +1529,7 @@
                       },
                       "op": "*",
                       "left": {
-                        "type": "PercentValue",
+                        "type": "Percent",
                         "span": {
                           "start": 352,
                           "end": 354,
@@ -1629,7 +1629,7 @@
                       },
                       "op": "*",
                       "left": {
-                        "type": "PercentValue",
+                        "type": "Percent",
                         "span": {
                           "start": 370,
                           "end": 372,

--- a/crates/swc_css_parser/tests/fixture/rome/min-and-max/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/min-and-max/span.rust-debug
@@ -323,7 +323,7 @@ error: Value
 4 |     width: max(500px, 40px + 5%);
   |                              ^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/rome/min-and-max/input.css:4:27
   |
 4 |     width: max(500px, 40px + 5%);
@@ -419,7 +419,7 @@ error: Value
 5 |     width: max(500px, 5% * 400px + 2px);
   |                       ^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/rome/min-and-max/input.css:5:20
   |
 5 |     width: max(500px, 5% * 400px + 2px);
@@ -575,7 +575,7 @@ error: Value
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                       ^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:20
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -677,7 +677,7 @@ error: Value
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                         ^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:38
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -779,7 +779,7 @@ error: Value
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                                           ^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:56
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1091,7 +1091,7 @@ error: Value
 9 |     width: min(500px, 40px + 5%);
   |                              ^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/rome/min-and-max/input.css:9:27
   |
 9 |     width: min(500px, 40px + 5%);
@@ -1187,7 +1187,7 @@ error: Value
 10 |     width: min(500px, 5% * 400px + 2px);
    |                       ^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/rome/min-and-max/input.css:10:20
    |
 10 |     width: min(500px, 5% * 400px + 2px);
@@ -1343,7 +1343,7 @@ error: Value
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                       ^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:20
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1445,7 +1445,7 @@ error: Value
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                         ^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:38
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1547,7 +1547,7 @@ error: Value
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                                           ^^
 
-error: PercentValue
+error: Percent
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:56
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);

--- a/crates/swc_css_parser/tests/fixture/rome/smoke/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/smoke/output.json
@@ -173,7 +173,7 @@
                       }
                     },
                     "right": {
-                      "type": "PercentValue",
+                      "type": "Percent",
                       "span": {
                         "start": 72,
                         "end": 74,

--- a/crates/swc_css_parser/tests/fixture/rome/smoke/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/smoke/span.rust-debug
@@ -165,7 +165,7 @@ error: Value
 4 |     width: calc(1px + 2%);
   |                       ^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/rome/smoke/input.css:4:23
   |
 4 |     width: calc(1px + 2%);

--- a/crates/swc_css_parser/tests/fixture/rome/values/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/values/output.json
@@ -270,7 +270,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 91,
                   "end": 94,
@@ -309,7 +309,7 @@
             },
             "value": [
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 109,
                   "end": 112,

--- a/crates/swc_css_parser/tests/fixture/rome/values/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/values/span.rust-debug
@@ -243,7 +243,7 @@ error: Value
 8 |     width: 20%;
   |            ^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/rome/values/input.css:8:9
   |
 8 |     width: 20%;
@@ -273,7 +273,7 @@ error: Value
 9 |     margin-top: -5%;
   |                 ^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/rome/values/input.css:9:14
   |
 9 |     margin-top: -5%;

--- a/crates/swc_css_parser/tests/fixture/value/square-brackets/output.json
+++ b/crates/swc_css_parser/tests/fixture/value/square-brackets/output.json
@@ -335,7 +335,7 @@
                 ]
               },
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 163,
                   "end": 166,
@@ -384,7 +384,7 @@
                 ]
               },
               {
-                "type": "PercentValue",
+                "type": "Percent",
                 "span": {
                   "start": 189,
                   "end": 192,

--- a/crates/swc_css_parser/tests/fixture/value/square-brackets/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/square-brackets/span.rust-debug
@@ -311,7 +311,7 @@ error: Value
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
   |                        ^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/value/square-brackets/input.css:7:24
   |
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
@@ -365,7 +365,7 @@ error: Value
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];
   |                                                  ^^^
 
-error: PercentValue
+error: Percent
  --> $DIR/tests/fixture/value/square-brackets/input.css:7:50
   |
 7 |     prop: [row1-start] 25% [row1-end row2-start] 25% [row2-end];

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -88,7 +88,7 @@ define!({
 
         Number(Number),
 
-        Percent(PercentValue),
+        Percent(Percent),
 
         Ratio(Ratio),
 
@@ -151,7 +151,7 @@ define!({
         pub unit: Unit,
     }
 
-    pub struct PercentValue {
+    pub struct Percent {
         pub span: Span,
         pub value: Number,
     }
@@ -423,7 +423,7 @@ define!({
 
     pub enum KeyframeSelector {
         Ident(Ident),
-        Percent(PercentValue),
+        Percent(Percent),
     }
 
     pub enum KeyframeBlockRule {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Rename `PercentValue` to `Percent`:
1. CSS spec show explicity `Percent` https://www.w3.org/TR/css-values-4/#percentages
2. I think we don't need `Value` suffix, because only one type for percent values

**BREAKING CHANGE:**

Yes

**Related issue (if exists):**

No