### PR TITLE
fix(plugin): Allow testing

### DIFF
--- a/crates/swc_plugin/src/context.rs
+++ b/crates/swc_plugin/src/context.rs
@@ -1,5 +1,6 @@
 use swc_common::plugin::Serialized;
 
+#[cfg(target_arch = "wasm32")] // Allow testing
 extern "C" {
     fn __emit_diagnostics(bytes_ptr: i32, bytes_ptr_len: i32);
     fn __free(bytes_ptr: i32, size: i32) -> i32;
@@ -13,14 +14,16 @@ extern "C" {
 pub struct PluginDiagnosticsEmitter {}
 
 impl swc_common::errors::Emitter for PluginDiagnosticsEmitter {
+    #[cfg_attr(not(target_arch = "wasm32"), allow(unused))]
     fn emit(&mut self, db: &swc_common::errors::DiagnosticBuilder<'_>) {
         let diag =
             Serialized::serialize(&*db.diagnostic).expect("Should able to serialize Diagnostic");
         let diag_ref = diag.as_ref();
 
-        let ptr = diag_ref.as_ptr() as _;
+        let ptr = diag_ref.as_ptr() as i32;
         let len = diag_ref.len() as i32;
 
+        #[cfg(target_arch = "wasm32")] // Allow testing
         unsafe {
             __emit_diagnostics(ptr, len);
         }

--- a/crates/swc_plugin_macro/src/lib.rs
+++ b/crates/swc_plugin_macro/src/lib.rs
@@ -26,6 +26,7 @@ fn handle_func(func: ItemFn) -> TokenStream {
 
         // Declaration for imported function from swc host.
         // Refer swc_plugin_runner for the actual implementation.
+        #[cfg(target_arch = "wasm32")] // Allow testing
         extern "C" {
             fn __set_transform_result(bytes_ptr: i32, bytes_ptr_len: i32);
             fn __free(bytes_ptr: i32, size: i32) -> i32;
@@ -36,6 +37,7 @@ fn handle_func(func: ItemFn) -> TokenStream {
         /// When guest calls __set_transform_result host should've completed read guest's memory and allocates its byte
         /// into host's enviroment so guest can free its memory later.
         fn set_transform_result_volatile(bytes_ptr: i32, bytes_ptr_len: i32) {
+            #[cfg(target_arch = "wasm32")] // Allow testing
             unsafe {
                 __set_transform_result(bytes_ptr, bytes_ptr_len);
                 __free(bytes_ptr, bytes_ptr_len);


### PR DESCRIPTION
**Description:**

Currently `cargo test` fails with

```
  = note: Undefined symbols for architecture x86_64:
            "___emit_diagnostics", referenced from:
                _$LT$swc_plugin..context..PluginDiagnosticsEmitter$u20$as$u20$swc_common..errors..emitter..Emitter$GT$::emit::hb8bdbe3885eb4b4f in libswc_plugin-8be2ba2e16f954f6.rlib(swc_plugin-8be2ba2e16f954f6.swc_plugin.2cc07108-cgu.14.rcgu.o)
            "___set_transform_result", referenced from:
                swc_plugin_jest::set_transform_result_volatile::h14162bf262599416 in swc_plugin_jest.4zn9g3m3so5oukfc.rcgu.o
            "___free", referenced from:
                swc_plugin_jest::set_transform_result_volatile::h14162bf262599416 in swc_plugin_jest.4zn9g3m3so5oukfc.rcgu.o
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)

```


**Related issue (if exists):**

- https://github.com/swc-project/plugins/pull/18