### PR TITLE
fix(es/modules): Fix span of imports

### DIFF
--- a/crates/swc/tests/fixture/jest/sourcemap-1/input/.swcrc
+++ b/crates/swc/tests/fixture/jest/sourcemap-1/input/.swcrc
@@ -11,12 +11,11 @@
             "hidden": {
                 "jest": true
             }
-        },
+        }
     },
     "module": {
         "type": "commonjs"
     },
     "minify": false,
-    "isModule": true,
     "sourceMaps": "inline"
 }

--- a/crates/swc/tests/fixture/jest/sourcemap-1/input/.swcrc
+++ b/crates/swc/tests/fixture/jest/sourcemap-1/input/.swcrc
@@ -1,0 +1,22 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true
+        },
+        "target": "es2020",
+        "loose": true,
+        "transform": {
+            "legacyDecorator": true,
+            "hidden": {
+                "jest": true
+            }
+        },
+    },
+    "module": {
+        "type": "commonjs"
+    },
+    "minify": false,
+    "isModule": true,
+    "sourceMaps": "inline"
+}

--- a/crates/swc/tests/fixture/jest/sourcemap-1/input/index.ts
+++ b/crates/swc/tests/fixture/jest/sourcemap-1/input/index.ts
@@ -1,0 +1,5 @@
+import { css } from "linaria"
+
+export const Button = css`
+    color: red;
+`

--- a/crates/swc/tests/fixture/jest/sourcemap-1/output/index.ts
+++ b/crates/swc/tests/fixture/jest/sourcemap-1/output/index.ts
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.Button = void 0;
+var _linaria = require("linaria");
+const Button = _linaria.css`
+    color: red;
+`;
+exports.Button = Button;
+
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL2lucHV0L2luZGV4LnRzIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gXCJsaW5hcmlhXCJcblxuZXhwb3J0IGNvbnN0IEJ1dHRvbiA9IGNzc2BcbiAgICBjb2xvcjogcmVkO1xuYCJdLCJuYW1lcyI6WyJCdXR0b24iLCJjc3MiXSwibWFwcGluZ3MiOiI7Ozs7O0FBQW9CLEdBQVMsQ0FBVCxRQUFTO0FBRXRCLEtBQUssQ0FBQ0EsTUFBTSxHQUFHQyxRQUFHLEtBQUM7O0FBRTFCO1FBRmFELE1BQU0sR0FBTkEsTUFBTSJ9

--- a/crates/swc_ecma_transforms_module/src/util.rs
+++ b/crates/swc_ecma_transforms_module/src/util.rs
@@ -430,6 +430,7 @@ impl Scope {
     }
 
     fn fold_ident(folder: &mut impl ModulePass, i: Ident) -> Result<Expr, Ident> {
+        let orig_span = i.span;
         let v = folder.scope().idents.get(&i.to_id()).cloned();
         match v {
             None => Err(i),
@@ -444,7 +445,7 @@ impl Scope {
                 let (ident, span) = scope.imports.get(&src).as_ref().unwrap().as_ref().unwrap();
 
                 let obj = {
-                    let ident = Ident::new(ident.clone(), *span);
+                    let ident = Ident::new(ident.clone(), orig_span.with_ctxt(span.ctxt));
 
                     if lazy {
                         Expr::Call(CallExpr {


### PR DESCRIPTION

**Description:**

swc_ecma_transforms_module:
 - `common_js`: Use original span with the syntax conext of an import specifier.

**Related issue (if exists):**

 - Closes #3416