### PR TITLE
feat(swc/plugin): implement proxy for Mark::fresh

### DIFF
--- a/crates/swc_plugin/src/handler.rs
+++ b/crates/swc_plugin/src/handler.rs
@@ -24,9 +24,9 @@ impl PseudoScopedKey {
 // This is to conform some of swc_common::errors::Handler's thread-safety
 // required properties.
 //
-// NOTE: This only works we know each plugin transform doesn't need any thread
-// safety. However, if wasm gets thread support and if we're going to support it
-// this should be revisited.
+// NOTE: This only works cause we know each plugin transform doesn't need any
+// thread safety. However, if wasm gets thread support and if we're going to
+// support it this should be revisited.
 unsafe impl std::marker::Sync for PseudoScopedKey {}
 
 /// global context HANDLER in plugin's transform function.

--- a/crates/swc_plugin/src/lib.rs
+++ b/crates/swc_plugin/src/lib.rs
@@ -2,12 +2,15 @@
 pub use swc_common::{
     chain,
     plugin::{PluginError, Serialized},
-    DUMMY_SP,
 };
 pub mod ast {
     pub use swc_atoms::*;
     pub use swc_ecma_ast::*;
     pub use swc_ecma_visit::*;
+}
+
+pub mod syntax_pos {
+    pub use swc_common::{Mark, DUMMY_SP};
 }
 
 mod handler;

--- a/crates/swc_plugin_macro/src/lib.rs
+++ b/crates/swc_plugin_macro/src/lib.rs
@@ -78,6 +78,7 @@ fn handle_func(func: ItemFn) -> TokenStream {
             let raw_config_serialized_bytes =
                 unsafe { std::slice::from_raw_parts(config_str_ptr, config_str_ptr_len_usize.unwrap()) };
 
+
             // Reconstruct SerializedProgram from raw bytes
             let serialized_program = swc_plugin::Serialized::new_for_plugin(raw_ast_serialized_bytes, ast_ptr_len);
             let serialized_config = swc_plugin::Serialized::new_for_plugin(raw_config_serialized_bytes, config_str_ptr_len);
@@ -93,7 +94,7 @@ fn handle_func(func: ItemFn) -> TokenStream {
                     );
                 return construct_error_ptr(err);
             }
-            let program = program.expect("Should be a program");
+            let program: Program = program.expect("Should be a program");
 
             if config.is_err() {
                 let err = swc_plugin::PluginError::Deserialize(
@@ -102,7 +103,8 @@ fn handle_func(func: ItemFn) -> TokenStream {
                     );
                 return construct_error_ptr(err);
             }
-            let config = config.expect("Should be a string");
+            let config: String = config.expect("Should be a string");
+
 
             // Create a handler wired with plugin's diagnostic emitter, set it for global context.
             let handler = swc_plugin::errors::Handler::with_emitter(
@@ -110,7 +112,14 @@ fn handle_func(func: ItemFn) -> TokenStream {
                 false,
                 Box::new(swc_plugin::environment::PluginDiagnosticsEmitter {})
             );
-            swc_plugin::errors::HANDLER.inner.set(handler);
+            let handler_set_result = swc_plugin::errors::HANDLER.inner.set(handler);
+
+            if handler_set_result.is_err() {
+                let err = swc_plugin::PluginError::Serialize(
+                        "Failed to set handler for plugin".to_string()
+                    );
+                return construct_error_ptr(err);
+            }
 
             // Take original plugin fn ident, then call it with interop'ed args
             let transformed_program = #ident(program, config);

--- a/tests/rust-plugins/swc_internal_plugin/Cargo.lock
+++ b/tests/rust-plugins/swc_internal_plugin/Cargo.lock
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "ahash",
  "anyhow",

--- a/tests/rust-plugins/swc_internal_plugin/src/lib.rs
+++ b/tests/rust-plugins/swc_internal_plugin/src/lib.rs
@@ -1,4 +1,4 @@
-use swc_plugin::{ast::*, plugin_module, DUMMY_SP, errors::HANDLER};
+use swc_plugin::{ast::*, errors::HANDLER, plugin_module, syntax_pos::DUMMY_SP};
 
 struct ConsoleOutputReplacer;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Partial implementation for https://github.com/swc-project/swc/issues/3309, before applying same practices, would like to confirm this would bea feasiblee approach.

As similar to previous implementation with plugin_runtime, this PR implements proxy fn for the globals (Mark::fresh in here) which calls host fn when it's being called in plugin's context. Unlike other imported fn signature this doesn't do serialization or copy bytes across memories as Mark is wrapper to u32 value. Fn passes over values directly then each context construct Mark as needed.

**BREAKING CHANGE:**

- DUMMY_SP moved into swc_plugin::syntax_pos namespace.

**Related issue (if exists):**

- #3309
