### PR TITLE
fix(ecma/parser): disallow opt chain as assign target

### DIFF
--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -568,7 +568,9 @@ impl SyntaxError {
             SyntaxError::TS2371 => "A parameter initializer is only allowed in a function or \
                                     constructor implementation"
                 .into(),
-            SyntaxError::TS2406 => "Invalid left-hand side in 'for...in' statement".into(),
+            SyntaxError::TS2406 => "The left-hand side of an assignment expression must be a \
+                                    variable or a property access."
+                .into(),
             SyntaxError::TS2410 => "The 'with' statement is not supported. All symbols in a \
                                     'with' block will have type 'any'."
                 .into(),

--- a/crates/swc_ecma_parser/src/parser/util.rs
+++ b/crates/swc_ecma_parser/src/parser/util.rs
@@ -281,6 +281,8 @@ pub(super) trait ExprExt {
 
             Expr::Seq(..) => false,
 
+            Expr::OptChain(..) => false,
+
             // MemberExpression is valid assignment target
             Expr::PrivateName(..) => false,
 
@@ -292,8 +294,7 @@ pub(super) trait ExprExt {
             | Expr::JSXFragment(..) => false,
 
             // typescript
-            Expr::OptChain(OptChainExpr { ref expr, .. })
-            | Expr::TsNonNull(TsNonNullExpr { ref expr, .. })
+            Expr::TsNonNull(TsNonNullExpr { ref expr, .. })
             | Expr::TsTypeAssertion(TsTypeAssertion { ref expr, .. })
             | Expr::TsAs(TsAsExpr { ref expr, .. }) => {
                 expr.is_valid_simple_assignment_target(strict)

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/0eb4ed330b5d7e2f.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/0eb4ed330b5d7e2f.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/0eb4ed330b5d7e2f.js:1:1
   |
 1 | ({get a(){}})=0

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/12a3250154ea8ef5.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/12a3250154ea8ef5.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/12a3250154ea8ef5.js:1:5
   |
 1 | for(let ? b : c in 0);

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/15de970e269ae56f.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/15de970e269ae56f.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/15de970e269ae56f.js:1:1
   |
 1 | (1 + 1) = 10

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/168502012959421f.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/168502012959421f.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/168502012959421f.js:1:5
   |
 1 | for(([a]) of 0);

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/23368c25ea374e2f.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/23368c25ea374e2f.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/23368c25ea374e2f.js:1:1
   |
 1 | (a,b)=(c,d);

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/2884c585d2f035a5.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/2884c585d2f035a5.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/2884c585d2f035a5.js:1:2
   |
 1 | (([a])=0);

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/2e8378f658290622.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/2e8378f658290622.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/2e8378f658290622.js:1:6
   |
 1 | for (+i in {});

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/3a3e59edfed719b0.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/3a3e59edfed719b0.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/3a3e59edfed719b0.js:1:1
   |
 1 | ({ obj:20 }) = 42

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/4f0b15bd78646107.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/4f0b15bd78646107.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/4f0b15bd78646107.js:1:1
   |
 1 | 1--

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/581bedbbce2541be.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/581bedbbce2541be.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/581bedbbce2541be.js:1:6
   |
 1 | for (i + 1 in {});

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/5ab1050053c11514.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/5ab1050053c11514.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/5ab1050053c11514.js:1:5
   |
 1 | for((1 + 1) in list) process(x);

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/66abd1d09c28ada8.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/66abd1d09c28ada8.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/66abd1d09c28ada8.js:1:5
   |
 1 | for(this of 0);

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/75b52e0f57aab958.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/75b52e0f57aab958.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/75b52e0f57aab958.js:1:15
   |
 1 | "use strict"; ({ v: eval }) = obj

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/783aeb8c90c3775d.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/783aeb8c90c3775d.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/783aeb8c90c3775d.js:1:5
   |
 1 | for(({a}) of 0);

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/851bfeb09635c752.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/851bfeb09635c752.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/851bfeb09635c752.js:1:1
   |
 1 | 1++

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/939b16a89d0e8704.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/939b16a89d0e8704.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/939b16a89d0e8704.js:1:15
   |
 1 | "use strict"; ({ v: arguments }) = obj

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/95682e688db64065.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/95682e688db64065.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/95682e688db64065.js:1:6
   |
 1 | for (this of that);

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/a793dd27762c8ec8.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/a793dd27762c8ec8.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/a793dd27762c8ec8.js:1:5
   |
 1 | for(([a]) in 0);

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/a8beb1480f385441.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/a8beb1480f385441.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/a8beb1480f385441.js:1:1
   |
 1 | func() = 4

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/ab9d14c2ef38f180.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/ab9d14c2ef38f180.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/ab9d14c2ef38f180.js:1:1
   |
 1 | (0, {a = 0}) = 0

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/d012888b0c720723.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/d012888b0c720723.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/d012888b0c720723.js:1:1
   |
 1 | ( { get x() {} } ) = 0

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/dc14ac854168468f.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/dc14ac854168468f.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/dc14ac854168468f.js:1:2
   |
 1 | (({a})=0);

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/dfc6f1cc5533e0bb.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/dfc6f1cc5533e0bb.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/dfc6f1cc5533e0bb.js:1:5
   |
 1 | for(({a}) in 0);

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/f4c0cdc8d5782f3f.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/f4c0cdc8d5782f3f.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/f4c0cdc8d5782f3f.js:1:1
   |
 1 | 3 = 4

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/f51aea0352bb03f3.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/f51aea0352bb03f3.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/f51aea0352bb03f3.js:1:3
   |
 1 | --1

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/f6cc48c72caf2e32.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/f6cc48c72caf2e32.js.stderr
@@ -1,4 +1,4 @@
-error: Invalid left-hand side in 'for...in' statement
+error: The left-hand side of an assignment expression must be a variable or a property access.
  --> $DIR/tests/test262-parser/fail/f6cc48c72caf2e32.js:1:3
   |
 1 | ++1


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Only identifier and property access is valid assignment target

**BREAKING CHANGE:**
No

**Related issue (if exists):**
