### PR TITLE
feat(swc/plugin): implement proxy for Mark / SyntaxContext

### DIFF
--- a/crates/swc_common/src/syntax_pos/hygiene.rs
+++ b/crates/swc_common/src/syntax_pos/hygiene.rs
@@ -15,6 +15,7 @@
 //! and definition contexts*. J. Funct. Program. 22, 2 (March 2012), 181-216.
 //! DOI=10.1017/S0956796812000093 <https://doi.org/10.1017/S0956796812000093>
 
+#[allow(unused)]
 use std::{
     collections::{HashMap, HashSet},
     fmt,
@@ -43,6 +44,7 @@ impl<'a> arbitrary::Arbitrary<'a> for SyntaxContext {
     }
 }
 
+#[allow(unused)]
 #[derive(Copy, Clone, Debug)]
 struct SyntaxContextData {
     outer_mark: Mark,
@@ -57,11 +59,18 @@ struct SyntaxContextData {
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Mark(u32);
 
+#[allow(unused)]
 #[derive(Clone, Debug)]
 struct MarkData {
     parent: Mark,
     is_builtin: bool,
 }
+
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+pub struct MutableMarkContext(pub u32, pub u32, pub u32);
 
 /// List of proxy calls injected by the host in the plugin's runtime context.
 /// When related calls being executed inside of the plugin, it'll call these
@@ -70,7 +79,21 @@ extern "C" {
     // Instead of trying to copy-serialize `Mark`, this fn directly consume
     // inner raw value as well as fn and let each context constrcuts struct
     // on their side.
-    fn __mark_fresh_proxy(mark: i32) -> i32;
+    fn __mark_fresh_proxy(mark: u32) -> u32;
+    fn __mark_parent_proxy(self_mark: u32) -> u32;
+    fn __mark_is_builtin(self_mark: u32) -> u32;
+    fn __mark_set_builtin(self_mark: u32, is_builtin: u32);
+    fn __syntax_context_apply_mark(self_syntax_context: u32, mark: u32) -> u32;
+    fn __syntax_context_outer(self_mark: u32) -> u32;
+
+    // These are proxy fn uses serializable context to pass forward mutated param
+    // with return value back to the guest.
+    fn __mark_is_descendant_of(self_mark: u32, ancestor: u32, allocated_ptr: i32);
+    fn __mark_least_ancestor(a: u32, b: u32, allocated_ptr: i32);
+    fn __syntax_context_remove_mark(self_mark: u32, allocated_ptr: i32);
+
+    fn __alloc(size: usize) -> *mut u8;
+    fn __free(ptr: *mut u8, size: usize) -> i32;
 }
 
 impl Mark {
@@ -78,22 +101,11 @@ impl Mark {
         // Note: msvc tries to link against proxied fn for normal build,
         // have to limit build target to wasm only to avoid it.
         #[cfg(all(feature = "plugin-mode", target_arch = "wasm32"))]
-        return Mark(unsafe {
-            __mark_fresh_proxy(
-                parent
-                    .as_u32()
-                    .try_into()
-                    .expect("Should able to convert mark into i32"),
-            )
-            .try_into()
-            .expect("Should able to convert i32 into mark")
-        });
+        return Mark(unsafe { __mark_fresh_proxy(parent.as_u32()) });
 
         // https://github.com/swc-project/swc/pull/3492#discussion_r802224857
-        // This is unreachable path for noraml execution. However for some
-        // cases like running plugin's test without targeting wasm32-*, we'll
-        // allow to not panic in here at least.
-
+        // We loosen conditions here for the cases like running plugin's test without
+        // targeting wasm32-*.
         #[cfg(not(all(feature = "plugin-mode", target_arch = "wasm32")))]
         return HygieneData::with(|data| {
             data.marks.push(MarkData {
@@ -123,23 +135,73 @@ impl Mark {
 
     #[inline]
     pub fn parent(self) -> Mark {
-        HygieneData::with(|data| data.marks[self.0 as usize].parent)
+        #[cfg(all(feature = "plugin-mode", target_arch = "wasm32"))]
+        return Mark(unsafe { __mark_parent_proxy(self.0) });
+
+        #[cfg(not(all(feature = "plugin-mode", target_arch = "wasm32")))]
+        return HygieneData::with(|data| data.marks[self.0 as usize].parent);
     }
 
     #[inline]
     pub fn is_builtin(self) -> bool {
-        assert_ne!(self, Mark::root());
+        #[cfg(all(feature = "plugin-mode", target_arch = "wasm32"))]
+        return unsafe { __mark_is_builtin(self.0) != 0 };
 
-        HygieneData::with(|data| data.marks[self.0 as usize].is_builtin)
+        #[cfg(not(all(feature = "plugin-mode", target_arch = "wasm32")))]
+        {
+            assert_ne!(self, Mark::root());
+
+            HygieneData::with(|data| data.marks[self.0 as usize].is_builtin)
+        }
     }
 
     #[inline]
     pub fn set_is_builtin(self, is_builtin: bool) {
-        assert_ne!(self, Mark::root());
+        #[cfg(all(feature = "plugin-mode", target_arch = "wasm32"))]
+        unsafe {
+            __mark_set_builtin(self.0, is_builtin as u32)
+        }
+        #[cfg(not(all(feature = "plugin-mode", target_arch = "wasm32")))]
+        {
+            assert_ne!(self, Mark::root());
 
-        HygieneData::with(|data| data.marks[self.0 as usize].is_builtin = is_builtin)
+            HygieneData::with(|data| data.marks[self.0 as usize].is_builtin = is_builtin)
+        }
     }
 
+    #[allow(unused_assignments)]
+    #[cfg(all(feature = "plugin-mode", target_arch = "wasm32"))]
+    pub fn is_descendant_of(mut self, ancestor: Mark) -> bool {
+        // This code path executed inside of the guest memory context.
+        // In here, preallocate memory for the context.
+        let serialized = crate::plugin::Serialized::serialize(&MutableMarkContext(0, 0, 0))
+            .expect("Should be serializable");
+        let len = serialized.as_ref().len();
+        let ptr = unsafe { __alloc(len) };
+
+        // Calling host proxy fn. Inside of host proxy, host will
+        // write the result into allocated context in the guest memory space.
+        unsafe {
+            __mark_is_descendant_of(self.0, ancestor.0, ptr as _);
+        }
+
+        // Deserialize result, assign / return values as needed.
+        let raw_result_bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+        let result =
+            crate::plugin::Serialized::new_for_plugin(raw_result_bytes, len.try_into().expect(""));
+        let context: MutableMarkContext =
+            crate::plugin::Serialized::deserialize(&result).expect("Should be deserializable");
+
+        self = Mark::from_u32(context.0);
+
+        unsafe {
+            __free(ptr, len);
+        }
+
+        return context.2 != 0;
+    }
+
+    #[cfg(not(all(feature = "plugin-mode", target_arch = "wasm32")))]
     pub fn is_descendant_of(mut self, ancestor: Mark) -> bool {
         HygieneData::with(|data| {
             while self != ancestor {
@@ -152,6 +214,34 @@ impl Mark {
         })
     }
 
+    #[allow(unused_mut, unused_assignments)]
+    #[cfg(all(feature = "plugin-mode", target_arch = "wasm32"))]
+    pub fn least_ancestor(mut a: Mark, mut b: Mark) -> Mark {
+        let serialized = crate::plugin::Serialized::serialize(&MutableMarkContext(0, 0, 0))
+            .expect("Should be serializable");
+        let len = serialized.as_ref().len();
+        let ptr = unsafe { __alloc(len) };
+
+        unsafe {
+            __mark_least_ancestor(a.0, b.0, ptr as _);
+        }
+
+        let raw_result_bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+        let result =
+            crate::plugin::Serialized::new_for_plugin(raw_result_bytes, len.try_into().expect(""));
+        let context: MutableMarkContext =
+            crate::plugin::Serialized::deserialize(&result).expect("Should be deserializable");
+
+        a = Mark::from_u32(context.0);
+        b = Mark::from_u32(context.1);
+
+        unsafe {
+            __free(ptr, len);
+        }
+
+        return Mark(context.2);
+    }
+
     /// Computes a mark such that both input marks are descendants of (or equal
     /// to) the returned mark. That is, the following holds:
     ///
@@ -161,6 +251,7 @@ impl Mark {
     /// assert!(b.is_descendant_of(la))
     /// ```
     #[allow(unused_mut)]
+    #[cfg(not(all(feature = "plugin-mode", target_arch = "wasm32")))]
     pub fn least_ancestor(mut a: Mark, mut b: Mark) -> Mark {
         HygieneData::with(|data| {
             // Compute the path from a to the root
@@ -180,6 +271,7 @@ impl Mark {
     }
 }
 
+#[allow(unused)]
 #[derive(Debug)]
 pub(crate) struct HygieneData {
     marks: Vec<MarkData>,
@@ -232,21 +324,30 @@ impl SyntaxContext {
         SyntaxContext(0)
     }
 
-    // pub(crate) fn as_u32(self) -> u32 {
-    //     self.0
-    // }
-    //
-    // pub(crate) fn from_u32(raw: u32) -> SyntaxContext {
-    //     SyntaxContext(raw)
-    // }
+    #[inline]
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
+
+    #[inline]
+    pub fn from_u32(raw: u32) -> SyntaxContext {
+        SyntaxContext(raw)
+    }
 
     /// Extend a syntax context with a given mark and default transparency for
     /// that mark.
     pub fn apply_mark(self, mark: Mark) -> SyntaxContext {
-        assert_ne!(mark, Mark::root());
-        self.apply_mark_internal(mark)
+        #[cfg(all(feature = "plugin-mode", target_arch = "wasm32"))]
+        return unsafe { SyntaxContext(__syntax_context_apply_mark(self.0, mark.0)) };
+
+        #[cfg(not(all(feature = "plugin-mode", target_arch = "wasm32")))]
+        {
+            assert_ne!(mark, Mark::root());
+            self.apply_mark_internal(mark)
+        }
     }
 
+    #[allow(unused)]
     fn apply_mark_internal(self, mark: Mark) -> SyntaxContext {
         HygieneData::with(|data| {
             let syntax_contexts = &mut data.syntax_contexts;
@@ -281,6 +382,33 @@ impl SyntaxContext {
         })
     }
 
+    #[cfg(all(feature = "plugin-mode", target_arch = "wasm32"))]
+    pub fn remove_mark(&mut self) -> Mark {
+        let context = MutableMarkContext(0, 0, 0);
+        let serialized =
+            crate::plugin::Serialized::serialize(&context).expect("Should be serializable");
+        let len = serialized.as_ref().len();
+        let ptr = unsafe { __alloc(len) };
+
+        unsafe {
+            __syntax_context_remove_mark(self.0, ptr as _);
+        }
+
+        let raw_result_bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+        let result =
+            crate::plugin::Serialized::new_for_plugin(raw_result_bytes, len.try_into().expect(""));
+        let context: MutableMarkContext =
+            crate::plugin::Serialized::deserialize(&result).expect("Should be deserializable");
+
+        *self = SyntaxContext(context.0);
+
+        unsafe {
+            __free(ptr, len);
+        }
+
+        return Mark::from_u32(context.2);
+    }
+
     /// Pulls a single mark off of the syntax context. This effectively moves
     /// the context up one macro definition level. That is, if we have a
     /// nested macro definition as follows:
@@ -297,6 +425,7 @@ impl SyntaxContext {
     /// an invocation of g (call it g1), calling remove_mark will result in
     /// the SyntaxContext for the invocation of f that created g1.
     /// Returns the mark that was removed.
+    #[cfg(not(all(feature = "plugin-mode", target_arch = "wasm32")))]
     pub fn remove_mark(&mut self) -> Mark {
         HygieneData::with(|data| {
             let outer_mark = data.syntax_contexts[self.0 as usize].outer_mark;
@@ -415,6 +544,10 @@ impl SyntaxContext {
 
     #[inline]
     pub fn outer(self) -> Mark {
+        #[cfg(all(feature = "plugin-mode", target_arch = "wasm32"))]
+        return unsafe { Mark(__syntax_context_outer(self.0)) };
+
+        #[cfg(not(all(feature = "plugin-mode", target_arch = "wasm32")))]
         HygieneData::with(|data| data.syntax_contexts[self.0 as usize].outer_mark)
     }
 }

--- a/crates/swc_plugin_runner/src/lib.rs
+++ b/crates/swc_plugin_runner/src/lib.rs
@@ -10,8 +10,9 @@ use resolve::PluginCache;
 use swc_common::{
     collections::AHashMap,
     errors::{Diagnostic, HANDLER},
+    hygiene::MutableMarkContext,
     plugin::{PluginError, Serialized},
-    Mark,
+    Mark, SyntaxContext,
 };
 use wasmer::{
     imports, Array, Exports, Function, Instance, LazyInit, Memory, Module, Store, WasmPtr,
@@ -35,6 +36,43 @@ fn copy_bytes_into_host(memory: &Memory, bytes_ptr: i32, bytes_ptr_len: i32) -> 
         .take(bytes_ptr_len as usize)
         .map(|(_size, cell)| cell.get())
         .collect::<Vec<u8>>()
+}
+
+/// Locate a view from given memory, write serialized bytes into.
+fn write_into_memory_view<F>(
+    memory: &Memory,
+    serialized_bytes: &Serialized,
+    get_allocated_ptr: F,
+) -> (i32, i32)
+where
+    F: Fn(usize) -> i32,
+{
+    let serialized = serialized_bytes.as_ref();
+    let serialized_len = serialized.len();
+
+    let ptr_start = get_allocated_ptr(serialized_len);
+    let ptr_start_size = ptr_start
+        .try_into()
+        .expect("Should be able to convert to usize");
+
+    // Note: it's important to get a view from memory _after_ alloc completes
+    let view = memory.view::<u8>();
+
+    // loop over the Wasm memory view's bytes, assign bytes value of alignedvec from
+    // serialized
+    for (cell, byte) in view[ptr_start_size..ptr_start_size + serialized_len + 1]
+        .iter()
+        .zip(serialized.iter())
+    {
+        cell.set(*byte)
+    }
+
+    (
+        ptr_start,
+        serialized_len
+            .try_into()
+            .expect("Should be able to convert to i32"),
+    )
 }
 
 /// Set plugin's transformed result into host's enviroment.
@@ -67,15 +105,90 @@ fn emit_diagnostics(env: &HostEnvironment, bytes_ptr: i32, bytes_ptr_len: i32) {
 /// A proxy to Mark::fresh() that can be used in plugin.
 /// This it not direcly called by plugin, instead `impl Mark` will selectively
 /// call this depends on the running context.
-fn mark_fresh_proxy(parent: i32) -> i32 {
-    Mark::fresh(Mark::from_u32(
-        parent
-            .try_into()
-            .expect("Should able to convert i32 into mark"),
-    ))
-    .as_u32()
-    .try_into()
-    .expect("Should able to convert mark into i32")
+fn mark_fresh_proxy(parent: u32) -> u32 {
+    Mark::fresh(Mark::from_u32(parent)).as_u32()
+}
+
+fn mark_parent_proxy(self_mark: u32) -> u32 {
+    Mark::from_u32(self_mark).parent().as_u32()
+}
+
+fn mark_is_builtin_proxy(self_mark: u32) -> u32 {
+    Mark::from_u32(self_mark).is_builtin() as u32
+}
+
+fn mark_set_builtin_proxy(self_mark: u32, is_builtin: u32) {
+    Mark::from_u32(self_mark).set_is_builtin(is_builtin != 0);
+}
+
+/// A proxy to Mark::is_descendant_of_() that can be used in plugin.
+/// Origianl call site have mutable param, which we'll pass over as return value
+/// via serialized MutableMarkContext.
+/// Inside of guest context, once this host function returns it'll assign params
+/// with return value accordingly.
+fn mark_is_descendant_of_proxy(
+    env: &HostEnvironment,
+    self_mark: u32,
+    ancestor: u32,
+    allocated_ptr: i32,
+) {
+    let self_mark = Mark::from_u32(self_mark);
+    let ancestor = Mark::from_u32(ancestor);
+
+    let return_value = self_mark.is_descendant_of(ancestor);
+
+    if let Some(memory) = env.memory_ref() {
+        let serialized_bytes = Serialized::serialize(&MutableMarkContext(
+            self_mark.as_u32(),
+            0,
+            return_value as u32,
+        ))
+        .expect("Should be serializable");
+
+        write_into_memory_view(memory, &serialized_bytes, |_| allocated_ptr);
+    }
+}
+
+fn mark_least_ancestor_proxy(env: &HostEnvironment, a: u32, b: u32, allocated_ptr: i32) {
+    let a = Mark::from_u32(a);
+    let b = Mark::from_u32(b);
+
+    let return_value = Mark::least_ancestor(a, b).as_u32();
+
+    if let Some(memory) = env.memory_ref() {
+        let serialized_bytes =
+            Serialized::serialize(&MutableMarkContext(a.as_u32(), b.as_u32(), return_value))
+                .expect("Should be serializable");
+
+        write_into_memory_view(memory, &serialized_bytes, |_| allocated_ptr);
+    }
+}
+
+fn syntax_context_apply_mark_proxy(self_syntax_context: u32, mark: u32) -> u32 {
+    SyntaxContext::from_u32(self_syntax_context)
+        .apply_mark(Mark::from_u32(mark))
+        .as_u32()
+}
+
+fn syntax_context_remove_mark_proxy(env: &HostEnvironment, self_mark: u32, allocated_ptr: i32) {
+    let mut self_mark = SyntaxContext::from_u32(self_mark);
+
+    let return_value = self_mark.remove_mark();
+
+    if let Some(memory) = env.memory_ref() {
+        let serialized_bytes = Serialized::serialize(&MutableMarkContext(
+            self_mark.as_u32(),
+            0,
+            return_value.as_u32(),
+        ))
+        .expect("Should be serializable");
+
+        write_into_memory_view(memory, &serialized_bytes, |_| allocated_ptr);
+    }
+}
+
+fn syntax_context_outer_proxy(self_mark: u32) -> u32 {
+    SyntaxContext::from_u32(self_mark).outer().as_u32()
 }
 
 #[derive(wasmer::WasmerEnv, Clone)]
@@ -194,6 +307,41 @@ fn load_plugin(
             );
 
             let mark_fresh_fn_decl = Function::new_native(&wasmer_store, mark_fresh_proxy);
+            let mark_parent_fn_decl = Function::new_native(&wasmer_store, mark_parent_proxy);
+            let mark_is_builtin_fn_decl =
+                Function::new_native(&wasmer_store, mark_is_builtin_proxy);
+            let mark_set_builtin_fn_decl =
+                Function::new_native(&wasmer_store, mark_set_builtin_proxy);
+            let mark_is_descendant_of_fn_decl = Function::new_native_with_env(
+                &wasmer_store,
+                HostEnvironment {
+                    memory: LazyInit::default(),
+                    transform_result: transform_result.clone(),
+                },
+                mark_is_descendant_of_proxy,
+            );
+
+            let mark_least_ancestor_fn_decl = Function::new_native_with_env(
+                &wasmer_store,
+                HostEnvironment {
+                    memory: LazyInit::default(),
+                    transform_result: transform_result.clone(),
+                },
+                mark_least_ancestor_proxy,
+            );
+
+            let syntax_context_apply_mark_fn_decl =
+                Function::new_native(&wasmer_store, syntax_context_apply_mark_proxy);
+            let syntax_context_remove_mark_fn_decl = Function::new_native_with_env(
+                &wasmer_store,
+                HostEnvironment {
+                    memory: LazyInit::default(),
+                    transform_result: transform_result.clone(),
+                },
+                syntax_context_remove_mark_proxy,
+            );
+            let syntax_context_outer_fn_decl =
+                Function::new_native(&wasmer_store, syntax_context_outer_proxy);
 
             // Plugin binary can be either wasm32-wasi or wasm32-unknown-unknown
             let import_object = if is_wasi_module(&module) {
@@ -214,7 +362,26 @@ fn load_plugin(
                 let mut env = Exports::new();
                 env.insert("__set_transform_result", set_transform_result_fn_decl);
                 env.insert("__emit_diagnostics", emit_diagnostics_fn_decl);
+
                 env.insert("__mark_fresh_proxy", mark_fresh_fn_decl);
+                env.insert("__mark_parent_proxy", mark_parent_fn_decl);
+                env.insert("__mark_is_builtin_proxy", mark_is_builtin_fn_decl);
+                env.insert("__mark_set_builtin_proxy", mark_set_builtin_fn_decl);
+                env.insert(
+                    "__mark_is_descendant_of_proxy",
+                    mark_is_descendant_of_fn_decl,
+                );
+                env.insert("__mark_least_ancestor", mark_least_ancestor_fn_decl);
+                env.insert(
+                    "__syntax_context_apply_mark_proxy",
+                    syntax_context_apply_mark_fn_decl,
+                );
+                env.insert(
+                    "__syntax_context_remove_mark_proxy",
+                    syntax_context_remove_mark_fn_decl,
+                );
+                env.insert("__syntax_context_outer_proxy", syntax_context_outer_fn_decl);
+
                 import_object.register("env", env);
                 import_object
             }
@@ -226,6 +393,14 @@ fn load_plugin(
                         "__set_transform_result" => set_transform_result_fn_decl,
                         "__emit_diagnostics" => emit_diagnostics_fn_decl,
                         "__mark_fresh_proxy" => mark_fresh_fn_decl,
+                        "__mark_parent_proxy" => mark_parent_fn_decl,
+                        "__mark_is_builtin_proxy" => mark_is_builtin_fn_decl,
+                        "__mark_set_builtin_proxy" => mark_set_builtin_fn_decl,
+                        "__mark_is_descendant_of_proxy" => mark_is_descendant_of_fn_decl,
+                        "__mark_least_ancestor" => mark_least_ancestor_fn_decl,
+                        "__syntax_context_apply_mark_proxy" => syntax_context_apply_mark_fn_decl,
+                        "__syntax_context_remove_mark_proxy" => syntax_context_remove_mark_fn_decl,
+                        "__syntax_context_outer_proxy" => syntax_context_outer_fn_decl
                     }
                 }
             };
@@ -285,27 +460,11 @@ impl PluginTransformTracker {
     ) -> Result<(i32, i32), Error> {
         let memory = self.instance.exports.get_memory("memory")?;
 
-        let serialized = serialized_bytes.as_ref();
-        let serialized_len = serialized.len();
-
-        let allocated_ptr = self
-            .exported_plugin_alloc
-            .call(serialized_len.try_into()?)?;
-
-        // Note: it's important to get a view from memory _after_ alloc completes
-        let view = memory.view::<u8>();
-
-        // loop over the Wasm memory view's bytes, assign bytes value of alignedvec from
-        // serialized
-        let ptr_start: usize = allocated_ptr.try_into()?;
-        for (cell, byte) in view[ptr_start..ptr_start + serialized_len + 1]
-            .iter()
-            .zip(serialized.iter())
-        {
-            cell.set(*byte)
-        }
-
-        let ptr = (allocated_ptr, serialized_len.try_into()?);
+        let ptr = write_into_memory_view(memory, serialized_bytes, |serialized_len| {
+            self.exported_plugin_alloc
+                .call(serialized_len.try_into().expect(""))
+                .expect("")
+        });
 
         self.allocated_ptr_vec.push(ptr);
         Ok(ptr)

--- a/tests/rust-plugins/swc_internal_plugin/src/lib.rs
+++ b/tests/rust-plugins/swc_internal_plugin/src/lib.rs
@@ -1,4 +1,9 @@
-use swc_plugin::{ast::*, errors::HANDLER, plugin_module, syntax_pos::DUMMY_SP};
+use swc_plugin::{
+    ast::*,
+    errors::HANDLER,
+    plugin_module,
+    syntax_pos::{DUMMY_SP},
+};
 
 struct ConsoleOutputReplacer;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Followup for https://github.com/swc-project/swc/pull/3492, attempt to close https://github.com/swc-project/swc/issues/3309.

PR implements rest of Mark / SyntaxContext host fn proxies as same as #3492. It took somewhat longer than I expected to deal with exceptions, which have mutable param with return value. Since we can't call host fn with mutable param, guest fn and host trampoline with serializable context then reassign param from host fn's result.

With this PR, I expect and hope we reached initial feature complete for plugin implementation for the experimental testing phase. Once this PR goes in, will try to make simple scaffolding from swc's cli to create a plugin template for the conviniences.

**BREAKING CHANGE:**
-

**Related issue (if exists):**
#3309