### PR TITLE
Fix `!important` ast

### DIFF
--- a/crates/swc_css_ast/src/style_rule.rs
+++ b/crates/swc_css_ast/src/style_rule.rs
@@ -59,7 +59,7 @@ pub struct Declaration {
     pub name: DeclarationName,
     pub value: Vec<Value>,
     /// The span includes `!`
-    pub important: Option<Span>,
+    pub important: Option<ImportantFlag>,
 }
 
 #[ast_node]
@@ -68,4 +68,10 @@ pub enum DeclarationName {
     Ident(Ident),
     #[tag("DashedIdent")]
     DashedIdent(DashedIdent),
+}
+
+#[ast_node("ImportantFlag")]
+pub struct ImportantFlag {
+    pub span: Span,
+    pub value: Ident,
 }

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -819,14 +819,6 @@ where
     }
 
     #[emitter]
-    fn emit_declaration_name(&mut self, n: &DeclarationName) -> Result {
-        match n {
-            DeclarationName::Ident(n) => emit!(self, n),
-            DeclarationName::DashedIdent(n) => emit!(self, n),
-        }
-    }
-
-    #[emitter]
     fn emit_declaration(&mut self, n: &Declaration) -> Result {
         emit!(self, n.name);
         punct!(self, ":");
@@ -861,18 +853,35 @@ where
             )?;
         }
 
-        if let Some(tok) = n.important {
+        if n.important.is_some() {
             if !is_custom_property {
                 formatting_space!(self);
             }
 
-            punct!(self, tok, "!");
-
-            self.wr.write_raw(Some(tok), "important")?;
+            emit!(self, n.important);
         }
 
         if self.ctx.semi_after_property {
             punct!(self, ";");
+        }
+    }
+
+    #[emitter]
+    fn emit_declaration_name(&mut self, n: &DeclarationName) -> Result {
+        match n {
+            DeclarationName::Ident(n) => emit!(self, n),
+            DeclarationName::DashedIdent(n) => emit!(self, n),
+        }
+    }
+
+    #[emitter]
+    fn emit_important_flag(&mut self, n: &ImportantFlag) -> Result {
+        punct!(self, "!");
+
+        if self.config.minify {
+            self.wr.write_raw(None, "important")?;
+        } else {
+            emit!(self, n.value);
         }
     }
 

--- a/crates/swc_css_codegen/tests/fixture.rs
+++ b/crates/swc_css_codegen/tests/fixture.rs
@@ -4,6 +4,7 @@ use std::{
 };
 use swc_common::{FileName, Span};
 use swc_css_ast::{HexColor, Number, Str, Stylesheet, UrlValueRaw};
+use swc_css_ast::{ImportantFlag, Number, Str, Stylesheet};
 use swc_css_codegen::{
     writer::basic::{BasicCssWriter, BasicCssWriterConfig},
     CodeGenerator, CodegenConfig, Emit,
@@ -107,6 +108,11 @@ impl VisitMut for NormalizeTest {
         n.before = "".into();
         n.after = "".into();
         n.raw = "".into();
+    fn visit_mut_important_flag(&mut self, n: &mut ImportantFlag) {
+        n.visit_mut_children_with(self);
+
+        n.value.value = n.value.value.to_lowercase().into();
+        n.value.raw = n.value.raw.to_lowercase().into();
     }
 
     fn visit_mut_number(&mut self, n: &mut Number) {

--- a/crates/swc_css_codegen/tests/fixture.rs
+++ b/crates/swc_css_codegen/tests/fixture.rs
@@ -3,8 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use swc_common::{FileName, Span};
-use swc_css_ast::{HexColor, Number, Str, Stylesheet, UrlValueRaw};
-use swc_css_ast::{ImportantFlag, Number, Str, Stylesheet};
+use swc_css_ast::{HexColor, ImportantFlag, Number, Str, Stylesheet, UrlValueRaw};
 use swc_css_codegen::{
     writer::basic::{BasicCssWriter, BasicCssWriterConfig},
     CodeGenerator, CodegenConfig, Emit,
@@ -102,17 +101,19 @@ impl VisitMut for NormalizeTest {
         *n = Default::default()
     }
 
+    fn visit_mut_important_flag(&mut self, n: &mut ImportantFlag) {
+        n.visit_mut_children_with(self);
+
+        n.value.value = n.value.value.to_lowercase().into();
+        n.value.raw = n.value.raw.to_lowercase().into();
+    }
+
     fn visit_mut_url_value_raw(&mut self, n: &mut UrlValueRaw) {
         n.visit_mut_children_with(self);
 
         n.before = "".into();
         n.after = "".into();
         n.raw = "".into();
-    fn visit_mut_important_flag(&mut self, n: &mut ImportantFlag) {
-        n.visit_mut_children_with(self);
-
-        n.value.value = n.value.value.to_lowercase().into();
-        n.value.raw = n.value.raw.to_lowercase().into();
     }
 
     fn visit_mut_number(&mut self, n: &mut Number) {

--- a/crates/swc_css_codegen/tests/fixture/declaration/important/input.css
+++ b/crates/swc_css_codegen/tests/fixture/declaration/important/input.css
@@ -1,0 +1,13 @@
+:root {
+    --foo: red !important;
+    --foo: red!important;
+}
+
+div {
+    color: red!important;
+    color: red !important;
+    color: red !   important;
+    color: red   !   important;
+    color: red   !   IMPORTANT;
+    color: red   !   iMpOrTaNt;
+}

--- a/crates/swc_css_codegen/tests/fixture/declaration/important/output.css
+++ b/crates/swc_css_codegen/tests/fixture/declaration/important/output.css
@@ -1,0 +1,8 @@
+:root {--foo: red !important;
+--foo: red!important}
+div {color: red !important;
+color: red !important;
+color: red !important;
+color: red !important;
+color: red !IMPORTANT;
+color: red !iMpOrTaNt}

--- a/crates/swc_css_codegen/tests/fixture/declaration/important/output.min.css
+++ b/crates/swc_css_codegen/tests/fixture/declaration/important/output.min.css
@@ -1,0 +1,1 @@
+:root{--foo:red !important;--foo:red!important}div{color:red!important;color:red!important;color:red!important;color:red!important;color:red!important;color:red!important}

--- a/crates/swc_css_parser/src/parser/style_rule.rs
+++ b/crates/swc_css_parser/src/parser/style_rule.rs
@@ -253,32 +253,12 @@ where
 
         self.input.skip_ws()?;
 
-        let span_import = self.input.cur_span()?;
-
-        let important = if !is!(self, EOF) && eat!(self, "!") {
-            self.input.skip_ws()?;
-
-            let is_important = match bump!(self) {
-                Token::Ident { value, .. } => &*value.to_ascii_lowercase() == "important",
-                _ => false,
-            };
-
-            if !is_important {
-                return Err(Error::new(
-                    Span::new(
-                        span_import.lo,
-                        self.input.cur_span()?.hi,
-                        Default::default(),
-                    ),
-                    ErrorKind::ExpectedButGot("!important"),
-                ));
-            }
-
-            self.input.skip_ws()?;
+        let important = if !is!(self, EOF) && is!(self, "!") {
+            let important_flag = self.parse()?;
 
             end = self.input.last_pos()?;
 
-            Some(span!(self, span_import.lo))
+            Some(important_flag)
         } else {
             None
         };
@@ -290,6 +270,30 @@ where
             name,
             value,
             important,
+        })
+    }
+}
+
+impl<I> Parse<ImportantFlag> for Parser<I>
+where
+    I: ParserInput,
+{
+    fn parse(&mut self) -> PResult<ImportantFlag> {
+        let span = self.input.cur_span()?;
+
+        expect!(self, "!");
+
+        self.input.skip_ws()?;
+
+        let ident: Ident = self.parse()?;
+
+        if &*ident.value.to_ascii_lowercase() != "important" {
+            return Err(Error::new(span, ErrorKind::Expected("important")));
+        }
+
+        Ok(ImportantFlag {
+            span: span!(self, span.lo),
+            value: ident,
         })
     }
 }

--- a/crates/swc_css_parser/src/parser/style_rule.rs
+++ b/crates/swc_css_parser/src/parser/style_rule.rs
@@ -253,7 +253,7 @@ where
 
         self.input.skip_ws()?;
 
-        let important = if !is!(self, EOF) && is!(self, "!") {
+        let important = if is!(self, "!") {
             let important_flag = self.parse()?;
 
             end = self.input.last_pos()?;

--- a/crates/swc_css_parser/tests/errors/custom-properties/exclamation/output.stderr
+++ b/crates/swc_css_parser/tests/errors/custom-properties/exclamation/output.stderr
@@ -1,6 +1,6 @@
-error: Expected !important
- --> $DIR/tests/errors/custom-properties/exclamation/input.css:1:15
+error: Expected Ident
+ --> $DIR/tests/errors/custom-properties/exclamation/input.css:1:16
   |
 1 | .class {--foo:!; }
-  |               ^^^
+  |                ^
 

--- a/crates/swc_css_parser/tests/errors/important/basic/output.stderr
+++ b/crates/swc_css_parser/tests/errors/important/basic/output.stderr
@@ -1,6 +1,6 @@
-error: Expected !important
- --> $DIR/tests/errors/important/basic/input.css:2:18
+error: Expected Ident
+ --> $DIR/tests/errors/important/basic/input.css:2:19
   |
 2 |     color: white !!important;
-  |                  ^^^^^^^^^^^
+  |                   ^
 

--- a/crates/swc_css_parser/tests/fixture.rs
+++ b/crates/swc_css_parser/tests/fixture.rs
@@ -298,8 +298,9 @@ impl Visit for SpanVisualizer<'_> {
     mtd!(Number, visit_number);
     mtd!(Ratio, visit_ratio);
     mtd!(Percent, visit_percent);
-    mtd!(DeclarationName, visit_declaration_name);
     mtd!(Declaration, visit_declaration);
+    mtd!(DeclarationName, visit_declaration_name);
+    mtd!(ImportantFlag, visit_important_flag);
     mtd!(Nth, visit_nth);
     mtd!(AnPlusB, visit_an_plus_b);
     mtd!(PseudoClassSelector, visit_pseudo_class_selector);

--- a/crates/swc_css_parser/tests/fixture/at-rule/import/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/import/output.json
@@ -4716,9 +4716,22 @@
           }
         ],
         "important": {
-          "start": 3899,
-          "end": 3909,
-          "ctxt": 0
+          "type": "ImportantFlag",
+          "span": {
+            "start": 3899,
+            "end": 3909,
+            "ctxt": 0
+          },
+          "value": {
+            "type": "Identifier",
+            "span": {
+              "start": 3900,
+              "end": 3909,
+              "ctxt": 0
+            },
+            "value": "important",
+            "raw": "important"
+          }
         }
       },
       "media": null

--- a/crates/swc_css_parser/tests/fixture/at-rule/import/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/import/span.rust-debug
@@ -5716,6 +5716,18 @@ error: Ident
 129 | @import url("./test.css") supports(display: flex !important);
     |                                             ^^^^
 
+error: ImportantFlag
+   --> $DIR/tests/fixture/at-rule/import/input.css:129:50
+    |
+129 | @import url("./test.css") supports(display: flex !important);
+    |                                                  ^^^^^^^^^^
+
+error: Ident
+   --> $DIR/tests/fixture/at-rule/import/input.css:129:51
+    |
+129 | @import url("./test.css") supports(display: flex !important);
+    |                                                   ^^^^^^^^^
+
 error: Rule
    --> $DIR/tests/fixture/at-rule/import/input.css:130:1
     |

--- a/crates/swc_css_parser/tests/fixture/at-rule/supports/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/supports/output.json
@@ -2270,9 +2270,22 @@
               }
             ],
             "important": {
-              "start": 1226,
-              "end": 1236,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 1226,
+                "end": 1236,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 1227,
+                  "end": 1236,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           }
         ]

--- a/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
@@ -2834,6 +2834,18 @@ error: Ident
 33 | @supports (display: flex !important) {}
    |                     ^^^^
 
+error: ImportantFlag
+  --> $DIR/tests/fixture/at-rule/supports/input.css:33:26
+   |
+33 | @supports (display: flex !important) {}
+   |                          ^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/at-rule/supports/input.css:33:27
+   |
+33 | @supports (display: flex !important) {}
+   |                           ^^^^^^^^^
+
 error: Rule
   --> $DIR/tests/fixture/at-rule/supports/input.css:34:1
    |

--- a/crates/swc_css_parser/tests/fixture/important/basic/input.css
+++ b/crates/swc_css_parser/tests/fixture/important/basic/input.css
@@ -14,4 +14,6 @@
     height: 100px /*! test */ important;
     z-index: 1 ""! important;
     padding: 1px/* sep */!important;
+    prop: red !iMpOrTaNt;
+    color: red !imp\ortant;
 }

--- a/crates/swc_css_parser/tests/fixture/important/basic/output.json
+++ b/crates/swc_css_parser/tests/fixture/important/basic/output.json
@@ -2,7 +2,7 @@
   "type": "Stylesheet",
   "span": {
     "start": 0,
-    "end": 496,
+    "end": 550,
     "ctxt": 0
   },
   "rules": [
@@ -10,7 +10,7 @@
       "type": "QualifiedRule",
       "span": {
         "start": 0,
-        "end": 495,
+        "end": 549,
         "ctxt": 0
       },
       "prelude": {
@@ -67,7 +67,7 @@
         "type": "Block",
         "span": {
           "start": 3,
-          "end": 495,
+          "end": 549,
           "ctxt": 0
         },
         "value": [
@@ -191,9 +191,22 @@
               }
             ],
             "important": {
-              "start": 66,
-              "end": 76,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 66,
+                "end": 76,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 67,
+                  "end": 76,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -226,9 +239,22 @@
               }
             ],
             "important": {
-              "start": 92,
-              "end": 102,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 92,
+                "end": 102,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 93,
+                  "end": 102,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -261,9 +287,22 @@
               }
             ],
             "important": {
-              "start": 119,
-              "end": 129,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 119,
+                "end": 129,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 120,
+                  "end": 129,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -296,16 +335,29 @@
               }
             ],
             "important": {
-              "start": 147,
-              "end": 157,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 147,
+                "end": 157,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 148,
+                  "end": 157,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
             "type": "Declaration",
             "span": {
               "start": 163,
-              "end": 190,
+              "end": 187,
               "ctxt": 0
             },
             "name": {
@@ -331,9 +383,22 @@
               }
             ],
             "important": {
-              "start": 174,
-              "end": 190,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 174,
+                "end": 187,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 178,
+                  "end": 187,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -366,16 +431,29 @@
               }
             ],
             "important": {
-              "start": 208,
-              "end": 218,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 208,
+                "end": 218,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 209,
+                  "end": 218,
+                  "ctxt": 0
+                },
+                "value": "IMPORTANT",
+                "raw": "IMPORTANT"
+              }
             }
           },
           {
             "type": "Declaration",
             "span": {
               "start": 224,
-              "end": 253,
+              "end": 250,
               "ctxt": 0
             },
             "name": {
@@ -401,9 +479,22 @@
               }
             ],
             "important": {
-              "start": 237,
-              "end": 253,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 237,
+                "end": 250,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 241,
+                  "end": 250,
+                  "ctxt": 0
+                },
+                "value": "IMPORTANT",
+                "raw": "IMPORTANT"
+              }
             }
           },
           {
@@ -454,9 +545,22 @@
               }
             ],
             "important": {
-              "start": 277,
-              "end": 293,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 277,
+                "end": 293,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 284,
+                  "end": 293,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -507,9 +611,22 @@
               }
             ],
             "important": {
-              "start": 317,
-              "end": 342,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 317,
+                "end": 342,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 333,
+                  "end": 342,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -560,9 +677,22 @@
               }
             ],
             "important": {
-              "start": 361,
-              "end": 384,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 361,
+                "end": 384,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 375,
+                  "end": 384,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -664,9 +794,22 @@
               }
             ],
             "important": {
-              "start": 444,
-              "end": 455,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 444,
+                "end": 455,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 446,
+                  "end": 455,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -717,9 +860,118 @@
               }
             ],
             "important": {
-              "start": 482,
-              "end": 492,
+              "type": "ImportantFlag",
+              "span": {
+                "start": 482,
+                "end": 492,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 483,
+                  "end": 492,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
+            }
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 498,
+              "end": 518,
               "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 498,
+                "end": 502,
+                "ctxt": 0
+              },
+              "value": "prop",
+              "raw": "prop"
+            },
+            "value": [
+              {
+                "type": "Identifier",
+                "span": {
+                  "start": 504,
+                  "end": 507,
+                  "ctxt": 0
+                },
+                "value": "red",
+                "raw": "red"
+              }
+            ],
+            "important": {
+              "type": "ImportantFlag",
+              "span": {
+                "start": 508,
+                "end": 518,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 509,
+                  "end": 518,
+                  "ctxt": 0
+                },
+                "value": "iMpOrTaNt",
+                "raw": "iMpOrTaNt"
+              }
+            }
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 524,
+              "end": 546,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 524,
+                "end": 529,
+                "ctxt": 0
+              },
+              "value": "color",
+              "raw": "color"
+            },
+            "value": [
+              {
+                "type": "Identifier",
+                "span": {
+                  "start": 531,
+                  "end": 534,
+                  "ctxt": 0
+                },
+                "value": "red",
+                "raw": "red"
+              }
+            ],
+            "important": {
+              "type": "ImportantFlag",
+              "span": {
+                "start": 535,
+                "end": 546,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 536,
+                  "end": 546,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "imp\\ortant"
+              }
             }
           }
         ]

--- a/crates/swc_css_parser/tests/fixture/important/basic/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/important/basic/span.rust-debug
@@ -6,8 +6,8 @@ error: Stylesheet
 3  | |     color: red important;
 4  | |     width: 1px!important;
 ...  |
-16 | |     padding: 1px/* sep */!important;
-17 | | }
+18 | |     color: red !imp\ortant;
+19 | | }
    | |__^
 
 error: Rule
@@ -18,8 +18,8 @@ error: Rule
 3  | |     color: red important;
 4  | |     width: 1px!important;
 ...  |
-16 | |     padding: 1px/* sep */!important;
-17 | | }
+18 | |     color: red !imp\ortant;
+19 | | }
    | |_^
 
 error: QualifiedRule
@@ -30,8 +30,8 @@ error: QualifiedRule
 3  | |     color: red important;
 4  | |     width: 1px!important;
 ...  |
-16 | |     padding: 1px/* sep */!important;
-17 | | }
+18 | |     color: red !imp\ortant;
+19 | | }
    | |_^
 
 error: SelectorList
@@ -79,8 +79,8 @@ error: Block
 3  | |     color: red important;
 4  | |     width: 1px!important;
 ...  |
-16 | |     padding: 1px/* sep */!important;
-17 | | }
+18 | |     color: red !imp\ortant;
+19 | | }
    | |_^
 
 error: Declaration
@@ -197,6 +197,18 @@ error: Ident
 4 |     width: 1px!important;
   |             ^^
 
+error: ImportantFlag
+ --> $DIR/tests/fixture/important/basic/input.css:4:15
+  |
+4 |     width: 1px!important;
+  |               ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/important/basic/input.css:4:16
+  |
+4 |     width: 1px!important;
+  |                ^^^^^^^^^
+
 error: Declaration
  --> $DIR/tests/fixture/important/basic/input.css:5:5
   |
@@ -226,6 +238,18 @@ error: Ident
   |
 5 |     color: red!important;
   |            ^^^
+
+error: ImportantFlag
+ --> $DIR/tests/fixture/important/basic/input.css:5:15
+  |
+5 |     color: red!important;
+  |               ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/important/basic/input.css:5:16
+  |
+5 |     color: red!important;
+  |                ^^^^^^^^^
 
 error: Declaration
  --> $DIR/tests/fixture/important/basic/input.css:6:5
@@ -257,6 +281,18 @@ error: Ident
 6 |     color: red !important;
   |            ^^^
 
+error: ImportantFlag
+ --> $DIR/tests/fixture/important/basic/input.css:6:16
+  |
+6 |     color: red !important;
+  |                ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/important/basic/input.css:6:17
+  |
+6 |     color: red !important;
+  |                 ^^^^^^^^^
+
 error: Declaration
  --> $DIR/tests/fixture/important/basic/input.css:7:5
   |
@@ -287,11 +323,23 @@ error: Ident
 7 |     color: red  !important;
   |            ^^^
 
+error: ImportantFlag
+ --> $DIR/tests/fixture/important/basic/input.css:7:17
+  |
+7 |     color: red  !important;
+  |                 ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/important/basic/input.css:7:18
+  |
+7 |     color: red  !important;
+  |                  ^^^^^^^^^
+
 error: Declaration
  --> $DIR/tests/fixture/important/basic/input.css:8:5
   |
 8 |     color: red !   important   ;
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: DeclarationName
  --> $DIR/tests/fixture/important/basic/input.css:8:5
@@ -316,6 +364,18 @@ error: Ident
   |
 8 |     color: red !   important   ;
   |            ^^^
+
+error: ImportantFlag
+ --> $DIR/tests/fixture/important/basic/input.css:8:16
+  |
+8 |     color: red !   important   ;
+  |                ^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/important/basic/input.css:8:20
+  |
+8 |     color: red !   important   ;
+  |                    ^^^^^^^^^
 
 error: Declaration
  --> $DIR/tests/fixture/important/basic/input.css:9:5
@@ -347,11 +407,23 @@ error: Ident
 9 |     color: blue !IMPORTANT;
   |            ^^^^
 
+error: ImportantFlag
+ --> $DIR/tests/fixture/important/basic/input.css:9:17
+  |
+9 |     color: blue !IMPORTANT;
+  |                 ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/important/basic/input.css:9:18
+  |
+9 |     color: blue !IMPORTANT;
+  |                  ^^^^^^^^^
+
 error: Declaration
   --> $DIR/tests/fixture/important/basic/input.css:10:5
    |
 10 |     color: white !   IMPORTANT   ;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: DeclarationName
   --> $DIR/tests/fixture/important/basic/input.css:10:5
@@ -376,6 +448,18 @@ error: Ident
    |
 10 |     color: white !   IMPORTANT   ;
    |            ^^^^^
+
+error: ImportantFlag
+  --> $DIR/tests/fixture/important/basic/input.css:10:18
+   |
+10 |     color: white !   IMPORTANT   ;
+   |                  ^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/important/basic/input.css:10:22
+   |
+10 |     color: white !   IMPORTANT   ;
+   |                      ^^^^^^^^^
 
 error: Declaration
   --> $DIR/tests/fixture/important/basic/input.css:11:5
@@ -419,6 +503,18 @@ error: Ident
 11 |     margin: 10px      !      important;
    |               ^^
 
+error: ImportantFlag
+  --> $DIR/tests/fixture/important/basic/input.css:11:23
+   |
+11 |     margin: 10px      !      important;
+   |                       ^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/important/basic/input.css:11:30
+   |
+11 |     margin: 10px      !      important;
+   |                              ^^^^^^^^^
+
 error: Declaration
   --> $DIR/tests/fixture/important/basic/input.css:12:5
    |
@@ -461,6 +557,18 @@ error: Ident
 12 |     padding: 20px     !  /* test */   important;
    |                ^^
 
+error: ImportantFlag
+  --> $DIR/tests/fixture/important/basic/input.css:12:23
+   |
+12 |     padding: 20px     !  /* test */   important;
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/important/basic/input.css:12:39
+   |
+12 |     padding: 20px     !  /* test */   important;
+   |                                       ^^^^^^^^^
+
 error: Declaration
   --> $DIR/tests/fixture/important/basic/input.css:13:5
    |
@@ -502,6 +610,18 @@ error: Ident
    |
 13 |     width: 100px ! /*! test */ important;
    |               ^^
+
+error: ImportantFlag
+  --> $DIR/tests/fixture/important/basic/input.css:13:18
+   |
+13 |     width: 100px ! /*! test */ important;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/important/basic/input.css:13:32
+   |
+13 |     width: 100px ! /*! test */ important;
+   |                                ^^^^^^^^^
 
 error: Declaration
   --> $DIR/tests/fixture/important/basic/input.css:14:5
@@ -599,6 +719,18 @@ error: Str
 15 |     z-index: 1 ""! important;
    |                ^^
 
+error: ImportantFlag
+  --> $DIR/tests/fixture/important/basic/input.css:15:18
+   |
+15 |     z-index: 1 ""! important;
+   |                  ^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/important/basic/input.css:15:20
+   |
+15 |     z-index: 1 ""! important;
+   |                    ^^^^^^^^^
+
 error: Declaration
   --> $DIR/tests/fixture/important/basic/input.css:16:5
    |
@@ -640,4 +772,100 @@ error: Ident
    |
 16 |     padding: 1px/* sep */!important;
    |               ^^
+
+error: ImportantFlag
+  --> $DIR/tests/fixture/important/basic/input.css:16:26
+   |
+16 |     padding: 1px/* sep */!important;
+   |                          ^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/important/basic/input.css:16:27
+   |
+16 |     padding: 1px/* sep */!important;
+   |                           ^^^^^^^^^
+
+error: Declaration
+  --> $DIR/tests/fixture/important/basic/input.css:17:5
+   |
+17 |     prop: red !iMpOrTaNt;
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: DeclarationName
+  --> $DIR/tests/fixture/important/basic/input.css:17:5
+   |
+17 |     prop: red !iMpOrTaNt;
+   |     ^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/important/basic/input.css:17:5
+   |
+17 |     prop: red !iMpOrTaNt;
+   |     ^^^^
+
+error: Value
+  --> $DIR/tests/fixture/important/basic/input.css:17:11
+   |
+17 |     prop: red !iMpOrTaNt;
+   |           ^^^
+
+error: Ident
+  --> $DIR/tests/fixture/important/basic/input.css:17:11
+   |
+17 |     prop: red !iMpOrTaNt;
+   |           ^^^
+
+error: ImportantFlag
+  --> $DIR/tests/fixture/important/basic/input.css:17:15
+   |
+17 |     prop: red !iMpOrTaNt;
+   |               ^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/important/basic/input.css:17:16
+   |
+17 |     prop: red !iMpOrTaNt;
+   |                ^^^^^^^^^
+
+error: Declaration
+  --> $DIR/tests/fixture/important/basic/input.css:18:5
+   |
+18 |     color: red !imp\ortant;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: DeclarationName
+  --> $DIR/tests/fixture/important/basic/input.css:18:5
+   |
+18 |     color: red !imp\ortant;
+   |     ^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/important/basic/input.css:18:5
+   |
+18 |     color: red !imp\ortant;
+   |     ^^^^^
+
+error: Value
+  --> $DIR/tests/fixture/important/basic/input.css:18:12
+   |
+18 |     color: red !imp\ortant;
+   |            ^^^
+
+error: Ident
+  --> $DIR/tests/fixture/important/basic/input.css:18:12
+   |
+18 |     color: red !imp\ortant;
+   |            ^^^
+
+error: ImportantFlag
+  --> $DIR/tests/fixture/important/basic/input.css:18:16
+   |
+18 |     color: red !imp\ortant;
+   |                ^^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/important/basic/input.css:18:17
+   |
+18 |     color: red !imp\ortant;
+   |                 ^^^^^^^^^^
 

--- a/crates/swc_css_parser/tests/fixture/rome/keyframe/output.json
+++ b/crates/swc_css_parser/tests/fixture/rome/keyframe/output.json
@@ -98,9 +98,22 @@
                   }
                 ],
                 "important": {
-                  "start": 60,
-                  "end": 70,
-                  "ctxt": 0
+                  "type": "ImportantFlag",
+                  "span": {
+                    "start": 60,
+                    "end": 70,
+                    "ctxt": 0
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 61,
+                      "end": 70,
+                      "ctxt": 0
+                    },
+                    "value": "important",
+                    "raw": "important"
+                  }
                 }
               }
             ]
@@ -180,9 +193,22 @@
                   }
                 ],
                 "important": {
-                  "start": 113,
-                  "end": 123,
-                  "ctxt": 0
+                  "type": "ImportantFlag",
+                  "span": {
+                    "start": 113,
+                    "end": 123,
+                    "ctxt": 0
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 114,
+                      "end": 123,
+                      "ctxt": 0
+                    },
+                    "value": "important",
+                    "raw": "important"
+                  }
                 }
               }
             ]

--- a/crates/swc_css_parser/tests/fixture/rome/keyframe/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/keyframe/span.rust-debug
@@ -123,6 +123,18 @@ error: Ident
 3 |         margin-top: 50px !important;
   |                       ^^
 
+error: ImportantFlag
+ --> $DIR/tests/fixture/rome/keyframe/input.css:3:26
+  |
+3 |         margin-top: 50px !important;
+  |                          ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/rome/keyframe/input.css:3:27
+  |
+3 |         margin-top: 50px !important;
+  |                           ^^^^^^^^^
+
 error: KeyframeBlock
  --> $DIR/tests/fixture/rome/keyframe/input.css:5:5
   |
@@ -193,6 +205,18 @@ error: Ident
   |
 6 |         margin-top: 100px !important;
   |                        ^^
+
+error: ImportantFlag
+ --> $DIR/tests/fixture/rome/keyframe/input.css:6:27
+  |
+6 |         margin-top: 100px !important;
+  |                           ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/rome/keyframe/input.css:6:28
+  |
+6 |         margin-top: 100px !important;
+  |                            ^^^^^^^^^
 
 error: Rule
   --> $DIR/tests/fixture/rome/keyframe/input.css:10:1

--- a/crates/swc_css_parser/tests/fixture/value/custom-property/output.json
+++ b/crates/swc_css_parser/tests/fixture/value/custom-property/output.json
@@ -159,9 +159,22 @@
               }
             ],
             "important": {
-              "start": 44,
-              "end": 54,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 44,
+                "end": 54,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 45,
+                  "end": 54,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -207,9 +220,22 @@
               }
             ],
             "important": {
-              "start": 79,
-              "end": 89,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 79,
+                "end": 89,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 80,
+                  "end": 89,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -267,9 +293,22 @@
               }
             ],
             "important": {
-              "start": 115,
-              "end": 125,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 115,
+                "end": 125,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 116,
+                  "end": 125,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -327,9 +366,22 @@
               }
             ],
             "important": {
-              "start": 150,
-              "end": 160,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 150,
+                "end": 160,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 151,
+                  "end": 160,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -397,9 +449,22 @@
               }
             ],
             "important": {
-              "start": 187,
-              "end": 197,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 187,
+                "end": 197,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 188,
+                  "end": 197,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -491,9 +556,22 @@
               }
             ],
             "important": {
-              "start": 249,
-              "end": 259,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 249,
+                "end": 259,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 250,
+                  "end": 259,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {
@@ -525,9 +603,22 @@
               }
             ],
             "important": {
-              "start": 279,
-              "end": 289,
-              "ctxt": 0
+              "type": "ImportantFlag",
+              "span": {
+                "start": 279,
+                "end": 289,
+                "ctxt": 0
+              },
+              "value": {
+                "type": "Identifier",
+                "span": {
+                  "start": 280,
+                  "end": 289,
+                  "ctxt": 0
+                },
+                "value": "important",
+                "raw": "important"
+              }
             }
           },
           {

--- a/crates/swc_css_parser/tests/fixture/value/custom-property/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/custom-property/span.rust-debug
@@ -155,6 +155,18 @@ error: Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) 
 4 |     --important:value!important;
   |                 ^^^^^
 
+error: ImportantFlag
+ --> $DIR/tests/fixture/value/custom-property/input.css:4:22
+  |
+4 |     --important:value!important;
+  |                      ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/custom-property/input.css:4:23
+  |
+4 |     --important:value!important;
+  |                       ^^^^^^^^^
+
 error: Declaration
  --> $DIR/tests/fixture/value/custom-property/input.css:5:5
   |
@@ -190,6 +202,18 @@ error: Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) 
   |
 5 |     --important1: value!important;
   |                   ^^^^^
+
+error: ImportantFlag
+ --> $DIR/tests/fixture/value/custom-property/input.css:5:24
+  |
+5 |     --important1: value!important;
+  |                        ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/custom-property/input.css:5:25
+  |
+5 |     --important1: value!important;
+  |                         ^^^^^^^^^
 
 error: Declaration
  --> $DIR/tests/fixture/value/custom-property/input.css:6:5
@@ -233,6 +257,18 @@ error: WhiteSpace { value: Atom(' ' type=inline) }
 6 |     --important2: value !important;
   |                        ^
 
+error: ImportantFlag
+ --> $DIR/tests/fixture/value/custom-property/input.css:6:25
+  |
+6 |     --important2: value !important;
+  |                         ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/custom-property/input.css:6:26
+  |
+6 |     --important2: value !important;
+  |                          ^^^^^^^^^
+
 error: Declaration
  --> $DIR/tests/fixture/value/custom-property/input.css:7:5
   |
@@ -274,6 +310,18 @@ error: WhiteSpace { value: Atom(' ' type=inline) }
   |
 7 |     --important3:value !important;
   |                       ^
+
+error: ImportantFlag
+ --> $DIR/tests/fixture/value/custom-property/input.css:7:24
+  |
+7 |     --important3:value !important;
+  |                        ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/custom-property/input.css:7:25
+  |
+7 |     --important3:value !important;
+  |                         ^^^^^^^^^
 
 error: Declaration
  --> $DIR/tests/fixture/value/custom-property/input.css:8:5
@@ -322,6 +370,18 @@ error: RParen
   |
 8 |     --important4: calc(1)!important;
   |                         ^
+
+error: ImportantFlag
+ --> $DIR/tests/fixture/value/custom-property/input.css:8:26
+  |
+8 |     --important4: calc(1)!important;
+  |                          ^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/value/custom-property/input.css:8:27
+  |
+8 |     --important4: calc(1)!important;
+  |                           ^^^^^^^^^
 
 error: Declaration
   --> $DIR/tests/fixture/value/custom-property/input.css:10:5
@@ -413,6 +473,18 @@ error: Tokens
 12 |     --empty3: !important;
    |               ^
 
+error: ImportantFlag
+  --> $DIR/tests/fixture/value/custom-property/input.css:12:15
+   |
+12 |     --empty3: !important;
+   |               ^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/custom-property/input.css:12:16
+   |
+12 |     --empty3: !important;
+   |                ^^^^^^^^^
+
 error: Declaration
   --> $DIR/tests/fixture/value/custom-property/input.css:13:5
    |
@@ -442,6 +514,18 @@ error: Tokens
    |
 13 |     --empty4:/**/ !important;
    |                   ^
+
+error: ImportantFlag
+  --> $DIR/tests/fixture/value/custom-property/input.css:13:19
+   |
+13 |     --empty4:/**/ !important;
+   |                   ^^^^^^^^^^
+
+error: Ident
+  --> $DIR/tests/fixture/value/custom-property/input.css:13:20
+   |
+13 |     --empty4:/**/ !important;
+   |                    ^^^^^^^^^
 
 error: Declaration
   --> $DIR/tests/fixture/value/custom-property/input.css:14:5

--- a/crates/swc_css_parser/tests/recovery/declaration/output.swc-stderr
+++ b/crates/swc_css_parser/tests/recovery/declaration/output.swc-stderr
@@ -1,6 +1,6 @@
-error: Expected !important
- --> $DIR/tests/recovery/declaration/input.css:7:11
+error: Expected Ident
+ --> $DIR/tests/recovery/declaration/input.css:7:12
   |
 7 |     prop: !!;
-  |           ^^^
+  |            ^
 

--- a/crates/swc_css_parser/tests/recovery/delim-token/bang/output.swc-stderr
+++ b/crates/swc_css_parser/tests/recovery/delim-token/bang/output.swc-stderr
@@ -1,6 +1,6 @@
-error: Expected !important
- --> $DIR/tests/recovery/delim-token/bang/input.css:2:12
+error: Expected Ident
+ --> $DIR/tests/recovery/delim-token/bang/input.css:2:13
   |
 2 |     color: !!;
-  |            ^^^
+  |             ^
 

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -61,12 +61,17 @@ define!({
         pub span: Span,
         pub name: DeclarationName,
         pub value: Vec<Value>,
-        pub important: Option<Span>,
+        pub important: Option<ImportantFlag>,
     }
 
     pub enum DeclarationName {
         Ident(Ident),
         DashedIdent(DashedIdent),
+    }
+
+    pub struct ImportantFlag {
+        pub span: Span,
+        pub value: Ident,
     }
 
     pub struct QualifiedRule {

--- a/crates/swc_stylis/src/prefixer.rs
+++ b/crates/swc_stylis/src/prefixer.rs
@@ -34,15 +34,11 @@ impl VisitMut for Prefixer {
                     value: $name.into(),
                     raw: $name.into(),
                 });
-                let important = match &n.important {
-                    Some(i) => Some(i.clone()),
-                    None => None,
-                };
                 self.added.push(Declaration {
                     span: n.span,
                     name,
                     value: vec![val],
-                    important,
+                    important: n.important.clone(),
                 });
             }};
         }
@@ -54,15 +50,11 @@ impl VisitMut for Prefixer {
                     value: $name.into(),
                     raw: $name.into(),
                 });
-                let important = match &n.important {
-                    Some(i) => Some(i.clone()),
-                    None => None,
-                };
                 self.added.push(Declaration {
                     span: n.span,
                     name,
                     value: n.value.clone(),
-                    important,
+                    important: n.important.clone(),
                 });
             }};
         }
@@ -74,15 +66,11 @@ impl VisitMut for Prefixer {
                     value: $name.into(),
                     raw: $name.into(),
                 };
-                let important = match &n.important {
-                    Some(i) => Some(i.clone()),
-                    None => None,
-                };
                 self.added.push(Declaration {
                     span: n.span,
                     name: n.name.clone(),
                     value: vec![Value::Ident(val)],
-                    important,
+                    important: n.important.clone(),
                 });
             }};
         }
@@ -195,15 +183,11 @@ impl VisitMut for Prefixer {
                                 },
                                 value: f.value.clone(),
                             });
-                            let important = match &n.important {
-                                Some(i) => Some(i.clone()),
-                                None => None,
-                            };
                             self.added.push(Declaration {
                                 span: n.span,
                                 name: n.name.clone(),
                                 value: vec![val],
-                                important,
+                                important: n.important.clone(),
                             });
                         }
                     }
@@ -223,15 +207,11 @@ impl VisitMut for Prefixer {
                                 },
                                 value: f.value.clone(),
                             });
-                            let important = match &n.important {
-                                Some(i) => Some(i.clone()),
-                                None => None,
-                            };
                             self.added.push(Declaration {
                                 span: n.span,
                                 name: n.name.clone(),
                                 value: vec![val],
-                                important,
+                                important: n.important.clone(),
                             });
                         }
                     }
@@ -275,15 +255,11 @@ impl VisitMut for Prefixer {
                         .collect();
 
                     if n.value != new_value {
-                        let important = match &n.important {
-                            Some(i) => Some(i.clone()),
-                            None => None,
-                        };
                         self.added.push(Declaration {
                             span: n.span,
                             name: n.name.clone(),
                             value: new_value,
-                            important,
+                            important: n.important.clone(),
                         });
                     }
                 }
@@ -499,15 +475,11 @@ impl VisitMut for Prefixer {
                     value: "-webkit-transition".into(),
                     raw: "-webkit-transition".into(),
                 });
-                let important = match &n.important {
-                    Some(i) => Some(i.clone()),
-                    None => None,
-                };
                 self.added.push(Declaration {
                     span: n.span,
                     name,
                     value,
-                    important,
+                    important: n.important.clone(),
                 });
             }
 

--- a/crates/swc_stylis/src/prefixer.rs
+++ b/crates/swc_stylis/src/prefixer.rs
@@ -34,11 +34,15 @@ impl VisitMut for Prefixer {
                     value: $name.into(),
                     raw: $name.into(),
                 });
+                let important = match &n.important {
+                    Some(i) => Some(i.clone()),
+                    None => None,
+                };
                 self.added.push(Declaration {
                     span: n.span,
                     name,
                     value: vec![val],
-                    important: n.important.clone(),
+                    important,
                 });
             }};
         }
@@ -50,12 +54,15 @@ impl VisitMut for Prefixer {
                     value: $name.into(),
                     raw: $name.into(),
                 });
-
+                let important = match &n.important {
+                    Some(i) => Some(i.clone()),
+                    None => None,
+                };
                 self.added.push(Declaration {
                     span: n.span,
                     name,
                     value: n.value.clone(),
-                    important: n.important.clone(),
+                    important,
                 });
             }};
         }
@@ -67,12 +74,15 @@ impl VisitMut for Prefixer {
                     value: $name.into(),
                     raw: $name.into(),
                 };
-
+                let important = match &n.important {
+                    Some(i) => Some(i.clone()),
+                    None => None,
+                };
                 self.added.push(Declaration {
                     span: n.span,
                     name: n.name.clone(),
                     value: vec![Value::Ident(val)],
-                    important: n.important.clone(),
+                    important,
                 });
             }};
         }
@@ -185,11 +195,15 @@ impl VisitMut for Prefixer {
                                 },
                                 value: f.value.clone(),
                             });
+                            let important = match &n.important {
+                                Some(i) => Some(i.clone()),
+                                None => None,
+                            };
                             self.added.push(Declaration {
                                 span: n.span,
                                 name: n.name.clone(),
                                 value: vec![val],
-                                important: n.important,
+                                important,
                             });
                         }
                     }
@@ -209,11 +223,15 @@ impl VisitMut for Prefixer {
                                 },
                                 value: f.value.clone(),
                             });
+                            let important = match &n.important {
+                                Some(i) => Some(i.clone()),
+                                None => None,
+                            };
                             self.added.push(Declaration {
                                 span: n.span,
                                 name: n.name.clone(),
                                 value: vec![val],
-                                important: n.important,
+                                important,
                             });
                         }
                     }
@@ -257,11 +275,15 @@ impl VisitMut for Prefixer {
                         .collect();
 
                     if n.value != new_value {
+                        let important = match &n.important {
+                            Some(i) => Some(i.clone()),
+                            None => None,
+                        };
                         self.added.push(Declaration {
                             span: n.span,
                             name: n.name.clone(),
                             value: new_value,
-                            important: n.important.clone(),
+                            important,
                         });
                     }
                 }
@@ -469,17 +491,23 @@ impl VisitMut for Prefixer {
 
             "transition" => {
                 let mut value = n.value.clone();
+
                 replace_ident(&mut value, "transform", "-webkit-transform");
+
                 let name = DeclarationName::Ident(Ident {
                     span: DUMMY_SP,
                     value: "-webkit-transition".into(),
                     raw: "-webkit-transition".into(),
                 });
+                let important = match &n.important {
+                    Some(i) => Some(i.clone()),
+                    None => None,
+                };
                 self.added.push(Declaration {
                     span: n.span,
                     name,
                     value,
-                    important: n.important,
+                    important,
                 });
             }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Fix AST of `!important`, because `important` work is identifier we should use Ident AST node here, also it allows to parse and keep how important was written

**BREAKING CHANGE:**

Yes

**Related issue (if exists):**

No