### PR TITLE
fix: recovery mode for function

### DIFF
--- a/crates/swc_css_codegen/tests/fixture.rs
+++ b/crates/swc_css_codegen/tests/fixture.rs
@@ -4,7 +4,9 @@ use std::{
 };
 
 use swc_common::{FileName, Span};
-use swc_css_ast::{HexColor, ImportantFlag, Number, Str, Stylesheet, UrlValueRaw};
+use swc_css_ast::{
+    HexColor, ImportantFlag, Number, Str, Stylesheet, Token, TokenAndSpan, UrlValueRaw,
+};
 use swc_css_codegen::{
     writer::basic::{BasicCssWriter, BasicCssWriterConfig},
     CodeGenerator, CodegenConfig, Emit,
@@ -116,10 +118,6 @@ impl VisitMut for NormalizeTest {
         n.raw = "".into();
     }
 
-    fn visit_mut_span(&mut self, n: &mut Span) {
-        *n = Default::default()
-    }
-
     fn visit_mut_str(&mut self, n: &mut Str) {
         n.visit_mut_children_with(self);
 
@@ -132,6 +130,18 @@ impl VisitMut for NormalizeTest {
         n.before = "".into();
         n.after = "".into();
         n.raw = "".into();
+    }
+
+    fn visit_mut_token_and_span(&mut self, n: &mut TokenAndSpan) {
+        n.visit_mut_children_with(self);
+
+        if let Token::WhiteSpace { .. } = &n.token {
+            n.token = Token::WhiteSpace { value: "".into() }
+        }
+    }
+
+    fn visit_mut_span(&mut self, n: &mut Span) {
+        *n = Default::default()
     }
 }
 

--- a/crates/swc_css_codegen/tests/fixture/preserved-token/input.css
+++ b/crates/swc_css_codegen/tests/fixture/preserved-token/input.css
@@ -1,0 +1,12 @@
+.slide {
+    width: __styled-jsx-placeholder__7px;
+    height: __styled-jsx-placeholder__7px;
+    margin: 0 calc(__styled-jsx-placeholder__7vw - __styled-jsx-placeholder__7px);
+    border-radius: 7px;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08),
+    0 5px 12px rgba(0, 0, 0, 0.1);
+    transition: all 0.5s ease;
+    cursor: pointer;
+    overflow: hidden;
+    background: white;
+}

--- a/crates/swc_css_codegen/tests/fixture/preserved-token/output.css
+++ b/crates/swc_css_codegen/tests/fixture/preserved-token/output.css
@@ -1,0 +1,11 @@
+.slide {
+width: __styled-jsx-placeholder__7px;
+height: __styled-jsx-placeholder__7px;
+margin: 0 calc(__styled-jsx-placeholder__7vw   -   __styled-jsx-placeholder__7px);
+border-radius: 7px;
+box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08), 0 5px 12px rgba(0, 0, 0, 0.1);
+transition: all 0.5s ease;
+cursor: pointer;
+overflow: hidden;
+background: white;
+}

--- a/crates/swc_css_codegen/tests/fixture/preserved-token/output.min.css
+++ b/crates/swc_css_codegen/tests/fixture/preserved-token/output.min.css
@@ -1,0 +1,1 @@
+.slide{width:__styled-jsx-placeholder__7px;height:__styled-jsx-placeholder__7px;margin:0 calc(__styled-jsx-placeholder__7vw   -   __styled-jsx-placeholder__7px);border-radius:7px;box-shadow:0 10px 20px rgba(0,0,0,.08),0 5px 12px rgba(0,0,0,.1);transition:all.5s ease;cursor:pointer;overflow:hidden;background:white}

--- a/crates/swc_css_parser/tests/errors/rome/invalid/min-or-max/output.stderr
+++ b/crates/swc_css_parser/tests/errors/rome/invalid/min-or-max/output.stderr
@@ -4,3 +4,17 @@ error: Expected 'number', 'dimension', 'percentage', 'ident', '(' or 'function' 
 2 |     width: min(500px;
   |                     ^
 
+error: Expected 'number', 'dimension', 'percentage', 'ident', '(' or 'function' tokens
+ --> $DIR/tests/errors/rome/invalid/min-or-max/input.css:3:1
+  |
+3 | }
+  | ^
+
+error: Unexpected end of file
+ --> $DIR/tests/errors/rome/invalid/min-or-max/input.css:3:3
+  |
+3 | }
+  |   ^
+
+error: Unexpected end of file
+

--- a/crates/swc_css_parser/tests/recovery/delim-token/minus/output.json
+++ b/crates/swc_css_parser/tests/recovery/delim-token/minus/output.json
@@ -204,14 +204,32 @@
                 },
                 "value": [
                   {
-                    "type": "Number",
+                    "type": "PreservedToken",
                     "span": {
                       "start": 51,
                       "end": 52,
                       "ctxt": 0
                     },
-                    "value": 1.0,
-                    "raw": "1"
+                    "token": {
+                      "Number": {
+                        "value": 1.0,
+                        "raw": "1",
+                        "type": "integer"
+                      }
+                    }
+                  },
+                  {
+                    "type": "PreservedToken",
+                    "span": {
+                      "start": 52,
+                      "end": 53,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "WhiteSpace": {
+                        "value": " "
+                      }
+                    }
                   },
                   {
                     "type": "PreservedToken",

--- a/crates/swc_css_parser/tests/recovery/delim-token/plus/output.json
+++ b/crates/swc_css_parser/tests/recovery/delim-token/plus/output.json
@@ -204,14 +204,32 @@
                 },
                 "value": [
                   {
-                    "type": "Number",
+                    "type": "PreservedToken",
                     "span": {
                       "start": 51,
                       "end": 52,
                       "ctxt": 0
                     },
-                    "value": 1.0,
-                    "raw": "1"
+                    "token": {
+                      "Number": {
+                        "value": 1.0,
+                        "raw": "1",
+                        "type": "integer"
+                      }
+                    }
+                  },
+                  {
+                    "type": "PreservedToken",
+                    "span": {
+                      "start": 52,
+                      "end": 53,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "WhiteSpace": {
+                        "value": " "
+                      }
+                    }
                   },
                   {
                     "type": "PreservedToken",

--- a/crates/swc_css_parser/tests/recovery/function/output.json
+++ b/crates/swc_css_parser/tests/recovery/function/output.json
@@ -116,14 +116,32 @@
                 },
                 "value": [
                   {
-                    "type": "Number",
+                    "type": "PreservedToken",
                     "span": {
                       "start": 21,
                       "end": 22,
                       "ctxt": 0
                     },
-                    "value": 1.0,
-                    "raw": "1"
+                    "token": {
+                      "Number": {
+                        "value": 1.0,
+                        "raw": "1",
+                        "type": "integer"
+                      }
+                    }
+                  },
+                  {
+                    "type": "PreservedToken",
+                    "span": {
+                      "start": 22,
+                      "end": 23,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "WhiteSpace": {
+                        "value": " "
+                      }
+                    }
                   },
                   {
                     "type": "PreservedToken",
@@ -190,14 +208,18 @@
                 },
                 "value": [
                   {
-                    "type": "Ident",
+                    "type": "PreservedToken",
                     "span": {
                       "start": 44,
                       "end": 49,
                       "ctxt": 0
                     },
-                    "value": "ident",
-                    "raw": "ident"
+                    "token": {
+                      "Ident": {
+                        "value": "ident",
+                        "raw": "ident"
+                      }
+                    }
                   },
                   {
                     "type": "PreservedToken",
@@ -264,14 +286,31 @@
                 },
                 "value": [
                   {
-                    "type": "Ident",
+                    "type": "PreservedToken",
+                    "span": {
+                      "start": 74,
+                      "end": 77,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "WhiteSpace": {
+                        "value": "   "
+                      }
+                    }
+                  },
+                  {
+                    "type": "PreservedToken",
                     "span": {
                       "start": 77,
                       "end": 82,
                       "ctxt": 0
                     },
-                    "value": "ident",
-                    "raw": "ident"
+                    "token": {
+                      "Ident": {
+                        "value": "ident",
+                        "raw": "ident"
+                      }
+                    }
                   },
                   {
                     "type": "PreservedToken",

--- a/crates/swc_css_parser/tests/recovery/ie-progid/output.json
+++ b/crates/swc_css_parser/tests/recovery/ie-progid/output.json
@@ -181,14 +181,18 @@
                 },
                 "value": [
                   {
-                    "type": "Ident",
+                    "type": "PreservedToken",
                     "span": {
                       "start": 58,
                       "end": 71,
                       "ctxt": 0
                     },
-                    "value": "startColorstr",
-                    "raw": "startColorstr"
+                    "token": {
+                      "Ident": {
+                        "value": "startColorstr",
+                        "raw": "startColorstr"
+                      }
+                    }
                   },
                   {
                     "type": "PreservedToken",
@@ -204,33 +208,41 @@
                     }
                   },
                   {
-                    "type": "String",
+                    "type": "PreservedToken",
                     "span": {
                       "start": 72,
                       "end": 81,
                       "ctxt": 0
                     },
-                    "value": "#4f4f4f",
-                    "raw": "'#4f4f4f'"
+                    "token": {
+                      "String": {
+                        "value": "#4f4f4f",
+                        "raw": "'#4f4f4f'"
+                      }
+                    }
                   },
                   {
-                    "type": "Delimiter",
+                    "type": "PreservedToken",
                     "span": {
                       "start": 81,
                       "end": 82,
                       "ctxt": 0
                     },
-                    "value": ","
+                    "token": "Comma"
                   },
                   {
-                    "type": "Ident",
+                    "type": "PreservedToken",
                     "span": {
                       "start": 82,
                       "end": 93,
                       "ctxt": 0
                     },
-                    "value": "endColorstr",
-                    "raw": "endColorstr"
+                    "token": {
+                      "Ident": {
+                        "value": "endColorstr",
+                        "raw": "endColorstr"
+                      }
+                    }
                   },
                   {
                     "type": "PreservedToken",
@@ -246,33 +258,41 @@
                     }
                   },
                   {
-                    "type": "String",
+                    "type": "PreservedToken",
                     "span": {
                       "start": 94,
                       "end": 103,
                       "ctxt": 0
                     },
-                    "value": "#292929",
-                    "raw": "'#292929'"
+                    "token": {
+                      "String": {
+                        "value": "#292929",
+                        "raw": "'#292929'"
+                      }
+                    }
                   },
                   {
-                    "type": "Delimiter",
+                    "type": "PreservedToken",
                     "span": {
                       "start": 103,
                       "end": 104,
                       "ctxt": 0
                     },
-                    "value": ","
+                    "token": "Comma"
                   },
                   {
-                    "type": "Ident",
+                    "type": "PreservedToken",
                     "span": {
                       "start": 104,
                       "end": 116,
                       "ctxt": 0
                     },
-                    "value": "GradientType",
-                    "raw": "GradientType"
+                    "token": {
+                      "Ident": {
+                        "value": "GradientType",
+                        "raw": "GradientType"
+                      }
+                    }
                   },
                   {
                     "type": "PreservedToken",
@@ -404,14 +424,18 @@
                 },
                 "value": [
                   {
-                    "type": "Ident",
+                    "type": "PreservedToken",
                     "span": {
                       "start": 172,
                       "end": 183,
                       "ctxt": 0
                     },
-                    "value": "pixelradius",
-                    "raw": "pixelradius"
+                    "token": {
+                      "Ident": {
+                        "value": "pixelradius",
+                        "raw": "pixelradius"
+                      }
+                    }
                   },
                   {
                     "type": "PreservedToken",
@@ -522,14 +546,18 @@
                 },
                 "value": [
                   {
-                    "type": "Ident",
+                    "type": "PreservedToken",
                     "span": {
                       "start": 227,
                       "end": 235,
                       "ctxt": 0
                     },
-                    "value": "duration",
-                    "raw": "duration"
+                    "token": {
+                      "Ident": {
+                        "value": "duration",
+                        "raw": "duration"
+                      }
+                    }
                   },
                   {
                     "type": "PreservedToken",

--- a/crates/swc_css_parser/tests/recovery/vercel/002/input.css
+++ b/crates/swc_css_parser/tests/recovery/vercel/002/input.css
@@ -1,0 +1,12 @@
+.slide {
+    width: __styled-jsx-placeholder__7px;
+    height: __styled-jsx-placeholder__7px;
+    margin: 0 calc(__styled-jsx-placeholder__7vw - __styled-jsx-placeholder__7px);
+    border-radius: 7px;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08),
+        0 5px 12px rgba(0, 0, 0, 0.1);
+    transition: all 0.5s ease;
+    cursor: pointer;
+    overflow: hidden;
+    background: white;
+}

--- a/crates/swc_css_parser/tests/recovery/vercel/002/output.json
+++ b/crates/swc_css_parser/tests/recovery/vercel/002/output.json
@@ -1,0 +1,806 @@
+{
+  "type": "Stylesheet",
+  "span": {
+    "start": 0,
+    "end": 388,
+    "ctxt": 0
+  },
+  "rules": [
+    {
+      "type": "QualifiedRule",
+      "span": {
+        "start": 0,
+        "end": 387,
+        "ctxt": 0
+      },
+      "prelude": {
+        "type": "SelectorList",
+        "span": {
+          "start": 0,
+          "end": 6,
+          "ctxt": 0
+        },
+        "children": [
+          {
+            "type": "ComplexSelector",
+            "span": {
+              "start": 0,
+              "end": 6,
+              "ctxt": 0
+            },
+            "children": [
+              {
+                "type": "CompoundSelector",
+                "span": {
+                  "start": 0,
+                  "end": 6,
+                  "ctxt": 0
+                },
+                "nestingSelector": null,
+                "typeSelector": null,
+                "subclassSelectors": [
+                  {
+                    "type": "ClassSelector",
+                    "span": {
+                      "start": 0,
+                      "end": 6,
+                      "ctxt": 0
+                    },
+                    "text": {
+                      "type": "Ident",
+                      "span": {
+                        "start": 1,
+                        "end": 6,
+                        "ctxt": 0
+                      },
+                      "value": "slide",
+                      "raw": "slide"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "block": {
+        "type": "SimpleBlock",
+        "span": {
+          "start": 7,
+          "end": 387,
+          "ctxt": 0
+        },
+        "name": "{",
+        "value": [
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 13,
+              "end": 49,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Ident",
+              "span": {
+                "start": 13,
+                "end": 18,
+                "ctxt": 0
+              },
+              "value": "width",
+              "raw": "width"
+            },
+            "value": [
+              {
+                "type": "Ident",
+                "span": {
+                  "start": 20,
+                  "end": 49,
+                  "ctxt": 0
+                },
+                "value": "__styled-jsx-placeholder__7px",
+                "raw": "__styled-jsx-placeholder__7px"
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 55,
+              "end": 92,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Ident",
+              "span": {
+                "start": 55,
+                "end": 61,
+                "ctxt": 0
+              },
+              "value": "height",
+              "raw": "height"
+            },
+            "value": [
+              {
+                "type": "Ident",
+                "span": {
+                  "start": 63,
+                  "end": 92,
+                  "ctxt": 0
+                },
+                "value": "__styled-jsx-placeholder__7px",
+                "raw": "__styled-jsx-placeholder__7px"
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 98,
+              "end": 175,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Ident",
+              "span": {
+                "start": 98,
+                "end": 104,
+                "ctxt": 0
+              },
+              "value": "margin",
+              "raw": "margin"
+            },
+            "value": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 106,
+                  "end": 107,
+                  "ctxt": 0
+                },
+                "value": 0.0,
+                "raw": "0"
+              },
+              {
+                "type": "Function",
+                "span": {
+                  "start": 108,
+                  "end": 175,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Ident",
+                  "span": {
+                    "start": 108,
+                    "end": 112,
+                    "ctxt": 0
+                  },
+                  "value": "calc",
+                  "raw": "calc"
+                },
+                "value": [
+                  {
+                    "type": "PreservedToken",
+                    "span": {
+                      "start": 113,
+                      "end": 142,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "Ident": {
+                        "value": "__styled-jsx-placeholder__7vw",
+                        "raw": "__styled-jsx-placeholder__7vw"
+                      }
+                    }
+                  },
+                  {
+                    "type": "PreservedToken",
+                    "span": {
+                      "start": 142,
+                      "end": 143,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "WhiteSpace": {
+                        "value": " "
+                      }
+                    }
+                  },
+                  {
+                    "type": "PreservedToken",
+                    "span": {
+                      "start": 143,
+                      "end": 144,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "Delim": {
+                        "value": "-"
+                      }
+                    }
+                  },
+                  {
+                    "type": "PreservedToken",
+                    "span": {
+                      "start": 144,
+                      "end": 145,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "WhiteSpace": {
+                        "value": " "
+                      }
+                    }
+                  },
+                  {
+                    "type": "PreservedToken",
+                    "span": {
+                      "start": 145,
+                      "end": 174,
+                      "ctxt": 0
+                    },
+                    "token": {
+                      "Ident": {
+                        "value": "__styled-jsx-placeholder__7px",
+                        "raw": "__styled-jsx-placeholder__7px"
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 181,
+              "end": 199,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Ident",
+              "span": {
+                "start": 181,
+                "end": 194,
+                "ctxt": 0
+              },
+              "value": "border-radius",
+              "raw": "border-radius"
+            },
+            "value": [
+              {
+                "type": "Length",
+                "span": {
+                  "start": 196,
+                  "end": 199,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 196,
+                    "end": 197,
+                    "ctxt": 0
+                  },
+                  "value": 7.0,
+                  "raw": "7"
+                },
+                "unit": {
+                  "type": "Ident",
+                  "span": {
+                    "start": 197,
+                    "end": 199,
+                    "ctxt": 0
+                  },
+                  "value": "px",
+                  "raw": "px"
+                }
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 205,
+              "end": 287,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Ident",
+              "span": {
+                "start": 205,
+                "end": 215,
+                "ctxt": 0
+              },
+              "value": "box-shadow",
+              "raw": "box-shadow"
+            },
+            "value": [
+              {
+                "type": "Number",
+                "span": {
+                  "start": 217,
+                  "end": 218,
+                  "ctxt": 0
+                },
+                "value": 0.0,
+                "raw": "0"
+              },
+              {
+                "type": "Length",
+                "span": {
+                  "start": 219,
+                  "end": 223,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 219,
+                    "end": 221,
+                    "ctxt": 0
+                  },
+                  "value": 10.0,
+                  "raw": "10"
+                },
+                "unit": {
+                  "type": "Ident",
+                  "span": {
+                    "start": 221,
+                    "end": 223,
+                    "ctxt": 0
+                  },
+                  "value": "px",
+                  "raw": "px"
+                }
+              },
+              {
+                "type": "Length",
+                "span": {
+                  "start": 224,
+                  "end": 228,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 224,
+                    "end": 226,
+                    "ctxt": 0
+                  },
+                  "value": 20.0,
+                  "raw": "20"
+                },
+                "unit": {
+                  "type": "Ident",
+                  "span": {
+                    "start": 226,
+                    "end": 228,
+                    "ctxt": 0
+                  },
+                  "value": "px",
+                  "raw": "px"
+                }
+              },
+              {
+                "type": "Function",
+                "span": {
+                  "start": 229,
+                  "end": 248,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Ident",
+                  "span": {
+                    "start": 229,
+                    "end": 233,
+                    "ctxt": 0
+                  },
+                  "value": "rgba",
+                  "raw": "rgba"
+                },
+                "value": [
+                  {
+                    "type": "Number",
+                    "span": {
+                      "start": 234,
+                      "end": 235,
+                      "ctxt": 0
+                    },
+                    "value": 0.0,
+                    "raw": "0"
+                  },
+                  {
+                    "type": "Delimiter",
+                    "span": {
+                      "start": 235,
+                      "end": 236,
+                      "ctxt": 0
+                    },
+                    "value": ","
+                  },
+                  {
+                    "type": "Number",
+                    "span": {
+                      "start": 237,
+                      "end": 238,
+                      "ctxt": 0
+                    },
+                    "value": 0.0,
+                    "raw": "0"
+                  },
+                  {
+                    "type": "Delimiter",
+                    "span": {
+                      "start": 238,
+                      "end": 239,
+                      "ctxt": 0
+                    },
+                    "value": ","
+                  },
+                  {
+                    "type": "Number",
+                    "span": {
+                      "start": 240,
+                      "end": 241,
+                      "ctxt": 0
+                    },
+                    "value": 0.0,
+                    "raw": "0"
+                  },
+                  {
+                    "type": "Delimiter",
+                    "span": {
+                      "start": 241,
+                      "end": 242,
+                      "ctxt": 0
+                    },
+                    "value": ","
+                  },
+                  {
+                    "type": "Number",
+                    "span": {
+                      "start": 243,
+                      "end": 247,
+                      "ctxt": 0
+                    },
+                    "value": 0.08,
+                    "raw": "0.08"
+                  }
+                ]
+              },
+              {
+                "type": "Delimiter",
+                "span": {
+                  "start": 248,
+                  "end": 249,
+                  "ctxt": 0
+                },
+                "value": ","
+              },
+              {
+                "type": "Number",
+                "span": {
+                  "start": 258,
+                  "end": 259,
+                  "ctxt": 0
+                },
+                "value": 0.0,
+                "raw": "0"
+              },
+              {
+                "type": "Length",
+                "span": {
+                  "start": 260,
+                  "end": 263,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 260,
+                    "end": 261,
+                    "ctxt": 0
+                  },
+                  "value": 5.0,
+                  "raw": "5"
+                },
+                "unit": {
+                  "type": "Ident",
+                  "span": {
+                    "start": 261,
+                    "end": 263,
+                    "ctxt": 0
+                  },
+                  "value": "px",
+                  "raw": "px"
+                }
+              },
+              {
+                "type": "Length",
+                "span": {
+                  "start": 264,
+                  "end": 268,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 264,
+                    "end": 266,
+                    "ctxt": 0
+                  },
+                  "value": 12.0,
+                  "raw": "12"
+                },
+                "unit": {
+                  "type": "Ident",
+                  "span": {
+                    "start": 266,
+                    "end": 268,
+                    "ctxt": 0
+                  },
+                  "value": "px",
+                  "raw": "px"
+                }
+              },
+              {
+                "type": "Function",
+                "span": {
+                  "start": 269,
+                  "end": 287,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Ident",
+                  "span": {
+                    "start": 269,
+                    "end": 273,
+                    "ctxt": 0
+                  },
+                  "value": "rgba",
+                  "raw": "rgba"
+                },
+                "value": [
+                  {
+                    "type": "Number",
+                    "span": {
+                      "start": 274,
+                      "end": 275,
+                      "ctxt": 0
+                    },
+                    "value": 0.0,
+                    "raw": "0"
+                  },
+                  {
+                    "type": "Delimiter",
+                    "span": {
+                      "start": 275,
+                      "end": 276,
+                      "ctxt": 0
+                    },
+                    "value": ","
+                  },
+                  {
+                    "type": "Number",
+                    "span": {
+                      "start": 277,
+                      "end": 278,
+                      "ctxt": 0
+                    },
+                    "value": 0.0,
+                    "raw": "0"
+                  },
+                  {
+                    "type": "Delimiter",
+                    "span": {
+                      "start": 278,
+                      "end": 279,
+                      "ctxt": 0
+                    },
+                    "value": ","
+                  },
+                  {
+                    "type": "Number",
+                    "span": {
+                      "start": 280,
+                      "end": 281,
+                      "ctxt": 0
+                    },
+                    "value": 0.0,
+                    "raw": "0"
+                  },
+                  {
+                    "type": "Delimiter",
+                    "span": {
+                      "start": 281,
+                      "end": 282,
+                      "ctxt": 0
+                    },
+                    "value": ","
+                  },
+                  {
+                    "type": "Number",
+                    "span": {
+                      "start": 283,
+                      "end": 286,
+                      "ctxt": 0
+                    },
+                    "value": 0.1,
+                    "raw": "0.1"
+                  }
+                ]
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 293,
+              "end": 318,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Ident",
+              "span": {
+                "start": 293,
+                "end": 303,
+                "ctxt": 0
+              },
+              "value": "transition",
+              "raw": "transition"
+            },
+            "value": [
+              {
+                "type": "Ident",
+                "span": {
+                  "start": 305,
+                  "end": 308,
+                  "ctxt": 0
+                },
+                "value": "all",
+                "raw": "all"
+              },
+              {
+                "type": "Time",
+                "span": {
+                  "start": 309,
+                  "end": 313,
+                  "ctxt": 0
+                },
+                "value": {
+                  "type": "Number",
+                  "span": {
+                    "start": 309,
+                    "end": 312,
+                    "ctxt": 0
+                  },
+                  "value": 0.5,
+                  "raw": "0.5"
+                },
+                "unit": {
+                  "type": "Ident",
+                  "span": {
+                    "start": 312,
+                    "end": 313,
+                    "ctxt": 0
+                  },
+                  "value": "s",
+                  "raw": "s"
+                }
+              },
+              {
+                "type": "Ident",
+                "span": {
+                  "start": 314,
+                  "end": 318,
+                  "ctxt": 0
+                },
+                "value": "ease",
+                "raw": "ease"
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 324,
+              "end": 339,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Ident",
+              "span": {
+                "start": 324,
+                "end": 330,
+                "ctxt": 0
+              },
+              "value": "cursor",
+              "raw": "cursor"
+            },
+            "value": [
+              {
+                "type": "Ident",
+                "span": {
+                  "start": 332,
+                  "end": 339,
+                  "ctxt": 0
+                },
+                "value": "pointer",
+                "raw": "pointer"
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 345,
+              "end": 361,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Ident",
+              "span": {
+                "start": 345,
+                "end": 353,
+                "ctxt": 0
+              },
+              "value": "overflow",
+              "raw": "overflow"
+            },
+            "value": [
+              {
+                "type": "Ident",
+                "span": {
+                  "start": 355,
+                  "end": 361,
+                  "ctxt": 0
+                },
+                "value": "hidden",
+                "raw": "hidden"
+              }
+            ],
+            "important": null
+          },
+          {
+            "type": "Declaration",
+            "span": {
+              "start": 367,
+              "end": 384,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Ident",
+              "span": {
+                "start": 367,
+                "end": 377,
+                "ctxt": 0
+              },
+              "value": "background",
+              "raw": "background"
+            },
+            "value": [
+              {
+                "type": "Ident",
+                "span": {
+                  "start": 379,
+                  "end": 384,
+                  "ctxt": 0
+                },
+                "value": "white",
+                "raw": "white"
+              }
+            ],
+            "important": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/crates/swc_css_parser/tests/recovery/vercel/002/output.swc-stderr
+++ b/crates/swc_css_parser/tests/recovery/vercel/002/output.swc-stderr
@@ -1,0 +1,18 @@
+error: Expected 'e', 'pi', 'infinity', '-infinity' or 'NaN', ident tokens
+ --> $DIR/tests/recovery/vercel/002/input.css:4:20
+  |
+4 |     margin: 0 calc(__styled-jsx-placeholder__7vw - __styled-jsx-placeholder__7px);
+  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Expected 'number', 'dimension', 'percentage', 'ident', '(' or 'function' tokens
+ --> $DIR/tests/recovery/vercel/002/input.css:4:50
+  |
+4 |     margin: 0 calc(__styled-jsx-placeholder__7vw - __styled-jsx-placeholder__7px);
+  |                                                  ^
+
+error: Expected 'e', 'pi', 'infinity', '-infinity' or 'NaN', ident tokens
+ --> $DIR/tests/recovery/vercel/002/input.css:4:52
+  |
+4 |     margin: 0 calc(__styled-jsx-placeholder__7vw - __styled-jsx-placeholder__7px);
+  |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Fix recovery mode for `function` (regression in next.js)

Ideally we should refactor this logic more and consume components values firstly, when try to resolve to `Vec<Value>`, if failed keep them as is, if not failed apply `Vec<Value>` nodes, but it requires more refactor and can take a time (I will focus on it in this week, so we will not have such regressions in future)

No

**Related issue (if exists):**

No