### PR TITLE
feat(api/rust): Improve error messages for wrong usages of scoped thread-local variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "better_scoped_tls"
+version = "0.1.0"
+dependencies = [
+ "scoped-tls",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,6 +2728,7 @@ dependencies = [
  "arbitrary",
  "ast_node",
  "atty",
+ "better_scoped_tls",
  "cfg-if 0.1.10",
  "debug_unreachable",
  "either",
@@ -2732,7 +2740,6 @@ dependencies = [
  "rayon",
  "rkyv",
  "rustc-hash",
- "scoped-tls",
  "serde",
  "serde_json",
  "siphasher",
@@ -3069,10 +3076,10 @@ dependencies = [
 name = "swc_ecma_transforms_base"
 version = "0.58.2"
 dependencies = [
+ "better_scoped_tls",
  "once_cell",
  "phf",
  "rayon",
- "scoped-tls",
  "serde",
  "smallvec",
  "swc_atoms",
@@ -3337,7 +3344,7 @@ dependencies = [
 name = "swc_estree_ast"
 version = "0.7.0"
 dependencies = [
- "scoped-tls",
+ "better_scoped_tls",
  "serde",
  "serde_json",
  "swc_atoms",

--- a/crates/better_scoped_tls/Cargo.toml
+++ b/crates/better_scoped_tls/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
-name = "better_scoped_tls"
-version = "0.1.0"
+authors = ["강동윤 <kdy1997.dev@gmail.com>"]
+description = "scoped-tls, but with good error message"
+documentation = "https://rustdoc.swc.rs/better_scoped_tls/"
 edition = "2021"
+license = "Apache-2.0"
+name = "better_scoped_tls"
+repository = "https://github.com/swc-project/swc.git"
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/better_scoped_tls/Cargo.toml
+++ b/crates/better_scoped_tls/Cargo.toml
@@ -11,3 +11,4 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+scoped-tls = "1.0.0"

--- a/crates/better_scoped_tls/Cargo.toml
+++ b/crates/better_scoped_tls/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "better_scoped_tls"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/better_scoped_tls/README.md
+++ b/crates/better_scoped_tls/README.md
@@ -1,0 +1,11 @@
+# better_scoped_tls
+
+This crate provides an opinionated version of [scoped-tls](https://docs.rs/scoped-tls/1.0.0/scoped_tls/index.html).
+
+Scoped thread local variables created by this crate will panic with a good message on usage without `.set`, like
+
+```
+You should perform this operation in the closure passed to `set` of better_scoped_tls::tests::TESTTLS
+```
+
+Syntax is exactly same to the original scoped-tls.

--- a/crates/better_scoped_tls/src/lib.rs
+++ b/crates/better_scoped_tls/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}

--- a/crates/better_scoped_tls/src/lib.rs
+++ b/crates/better_scoped_tls/src/lib.rs
@@ -1,8 +1,83 @@
+//! Better scoped thread local storage.
+
+#[doc(hidden)]
+pub extern crate scoped_tls;
+
+/// See [scoped_tls::scoped_thread_local] for actual documentation.
+///
+/// This is noop on release builds.
+#[macro_export]
+macro_rules! scoped_tls_with_good_error {
+    ($(#[$attrs:meta])* $vis:vis static $name:ident: $ty:ty) => {
+        $crate::scoped_tls::scoped_thread_local!(
+            static INNER: $ty
+        );
+
+
+        $(#[$attrs])*
+        $vis static $name: $crate::ScopedKey<$ty> = $crate::ScopedKey {
+            inner: &INNER,
+            #[cfg(debug_assertions)]
+            module_path: module_path!(),
+        };
+    };
+}
+
+/// Wrapper for [scoped_tls::ScopedKey] with better error messages.
+pub struct ScopedKey<T>
+where
+    T: 'static,
+{
+    #[doc(hidden)]
+    pub inner: &'static scoped_tls::ScopedKey<T>,
+
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub module_path: &'static str,
+}
+
+impl<T> ScopedKey<T>
+where
+    T: 'static,
+{
+    /// See [scoped_tls::ScopedKey] for actual documentation.
+    pub fn set<F, R>(&'static self, t: &T, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        self.inner.set(t, f)
+    }
+
+    /// See [scoped_tls::ScopedKey] for actual documentation.
+    pub fn with<F, R>(&'static self, f: F) -> R
+    where
+        F: FnOnce(&T) -> R,
+    {
+        #[cfg(debug_assertions)]
+        if !self.inner.is_set() {
+            // Override panic message
+            panic!("Module path: {}", self.module_path)
+        }
+
+        self.inner.with(f)
+    }
+
+    /// See [scoped_tls::ScopedKey] for actual documentation.
+    pub fn is_set(&'static self) -> bool {
+        self.inner.is_set()
+    }
+}
+
 #[cfg(test)]
 mod tests {
+
+    scoped_tls_with_good_error!(
+        pub static TESTTLS: String
+    );
+
+    #[cfg(debug_assertions)]
     #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
+    #[should_panic = "You need to call set on tests::TESTTLS first"]
+
+    fn panic_on_with() {}
 }

--- a/crates/better_scoped_tls/src/lib.rs
+++ b/crates/better_scoped_tls/src/lib.rs
@@ -7,7 +7,7 @@ pub extern crate scoped_tls;
 ///
 /// This is noop on release builds.
 #[macro_export]
-macro_rules! scoped_tls_with_good_error {
+macro_rules! scoped_tls {
     ($(#[$attrs:meta])* $vis:vis static $name:ident: $ty:ty) => {
         $crate::scoped_tls::scoped_thread_local!(
             static INNER: $ty
@@ -83,7 +83,7 @@ where
 #[cfg(test)]
 mod tests {
 
-    scoped_tls_with_good_error!(
+    scoped_tls!(
         pub static TESTTLS: String
     );
 

--- a/crates/better_scoped_tls/src/lib.rs
+++ b/crates/better_scoped_tls/src/lib.rs
@@ -97,4 +97,13 @@ mod tests {
             println!("S: {}", s);
         })
     }
+    #[test]
+
+    fn valid() {
+        TESTTLS.set(&String::new(), || {
+            TESTTLS.with(|s| {
+                assert_eq!(*s, String::new());
+            })
+        })
+    }
 }

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -20,7 +20,7 @@ concurrent = ["parking_lot"]
 debug = []
 default = []
 diagnostic-serde = []
-plugin-base = [ "anyhow", "rkyv-impl", "diagnostic-serde"]
+plugin-base = ["anyhow", "rkyv-impl", "diagnostic-serde"]
 plugin-mode = ["plugin-base"]
 plugin-rt = ["plugin-base"]
 rkyv-impl = ["rkyv"]
@@ -32,6 +32,7 @@ anyhow = {version = "1.0.45", optional = true}
 arbitrary = {version = "1", optional = true, features = ["derive"]}
 ast_node = {version = "0.7.5", path = "../ast_node"}
 atty = {version = "0.2", optional = true}
+better_scoped_tls = {version = "0.1.0", path = "../better_scoped_tls"}
 cfg-if = "0.1.2"
 debug_unreachable = "0.1.1"
 either = "1.5"
@@ -39,10 +40,9 @@ from_variant = {version = "0.1.3", path = "../from_variant"}
 num-bigint = "0.2"
 once_cell = "1.9.0"
 owning_ref = "0.4"
-parking_lot = { version = "0.12.0", optional = true }
+parking_lot = {version = "0.12.0", optional = true}
 rkyv = {version = "0.7.28", optional = true}
 rustc-hash = "1.1.0"
-scoped-tls = "1"
 serde = {version = "1.0.119", features = ["derive"]}
 siphasher = "0.3.9"
 sourcemap = {version = "6", optional = true}

--- a/crates/swc_common/src/errors/mod.rs
+++ b/crates/swc_common/src/errors/mod.rs
@@ -17,7 +17,6 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering::SeqCst},
 };
 
-use scoped_tls::scoped_thread_local;
 #[cfg(feature = "tty-emitter")]
 use termcolor::{Color, ColorSpec};
 
@@ -899,7 +898,7 @@ impl Level {
     }
 }
 
-scoped_thread_local!(
+better_scoped_tls::scoped_tls_with_good_error!(
     /// Used for error reporting in transform.
     ///
     /// This should be only used for errors from the api which does not returning errors.

--- a/crates/swc_common/src/errors/mod.rs
+++ b/crates/swc_common/src/errors/mod.rs
@@ -898,7 +898,7 @@ impl Level {
     }
 }
 
-better_scoped_tls::scoped_tls_with_good_error!(
+better_scoped_tls::scoped_tls!(
     /// Used for error reporting in transform.
     ///
     /// This should be only used for errors from the api which does not returning errors.

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -77,7 +77,7 @@ impl Globals {
     }
 }
 
-better_scoped_tls::scoped_tls_with_good_error!(
+better_scoped_tls::scoped_tls!(
 
     /// Storage for span hygiene data.
     ///

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -77,29 +77,24 @@ impl Globals {
     }
 }
 
-/// Storage for span hygiene data.
-///
-/// This variable is used to manage identifiers or to identify nodes.
-/// Note that it's stored as a thread-local storage, but actually it's shared
-/// between threads.
-///
-/// # Usages
-///
-/// ## Span hygiene
-///
-/// [Mark]s are stored in this variable.
-///
-/// You can see the document how swc uses the span hygiene info at
-/// https://rustdoc.swc.rs/swc_ecma_transforms_base/resolver/fn.resolver_with_mark.html
-pub static GLOBALS: ::scoped_tls::ScopedKey<Globals> = ::scoped_tls::ScopedKey {
-    inner: {
-        thread_local!(static FOO: ::std::cell::Cell<usize> = {
-            ::std::cell::Cell::new(0)
-        });
-        &FOO
-    },
-    _marker: ::std::marker::PhantomData,
-};
+better_scoped_tls::scoped_tls_with_good_error!(
+
+    /// Storage for span hygiene data.
+    ///
+    /// This variable is used to manage identifiers or to identify nodes.
+    /// Note that it's stored as a thread-local storage, but actually it's shared
+    /// between threads.
+    ///
+    /// # Usages
+    ///
+    /// ## Span hygiene
+    ///
+    /// [Mark]s are stored in this variable.
+    ///
+    /// You can see the document how swc uses the span hygiene info at
+    /// https://rustdoc.swc.rs/swc_ecma_transforms_base/resolver/fn.resolver_with_mark.html
+    pub static GLOBALS: Globals
+);
 
 /// Differentiates between real files and common virtual files.
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]

--- a/crates/swc_ecma_transforms_base/Cargo.toml
+++ b/crates/swc_ecma_transforms_base/Cargo.toml
@@ -15,10 +15,10 @@ concurrent = [
 ]
 
 [dependencies]
+better_scoped_tls = {version = "0.1.0", path = "../better_scoped_tls"}
 once_cell = "1.9.0"
 phf = {version = "0.8.0", features = ["macros"]}
 rayon = {version = "1", optional = true}
-scoped-tls = "1.0.0"
 serde = {version = "1", features = ["derive"]}
 smallvec = "1.6.0"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}

--- a/crates/swc_ecma_transforms_base/src/helpers/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/helpers/mod.rs
@@ -1,7 +1,6 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use once_cell::sync::Lazy;
-use scoped_tls::scoped_thread_local;
 use swc_common::{FileName, FilePathMapping, Mark, SourceMap, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput};
@@ -61,7 +60,7 @@ macro_rules! add_to {
     }};
 }
 
-scoped_thread_local!(
+better_scoped_tls::scoped_tls_with_good_error!(
     /// This variable is used to manage helper scripts like `_inherits` from babel.
     ///
     /// The instance contains flags where each flag denotes if a helper script should be injected.

--- a/crates/swc_ecma_transforms_base/src/helpers/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/helpers/mod.rs
@@ -60,7 +60,7 @@ macro_rules! add_to {
     }};
 }
 
-better_scoped_tls::scoped_tls_with_good_error!(
+better_scoped_tls::scoped_tls!(
     /// This variable is used to manage helper scripts like `_inherits` from babel.
     ///
     /// The instance contains flags where each flag denotes if a helper script should be injected.

--- a/crates/swc_estree_ast/Cargo.toml
+++ b/crates/swc_estree_ast/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.7.0"
 all-features = true
 
 [dependencies]
-scoped-tls = "1.0.0"
+better_scoped_tls = {version = "0.1.0", path = "../better_scoped_tls"}
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}

--- a/crates/swc_estree_ast/src/flavor.rs
+++ b/crates/swc_estree_ast/src/flavor.rs
@@ -1,6 +1,4 @@
-use scoped_tls::scoped_thread_local;
-
-scoped_thread_local!(static FLAVOR: Flavor);
+better_scoped_tls::scoped_tls!(static FLAVOR: Flavor);
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]


### PR DESCRIPTION
**Description:**

`scoped-tls` is used various places in swc, but it does not provides meaningful error message on wrong usages.

```
cannot access a scoped thread local variable without calling set first
```

This is all of the error messages. This is not useful, so I created a new wrapper crate, which panics with

```
You should perform this operation in the closure passed to `set` of better_scoped_tls::tests::TESTTLS
```

Note that this wrapper is actually noop on release builds. It will still panic with a bad error message on release builds.


**Related issue (if exists):**
