### PR TITLE
feat(swc/plugin): support `context` for the plugin transform

### DIFF
--- a/crates/swc_cli/src/commands/plugin.rs
+++ b/crates/swc_cli/src/commands/plugin.rs
@@ -222,26 +222,27 @@ impl VisitMut for TransformVisitor {
     // Implement necessary visit_mut_* methods for actual custom transform.
 }
 
-/// An entrypoint to the SWC's transform plugin.
-/// `plugin_transform` macro handles necessary interop to communicate with the host,
-/// and entrypoint function name (`process_transform`) can be anything else.
+/// An example plugin function with macro support.
+/// `plugin_transform` macro interop pointers into deserialized structs, as well
+/// as returning ptr back to host.
 ///
-/// If plugin need to handle low-level ptr directly,
-/// it is possible to opt out from macro by writing transform fn manually via raw interface
-///
+/// It is possible to opt out from macro by writing transform fn manually via
 /// `__plugin_process_impl(
 ///     ast_ptr: *const u8,
 ///     ast_ptr_len: i32,
 ///     config_str_ptr: *const u8,
-///     config_str_ptr_len: i32) ->
+///     config_str_ptr_len: i32,
+///     context_str_ptr: *const u8,
+///     context_str_ptr_len: i32) ->
 ///     i32 /*  0 for success, fail otherwise.
 ///             Note this is only for internal pointer interop result,
 ///             not actual transform result */
 ///
-/// However, this means plugin author need to handle all of serialization/deserialization
-/// steps with communicating with host. Refer `swc_plugin_macro` for more details.
+/// if plugin need to handle low-level ptr directly. However, there are
+/// important steps manually need to be performed like sending transformed
+/// results back to host. Refer swc_plugin_macro how does it work internally.
 #[plugin_transform]
-pub fn process_transform(program: Program, _plugin_config: String) -> Program {
+pub fn process_transform(program: Program, _plugin_config: String, _context: String) -> Program {
     program.fold_with(&mut as_folder(TransformVisitor))
 }
 "#

--- a/crates/swc_plugin_runner/tests/integration.rs
+++ b/crates/swc_plugin_runner/tests/integration.rs
@@ -82,10 +82,18 @@ fn internal() -> Result<(), Error> {
 
         let program = Serialized::serialize(&program).expect("Should serializable");
         let config = Serialized::serialize(&"{}".to_string()).expect("Should serializable");
+        let context = Serialized::serialize(&"{sourceFileName: 'single_plugin_test'}".to_string())
+            .expect("Should serializable");
 
-        let program_bytes =
-            swc_plugin_runner::apply_js_plugin("internal-test", &path, &mut None, config, program)
-                .expect("Plugin should apply transform");
+        let program_bytes = swc_plugin_runner::apply_js_plugin(
+            "internal-test",
+            &path,
+            &mut None,
+            program,
+            config,
+            context,
+        )
+        .expect("Plugin should apply transform");
 
         let program: Program =
             Serialized::deserialize(&program_bytes).expect("Should able to deserialize");
@@ -119,10 +127,20 @@ fn internal() -> Result<(), Error> {
 
         let program = Serialized::serialize(&program).expect("Should serializable");
         let config = Serialized::serialize(&"{}".to_string()).expect("Should serializable");
+        let context =
+            Serialized::serialize(&"{sourceFileName: 'single_plugin_handler_test'}".to_string())
+                .expect("Should serializable");
 
         let _res = HANDLER.set(&handler, || {
-            swc_plugin_runner::apply_js_plugin("internal-test", &path, &mut None, config, program)
-                .expect("Plugin should apply transform")
+            swc_plugin_runner::apply_js_plugin(
+                "internal-test",
+                &path,
+                &mut None,
+                program,
+                config,
+                context,
+            )
+            .expect("Plugin should apply transform")
         });
 
         Ok(())
@@ -151,8 +169,10 @@ fn internal() -> Result<(), Error> {
             "internal-test",
             &path,
             &mut None,
-            Serialized::serialize(&"{}".to_string()).expect("Should serializable"),
             serialized_program,
+            Serialized::serialize(&"{}".to_string()).expect("Should serializable"),
+            Serialized::serialize(&"{sourceFileName: 'multiple_plugin_test'}".to_string())
+                .expect("Should serializable"),
         )
         .expect("Plugin should apply transform");
 
@@ -161,8 +181,10 @@ fn internal() -> Result<(), Error> {
             "internal-test",
             &path,
             &mut None,
-            Serialized::serialize(&"{}".to_string()).expect("Should serializable"),
             serialized_program,
+            Serialized::serialize(&"{}".to_string()).expect("Should serializable"),
+            Serialized::serialize(&"{sourceFileName: 'multiple_plugin_test2'}".to_string())
+                .expect("Should serializable"),
         )
         .expect("Plugin should apply transform");
 

--- a/tests/rust-plugins/swc_internal_plugin/Cargo.lock
+++ b/tests/rust-plugins/swc_internal_plugin/Cargo.lock
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.65.3"
+version = "0.65.4"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.25.0"
+version = "0.26.1"
 dependencies = [
  "once_cell",
  "swc_atoms",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/rust-plugins/swc_internal_plugin/src/lib.rs
+++ b/tests/rust-plugins/swc_internal_plugin/src/lib.rs
@@ -32,7 +32,9 @@ impl VisitMut for ConsoleOutputReplacer {
 ///     ast_ptr: *const u8,
 ///     ast_ptr_len: i32,
 ///     config_str_ptr: *const u8,
-///     config_str_ptr_len: i32) ->
+///     config_str_ptr_len: i32,
+///     context_str_ptr: *const u8,
+///     context_str_ptr_len: i32) ->
 ///     i32 /*  0 for success, fail otherwise.
 ///             Note this is only for internal pointer interop result,
 ///             not actual transform result */
@@ -41,7 +43,7 @@ impl VisitMut for ConsoleOutputReplacer {
 /// important steps manually need to be performed like sending transformed
 /// results back to host. Refer swc_plugin_macro how does it work internally.
 #[plugin_transform]
-pub fn process(program: Program, _plugin_config: String) -> Program {
+pub fn process(program: Program, _plugin_config: String, _context: String) -> Program {
     HANDLER.with(|handler| {
         handler
             .struct_span_err(DUMMY_SP, "Test diagnostics from plugin")


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

From discussion https://github.com/swc-project/swc/discussions/3540#discussioncomment-2163757. 

Plugin may need additional data other than config to plugin itself, mostly state around swc/core. Some examples like

- specific file name for current transform
- maybe whole swcrc config, not only for the plugin itself

or possibly more. This PR attempts to resolve those by forwarding new param named `context`.

There are few possible approaches to enable this.

1. expand plugin interface param signature
```
#[plugin_transform]
fn process(program: Program, plugin_config: String, filename: String, swcrc: String...);
```

Obviously, this is not preferrable as we'll continously expand signatures and each time we add new param it'll cause breaking changes.

2. Typed struct param
```
struct PluginContext {
 filename: String,
 other: ...
}

#[plugin_transform]
fn process(program: Program, plugin_config: String, context: PluginContext);
```

This is most clear interface signature. However, have same pitfall as first. Each time we add new properties into struct, it'll be a breaking change since our serialization does not support add-only / versioned

3. Context as JSON-string

Current approach. Safe to add new properties since it's string, plugin can try to pick up necessary properties for their use.


Though I picked 3rd, I'm currently bit debating 2 also - if we can add enough context properties in experimental phase, we can stabilize those to avoid frequent breaking changes. The part I'm not sure is how frequent we'll need to change this context information. Would like to hear thoughts, and update PR into second if needed.

**BREAKING CHANGE:**
Plugin will need to accept 3rd param in any case, it could be a string or a typed struct.

**Related issue (if exists):**

https://github.com/swc-project/swc/discussions/3540#discussioncomment-2163757. 