### PR TITLE
feat(swc/cli): initial compile command implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
 dependencies = [
  "atty",
  "bitflags",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1715,10 +1715,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-absolutize"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b288298a7a3a7b42539e3181ba590d32f2d91237b0691ed5f103875c754b3bf5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
 name = "path-clean"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
+
+[[package]]
+name = "path-dedot"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfa72956f6be8524f7f7e2b07972dda393cb0008a6df4451f658b7e1bd1af80"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "pathdiff"
@@ -2113,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "relative-path"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d4caf086b102ab49d0525b721594a555ab55c6556086bbe52a430ad26c3bd7"
+checksum = "a49a831dc1e13c9392b660b162333d4cb0033bbbdfe6a1687177e59e89037c86"
 
 [[package]]
 name = "remove_dir_all"
@@ -2320,9 +2338,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -2350,9 +2368,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2361,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -2710,6 +2728,14 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
+ "path-absolutize",
+ "rayon",
+ "relative-path",
+ "serde",
+ "serde_json",
+ "swc",
+ "swc_common",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/swc_cli/Cargo.toml
+++ b/crates/swc_cli/Cargo.toml
@@ -14,6 +14,17 @@ path = "./src/main.rs"
 
 [dependencies]
 anyhow = "1.0.53"
-clap = {version = "3.0.14", features = ["derive", "wrap_help"]}
+clap = { version = "3.1.0", features = ["derive", "wrap_help"] }
+walkdir = "2"
+rayon = "1"
+swc = { version = "0.127.1", path = "../swc" }
+swc_common = { version = "0.17.5", path = "../swc_common" }
+relative-path = "1.6.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["unbounded_depth"] }
+
+[dependencies.path-absolutize]
+version = "3.0.11"
+features = ["once_cell_cache"]
 
 [features]

--- a/crates/swc_cli/src/commands/compile.rs
+++ b/crates/swc_cli/src/commands/compile.rs
@@ -1,5 +1,214 @@
-use clap::Parser;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
+use anyhow::Context;
+use clap::Parser;
+use path_absolutize::Absolutize;
+use rayon::prelude::*;
+use relative_path::RelativePath;
+use swc::{
+    config::{Config, Options},
+    try_with_handler, Compiler, TransformOutput,
+};
+use swc_common::{sync::Lazy, FilePathMapping, SourceMap};
+use walkdir::WalkDir;
+
+/// Configuration option for transform files.
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
-pub struct CompileOptions {}
+pub struct CompileOptions {
+    /// Path to a .swcrc file to use
+    #[clap(long = "config")]
+    config_file: Option<PathBuf>,
+
+    /// Files to compile
+    files: Vec<PathBuf>,
+
+    /// The output directory
+    #[clap(long)]
+    out_dir: Option<PathBuf>,
+
+    /// Specify specific file extensions to compile.
+    #[clap(long)]
+    extensions: Option<Vec<String>>,
+}
+
+static COMPILER: Lazy<Arc<Compiler>> = Lazy::new(|| {
+    let cm = Arc::new(SourceMap::new(FilePathMapping::empty()));
+
+    Arc::new(Compiler::new(cm))
+});
+
+/// List of file extensions supported by default.
+static DEFAULT_EXTENSIONS: &[&str] = &["js", "jsx", "es6", "es", "mjs", "ts", "tsx"];
+
+/// Infer list of files to be transformed from cli arguments.
+/// If given input is a directory, it'll traverse it and collect all supported
+/// files.
+fn get_files_list(
+    raw_files_input: &[PathBuf],
+    extensions: &[String],
+    _include_dotfiles: bool,
+) -> anyhow::Result<Vec<PathBuf>> {
+    let input_dir = raw_files_input.iter().find(|p| p.is_dir());
+
+    let files = if let Some(input_dir) = input_dir {
+        if raw_files_input.len() > 1 {
+            return Err(anyhow::anyhow!(
+                "Cannot specify multiple files when using a directory as input"
+            ));
+        }
+
+        WalkDir::new(input_dir)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .map(|e| e.into_path())
+            .filter(|e| {
+                extensions
+                    .iter()
+                    .any(|ext| e.extension().map(|v| v == &**ext).unwrap_or(false))
+            })
+            .collect()
+    } else {
+        raw_files_input.to_owned()
+    };
+
+    Ok(files)
+}
+
+fn build_transform_options(
+    config_file: &Option<PathBuf>,
+    file_path: &Path,
+) -> anyhow::Result<Options> {
+    let base_options = Options::default();
+    let base_config = Config::default();
+
+    let config_file = if let Some(config_file_path) = config_file {
+        let config_file_contents = fs::read(config_file_path)?;
+        serde_json::from_slice(&config_file_contents)
+            .map_err(|e| anyhow::anyhow!("{}", e))
+            .context("Failed to parse config file")?
+    } else {
+        None
+    };
+
+    Ok(Options {
+        config: Config { ..base_config },
+        config_file,
+        filename: file_path.to_str().unwrap_or_default().to_owned(),
+        ..base_options
+    })
+}
+
+/// Calculate full, absolute path to the file to emit.
+/// Currently this is quite naive calculation based on assumption input file's
+/// path and output dir are relative to the same directory.
+fn resolve_output_file_path(out_dir: &Path, file_path: &Path) -> anyhow::Result<PathBuf> {
+    let default = PathBuf::from(".");
+    let base = file_path.parent().unwrap_or(&default).display().to_string();
+
+    let dist_absolute_path = out_dir.absolutize()?;
+
+    // These are possible combinations between input to output dir.
+    // cwd: /c/github/swc
+    //
+    // Input
+    // 1. Relative to cwd                   : ./crates/swc/tests/serde/a.js
+    // 2. Relative to cwd, traverse up      : ../repo/some/dir/b.js
+    // 3. Absolute path, relative to cwd: /c/github/swc/crates/swc/tests/serde/a.js
+    // 4. Absolute path, not relative to cwd: /c/github/repo/some/dir/b.js
+    //
+    // OutDir
+    // a. Relative to cwd: ./dist
+    // b. Relative to cwd, traverse up: ../outer_dist
+    // c. Absolute path: /c/github/swc/dist
+    // d. Absolute path, not relative to cwd: /c/github/outer_dist
+    //
+    // It is unclear how to calculate output path when either input or output is not
+    // relative to cwd (2,4 and b,d) and it is UB for now.
+    let base = RelativePath::new(&*base);
+    let output_path = base.to_logical_path(dist_absolute_path).join(
+        // Custom output file extension is not supported yet
+        file_path
+            .with_extension("js")
+            .file_name()
+            .expect("Filename should be available"),
+    );
+
+    Ok(output_path)
+}
+
+fn emit_output(
+    output: &TransformOutput,
+    out_dir: &Option<PathBuf>,
+    file_path: &Path,
+) -> anyhow::Result<()> {
+    if let Some(out_dir) = out_dir {
+        let output_file_path = resolve_output_file_path(out_dir, file_path)?;
+        let output_dir = output_file_path
+            .parent()
+            .expect("Parent should be available");
+
+        if !output_dir.is_dir() {
+            fs::create_dir_all(output_dir)?;
+        }
+
+        fs::write(&output_file_path, &output.code)?;
+
+        if let Some(source_map) = &output.map {
+            let source_map_path = output_file_path.with_extension("js.map");
+            fs::write(source_map_path, source_map)?;
+        }
+    } else {
+        println!(
+            "{}\n{}\n{}",
+            file_path.display(),
+            output.code,
+            output
+                .map
+                .as_ref()
+                .map(|m| m.to_string())
+                .unwrap_or_default()
+        );
+    };
+    Ok(())
+}
+
+impl super::CommandRunner for CompileOptions {
+    fn execute(&self) -> anyhow::Result<()> {
+        let included_extensions = if let Some(extensions) = &self.extensions {
+            extensions.clone()
+        } else {
+            DEFAULT_EXTENSIONS.iter().map(|v| v.to_string()).collect()
+        };
+
+        let files = get_files_list(&self.files, &included_extensions, false)?;
+        let cm = COMPILER.clone();
+
+        if let Some(out_dir) = &self.out_dir {
+            fs::create_dir_all(out_dir)?;
+        }
+
+        files
+            .into_par_iter()
+            .try_for_each_with(cm, |compiler, file_path| {
+                let result = try_with_handler(compiler.cm.clone(), false, |handler| {
+                    let options = build_transform_options(&self.config_file, &file_path)?;
+                    let fm = compiler
+                        .cm
+                        .load_file(&file_path)
+                        .context("failed to load file")?;
+                    compiler.process_js_file(fm, handler, &options)
+                });
+
+                match result {
+                    Ok(output) => emit_output(&output, &self.out_dir, &file_path)?,
+                    Err(e) => return Err(e),
+                };
+
+                Ok(())
+            })
+    }
+}

--- a/crates/swc_cli/src/commands/mod.rs
+++ b/crates/swc_cli/src/commands/mod.rs
@@ -1,4 +1,4 @@
-use clap::{AppSettings, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 
 mod compile;
 mod plugin;
@@ -17,9 +17,7 @@ pub enum Command {
 }
 
 #[derive(Parser)]
-#[clap(name = "SWC", version)]
-#[clap(global_setting(AppSettings::PropagateVersion))]
-#[clap(global_setting(AppSettings::UseLongFormatForHelpSubcommand))]
+#[clap(name = "SWC", version, propagate_version = true)]
 pub struct SwcCliOptions {
     #[clap(subcommand)]
     pub command: Command,

--- a/crates/swc_cli/src/main.rs
+++ b/crates/swc_cli/src/main.rs
@@ -8,6 +8,6 @@ fn main() -> anyhow::Result<()> {
 
     match &command {
         Command::Plugin(PluginSubcommand::New(options)) => options.execute(),
-        Command::Compile(..) => anyhow::bail!("Compile command is not yet implemented"),
+        Command::Compile(options) => options.execute(),
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

We have `plugin` subcommand, now we can work on other subcommand. This is initial effort to port over `@swc/cli`'s compilation command features under `compile` subcommand. It doesn't cover all of existing cli args yet, only covers most basic execution paths.

There are a couple of challenges we need to deal in the future. First, output path calculation relates to the input. This is not unique to this cli, as we have known issues like https://github.com/swc-project/swc/issues/3028 already. However, it's something we need to take care of.

Second one is more tricky - `plugin` options for the js-written plugins. Previously we can rely on node.js runtime as cli runs on those, which new cli doesn't. I don't have great idea yet except either deprecate js plugin or spin node.js separately to get transformed output from those. Both are not great.

**Related issue (if exists):**

- https://github.com/swc-project/swc/issues/1589
