### PR TITLE
fix(es/compat): fix const array destructing with init hole

### DIFF
--- a/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
@@ -960,6 +960,18 @@ impl VisitMut for AssignFolder {
 
         *declarators = decls;
     }
+
+    fn visit_mut_var_decl(&mut self, var_decl: &mut VarDecl) {
+        var_decl.decls.visit_mut_with(self);
+
+        if var_decl.kind == VarDeclKind::Const {
+            var_decl.decls.iter_mut().for_each(|v| {
+                if v.init.is_none() {
+                    v.init = Some(undefined(DUMMY_SP));
+                }
+            })
+        }
+    }
 }
 
 impl Destructuring {

--- a/crates/swc_ecma_transforms_compat/tests/es2015_destructuring.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2015_destructuring.rs
@@ -2103,3 +2103,25 @@ test!(
     assert.sameValue(iterCount, 1, 'Iteration occurred as expected');
    "
 );
+
+test!(
+    syntax(),
+    |_| tr(),
+    statements_const_id_init_hole,
+    "\
+    const [x] = [,];
+    const [y] = [,], [z] = [,]
+    ",
+    "\
+    const x = void 0;
+    const y = void 0, z = void 0;
+    "
+);
+
+test!(
+    syntax(),
+    |_| tr(),
+    statements_let_id_init_hole,
+    "let [x] = [,];",
+    "let x;"
+);


### PR DESCRIPTION
**Description:**

Similar to #3433 but without default value.

Input([REPL](https://play.swc.rs/?version=1.2.139&code=H4sIAAAAAAAAA0vOzysuUYiuiFWwVYjWiQUAmTwjhw8AAAA%3D&config=H4sIAAAAAAAAA0WOSw7DIAwFr1J5zaKbdJE79BCIOikVP9mkKkLcPQZRZWf7zRu5wocNrBWSJkbqE5eQ9Q9WQOM1G7IpgxJMTpt2jE1B1rRj7ggvkrkYGWeqwNtgt9JNJvpEyHxFOuzuTzYR%2Bfg6%2BqFCLgmH8AHtcsye5ecEMx2yY%2FiOznhD9GDeFD3elju0dgI3ydbB0wAAAA%3D%3D)):

```javascript
const [x] = [,];
```

swc output:

```javascript
const x;
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
