### PR TITLE
feat(swc/plugin): support global HANDLER in plugin context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3451,6 +3451,7 @@ dependencies = [
 name = "swc_plugin"
 version = "0.25.0"
 dependencies = [
+ "once_cell",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",

--- a/crates/swc_common/src/errors/diagnostic_builder.rs
+++ b/crates/swc_common/src/errors/diagnostic_builder.rs
@@ -27,7 +27,10 @@ use tracing::debug;
 #[derive(Clone)]
 pub struct DiagnosticBuilder<'a> {
     pub handler: &'a Handler,
+    #[cfg(not(feature = "plugin-mode"))]
     pub(crate) diagnostic: Box<Diagnostic>,
+    #[cfg(feature = "plugin-mode")]
+    pub diagnostic: Box<Diagnostic>,
     allow_suggestions: bool,
 }
 

--- a/crates/swc_plugin/Cargo.toml
+++ b/crates/swc_plugin/Cargo.toml
@@ -14,3 +14,4 @@ swc_ecma_ast = {version = "0.65.0", path = "../swc_ecma_ast", features = ["rkyv-
 swc_ecma_visit = {version = "0.51.0", path = "../swc_ecma_visit"}
 swc_atoms = {version = "0.2.0", path = "../swc_atoms"}
 swc_plugin_macro = {version = "0.1.0", path = "../swc_plugin_macro"}
+once_cell = "1.9.0"

--- a/crates/swc_plugin/src/handler.rs
+++ b/crates/swc_plugin/src/handler.rs
@@ -1,0 +1,35 @@
+use once_cell::sync::OnceCell;
+
+/// Simple substitution for scoped_thread_local with limited interface parity.
+/// The only available fn in this struct is `with`, which is being used for the
+/// consumers when they need to access global scope handler (HANDLER.with()).
+/// Any other interfaces to support thread local is not available.
+pub struct PseudoScopedKey {
+    // As we can't use scoped_thread_local for the global HANDLER, it is challenging
+    // to set its inner handler for each plugin scope's diagnostic emitter.
+    // Via lazy init OnceCell we keep static HANDLER as immutable, also allows to set
+    // plugin specific values when proc_macro expands plugin's transform helper.
+    pub inner: OnceCell<swc_common::errors::Handler>,
+}
+
+impl PseudoScopedKey {
+    pub fn with<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&swc_common::errors::Handler) -> R,
+    {
+        f(self.inner.get().expect("Should set handler before call"))
+    }
+}
+
+// This is to conform some of swc_common::errors::Handler's thread-safety
+// required properties.
+//
+// NOTE: This only works we know each plugin transform doesn't need any thread
+// safety. However, if wasm gets thread support and if we're going to support it
+// this should be revisited.
+unsafe impl std::marker::Sync for PseudoScopedKey {}
+
+/// global context HANDLER in plugin's transform function.
+pub static HANDLER: PseudoScopedKey = PseudoScopedKey {
+    inner: OnceCell::new(),
+};

--- a/crates/swc_plugin/src/lib.rs
+++ b/crates/swc_plugin/src/lib.rs
@@ -10,8 +10,10 @@ pub mod ast {
     pub use swc_ecma_visit::*;
 }
 
+mod handler;
 pub mod errors {
-    pub use swc_common::errors::{Diagnostic, Level};
+    pub use crate::handler::HANDLER;
+    pub use swc_common::errors::{Diagnostic, Handler, Level};
 }
 
 mod context;

--- a/tests/rust-plugins/swc_internal_plugin/Cargo.lock
+++ b/tests/rust-plugins/swc_internal_plugin/Cargo.lock
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -760,6 +760,7 @@ dependencies = [
 name = "swc_plugin"
 version = "0.25.0"
 dependencies = [
+ "once_cell",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Followup changes to https://github.com/swc-project/swc/issues/3308 to support better ergonomics around sharing host context.

This PR follows suggested discussion from https://github.com/swc-project/swc/issues/3309#issuecomment-1020968828. PR creates / exports global `HANDLER` to the plugin side by resembling existing scoped_thread_local's interface (specifically, `HANDLER.with`) with existing emitter in the plugin's side. Primary goal for this change is preserving user ergonomics around `HANDLER`: as test case updated, now either plugin or host would use `HANDLER.with` with provided `swc_common::Handler` for same interfaces. 

One of change to support those was lazy initialization of HANDLER in plugin's context via oncecell. This allows us to create a proper handler per each plugin's context. It requires having stub sync impl, however we know plugin will not require thread safety at all.

**BREAKING CHANGE:**
Pretty much unused, but `HostContext` is removed again.

**Related issue (if exists):**
- https://github.com/swc-project/swc/issues/3308