### PR TITLE
fix(es/fixer): handle more extends expr

### DIFF
--- a/crates/swc_ecma_transforms_base/src/fixer.rs
+++ b/crates/swc_ecma_transforms_base/src/fixer.rs
@@ -1330,6 +1330,30 @@ var store = global[SHARED] || (global[SHARED] = {});
         "class MultiVector extends (options.baseType||Float32Array) {}"
     );
 
+    identical!(
+        extends_nullish_coalescing,
+        "class Foo extends (Bar ?? class{}) {}"
+    );
+
+    identical!(extends_assign, "class Foo extends (Bar = class{}) {}");
+
+    identical!(
+        extends_logical_or_assin,
+        "class Foo extends (Bar ||= class{}) {}"
+    );
+
+    identical!(
+        extends_logical_and_assin,
+        "class Foo extends (Bar &&= class{}) {}"
+    );
+
+    identical!(
+        extends_logical_nullish_assin,
+        "class Foo extends (Bar ??= class{}) {}"
+    );
+
+    identical!(extends_cond, "class Foo extends (true ? Bar : Baz) {}");
+
     identical!(deno_10668_1, "console.log(null ?? (undefined && true))");
 
     identical!(deno_10668_2, "console.log(null && (undefined ?? true))");

--- a/crates/swc_ecma_transforms_base/src/fixer.rs
+++ b/crates/swc_ecma_transforms_base/src/fixer.rs
@@ -305,7 +305,15 @@ impl VisitMut for Fixer<'_> {
         self.ctx = Context::Default;
         node.visit_mut_children_with(self);
         match &mut node.super_class {
-            Some(ref mut e) if e.is_seq() || e.is_await_expr() || e.is_bin() => self.wrap(&mut **e),
+            Some(ref mut e)
+                if e.is_seq()
+                    || e.is_await_expr()
+                    || e.is_bin()
+                    || e.is_assign()
+                    || e.is_cond() =>
+            {
+                self.wrap(&mut **e)
+            }
             _ => {}
         };
         self.ctx = old;


### PR DESCRIPTION
**Description:**
swc generates broken result from the following input.

[REPL](https://play.swc.rs/?version=1.2.136&code=H4sIAAAAAAAAA0vOSSwuVnDLz1dIrShJzUspVtBwSixSsFVIBktU12oCMRdXMkyZEaq6mhqcKo1RVaqp4VRpgqrS3h6nSlOEypKi0lQFewWQBisgWQVWCQBaJNOTzgAAAA%3D%3D&config=H4sIAAAAAAAAA0WMSwrDMAxE76K1F8WLLnKHHkK4SnDxD0mBGuO71w4u2Q0zb16DjzjYGhRkIZ5JalL8wgbkIopjXxTMwEa1YxDqBhT5IJ2I2Ie1Yw45Cy3AQPTJ73XKXI6FSeSeMB3hT%2Fbhivl9zqKB1kKX8wn9dqyfl9cClU%2FqPxrFaXe4AAAA)
```javascript
class Foo extends (Bar = class {}) {}

class Foo2 extends (Bar ||= class {}) {}

class Foo3 extends (Bar &&= class {}) {}

class Foo4 extends (Bar ??= class {}) {}

class Foo5 extends (true ? Bar : Baz) {}
```

**BREAKING CHANGE:**
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
