### PR TITLE
respect inline config when swcrc is false

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -42,7 +42,7 @@ use swc_ecma_minifier::option::{
 };
 #[allow(deprecated)]
 pub use swc_ecma_parser::JscTarget;
-use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig, EsConfig};
+use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, StringInput, Syntax, TsConfig};
 use swc_ecma_transforms::{
     hygiene, modules,
     modules::{

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -42,7 +42,7 @@ use swc_ecma_minifier::option::{
 };
 #[allow(deprecated)]
 pub use swc_ecma_parser::JscTarget;
-use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig, EsConfig};
 use swc_ecma_transforms::{
     hygiene, modules,
     modules::{
@@ -540,9 +540,31 @@ impl Default for Rc {
             Config {
                 env: None,
                 test: None,
-                exclude: Some(FileMatcher::Regex("\\.tsx?$".into())),
+                exclude: Some(FileMatcher::Regex("(\\.jsx|\\.ts|\\.tsx)$".into())),
                 jsc: JscConfig {
                     syntax: Some(Default::default()),
+                    transform: None,
+                    external_helpers: false,
+                    target: Default::default(),
+                    loose: false,
+                    keep_class_names: false,
+                    ..Default::default()
+                },
+                module: None,
+                minify: false,
+                source_maps: None,
+                input_source_map: InputSourceMap::default(),
+                ..Default::default()
+            },
+            Config {
+                env: None,
+                test: Some(FileMatcher::Regex("\\.jsx$".into())),
+                exclude: None,
+                jsc: JscConfig {
+                    syntax: Some(Syntax::Es(EsConfig {
+                        jsx: true,
+                        ..Default::default()
+                    })),
                     transform: None,
                     external_helpers: false,
                     target: Default::default(),
@@ -1569,7 +1591,7 @@ impl Merge for swc_ecma_parser::EsConfig {
     }
 }
 
-impl Merge for swc_ecma_parser::TsConfig {
+impl Merge for TsConfig {
     fn merge(&mut self, from: &Self) {
         self.tsx |= from.tsx;
         self.decorators |= from.decorators;

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -265,8 +265,13 @@ impl Options {
     where
         P: 'a + swc_ecma_visit::Fold,
     {
-        let mut config = config.unwrap_or_default();
-        config.merge(&self.config);
+        let config = match config {
+            Some(mut config) => {
+                config.merge(&self.config);
+                config
+            }
+            None => self.config.clone(),
+        };
 
         let mut source_maps = self.source_maps.clone();
         source_maps.merge(&config.source_maps);
@@ -1568,6 +1573,8 @@ impl Merge for swc_ecma_parser::TsConfig {
     fn merge(&mut self, from: &Self) {
         self.tsx |= from.tsx;
         self.decorators |= from.decorators;
+        self.dts |= from.dts;
+        self.no_early_errors |= from.no_early_errors;
     }
 }
 

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -795,12 +795,6 @@ impl Compiler {
         P: 'a + swc_ecma_visit::Fold,
     {
         self.run(|| {
-            let config = self.read_config(opts, name)?;
-            let config = match config {
-                Some(v) => v,
-                None => return Ok(None),
-            };
-
             let built = opts.build_as_input(
                 &self.cm,
                 name,
@@ -812,7 +806,16 @@ impl Compiler {
                 opts.source_file_name.clone(),
                 handler,
                 opts.is_module,
-                Some(config),
+                if opts.swcrc {
+                    let config = self.read_config(opts, name)?;
+                    let config = match config {
+                        Some(v) => v,
+                        None => return Ok(None),
+                    };
+                    Some(config)
+                } else {
+                    None
+                },
                 Some(&self.comments),
                 before_pass,
             )?;

--- a/crates/swc/tests/projects.rs
+++ b/crates/swc/tests/projects.rs
@@ -898,3 +898,81 @@ fn opt_source_file_name_1() {
 
     assert!(map.contains("entry-foo"));
 }
+
+#[test]
+fn auto_detect_jsx() {
+    testing::run_test2(false, |cm, handler| {
+        let c = swc::Compiler::new(cm.clone());
+
+        let fm = cm
+            .load_file(Path::new("tests/projects/jsx/input.jsx"))
+            .expect("failed to load file");
+
+        c.process_js_file(
+            fm,
+            &handler,
+            &Options {
+                swcrc: true,
+                ..Default::default()
+            },
+        )
+        .expect("failed to process file");
+        Ok(())
+    })
+    .unwrap()
+}
+
+#[test]
+fn should_not_merge() {
+    testing::run_test2(false, |cm, handler| {
+        let c = swc::Compiler::new(cm.clone());
+
+        let fm = cm
+            .load_file(Path::new("tests/projects/merge/1/input.tsx"))
+            .expect("failed to load file");
+
+        c.process_js_file(
+            fm,
+            &handler,
+            &Options {
+                swcrc: false,
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        Ok(())
+    })
+    .unwrap();
+}
+#[test]
+fn merge() {
+    testing::run_test2(false, |cm, handler| {
+        let c = swc::Compiler::new(cm.clone());
+
+        let fm = cm
+            .load_file(Path::new("tests/projects/merge/2/input.tsx"))
+            .expect("failed to load file");
+
+        c.process_js_file(
+            fm,
+            &handler,
+            &Options {
+                swcrc: true,
+                config: Config {
+                    jsc: JscConfig {
+                        syntax: Some(Syntax::Typescript(TsConfig {
+                            tsx: false,
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .expect("failed to process file");
+        Ok(())
+    })
+    .unwrap();
+}

--- a/crates/swc/tests/projects/jsx/input.jsx
+++ b/crates/swc/tests/projects/jsx/input.jsx
@@ -1,0 +1,3 @@
+function fn(){
+    return (<div></div>)
+}

--- a/crates/swc/tests/projects/merge/1/.swcrc
+++ b/crates/swc/tests/projects/merge/1/.swcrc
@@ -1,0 +1,8 @@
+{
+    "jsc": {
+      "parser": {
+        "syntax": "typescript",
+        "tsx": true
+      }
+    }
+  }

--- a/crates/swc/tests/projects/merge/1/input.tsx
+++ b/crates/swc/tests/projects/merge/1/input.tsx
@@ -1,0 +1,3 @@
+function fn() {
+    return <div></div>;
+}

--- a/crates/swc/tests/projects/merge/2/.swcrc
+++ b/crates/swc/tests/projects/merge/2/.swcrc
@@ -1,0 +1,8 @@
+{
+    "jsc": {
+      "parser": {
+        "syntax": "typescript",
+        "tsx": true
+      }
+    }
+  }

--- a/crates/swc/tests/projects/merge/2/input.tsx
+++ b/crates/swc/tests/projects/merge/2/input.tsx
@@ -1,0 +1,3 @@
+function fn() {
+    return <div></div>;
+}

--- a/crates/swc/tests/tsc.rs
+++ b/crates/swc/tests/tsc.rs
@@ -112,14 +112,13 @@ fn compile(input: &Path, output: &Path, opts: Options) {
                 &handler,
                 &Options {
                     is_module: IsModule::Bool(true),
-
                     config: Config {
                         jsc: JscConfig {
                             syntax: Some(Syntax::Typescript(TsConfig {
                                 tsx: input.to_string_lossy().ends_with(".tsx"),
                                 decorators: true,
                                 dts: false,
-                                no_early_errors: true,
+                                no_early_errors: false,
                             })),
                             ..opts.config.jsc
                         },


### PR DESCRIPTION
**Description:**
1. add a rc to auto detection jsx
2. only try to find and merge `.swcrc` when `Options.swcrc = true`
3. merge `TsConfig.dts` and `TsConfig.no_early_errors`

**BREAKING CHANGE:**
since the second poiint change the behavior of `process_js_with_custom_pass`, it may break a lot of things, like rust api, js api and cli. 
I took a brief look at cli, and it seemed use `swcrc=true` by default, so I guess it is fine

**Related issue (if exists):**
#3374