### PR TITLE
refactor: color

### DIFF
--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -20,8 +20,8 @@ pub enum Value {
     #[tag("Ratio")]
     Ratio(Ratio),
 
-    #[tag("HashValue")]
-    Hash(HashValue),
+    #[tag("Color")]
+    Color(Color),
 
     #[tag("Ident")]
     Ident(Ident),
@@ -84,8 +84,15 @@ pub struct Function {
     pub value: Vec<Value>,
 }
 
-#[ast_node("HashValue")]
-pub struct HashValue {
+#[ast_node]
+pub enum Color {
+    // TODO more
+    #[tag("HexColor")]
+    HexColor(HexColor),
+}
+
+#[ast_node("HexColor")]
+pub struct HexColor {
     /// Includes `#`
     pub span: Span,
     /// Does **not** include `#`

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -652,7 +652,7 @@ where
             Value::Number(n) => emit!(self, n),
             Value::Percent(n) => emit!(self, n),
             Value::Ratio(n) => emit!(self, n),
-            Value::Hash(n) => emit!(self, n),
+            Value::Color(n) => emit!(self, n),
             Value::Ident(n) => emit!(self, n),
             Value::DashedIdent(n) => emit!(self, n),
             Value::Str(n) => emit!(self, n),
@@ -883,7 +883,14 @@ where
     }
 
     #[emitter]
-    fn emit_hash_value(&mut self, n: &HashValue) -> Result {
+    fn emit_color(&mut self, n: &Color) -> Result {
+        match n {
+            Color::HexColor(n) => emit!(self, n),
+        }
+    }
+
+    #[emitter]
+    fn emit_hex_color(&mut self, n: &HexColor) -> Result {
         punct!(self, "#");
 
         self.wr.write_raw(Some(n.span), &n.raw)?;

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -287,18 +287,7 @@ where
                 return self.parse_brace_value().map(From::from);
             }
 
-            tok!("#") => {
-                let token = bump!(self);
-
-                match token {
-                    Token::Hash { value, raw, .. } => {
-                        return Ok(Value::Hash(HashValue { span, value, raw }))
-                    }
-                    _ => {
-                        unreachable!()
-                    }
-                }
-            }
+            tok!("#") => return Ok(Value::Color(Color::HexColor(self.parse()?))),
 
             Token::AtKeyword { .. } => {
                 let name = bump!(self);
@@ -730,6 +719,26 @@ where
                     },
                 })
             }
+            _ => {
+                unreachable!()
+            }
+        }
+    }
+}
+
+impl<I> Parse<HexColor> for Parser<I>
+where
+    I: ParserInput,
+{
+    fn parse(&mut self) -> PResult<HexColor> {
+        let span = self.input.cur_span()?;
+
+        if !is!(self, "#") {
+            return Err(Error::new(span, ErrorKind::Expected("hash token")));
+        }
+
+        match bump!(self) {
+            Token::Hash { value, raw, .. } => Ok(HexColor { span, value, raw }),
             _ => {
                 unreachable!()
             }

--- a/crates/swc_css_parser/tests/fixture.rs
+++ b/crates/swc_css_parser/tests/fixture.rs
@@ -292,7 +292,7 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(Block, visit_block);
     mtd!(SimpleBlock, visit_simple_block);
     mtd!(Function, visit_function);
-    mtd!(HashValue, visit_hash_value);
+    mtd!(HexColor, visit_hex_color);
     mtd!(NestingSelector, visit_nesting_selector);
     mtd!(IdSelector, visit_id_selector);
     mtd!(TypeSelector, visit_type_selector);

--- a/crates/swc_css_parser/tests/fixture/at-rule/layer/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/layer/output.json
@@ -1480,7 +1480,7 @@
                     },
                     "value": [
                       {
-                        "type": "HashValue",
+                        "type": "HexColor",
                         "span": {
                           "start": 736,
                           "end": 740,

--- a/crates/swc_css_parser/tests/fixture/at-rule/layer/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/layer/span.rust-debug
@@ -1504,7 +1504,7 @@ error: Value
 44 |         p { color: #222; }
    |                    ^^^^
 
-error: HashValue
+error: HexColor
   --> $DIR/tests/fixture/at-rule/layer/input.css:44:20
    |
 44 |         p { color: #222; }

--- a/crates/swc_css_parser/tests/fixture/declaration/output.json
+++ b/crates/swc_css_parser/tests/fixture/declaration/output.json
@@ -689,7 +689,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 285,
                   "end": 289,
@@ -699,7 +699,7 @@
                 "raw": "ccc"
               },
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 289,
                   "end": 293,

--- a/crates/swc_css_parser/tests/fixture/declaration/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/declaration/span.rust-debug
@@ -701,7 +701,7 @@ error: Value
 14 |     prop: #ccc#ccc;
    |           ^^^^
 
-error: HashValue
+error: HexColor
   --> $DIR/tests/fixture/declaration/input.css:14:11
    |
 14 |     prop: #ccc#ccc;
@@ -713,7 +713,7 @@ error: Value
 14 |     prop: #ccc#ccc;
    |               ^^^^
 
-error: HashValue
+error: HexColor
   --> $DIR/tests/fixture/declaration/input.css:14:15
    |
 14 |     prop: #ccc#ccc;

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/-4j83DwgJa0nPQIjlb0RIA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/-4j83DwgJa0nPQIjlb0RIA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/-4j83DwgJa0nPQIjlb0RIA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/-4j83DwgJa0nPQIjlb0RIA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #112333 }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/-4j83DwgJa0nPQIjlb0RIA/input.css:1:12
   |
 1 | a { color: #112333 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/39pbt1sIeFh8WWhCalZS4g/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/39pbt1sIeFh8WWhCalZS4g/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/39pbt1sIeFh8WWhCalZS4g/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/39pbt1sIeFh8WWhCalZS4g/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #ABCD }
   |            ^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/39pbt1sIeFh8WWhCalZS4g/input.css:1:12
   |
 1 | a { color: #ABCD }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/3EgMpLwjJNG0ht4U_r6cnw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/3EgMpLwjJNG0ht4U_r6cnw/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/3EgMpLwjJNG0ht4U_r6cnw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/3EgMpLwjJNG0ht4U_r6cnw/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #ABBBCCDD }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/3EgMpLwjJNG0ht4U_r6cnw/input.css:1:12
   |
 1 | a { color: #ABBBCCDD }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/3JGye8AhworwNFoUL1gKbg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/3JGye8AhworwNFoUL1gKbg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/3JGye8AhworwNFoUL1gKbg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/3JGye8AhworwNFoUL1gKbg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #abcf }
   |            ^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/3JGye8AhworwNFoUL1gKbg/input.css:1:12
   |
 1 | a { color: #abcf }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/486QvEO8dmLFsXYp6xgKVw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/486QvEO8dmLFsXYp6xgKVw/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 19,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/486QvEO8dmLFsXYp6xgKVw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/486QvEO8dmLFsXYp6xgKVw/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: #\30hash }
   |            ^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/486QvEO8dmLFsXYp6xgKVw/input.css:1:12
   |
 1 | a { value: #\30hash }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/5yer6GUWydidDHrfgacUkA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/5yer6GUWydidDHrfgacUkA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/5yer6GUWydidDHrfgacUkA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/5yer6GUWydidDHrfgacUkA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #1234 }
   |            ^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/5yer6GUWydidDHrfgacUkA/input.css:1:12
   |
 1 | a { color: #1234 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/7CK6ZYt4CWz7Ge5KWLKBYg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/7CK6ZYt4CWz7Ge5KWLKBYg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/7CK6ZYt4CWz7Ge5KWLKBYg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/7CK6ZYt4CWz7Ge5KWLKBYg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #aabbccef }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/7CK6ZYt4CWz7Ge5KWLKBYg/input.css:1:12
   |
 1 | a { color: #aabbccef }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/9IIa-42s3YQFw8ilk39GdQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/9IIa-42s3YQFw8ilk39GdQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/9IIa-42s3YQFw8ilk39GdQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/9IIa-42s3YQFw8ilk39GdQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #AABBCCFF }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/9IIa-42s3YQFw8ilk39GdQ/input.css:1:12
   |
 1 | a { color: #AABBCCFF }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Afm91-TMNbzd52HsPrCCNA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Afm91-TMNbzd52HsPrCCNA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Afm91-TMNbzd52HsPrCCNA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Afm91-TMNbzd52HsPrCCNA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #abbbccff }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/Afm91-TMNbzd52HsPrCCNA/input.css:1:12
   |
 1 | a { color: #abbbccff }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/AigZ338AGwCqF4M9a3Quqw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/AigZ338AGwCqF4M9a3Quqw/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/AigZ338AGwCqF4M9a3Quqw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/AigZ338AGwCqF4M9a3Quqw/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #AABCCCDD }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/AigZ338AGwCqF4M9a3Quqw/input.css:1:12
   |
 1 | a { color: #AABCCCDD }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/AocxkR5Gt30Hu6JV7J56Wg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/AocxkR5Gt30Hu6JV7J56Wg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/AocxkR5Gt30Hu6JV7J56Wg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/AocxkR5Gt30Hu6JV7J56Wg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #aabccc }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/AocxkR5Gt30Hu6JV7J56Wg/input.css:1:12
   |
 1 | a { color: #aabccc }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/BKyQWW5j9vRP-kr41nqcjg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/BKyQWW5j9vRP-kr41nqcjg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 19,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/BKyQWW5j9vRP-kr41nqcjg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/BKyQWW5j9vRP-kr41nqcjg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: #\68 ash }
   |            ^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/BKyQWW5j9vRP-kr41nqcjg/input.css:1:12
   |
 1 | a { value: #\68 ash }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/C4I0cdQcSbpaGOS-V8fwew/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/C4I0cdQcSbpaGOS-V8fwew/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 19,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/C4I0cdQcSbpaGOS-V8fwew/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/C4I0cdQcSbpaGOS-V8fwew/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: #0h\61sh }
   |            ^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/C4I0cdQcSbpaGOS-V8fwew/input.css:1:12
   |
 1 | a { value: #0h\61sh }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/C6gS3Kl0KEwGsFaUUGXzFg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/C6gS3Kl0KEwGsFaUUGXzFg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/C6gS3Kl0KEwGsFaUUGXzFg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/C6gS3Kl0KEwGsFaUUGXzFg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #112234ff }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/C6gS3Kl0KEwGsFaUUGXzFg/input.css:1:12
   |
 1 | a { color: #112234ff }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/CQiowK9DjojqKtlpQifemA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/CQiowK9DjojqKtlpQifemA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/CQiowK9DjojqKtlpQifemA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/CQiowK9DjojqKtlpQifemA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #ABBBCC }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/CQiowK9DjojqKtlpQifemA/input.css:1:12
   |
 1 | a { color: #ABBBCC }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/EJPa4WhTn_fRRrDiA2bczg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/EJPa4WhTn_fRRrDiA2bczg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/EJPa4WhTn_fRRrDiA2bczg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/EJPa4WhTn_fRRrDiA2bczg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #aabbcc }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/EJPa4WhTn_fRRrDiA2bczg/input.css:1:12
   |
 1 | a { color: #aabbcc }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/EYFn-trzBus37dDEvK1jUQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/EYFn-trzBus37dDEvK1jUQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/EYFn-trzBus37dDEvK1jUQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/EYFn-trzBus37dDEvK1jUQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #122233 }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/EYFn-trzBus37dDEvK1jUQ/input.css:1:12
   |
 1 | a { color: #122233 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/FlqjDLebWxQvNIxKppBllw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/FlqjDLebWxQvNIxKppBllw/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/FlqjDLebWxQvNIxKppBllw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/FlqjDLebWxQvNIxKppBllw/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #aabbcd }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/FlqjDLebWxQvNIxKppBllw/input.css:1:12
   |
 1 | a { color: #aabbcd }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Fm7gvlx7uRyvrfzUC7rJxg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Fm7gvlx7uRyvrfzUC7rJxg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 15,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Fm7gvlx7uRyvrfzUC7rJxg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Fm7gvlx7uRyvrfzUC7rJxg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: #x\, }
   |            ^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/Fm7gvlx7uRyvrfzUC7rJxg/input.css:1:12
   |
 1 | a { value: #x\, }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/HDNE73X9waUrBkTAzz-20g/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/HDNE73X9waUrBkTAzz-20g/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/HDNE73X9waUrBkTAzz-20g/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/HDNE73X9waUrBkTAzz-20g/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: #h\61sh }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/HDNE73X9waUrBkTAzz-20g/input.css:1:12
   |
 1 | a { value: #h\61sh }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/LoeMqdekBkn3XKYHQFHOZA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/LoeMqdekBkn3XKYHQFHOZA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/LoeMqdekBkn3XKYHQFHOZA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/LoeMqdekBkn3XKYHQFHOZA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #AABCCC }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/LoeMqdekBkn3XKYHQFHOZA/input.css:1:12
   |
 1 | a { color: #AABCCC }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/MK5PGiCFMf7RHDp05gnDCw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/MK5PGiCFMf7RHDp05gnDCw/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/MK5PGiCFMf7RHDp05gnDCw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/MK5PGiCFMf7RHDp05gnDCw/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #aabbccdd }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/MK5PGiCFMf7RHDp05gnDCw/input.css:1:12
   |
 1 | a { color: #aabbccdd }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/MU8JgGd_-h5ocqkfawNxeQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/MU8JgGd_-h5ocqkfawNxeQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/MU8JgGd_-h5ocqkfawNxeQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/MU8JgGd_-h5ocqkfawNxeQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #abbbccdd }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/MU8JgGd_-h5ocqkfawNxeQ/input.css:1:12
   |
 1 | a { color: #abbbccdd }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Oc6Obl7mbH-MlFllIoAbdg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Oc6Obl7mbH-MlFllIoAbdg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Oc6Obl7mbH-MlFllIoAbdg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Oc6Obl7mbH-MlFllIoAbdg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #AABBCCDE }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/Oc6Obl7mbH-MlFllIoAbdg/input.css:1:12
   |
 1 | a { color: #AABBCCDE }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/R6OYU1g_sB_euLV8Yzjw6w/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/R6OYU1g_sB_euLV8Yzjw6w/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/R6OYU1g_sB_euLV8Yzjw6w/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/R6OYU1g_sB_euLV8Yzjw6w/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #AABBCCEF }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/R6OYU1g_sB_euLV8Yzjw6w/input.css:1:12
   |
 1 | a { color: #AABBCCEF }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/RmGccmub1dooAN8WPKTwhQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/RmGccmub1dooAN8WPKTwhQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/RmGccmub1dooAN8WPKTwhQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/RmGccmub1dooAN8WPKTwhQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #123f }
   |            ^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/RmGccmub1dooAN8WPKTwhQ/input.css:1:12
   |
 1 | a { color: #123f }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/SFBgyV9jnFbMzWZoo9VbSQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/SFBgyV9jnFbMzWZoo9VbSQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/SFBgyV9jnFbMzWZoo9VbSQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/SFBgyV9jnFbMzWZoo9VbSQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #ABCF }
   |            ^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/SFBgyV9jnFbMzWZoo9VbSQ/input.css:1:12
   |
 1 | a { color: #ABCF }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Ssg_Qhdw7h_c6ZtY52Qe4A/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Ssg_Qhdw7h_c6ZtY52Qe4A/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Ssg_Qhdw7h_c6ZtY52Qe4A/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Ssg_Qhdw7h_c6ZtY52Qe4A/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #112333ff }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/Ssg_Qhdw7h_c6ZtY52Qe4A/input.css:1:12
   |
 1 | a { color: #112333ff }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/T1SOp4KXmIb1WNsyPFEKqg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/T1SOp4KXmIb1WNsyPFEKqg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/T1SOp4KXmIb1WNsyPFEKqg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/T1SOp4KXmIb1WNsyPFEKqg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #aabbccde }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/T1SOp4KXmIb1WNsyPFEKqg/input.css:1:12
   |
 1 | a { color: #aabbccde }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/U2nuhvtnEWZ_kMd6i7EDWA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/U2nuhvtnEWZ_kMd6i7EDWA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/U2nuhvtnEWZ_kMd6i7EDWA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/U2nuhvtnEWZ_kMd6i7EDWA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #AABBCD }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/U2nuhvtnEWZ_kMd6i7EDWA/input.css:1:12
   |
 1 | a { color: #AABBCD }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/W3R-c5DPSkhG9QWYdcFdFg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/W3R-c5DPSkhG9QWYdcFdFg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/W3R-c5DPSkhG9QWYdcFdFg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/W3R-c5DPSkhG9QWYdcFdFg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #AABBCCDD }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/W3R-c5DPSkhG9QWYdcFdFg/input.css:1:12
   |
 1 | a { color: #AABBCCDD }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/YIW6UUMmxrTYJjJ3JSL3uQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/YIW6UUMmxrTYJjJ3JSL3uQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/YIW6UUMmxrTYJjJ3JSL3uQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/YIW6UUMmxrTYJjJ3JSL3uQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #112234 }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/YIW6UUMmxrTYJjJ3JSL3uQ/input.css:1:12
   |
 1 | a { color: #112234 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Ys7z8C2qi5O_HM9ElZQrUQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Ys7z8C2qi5O_HM9ElZQrUQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 15,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/Ys7z8C2qi5O_HM9ElZQrUQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/Ys7z8C2qi5O_HM9ElZQrUQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: #\,x }
   |            ^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/Ys7z8C2qi5O_HM9ElZQrUQ/input.css:1:12
   |
 1 | a { value: #\,x }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/_APxY5Pe47Bb71-CwD1nhw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/_APxY5Pe47Bb71-CwD1nhw/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/_APxY5Pe47Bb71-CwD1nhw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/_APxY5Pe47Bb71-CwD1nhw/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #AABBCDFF }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/_APxY5Pe47Bb71-CwD1nhw/input.css:1:12
   |
 1 | a { color: #AABBCDFF }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/_U4zAUbS93Xo7_tJOolGuA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/_U4zAUbS93Xo7_tJOolGuA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 15,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/_U4zAUbS93Xo7_tJOolGuA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/_U4zAUbS93Xo7_tJOolGuA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #f00 }
   |            ^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/_U4zAUbS93Xo7_tJOolGuA/input.css:1:12
   |
 1 | a { color: #f00 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/a0Yurt7E7InOYieD7nMCXg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/a0Yurt7E7InOYieD7nMCXg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/a0Yurt7E7InOYieD7nMCXg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/a0Yurt7E7InOYieD7nMCXg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #AABCCCFF }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/a0Yurt7E7InOYieD7nMCXg/input.css:1:12
   |
 1 | a { color: #AABCCCFF }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/a7KElWOMF9ilrSsoliHkcg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/a7KElWOMF9ilrSsoliHkcg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/a7KElWOMF9ilrSsoliHkcg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/a7KElWOMF9ilrSsoliHkcg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #AABBCDDD }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/a7KElWOMF9ilrSsoliHkcg/input.css:1:12
   |
 1 | a { color: #AABBCDDD }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/b102IE1MrM3aGTKCRrSU6Q/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/b102IE1MrM3aGTKCRrSU6Q/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/b102IE1MrM3aGTKCRrSU6Q/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/b102IE1MrM3aGTKCRrSU6Q/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #ff0000ff }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/b102IE1MrM3aGTKCRrSU6Q/input.css:1:12
   |
 1 | a { color: #ff0000ff }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/b2m1STf0F5CKity6Nd4vmQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/b2m1STf0F5CKity6Nd4vmQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/b2m1STf0F5CKity6Nd4vmQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/b2m1STf0F5CKity6Nd4vmQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #aabbccff }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/b2m1STf0F5CKity6Nd4vmQ/input.css:1:12
   |
 1 | a { color: #aabbccff }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/bdiLSVQWZCfQNNwD_OM6qA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/bdiLSVQWZCfQNNwD_OM6qA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/bdiLSVQWZCfQNNwD_OM6qA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/bdiLSVQWZCfQNNwD_OM6qA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: #\68ash }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/bdiLSVQWZCfQNNwD_OM6qA/input.css:1:12
   |
 1 | a { value: #\68ash }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/cxYYDM0_rXbkvaqi8UPWOg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/cxYYDM0_rXbkvaqi8UPWOg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/cxYYDM0_rXbkvaqi8UPWOg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/cxYYDM0_rXbkvaqi8UPWOg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #aabbcddd }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/cxYYDM0_rXbkvaqi8UPWOg/input.css:1:12
   |
 1 | a { color: #aabbcddd }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/eVSpM_pYsIvyyewUkjTa2A/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/eVSpM_pYsIvyyewUkjTa2A/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/eVSpM_pYsIvyyewUkjTa2A/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/eVSpM_pYsIvyyewUkjTa2A/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #12223344 }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/eVSpM_pYsIvyyewUkjTa2A/input.css:1:12
   |
 1 | a { color: #12223344 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/eivsIn6ub-xYiqErLqd8oA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/eivsIn6ub-xYiqErLqd8oA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/eivsIn6ub-xYiqErLqd8oA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/eivsIn6ub-xYiqErLqd8oA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: #\2cx }
   |            ^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/eivsIn6ub-xYiqErLqd8oA/input.css:1:12
   |
 1 | a { value: #\2cx }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/fTZzFds73kLZoyY9Y2gZdQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/fTZzFds73kLZoyY9Y2gZdQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/fTZzFds73kLZoyY9Y2gZdQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/fTZzFds73kLZoyY9Y2gZdQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #11223345 }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/fTZzFds73kLZoyY9Y2gZdQ/input.css:1:12
   |
 1 | a { color: #11223345 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ftc5-zf_sliOrFRRBGGS-g/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ftc5-zf_sliOrFRRBGGS-g/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/ftc5-zf_sliOrFRRBGGS-g/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/ftc5-zf_sliOrFRRBGGS-g/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #122233ff }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/ftc5-zf_sliOrFRRBGGS-g/input.css:1:12
   |
 1 | a { color: #122233ff }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/gxBoWO36fKxIuYwPzrWyKQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/gxBoWO36fKxIuYwPzrWyKQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 17,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/gxBoWO36fKxIuYwPzrWyKQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/gxBoWO36fKxIuYwPzrWyKQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { value: #x\2c }
   |            ^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/gxBoWO36fKxIuYwPzrWyKQ/input.css:1:12
   |
 1 | a { value: #x\2c }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/inMW5rttJFPDfH0aKVFg_Q/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/inMW5rttJFPDfH0aKVFg_Q/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/inMW5rttJFPDfH0aKVFg_Q/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/inMW5rttJFPDfH0aKVFg_Q/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #11233344 }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/inMW5rttJFPDfH0aKVFg_Q/input.css:1:12
   |
 1 | a { color: #11233344 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/isfWm5W8qb6_aJSz_bdwDw/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/isfWm5W8qb6_aJSz_bdwDw/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/isfWm5W8qb6_aJSz_bdwDw/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/isfWm5W8qb6_aJSz_bdwDw/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #112233 }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/isfWm5W8qb6_aJSz_bdwDw/input.css:1:12
   |
 1 | a { color: #112233 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/j9dr5-Ih68VDH1exMwsmZA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/j9dr5-Ih68VDH1exMwsmZA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/j9dr5-Ih68VDH1exMwsmZA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/j9dr5-Ih68VDH1exMwsmZA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #aabcccff }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/j9dr5-Ih68VDH1exMwsmZA/input.css:1:12
   |
 1 | a { color: #aabcccff }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/mJEhy0k_dxoszsTVHb3x_Q/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/mJEhy0k_dxoszsTVHb3x_Q/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/mJEhy0k_dxoszsTVHb3x_Q/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/mJEhy0k_dxoszsTVHb3x_Q/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #112233ef }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/mJEhy0k_dxoszsTVHb3x_Q/input.css:1:12
   |
 1 | a { color: #112233ef }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/niufyVEBI4s-ZqSXdfhptA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/niufyVEBI4s-ZqSXdfhptA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/niufyVEBI4s-ZqSXdfhptA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/niufyVEBI4s-ZqSXdfhptA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #abcd }
   |            ^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/niufyVEBI4s-ZqSXdfhptA/input.css:1:12
   |
 1 | a { color: #abcd }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/nlYSjWzJfpf38YhsJNbwmA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/nlYSjWzJfpf38YhsJNbwmA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 16,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/nlYSjWzJfpf38YhsJNbwmA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/nlYSjWzJfpf38YhsJNbwmA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #f00f }
   |            ^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/nlYSjWzJfpf38YhsJNbwmA/input.css:1:12
   |
 1 | a { color: #f00f }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/oj5Yn0RxnGFEbVphKqrL2Q/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/oj5Yn0RxnGFEbVphKqrL2Q/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/oj5Yn0RxnGFEbVphKqrL2Q/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/oj5Yn0RxnGFEbVphKqrL2Q/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #aabcccdd }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/oj5Yn0RxnGFEbVphKqrL2Q/input.css:1:12
   |
 1 | a { color: #aabcccdd }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/pTW2Z7kJ0nR_yQzsOsjAwQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/pTW2Z7kJ0nR_yQzsOsjAwQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/pTW2Z7kJ0nR_yQzsOsjAwQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/pTW2Z7kJ0nR_yQzsOsjAwQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #aabbcdff }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/pTW2Z7kJ0nR_yQzsOsjAwQ/input.css:1:12
   |
 1 | a { color: #aabbcdff }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/qmXSF9N8euK5gfPoFGmV_Q/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/qmXSF9N8euK5gfPoFGmV_Q/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/qmXSF9N8euK5gfPoFGmV_Q/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/qmXSF9N8euK5gfPoFGmV_Q/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #AABBCC }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/qmXSF9N8euK5gfPoFGmV_Q/input.css:1:12
   |
 1 | a { color: #AABBCC }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/rZIFO-RMBeLmmQK8U6nNmQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/rZIFO-RMBeLmmQK8U6nNmQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/rZIFO-RMBeLmmQK8U6nNmQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/rZIFO-RMBeLmmQK8U6nNmQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #11223444 }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/rZIFO-RMBeLmmQK8U6nNmQ/input.css:1:12
   |
 1 | a { color: #11223444 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/vN7xRB9YekSqanW68eIoNA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/vN7xRB9YekSqanW68eIoNA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/vN7xRB9YekSqanW68eIoNA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/vN7xRB9YekSqanW68eIoNA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #112233ff }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/vN7xRB9YekSqanW68eIoNA/input.css:1:12
   |
 1 | a { color: #112233ff }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/xc1mD3YfHByTKL-N-FL49A/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/xc1mD3YfHByTKL-N-FL49A/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/xc1mD3YfHByTKL-N-FL49A/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/xc1mD3YfHByTKL-N-FL49A/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #ABBBCCFF }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/xc1mD3YfHByTKL-N-FL49A/input.css:1:12
   |
 1 | a { color: #ABBBCCFF }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/xdJ7w6fdV3po3r2aWrgPdA/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/xdJ7w6fdV3po3r2aWrgPdA/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/xdJ7w6fdV3po3r2aWrgPdA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/xdJ7w6fdV3po3r2aWrgPdA/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #abbbcc }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/xdJ7w6fdV3po3r2aWrgPdA/input.css:1:12
   |
 1 | a { color: #abbbcc }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/yboE7Tr5zjKHy9-m10AZTg/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/yboE7Tr5zjKHy9-m10AZTg/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 20,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/yboE7Tr5zjKHy9-m10AZTg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/yboE7Tr5zjKHy9-m10AZTg/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #11223344 }
   |            ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/yboE7Tr5zjKHy9-m10AZTg/input.css:1:12
   |
 1 | a { color: #11223344 }

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/zUuWz4A8Y6yZO8JMLAe2fQ/output.json
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/zUuWz4A8Y6yZO8JMLAe2fQ/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 11,
                   "end": 18,

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/zUuWz4A8Y6yZO8JMLAe2fQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/zUuWz4A8Y6yZO8JMLAe2fQ/span.rust-debug
@@ -76,7 +76,7 @@ error: Value
 1 | a { color: #ff0000 }
   |            ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/esbuild/misc/zUuWz4A8Y6yZO8JMLAe2fQ/input.css:1:12
   |
 1 | a { color: #ff0000 }

--- a/crates/swc_css_parser/tests/fixture/hex-colors/output.json
+++ b/crates/swc_css_parser/tests/fixture/hex-colors/output.json
@@ -89,7 +89,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 13,
                   "end": 20,
@@ -120,7 +120,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 31,
                   "end": 38,
@@ -151,7 +151,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 49,
                   "end": 56,
@@ -182,7 +182,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 67,
                   "end": 76,
@@ -213,7 +213,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 87,
                   "end": 96,
@@ -244,7 +244,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 107,
                   "end": 111,
@@ -275,7 +275,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 122,
                   "end": 126,
@@ -306,7 +306,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 137,
                   "end": 141,
@@ -337,7 +337,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 152,
                   "end": 157,
@@ -368,7 +368,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 168,
                   "end": 173,
@@ -399,7 +399,7 @@
             },
             "value": [
               {
-                "type": "HashValue",
+                "type": "HexColor",
                 "span": {
                   "start": 184,
                   "end": 189,

--- a/crates/swc_css_parser/tests/fixture/hex-colors/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/hex-colors/span.rust-debug
@@ -101,7 +101,7 @@ error: Value
 2 |   color: #000000;
   |          ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/hex-colors/input.css:2:10
   |
 2 |   color: #000000;
@@ -131,7 +131,7 @@ error: Value
 3 |   color: #ffffff;
   |          ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/hex-colors/input.css:3:10
   |
 3 |   color: #ffffff;
@@ -161,7 +161,7 @@ error: Value
 4 |   color: #FFFFFF;
   |          ^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/hex-colors/input.css:4:10
   |
 4 |   color: #FFFFFF;
@@ -191,7 +191,7 @@ error: Value
 5 |   color: #0000ffcc;
   |          ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/hex-colors/input.css:5:10
   |
 5 |   color: #0000ffcc;
@@ -221,7 +221,7 @@ error: Value
 6 |   color: #0000FFCC;
   |          ^^^^^^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/hex-colors/input.css:6:10
   |
 6 |   color: #0000FFCC;
@@ -251,7 +251,7 @@ error: Value
 7 |   color: #000;
   |          ^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/hex-colors/input.css:7:10
   |
 7 |   color: #000;
@@ -281,7 +281,7 @@ error: Value
 8 |   color: #fff;
   |          ^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/hex-colors/input.css:8:10
   |
 8 |   color: #fff;
@@ -311,7 +311,7 @@ error: Value
 9 |   color: #FFF;
   |          ^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/hex-colors/input.css:9:10
   |
 9 |   color: #FFF;
@@ -341,7 +341,7 @@ error: Value
 10 |   color: #0000;
    |          ^^^^^
 
-error: HashValue
+error: HexColor
   --> $DIR/tests/fixture/hex-colors/input.css:10:10
    |
 10 |   color: #0000;
@@ -371,7 +371,7 @@ error: Value
 11 |   color: #ffff;
    |          ^^^^^
 
-error: HashValue
+error: HexColor
   --> $DIR/tests/fixture/hex-colors/input.css:11:10
    |
 11 |   color: #ffff;
@@ -401,7 +401,7 @@ error: Value
 12 |   color: #FFFF;
    |          ^^^^^
 
-error: HashValue
+error: HexColor
   --> $DIR/tests/fixture/hex-colors/input.css:12:10
    |
 12 |   color: #FFFF;

--- a/crates/swc_css_parser/tests/fixture/value/square-brackets/output.json
+++ b/crates/swc_css_parser/tests/fixture/value/square-brackets/output.json
@@ -254,7 +254,7 @@
                     "raw": "red"
                   },
                   {
-                    "type": "HashValue",
+                    "type": "HexColor",
                     "span": {
                       "start": 128,
                       "end": 132,

--- a/crates/swc_css_parser/tests/fixture/value/square-brackets/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/square-brackets/span.rust-debug
@@ -269,7 +269,7 @@ error: Value
 6 |     prop:  [red #fff 12px];
   |                 ^^^^
 
-error: HashValue
+error: HexColor
  --> $DIR/tests/fixture/value/square-brackets/input.css:6:17
   |
 6 |     prop:  [red #fff 12px];

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -97,7 +97,7 @@ define!({
 
         Ratio(Ratio),
 
-        Hash(HashValue),
+        Color(Color),
 
         Ident(Ident),
 
@@ -144,7 +144,11 @@ define!({
         pub value: Vec<Value>,
     }
 
-    pub struct HashValue {
+    pub enum Color {
+        HexColor(HexColor),
+    }
+
+    pub struct HexColor {
         pub span: Span,
         pub value: JsWord,
         pub raw: JsWord,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Refactor colors:
1. Rename to `HexColor` due https://www.w3.org/TR/css-color-4/#typedef-color

There are more subtypes of color type, they will be implemented late

Also it allows to minify/transform colors faster and easy

**BREAKING CHANGE:**

Yes

**Related issue (if exists):**

No