### PR TITLE
refactor: remove unused code

### DIFF
--- a/crates/swc_css_ast/src/selector.rs
+++ b/crates/swc_css_ast/src/selector.rs
@@ -113,9 +113,6 @@ pub enum SubclassSelector {
 
     #[tag("PseudoElementSelector")]
     PseudoElement(PseudoElementSelector),
-
-    #[tag("AtSelector")]
-    At(AtSelector),
 }
 
 #[ast_node("IdSelector")]
@@ -195,13 +192,6 @@ pub struct PseudoElementSelector {
     pub span: Span,
     pub name: Ident,
     pub children: Option<Tokens>,
-}
-
-/// Type for `@top-center`. Allowwed in only some contexts.
-#[ast_node("AtSelector")]
-pub struct AtSelector {
-    pub span: Span,
-    pub text: Ident,
 }
 
 #[ast_node]

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -1298,7 +1298,6 @@ where
             SubclassSelector::Attribute(n) => emit!(self, n),
             SubclassSelector::PseudoClass(n) => emit!(self, n),
             SubclassSelector::PseudoElement(n) => emit!(self, n),
-            SubclassSelector::At(n) => emit!(self, n),
         }
     }
 
@@ -1458,12 +1457,6 @@ where
             emit!(self, n.children);
             punct!(self, ")");
         }
-    }
-
-    #[emitter]
-    fn emit_at_selector(&mut self, n: &AtSelector) -> Result {
-        punct!(self, "@");
-        emit!(self, n.text);
     }
 
     fn emit_list<N>(&mut self, nodes: &[N], format: ListFormat) -> Result

--- a/crates/swc_css_parser/src/parser/mod.rs
+++ b/crates/swc_css_parser/src/parser/mod.rs
@@ -36,8 +36,6 @@ struct Ctx {
 
     allow_operation_in_value: bool,
 
-    allow_at_selector: bool,
-
     recover_from_property_value: bool,
 }
 

--- a/crates/swc_css_parser/src/parser/selector/mod.rs
+++ b/crates/swc_css_parser/src/parser/selector/mod.rs
@@ -170,9 +170,7 @@ where
             if !(is!(self, "#")
                 || is!(self, ".")
                 || is!(self, "[")
-                || (is!(self, ":") && !peeked_is!(self, ":"))
-                // TODO remove `@`
-                || is!(self, "@"))
+                || (is!(self, ":") && !peeked_is!(self, ":")))
             {
                 break;
             }
@@ -340,26 +338,6 @@ where
             tok!(".") => Ok(SubclassSelector::Class(self.parse()?)),
             tok!("[") => Ok(SubclassSelector::Attribute(self.parse()?)),
             tok!(":") => Ok(SubclassSelector::PseudoClass(self.parse()?)),
-            // TODO remove me from here
-            Token::AtKeyword { .. } if self.ctx.allow_at_selector => {
-                let span = self.input.cur_span()?;
-
-                let values = match bump!(self) {
-                    Token::AtKeyword { value, raw } => (value, raw),
-                    _ => {
-                        unreachable!()
-                    }
-                };
-
-                Ok(SubclassSelector::At(AtSelector {
-                    span,
-                    text: Ident {
-                        span,
-                        value: values.0,
-                        raw: values.1,
-                    },
-                }))
-            }
             _ => {
                 let span = self.input.cur_span()?;
 

--- a/crates/swc_css_parser/tests/fixture.rs
+++ b/crates/swc_css_parser/tests/fixture.rs
@@ -280,7 +280,6 @@ macro_rules! mtd {
 
 impl Visit for SpanVisualizer<'_> {
     mtd!(AtRule, visit_at_rule);
-    mtd!(AtSelector, visit_at_selector);
     mtd!(BinValue, visit_bin_value);
     mtd!(SelectorList, visit_selector_list);
     mtd!(ComplexSelector, visit_complex_selector);

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -262,7 +262,6 @@ define!({
         Attribute(AttributeSelector),
         PseudoClass(PseudoClassSelector),
         PseudoElement(PseudoElementSelector),
-        At(AtSelector),
     }
 
     pub struct AttributeSelector {
@@ -332,11 +331,6 @@ define!({
     }
 
     pub struct ClassSelector {
-        pub span: Span,
-        pub text: Ident,
-    }
-
-    pub struct AtSelector {
         pub span: Span,
         pub text: Ident,
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Refactor code - remove `AtSelector`, no grammar for `@` in selector spec, we use it before for parsing nested at-rules in `@page`, but now we refactor code and don't need it anymore

**BREAKING CHANGE:**

Yes

**Related issue (if exists):**

No