### PR TITLE
fix: semicolon is delim in new spec

### DIFF
--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -87,6 +87,8 @@ pub enum DelimiterValue {
     Comma,
     /// `/`
     Solidus,
+    /// `;`
+    Semicolon,
 }
 
 #[ast_node("Delimiter")]

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -177,6 +177,15 @@ where
                 }));
             }
 
+            tok!(";") => {
+                bump!(self);
+
+                return Ok(Value::Delimiter(Delimiter {
+                    span: span!(self, span.lo),
+                    value: DelimiterValue::Semicolon,
+                }));
+            }
+
             tok!("str") => return Ok(Value::Str(self.parse()?)),
 
             tok!("url") => return Ok(Value::Url(self.parse()?)),

--- a/crates/swc_css_parser/tests/errors/rome/invalid/fit-content/invalid-call/output.stderr
+++ b/crates/swc_css_parser/tests/errors/rome/invalid/fit-content/invalid-call/output.stderr
@@ -1,10 +1,4 @@
 error: Expected Declaration value
- --> $DIR/tests/errors/rome/invalid/fit-content/invalid-call/input.css:2:45
-  |
-2 |     grid-template-columns: fit-content("broken";
-  |                                                ^
-
-error: Expected Declaration value
  --> $DIR/tests/errors/rome/invalid/fit-content/invalid-call/input.css:3:1
   |
 3 | }

--- a/crates/swc_css_parser/tests/errors/rome/invalid/grid/repeat/unclosed-lint-name/output.stderr
+++ b/crates/swc_css_parser/tests/errors/rome/invalid/grid/repeat/unclosed-lint-name/output.stderr
@@ -5,12 +5,6 @@ error: Expected Declaration value
   |                                                ^
 
 error: Expected Declaration value
- --> $DIR/tests/errors/rome/invalid/grid/repeat/unclosed-lint-name/input.css:2:46
-  |
-2 |     grid-template-columns: repeat(4, [col-start);
-  |                                                 ^
-
-error: Expected Declaration value
  --> $DIR/tests/errors/rome/invalid/grid/repeat/unclosed-lint-name/input.css:3:1
   |
 3 | }

--- a/crates/swc_css_parser/tests/errors/rome/invalid/min-or-max/output.stderr
+++ b/crates/swc_css_parser/tests/errors/rome/invalid/min-or-max/output.stderr
@@ -1,10 +1,4 @@
 error: Expected Declaration value
- --> $DIR/tests/errors/rome/invalid/min-or-max/input.css:2:18
-  |
-2 |     width: min(500px;
-  |                     ^
-
-error: Expected Declaration value
  --> $DIR/tests/errors/rome/invalid/min-or-max/input.css:3:1
   |
 3 | }

--- a/crates/swc_css_parser/tests/fixture/function/mix/input.css
+++ b/crates/swc_css_parser/tests/fixture/function/mix/input.css
@@ -1,0 +1,5 @@
+div {
+    /*   mix( [ <timeline> && [ by <easing-function> ]? ] ; <start-value> ; <end-value>) */
+    opacity: mix( 70% by ease ; 0% ; 100% );
+    opacity: mix(70%;0%;100%);
+}

--- a/crates/swc_css_parser/tests/fixture/function/mix/output.json
+++ b/crates/swc_css_parser/tests/fixture/function/mix/output.json
@@ -1,0 +1,332 @@
+{
+  "type": "Stylesheet",
+  "span": {
+    "start": 0,
+    "end": 176,
+    "ctxt": 0
+  },
+  "rules": [
+    {
+      "type": "QualifiedRule",
+      "span": {
+        "start": 0,
+        "end": 175,
+        "ctxt": 0
+      },
+      "prelude": {
+        "type": "SelectorList",
+        "span": {
+          "start": 0,
+          "end": 3,
+          "ctxt": 0
+        },
+        "children": [
+          {
+            "type": "ComplexSelector",
+            "span": {
+              "start": 0,
+              "end": 3,
+              "ctxt": 0
+            },
+            "children": [
+              {
+                "type": "CompoundSelector",
+                "span": {
+                  "start": 0,
+                  "end": 3,
+                  "ctxt": 0
+                },
+                "nestingSelector": null,
+                "typeSelector": {
+                  "type": "TagNameSelector",
+                  "span": {
+                    "start": 0,
+                    "end": 3,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "WqName",
+                    "span": {
+                      "start": 0,
+                      "end": 3,
+                      "ctxt": 0
+                    },
+                    "prefix": null,
+                    "value": {
+                      "type": "Ident",
+                      "span": {
+                        "start": 0,
+                        "end": 3,
+                        "ctxt": 0
+                      },
+                      "value": "div",
+                      "raw": "div"
+                    }
+                  }
+                },
+                "subclassSelectors": []
+              }
+            ]
+          }
+        ]
+      },
+      "block": {
+        "type": "SimpleBlock",
+        "span": {
+          "start": 4,
+          "end": 175,
+          "ctxt": 0
+        },
+        "name": "{",
+        "value": [
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 102,
+              "end": 141,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Ident",
+              "span": {
+                "start": 102,
+                "end": 109,
+                "ctxt": 0
+              },
+              "value": "opacity",
+              "raw": "opacity"
+            },
+            "value": [
+              {
+                "type": "Function",
+                "span": {
+                  "start": 111,
+                  "end": 141,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Ident",
+                  "span": {
+                    "start": 111,
+                    "end": 114,
+                    "ctxt": 0
+                  },
+                  "value": "mix",
+                  "raw": "mix"
+                },
+                "value": [
+                  {
+                    "type": "Percentage",
+                    "span": {
+                      "start": 116,
+                      "end": 119,
+                      "ctxt": 0
+                    },
+                    "value": {
+                      "type": "Number",
+                      "span": {
+                        "start": 116,
+                        "end": 118,
+                        "ctxt": 0
+                      },
+                      "value": 70.0,
+                      "raw": "70"
+                    }
+                  },
+                  {
+                    "type": "Ident",
+                    "span": {
+                      "start": 120,
+                      "end": 122,
+                      "ctxt": 0
+                    },
+                    "value": "by",
+                    "raw": "by"
+                  },
+                  {
+                    "type": "Ident",
+                    "span": {
+                      "start": 123,
+                      "end": 127,
+                      "ctxt": 0
+                    },
+                    "value": "ease",
+                    "raw": "ease"
+                  },
+                  {
+                    "type": "Delimiter",
+                    "span": {
+                      "start": 128,
+                      "end": 129,
+                      "ctxt": 0
+                    },
+                    "value": ";"
+                  },
+                  {
+                    "type": "Percentage",
+                    "span": {
+                      "start": 130,
+                      "end": 132,
+                      "ctxt": 0
+                    },
+                    "value": {
+                      "type": "Number",
+                      "span": {
+                        "start": 130,
+                        "end": 131,
+                        "ctxt": 0
+                      },
+                      "value": 0.0,
+                      "raw": "0"
+                    }
+                  },
+                  {
+                    "type": "Delimiter",
+                    "span": {
+                      "start": 133,
+                      "end": 134,
+                      "ctxt": 0
+                    },
+                    "value": ";"
+                  },
+                  {
+                    "type": "Percentage",
+                    "span": {
+                      "start": 135,
+                      "end": 139,
+                      "ctxt": 0
+                    },
+                    "value": {
+                      "type": "Number",
+                      "span": {
+                        "start": 135,
+                        "end": 138,
+                        "ctxt": 0
+                      },
+                      "value": 100.0,
+                      "raw": "100"
+                    }
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 147,
+              "end": 172,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Ident",
+              "span": {
+                "start": 147,
+                "end": 154,
+                "ctxt": 0
+              },
+              "value": "opacity",
+              "raw": "opacity"
+            },
+            "value": [
+              {
+                "type": "Function",
+                "span": {
+                  "start": 156,
+                  "end": 172,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Ident",
+                  "span": {
+                    "start": 156,
+                    "end": 159,
+                    "ctxt": 0
+                  },
+                  "value": "mix",
+                  "raw": "mix"
+                },
+                "value": [
+                  {
+                    "type": "Percentage",
+                    "span": {
+                      "start": 160,
+                      "end": 163,
+                      "ctxt": 0
+                    },
+                    "value": {
+                      "type": "Number",
+                      "span": {
+                        "start": 160,
+                        "end": 162,
+                        "ctxt": 0
+                      },
+                      "value": 70.0,
+                      "raw": "70"
+                    }
+                  },
+                  {
+                    "type": "Delimiter",
+                    "span": {
+                      "start": 163,
+                      "end": 164,
+                      "ctxt": 0
+                    },
+                    "value": ";"
+                  },
+                  {
+                    "type": "Percentage",
+                    "span": {
+                      "start": 164,
+                      "end": 166,
+                      "ctxt": 0
+                    },
+                    "value": {
+                      "type": "Number",
+                      "span": {
+                        "start": 164,
+                        "end": 165,
+                        "ctxt": 0
+                      },
+                      "value": 0.0,
+                      "raw": "0"
+                    }
+                  },
+                  {
+                    "type": "Delimiter",
+                    "span": {
+                      "start": 166,
+                      "end": 167,
+                      "ctxt": 0
+                    },
+                    "value": ";"
+                  },
+                  {
+                    "type": "Percentage",
+                    "span": {
+                      "start": 167,
+                      "end": 171,
+                      "ctxt": 0
+                    },
+                    "value": {
+                      "type": "Number",
+                      "span": {
+                        "start": 167,
+                        "end": 170,
+                        "ctxt": 0
+                      },
+                      "value": 100.0,
+                      "raw": "100"
+                    }
+                  }
+                ]
+              }
+            ],
+            "important": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/crates/swc_css_parser/tests/fixture/function/mix/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/function/mix/span.rust-debug
@@ -1,0 +1,335 @@
+error: Stylesheet
+ --> $DIR/tests/fixture/function/mix/input.css:1:1
+  |
+1 | / div {
+2 | |     /*   mix( [ <timeline> && [ by <easing-function> ]? ] ; <start-value> ; <end-value>) */
+3 | |     opacity: mix( 70% by ease ; 0% ; 100% );
+4 | |     opacity: mix(70%;0%;100%);
+5 | | }
+  | |__^
+
+error: Rule
+ --> $DIR/tests/fixture/function/mix/input.css:1:1
+  |
+1 | / div {
+2 | |     /*   mix( [ <timeline> && [ by <easing-function> ]? ] ; <start-value> ; <end-value>) */
+3 | |     opacity: mix( 70% by ease ; 0% ; 100% );
+4 | |     opacity: mix(70%;0%;100%);
+5 | | }
+  | |_^
+
+error: QualifiedRule
+ --> $DIR/tests/fixture/function/mix/input.css:1:1
+  |
+1 | / div {
+2 | |     /*   mix( [ <timeline> && [ by <easing-function> ]? ] ; <start-value> ; <end-value>) */
+3 | |     opacity: mix( 70% by ease ; 0% ; 100% );
+4 | |     opacity: mix(70%;0%;100%);
+5 | | }
+  | |_^
+
+error: SelectorList
+ --> $DIR/tests/fixture/function/mix/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: ComplexSelector
+ --> $DIR/tests/fixture/function/mix/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: CompoundSelector
+ --> $DIR/tests/fixture/function/mix/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: TypeSelector
+ --> $DIR/tests/fixture/function/mix/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: TagNameSelector
+ --> $DIR/tests/fixture/function/mix/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: WqName
+ --> $DIR/tests/fixture/function/mix/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: Ident
+ --> $DIR/tests/fixture/function/mix/input.css:1:1
+  |
+1 | div {
+  | ^^^
+
+error: SimpleBlock
+ --> $DIR/tests/fixture/function/mix/input.css:1:5
+  |
+1 |   div {
+  |  _____^
+2 | |     /*   mix( [ <timeline> && [ by <easing-function> ]? ] ; <start-value> ; <end-value>) */
+3 | |     opacity: mix( 70% by ease ; 0% ; 100% );
+4 | |     opacity: mix(70%;0%;100%);
+5 | | }
+  | |_^
+
+error: Declaration
+ --> $DIR/tests/fixture/function/mix/input.css:3:5
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: DeclarationName
+ --> $DIR/tests/fixture/function/mix/input.css:3:5
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |     ^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/function/mix/input.css:3:5
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |     ^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:3:14
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Function
+ --> $DIR/tests/fixture/function/mix/input.css:3:14
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/function/mix/input.css:3:14
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |              ^^^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:3:19
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                   ^^^
+
+error: Percentage
+ --> $DIR/tests/fixture/function/mix/input.css:3:19
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                   ^^^
+
+error: Number
+ --> $DIR/tests/fixture/function/mix/input.css:3:19
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                   ^^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:3:23
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                       ^^
+
+error: Ident
+ --> $DIR/tests/fixture/function/mix/input.css:3:23
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                       ^^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:3:26
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                          ^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/function/mix/input.css:3:26
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                          ^^^^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:3:31
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                               ^
+
+error: Delimiter
+ --> $DIR/tests/fixture/function/mix/input.css:3:31
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                               ^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:3:33
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                                 ^^
+
+error: Percentage
+ --> $DIR/tests/fixture/function/mix/input.css:3:33
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                                 ^^
+
+error: Number
+ --> $DIR/tests/fixture/function/mix/input.css:3:33
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                                 ^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:3:36
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                                    ^
+
+error: Delimiter
+ --> $DIR/tests/fixture/function/mix/input.css:3:36
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                                    ^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:3:38
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                                      ^^^^
+
+error: Percentage
+ --> $DIR/tests/fixture/function/mix/input.css:3:38
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                                      ^^^^
+
+error: Number
+ --> $DIR/tests/fixture/function/mix/input.css:3:38
+  |
+3 |     opacity: mix( 70% by ease ; 0% ; 100% );
+  |                                      ^^^
+
+error: Declaration
+ --> $DIR/tests/fixture/function/mix/input.css:4:5
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: DeclarationName
+ --> $DIR/tests/fixture/function/mix/input.css:4:5
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |     ^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/function/mix/input.css:4:5
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |     ^^^^^^^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:4:14
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |              ^^^^^^^^^^^^^^^^
+
+error: Function
+ --> $DIR/tests/fixture/function/mix/input.css:4:14
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |              ^^^^^^^^^^^^^^^^
+
+error: Ident
+ --> $DIR/tests/fixture/function/mix/input.css:4:14
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |              ^^^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:4:18
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |                  ^^^
+
+error: Percentage
+ --> $DIR/tests/fixture/function/mix/input.css:4:18
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |                  ^^^
+
+error: Number
+ --> $DIR/tests/fixture/function/mix/input.css:4:18
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |                  ^^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:4:21
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |                     ^
+
+error: Delimiter
+ --> $DIR/tests/fixture/function/mix/input.css:4:21
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |                     ^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:4:22
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |                      ^^
+
+error: Percentage
+ --> $DIR/tests/fixture/function/mix/input.css:4:22
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |                      ^^
+
+error: Number
+ --> $DIR/tests/fixture/function/mix/input.css:4:22
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |                      ^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:4:24
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |                        ^
+
+error: Delimiter
+ --> $DIR/tests/fixture/function/mix/input.css:4:24
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |                        ^
+
+error: Value
+ --> $DIR/tests/fixture/function/mix/input.css:4:25
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |                         ^^^^
+
+error: Percentage
+ --> $DIR/tests/fixture/function/mix/input.css:4:25
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |                         ^^^^
+
+error: Number
+ --> $DIR/tests/fixture/function/mix/input.css:4:25
+  |
+4 |     opacity: mix(70%;0%;100%);
+  |                         ^^^
+

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -112,6 +112,7 @@ define!({
     pub enum DelimiterValue {
         Comma,
         Solidus,
+        Semicolon,
     }
 
     pub struct Delimiter {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Fix `;` is delim in new spec, example - https://www.w3.org/TR/css-values-4/#interpolate

**BREAKING CHANGE:**

yes, new types

**Related issue (if exists):**

no