### PR TITLE
refactor: dimension

### DIFF
--- a/crates/swc_css_ast/src/at_rule/media.rs
+++ b/crates/swc_css_ast/src/at_rule/media.rs
@@ -1,4 +1,4 @@
-use crate::{Ident, Number, Ratio, Rule, UnitValue};
+use crate::{Dimension, Ident, Number, Ratio, Rule};
 use string_enum::StringEnum;
 use swc_common::{ast_node, EqIgnoreSpan, Span};
 
@@ -125,8 +125,8 @@ pub enum MediaFeatureValue {
     #[tag("Number")]
     Number(Number),
 
-    #[tag("UnitValue")]
-    Dimension(UnitValue),
+    #[tag("Dimension")]
+    Dimension(Dimension),
 
     #[tag("Ident")]
     Ident(Ident),

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -8,8 +8,8 @@ pub enum Value {
     #[tag("SimpleBlock")]
     SimpleBlock(SimpleBlock),
 
-    #[tag("UnitValue")]
-    Unit(UnitValue),
+    #[tag("Dimension")]
+    Dimension(Dimension),
 
     #[tag("Number")]
     Number(Number),
@@ -94,18 +94,11 @@ pub struct HashValue {
     pub raw: JsWord,
 }
 
-#[ast_node]
-pub struct Unit {
-    pub span: Span,
-    pub value: JsWord,
-    pub raw: JsWord,
-}
-
-#[ast_node("UnitValue")]
-pub struct UnitValue {
+#[ast_node("Dimension")]
+pub struct Dimension {
     pub span: Span,
     pub value: Number,
-    pub unit: Unit,
+    pub unit: Ident,
 }
 
 #[ast_node("Percent")]

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -648,7 +648,7 @@ where
         match n {
             Value::Function(n) => emit!(self, n),
             Value::SimpleBlock(n) => emit!(self, n),
-            Value::Unit(n) => emit!(self, n),
+            Value::Dimension(n) => emit!(self, n),
             Value::Number(n) => emit!(self, n),
             Value::Percent(n) => emit!(self, n),
             Value::Ratio(n) => emit!(self, n),
@@ -862,7 +862,7 @@ where
     }
 
     #[emitter]
-    fn emit_unit_value(&mut self, n: &UnitValue) -> Result {
+    fn emit_dimension(&mut self, n: &Dimension) -> Result {
         emit!(self, n.value);
         emit!(self, n.unit);
     }
@@ -1125,11 +1125,6 @@ where
             SubclassSelector::PseudoElement(n) => emit!(self, n),
             SubclassSelector::At(n) => emit!(self, n),
         }
-    }
-
-    #[emitter]
-    fn emit_unit(&mut self, n: &Unit) -> Result {
-        self.wr.write_raw(Some(n.span), &n.raw)?;
     }
 
     #[emitter]

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -430,7 +430,7 @@ where
     fn parse_basical_numeric_value(&mut self) -> PResult<Value> {
         match cur!(self) {
             tok!("percent") => Ok(Value::Percent(self.parse()?)),
-            tok!("dimension") => Ok(Value::Unit(self.parse()?)),
+            tok!("dimension") => Ok(Value::Dimension(self.parse()?)),
             tok!("num") => Ok(Value::Number(self.parse()?)),
             _ => {
                 unreachable!()
@@ -687,11 +687,11 @@ where
     }
 }
 
-impl<I> Parse<UnitValue> for Parser<I>
+impl<I> Parse<Dimension> for Parser<I>
 where
     I: ParserInput,
 {
-    fn parse(&mut self) -> PResult<UnitValue> {
+    fn parse(&mut self) -> PResult<Dimension> {
         let span = self.input.cur_span()?;
 
         if !is!(self, Dimension) {
@@ -708,7 +708,7 @@ where
             } => {
                 let unit_len = raw_unit.len() as u32;
 
-                Ok(UnitValue {
+                Ok(Dimension {
                     span,
                     value: Number {
                         value,
@@ -719,7 +719,7 @@ where
                             Default::default(),
                         ),
                     },
-                    unit: Unit {
+                    unit: Ident {
                         span: swc_common::Span::new(
                             span.hi - BytePos(unit_len),
                             span.hi,

--- a/crates/swc_css_parser/tests/fixture.rs
+++ b/crates/swc_css_parser/tests/fixture.rs
@@ -316,8 +316,7 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(CustomIdent, visit_custom_ident);
     mtd!(DashedIdent, visit_dashed_ident);
     mtd!(Tokens, visit_tokens);
-    mtd!(Unit, visit_unit);
-    mtd!(UnitValue, visit_unit_value);
+    mtd!(Dimension, visit_dimension);
     mtd!(Url, visit_url);
     mtd!(UrlValue, visit_url_value);
     mtd!(UrlValueRaw, visit_url_value_raw);

--- a/crates/swc_css_parser/tests/fixture/at-rule/import/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/import/output.json
@@ -5938,7 +5938,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 4614,
                       "end": 4619,
@@ -5955,6 +5955,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 4617,
                         "end": 4619,
@@ -6303,7 +6304,7 @@
                     "raw": "MIN-WIDTH"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 4874,
                       "end": 4879,
@@ -6320,6 +6321,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 4877,
                         "end": 4879,

--- a/crates/swc_css_parser/tests/fixture/at-rule/import/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/import/output.json
@@ -928,7 +928,7 @@
                     "raw": "max-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 672,
                       "end": 677,
@@ -945,6 +945,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 675,
                         "end": 677,
@@ -1081,7 +1082,7 @@
                     "raw": "max-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 755,
                       "end": 760,
@@ -1098,6 +1099,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 758,
                         "end": 760,
@@ -4781,7 +4783,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 3985,
                       "end": 3990,
@@ -4798,6 +4800,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 3988,
                         "end": 3990,
@@ -5081,7 +5084,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 4156,
                       "end": 4161,
@@ -5098,6 +5101,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 4159,
                         "end": 4161,
@@ -5243,7 +5247,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 4243,
                       "end": 4248,
@@ -5260,6 +5264,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 4246,
                         "end": 4248,
@@ -5414,7 +5419,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 4332,
                       "end": 4337,
@@ -5431,6 +5436,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 4335,
                         "end": 4337,
@@ -5625,7 +5631,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 4466,
                       "end": 4471,
@@ -5642,6 +5648,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 4469,
                         "end": 4471,
@@ -5807,7 +5814,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 4558,
                       "end": 4563,
@@ -5824,6 +5831,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 4561,
                         "end": 4563,
@@ -6112,7 +6120,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 4773,
                       "end": 4778,
@@ -6129,6 +6137,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 4776,
                         "end": 4778,
@@ -6476,7 +6485,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 5154,
                       "end": 5159,
@@ -6493,6 +6502,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 5157,
                         "end": 5159,
@@ -7388,7 +7398,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 5917,
                       "end": 5922,
@@ -7405,6 +7415,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 5920,
                         "end": 5922,

--- a/crates/swc_css_parser/tests/fixture/at-rule/import/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/import/span.rust-debug
@@ -7330,7 +7330,7 @@ error: MediaFeatureValue
 140 | @import url("./test.css")     layer(     default     )     supports(     display     :     flex     )     screen     and     (     min-width     :     400px     );
     |                                                                                                                                                        ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/import/input.css:140:152
     |
 140 | @import url("./test.css")     layer(     default     )     supports(     display     :     flex     )     screen     and     (     min-width     :     400px     );
@@ -7342,7 +7342,7 @@ error: Number
 140 | @import url("./test.css")     layer(     default     )     supports(     display     :     flex     )     screen     and     (     min-width     :     400px     );
     |                                                                                                                                                        ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/import/input.css:140:155
     |
 140 | @import url("./test.css")     layer(     default     )     supports(     display     :     flex     )     screen     and     (     min-width     :     400px     );
@@ -7528,7 +7528,7 @@ error: MediaFeatureValue
 141 | @import url("./test.css") LAYER(DEFAULT) SUPPORTS(DISPLAY: FLEX) SCREEN AND (MIN-WIDTH: 400PX);
     |                                                                                         ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/import/input.css:141:89
     |
 141 | @import url("./test.css") LAYER(DEFAULT) SUPPORTS(DISPLAY: FLEX) SCREEN AND (MIN-WIDTH: 400PX);
@@ -7540,7 +7540,7 @@ error: Number
 141 | @import url("./test.css") LAYER(DEFAULT) SUPPORTS(DISPLAY: FLEX) SCREEN AND (MIN-WIDTH: 400PX);
     |                                                                                         ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/import/input.css:141:92
     |
 141 | @import url("./test.css") LAYER(DEFAULT) SUPPORTS(DISPLAY: FLEX) SCREEN AND (MIN-WIDTH: 400PX);

--- a/crates/swc_css_parser/tests/fixture/at-rule/import/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/import/span.rust-debug
@@ -1108,7 +1108,7 @@ error: MediaFeatureValue
 19 | @import url("narrow.css") supports(display: flex) handheld and (max-width: 400px);
    |                                                                            ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/import/input.css:19:76
    |
 19 | @import url("narrow.css") supports(display: flex) handheld and (max-width: 400px);
@@ -1120,7 +1120,7 @@ error: Number
 19 | @import url("narrow.css") supports(display: flex) handheld and (max-width: 400px);
    |                                                                            ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/import/input.css:19:79
    |
 19 | @import url("narrow.css") supports(display: flex) handheld and (max-width: 400px);
@@ -1276,7 +1276,7 @@ error: MediaFeatureValue
 20 | @import url("narrow.css") SUPPORTS(display: flex) handheld and (max-width: 400px);
    |                                                                            ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/import/input.css:20:76
    |
 20 | @import url("narrow.css") SUPPORTS(display: flex) handheld and (max-width: 400px);
@@ -1288,7 +1288,7 @@ error: Number
 20 | @import url("narrow.css") SUPPORTS(display: flex) handheld and (max-width: 400px);
    |                                                                            ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/import/input.css:20:79
    |
 20 | @import url("narrow.css") SUPPORTS(display: flex) handheld and (max-width: 400px);
@@ -5866,7 +5866,7 @@ error: MediaFeatureValue
 130 | @import url("./test.css") supports(display: flex) screen and (min-width: 400px);
     |                                                                          ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/import/input.css:130:74
     |
 130 | @import url("./test.css") supports(display: flex) screen and (min-width: 400px);
@@ -5878,7 +5878,7 @@ error: Number
 130 | @import url("./test.css") supports(display: flex) screen and (min-width: 400px);
     |                                                                          ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/import/input.css:130:77
     |
 130 | @import url("./test.css") supports(display: flex) screen and (min-width: 400px);
@@ -6202,7 +6202,7 @@ error: MediaFeatureValue
 133 | @import url("./test.css") layer(default) supports(display: flex) screen and (min-width: 400px);
     |                                                                                         ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/import/input.css:133:89
     |
 133 | @import url("./test.css") layer(default) supports(display: flex) screen and (min-width: 400px);
@@ -6214,7 +6214,7 @@ error: Number
 133 | @import url("./test.css") layer(default) supports(display: flex) screen and (min-width: 400px);
     |                                                                                         ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/import/input.css:133:92
     |
 133 | @import url("./test.css") layer(default) supports(display: flex) screen and (min-width: 400px);
@@ -6382,7 +6382,7 @@ error: MediaFeatureValue
 134 | @import url("./test.css") layer supports(display: flex) screen and (min-width: 400px);
     |                                                                                ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/import/input.css:134:80
     |
 134 | @import url("./test.css") layer supports(display: flex) screen and (min-width: 400px);
@@ -6394,7 +6394,7 @@ error: Number
 134 | @import url("./test.css") layer supports(display: flex) screen and (min-width: 400px);
     |                                                                                ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/import/input.css:134:83
     |
 134 | @import url("./test.css") layer supports(display: flex) screen and (min-width: 400px);
@@ -6568,7 +6568,7 @@ error: MediaFeatureValue
 135 | @import url("./test.css") layer() supports(display: flex) screen and (min-width: 400px);
     |                                                                                  ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/import/input.css:135:82
     |
 135 | @import url("./test.css") layer() supports(display: flex) screen and (min-width: 400px);
@@ -6580,7 +6580,7 @@ error: Number
 135 | @import url("./test.css") layer() supports(display: flex) screen and (min-width: 400px);
     |                                                                                  ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/import/input.css:135:85
     |
 135 | @import url("./test.css") layer() supports(display: flex) screen and (min-width: 400px);
@@ -6802,7 +6802,7 @@ error: MediaFeatureValue
 137 | @import url("http://example.com/style.css") supports(display: flex) screen and (min-width: 400px);
     |                                                                                            ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/import/input.css:137:92
     |
 137 | @import url("http://example.com/style.css") supports(display: flex) screen and (min-width: 400px);
@@ -6814,7 +6814,7 @@ error: Number
 137 | @import url("http://example.com/style.css") supports(display: flex) screen and (min-width: 400px);
     |                                                                                            ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/import/input.css:137:95
     |
 137 | @import url("http://example.com/style.css") supports(display: flex) screen and (min-width: 400px);
@@ -7000,7 +7000,7 @@ error: MediaFeatureValue
 138 | @import url("./test.css")layer(default)supports(display: flex)screen and (min-width:400px);
     |                                                                                     ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/import/input.css:138:85
     |
 138 | @import url("./test.css")layer(default)supports(display: flex)screen and (min-width:400px);
@@ -7012,7 +7012,7 @@ error: Number
 138 | @import url("./test.css")layer(default)supports(display: flex)screen and (min-width:400px);
     |                                                                                     ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/import/input.css:138:88
     |
 138 | @import url("./test.css")layer(default)supports(display: flex)screen and (min-width:400px);
@@ -7132,7 +7132,7 @@ error: MediaFeatureValue
 139 | @import url("./test.css")screen and (min-width: 400px);
     |                                                 ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/import/input.css:139:49
     |
 139 | @import url("./test.css")screen and (min-width: 400px);
@@ -7144,7 +7144,7 @@ error: Number
 139 | @import url("./test.css")screen and (min-width: 400px);
     |                                                 ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/import/input.css:139:52
     |
 139 | @import url("./test.css")screen and (min-width: 400px);
@@ -7726,7 +7726,7 @@ error: MediaFeatureValue
 142 | @import url("./test.css") /* Comment */ layer(/* Comment */default/* Comment */) /* Comment */ supports(/* Comment */display/* Comment */:/* Comment */ flex/* Comment */)/* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */);
     |                                                                                                                                                                                                                                                                                 ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/import/input.css:142:273
     |
 142 | @import url("./test.css") /* Comment */ layer(/* Comment */default/* Comment */) /* Comment */ supports(/* Comment */display/* Comment */:/* Comment */ flex/* Comment */)/* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */);
@@ -7738,7 +7738,7 @@ error: Number
 142 | @import url("./test.css") /* Comment */ layer(/* Comment */default/* Comment */) /* Comment */ supports(/* Comment */display/* Comment */:/* Comment */ flex/* Comment */)/* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */);
     |                                                                                                                                                                                                                                                                                 ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/import/input.css:142:276
     |
 142 | @import url("./test.css") /* Comment */ layer(/* Comment */default/* Comment */) /* Comment */ supports(/* Comment */display/* Comment */:/* Comment */ flex/* Comment */)/* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */);
@@ -8806,7 +8806,7 @@ error: MediaFeatureValue
 154 | @import url("./import-with-supports-and-media.css") supports(display: flex) screen and (min-width: 400px);
     |                                                                                                    ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/import/input.css:154:100
     |
 154 | @import url("./import-with-supports-and-media.css") supports(display: flex) screen and (min-width: 400px);
@@ -8818,7 +8818,7 @@ error: Number
 154 | @import url("./import-with-supports-and-media.css") supports(display: flex) screen and (min-width: 400px);
     |                                                                                                    ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/import/input.css:154:103
     |
 154 | @import url("./import-with-supports-and-media.css") supports(display: flex) screen and (min-width: 400px);

--- a/crates/swc_css_parser/tests/fixture/at-rule/keyframe/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/keyframe/output.json
@@ -429,7 +429,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 292,
                       "end": 296,
@@ -446,6 +446,7 @@
                       "raw": "50"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 294,
                         "end": 296,
@@ -532,7 +533,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 321,
                       "end": 325,
@@ -549,6 +550,7 @@
                       "raw": "50"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 323,
                         "end": 325,
@@ -617,7 +619,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 345,
                       "end": 350,
@@ -634,6 +636,7 @@
                       "raw": "100"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 348,
                         "end": 350,

--- a/crates/swc_css_parser/tests/fixture/at-rule/keyframe/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/keyframe/span.rust-debug
@@ -503,7 +503,7 @@ error: Value
 17 |     30% { top: 50px; }
    |                ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:17:16
    |
 17 |     30% { top: 50px; }
@@ -515,7 +515,7 @@ error: Number
 17 |     30% { top: 50px; }
    |                ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:17:18
    |
 17 |     30% { top: 50px; }
@@ -599,7 +599,7 @@ error: Value
 18 |     68%, 72% { left: 50px; }
    |                      ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:18:22
    |
 18 |     68%, 72% { left: 50px; }
@@ -611,7 +611,7 @@ error: Number
 18 |     68%, 72% { left: 50px; }
    |                      ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:18:24
    |
 18 |     68%, 72% { left: 50px; }
@@ -677,7 +677,7 @@ error: Value
 19 |     100% { top: 100px; left: 100%; }
    |                 ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:19:17
    |
 19 |     100% { top: 100px; left: 100%; }
@@ -689,7 +689,7 @@ error: Number
 19 |     100% { top: 100px; left: 100%; }
    |                 ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/keyframe/input.css:19:20
    |
 19 |     100% { top: 100px; left: 100%; }

--- a/crates/swc_css_parser/tests/fixture/at-rule/layer/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/layer/output.json
@@ -575,7 +575,7 @@
                 "raw": "slide-left"
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 332,
                   "end": 337,
@@ -592,6 +592,7 @@
                   "raw": "300"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 335,
                     "end": 337,
@@ -1333,7 +1334,7 @@
                     },
                     "value": [
                       {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 681,
                           "end": 687,
@@ -1350,6 +1351,7 @@
                           "raw": "0.75"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 685,
                             "end": 687,

--- a/crates/swc_css_parser/tests/fixture/at-rule/layer/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/layer/span.rust-debug
@@ -616,7 +616,7 @@ error: Value
 17 | .sidebar { animation: slide-left 300ms; }
    |                                  ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/layer/input.css:17:34
    |
 17 | .sidebar { animation: slide-left 300ms; }
@@ -628,7 +628,7 @@ error: Number
 17 | .sidebar { animation: slide-left 300ms; }
    |                                  ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/layer/input.css:17:37
    |
 17 | .sidebar { animation: slide-left 300ms; }
@@ -1372,7 +1372,7 @@ error: Value
 40 |         p { margin-block: 0.75em; }
    |                           ^^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/layer/input.css:40:27
    |
 40 |         p { margin-block: 0.75em; }
@@ -1384,7 +1384,7 @@ error: Number
 40 |         p { margin-block: 0.75em; }
    |                           ^^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/layer/input.css:40:31
    |
 40 |         p { margin-block: 0.75em; }

--- a/crates/swc_css_parser/tests/fixture/at-rule/media/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/media/output.json
@@ -552,7 +552,7 @@
                     "raw": "min-resolution"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 287,
                       "end": 294,
@@ -569,6 +569,7 @@
                       "raw": "118"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 290,
                         "end": 294,
@@ -1436,7 +1437,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 714,
                       "end": 718,
@@ -1453,6 +1454,7 @@
                       "raw": "20"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 716,
                         "end": 718,
@@ -1520,7 +1522,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 741,
                       "end": 745,
@@ -1537,6 +1539,7 @@
                       "raw": "20"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 743,
                         "end": 745,
@@ -1604,7 +1607,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 778,
                       "end": 782,
@@ -1621,6 +1624,7 @@
                       "raw": "20"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 780,
                         "end": 782,
@@ -1883,7 +1887,7 @@
                       "raw": "max-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 921,
                         "end": 925,
@@ -1900,6 +1904,7 @@
                         "raw": "15"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 923,
                           "end": 925,
@@ -2025,7 +2030,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 973,
                       "end": 977,
@@ -2042,6 +2047,7 @@
                       "raw": "20"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 975,
                         "end": 977,
@@ -2077,7 +2083,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 995,
                         "end": 999,
@@ -2094,6 +2100,7 @@
                         "raw": "20"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 997,
                           "end": 999,
@@ -2162,7 +2169,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1030,
                       "end": 1034,
@@ -2179,6 +2186,7 @@
                       "raw": "20"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1032,
                         "end": 1034,
@@ -2214,7 +2222,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 1067,
                         "end": 1071,
@@ -2231,6 +2239,7 @@
                         "raw": "20"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 1069,
                           "end": 1071,
@@ -2299,7 +2308,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1100,
                       "end": 1106,
@@ -2316,6 +2325,7 @@
                       "raw": "1024"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1104,
                         "end": 1106,
@@ -2351,7 +2361,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 1124,
                         "end": 1130,
@@ -2368,6 +2378,7 @@
                         "raw": "1024"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 1128,
                           "end": 1130,
@@ -2404,7 +2415,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 1148,
                         "end": 1154,
@@ -2421,6 +2432,7 @@
                         "raw": "1024"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 1152,
                           "end": 1154,
@@ -2489,7 +2501,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1176,
                       "end": 1180,
@@ -2506,6 +2518,7 @@
                       "raw": "20"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1178,
                         "end": 1180,
@@ -2541,7 +2554,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 1197,
                         "end": 1201,
@@ -2558,6 +2571,7 @@
                         "raw": "20"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 1199,
                           "end": 1201,
@@ -2626,7 +2640,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1222,
                       "end": 1226,
@@ -2643,6 +2657,7 @@
                       "raw": "20"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1224,
                         "end": 1226,
@@ -2678,7 +2693,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 1242,
                         "end": 1246,
@@ -2695,6 +2710,7 @@
                         "raw": "20"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 1244,
                           "end": 1246,
@@ -3073,7 +3089,7 @@
                   },
                   "comparison": "<",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1424,
                       "end": 1429,
@@ -3090,6 +3106,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1427,
                         "end": 1429,
@@ -3158,7 +3175,7 @@
                   },
                   "comparison": "<=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1452,
                       "end": 1457,
@@ -3175,6 +3192,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1455,
                         "end": 1457,
@@ -3243,7 +3261,7 @@
                   },
                   "comparison": ">",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1479,
                       "end": 1484,
@@ -3260,6 +3278,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1482,
                         "end": 1484,
@@ -3328,7 +3347,7 @@
                   },
                   "comparison": ">=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1507,
                       "end": 1512,
@@ -3345,6 +3364,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1510,
                         "end": 1512,
@@ -3413,7 +3433,7 @@
                   },
                   "comparison": "=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1534,
                       "end": 1539,
@@ -3430,6 +3450,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1537,
                         "end": 1539,
@@ -3498,7 +3519,7 @@
                   },
                   "comparison": "<",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1570,
                       "end": 1575,
@@ -3515,6 +3536,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1573,
                         "end": 1575,
@@ -3583,7 +3605,7 @@
                   },
                   "comparison": "<=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1612,
                       "end": 1617,
@@ -3600,6 +3622,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1615,
                         "end": 1617,
@@ -3668,7 +3691,7 @@
                   },
                   "comparison": ">",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1653,
                       "end": 1658,
@@ -3685,6 +3708,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1656,
                         "end": 1658,
@@ -3753,7 +3777,7 @@
                   },
                   "comparison": ">=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1695,
                       "end": 1700,
@@ -3770,6 +3794,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1698,
                         "end": 1700,
@@ -3838,7 +3863,7 @@
                   },
                   "comparison": "=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1736,
                       "end": 1741,
@@ -3855,6 +3880,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1739,
                         "end": 1741,
@@ -3923,7 +3949,7 @@
                   },
                   "comparison": "=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1765,
                       "end": 1770,
@@ -3940,6 +3966,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1768,
                         "end": 1770,
@@ -4008,7 +4035,7 @@
                   },
                   "comparison": ">=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1789,
                       "end": 1794,
@@ -4025,6 +4052,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1792,
                         "end": 1794,
@@ -4082,7 +4110,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1808,
                       "end": 1813,
@@ -4099,6 +4127,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1811,
                         "end": 1813,
@@ -4167,7 +4196,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1835,
                       "end": 1840,
@@ -4184,6 +4213,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1838,
                         "end": 1840,
@@ -4252,7 +4282,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1863,
                       "end": 1868,
@@ -4269,6 +4299,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1866,
                         "end": 1868,
@@ -4337,7 +4368,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1890,
                       "end": 1895,
@@ -4354,6 +4385,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1893,
                         "end": 1895,
@@ -4422,7 +4454,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1918,
                       "end": 1923,
@@ -4439,6 +4471,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1921,
                         "end": 1923,
@@ -4507,7 +4540,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1950,
                       "end": 1955,
@@ -4524,6 +4557,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1953,
                         "end": 1955,
@@ -4592,7 +4626,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 1991,
                       "end": 1996,
@@ -4609,6 +4643,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 1994,
                         "end": 1996,
@@ -4677,7 +4712,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2033,
                       "end": 2038,
@@ -4694,6 +4729,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2036,
                         "end": 2038,
@@ -4762,7 +4798,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2074,
                       "end": 2079,
@@ -4779,6 +4815,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2077,
                         "end": 2079,
@@ -4847,7 +4884,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2116,
                       "end": 2121,
@@ -4864,6 +4901,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2119,
                         "end": 2121,
@@ -4932,7 +4970,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2151,
                       "end": 2156,
@@ -4949,6 +4987,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2154,
                         "end": 2156,
@@ -5017,7 +5056,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2175,
                       "end": 2180,
@@ -5034,6 +5073,7 @@
                       "raw": "600"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2178,
                         "end": 2180,
@@ -5102,7 +5142,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2202,
                       "end": 2207,
@@ -5119,6 +5159,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2205,
                         "end": 2207,
@@ -5141,7 +5182,7 @@
                   },
                   "rightComparison": "<",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2218,
                       "end": 2223,
@@ -5158,6 +5199,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2221,
                         "end": 2223,
@@ -5215,7 +5257,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2236,
                       "end": 2241,
@@ -5232,6 +5274,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2239,
                         "end": 2241,
@@ -5254,7 +5297,7 @@
                   },
                   "rightComparison": "<",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2253,
                       "end": 2258,
@@ -5271,6 +5314,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2256,
                         "end": 2258,
@@ -5328,7 +5372,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2271,
                       "end": 2276,
@@ -5345,6 +5389,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2274,
                         "end": 2276,
@@ -5367,7 +5412,7 @@
                   },
                   "rightComparison": "<=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2288,
                       "end": 2293,
@@ -5384,6 +5429,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2291,
                         "end": 2293,
@@ -5441,7 +5487,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2306,
                       "end": 2311,
@@ -5458,6 +5504,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2309,
                         "end": 2311,
@@ -5480,7 +5527,7 @@
                   },
                   "rightComparison": "<=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2324,
                       "end": 2329,
@@ -5497,6 +5544,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2327,
                         "end": 2329,
@@ -5554,7 +5602,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2341,
                       "end": 2346,
@@ -5571,6 +5619,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2344,
                         "end": 2346,
@@ -5593,7 +5642,7 @@
                   },
                   "rightComparison": "<",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2353,
                       "end": 2358,
@@ -5610,6 +5659,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2356,
                         "end": 2358,
@@ -5667,7 +5717,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2369,
                       "end": 2374,
@@ -5684,6 +5734,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2372,
                         "end": 2374,
@@ -5706,7 +5757,7 @@
                   },
                   "rightComparison": "<=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2383,
                       "end": 2388,
@@ -5723,6 +5774,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2386,
                         "end": 2388,
@@ -5780,7 +5832,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2405,
                       "end": 2410,
@@ -5797,6 +5849,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2408,
                         "end": 2410,
@@ -5819,7 +5872,7 @@
                   },
                   "rightComparison": "<",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2429,
                       "end": 2434,
@@ -5836,6 +5889,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2432,
                         "end": 2434,
@@ -5893,7 +5947,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2457,
                       "end": 2462,
@@ -5910,6 +5964,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2460,
                         "end": 2462,
@@ -5932,7 +5987,7 @@
                   },
                   "rightComparison": "<",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2482,
                       "end": 2487,
@@ -5949,6 +6004,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2485,
                         "end": 2487,
@@ -6006,7 +6062,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2510,
                       "end": 2515,
@@ -6023,6 +6079,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2513,
                         "end": 2515,
@@ -6045,7 +6102,7 @@
                   },
                   "rightComparison": "<=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2535,
                       "end": 2540,
@@ -6062,6 +6119,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2538,
                         "end": 2540,
@@ -6119,7 +6177,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2563,
                       "end": 2568,
@@ -6136,6 +6194,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2566,
                         "end": 2568,
@@ -6158,7 +6217,7 @@
                   },
                   "rightComparison": "<=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2589,
                       "end": 2594,
@@ -6175,6 +6234,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2592,
                         "end": 2594,
@@ -6232,7 +6292,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2611,
                       "end": 2616,
@@ -6249,6 +6309,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2614,
                         "end": 2616,
@@ -6271,7 +6332,7 @@
                   },
                   "rightComparison": "<",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2623,
                       "end": 2628,
@@ -6288,6 +6349,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2626,
                         "end": 2628,
@@ -6345,7 +6407,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2639,
                       "end": 2644,
@@ -6362,6 +6424,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2642,
                         "end": 2644,
@@ -6384,7 +6447,7 @@
                   },
                   "rightComparison": "<=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2653,
                       "end": 2658,
@@ -6401,6 +6464,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2656,
                         "end": 2658,
@@ -6458,7 +6522,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2671,
                       "end": 2676,
@@ -6475,6 +6539,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2674,
                         "end": 2676,
@@ -6497,7 +6562,7 @@
                   },
                   "rightComparison": ">",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2687,
                       "end": 2692,
@@ -6514,6 +6579,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2690,
                         "end": 2692,
@@ -6571,7 +6637,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2705,
                       "end": 2710,
@@ -6588,6 +6654,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2708,
                         "end": 2710,
@@ -6610,7 +6677,7 @@
                   },
                   "rightComparison": ">",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2722,
                       "end": 2727,
@@ -6627,6 +6694,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2725,
                         "end": 2727,
@@ -6684,7 +6752,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2740,
                       "end": 2745,
@@ -6701,6 +6769,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2743,
                         "end": 2745,
@@ -6723,7 +6792,7 @@
                   },
                   "rightComparison": ">=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2757,
                       "end": 2762,
@@ -6740,6 +6809,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2760,
                         "end": 2762,
@@ -6797,7 +6867,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2775,
                       "end": 2780,
@@ -6814,6 +6884,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2778,
                         "end": 2780,
@@ -6836,7 +6907,7 @@
                   },
                   "rightComparison": ">=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2793,
                       "end": 2798,
@@ -6853,6 +6924,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2796,
                         "end": 2798,
@@ -6910,7 +6982,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2810,
                       "end": 2815,
@@ -6927,6 +6999,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2813,
                         "end": 2815,
@@ -6949,7 +7022,7 @@
                   },
                   "rightComparison": ">",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2822,
                       "end": 2827,
@@ -6966,6 +7039,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2825,
                         "end": 2827,
@@ -7023,7 +7097,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2838,
                       "end": 2843,
@@ -7040,6 +7114,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2841,
                         "end": 2843,
@@ -7062,7 +7137,7 @@
                   },
                   "rightComparison": ">=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2852,
                       "end": 2857,
@@ -7079,6 +7154,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2855,
                         "end": 2857,
@@ -7136,7 +7212,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2875,
                       "end": 2880,
@@ -7153,6 +7229,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2878,
                         "end": 2880,
@@ -7175,7 +7252,7 @@
                   },
                   "rightComparison": ">",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2899,
                       "end": 2904,
@@ -7192,6 +7269,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2902,
                         "end": 2904,
@@ -7249,7 +7327,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2927,
                       "end": 2932,
@@ -7266,6 +7344,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2930,
                         "end": 2932,
@@ -7288,7 +7367,7 @@
                   },
                   "rightComparison": ">",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2952,
                       "end": 2957,
@@ -7305,6 +7384,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2955,
                         "end": 2957,
@@ -7362,7 +7442,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 2980,
                       "end": 2985,
@@ -7379,6 +7459,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 2983,
                         "end": 2985,
@@ -7401,7 +7482,7 @@
                   },
                   "rightComparison": ">=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 3005,
                       "end": 3010,
@@ -7418,6 +7499,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 3008,
                         "end": 3010,
@@ -7475,7 +7557,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 3033,
                       "end": 3038,
@@ -7492,6 +7574,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 3036,
                         "end": 3038,
@@ -7514,7 +7597,7 @@
                   },
                   "rightComparison": ">=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 3059,
                       "end": 3064,
@@ -7531,6 +7614,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 3062,
                         "end": 3064,
@@ -7588,7 +7672,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 3081,
                       "end": 3086,
@@ -7605,6 +7689,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 3084,
                         "end": 3086,
@@ -7627,7 +7712,7 @@
                   },
                   "rightComparison": ">",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 3093,
                       "end": 3098,
@@ -7644,6 +7729,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 3096,
                         "end": 3098,
@@ -7701,7 +7787,7 @@
                     "ctxt": 0
                   },
                   "left": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 3109,
                       "end": 3114,
@@ -7718,6 +7804,7 @@
                       "raw": "400"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 3112,
                         "end": 3114,
@@ -7740,7 +7827,7 @@
                   },
                   "rightComparison": ">=",
                   "right": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 3123,
                       "end": 3128,
@@ -7757,6 +7844,7 @@
                       "raw": "700"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 3126,
                         "end": 3128,
@@ -7849,7 +7937,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 3167,
                         "end": 3173,
@@ -7866,6 +7954,7 @@
                         "raw": "1024"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 3171,
                           "end": 3173,
@@ -8198,7 +8287,7 @@
                     },
                     "comparison": ">",
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 3319,
                         "end": 3325,
@@ -8215,6 +8304,7 @@
                         "raw": "1024"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 3323,
                           "end": 3325,
@@ -8365,7 +8455,7 @@
                     },
                     "comparison": ">",
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 3375,
                         "end": 3381,
@@ -8382,6 +8472,7 @@
                         "raw": "1024"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 3379,
                           "end": 3381,
@@ -8552,7 +8643,7 @@
                     },
                     "comparison": ">",
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 3435,
                         "end": 3441,
@@ -8569,6 +8660,7 @@
                         "raw": "1024"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 3439,
                           "end": 3441,
@@ -8739,7 +8831,7 @@
                     },
                     "comparison": ">",
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 3554,
                         "end": 3560,
@@ -8756,6 +8848,7 @@
                         "raw": "1024"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 3558,
                           "end": 3560,
@@ -8832,7 +8925,7 @@
                         "raw": "min-width"
                       },
                       "value": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 3591,
                           "end": 3596,
@@ -8849,6 +8942,7 @@
                           "raw": "800"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 3594,
                             "end": 3596,
@@ -8884,7 +8978,7 @@
                           "raw": "min-width"
                         },
                         "value": {
-                          "type": "UnitValue",
+                          "type": "Dimension",
                           "span": {
                             "start": 3614,
                             "end": 3619,
@@ -8901,6 +8995,7 @@
                             "raw": "800"
                           },
                           "unit": {
+                            "type": "Identifier",
                             "span": {
                               "start": 3617,
                               "end": 3619,
@@ -8939,7 +9034,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 3637,
                         "end": 3642,
@@ -8956,6 +9051,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 3640,
                           "end": 3642,
@@ -9024,7 +9120,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 3666,
                       "end": 3671,
@@ -9041,6 +9137,7 @@
                       "raw": "800"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 3669,
                         "end": 3671,
@@ -9084,7 +9181,7 @@
                           "raw": "min-width"
                         },
                         "value": {
-                          "type": "UnitValue",
+                          "type": "Dimension",
                           "span": {
                             "start": 3690,
                             "end": 3695,
@@ -9101,6 +9198,7 @@
                             "raw": "800"
                           },
                           "unit": {
+                            "type": "Identifier",
                             "span": {
                               "start": 3693,
                               "end": 3695,
@@ -9136,7 +9234,7 @@
                             "raw": "min-width"
                           },
                           "value": {
-                            "type": "UnitValue",
+                            "type": "Dimension",
                             "span": {
                               "start": 3712,
                               "end": 3717,
@@ -9153,6 +9251,7 @@
                               "raw": "800"
                             },
                             "unit": {
+                              "type": "Identifier",
                               "span": {
                                 "start": 3715,
                                 "end": 3717,

--- a/crates/swc_css_parser/tests/fixture/at-rule/media/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/media/output.json
@@ -9454,7 +9454,7 @@
                         "raw": "min-width"
                       },
                       "value": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 3803,
                           "end": 3808,
@@ -9471,6 +9471,7 @@
                           "raw": "800"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 3806,
                             "end": 3808,
@@ -9506,7 +9507,7 @@
                           "raw": "min-width"
                         },
                         "value": {
-                          "type": "UnitValue",
+                          "type": "Dimension",
                           "span": {
                             "start": 3826,
                             "end": 3831,
@@ -9523,6 +9524,7 @@
                             "raw": "800"
                           },
                           "unit": {
+                            "type": "Identifier",
                             "span": {
                               "start": 3829,
                               "end": 3831,
@@ -9561,7 +9563,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 3849,
                         "end": 3854,
@@ -9578,6 +9580,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 3852,
                           "end": 3854,
@@ -9646,7 +9649,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 3878,
                       "end": 3883,
@@ -9663,6 +9666,7 @@
                       "raw": "800"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 3881,
                         "end": 3883,
@@ -9706,7 +9710,7 @@
                           "raw": "min-width"
                         },
                         "value": {
-                          "type": "UnitValue",
+                          "type": "Dimension",
                           "span": {
                             "start": 3902,
                             "end": 3907,
@@ -9723,6 +9727,7 @@
                             "raw": "800"
                           },
                           "unit": {
+                            "type": "Identifier",
                             "span": {
                               "start": 3905,
                               "end": 3907,
@@ -9758,7 +9763,7 @@
                             "raw": "min-width"
                           },
                           "value": {
-                            "type": "UnitValue",
+                            "type": "Dimension",
                             "span": {
                               "start": 3924,
                               "end": 3929,
@@ -9775,6 +9780,7 @@
                               "raw": "800"
                             },
                             "unit": {
+                              "type": "Identifier",
                               "span": {
                                 "start": 3927,
                                 "end": 3929,

--- a/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
@@ -616,7 +616,7 @@ error: MediaFeatureValue
 10 | @media print and (min-resolution: 118dpcm) {}
    |                                   ^^^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:10:35
    |
 10 | @media print and (min-resolution: 118dpcm) {}
@@ -628,7 +628,7 @@ error: Number
 10 | @media print and (min-resolution: 118dpcm) {}
    |                                   ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:10:38
    |
 10 | @media print and (min-resolution: 118dpcm) {}
@@ -1582,7 +1582,7 @@ error: MediaFeatureValue
 25 | @media (min-width: 20px) {}
    |                    ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:25:20
    |
 25 | @media (min-width: 20px) {}
@@ -1594,7 +1594,7 @@ error: Number
 25 | @media (min-width: 20px) {}
    |                    ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:25:22
    |
 25 | @media (min-width: 20px) {}
@@ -1678,7 +1678,7 @@ error: MediaFeatureValue
 26 | @media(min-width: 20px){}
    |                   ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:26:19
    |
 26 | @media(min-width: 20px){}
@@ -1690,7 +1690,7 @@ error: Number
 26 | @media(min-width: 20px){}
    |                   ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:26:21
    |
 26 | @media(min-width: 20px){}
@@ -1774,7 +1774,7 @@ error: MediaFeatureValue
 27 | @media   (   min-width   :   20px   )   {}
    |                              ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:27:30
    |
 27 | @media   (   min-width   :   20px   )   {}
@@ -1786,7 +1786,7 @@ error: Number
 27 | @media   (   min-width   :   20px   )   {}
    |                              ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:27:32
    |
 27 | @media   (   min-width   :   20px   )   {}
@@ -2104,7 +2104,7 @@ error: MediaFeatureValue
 30 | @media (grid) and (max-width: 15em) {}
    |                               ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:30:31
    |
 30 | @media (grid) and (max-width: 15em) {}
@@ -2116,7 +2116,7 @@ error: Number
 30 | @media (grid) and (max-width: 15em) {}
    |                               ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:30:33
    |
 30 | @media (grid) and (max-width: 15em) {}
@@ -2272,7 +2272,7 @@ error: MediaFeatureValue
 33 | @media (min-width: 20em) and (min-width: 20em) {}
    |                    ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:33:20
    |
 33 | @media (min-width: 20em) and (min-width: 20em) {}
@@ -2284,7 +2284,7 @@ error: Number
 33 | @media (min-width: 20em) and (min-width: 20em) {}
    |                    ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:33:22
    |
 33 | @media (min-width: 20em) and (min-width: 20em) {}
@@ -2338,7 +2338,7 @@ error: MediaFeatureValue
 33 | @media (min-width: 20em) and (min-width: 20em) {}
    |                                          ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:33:42
    |
 33 | @media (min-width: 20em) and (min-width: 20em) {}
@@ -2350,7 +2350,7 @@ error: Number
 33 | @media (min-width: 20em) and (min-width: 20em) {}
    |                                          ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:33:44
    |
 33 | @media (min-width: 20em) and (min-width: 20em) {}
@@ -2434,7 +2434,7 @@ error: MediaFeatureValue
 34 | @media   (min-width   :   20em   )   and   (   min-width   :   20em   )   {}
    |                           ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:34:27
    |
 34 | @media   (min-width   :   20em   )   and   (   min-width   :   20em   )   {}
@@ -2446,7 +2446,7 @@ error: Number
 34 | @media   (min-width   :   20em   )   and   (   min-width   :   20em   )   {}
    |                           ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:34:29
    |
 34 | @media   (min-width   :   20em   )   and   (   min-width   :   20em   )   {}
@@ -2500,7 +2500,7 @@ error: MediaFeatureValue
 34 | @media   (min-width   :   20em   )   and   (   min-width   :   20em   )   {}
    |                                                                ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:34:64
    |
 34 | @media   (min-width   :   20em   )   and   (   min-width   :   20em   )   {}
@@ -2512,7 +2512,7 @@ error: Number
 34 | @media   (min-width   :   20em   )   and   (   min-width   :   20em   )   {}
    |                                                                ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:34:66
    |
 34 | @media   (min-width   :   20em   )   and   (   min-width   :   20em   )   {}
@@ -2596,7 +2596,7 @@ error: MediaFeatureValue
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
    |                    ^^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:35:20
    |
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
@@ -2608,7 +2608,7 @@ error: Number
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
    |                    ^^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:35:24
    |
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
@@ -2662,7 +2662,7 @@ error: MediaFeatureValue
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
    |                                            ^^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:35:44
    |
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
@@ -2674,7 +2674,7 @@ error: Number
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
    |                                            ^^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:35:48
    |
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
@@ -2728,7 +2728,7 @@ error: MediaFeatureValue
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
    |                                                                    ^^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:35:68
    |
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
@@ -2740,7 +2740,7 @@ error: Number
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
    |                                                                    ^^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:35:72
    |
 35 | @media (min-width: 1024px) and (min-width: 1024px) and (min-width: 1024px) {}
@@ -2824,7 +2824,7 @@ error: MediaFeatureValue
 36 | @media(min-width:20em)and (min-width: 20em){}
    |                  ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:36:18
    |
 36 | @media(min-width:20em)and (min-width: 20em){}
@@ -2836,7 +2836,7 @@ error: Number
 36 | @media(min-width:20em)and (min-width: 20em){}
    |                  ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:36:20
    |
 36 | @media(min-width:20em)and (min-width: 20em){}
@@ -2890,7 +2890,7 @@ error: MediaFeatureValue
 36 | @media(min-width:20em)and (min-width: 20em){}
    |                                       ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:36:39
    |
 36 | @media(min-width:20em)and (min-width: 20em){}
@@ -2902,7 +2902,7 @@ error: Number
 36 | @media(min-width:20em)and (min-width: 20em){}
    |                                       ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:36:41
    |
 36 | @media(min-width:20em)and (min-width: 20em){}
@@ -2986,7 +2986,7 @@ error: MediaFeatureValue
 37 | @media(min-width:20em)and (min-width:20em){}
    |                  ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:37:18
    |
 37 | @media(min-width:20em)and (min-width:20em){}
@@ -2998,7 +2998,7 @@ error: Number
 37 | @media(min-width:20em)and (min-width:20em){}
    |                  ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:37:20
    |
 37 | @media(min-width:20em)and (min-width:20em){}
@@ -3052,7 +3052,7 @@ error: MediaFeatureValue
 37 | @media(min-width:20em)and (min-width:20em){}
    |                                      ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:37:38
    |
 37 | @media(min-width:20em)and (min-width:20em){}
@@ -3064,7 +3064,7 @@ error: Number
 37 | @media(min-width:20em)and (min-width:20em){}
    |                                      ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:37:40
    |
 37 | @media(min-width:20em)and (min-width:20em){}
@@ -3562,7 +3562,7 @@ error: MediaFeatureValue
 43 | @media (height < 600px) {}
    |                  ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:43:18
    |
 43 | @media (height < 600px) {}
@@ -3574,7 +3574,7 @@ error: Number
 43 | @media (height < 600px) {}
    |                  ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:43:21
    |
 43 | @media (height < 600px) {}
@@ -3658,7 +3658,7 @@ error: MediaFeatureValue
 44 | @media (height <= 600px) {}
    |                   ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:44:19
    |
 44 | @media (height <= 600px) {}
@@ -3670,7 +3670,7 @@ error: Number
 44 | @media (height <= 600px) {}
    |                   ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:44:22
    |
 44 | @media (height <= 600px) {}
@@ -3754,7 +3754,7 @@ error: MediaFeatureValue
 45 | @media (height > 600px) {}
    |                  ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:45:18
    |
 45 | @media (height > 600px) {}
@@ -3766,7 +3766,7 @@ error: Number
 45 | @media (height > 600px) {}
    |                  ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:45:21
    |
 45 | @media (height > 600px) {}
@@ -3850,7 +3850,7 @@ error: MediaFeatureValue
 46 | @media (height >= 600px) {}
    |                   ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:46:19
    |
 46 | @media (height >= 600px) {}
@@ -3862,7 +3862,7 @@ error: Number
 46 | @media (height >= 600px) {}
    |                   ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:46:22
    |
 46 | @media (height >= 600px) {}
@@ -3946,7 +3946,7 @@ error: MediaFeatureValue
 47 | @media (height = 600px) {}
    |                  ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:47:18
    |
 47 | @media (height = 600px) {}
@@ -3958,7 +3958,7 @@ error: Number
 47 | @media (height = 600px) {}
    |                  ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:47:21
    |
 47 | @media (height = 600px) {}
@@ -4042,7 +4042,7 @@ error: MediaFeatureValue
 48 | @media   (   height   <   600px   )   {}
    |                           ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:48:27
    |
 48 | @media   (   height   <   600px   )   {}
@@ -4054,7 +4054,7 @@ error: Number
 48 | @media   (   height   <   600px   )   {}
    |                           ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:48:30
    |
 48 | @media   (   height   <   600px   )   {}
@@ -4138,7 +4138,7 @@ error: MediaFeatureValue
 49 | @media   (   height   <=   600px   )   {}
    |                            ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:49:28
    |
 49 | @media   (   height   <=   600px   )   {}
@@ -4150,7 +4150,7 @@ error: Number
 49 | @media   (   height   <=   600px   )   {}
    |                            ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:49:31
    |
 49 | @media   (   height   <=   600px   )   {}
@@ -4234,7 +4234,7 @@ error: MediaFeatureValue
 50 | @media   (   height   >   600px   )   {}
    |                           ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:50:27
    |
 50 | @media   (   height   >   600px   )   {}
@@ -4246,7 +4246,7 @@ error: Number
 50 | @media   (   height   >   600px   )   {}
    |                           ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:50:30
    |
 50 | @media   (   height   >   600px   )   {}
@@ -4330,7 +4330,7 @@ error: MediaFeatureValue
 51 | @media   (   height   >=   600px   )   {}
    |                            ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:51:28
    |
 51 | @media   (   height   >=   600px   )   {}
@@ -4342,7 +4342,7 @@ error: Number
 51 | @media   (   height   >=   600px   )   {}
    |                            ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:51:31
    |
 51 | @media   (   height   >=   600px   )   {}
@@ -4426,7 +4426,7 @@ error: MediaFeatureValue
 52 | @media   (   height   =   600px   )   {}
    |                           ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:52:27
    |
 52 | @media   (   height   =   600px   )   {}
@@ -4438,7 +4438,7 @@ error: Number
 52 | @media   (   height   =   600px   )   {}
    |                           ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:52:30
    |
 52 | @media   (   height   =   600px   )   {}
@@ -4522,7 +4522,7 @@ error: MediaFeatureValue
 53 | @media(height=600px){}
    |               ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:53:15
    |
 53 | @media(height=600px){}
@@ -4534,7 +4534,7 @@ error: Number
 53 | @media(height=600px){}
    |               ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:53:18
    |
 53 | @media(height=600px){}
@@ -4618,7 +4618,7 @@ error: MediaFeatureValue
 54 | @media(height>=600px) {}
    |                ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:54:16
    |
 54 | @media(height>=600px) {}
@@ -4630,7 +4630,7 @@ error: Number
 54 | @media(height>=600px) {}
    |                ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:54:19
    |
 54 | @media(height>=600px) {}
@@ -4702,7 +4702,7 @@ error: MediaFeatureValue
 56 | @media (600px < height) {}
    |         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:56:9
    |
 56 | @media (600px < height) {}
@@ -4714,7 +4714,7 @@ error: Number
 56 | @media (600px < height) {}
    |         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:56:12
    |
 56 | @media (600px < height) {}
@@ -4798,7 +4798,7 @@ error: MediaFeatureValue
 57 | @media (600px <= height) {}
    |         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:57:9
    |
 57 | @media (600px <= height) {}
@@ -4810,7 +4810,7 @@ error: Number
 57 | @media (600px <= height) {}
    |         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:57:12
    |
 57 | @media (600px <= height) {}
@@ -4894,7 +4894,7 @@ error: MediaFeatureValue
 58 | @media (600px > height) {}
    |         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:58:9
    |
 58 | @media (600px > height) {}
@@ -4906,7 +4906,7 @@ error: Number
 58 | @media (600px > height) {}
    |         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:58:12
    |
 58 | @media (600px > height) {}
@@ -4990,7 +4990,7 @@ error: MediaFeatureValue
 59 | @media (600px >= height) {}
    |         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:59:9
    |
 59 | @media (600px >= height) {}
@@ -5002,7 +5002,7 @@ error: Number
 59 | @media (600px >= height) {}
    |         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:59:12
    |
 59 | @media (600px >= height) {}
@@ -5086,7 +5086,7 @@ error: MediaFeatureValue
 60 | @media (600px = height) {}
    |         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:60:9
    |
 60 | @media (600px = height) {}
@@ -5098,7 +5098,7 @@ error: Number
 60 | @media (600px = height) {}
    |         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:60:12
    |
 60 | @media (600px = height) {}
@@ -5182,7 +5182,7 @@ error: MediaFeatureValue
 61 | @media   (   600px   <   height   )   {}
    |              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:61:14
    |
 61 | @media   (   600px   <   height   )   {}
@@ -5194,7 +5194,7 @@ error: Number
 61 | @media   (   600px   <   height   )   {}
    |              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:61:17
    |
 61 | @media   (   600px   <   height   )   {}
@@ -5278,7 +5278,7 @@ error: MediaFeatureValue
 62 | @media   (   600px   <=   height   )   {}
    |              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:62:14
    |
 62 | @media   (   600px   <=   height   )   {}
@@ -5290,7 +5290,7 @@ error: Number
 62 | @media   (   600px   <=   height   )   {}
    |              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:62:17
    |
 62 | @media   (   600px   <=   height   )   {}
@@ -5374,7 +5374,7 @@ error: MediaFeatureValue
 63 | @media   (   600px   >   height   )   {}
    |              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:63:14
    |
 63 | @media   (   600px   >   height   )   {}
@@ -5386,7 +5386,7 @@ error: Number
 63 | @media   (   600px   >   height   )   {}
    |              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:63:17
    |
 63 | @media   (   600px   >   height   )   {}
@@ -5470,7 +5470,7 @@ error: MediaFeatureValue
 64 | @media   (   600px   >=   height   )   {}
    |              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:64:14
    |
 64 | @media   (   600px   >=   height   )   {}
@@ -5482,7 +5482,7 @@ error: Number
 64 | @media   (   600px   >=   height   )   {}
    |              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:64:17
    |
 64 | @media   (   600px   >=   height   )   {}
@@ -5566,7 +5566,7 @@ error: MediaFeatureValue
 65 | @media   (   600px   =   height   )   {}
    |              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:65:14
    |
 65 | @media   (   600px   =   height   )   {}
@@ -5578,7 +5578,7 @@ error: Number
 65 | @media   (   600px   =   height   )   {}
    |              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:65:17
    |
 65 | @media   (   600px   =   height   )   {}
@@ -5662,7 +5662,7 @@ error: MediaFeatureValue
 66 | @media(600px=height) {}
    |        ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:66:8
    |
 66 | @media(600px=height) {}
@@ -5674,7 +5674,7 @@ error: Number
 66 | @media(600px=height) {}
    |        ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:66:11
    |
 66 | @media(600px=height) {}
@@ -5758,7 +5758,7 @@ error: MediaFeatureValue
 67 | @media(600px>=height) {}
    |        ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:67:8
    |
 67 | @media(600px>=height) {}
@@ -5770,7 +5770,7 @@ error: Number
 67 | @media(600px>=height) {}
    |        ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:67:11
    |
 67 | @media(600px>=height) {}
@@ -5854,7 +5854,7 @@ error: MediaFeatureValue
 69 | @media (400px < width < 700px) {}
    |         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:69:9
    |
 69 | @media (400px < width < 700px) {}
@@ -5866,7 +5866,7 @@ error: Number
 69 | @media (400px < width < 700px) {}
    |         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:69:12
    |
 69 | @media (400px < width < 700px) {}
@@ -5890,7 +5890,7 @@ error: MediaFeatureValue
 69 | @media (400px < width < 700px) {}
    |                         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:69:25
    |
 69 | @media (400px < width < 700px) {}
@@ -5902,7 +5902,7 @@ error: Number
 69 | @media (400px < width < 700px) {}
    |                         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:69:28
    |
 69 | @media (400px < width < 700px) {}
@@ -5974,7 +5974,7 @@ error: MediaFeatureValue
 70 | @media (400px <= width < 700px) {}
    |         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:70:9
    |
 70 | @media (400px <= width < 700px) {}
@@ -5986,7 +5986,7 @@ error: Number
 70 | @media (400px <= width < 700px) {}
    |         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:70:12
    |
 70 | @media (400px <= width < 700px) {}
@@ -6010,7 +6010,7 @@ error: MediaFeatureValue
 70 | @media (400px <= width < 700px) {}
    |                          ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:70:26
    |
 70 | @media (400px <= width < 700px) {}
@@ -6022,7 +6022,7 @@ error: Number
 70 | @media (400px <= width < 700px) {}
    |                          ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:70:29
    |
 70 | @media (400px <= width < 700px) {}
@@ -6094,7 +6094,7 @@ error: MediaFeatureValue
 71 | @media (400px < width <= 700px) {}
    |         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:71:9
    |
 71 | @media (400px < width <= 700px) {}
@@ -6106,7 +6106,7 @@ error: Number
 71 | @media (400px < width <= 700px) {}
    |         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:71:12
    |
 71 | @media (400px < width <= 700px) {}
@@ -6130,7 +6130,7 @@ error: MediaFeatureValue
 71 | @media (400px < width <= 700px) {}
    |                          ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:71:26
    |
 71 | @media (400px < width <= 700px) {}
@@ -6142,7 +6142,7 @@ error: Number
 71 | @media (400px < width <= 700px) {}
    |                          ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:71:29
    |
 71 | @media (400px < width <= 700px) {}
@@ -6214,7 +6214,7 @@ error: MediaFeatureValue
 72 | @media (400px <= width <= 700px) {}
    |         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:72:9
    |
 72 | @media (400px <= width <= 700px) {}
@@ -6226,7 +6226,7 @@ error: Number
 72 | @media (400px <= width <= 700px) {}
    |         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:72:12
    |
 72 | @media (400px <= width <= 700px) {}
@@ -6250,7 +6250,7 @@ error: MediaFeatureValue
 72 | @media (400px <= width <= 700px) {}
    |                           ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:72:27
    |
 72 | @media (400px <= width <= 700px) {}
@@ -6262,7 +6262,7 @@ error: Number
 72 | @media (400px <= width <= 700px) {}
    |                           ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:72:30
    |
 72 | @media (400px <= width <= 700px) {}
@@ -6334,7 +6334,7 @@ error: MediaFeatureValue
 73 | @media(400px<width<700px){}
    |        ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:73:8
    |
 73 | @media(400px<width<700px){}
@@ -6346,7 +6346,7 @@ error: Number
 73 | @media(400px<width<700px){}
    |        ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:73:11
    |
 73 | @media(400px<width<700px){}
@@ -6370,7 +6370,7 @@ error: MediaFeatureValue
 73 | @media(400px<width<700px){}
    |                    ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:73:20
    |
 73 | @media(400px<width<700px){}
@@ -6382,7 +6382,7 @@ error: Number
 73 | @media(400px<width<700px){}
    |                    ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:73:23
    |
 73 | @media(400px<width<700px){}
@@ -6454,7 +6454,7 @@ error: MediaFeatureValue
 74 | @media(400px<=width<=700px){}
    |        ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:74:8
    |
 74 | @media(400px<=width<=700px){}
@@ -6466,7 +6466,7 @@ error: Number
 74 | @media(400px<=width<=700px){}
    |        ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:74:11
    |
 74 | @media(400px<=width<=700px){}
@@ -6490,7 +6490,7 @@ error: MediaFeatureValue
 74 | @media(400px<=width<=700px){}
    |                      ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:74:22
    |
 74 | @media(400px<=width<=700px){}
@@ -6502,7 +6502,7 @@ error: Number
 74 | @media(400px<=width<=700px){}
    |                      ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:74:25
    |
 74 | @media(400px<=width<=700px){}
@@ -6574,7 +6574,7 @@ error: MediaFeatureValue
 75 | @media   (   400px   <   width   <   700px   )   {}
    |              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:75:14
    |
 75 | @media   (   400px   <   width   <   700px   )   {}
@@ -6586,7 +6586,7 @@ error: Number
 75 | @media   (   400px   <   width   <   700px   )   {}
    |              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:75:17
    |
 75 | @media   (   400px   <   width   <   700px   )   {}
@@ -6610,7 +6610,7 @@ error: MediaFeatureValue
 75 | @media   (   400px   <   width   <   700px   )   {}
    |                                      ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:75:38
    |
 75 | @media   (   400px   <   width   <   700px   )   {}
@@ -6622,7 +6622,7 @@ error: Number
 75 | @media   (   400px   <   width   <   700px   )   {}
    |                                      ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:75:41
    |
 75 | @media   (   400px   <   width   <   700px   )   {}
@@ -6694,7 +6694,7 @@ error: MediaFeatureValue
 76 | @media   (   400px   <=   width   <   700px   )   {}
    |              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:76:14
    |
 76 | @media   (   400px   <=   width   <   700px   )   {}
@@ -6706,7 +6706,7 @@ error: Number
 76 | @media   (   400px   <=   width   <   700px   )   {}
    |              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:76:17
    |
 76 | @media   (   400px   <=   width   <   700px   )   {}
@@ -6730,7 +6730,7 @@ error: MediaFeatureValue
 76 | @media   (   400px   <=   width   <   700px   )   {}
    |                                       ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:76:39
    |
 76 | @media   (   400px   <=   width   <   700px   )   {}
@@ -6742,7 +6742,7 @@ error: Number
 76 | @media   (   400px   <=   width   <   700px   )   {}
    |                                       ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:76:42
    |
 76 | @media   (   400px   <=   width   <   700px   )   {}
@@ -6814,7 +6814,7 @@ error: MediaFeatureValue
 77 | @media   (   400px   <   width   <=   700px   )   {}
    |              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:77:14
    |
 77 | @media   (   400px   <   width   <=   700px   )   {}
@@ -6826,7 +6826,7 @@ error: Number
 77 | @media   (   400px   <   width   <=   700px   )   {}
    |              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:77:17
    |
 77 | @media   (   400px   <   width   <=   700px   )   {}
@@ -6850,7 +6850,7 @@ error: MediaFeatureValue
 77 | @media   (   400px   <   width   <=   700px   )   {}
    |                                       ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:77:39
    |
 77 | @media   (   400px   <   width   <=   700px   )   {}
@@ -6862,7 +6862,7 @@ error: Number
 77 | @media   (   400px   <   width   <=   700px   )   {}
    |                                       ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:77:42
    |
 77 | @media   (   400px   <   width   <=   700px   )   {}
@@ -6934,7 +6934,7 @@ error: MediaFeatureValue
 78 | @media   (   400px   <=   width   <=   700px   )   {}
    |              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:78:14
    |
 78 | @media   (   400px   <=   width   <=   700px   )   {}
@@ -6946,7 +6946,7 @@ error: Number
 78 | @media   (   400px   <=   width   <=   700px   )   {}
    |              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:78:17
    |
 78 | @media   (   400px   <=   width   <=   700px   )   {}
@@ -6970,7 +6970,7 @@ error: MediaFeatureValue
 78 | @media   (   400px   <=   width   <=   700px   )   {}
    |                                        ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:78:40
    |
 78 | @media   (   400px   <=   width   <=   700px   )   {}
@@ -6982,7 +6982,7 @@ error: Number
 78 | @media   (   400px   <=   width   <=   700px   )   {}
    |                                        ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:78:43
    |
 78 | @media   (   400px   <=   width   <=   700px   )   {}
@@ -7054,7 +7054,7 @@ error: MediaFeatureValue
 79 | @media(400px<width<700px){}
    |        ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:79:8
    |
 79 | @media(400px<width<700px){}
@@ -7066,7 +7066,7 @@ error: Number
 79 | @media(400px<width<700px){}
    |        ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:79:11
    |
 79 | @media(400px<width<700px){}
@@ -7090,7 +7090,7 @@ error: MediaFeatureValue
 79 | @media(400px<width<700px){}
    |                    ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:79:20
    |
 79 | @media(400px<width<700px){}
@@ -7102,7 +7102,7 @@ error: Number
 79 | @media(400px<width<700px){}
    |                    ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:79:23
    |
 79 | @media(400px<width<700px){}
@@ -7174,7 +7174,7 @@ error: MediaFeatureValue
 80 | @media(400px<=width<=700px){}
    |        ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:80:8
    |
 80 | @media(400px<=width<=700px){}
@@ -7186,7 +7186,7 @@ error: Number
 80 | @media(400px<=width<=700px){}
    |        ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:80:11
    |
 80 | @media(400px<=width<=700px){}
@@ -7210,7 +7210,7 @@ error: MediaFeatureValue
 80 | @media(400px<=width<=700px){}
    |                      ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:80:22
    |
 80 | @media(400px<=width<=700px){}
@@ -7222,7 +7222,7 @@ error: Number
 80 | @media(400px<=width<=700px){}
    |                      ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:80:25
    |
 80 | @media(400px<=width<=700px){}
@@ -7294,7 +7294,7 @@ error: MediaFeatureValue
 82 | @media (400px > width > 700px) {}
    |         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:82:9
    |
 82 | @media (400px > width > 700px) {}
@@ -7306,7 +7306,7 @@ error: Number
 82 | @media (400px > width > 700px) {}
    |         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:82:12
    |
 82 | @media (400px > width > 700px) {}
@@ -7330,7 +7330,7 @@ error: MediaFeatureValue
 82 | @media (400px > width > 700px) {}
    |                         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:82:25
    |
 82 | @media (400px > width > 700px) {}
@@ -7342,7 +7342,7 @@ error: Number
 82 | @media (400px > width > 700px) {}
    |                         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:82:28
    |
 82 | @media (400px > width > 700px) {}
@@ -7414,7 +7414,7 @@ error: MediaFeatureValue
 83 | @media (400px >= width > 700px) {}
    |         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:83:9
    |
 83 | @media (400px >= width > 700px) {}
@@ -7426,7 +7426,7 @@ error: Number
 83 | @media (400px >= width > 700px) {}
    |         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:83:12
    |
 83 | @media (400px >= width > 700px) {}
@@ -7450,7 +7450,7 @@ error: MediaFeatureValue
 83 | @media (400px >= width > 700px) {}
    |                          ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:83:26
    |
 83 | @media (400px >= width > 700px) {}
@@ -7462,7 +7462,7 @@ error: Number
 83 | @media (400px >= width > 700px) {}
    |                          ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:83:29
    |
 83 | @media (400px >= width > 700px) {}
@@ -7534,7 +7534,7 @@ error: MediaFeatureValue
 84 | @media (400px > width >= 700px) {}
    |         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:84:9
    |
 84 | @media (400px > width >= 700px) {}
@@ -7546,7 +7546,7 @@ error: Number
 84 | @media (400px > width >= 700px) {}
    |         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:84:12
    |
 84 | @media (400px > width >= 700px) {}
@@ -7570,7 +7570,7 @@ error: MediaFeatureValue
 84 | @media (400px > width >= 700px) {}
    |                          ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:84:26
    |
 84 | @media (400px > width >= 700px) {}
@@ -7582,7 +7582,7 @@ error: Number
 84 | @media (400px > width >= 700px) {}
    |                          ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:84:29
    |
 84 | @media (400px > width >= 700px) {}
@@ -7654,7 +7654,7 @@ error: MediaFeatureValue
 85 | @media (400px >= width >= 700px) {}
    |         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:85:9
    |
 85 | @media (400px >= width >= 700px) {}
@@ -7666,7 +7666,7 @@ error: Number
 85 | @media (400px >= width >= 700px) {}
    |         ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:85:12
    |
 85 | @media (400px >= width >= 700px) {}
@@ -7690,7 +7690,7 @@ error: MediaFeatureValue
 85 | @media (400px >= width >= 700px) {}
    |                           ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:85:27
    |
 85 | @media (400px >= width >= 700px) {}
@@ -7702,7 +7702,7 @@ error: Number
 85 | @media (400px >= width >= 700px) {}
    |                           ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:85:30
    |
 85 | @media (400px >= width >= 700px) {}
@@ -7774,7 +7774,7 @@ error: MediaFeatureValue
 86 | @media(400px>width>700px){}
    |        ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:86:8
    |
 86 | @media(400px>width>700px){}
@@ -7786,7 +7786,7 @@ error: Number
 86 | @media(400px>width>700px){}
    |        ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:86:11
    |
 86 | @media(400px>width>700px){}
@@ -7810,7 +7810,7 @@ error: MediaFeatureValue
 86 | @media(400px>width>700px){}
    |                    ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:86:20
    |
 86 | @media(400px>width>700px){}
@@ -7822,7 +7822,7 @@ error: Number
 86 | @media(400px>width>700px){}
    |                    ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:86:23
    |
 86 | @media(400px>width>700px){}
@@ -7894,7 +7894,7 @@ error: MediaFeatureValue
 87 | @media(400px>=width>=700px) {}
    |        ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:87:8
    |
 87 | @media(400px>=width>=700px) {}
@@ -7906,7 +7906,7 @@ error: Number
 87 | @media(400px>=width>=700px) {}
    |        ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:87:11
    |
 87 | @media(400px>=width>=700px) {}
@@ -7930,7 +7930,7 @@ error: MediaFeatureValue
 87 | @media(400px>=width>=700px) {}
    |                      ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:87:22
    |
 87 | @media(400px>=width>=700px) {}
@@ -7942,7 +7942,7 @@ error: Number
 87 | @media(400px>=width>=700px) {}
    |                      ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:87:25
    |
 87 | @media(400px>=width>=700px) {}
@@ -8014,7 +8014,7 @@ error: MediaFeatureValue
 88 | @media   (   400px   >   width   >   700px   )   {}
    |              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:88:14
    |
 88 | @media   (   400px   >   width   >   700px   )   {}
@@ -8026,7 +8026,7 @@ error: Number
 88 | @media   (   400px   >   width   >   700px   )   {}
    |              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:88:17
    |
 88 | @media   (   400px   >   width   >   700px   )   {}
@@ -8050,7 +8050,7 @@ error: MediaFeatureValue
 88 | @media   (   400px   >   width   >   700px   )   {}
    |                                      ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:88:38
    |
 88 | @media   (   400px   >   width   >   700px   )   {}
@@ -8062,7 +8062,7 @@ error: Number
 88 | @media   (   400px   >   width   >   700px   )   {}
    |                                      ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:88:41
    |
 88 | @media   (   400px   >   width   >   700px   )   {}
@@ -8134,7 +8134,7 @@ error: MediaFeatureValue
 89 | @media   (   400px   >=   width   >   700px   )   {}
    |              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:89:14
    |
 89 | @media   (   400px   >=   width   >   700px   )   {}
@@ -8146,7 +8146,7 @@ error: Number
 89 | @media   (   400px   >=   width   >   700px   )   {}
    |              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:89:17
    |
 89 | @media   (   400px   >=   width   >   700px   )   {}
@@ -8170,7 +8170,7 @@ error: MediaFeatureValue
 89 | @media   (   400px   >=   width   >   700px   )   {}
    |                                       ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:89:39
    |
 89 | @media   (   400px   >=   width   >   700px   )   {}
@@ -8182,7 +8182,7 @@ error: Number
 89 | @media   (   400px   >=   width   >   700px   )   {}
    |                                       ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:89:42
    |
 89 | @media   (   400px   >=   width   >   700px   )   {}
@@ -8254,7 +8254,7 @@ error: MediaFeatureValue
 90 | @media   (   400px   >   width   >=   700px   )   {}
    |              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:90:14
    |
 90 | @media   (   400px   >   width   >=   700px   )   {}
@@ -8266,7 +8266,7 @@ error: Number
 90 | @media   (   400px   >   width   >=   700px   )   {}
    |              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:90:17
    |
 90 | @media   (   400px   >   width   >=   700px   )   {}
@@ -8290,7 +8290,7 @@ error: MediaFeatureValue
 90 | @media   (   400px   >   width   >=   700px   )   {}
    |                                       ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:90:39
    |
 90 | @media   (   400px   >   width   >=   700px   )   {}
@@ -8302,7 +8302,7 @@ error: Number
 90 | @media   (   400px   >   width   >=   700px   )   {}
    |                                       ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:90:42
    |
 90 | @media   (   400px   >   width   >=   700px   )   {}
@@ -8374,7 +8374,7 @@ error: MediaFeatureValue
 91 | @media   (   400px   >=   width   >=   700px   )   {}
    |              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:91:14
    |
 91 | @media   (   400px   >=   width   >=   700px   )   {}
@@ -8386,7 +8386,7 @@ error: Number
 91 | @media   (   400px   >=   width   >=   700px   )   {}
    |              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:91:17
    |
 91 | @media   (   400px   >=   width   >=   700px   )   {}
@@ -8410,7 +8410,7 @@ error: MediaFeatureValue
 91 | @media   (   400px   >=   width   >=   700px   )   {}
    |                                        ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:91:40
    |
 91 | @media   (   400px   >=   width   >=   700px   )   {}
@@ -8422,7 +8422,7 @@ error: Number
 91 | @media   (   400px   >=   width   >=   700px   )   {}
    |                                        ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:91:43
    |
 91 | @media   (   400px   >=   width   >=   700px   )   {}
@@ -8494,7 +8494,7 @@ error: MediaFeatureValue
 92 | @media(400px>width>700px){}
    |        ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:92:8
    |
 92 | @media(400px>width>700px){}
@@ -8506,7 +8506,7 @@ error: Number
 92 | @media(400px>width>700px){}
    |        ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:92:11
    |
 92 | @media(400px>width>700px){}
@@ -8530,7 +8530,7 @@ error: MediaFeatureValue
 92 | @media(400px>width>700px){}
    |                    ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:92:20
    |
 92 | @media(400px>width>700px){}
@@ -8542,7 +8542,7 @@ error: Number
 92 | @media(400px>width>700px){}
    |                    ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:92:23
    |
 92 | @media(400px>width>700px){}
@@ -8614,7 +8614,7 @@ error: MediaFeatureValue
 93 | @media(400px>=width>=700px){}
    |        ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:93:8
    |
 93 | @media(400px>=width>=700px){}
@@ -8626,7 +8626,7 @@ error: Number
 93 | @media(400px>=width>=700px){}
    |        ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:93:11
    |
 93 | @media(400px>=width>=700px){}
@@ -8650,7 +8650,7 @@ error: MediaFeatureValue
 93 | @media(400px>=width>=700px){}
    |                      ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:93:22
    |
 93 | @media(400px>=width>=700px){}
@@ -8662,7 +8662,7 @@ error: Number
 93 | @media(400px>=width>=700px){}
    |                      ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:93:25
    |
 93 | @media(400px>=width>=700px){}
@@ -8788,7 +8788,7 @@ error: MediaFeatureValue
 95 | @media (--modern) and (min-width: 1024px) {}
    |                                   ^^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:95:35
    |
 95 | @media (--modern) and (min-width: 1024px) {}
@@ -8800,7 +8800,7 @@ error: Number
 95 | @media (--modern) and (min-width: 1024px) {}
    |                                   ^^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:95:39
    |
 95 | @media (--modern) and (min-width: 1024px) {}
@@ -9250,7 +9250,7 @@ error: MediaFeatureValue
 99 | @media ((color) or (hover)) and (width > 1024px) {}
    |                                          ^^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/media/input.css:99:42
    |
 99 | @media ((color) or (hover)) and (width > 1024px) {}
@@ -9262,7 +9262,7 @@ error: Number
 99 | @media ((color) or (hover)) and (width > 1024px) {}
    |                                          ^^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/media/input.css:99:46
    |
 99 | @media ((color) or (hover)) and (width > 1024px) {}
@@ -9466,7 +9466,7 @@ error: MediaFeatureValue
 100 | @media (((color)) or ((hover))) and (width > 1024px) {}
     |                                              ^^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:100:46
     |
 100 | @media (((color)) or ((hover))) and (width > 1024px) {}
@@ -9478,7 +9478,7 @@ error: Number
 100 | @media (((color)) or ((hover))) and (width > 1024px) {}
     |                                              ^^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:100:50
     |
 100 | @media (((color)) or ((hover))) and (width > 1024px) {}
@@ -9718,7 +9718,7 @@ error: MediaFeatureValue
 101 | @media (((((color)) or ((hover))))) and (width > 1024px) {}
     |                                                  ^^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:101:50
     |
 101 | @media (((((color)) or ((hover))))) and (width > 1024px) {}
@@ -9730,7 +9730,7 @@ error: Number
 101 | @media (((((color)) or ((hover))))) and (width > 1024px) {}
     |                                                  ^^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:101:54
     |
 101 | @media (((((color)) or ((hover))))) and (width > 1024px) {}
@@ -9970,7 +9970,7 @@ error: MediaFeatureValue
 102 | @media   (   (   (   (   (   color   )   )   or   (   (   hover   )   )   )   )   )   and   (   width   >   1024px   )   {}
     |                                                                                                             ^^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:102:109
     |
 102 | @media   (   (   (   (   (   color   )   )   or   (   (   hover   )   )   )   )   )   and   (   width   >   1024px   )   {}
@@ -9982,7 +9982,7 @@ error: Number
 102 | @media   (   (   (   (   (   color   )   )   or   (   (   hover   )   )   )   )   )   and   (   width   >   1024px   )   {}
     |                                                                                                             ^^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:102:113
     |
 102 | @media   (   (   (   (   (   color   )   )   or   (   (   hover   )   )   )   )   )   and   (   width   >   1024px   )   {}
@@ -10084,7 +10084,7 @@ error: MediaFeatureValue
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
     |                     ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:104:21
     |
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -10096,7 +10096,7 @@ error: Number
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
     |                     ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:104:24
     |
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -10150,7 +10150,7 @@ error: MediaFeatureValue
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
     |                                            ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:104:44
     |
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -10162,7 +10162,7 @@ error: Number
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
     |                                            ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:104:47
     |
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -10216,7 +10216,7 @@ error: MediaFeatureValue
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
     |                                                                   ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:104:67
     |
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -10228,7 +10228,7 @@ error: Number
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
     |                                                                   ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:104:70
     |
 104 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -10312,7 +10312,7 @@ error: MediaFeatureValue
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
     |                    ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:105:20
     |
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -10324,7 +10324,7 @@ error: Number
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
     |                    ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:105:23
     |
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -10396,7 +10396,7 @@ error: MediaFeatureValue
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
     |                                            ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:105:44
     |
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -10408,7 +10408,7 @@ error: Number
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
     |                                            ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:105:47
     |
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -10462,7 +10462,7 @@ error: MediaFeatureValue
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
     |                                                                  ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:105:66
     |
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -10474,7 +10474,7 @@ error: Number
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
     |                                                                  ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:105:69
     |
 105 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}

--- a/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
@@ -10702,7 +10702,7 @@ error: MediaFeatureValue
 109 | @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
     |                     ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:109:21
     |
 109 | @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
@@ -10714,7 +10714,7 @@ error: Number
 109 | @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
     |                     ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:109:24
     |
 109 | @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
@@ -10768,7 +10768,7 @@ error: MediaFeatureValue
 109 | @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
     |                                            ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:109:44
     |
 109 | @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
@@ -10780,7 +10780,7 @@ error: Number
 109 | @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
     |                                            ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:109:47
     |
 109 | @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
@@ -10834,7 +10834,7 @@ error: MediaFeatureValue
 109 | @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
     |                                                                   ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:109:67
     |
 109 | @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
@@ -10846,7 +10846,7 @@ error: Number
 109 | @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
     |                                                                   ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:109:70
     |
 109 | @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
@@ -10930,7 +10930,7 @@ error: MediaFeatureValue
 110 | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
     |                    ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:110:20
     |
 110 | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
@@ -10942,7 +10942,7 @@ error: Number
 110 | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
     |                    ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:110:23
     |
 110 | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
@@ -11014,7 +11014,7 @@ error: MediaFeatureValue
 110 | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
     |                                            ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:110:44
     |
 110 | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
@@ -11026,7 +11026,7 @@ error: Number
 110 | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
     |                                            ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:110:47
     |
 110 | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
@@ -11080,7 +11080,7 @@ error: MediaFeatureValue
 110 | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
     |                                                                  ^^^^^
 
-error: UnitValue
+error: Dimension
    --> $DIR/tests/fixture/at-rule/media/input.css:110:66
     |
 110 | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
@@ -11092,7 +11092,7 @@ error: Number
 110 | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
     |                                                                  ^^^
 
-error: Unit
+error: Ident
    --> $DIR/tests/fixture/at-rule/media/input.css:110:69
     |
 110 | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}

--- a/crates/swc_css_parser/tests/fixture/at-rule/page/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/page/output.json
@@ -74,7 +74,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 31,
                   "end": 34,
@@ -91,6 +91,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 32,
                     "end": 34,
@@ -140,7 +141,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 51,
                   "end": 54,
@@ -157,6 +158,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 52,
                     "end": 54,
@@ -206,7 +208,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 71,
                   "end": 74,
@@ -223,6 +225,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 72,
                     "end": 74,
@@ -291,7 +294,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 99,
                   "end": 102,
@@ -308,6 +311,7 @@
                   "raw": "2"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 100,
                     "end": 102,
@@ -376,7 +380,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 126,
                   "end": 129,
@@ -393,6 +397,7 @@
                   "raw": "2"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 127,
                     "end": 129,
@@ -461,7 +466,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 153,
                   "end": 156,
@@ -478,6 +483,7 @@
                   "raw": "2"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 154,
                     "end": 156,

--- a/crates/swc_css_parser/tests/fixture/at-rule/page/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/page/span.rust-debug
@@ -112,7 +112,7 @@ error: Value
 3 | @page{margin: 1cm}
   |               ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/at-rule/page/input.css:3:15
   |
 3 | @page{margin: 1cm}
@@ -124,7 +124,7 @@ error: Number
 3 | @page{margin: 1cm}
   |               ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/at-rule/page/input.css:3:16
   |
 3 | @page{margin: 1cm}
@@ -184,7 +184,7 @@ error: Value
 4 | @page {margin: 1cm}
   |                ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/at-rule/page/input.css:4:16
   |
 4 | @page {margin: 1cm}
@@ -196,7 +196,7 @@ error: Number
 4 | @page {margin: 1cm}
   |                ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/at-rule/page/input.css:4:17
   |
 4 | @page {margin: 1cm}
@@ -256,7 +256,7 @@ error: Value
 5 | @page {margin: 1cm;}
   |                ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/at-rule/page/input.css:5:16
   |
 5 | @page {margin: 1cm;}
@@ -268,7 +268,7 @@ error: Number
 5 | @page {margin: 1cm;}
   |                ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/at-rule/page/input.css:5:17
   |
 5 | @page {margin: 1cm;}
@@ -340,7 +340,7 @@ error: Value
 6 | @page :first {margin: 2cm}
   |                       ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/at-rule/page/input.css:6:23
   |
 6 | @page :first {margin: 2cm}
@@ -352,7 +352,7 @@ error: Number
 6 | @page :first {margin: 2cm}
   |                       ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/at-rule/page/input.css:6:24
   |
 6 | @page :first {margin: 2cm}
@@ -424,7 +424,7 @@ error: Value
 7 | @page :first {margin: 2cm;}
   |                       ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/at-rule/page/input.css:7:23
   |
 7 | @page :first {margin: 2cm;}
@@ -436,7 +436,7 @@ error: Number
 7 | @page :first {margin: 2cm;}
   |                       ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/at-rule/page/input.css:7:24
   |
 7 | @page :first {margin: 2cm;}
@@ -508,7 +508,7 @@ error: Value
 8 | @page :first{margin: 2cm;}
   |                      ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/at-rule/page/input.css:8:22
   |
 8 | @page :first{margin: 2cm;}
@@ -520,7 +520,7 @@ error: Number
 8 | @page :first{margin: 2cm;}
   |                      ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/at-rule/page/input.css:8:23
   |
 8 | @page :first{margin: 2cm;}

--- a/crates/swc_css_parser/tests/fixture/at-rule/supports/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/supports/output.json
@@ -361,7 +361,7 @@
                         "raw": "min-width"
                       },
                       "value": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 171,
                           "end": 176,
@@ -378,6 +378,7 @@
                           "raw": "900"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 174,
                             "end": 176,
@@ -716,7 +717,7 @@
                 "raw": "0"
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 380,
                   "end": 383,
@@ -733,6 +734,7 @@
                   "raw": "2"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 381,
                     "end": 383,
@@ -811,7 +813,7 @@
                   "raw": "0"
                 },
                 {
-                  "type": "UnitValue",
+                  "type": "Dimension",
                   "span": {
                     "start": 423,
                     "end": 426,
@@ -828,6 +830,7 @@
                     "raw": "2"
                   },
                   "unit": {
+                    "type": "Identifier",
                     "span": {
                       "start": 424,
                       "end": 426,
@@ -907,7 +910,7 @@
                   "raw": "0"
                 },
                 {
-                  "type": "UnitValue",
+                  "type": "Dimension",
                   "span": {
                     "start": 469,
                     "end": 472,
@@ -924,6 +927,7 @@
                     "raw": "2"
                   },
                   "unit": {
+                    "type": "Identifier",
                     "span": {
                       "start": 470,
                       "end": 472,
@@ -1003,7 +1007,7 @@
                   "raw": "0"
                 },
                 {
-                  "type": "UnitValue",
+                  "type": "Dimension",
                   "span": {
                     "start": 510,
                     "end": 513,
@@ -1020,6 +1024,7 @@
                     "raw": "2"
                   },
                   "unit": {
+                    "type": "Identifier",
                     "span": {
                       "start": 511,
                       "end": 513,
@@ -1111,7 +1116,7 @@
                 "raw": "0"
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 559,
                   "end": 562,
@@ -1128,6 +1133,7 @@
                   "raw": "2"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 560,
                     "end": 562,
@@ -1206,7 +1212,7 @@
                   "raw": "0"
                 },
                 {
-                  "type": "UnitValue",
+                  "type": "Dimension",
                   "span": {
                     "start": 605,
                     "end": 608,
@@ -1223,6 +1229,7 @@
                     "raw": "2"
                   },
                   "unit": {
+                    "type": "Identifier",
                     "span": {
                       "start": 606,
                       "end": 608,
@@ -1302,7 +1309,7 @@
                   "raw": "0"
                 },
                 {
-                  "type": "UnitValue",
+                  "type": "Dimension",
                   "span": {
                     "start": 654,
                     "end": 657,
@@ -1319,6 +1326,7 @@
                     "raw": "2"
                   },
                   "unit": {
+                    "type": "Identifier",
                     "span": {
                       "start": 655,
                       "end": 657,
@@ -1398,7 +1406,7 @@
                   "raw": "0"
                 },
                 {
-                  "type": "UnitValue",
+                  "type": "Dimension",
                   "span": {
                     "start": 698,
                     "end": 701,
@@ -1415,6 +1423,7 @@
                     "raw": "2"
                   },
                   "unit": {
+                    "type": "Identifier",
                     "span": {
                       "start": 699,
                       "end": 701,
@@ -1591,7 +1600,7 @@
                   },
                   "value": [
                     {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 814,
                         "end": 819,
@@ -1608,6 +1617,7 @@
                         "raw": "10"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 816,
                           "end": 819,
@@ -1763,7 +1773,7 @@
                         },
                         "value": [
                           {
-                            "type": "UnitValue",
+                            "type": "Dimension",
                             "span": {
                               "start": 913,
                               "end": 918,
@@ -1780,6 +1790,7 @@
                               "raw": "10"
                             },
                             "unit": {
+                              "type": "Identifier",
                               "span": {
                                 "start": 915,
                                 "end": 918,
@@ -1938,7 +1949,7 @@
                         },
                         "value": [
                           {
-                            "type": "UnitValue",
+                            "type": "Dimension",
                             "span": {
                               "start": 1057,
                               "end": 1062,
@@ -1955,6 +1966,7 @@
                               "raw": "10"
                             },
                             "unit": {
+                              "type": "Identifier",
                               "span": {
                                 "start": 1059,
                                 "end": 1062,
@@ -2113,7 +2125,7 @@
                         },
                         "value": [
                           {
-                            "type": "UnitValue",
+                            "type": "Dimension",
                             "span": {
                               "start": 1159,
                               "end": 1164,
@@ -2130,6 +2142,7 @@
                               "raw": "10"
                             },
                             "unit": {
+                              "type": "Identifier",
                               "span": {
                                 "start": 1161,
                                 "end": 1164,

--- a/crates/swc_css_parser/tests/fixture/at-rule/supports/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/supports/output.json
@@ -2476,7 +2476,7 @@
                   },
                   "value": [
                     {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 1363,
                         "end": 1368,
@@ -2493,6 +2493,7 @@
                         "raw": "10"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 1365,
                           "end": 1368,
@@ -2648,7 +2649,7 @@
                         },
                         "value": [
                           {
-                            "type": "UnitValue",
+                            "type": "Dimension",
                             "span": {
                               "start": 1462,
                               "end": 1467,
@@ -2665,6 +2666,7 @@
                               "raw": "10"
                             },
                             "unit": {
+                              "type": "Identifier",
                               "span": {
                                 "start": 1464,
                                 "end": 1467,

--- a/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
@@ -3122,7 +3122,7 @@ error: Value
 35 | @supports ((transition-property: color) OR (animation-name: foo)) AND (transform: rotate(10deg)) {}
    |                                                                                          ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:35:90
    |
 35 | @supports ((transition-property: color) OR (animation-name: foo)) AND (transform: rotate(10deg)) {}
@@ -3134,7 +3134,7 @@ error: Number
 35 | @supports ((transition-property: color) OR (animation-name: foo)) AND (transform: rotate(10deg)) {}
    |                                                                                          ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:35:92
    |
 35 | @supports ((transition-property: color) OR (animation-name: foo)) AND (transform: rotate(10deg)) {}
@@ -3350,7 +3350,7 @@ error: Value
 36 | @supports (transition-property: color) OR ((animation-name: foo) AND (transform: rotate(10deg))) {}
    |                                                                                         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:36:89
    |
 36 | @supports (transition-property: color) OR ((animation-name: foo) AND (transform: rotate(10deg))) {}
@@ -3362,7 +3362,7 @@ error: Number
 36 | @supports (transition-property: color) OR ((animation-name: foo) AND (transform: rotate(10deg))) {}
    |                                                                                         ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:36:91
    |
 36 | @supports (transition-property: color) OR ((animation-name: foo) AND (transform: rotate(10deg))) {}

--- a/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
@@ -450,7 +450,7 @@ error: MediaFeatureValue
 12 |     @media screen and (min-width: 900px) {
    |                                   ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:12:35
    |
 12 |     @media screen and (min-width: 900px) {
@@ -462,7 +462,7 @@ error: Number
 12 |     @media screen and (min-width: 900px) {
    |                                   ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:12:38
    |
 12 |     @media screen and (min-width: 900px) {
@@ -871,7 +871,7 @@ error: Value
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                            ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:28
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -883,7 +883,7 @@ error: Number
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                            ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:29
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -985,7 +985,7 @@ error: Value
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                       ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:71
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -997,7 +997,7 @@ error: Number
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                       ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:72
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -1099,7 +1099,7 @@ error: Value
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                                                                     ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:117
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -1111,7 +1111,7 @@ error: Number
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                                                                     ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:118
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -1213,7 +1213,7 @@ error: Value
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                                                                                                              ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:158
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -1225,7 +1225,7 @@ error: Number
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
    |                                                                                                                                                              ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:21:159
    |
 21 | @supports (box-shadow: 0 0 2px black inset ) or (-moz-box-shadow: 0 0 2px black inset ) or (-webkit-box-shadow: 0 0 2px black inset ) or (-o-box-shadow: 0 0 2px black inset ) {}
@@ -1364,7 +1364,7 @@ error: Value
 22 | @supports ( box-shadow: 0 0 2px black inset ) or
    |                             ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:22:29
    |
 22 | @supports ( box-shadow: 0 0 2px black inset ) or
@@ -1376,7 +1376,7 @@ error: Number
 22 | @supports ( box-shadow: 0 0 2px black inset ) or
    |                             ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:22:30
    |
 22 | @supports ( box-shadow: 0 0 2px black inset ) or
@@ -1482,7 +1482,7 @@ error: Value
 23 |   ( -moz-box-shadow: 0 0 2px black inset ) or
    |                          ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:23:26
    |
 23 |   ( -moz-box-shadow: 0 0 2px black inset ) or
@@ -1494,7 +1494,7 @@ error: Number
 23 |   ( -moz-box-shadow: 0 0 2px black inset ) or
    |                          ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:23:27
    |
 23 |   ( -moz-box-shadow: 0 0 2px black inset ) or
@@ -1600,7 +1600,7 @@ error: Value
 24 |   ( -webkit-box-shadow: 0 0 2px black inset ) or
    |                             ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:24:29
    |
 24 |   ( -webkit-box-shadow: 0 0 2px black inset ) or
@@ -1612,7 +1612,7 @@ error: Number
 24 |   ( -webkit-box-shadow: 0 0 2px black inset ) or
    |                             ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:24:30
    |
 24 |   ( -webkit-box-shadow: 0 0 2px black inset ) or
@@ -1718,7 +1718,7 @@ error: Value
 25 |   ( -o-box-shadow: 0 0 2px black inset ) {
    |                        ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:25:24
    |
 25 |   ( -o-box-shadow: 0 0 2px black inset ) {
@@ -1730,7 +1730,7 @@ error: Number
 25 |   ( -o-box-shadow: 0 0 2px black inset ) {
    |                        ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:25:25
    |
 25 |   ( -o-box-shadow: 0 0 2px black inset ) {
@@ -1970,7 +1970,7 @@ error: Value
 28 | @supports ((transition-property: color) or (animation-name: foo)) and (transform: rotate(10deg)) {}
    |                                                                                          ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:28:90
    |
 28 | @supports ((transition-property: color) or (animation-name: foo)) and (transform: rotate(10deg)) {}
@@ -1982,7 +1982,7 @@ error: Number
 28 | @supports ((transition-property: color) or (animation-name: foo)) and (transform: rotate(10deg)) {}
    |                                                                                          ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:28:92
    |
 28 | @supports ((transition-property: color) or (animation-name: foo)) and (transform: rotate(10deg)) {}
@@ -2198,7 +2198,7 @@ error: Value
 29 | @supports (transition-property: color) or ((animation-name: foo) and (transform: rotate(10deg))) {}
    |                                                                                         ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:29:89
    |
 29 | @supports (transition-property: color) or ((animation-name: foo) and (transform: rotate(10deg))) {}
@@ -2210,7 +2210,7 @@ error: Number
 29 | @supports (transition-property: color) or ((animation-name: foo) and (transform: rotate(10deg))) {}
    |                                                                                         ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:29:91
    |
 29 | @supports (transition-property: color) or ((animation-name: foo) and (transform: rotate(10deg))) {}
@@ -2426,7 +2426,7 @@ error: Value
 30 | @supports   (   transition-property   :   color   )   or   (   (   animation-name   :   foo   )   and   (   transform   :    rotate(10deg)   )   )   {}
    |                                                                                                                                     ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:30:133
    |
 30 | @supports   (   transition-property   :   color   )   or   (   (   animation-name   :   foo   )   and   (   transform   :    rotate(10deg)   )   )   {}
@@ -2438,7 +2438,7 @@ error: Number
 30 | @supports   (   transition-property   :   color   )   or   (   (   animation-name   :   foo   )   and   (   transform   :    rotate(10deg)   )   )   {}
    |                                                                                                                                     ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:30:135
    |
 30 | @supports   (   transition-property   :   color   )   or   (   (   animation-name   :   foo   )   and   (   transform   :    rotate(10deg)   )   )   {}
@@ -2654,7 +2654,7 @@ error: Value
 31 | @supports(transition-property:color)or ((animation-name:foo)and (transform:rotate(10deg))){}
    |                                                                                   ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/at-rule/supports/input.css:31:83
    |
 31 | @supports(transition-property:color)or ((animation-name:foo)and (transform:rotate(10deg))){}
@@ -2666,7 +2666,7 @@ error: Number
 31 | @supports(transition-property:color)or ((animation-name:foo)and (transform:rotate(10deg))){}
    |                                                                                   ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/at-rule/supports/input.css:31:85
    |
 31 | @supports(transition-property:color)or ((animation-name:foo)and (transform:rotate(10deg))){}

--- a/crates/swc_css_parser/tests/fixture/declaration/output.json
+++ b/crates/swc_css_parser/tests/fixture/declaration/output.json
@@ -1043,7 +1043,7 @@
                 "value": "/"
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 422,
                   "end": 425,
@@ -1060,6 +1060,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 423,
                     "end": 425,
@@ -1110,7 +1111,7 @@
                 "value": "/"
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 445,
                   "end": 448,
@@ -1127,6 +1128,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 446,
                     "end": 448,
@@ -1177,7 +1179,7 @@
                 "value": "/"
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 468,
                   "end": 471,
@@ -1194,6 +1196,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 469,
                     "end": 471,
@@ -1244,7 +1247,7 @@
                 "value": "/"
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 492,
                   "end": 495,
@@ -1261,6 +1264,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 493,
                     "end": 495,

--- a/crates/swc_css_parser/tests/fixture/declaration/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/declaration/span.rust-debug
@@ -1055,7 +1055,7 @@ error: Value
 19 |     prop: center/1em;
    |                  ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/declaration/input.css:19:18
    |
 19 |     prop: center/1em;
@@ -1067,7 +1067,7 @@ error: Number
 19 |     prop: center/1em;
    |                  ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/declaration/input.css:19:19
    |
 19 |     prop: center/1em;
@@ -1121,7 +1121,7 @@ error: Value
 20 |     prop: center/ 1em;
    |                   ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/declaration/input.css:20:19
    |
 20 |     prop: center/ 1em;
@@ -1133,7 +1133,7 @@ error: Number
 20 |     prop: center/ 1em;
    |                   ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/declaration/input.css:20:20
    |
 20 |     prop: center/ 1em;
@@ -1187,7 +1187,7 @@ error: Value
 21 |     prop: center /1em;
    |                   ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/declaration/input.css:21:19
    |
 21 |     prop: center /1em;
@@ -1199,7 +1199,7 @@ error: Number
 21 |     prop: center /1em;
    |                   ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/declaration/input.css:21:20
    |
 21 |     prop: center /1em;
@@ -1253,7 +1253,7 @@ error: Value
 22 |     prop: center / 1em;
    |                    ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/declaration/input.css:22:20
    |
 22 |     prop: center / 1em;
@@ -1265,7 +1265,7 @@ error: Number
 22 |     prop: center / 1em;
    |                    ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/declaration/input.css:22:21
    |
 22 |     prop: center / 1em;

--- a/crates/swc_css_parser/tests/fixture/dimension/basic/output.json
+++ b/crates/swc_css_parser/tests/fixture/dimension/basic/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 14,
                   "end": 18,
@@ -106,6 +106,7 @@
                   "raw": "10"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 16,
                     "end": 18,
@@ -137,7 +138,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 30,
                   "end": 35,
@@ -154,6 +155,7 @@
                   "raw": ".10"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 33,
                     "end": 35,
@@ -185,7 +187,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 47,
                   "end": 54,
@@ -202,6 +204,7 @@
                   "raw": "12.34"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 52,
                     "end": 54,
@@ -233,7 +236,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 66,
                   "end": 76,
@@ -250,6 +253,7 @@
                   "raw": "0000.000"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 74,
                     "end": 76,
@@ -281,7 +285,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 88,
                   "end": 94,
@@ -298,6 +302,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 89,
                     "end": 94,
@@ -329,7 +334,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 106,
                   "end": 108,
@@ -346,6 +351,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 107,
                     "end": 108,
@@ -377,7 +383,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 120,
                   "end": 128,
@@ -394,6 +400,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 121,
                     "end": 128,

--- a/crates/swc_css_parser/tests/fixture/dimension/basic/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/dimension/basic/span.rust-debug
@@ -101,7 +101,7 @@ error: Value
 2 |     prop: 10px;
   |           ^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/dimension/basic/input.css:2:11
   |
 2 |     prop: 10px;
@@ -113,7 +113,7 @@ error: Number
 2 |     prop: 10px;
   |           ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/dimension/basic/input.css:2:13
   |
 2 |     prop: 10px;
@@ -143,7 +143,7 @@ error: Value
 3 |     prop: .10px;
   |           ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/dimension/basic/input.css:3:11
   |
 3 |     prop: .10px;
@@ -155,7 +155,7 @@ error: Number
 3 |     prop: .10px;
   |           ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/dimension/basic/input.css:3:14
   |
 3 |     prop: .10px;
@@ -185,7 +185,7 @@ error: Value
 4 |     prop: 12.34px;
   |           ^^^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/dimension/basic/input.css:4:11
   |
 4 |     prop: 12.34px;
@@ -197,7 +197,7 @@ error: Number
 4 |     prop: 12.34px;
   |           ^^^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/dimension/basic/input.css:4:16
   |
 4 |     prop: 12.34px;
@@ -227,7 +227,7 @@ error: Value
 5 |     prop: 0000.000px;
   |           ^^^^^^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/dimension/basic/input.css:5:11
   |
 5 |     prop: 0000.000px;
@@ -239,7 +239,7 @@ error: Number
 5 |     prop: 0000.000px;
   |           ^^^^^^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/dimension/basic/input.css:5:19
   |
 5 |     prop: 0000.000px;
@@ -269,7 +269,7 @@ error: Value
 6 |     prop: 1px\\9;
   |           ^^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/dimension/basic/input.css:6:11
   |
 6 |     prop: 1px\\9;
@@ -281,7 +281,7 @@ error: Number
 6 |     prop: 1px\\9;
   |           ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/dimension/basic/input.css:6:12
   |
 6 |     prop: 1px\\9;
@@ -311,7 +311,7 @@ error: Value
 7 |     prop: 1e;
   |           ^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/dimension/basic/input.css:7:11
   |
 7 |     prop: 1e;
@@ -323,7 +323,7 @@ error: Number
 7 |     prop: 1e;
   |           ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/dimension/basic/input.css:7:12
   |
 7 |     prop: 1e;
@@ -353,7 +353,7 @@ error: Value
 8 |     prop: 1unknown;
   |           ^^^^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/dimension/basic/input.css:8:11
   |
 8 |     prop: 1unknown;
@@ -365,7 +365,7 @@ error: Number
 8 |     prop: 1unknown;
   |           ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/dimension/basic/input.css:8:12
   |
 8 |     prop: 1unknown;

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 11,
                   "end": 18,
@@ -106,6 +106,7 @@
                   "raw": "10"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 13,
                     "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: 10p\32x }
   |            ^^^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/input.css:1:12
   |
 1 | a { value: 10p\32x }
@@ -88,7 +88,7 @@ error: Number
 1 | a { value: 10p\32x }
   |            ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/0LKvnY2GhG7ss8EXa0t6tQ/input.css:1:14
   |
 1 | a { value: 10p\32x }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/output.json
@@ -109,7 +109,7 @@
                 "raw": "1"
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 17,
                   "end": 20,
@@ -126,6 +126,7 @@
                   "raw": "0"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 18,
                     "end": 20,
@@ -136,7 +137,7 @@
                 }
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 21,
                   "end": 24,
@@ -153,6 +154,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 22,
                     "end": 24,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/span.rust-debug
@@ -100,7 +100,7 @@ error: Value
 1 | a { padding: 0 1 0px 1px }
   |                  ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/input.css:1:18
   |
 1 | a { padding: 0 1 0px 1px }
@@ -112,7 +112,7 @@ error: Number
 1 | a { padding: 0 1 0px 1px }
   |                  ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/input.css:1:19
   |
 1 | a { padding: 0 1 0px 1px }
@@ -124,7 +124,7 @@ error: Value
 1 | a { padding: 0 1 0px 1px }
   |                      ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/input.css:1:22
   |
 1 | a { padding: 0 1 0px 1px }
@@ -136,7 +136,7 @@ error: Number
 1 | a { padding: 0 1 0px 1px }
   |                      ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/4WSp4-HbKB-f1GLF00sf6A/input.css:1:23
   |
 1 | a { padding: 0 1 0px 1px }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 11,
                   "end": 17,
@@ -106,6 +106,7 @@
                   "raw": "10"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 13,
                     "end": 17,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: 10\2cx }
   |            ^^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/input.css:1:12
   |
 1 | a { value: 10\2cx }
@@ -88,7 +88,7 @@ error: Number
 1 | a { value: 10\2cx }
   |            ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/53OltIbJ-YBXtSKedVvYwA/input.css:1:14
   |
 1 | a { value: 10\2cx }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 11,
                   "end": 18,
@@ -106,6 +106,7 @@
                   "raw": "10"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 13,
                     "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: 10x\2c }
   |            ^^^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/input.css:1:12
   |
 1 | a { value: 10x\2c }
@@ -88,7 +88,7 @@ error: Number
 1 | a { value: 10x\2c }
   |            ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/866Law8W0FQas7QMxFjUbw/input.css:1:14
   |
 1 | a { value: 10x\2c }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 11,
                   "end": 17,
@@ -106,6 +106,7 @@
                   "raw": "10"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 13,
                     "end": 17,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: 10\32x }
   |            ^^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/input.css:1:12
   |
 1 | a { value: 10\32x }
@@ -88,7 +88,7 @@ error: Number
 1 | a { value: 10\32x }
   |            ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/MMBANlJKeKQw886fHOYiHA/input.css:1:14
   |
 1 | a { value: 10\32x }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 11,
                   "end": 17,
@@ -106,6 +106,7 @@
                   "raw": "10"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 13,
                     "end": 17,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: 10\65m }
   |            ^^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/input.css:1:12
   |
 1 | a { value: 10\65m }
@@ -88,7 +88,7 @@ error: Number
 1 | a { value: 10\65m }
   |            ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/Mdtiu_Fpfso6gXZMciRJgw/input.css:1:14
   |
 1 | a { value: 10\65m }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/output.json
@@ -99,7 +99,7 @@
                 "raw": "inset"
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 22,
                   "end": 25,
@@ -116,6 +116,7 @@
                   "raw": "0"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 23,
                     "end": 25,
@@ -126,7 +127,7 @@
                 }
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 26,
                   "end": 29,
@@ -143,6 +144,7 @@
                   "raw": "0"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 27,
                     "end": 29,
@@ -153,7 +155,7 @@
                 }
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 30,
                   "end": 33,
@@ -170,6 +172,7 @@
                   "raw": "0"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 31,
                     "end": 33,
@@ -180,7 +183,7 @@
                 }
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 34,
                   "end": 37,
@@ -197,6 +200,7 @@
                   "raw": "0"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 35,
                     "end": 37,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/span.rust-debug
@@ -88,7 +88,7 @@ error: Value
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
   |                       ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/input.css:1:23
   |
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
@@ -100,7 +100,7 @@ error: Number
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
   |                       ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/input.css:1:24
   |
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
@@ -112,7 +112,7 @@ error: Value
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
   |                           ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/input.css:1:27
   |
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
@@ -124,7 +124,7 @@ error: Number
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
   |                           ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/input.css:1:28
   |
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
@@ -136,7 +136,7 @@ error: Value
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
   |                               ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/input.css:1:31
   |
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
@@ -148,7 +148,7 @@ error: Number
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
   |                               ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/input.css:1:32
   |
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
@@ -160,7 +160,7 @@ error: Value
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
   |                                   ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/input.css:1:35
   |
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
@@ -172,7 +172,7 @@ error: Number
 1 | a { box-shadow: inset 0px 0px 0px 0px black }
   |                                   ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/Rq1DOaNCa5Dl2jaozalLXQ/input.css:1:36
   |
 1 | a { box-shadow: inset 0px 0px 0px 0px black }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/aVoVLZHijXjMsJvx4rbJGQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/aVoVLZHijXjMsJvx4rbJGQ/output.json
@@ -40,7 +40,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 19,
                   "end": 24,
@@ -57,6 +57,7 @@
                   "raw": "100"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 22,
                     "end": 24,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/aVoVLZHijXjMsJvx4rbJGQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/aVoVLZHijXjMsJvx4rbJGQ/span.rust-debug
@@ -52,7 +52,7 @@ error: Value
 1 | @viewport { width: 100vw }
   |                    ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/aVoVLZHijXjMsJvx4rbJGQ/input.css:1:20
   |
 1 | @viewport { width: 100vw }
@@ -64,7 +64,7 @@ error: Number
 1 | @viewport { width: 100vw }
   |                    ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/aVoVLZHijXjMsJvx4rbJGQ/input.css:1:23
   |
 1 | @viewport { width: 100vw }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/output.json
@@ -109,7 +109,7 @@
                 "raw": "1"
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 16,
                   "end": 19,
@@ -126,6 +126,7 @@
                   "raw": "0"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 17,
                     "end": 19,
@@ -136,7 +137,7 @@
                 }
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 20,
                   "end": 23,
@@ -153,6 +154,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 21,
                     "end": 23,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/span.rust-debug
@@ -100,7 +100,7 @@ error: Value
 1 | a { margin: 0 1 0px 1px }
   |                 ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/input.css:1:17
   |
 1 | a { margin: 0 1 0px 1px }
@@ -112,7 +112,7 @@ error: Number
 1 | a { margin: 0 1 0px 1px }
   |                 ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/input.css:1:18
   |
 1 | a { margin: 0 1 0px 1px }
@@ -124,7 +124,7 @@ error: Value
 1 | a { margin: 0 1 0px 1px }
   |                     ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/input.css:1:21
   |
 1 | a { margin: 0 1 0px 1px }
@@ -136,7 +136,7 @@ error: Number
 1 | a { margin: 0 1 0px 1px }
   |                     ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/gVzUgfEllenh46I3Psx-uQ/input.css:1:22
   |
 1 | a { margin: 0 1 0px 1px }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 11,
                   "end": 16,
@@ -106,6 +106,7 @@
                   "raw": "10"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 13,
                     "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: 10x\, }
   |            ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/input.css:1:12
   |
 1 | a { value: 10x\, }
@@ -88,7 +88,7 @@ error: Number
 1 | a { value: 10x\, }
   |            ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/sPEO1vW1kIUNhCVdR2d7fg/input.css:1:14
   |
 1 | a { value: 10x\, }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ugX8SLCLRvWN-wDCK7ouyA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ugX8SLCLRvWN-wDCK7ouyA/output.json
@@ -40,7 +40,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 23,
                   "end": 28,
@@ -57,6 +57,7 @@
                   "raw": "100"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 26,
                     "end": 28,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ugX8SLCLRvWN-wDCK7ouyA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ugX8SLCLRvWN-wDCK7ouyA/span.rust-debug
@@ -52,7 +52,7 @@ error: Value
 1 | @-ms-viewport { width: 100vw }
   |                        ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/ugX8SLCLRvWN-wDCK7ouyA/input.css:1:24
   |
 1 | @-ms-viewport { width: 100vw }
@@ -64,7 +64,7 @@ error: Number
 1 | @-ms-viewport { width: 100vw }
   |                        ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/ugX8SLCLRvWN-wDCK7ouyA/input.css:1:27
   |
 1 | @-ms-viewport { width: 100vw }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 11,
                   "end": 16,
@@ -106,6 +106,7 @@
                   "raw": "10"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 13,
                     "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: 10\,x }
   |            ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/input.css:1:12
   |
 1 | a { value: 10\,x }
@@ -88,7 +88,7 @@ error: Number
 1 | a { value: 10\,x }
   |            ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/uxHrqNkMo_2PTuF8sIRQxA/input.css:1:14
   |
 1 | a { value: 10\,x }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 11,
                   "end": 18,
@@ -106,6 +106,7 @@
                   "raw": "10"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 13,
                     "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: 10e\32x }
   |            ^^^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/input.css:1:12
   |
 1 | a { value: 10e\32x }
@@ -88,7 +88,7 @@ error: Number
 1 | a { value: 10e\32x }
   |            ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/esbuild/misc/zz_B6vK87VUHpkOMFR_R1g/input.css:1:14
   |
 1 | a { value: 10e\32x }

--- a/crates/swc_css_parser/tests/fixture/important/basic/output.json
+++ b/crates/swc_css_parser/tests/fixture/important/basic/output.json
@@ -162,7 +162,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 63,
                   "end": 66,
@@ -179,6 +179,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 64,
                     "end": 66,
@@ -424,7 +425,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 267,
                   "end": 271,
@@ -441,6 +442,7 @@
                   "raw": "10"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 269,
                     "end": 271,
@@ -476,7 +478,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 308,
                   "end": 312,
@@ -493,6 +495,7 @@
                   "raw": "20"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 310,
                     "end": 312,
@@ -528,7 +531,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 355,
                   "end": 360,
@@ -545,6 +548,7 @@
                   "raw": "100"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 358,
                     "end": 360,
@@ -580,7 +584,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 398,
                   "end": 403,
@@ -597,6 +601,7 @@
                   "raw": "100"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 401,
                     "end": 403,
@@ -683,7 +688,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 470,
                   "end": 473,
@@ -700,6 +705,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 471,
                     "end": 473,

--- a/crates/swc_css_parser/tests/fixture/important/basic/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/important/basic/span.rust-debug
@@ -179,7 +179,7 @@ error: Value
 4 |     width: 1px!important;
   |            ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/important/basic/input.css:4:12
   |
 4 |     width: 1px!important;
@@ -191,7 +191,7 @@ error: Number
 4 |     width: 1px!important;
   |            ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/important/basic/input.css:4:13
   |
 4 |     width: 1px!important;
@@ -401,7 +401,7 @@ error: Value
 11 |     margin: 10px      !      important;
    |             ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/important/basic/input.css:11:13
    |
 11 |     margin: 10px      !      important;
@@ -413,7 +413,7 @@ error: Number
 11 |     margin: 10px      !      important;
    |             ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/important/basic/input.css:11:15
    |
 11 |     margin: 10px      !      important;
@@ -443,7 +443,7 @@ error: Value
 12 |     padding: 20px     !  /* test */   important;
    |              ^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/important/basic/input.css:12:14
    |
 12 |     padding: 20px     !  /* test */   important;
@@ -455,7 +455,7 @@ error: Number
 12 |     padding: 20px     !  /* test */   important;
    |              ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/important/basic/input.css:12:16
    |
 12 |     padding: 20px     !  /* test */   important;
@@ -485,7 +485,7 @@ error: Value
 13 |     width: 100px ! /*! test */ important;
    |            ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/important/basic/input.css:13:12
    |
 13 |     width: 100px ! /*! test */ important;
@@ -497,7 +497,7 @@ error: Number
 13 |     width: 100px ! /*! test */ important;
    |            ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/important/basic/input.css:13:15
    |
 13 |     width: 100px ! /*! test */ important;
@@ -527,7 +527,7 @@ error: Value
 14 |     height: 100px /*! test */ important;
    |             ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/important/basic/input.css:14:13
    |
 14 |     height: 100px /*! test */ important;
@@ -539,7 +539,7 @@ error: Number
 14 |     height: 100px /*! test */ important;
    |             ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/important/basic/input.css:14:16
    |
 14 |     height: 100px /*! test */ important;
@@ -623,7 +623,7 @@ error: Value
 16 |     padding: 1px/* sep */!important;
    |              ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/important/basic/input.css:16:14
    |
 16 |     padding: 1px/* sep */!important;
@@ -635,7 +635,7 @@ error: Number
 16 |     padding: 1px/* sep */!important;
    |              ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/important/basic/input.css:16:15
    |
 16 |     padding: 1px/* sep */!important;

--- a/crates/swc_css_parser/tests/fixture/number/output.json
+++ b/crates/swc_css_parser/tests/fixture/number/output.json
@@ -1112,7 +1112,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 670,
                   "end": 672,
@@ -1129,6 +1129,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 671,
                     "end": 672,

--- a/crates/swc_css_parser/tests/fixture/number/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/number/span.rust-debug
@@ -1091,7 +1091,7 @@ error: Value
 35 |     property: 1e;
    |               ^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/number/input.css:35:15
    |
 35 |     property: 1e;
@@ -1103,7 +1103,7 @@ error: Number
 35 |     property: 1e;
    |               ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/number/input.css:35:16
    |
 35 |     property: 1e;

--- a/crates/swc_css_parser/tests/fixture/rome/at-page/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/at-page/output.json
@@ -166,7 +166,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 66,
                   "end": 69,
@@ -183,6 +183,7 @@
                   "raw": "4"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 67,
                     "end": 69,
@@ -349,7 +350,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 134,
                   "end": 137,
@@ -366,6 +367,7 @@
                   "raw": "4"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 135,
                     "end": 137,
@@ -513,7 +515,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 195,
                   "end": 198,
@@ -530,6 +532,7 @@
                   "raw": "4"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 196,
                     "end": 198,
@@ -677,7 +680,7 @@
             },
             "value": [
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 256,
                   "end": 259,
@@ -694,6 +697,7 @@
                   "raw": "4"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 257,
                     "end": 259,

--- a/crates/swc_css_parser/tests/fixture/rome/at-page/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/at-page/span.rust-debug
@@ -185,7 +185,7 @@ error: Value
 3 |     margin-left: 4cm;
   |                  ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/at-page/input.css:3:15
   |
 3 |     margin-left: 4cm;
@@ -197,7 +197,7 @@ error: Number
 3 |     margin-left: 4cm;
   |                  ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/at-page/input.css:3:16
   |
 3 |     margin-left: 4cm;
@@ -372,7 +372,7 @@ error: Value
 8 |     margin-left: 4cm;
   |                  ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/at-page/input.css:8:15
   |
 8 |     margin-left: 4cm;
@@ -384,7 +384,7 @@ error: Number
 8 |     margin-left: 4cm;
   |                  ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/at-page/input.css:8:16
   |
 8 |     margin-left: 4cm;
@@ -547,7 +547,7 @@ error: Value
 13 |     margin-left: 4cm;
    |                  ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/at-page/input.css:13:15
    |
 13 |     margin-left: 4cm;
@@ -559,7 +559,7 @@ error: Number
 13 |     margin-left: 4cm;
    |                  ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/at-page/input.css:13:16
    |
 13 |     margin-left: 4cm;
@@ -722,7 +722,7 @@ error: Value
 18 |     MARGIN-LEFT: 4cm;
    |                  ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/at-page/input.css:18:15
    |
 18 |     MARGIN-LEFT: 4cm;
@@ -734,7 +734,7 @@ error: Number
 18 |     MARGIN-LEFT: 4cm;
    |                  ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/at-page/input.css:18:16
    |
 18 |     MARGIN-LEFT: 4cm;

--- a/crates/swc_css_parser/tests/fixture/rome/calc/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/calc/output.json
@@ -108,7 +108,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 22,
                       "end": 25,
@@ -125,6 +125,7 @@
                       "raw": "2"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 23,
                         "end": 25,
@@ -184,7 +185,7 @@
                     },
                     "op": "+",
                     "left": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 41,
                         "end": 44,
@@ -201,6 +202,7 @@
                         "raw": "2"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 42,
                           "end": 44,
@@ -211,7 +213,7 @@
                       }
                     },
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 47,
                         "end": 50,
@@ -228,6 +230,7 @@
                         "raw": "1"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 48,
                           "end": 50,
@@ -288,7 +291,7 @@
                     },
                     "op": "+",
                     "left": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 66,
                         "end": 69,
@@ -305,6 +308,7 @@
                         "raw": "2"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 67,
                           "end": 69,
@@ -391,7 +395,7 @@
                       },
                       "op": "*",
                       "left": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 90,
                           "end": 93,
@@ -408,6 +412,7 @@
                           "raw": "2"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 91,
                             "end": 93,
@@ -437,7 +442,7 @@
                       }
                     },
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 101,
                         "end": 104,
@@ -454,6 +459,7 @@
                         "raw": "3"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 102,
                           "end": 104,
@@ -522,7 +528,7 @@
                       },
                       "op": "/",
                       "left": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 120,
                           "end": 123,
@@ -539,6 +545,7 @@
                           "raw": "2"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 121,
                             "end": 123,
@@ -628,7 +635,7 @@
                       },
                       "op": "/",
                       "left": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 147,
                           "end": 150,
@@ -645,6 +652,7 @@
                           "raw": "2"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 148,
                             "end": 150,
@@ -794,7 +802,7 @@
                       },
                       "op": "*",
                       "left": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 186,
                           "end": 189,
@@ -811,6 +819,7 @@
                           "raw": "2"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 187,
                             "end": 189,
@@ -916,7 +925,7 @@
                           },
                           "op": "*",
                           "left": {
-                            "type": "UnitValue",
+                            "type": "Dimension",
                             "span": {
                               "start": 213,
                               "end": 216,
@@ -933,6 +942,7 @@
                               "raw": "2"
                             },
                             "unit": {
+                              "type": "Identifier",
                               "span": {
                                 "start": 214,
                                 "end": 216,
@@ -965,7 +975,7 @@
                         }
                       },
                       "right": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 227,
                           "end": 230,
@@ -982,6 +992,7 @@
                           "raw": "3"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 228,
                             "end": 230,

--- a/crates/swc_css_parser/tests/fixture/rome/calc/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/calc/span.rust-debug
@@ -125,7 +125,7 @@ error: Value
 2 |     width: calc(2px);
   |                 ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/calc/input.css:2:14
   |
 2 |     width: calc(2px);
@@ -137,7 +137,7 @@ error: Number
 2 |     width: calc(2px);
   |                 ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/calc/input.css:2:15
   |
 2 |     width: calc(2px);
@@ -197,7 +197,7 @@ error: Value
 3 |     width: calc(2px + 1px);
   |                 ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/calc/input.css:3:14
   |
 3 |     width: calc(2px + 1px);
@@ -209,7 +209,7 @@ error: Number
 3 |     width: calc(2px + 1px);
   |                 ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/calc/input.css:3:15
   |
 3 |     width: calc(2px + 1px);
@@ -221,7 +221,7 @@ error: Value
 3 |     width: calc(2px + 1px);
   |                       ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/calc/input.css:3:20
   |
 3 |     width: calc(2px + 1px);
@@ -233,7 +233,7 @@ error: Number
 3 |     width: calc(2px + 1px);
   |                       ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/calc/input.css:3:21
   |
 3 |     width: calc(2px + 1px);
@@ -293,7 +293,7 @@ error: Value
 4 |     width: calc(2em + 1%);
   |                 ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/calc/input.css:4:14
   |
 4 |     width: calc(2em + 1%);
@@ -305,7 +305,7 @@ error: Number
 4 |     width: calc(2em + 1%);
   |                 ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/calc/input.css:4:15
   |
 4 |     width: calc(2em + 1%);
@@ -395,7 +395,7 @@ error: Value
 5 |     width: calc(2em * 2% * 3px);
   |                 ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/calc/input.css:5:14
   |
 5 |     width: calc(2em * 2% * 3px);
@@ -407,7 +407,7 @@ error: Number
 5 |     width: calc(2em * 2% * 3px);
   |                 ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/calc/input.css:5:15
   |
 5 |     width: calc(2em * 2% * 3px);
@@ -437,7 +437,7 @@ error: Value
 5 |     width: calc(2em * 2% * 3px);
   |                            ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/calc/input.css:5:25
   |
 5 |     width: calc(2em * 2% * 3px);
@@ -449,7 +449,7 @@ error: Number
 5 |     width: calc(2em * 2% * 3px);
   |                            ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/calc/input.css:5:26
   |
 5 |     width: calc(2em * 2% * 3px);
@@ -521,7 +521,7 @@ error: Value
 6 |     width: calc(2em / 2 / 3);
   |                 ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/calc/input.css:6:14
   |
 6 |     width: calc(2em / 2 / 3);
@@ -533,7 +533,7 @@ error: Number
 6 |     width: calc(2em / 2 / 3);
   |                 ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/calc/input.css:6:15
   |
 6 |     width: calc(2em / 2 / 3);
@@ -629,7 +629,7 @@ error: Value
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
   |                 ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/calc/input.css:7:14
   |
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
@@ -641,7 +641,7 @@ error: Number
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
   |                 ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/calc/input.css:7:15
   |
 7 |     width: calc(2em / (2 - 3) / (2 - 6));
@@ -809,7 +809,7 @@ error: Value
 8 |     width: calc(2em * 2 + 3);
   |                 ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/calc/input.css:8:14
   |
 8 |     width: calc(2em * 2 + 3);
@@ -821,7 +821,7 @@ error: Number
 8 |     width: calc(2em * 2 + 3);
   |                 ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/calc/input.css:8:15
   |
 8 |     width: calc(2em * 2 + 3);
@@ -941,7 +941,7 @@ error: Value
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
   |                 ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/calc/input.css:9:14
   |
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
@@ -953,7 +953,7 @@ error: Number
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
   |                 ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/calc/input.css:9:15
   |
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
@@ -989,7 +989,7 @@ error: Value
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
   |                               ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/calc/input.css:9:28
   |
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
@@ -1001,7 +1001,7 @@ error: Number
 9 |     width: calc(2em * 2 - 3 + 3em / 5);
   |                               ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/calc/input.css:9:29
   |
 9 |     width: calc(2em * 2 - 3 + 3em / 5);

--- a/crates/swc_css_parser/tests/fixture/rome/fit-content/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/fit-content/output.json
@@ -108,7 +108,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 45,
                       "end": 48,
@@ -125,6 +125,7 @@
                       "raw": "8"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 46,
                         "end": 48,
@@ -155,7 +156,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 62,
                       "end": 65,
@@ -172,6 +173,7 @@
                       "raw": "8"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 63,
                         "end": 65,
@@ -184,7 +186,7 @@
                 ]
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 67,
                   "end": 70,
@@ -201,6 +203,7 @@
                   "raw": "1"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 68,
                     "end": 70,

--- a/crates/swc_css_parser/tests/fixture/rome/fit-content/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/fit-content/span.rust-debug
@@ -109,7 +109,7 @@ error: Value
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
   |                                        ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/fit-content/input.css:2:37
   |
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
@@ -121,7 +121,7 @@ error: Number
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
   |                                        ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/fit-content/input.css:2:38
   |
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
@@ -151,7 +151,7 @@ error: Value
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
   |                                                         ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/fit-content/input.css:2:54
   |
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
@@ -163,7 +163,7 @@ error: Number
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
   |                                                         ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/fit-content/input.css:2:55
   |
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
@@ -175,7 +175,7 @@ error: Value
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
   |                                                              ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/fit-content/input.css:2:59
   |
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
@@ -187,7 +187,7 @@ error: Number
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;
   |                                                              ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/fit-content/input.css:2:60
   |
 2 |     grid-template-columns: fit-content(8ch) fit-content(8ch) 1fr;

--- a/crates/swc_css_parser/tests/fixture/rome/functions/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/functions/output.json
@@ -226,7 +226,7 @@
                     },
                     "op": "+",
                     "left": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 64,
                         "end": 68,
@@ -243,6 +243,7 @@
                         "raw": "10"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 66,
                           "end": 68,
@@ -253,7 +254,7 @@
                       }
                     },
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 71,
                         "end": 75,
@@ -270,6 +271,7 @@
                         "raw": "5"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 72,
                           "end": 75,

--- a/crates/swc_css_parser/tests/fixture/rome/functions/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/functions/span.rust-debug
@@ -227,7 +227,7 @@ error: Value
 4 |     font-size: calc(10px + 5rem);
   |                     ^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/functions/input.css:4:18
   |
 4 |     font-size: calc(10px + 5rem);
@@ -239,7 +239,7 @@ error: Number
 4 |     font-size: calc(10px + 5rem);
   |                     ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/functions/input.css:4:20
   |
 4 |     font-size: calc(10px + 5rem);
@@ -251,7 +251,7 @@ error: Value
 4 |     font-size: calc(10px + 5rem);
   |                            ^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/functions/input.css:4:25
   |
 4 |     font-size: calc(10px + 5rem);
@@ -263,7 +263,7 @@ error: Number
 4 |     font-size: calc(10px + 5rem);
   |                            ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/functions/input.css:4:26
   |
 4 |     font-size: calc(10px + 5rem);

--- a/crates/swc_css_parser/tests/fixture/rome/grid/minmax/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/minmax/output.json
@@ -127,7 +127,7 @@
                     "value": ","
                   },
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 53,
                       "end": 58,
@@ -144,6 +144,7 @@
                       "raw": "300"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 56,
                         "end": 58,
@@ -174,7 +175,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 67,
                       "end": 72,
@@ -191,6 +192,7 @@
                       "raw": "200"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 70,
                         "end": 72,
@@ -210,7 +212,7 @@
                     "value": ","
                   },
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 74,
                       "end": 77,
@@ -227,6 +229,7 @@
                       "raw": "1"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 75,
                         "end": 77,

--- a/crates/swc_css_parser/tests/fixture/rome/grid/minmax/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/minmax/span.rust-debug
@@ -133,7 +133,7 @@ error: Value
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
   |                                                ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/grid/minmax/input.css:2:45
   |
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
@@ -145,7 +145,7 @@ error: Number
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
   |                                                ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/grid/minmax/input.css:2:48
   |
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
@@ -175,7 +175,7 @@ error: Value
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
   |                                                              ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/grid/minmax/input.css:2:59
   |
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
@@ -187,7 +187,7 @@ error: Number
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
   |                                                              ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/grid/minmax/input.css:2:62
   |
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
@@ -211,7 +211,7 @@ error: Value
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
   |                                                                     ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/grid/minmax/input.css:2:66
   |
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
@@ -223,7 +223,7 @@ error: Number
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);
   |                                                                     ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/grid/minmax/input.css:2:67
   |
 2 |     grid-template-columns: minmax(min-content, 300px) minmax(200px, 1fr) minmax(max-content, max-content);

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/fit-content/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/fit-content/output.json
@@ -145,7 +145,7 @@
                     },
                     "value": [
                       {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 55,
                           "end": 60,
@@ -162,6 +162,7 @@
                           "raw": "300"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 58,
                             "end": 60,

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/fit-content/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/fit-content/span.rust-debug
@@ -151,7 +151,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, fit-content(300px));
   |                                                  ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/grid/repeat/fit-content/input.css:2:47
   |
 2 |     grid-template-columns: repeat(4, fit-content(300px));
@@ -163,7 +163,7 @@ error: Number
 2 |     grid-template-columns: repeat(4, fit-content(300px));
   |                                                  ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/grid/repeat/fit-content/input.css:2:50
   |
 2 |     grid-template-columns: repeat(4, fit-content(300px));

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/flex/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/flex/output.json
@@ -127,7 +127,7 @@
                     "value": ","
                   },
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 43,
                       "end": 46,
@@ -144,6 +144,7 @@
                       "raw": "1"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 44,
                         "end": 46,

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/flex/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/flex/span.rust-debug
@@ -133,7 +133,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, 1fr);
   |                                      ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/grid/repeat/flex/input.css:2:35
   |
 2 |     grid-template-columns: repeat(4, 1fr);
@@ -145,7 +145,7 @@ error: Number
 2 |     grid-template-columns: repeat(4, 1fr);
   |                                      ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/grid/repeat/flex/input.css:2:36
   |
 2 |     grid-template-columns: repeat(4, 1fr);

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/minmax/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/minmax/output.json
@@ -164,7 +164,7 @@
                         "value": ","
                       },
                       {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 63,
                           "end": 68,
@@ -181,6 +181,7 @@
                           "raw": "300"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 66,
                             "end": 68,

--- a/crates/swc_css_parser/tests/fixture/rome/grid/repeat/minmax/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/grid/repeat/minmax/span.rust-debug
@@ -175,7 +175,7 @@ error: Value
 2 |     grid-template-columns: repeat(4, minmax(min-content, 300px));
   |                                                          ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/grid/repeat/minmax/input.css:2:55
   |
 2 |     grid-template-columns: repeat(4, minmax(min-content, 300px));
@@ -187,7 +187,7 @@ error: Number
 2 |     grid-template-columns: repeat(4, minmax(min-content, 300px));
   |                                                          ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/grid/repeat/minmax/input.css:2:58
   |
 2 |     grid-template-columns: repeat(4, minmax(min-content, 300px));

--- a/crates/swc_css_parser/tests/fixture/rome/keyframe/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/keyframe/output.json
@@ -69,7 +69,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 55,
                       "end": 59,
@@ -86,6 +86,7 @@
                       "raw": "50"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 57,
                         "end": 59,
@@ -150,7 +151,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 107,
                       "end": 112,
@@ -167,6 +168,7 @@
                       "raw": "100"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 110,
                         "end": 112,

--- a/crates/swc_css_parser/tests/fixture/rome/keyframe/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/keyframe/span.rust-debug
@@ -114,7 +114,7 @@ error: Value
 3 |         margin-top: 50px !important;
   |                     ^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/keyframe/input.css:3:21
   |
 3 |         margin-top: 50px !important;
@@ -126,7 +126,7 @@ error: Number
 3 |         margin-top: 50px !important;
   |                     ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/keyframe/input.css:3:23
   |
 3 |         margin-top: 50px !important;
@@ -194,7 +194,7 @@ error: Value
 6 |         margin-top: 100px !important;
   |                     ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/keyframe/input.css:6:21
   |
 6 |         margin-top: 100px !important;
@@ -206,7 +206,7 @@ error: Number
 6 |         margin-top: 100px !important;
   |                     ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/keyframe/input.css:6:24
   |
 6 |         margin-top: 100px !important;

--- a/crates/swc_css_parser/tests/fixture/rome/media/condition/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/media/condition/output.json
@@ -56,7 +56,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 19,
                       "end": 24,
@@ -73,6 +73,7 @@
                       "raw": "800"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 22,
                         "end": 24,
@@ -140,7 +141,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 48,
                       "end": 53,
@@ -157,6 +158,7 @@
                       "raw": "800"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 51,
                         "end": 53,
@@ -192,7 +194,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 71,
                         "end": 76,
@@ -209,6 +211,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 74,
                           "end": 76,
@@ -245,7 +248,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 94,
                         "end": 99,
@@ -262,6 +265,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 97,
                           "end": 99,
@@ -330,7 +334,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 123,
                       "end": 128,
@@ -347,6 +351,7 @@
                       "raw": "800"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 126,
                         "end": 128,
@@ -382,7 +387,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 146,
                         "end": 151,
@@ -399,6 +404,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 149,
                           "end": 151,
@@ -435,7 +441,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 169,
                         "end": 174,
@@ -452,6 +458,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 172,
                           "end": 174,
@@ -488,7 +495,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 192,
                         "end": 197,
@@ -505,6 +512,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 195,
                           "end": 197,
@@ -580,7 +588,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 225,
                         "end": 230,
@@ -597,6 +605,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 228,
                           "end": 230,
@@ -673,7 +682,7 @@
                         "raw": "min-width"
                       },
                       "value": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 255,
                           "end": 260,
@@ -690,6 +699,7 @@
                           "raw": "800"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 258,
                             "end": 260,
@@ -725,7 +735,7 @@
                           "raw": "min-width"
                         },
                         "value": {
-                          "type": "UnitValue",
+                          "type": "Dimension",
                           "span": {
                             "start": 278,
                             "end": 283,
@@ -742,6 +752,7 @@
                             "raw": "800"
                           },
                           "unit": {
+                            "type": "Identifier",
                             "span": {
                               "start": 281,
                               "end": 283,
@@ -780,7 +791,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 301,
                         "end": 306,
@@ -797,6 +808,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 304,
                           "end": 306,
@@ -865,7 +877,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 330,
                       "end": 335,
@@ -882,6 +894,7 @@
                       "raw": "800"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 333,
                         "end": 335,
@@ -925,7 +938,7 @@
                           "raw": "min-width"
                         },
                         "value": {
-                          "type": "UnitValue",
+                          "type": "Dimension",
                           "span": {
                             "start": 354,
                             "end": 359,
@@ -942,6 +955,7 @@
                             "raw": "800"
                           },
                           "unit": {
+                            "type": "Identifier",
                             "span": {
                               "start": 357,
                               "end": 359,
@@ -977,7 +991,7 @@
                             "raw": "min-width"
                           },
                           "value": {
-                            "type": "UnitValue",
+                            "type": "Dimension",
                             "span": {
                               "start": 376,
                               "end": 381,
@@ -994,6 +1008,7 @@
                               "raw": "800"
                             },
                             "unit": {
+                              "type": "Identifier",
                               "span": {
                                 "start": 379,
                                 "end": 381,
@@ -1073,7 +1088,7 @@
                         "raw": "min-width"
                       },
                       "value": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 407,
                           "end": 412,
@@ -1090,6 +1105,7 @@
                           "raw": "800"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 410,
                             "end": 412,
@@ -1125,7 +1141,7 @@
                           "raw": "min-width"
                         },
                         "value": {
-                          "type": "UnitValue",
+                          "type": "Dimension",
                           "span": {
                             "start": 430,
                             "end": 435,
@@ -1142,6 +1158,7 @@
                             "raw": "800"
                           },
                           "unit": {
+                            "type": "Identifier",
                             "span": {
                               "start": 433,
                               "end": 435,
@@ -1180,7 +1197,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 453,
                         "end": 458,
@@ -1197,6 +1214,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 456,
                           "end": 458,
@@ -1399,7 +1417,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 506,
                       "end": 511,
@@ -1416,6 +1434,7 @@
                       "raw": "800"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 509,
                         "end": 511,
@@ -1459,7 +1478,7 @@
                           "raw": "min-width"
                         },
                         "value": {
-                          "type": "UnitValue",
+                          "type": "Dimension",
                           "span": {
                             "start": 530,
                             "end": 535,
@@ -1476,6 +1495,7 @@
                             "raw": "800"
                           },
                           "unit": {
+                            "type": "Identifier",
                             "span": {
                               "start": 533,
                               "end": 535,
@@ -1511,7 +1531,7 @@
                             "raw": "min-width"
                           },
                           "value": {
-                            "type": "UnitValue",
+                            "type": "Dimension",
                             "span": {
                               "start": 552,
                               "end": 557,
@@ -1528,6 +1548,7 @@
                               "raw": "800"
                             },
                             "unit": {
+                              "type": "Identifier",
                               "span": {
                                 "start": 555,
                                 "end": 557,

--- a/crates/swc_css_parser/tests/fixture/rome/media/condition/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/media/condition/span.rust-debug
@@ -88,7 +88,7 @@ error: MediaFeatureValue
 1 | @media (min-width: 800px) {}
   |                    ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:1:20
   |
 1 | @media (min-width: 800px) {}
@@ -100,7 +100,7 @@ error: Number
 1 | @media (min-width: 800px) {}
   |                    ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:1:23
   |
 1 | @media (min-width: 800px) {}
@@ -184,7 +184,7 @@ error: MediaFeatureValue
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                    ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:2:20
   |
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -196,7 +196,7 @@ error: Number
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                    ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:2:23
   |
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -250,7 +250,7 @@ error: MediaFeatureValue
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                           ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:2:43
   |
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -262,7 +262,7 @@ error: Number
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                           ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:2:46
   |
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -316,7 +316,7 @@ error: MediaFeatureValue
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                                  ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:2:66
   |
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -328,7 +328,7 @@ error: Number
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                                  ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:2:69
   |
 2 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -412,7 +412,7 @@ error: MediaFeatureValue
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                    ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:3:20
   |
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -424,7 +424,7 @@ error: Number
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                    ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:3:23
   |
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -478,7 +478,7 @@ error: MediaFeatureValue
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                           ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:3:43
   |
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -490,7 +490,7 @@ error: Number
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                           ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:3:46
   |
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -544,7 +544,7 @@ error: MediaFeatureValue
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                                  ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:3:66
   |
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -556,7 +556,7 @@ error: Number
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                                  ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:3:69
   |
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -610,7 +610,7 @@ error: MediaFeatureValue
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                                                         ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:3:89
   |
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -622,7 +622,7 @@ error: Number
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                                                         ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:3:92
   |
 3 | @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -712,7 +712,7 @@ error: MediaFeatureValue
 4 | @media not (min-width: 800px) {}
   |                        ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:4:24
   |
 4 | @media not (min-width: 800px) {}
@@ -724,7 +724,7 @@ error: Number
 4 | @media not (min-width: 800px) {}
   |                        ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:4:27
   |
 4 | @media not (min-width: 800px) {}
@@ -826,7 +826,7 @@ error: MediaFeatureValue
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
   |                     ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:5:21
   |
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -838,7 +838,7 @@ error: Number
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
   |                     ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:5:24
   |
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -892,7 +892,7 @@ error: MediaFeatureValue
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
   |                                            ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:5:44
   |
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -904,7 +904,7 @@ error: Number
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
   |                                            ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:5:47
   |
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -958,7 +958,7 @@ error: MediaFeatureValue
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
   |                                                                   ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:5:67
   |
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -970,7 +970,7 @@ error: Number
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
   |                                                                   ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:5:70
   |
 5 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {}
@@ -1054,7 +1054,7 @@ error: MediaFeatureValue
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
   |                    ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:6:20
   |
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -1066,7 +1066,7 @@ error: Number
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
   |                    ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:6:23
   |
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -1138,7 +1138,7 @@ error: MediaFeatureValue
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
   |                                            ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:6:44
   |
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -1150,7 +1150,7 @@ error: Number
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
   |                                            ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:6:47
   |
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -1204,7 +1204,7 @@ error: MediaFeatureValue
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
   |                                                                  ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:6:66
   |
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -1216,7 +1216,7 @@ error: Number
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
   |                                                                  ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:6:69
   |
 6 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {}
@@ -1336,7 +1336,7 @@ error: MediaFeatureValue
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
   |                     ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:7:21
   |
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
@@ -1348,7 +1348,7 @@ error: Number
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
   |                     ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:7:24
   |
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
@@ -1402,7 +1402,7 @@ error: MediaFeatureValue
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
   |                                            ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:7:44
   |
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
@@ -1414,7 +1414,7 @@ error: Number
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
   |                                            ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:7:47
   |
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
@@ -1468,7 +1468,7 @@ error: MediaFeatureValue
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
   |                                                                   ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/condition/input.css:7:67
   |
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
@@ -1480,7 +1480,7 @@ error: Number
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
   |                                                                   ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/condition/input.css:7:70
   |
 7 | @media ((min-width: 800px) and (min-width: 800px)) or (min-width: 800px) {
@@ -1702,7 +1702,7 @@ error: MediaFeatureValue
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
    |                    ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/media/condition/input.css:15:20
    |
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
@@ -1714,7 +1714,7 @@ error: Number
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
    |                    ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/media/condition/input.css:15:23
    |
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
@@ -1786,7 +1786,7 @@ error: MediaFeatureValue
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
    |                                            ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/media/condition/input.css:15:44
    |
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
@@ -1798,7 +1798,7 @@ error: Number
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
    |                                            ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/media/condition/input.css:15:47
    |
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
@@ -1852,7 +1852,7 @@ error: MediaFeatureValue
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
    |                                                                  ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/media/condition/input.css:15:66
    |
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
@@ -1864,7 +1864,7 @@ error: Number
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {
    |                                                                  ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/media/condition/input.css:15:69
    |
 15 | @media (min-width: 800px) and ((min-width: 800px) or (min-width: 800px)) {

--- a/crates/swc_css_parser/tests/fixture/rome/media/feature/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/media/feature/output.json
@@ -215,7 +215,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 98,
                       "end": 103,
@@ -232,6 +232,7 @@
                       "raw": "800"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 101,
                         "end": 103,
@@ -308,7 +309,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 154,
                       "end": 159,
@@ -325,6 +326,7 @@
                       "raw": "800"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 157,
                         "end": 159,
@@ -401,7 +403,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 202,
                       "end": 207,
@@ -418,6 +420,7 @@
                       "raw": "800"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 205,
                         "end": 207,
@@ -453,7 +456,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 225,
                         "end": 230,
@@ -470,6 +473,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 228,
                           "end": 230,
@@ -506,7 +510,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 248,
                         "end": 253,
@@ -523,6 +527,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 251,
                           "end": 253,
@@ -600,7 +605,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 288,
                       "end": 293,
@@ -617,6 +622,7 @@
                       "raw": "800"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 291,
                         "end": 293,
@@ -652,7 +658,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 311,
                         "end": 316,
@@ -669,6 +675,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 314,
                           "end": 316,
@@ -705,7 +712,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 334,
                         "end": 339,
@@ -722,6 +729,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 337,
                           "end": 339,
@@ -758,7 +766,7 @@
                       "raw": "min-width"
                     },
                     "value": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 357,
                         "end": 362,
@@ -775,6 +783,7 @@
                         "raw": "800"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 360,
                           "end": 362,

--- a/crates/swc_css_parser/tests/fixture/rome/media/feature/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/media/feature/span.rust-debug
@@ -262,7 +262,7 @@ error: MediaFeatureValue
 3 | @media only screen and (min-width: 800px) {}
   |                                    ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/feature/input.css:3:36
   |
 3 | @media only screen and (min-width: 800px) {}
@@ -274,7 +274,7 @@ error: Number
 3 | @media only screen and (min-width: 800px) {}
   |                                    ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/feature/input.css:3:39
   |
 3 | @media only screen and (min-width: 800px) {}
@@ -364,7 +364,7 @@ error: MediaFeatureValue
 4 | @media screen and (min-width       :          800px        ) {}
   |                                               ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/feature/input.css:4:47
   |
 4 | @media screen and (min-width       :          800px        ) {}
@@ -376,7 +376,7 @@ error: Number
 4 | @media screen and (min-width       :          800px        ) {}
   |                                               ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/feature/input.css:4:50
   |
 4 | @media screen and (min-width       :          800px        ) {}
@@ -466,7 +466,7 @@ error: MediaFeatureValue
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                               ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/feature/input.css:5:31
   |
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -478,7 +478,7 @@ error: Number
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                               ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/feature/input.css:5:34
   |
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -532,7 +532,7 @@ error: MediaFeatureValue
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                      ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/feature/input.css:5:54
   |
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -544,7 +544,7 @@ error: Number
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                      ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/feature/input.css:5:57
   |
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -598,7 +598,7 @@ error: MediaFeatureValue
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                                             ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/feature/input.css:5:77
   |
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -610,7 +610,7 @@ error: Number
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
   |                                                                             ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/feature/input.css:5:80
   |
 5 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
@@ -700,7 +700,7 @@ error: MediaFeatureValue
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
   |                               ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/feature/input.css:6:31
   |
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
@@ -712,7 +712,7 @@ error: Number
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
   |                               ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/feature/input.css:6:34
   |
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
@@ -766,7 +766,7 @@ error: MediaFeatureValue
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
   |                                                      ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/feature/input.css:6:54
   |
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
@@ -778,7 +778,7 @@ error: Number
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
   |                                                      ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/feature/input.css:6:57
   |
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
@@ -832,7 +832,7 @@ error: MediaFeatureValue
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
   |                                                                             ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/feature/input.css:6:77
   |
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
@@ -844,7 +844,7 @@ error: Number
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
   |                                                                             ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/feature/input.css:6:80
   |
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
@@ -898,7 +898,7 @@ error: MediaFeatureValue
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
   |                                                                                                    ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/media/feature/input.css:6:100
   |
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
@@ -910,7 +910,7 @@ error: Number
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}
   |                                                                                                    ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/media/feature/input.css:6:103
   |
 6 | @media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){}

--- a/crates/swc_css_parser/tests/fixture/rome/min-and-max/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/min-and-max/output.json
@@ -108,7 +108,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 21,
                       "end": 26,
@@ -125,6 +125,7 @@
                       "raw": "500"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 24,
                         "end": 26,
@@ -176,7 +177,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 41,
                       "end": 46,
@@ -193,6 +194,7 @@
                       "raw": "500"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 44,
                         "end": 46,
@@ -282,7 +284,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 68,
                       "end": 73,
@@ -299,6 +301,7 @@
                       "raw": "500"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 71,
                         "end": 73,
@@ -326,7 +329,7 @@
                     },
                     "op": "+",
                     "left": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 75,
                         "end": 79,
@@ -343,6 +346,7 @@
                         "raw": "40"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 77,
                           "end": 79,
@@ -413,7 +417,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 99,
                       "end": 104,
@@ -430,6 +434,7 @@
                       "raw": "500"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 102,
                         "end": 104,
@@ -483,7 +488,7 @@
                         }
                       },
                       "right": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 111,
                           "end": 116,
@@ -500,6 +505,7 @@
                           "raw": "400"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 114,
                             "end": 116,
@@ -511,7 +517,7 @@
                       }
                     },
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 119,
                         "end": 122,
@@ -528,6 +534,7 @@
                         "raw": "2"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 120,
                           "end": 122,
@@ -580,7 +587,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 137,
                       "end": 142,
@@ -597,6 +604,7 @@
                       "raw": "500"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 140,
                         "end": 142,
@@ -650,7 +658,7 @@
                         }
                       },
                       "right": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 149,
                           "end": 154,
@@ -667,6 +675,7 @@
                           "raw": "400"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 152,
                             "end": 154,
@@ -678,7 +687,7 @@
                       }
                     },
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 157,
                         "end": 160,
@@ -695,6 +704,7 @@
                         "raw": "2"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 158,
                           "end": 160,
@@ -749,7 +759,7 @@
                         }
                       },
                       "right": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 167,
                           "end": 172,
@@ -766,6 +776,7 @@
                           "raw": "400"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 170,
                             "end": 172,
@@ -777,7 +788,7 @@
                       }
                     },
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 175,
                         "end": 178,
@@ -794,6 +805,7 @@
                         "raw": "2"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 176,
                           "end": 178,
@@ -848,7 +860,7 @@
                         }
                       },
                       "right": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 185,
                           "end": 190,
@@ -865,6 +877,7 @@
                           "raw": "400"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 188,
                             "end": 190,
@@ -876,7 +889,7 @@
                       }
                     },
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 193,
                         "end": 196,
@@ -893,6 +906,7 @@
                         "raw": "2"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 194,
                           "end": 196,
@@ -945,7 +959,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 211,
                       "end": 216,
@@ -962,6 +976,7 @@
                       "raw": "500"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 214,
                         "end": 216,
@@ -1013,7 +1028,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 231,
                       "end": 236,
@@ -1030,6 +1045,7 @@
                       "raw": "500"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 234,
                         "end": 236,
@@ -1119,7 +1135,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 258,
                       "end": 263,
@@ -1136,6 +1152,7 @@
                       "raw": "500"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 261,
                         "end": 263,
@@ -1163,7 +1180,7 @@
                     },
                     "op": "+",
                     "left": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 265,
                         "end": 269,
@@ -1180,6 +1197,7 @@
                         "raw": "40"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 267,
                           "end": 269,
@@ -1250,7 +1268,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 289,
                       "end": 294,
@@ -1267,6 +1285,7 @@
                       "raw": "500"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 292,
                         "end": 294,
@@ -1320,7 +1339,7 @@
                         }
                       },
                       "right": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 301,
                           "end": 306,
@@ -1337,6 +1356,7 @@
                           "raw": "400"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 304,
                             "end": 306,
@@ -1348,7 +1368,7 @@
                       }
                     },
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 309,
                         "end": 312,
@@ -1365,6 +1385,7 @@
                         "raw": "2"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 310,
                           "end": 312,
@@ -1417,7 +1438,7 @@
                 },
                 "value": [
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 327,
                       "end": 332,
@@ -1434,6 +1455,7 @@
                       "raw": "500"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 330,
                         "end": 332,
@@ -1487,7 +1509,7 @@
                         }
                       },
                       "right": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 339,
                           "end": 344,
@@ -1504,6 +1526,7 @@
                           "raw": "400"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 342,
                             "end": 344,
@@ -1515,7 +1538,7 @@
                       }
                     },
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 347,
                         "end": 350,
@@ -1532,6 +1555,7 @@
                         "raw": "2"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 348,
                           "end": 350,
@@ -1586,7 +1610,7 @@
                         }
                       },
                       "right": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 357,
                           "end": 362,
@@ -1603,6 +1627,7 @@
                           "raw": "400"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 360,
                             "end": 362,
@@ -1614,7 +1639,7 @@
                       }
                     },
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 365,
                         "end": 368,
@@ -1631,6 +1656,7 @@
                         "raw": "2"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 366,
                           "end": 368,
@@ -1685,7 +1711,7 @@
                         }
                       },
                       "right": {
-                        "type": "UnitValue",
+                        "type": "Dimension",
                         "span": {
                           "start": 375,
                           "end": 380,
@@ -1702,6 +1728,7 @@
                           "raw": "400"
                         },
                         "unit": {
+                          "type": "Identifier",
                           "span": {
                             "start": 378,
                             "end": 380,
@@ -1713,7 +1740,7 @@
                       }
                     },
                     "right": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 383,
                         "end": 386,
@@ -1730,6 +1757,7 @@
                         "raw": "2"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 384,
                           "end": 386,

--- a/crates/swc_css_parser/tests/fixture/rome/min-and-max/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/min-and-max/span.rust-debug
@@ -125,7 +125,7 @@ error: Value
 2 |     width: max(500px);
   |                ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:2:13
   |
 2 |     width: max(500px);
@@ -137,7 +137,7 @@ error: Number
 2 |     width: max(500px);
   |                ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:2:16
   |
 2 |     width: max(500px);
@@ -185,7 +185,7 @@ error: Value
 3 |     width: max(500px, 6 / 4);
   |                ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:3:13
   |
 3 |     width: max(500px, 6 / 4);
@@ -197,7 +197,7 @@ error: Number
 3 |     width: max(500px, 6 / 4);
   |                ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:3:16
   |
 3 |     width: max(500px, 6 / 4);
@@ -293,7 +293,7 @@ error: Value
 4 |     width: max(500px, 40px + 5%);
   |                ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:4:13
   |
 4 |     width: max(500px, 40px + 5%);
@@ -305,7 +305,7 @@ error: Number
 4 |     width: max(500px, 40px + 5%);
   |                ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:4:16
   |
 4 |     width: max(500px, 40px + 5%);
@@ -341,7 +341,7 @@ error: Value
 4 |     width: max(500px, 40px + 5%);
   |                       ^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:4:20
   |
 4 |     width: max(500px, 40px + 5%);
@@ -353,7 +353,7 @@ error: Number
 4 |     width: max(500px, 40px + 5%);
   |                       ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:4:22
   |
 4 |     width: max(500px, 40px + 5%);
@@ -419,7 +419,7 @@ error: Value
 5 |     width: max(500px, 5% * 400px + 2px);
   |                ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:5:13
   |
 5 |     width: max(500px, 5% * 400px + 2px);
@@ -431,7 +431,7 @@ error: Number
 5 |     width: max(500px, 5% * 400px + 2px);
   |                ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:5:16
   |
 5 |     width: max(500px, 5% * 400px + 2px);
@@ -497,7 +497,7 @@ error: Value
 5 |     width: max(500px, 5% * 400px + 2px);
   |                            ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:5:25
   |
 5 |     width: max(500px, 5% * 400px + 2px);
@@ -509,7 +509,7 @@ error: Number
 5 |     width: max(500px, 5% * 400px + 2px);
   |                            ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:5:28
   |
 5 |     width: max(500px, 5% * 400px + 2px);
@@ -521,7 +521,7 @@ error: Value
 5 |     width: max(500px, 5% * 400px + 2px);
   |                                    ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:5:33
   |
 5 |     width: max(500px, 5% * 400px + 2px);
@@ -533,7 +533,7 @@ error: Number
 5 |     width: max(500px, 5% * 400px + 2px);
   |                                    ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:5:34
   |
 5 |     width: max(500px, 5% * 400px + 2px);
@@ -581,7 +581,7 @@ error: Value
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:13
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -593,7 +593,7 @@ error: Number
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:16
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -659,7 +659,7 @@ error: Value
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                            ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:25
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -671,7 +671,7 @@ error: Number
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                            ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:28
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -683,7 +683,7 @@ error: Value
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                    ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:33
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -695,7 +695,7 @@ error: Number
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                    ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:34
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -761,7 +761,7 @@ error: Value
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                              ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:43
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -773,7 +773,7 @@ error: Number
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                              ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:46
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -785,7 +785,7 @@ error: Value
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                                      ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:51
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -797,7 +797,7 @@ error: Number
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                                      ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:52
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -863,7 +863,7 @@ error: Value
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                                                ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:61
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -875,7 +875,7 @@ error: Number
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                                                ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:64
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -887,7 +887,7 @@ error: Value
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                                                        ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:69
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -899,7 +899,7 @@ error: Number
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
   |                                                                        ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:6:70
   |
 6 |     width: max(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -947,7 +947,7 @@ error: Value
 7 |     width: min(500px);
   |                ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:7:13
   |
 7 |     width: min(500px);
@@ -959,7 +959,7 @@ error: Number
 7 |     width: min(500px);
   |                ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:7:16
   |
 7 |     width: min(500px);
@@ -1007,7 +1007,7 @@ error: Value
 8 |     width: min(500px, 6 / 4);
   |                ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:8:13
   |
 8 |     width: min(500px, 6 / 4);
@@ -1019,7 +1019,7 @@ error: Number
 8 |     width: min(500px, 6 / 4);
   |                ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:8:16
   |
 8 |     width: min(500px, 6 / 4);
@@ -1115,7 +1115,7 @@ error: Value
 9 |     width: min(500px, 40px + 5%);
   |                ^^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:9:13
   |
 9 |     width: min(500px, 40px + 5%);
@@ -1127,7 +1127,7 @@ error: Number
 9 |     width: min(500px, 40px + 5%);
   |                ^^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:9:16
   |
 9 |     width: min(500px, 40px + 5%);
@@ -1163,7 +1163,7 @@ error: Value
 9 |     width: min(500px, 40px + 5%);
   |                       ^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/min-and-max/input.css:9:20
   |
 9 |     width: min(500px, 40px + 5%);
@@ -1175,7 +1175,7 @@ error: Number
 9 |     width: min(500px, 40px + 5%);
   |                       ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/min-and-max/input.css:9:22
   |
 9 |     width: min(500px, 40px + 5%);
@@ -1241,7 +1241,7 @@ error: Value
 10 |     width: min(500px, 5% * 400px + 2px);
    |                ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/min-and-max/input.css:10:13
    |
 10 |     width: min(500px, 5% * 400px + 2px);
@@ -1253,7 +1253,7 @@ error: Number
 10 |     width: min(500px, 5% * 400px + 2px);
    |                ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/min-and-max/input.css:10:16
    |
 10 |     width: min(500px, 5% * 400px + 2px);
@@ -1319,7 +1319,7 @@ error: Value
 10 |     width: min(500px, 5% * 400px + 2px);
    |                            ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/min-and-max/input.css:10:25
    |
 10 |     width: min(500px, 5% * 400px + 2px);
@@ -1331,7 +1331,7 @@ error: Number
 10 |     width: min(500px, 5% * 400px + 2px);
    |                            ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/min-and-max/input.css:10:28
    |
 10 |     width: min(500px, 5% * 400px + 2px);
@@ -1343,7 +1343,7 @@ error: Value
 10 |     width: min(500px, 5% * 400px + 2px);
    |                                    ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/min-and-max/input.css:10:33
    |
 10 |     width: min(500px, 5% * 400px + 2px);
@@ -1355,7 +1355,7 @@ error: Number
 10 |     width: min(500px, 5% * 400px + 2px);
    |                                    ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/min-and-max/input.css:10:34
    |
 10 |     width: min(500px, 5% * 400px + 2px);
@@ -1403,7 +1403,7 @@ error: Value
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:13
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1415,7 +1415,7 @@ error: Number
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:16
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1481,7 +1481,7 @@ error: Value
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                            ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:25
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1493,7 +1493,7 @@ error: Number
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                            ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:28
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1505,7 +1505,7 @@ error: Value
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                    ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:33
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1517,7 +1517,7 @@ error: Number
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                    ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:34
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1583,7 +1583,7 @@ error: Value
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:43
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1595,7 +1595,7 @@ error: Number
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                              ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:46
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1607,7 +1607,7 @@ error: Value
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                                      ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:51
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1619,7 +1619,7 @@ error: Number
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                                      ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:52
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1685,7 +1685,7 @@ error: Value
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                                                ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:61
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1697,7 +1697,7 @@ error: Number
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                                                ^^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:64
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1709,7 +1709,7 @@ error: Value
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                                                        ^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:69
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
@@ -1721,7 +1721,7 @@ error: Number
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);
    |                                                                        ^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/min-and-max/input.css:11:70
    |
 11 |     width: min(500px, 5% * 400px + 2px, 5% * 400px + 2px, 5% * 400px + 2px);

--- a/crates/swc_css_parser/tests/fixture/rome/smoke/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/smoke/output.json
@@ -146,7 +146,7 @@
                     },
                     "op": "+",
                     "left": {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 66,
                         "end": 69,
@@ -163,6 +163,7 @@
                         "raw": "1"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 67,
                           "end": 69,

--- a/crates/swc_css_parser/tests/fixture/rome/smoke/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/smoke/span.rust-debug
@@ -153,7 +153,7 @@ error: Value
 4 |     width: calc(1px + 2%);
   |                 ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/smoke/input.css:4:17
   |
 4 |     width: calc(1px + 2%);
@@ -165,7 +165,7 @@ error: Number
 4 |     width: calc(1px + 2%);
   |                 ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/smoke/input.css:4:18
   |
 4 |     width: calc(1px + 2%);

--- a/crates/swc_css_parser/tests/fixture/rome/supports/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/supports/output.json
@@ -118,7 +118,7 @@
                 "raw": "0"
               },
               {
-                "type": "UnitValue",
+                "type": "Dimension",
                 "span": {
                   "start": 63,
                   "end": 66,
@@ -135,6 +135,7 @@
                   "raw": "2"
                 },
                 "unit": {
+                  "type": "Identifier",
                   "span": {
                     "start": 64,
                     "end": 66,
@@ -213,7 +214,7 @@
                   "raw": "0"
                 },
                 {
-                  "type": "UnitValue",
+                  "type": "Dimension",
                   "span": {
                     "start": 117,
                     "end": 120,
@@ -230,6 +231,7 @@
                     "raw": "2"
                   },
                   "unit": {
+                    "type": "Identifier",
                     "span": {
                       "start": 118,
                       "end": 120,
@@ -309,7 +311,7 @@
                   "raw": "0"
                 },
                 {
-                  "type": "UnitValue",
+                  "type": "Dimension",
                   "span": {
                     "start": 174,
                     "end": 177,
@@ -326,6 +328,7 @@
                     "raw": "2"
                   },
                   "unit": {
+                    "type": "Identifier",
                     "span": {
                       "start": 175,
                       "end": 177,
@@ -405,7 +408,7 @@
                   "raw": "0"
                 },
                 {
-                  "type": "UnitValue",
+                  "type": "Dimension",
                   "span": {
                     "start": 226,
                     "end": 229,
@@ -422,6 +425,7 @@
                     "raw": "2"
                   },
                   "unit": {
+                    "type": "Identifier",
                     "span": {
                       "start": 227,
                       "end": 229,
@@ -598,7 +602,7 @@
                   },
                   "value": [
                     {
-                      "type": "UnitValue",
+                      "type": "Dimension",
                       "span": {
                         "start": 359,
                         "end": 364,
@@ -615,6 +619,7 @@
                         "raw": "10"
                       },
                       "unit": {
+                        "type": "Identifier",
                         "span": {
                           "start": 361,
                           "end": 364,

--- a/crates/swc_css_parser/tests/fixture/rome/supports/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/supports/span.rust-debug
@@ -194,7 +194,7 @@ error: Value
 4 | @supports ( box-shadow: 0 0 2px black inset ) or
   |                             ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/supports/input.css:4:29
   |
 4 | @supports ( box-shadow: 0 0 2px black inset ) or
@@ -206,7 +206,7 @@ error: Number
 4 | @supports ( box-shadow: 0 0 2px black inset ) or
   |                             ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/supports/input.css:4:30
   |
 4 | @supports ( box-shadow: 0 0 2px black inset ) or
@@ -312,7 +312,7 @@ error: Value
 5 |           ( -moz-box-shadow: 0 0 2px black inset ) or
   |                                  ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/supports/input.css:5:34
   |
 5 |           ( -moz-box-shadow: 0 0 2px black inset ) or
@@ -324,7 +324,7 @@ error: Number
 5 |           ( -moz-box-shadow: 0 0 2px black inset ) or
   |                                  ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/supports/input.css:5:35
   |
 5 |           ( -moz-box-shadow: 0 0 2px black inset ) or
@@ -430,7 +430,7 @@ error: Value
 6 |           ( -webkit-box-shadow: 0 0 2px black inset ) or
   |                                     ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/supports/input.css:6:37
   |
 6 |           ( -webkit-box-shadow: 0 0 2px black inset ) or
@@ -442,7 +442,7 @@ error: Number
 6 |           ( -webkit-box-shadow: 0 0 2px black inset ) or
   |                                     ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/supports/input.css:6:38
   |
 6 |           ( -webkit-box-shadow: 0 0 2px black inset ) or
@@ -548,7 +548,7 @@ error: Value
 7 |           ( -o-box-shadow: 0 0 2px black inset ) {}
   |                                ^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/rome/supports/input.css:7:32
   |
 7 |           ( -o-box-shadow: 0 0 2px black inset ) {}
@@ -560,7 +560,7 @@ error: Number
 7 |           ( -o-box-shadow: 0 0 2px black inset ) {}
   |                                ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/rome/supports/input.css:7:33
   |
 7 |           ( -o-box-shadow: 0 0 2px black inset ) {}
@@ -823,7 +823,7 @@ error: Value
 12 |           (transform: rotate(10deg)) {}
    |                              ^^^^^
 
-error: UnitValue
+error: Dimension
   --> $DIR/tests/fixture/rome/supports/input.css:12:30
    |
 12 |           (transform: rotate(10deg)) {}
@@ -835,7 +835,7 @@ error: Number
 12 |           (transform: rotate(10deg)) {}
    |                              ^^
 
-error: Unit
+error: Ident
   --> $DIR/tests/fixture/rome/supports/input.css:12:32
    |
 12 |           (transform: rotate(10deg)) {}

--- a/crates/swc_css_parser/tests/fixture/stylis/comma/01/output.json
+++ b/crates/swc_css_parser/tests/fixture/stylis/comma/01/output.json
@@ -136,7 +136,7 @@
                     "modifiers": null
                   },
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 39,
                       "end": 41,
@@ -153,6 +153,7 @@
                       "raw": "2"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 40,
                         "end": 41,

--- a/crates/swc_css_parser/tests/fixture/stylis/comma/01/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/stylis/comma/01/span.rust-debug
@@ -133,7 +133,7 @@ error: Value
 2 |     cursor: image-set(url(foo.jpg) 2x), pointer;
   |                                    ^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/stylis/comma/01/input.css:2:36
   |
 2 |     cursor: image-set(url(foo.jpg) 2x), pointer;
@@ -145,7 +145,7 @@ error: Number
 2 |     cursor: image-set(url(foo.jpg) 2x), pointer;
   |                                    ^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/stylis/comma/01/input.css:2:37
   |
 2 |     cursor: image-set(url(foo.jpg) 2x), pointer;

--- a/crates/swc_css_parser/tests/fixture/value/square-brackets/output.json
+++ b/crates/swc_css_parser/tests/fixture/value/square-brackets/output.json
@@ -264,7 +264,7 @@
                     "raw": "fff"
                   },
                   {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 133,
                       "end": 137,
@@ -281,6 +281,7 @@
                       "raw": "12"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 135,
                         "end": 137,

--- a/crates/swc_css_parser/tests/fixture/value/square-brackets/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/square-brackets/span.rust-debug
@@ -281,7 +281,7 @@ error: Value
 6 |     prop:  [red #fff 12px];
   |                      ^^^^
 
-error: UnitValue
+error: Dimension
  --> $DIR/tests/fixture/value/square-brackets/input.css:6:22
   |
 6 |     prop:  [red #fff 12px];
@@ -293,7 +293,7 @@ error: Number
 6 |     prop:  [red #fff 12px];
   |                      ^^
 
-error: Unit
+error: Ident
  --> $DIR/tests/fixture/value/square-brackets/input.css:6:24
   |
 6 |     prop:  [red #fff 12px];

--- a/crates/swc_css_parser/tests/recovery/vercel/001/output.json
+++ b/crates/swc_css_parser/tests/recovery/vercel/001/output.json
@@ -56,7 +56,7 @@
                     "raw": "min-width"
                   },
                   "value": {
-                    "type": "UnitValue",
+                    "type": "Dimension",
                     "span": {
                       "start": 19,
                       "end": 24,
@@ -73,6 +73,7 @@
                       "raw": "935"
                     },
                     "unit": {
+                      "type": "Identifier",
                       "span": {
                         "start": 22,
                         "end": 24,

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -86,16 +86,10 @@ define!({
         AtRule(AtRule),
     }
 
-    pub struct Unit {
-        pub span: Span,
-        pub value: JsWord,
-        pub raw: JsWord,
-    }
-
     pub enum Value {
         SimpleBlock(SimpleBlock),
 
-        Unit(UnitValue),
+        Dimension(Dimension),
 
         Number(Number),
 
@@ -156,10 +150,10 @@ define!({
         pub raw: JsWord,
     }
 
-    pub struct UnitValue {
+    pub struct Dimension {
         pub span: Span,
         pub value: Number,
-        pub unit: Unit,
+        pub unit: Ident,
     }
 
     pub struct Percent {
@@ -548,7 +542,7 @@ define!({
 
     pub enum MediaFeatureValue {
         Number(Number),
-        Dimension(UnitValue),
+        Dimension(Dimension),
         Ident(Ident),
         Ratio(Ratio),
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Refactor `UnitValue`:
1. Use `Dimension` (spec https://www.w3.org/TR/css-values-4/#dimensions)
2. Use `Ident` in `unit`, we don't need extra AST type, because (from spec):

> When written literally, a dimension is a number immediately followed by a unit identifier, which is an identifier. 

Yes

**Related issue (if exists):**

No