### PR TITLE
fix: empty `@media` parsing

### DIFF
--- a/crates/swc_css_ast/src/at_rule/media.rs
+++ b/crates/swc_css_ast/src/at_rule/media.rs
@@ -5,7 +5,7 @@ use swc_common::{ast_node, EqIgnoreSpan, Span};
 #[ast_node("MediaRule")]
 pub struct MediaRule {
     pub span: Span,
-    pub media: MediaQueryList,
+    pub media: Option<MediaQueryList>,
     pub rules: Vec<Rule>,
 }
 

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -288,11 +288,14 @@ where
     fn emit_media_rule(&mut self, n: &MediaRule) -> Result {
         punct!(self, "@");
         keyword!(self, "media");
-        space!(self);
 
-        emit!(self, n.media);
-
-        formatting_space!(self);
+        if n.media.is_some() {
+            space!(self);
+            emit!(self, n.media);
+            formatting_space!(self);
+        } else {
+            formatting_space!(self);
+        }
 
         punct!(self, "{");
         self.emit_list(&n.rules, ListFormat::NotDelimited | ListFormat::MultiLine)?;

--- a/crates/swc_css_codegen/tests/fixture/at-rules/media/3/input.css
+++ b/crates/swc_css_codegen/tests/fixture/at-rules/media/3/input.css
@@ -1,0 +1,5 @@
+@media {
+    div {
+        color: red
+    }
+}

--- a/crates/swc_css_codegen/tests/fixture/at-rules/media/3/output.css
+++ b/crates/swc_css_codegen/tests/fixture/at-rules/media/3/output.css
@@ -1,0 +1,1 @@
+@media {div {color: red}}

--- a/crates/swc_css_codegen/tests/fixture/at-rules/media/3/output.min.css
+++ b/crates/swc_css_codegen/tests/fixture/at-rules/media/3/output.min.css
@@ -1,0 +1,1 @@
+@media{div{color:red}}

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -811,7 +811,14 @@ where
 {
     fn parse(&mut self) -> PResult<MediaRule> {
         let span = self.input.cur_span()?;
-        let media = self.parse()?;
+
+        let media = if !is!(self, "{") {
+            let media_query_list = self.parse()?;
+
+            Some(media_query_list)
+        } else {
+            None
+        };
 
         expect!(self, "{");
 

--- a/crates/swc_css_parser/tests/fixture/at-rule/media/input.css
+++ b/crates/swc_css_parser/tests/fixture/at-rule/media/input.css
@@ -108,3 +108,6 @@
 @media ONLY screen AND (color) {}
 @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
 @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
+
+@media {}
+@media    {}

--- a/crates/swc_css_parser/tests/fixture/at-rule/media/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/media/output.json
@@ -2,8 +2,7 @@
   "type": "Stylesheet",
   "span": {
     "start": 0,
-    "end": 3935,
-    "end": 3747,
+    "end": 3959,
     "ctxt": 0
   },
   "rules": [
@@ -9395,10 +9394,6 @@
           }
         ]
       },
-        "end": 3733,
-        "ctxt": 0
-      },
-      "media": null,
       "rules": []
     },
     {
@@ -9805,8 +9800,23 @@
           }
         ]
       },
-        "start": 3734,
-        "end": 3746,
+      "rules": []
+    },
+    {
+      "type": "MediaRule",
+      "span": {
+        "start": 3936,
+        "end": 3945,
+        "ctxt": 0
+      },
+      "media": null,
+      "rules": []
+    },
+    {
+      "type": "MediaRule",
+      "span": {
+        "start": 3946,
+        "end": 3958,
         "ctxt": 0
       },
       "media": null,

--- a/crates/swc_css_parser/tests/fixture/at-rule/media/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/media/output.json
@@ -3,6 +3,7 @@
   "span": {
     "start": 0,
     "end": 3935,
+    "end": 3747,
     "ctxt": 0
   },
   "rules": [
@@ -9394,6 +9395,10 @@
           }
         ]
       },
+        "end": 3733,
+        "ctxt": 0
+      },
+      "media": null,
       "rules": []
     },
     {
@@ -9800,6 +9805,11 @@
           }
         ]
       },
+        "start": 3734,
+        "end": 3746,
+        "ctxt": 0
+      },
+      "media": null,
       "rules": []
     }
   ]

--- a/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
@@ -6,9 +6,9 @@ error: Stylesheet
 3   | |
 4   | | @media all {}
 ...   |
-109 | | @media ((min-width: 800px) AND (min-width: 800px)) OR (min-width: 800px) {}
-110 | | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
-    | |____________________________________________________________________________^
+112 | | @media {}
+113 | | @media    {}
+    | |_____________^
 
 error: Rule
  --> $DIR/tests/fixture/at-rule/media/input.css:1:1
@@ -11097,4 +11097,40 @@ error: Ident
     |
 110 | @media (min-width: 800px) AND ((min-width: 800px) OR (min-width: 800px)) {}
     |                                                                     ^^
+
+error: Rule
+   --> $DIR/tests/fixture/at-rule/media/input.css:112:1
+    |
+112 | @media {}
+    | ^^^^^^^^^
+
+error: AtRule
+   --> $DIR/tests/fixture/at-rule/media/input.css:112:1
+    |
+112 | @media {}
+    | ^^^^^^^^^
+
+error: MediaRule
+   --> $DIR/tests/fixture/at-rule/media/input.css:112:1
+    |
+112 | @media {}
+    | ^^^^^^^^^
+
+error: Rule
+   --> $DIR/tests/fixture/at-rule/media/input.css:113:1
+    |
+113 | @media    {}
+    | ^^^^^^^^^^^^
+
+error: AtRule
+   --> $DIR/tests/fixture/at-rule/media/input.css:113:1
+    |
+113 | @media    {}
+    | ^^^^^^^^^^^^
+
+error: MediaRule
+   --> $DIR/tests/fixture/at-rule/media/input.css:113:1
+    |
+113 | @media    {}
+    | ^^^^^^^^^^^^
 

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -465,7 +465,7 @@ define!({
 
     pub struct MediaRule {
         pub span: Span,
-        pub media: MediaQueryList,
+        pub media: Option<MediaQueryList>,
         pub rules: Vec<Rule>,
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Bugfix - empty `@media {}`

**BREAKING CHANGE:**

Yes, type changed

**Related issue (if exists):**

No