### PR TITLE
fix(ecma): dynamic import with name from another import

### DIFF
--- a/crates/swc_ecma_transforms_module/src/util.rs
+++ b/crates/swc_ecma_transforms_module/src/util.rs
@@ -514,20 +514,7 @@ impl Scope {
             {
                 let expr = match *(args.pop().unwrap().expr) {
                     Expr::Ident(ident) => match Self::fold_ident(folder, ident) {
-                        Ok(mut expr) => {
-                            if let Expr::Member(member) = &mut expr {
-                                if let Expr::Ident(ident) = member.obj.as_mut() {
-                                    member.obj = Box::new(Expr::Paren(ParenExpr {
-                                        expr: Box::new(Expr::Seq(SeqExpr {
-                                            span,
-                                            exprs: vec![Box::new(ident.take().into())],
-                                        })),
-                                        span,
-                                    }))
-                                }
-                            };
-                            expr
-                        }
+                        Ok(expr) => expr,
                         Err(ident) => Expr::Ident(ident),
                     },
                     expr => expr,

--- a/crates/swc_ecma_transforms_module/tests/common_js.rs
+++ b/crates/swc_ecma_transforms_module/tests/common_js.rs
@@ -4283,6 +4283,41 @@ test!(
   }
   "
 );
+test!(
+    syntax(),
+    |_| tr(Config {
+        ..Default::default()
+    }),
+    issue_3246_1,
+    "import { foo } from 'bar';
+
+    import(foo);
+    ",
+    r#""use strict";
+    var _bar = require("bar");
+    Promise.resolve().then(function() {
+        return _interopRequireWildcard(require(_bar.foo));
+    });
+    "#
+);
+
+test!(
+    syntax(),
+    |_| tr(Config {
+        ..Default::default()
+    }),
+    issue_3246_2,
+    "import foo from 'bar';
+
+  import(foo);
+  ",
+    r#""use strict";
+  var _bar = _interopRequireDefault(require("bar"));
+  Promise.resolve().then(function() {
+      return _interopRequireWildcard(require(_bar.default));
+  });
+  "#
+);
 
 test!(
     syntax(),


### PR DESCRIPTION
**Description:**
```js
import { foo }from 'bar';
import(foo);
```
to 
```js
var _bar = require("bar");
Promise.resolve().then(function() {
    return _interopRequireWildcard(require(_bar.foo)); // not return _interopRequireWildcard(require(foo));
});
```
babel generates like 
```js
Promise.resolve("" + _bar.foo).then(function (s) {
  return _interopRequireWildcard(require(s));
});
```
But I think they work the same.
**Related issue (if exists):**
fix #3246