### PR TITLE
refactor(swc/plugin): remove direct dep to oncecell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3440,7 +3440,6 @@ dependencies = [
 name = "swc_plugin"
 version = "0.27.0"
 dependencies = [
- "once_cell",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",

--- a/crates/swc_plugin/Cargo.toml
+++ b/crates/swc_plugin/Cargo.toml
@@ -14,4 +14,3 @@ swc_ecma_ast = {version = "0.65.0", path = "../swc_ecma_ast", features = ["rkyv-
 swc_ecma_visit = {version = "0.51.0", path = "../swc_ecma_visit"}
 swc_atoms = {version = "0.2.0", path = "../swc_atoms"}
 swc_plugin_macro = {version = "0.3.0", path = "../swc_plugin_macro"}
-once_cell = "1.9.0"

--- a/crates/swc_plugin/src/handler.rs
+++ b/crates/swc_plugin/src/handler.rs
@@ -1,4 +1,4 @@
-use once_cell::sync::OnceCell;
+use swc_common::sync::OnceCell;
 
 /// Simple substitution for scoped_thread_local with limited interface parity.
 /// The only available fn in this struct is `with`, which is being used for the

--- a/tests/rust-plugins/swc_internal_plugin/Cargo.lock
+++ b/tests/rust-plugins/swc_internal_plugin/Cargo.lock
@@ -766,9 +766,8 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
- "once_cell",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -778,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Minor refactor to use reexport onceCell from swc_common instead of direct dependency.
