### PR TITLE
fix(ecma/transform/compat): apply `new.target` before `classes`

### DIFF
--- a/crates/swc/tests/fixture/new-target/output/class-extends-error.ts
+++ b/crates/swc/tests/fixture/new-target/output/class-extends-error.ts
@@ -56,6 +56,13 @@ function _inherits(subClass, superClass) {
     });
     if (superClass) _setPrototypeOf(subClass, superClass);
 }
+function _instanceof(left, right) {
+    if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) {
+        return right[Symbol.hasInstance](left);
+    } else {
+        return left instanceof right;
+    }
+}
 function _isNativeFunction(fn) {
     return Function.toString.call(fn).indexOf("[native code]") !== -1;
 }
@@ -126,7 +133,7 @@ function _createSuper(Derived) {
         return _possibleConstructorReturn(this, result);
     };
 }
-var CustomError = /*#__PURE__*/ function(Error) {
+var CustomError = /*#__PURE__*/ function _target(Error) {
     "use strict";
     _inherits(CustomError, Error);
     var _super = _createSuper(CustomError);
@@ -134,7 +141,7 @@ var CustomError = /*#__PURE__*/ function(Error) {
         _classCallCheck(this, CustomError);
         var _this;
         _this = _super.call(this, message); // 'Error' breaks prototype chain here
-        Object.setPrototypeOf(_assertThisInitialized(_this), _this.constructor.prototype); // restore prototype chain
+        Object.setPrototypeOf(_assertThisInitialized(_this), (_instanceof(this, CustomError) ? this.constructor : void 0).prototype); // restore prototype chain
         return _this;
     }
     return CustomError;

--- a/crates/swc/tests/tsc-references/newTarget.es5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/newTarget.es5_es5.1.normal.js
@@ -78,13 +78,13 @@ function _createSuper(Derived) {
 }
 var A = function A() {
     "use strict";
+    var _newtarget = _instanceof(this, A) ? this.constructor : void 0;
     _classCallCheck(this, A);
-    var _newtarget = this.constructor;
     // @target: es5
     this.d = function _target() {
-        return this.constructor;
+        return _instanceof(this, _target) ? this.constructor : void 0;
     };
-    var a = this.constructor;
+    var a = _instanceof(this, A) ? this.constructor : void 0;
     var b = function() {
         return _newtarget;
     };
@@ -92,16 +92,15 @@ var A = function A() {
 A.c = function _target() {
     return _instanceof(this, _target) ? this.constructor : void 0;
 };
-var B = /*#__PURE__*/ function(A) {
+var B = /*#__PURE__*/ function _target(A) {
     "use strict";
     _inherits(B, A);
     var _super = _createSuper(B);
     function B() {
+        var _newtarget = _instanceof(this, B) ? this.constructor : void 0;
         _classCallCheck(this, B);
-        var _this;
-        var _newtarget = _this.constructor;
-        _this = _super.call(this);
-        var e = _this.constructor;
+        var _this = _super.call(this);
+        var e = _instanceof(this, B) ? this.constructor : void 0;
         var f = function() {
             return _newtarget;
         };

--- a/crates/swc/tests/tsc-references/newTarget.es5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/newTarget.es5_es5.2.minified.js
@@ -16,9 +16,9 @@ function _setPrototypeOf(o, p) {
 }
 var A = function() {
     "use strict";
-    _classCallCheck(this, A), this.constructor, this.d = function() {
-        return this.constructor;
-    }, this.constructor;
+    _instanceof(this, A) && this.constructor, _classCallCheck(this, A), this.d = function _target() {
+        return _instanceof(this, _target) ? this.constructor : void 0;
+    }, _instanceof(this, A) && this.constructor;
 };
 A.c = function _target() {
     return _instanceof(this, _target) ? this.constructor : void 0;
@@ -56,8 +56,9 @@ var B = function(A1) {
         })(self);
     });
     function B() {
-        var _this;
-        return _classCallCheck(this, B), _this.constructor, (_this = _super.call(this)).constructor, _this;
+        _instanceof(this, B) && this.constructor, _classCallCheck(this, B);
+        var _this = _super.call(this);
+        return _instanceof(this, B) && this.constructor, _this;
     }
     return B;
 }(A);

--- a/crates/swc/tests/tsc-references/newTarget.es6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/newTarget.es6_es5.1.normal.js
@@ -78,13 +78,13 @@ function _createSuper(Derived) {
 }
 var A = function A() {
     "use strict";
+    var _newtarget = _instanceof(this, A) ? this.constructor : void 0;
     _classCallCheck(this, A);
-    var _newtarget = this.constructor;
     // @target: es6
     this.d = function _target() {
-        return this.constructor;
+        return _instanceof(this, _target) ? this.constructor : void 0;
     };
-    var a = this.constructor;
+    var a = _instanceof(this, A) ? this.constructor : void 0;
     var b = function() {
         return _newtarget;
     };
@@ -92,16 +92,15 @@ var A = function A() {
 A.c = function _target() {
     return _instanceof(this, _target) ? this.constructor : void 0;
 };
-var B = /*#__PURE__*/ function(A) {
+var B = /*#__PURE__*/ function _target(A) {
     "use strict";
     _inherits(B, A);
     var _super = _createSuper(B);
     function B() {
+        var _newtarget = _instanceof(this, B) ? this.constructor : void 0;
         _classCallCheck(this, B);
-        var _this;
-        var _newtarget = _this.constructor;
-        _this = _super.call(this);
-        var e = _this.constructor;
+        var _this = _super.call(this);
+        var e = _instanceof(this, B) ? this.constructor : void 0;
         var f = function() {
             return _newtarget;
         };

--- a/crates/swc/tests/tsc-references/newTarget.es6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/newTarget.es6_es5.2.minified.js
@@ -16,9 +16,9 @@ function _setPrototypeOf(o, p) {
 }
 var A = function() {
     "use strict";
-    _classCallCheck(this, A), this.constructor, this.d = function() {
-        return this.constructor;
-    }, this.constructor;
+    _instanceof(this, A) && this.constructor, _classCallCheck(this, A), this.d = function _target() {
+        return _instanceof(this, _target) ? this.constructor : void 0;
+    }, _instanceof(this, A) && this.constructor;
 };
 A.c = function _target() {
     return _instanceof(this, _target) ? this.constructor : void 0;
@@ -56,8 +56,9 @@ var B = function(A1) {
         })(self);
     });
     function B() {
-        var _this;
-        return _classCallCheck(this, B), _this.constructor, (_this = _super.call(this)).constructor, _this;
+        _instanceof(this, B) && this.constructor, _classCallCheck(this, B);
+        var _this = _super.call(this);
+        return _instanceof(this, B) && this.constructor, _this;
     }
     return B;
 }(A);

--- a/crates/swc_ecma_transforms_compat/src/es2015/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/mod.rs
@@ -50,8 +50,8 @@ where
     chain!(
         block_scoped_functions(),
         template_literal(c.template_literal),
-        new_target(),
         classes(comments),
+        new_target(),
         spread(c.spread),
         // https://github.com/Microsoft/TypeScript/issues/5441
         Optional::new(object_super(), !c.typescript),
@@ -386,6 +386,24 @@ return new B(20).print()"
             ]);
             return _class;
         }());
+        "
+    );
+
+    test_exec!(
+        ::swc_ecma_parser::Syntax::default(),
+        |t| es2015(
+            Mark::fresh(Mark::root()),
+            Some(t.comments.clone()),
+            Default::default()
+        ),
+        issue_2682,
+        "class MyObject extends null {
+            constructor() {
+              return Object.create(new.target.prototype);
+            }
+          }
+        var obj = new MyObject();
+        expect(obj.constructor).toBe(MyObject);
         "
     );
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
A proper fix is impossible, since the only other way to get `new.target` is by `this.constructor`, however in this situation any access to `this` would throw an error. The following code would also generate wrong output
```js
class A {
  constructor() {
    Object.setPrototypeOf(this, null)
    console.log(new.target)
  }
}
```
But consider original issue, apply `new.target` transform later would generate correct result because after class transformation, access `this` in normal function would not throw. If `new.target` is applied first, `this` would be transpiled to `_this` in `classes` which would be `undefined`. The result is **technically incorrect**, but there's no better way. Babel behaves the same, and so does in current swc's `preset-env`
**Related issue (if exists):**
fixes #2682, incompletely