### PR TITLE
improve swc-plugin package.json template

### DIFF
--- a/crates/swc_cli/src/commands/plugin.rs
+++ b/crates/swc_cli/src/commands/plugin.rs
@@ -190,20 +190,17 @@ target = "{}""#,
     "name": "{}",
     "version": "0.1.0",
     "description": "",
-    "main": "{}",
-    "scripts": {{
-        "test": "echo \"Error: no test specified\" && exit 1"
-    }},
-    "keywords": [],
     "author": "",
     "license": "ISC",
-    "files": [
-        "{}",
-        "README.md"
-    ]
+    "keywords": ["swc-plugin"],
+    "main": "{}",
+    "scripts": {{
+        "prepublishOnly": "cargo build --release"
+    }},
+    "files": []
 }}
 "#,
-                name, dist_output_path, dist_output_path
+                name, dist_output_path
             )
             .as_bytes(),
         )


### PR DESCRIPTION
I had some ideas to improves the generated `package.json` of the `swc plugin new` command.

 1) package.json `scripts`
    -  
    
- `prepublishOnly` (will be run automatically on `npm publish`)
ensure that the very latest source is compiled.
- `test`
I thought running `cargo test` might be a better default than `"echo \"Error: no test specified\" && exit 1"`
what do you think?
- `dev`
maybe this is too much - what do you think?

<br>


 2) package.json `files`
    -  
    
The result will stay the same as before just with less config.

from [https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files):

> Certain files are always included, regardless of settings:
> 
> package.json
> README
> LICENSE / LICENCE
> The file in the "main" field


you can try it with:

```
npm pack
```

<img width="284" alt="swc-plugin-console-prefix" src="https://user-images.githubusercontent.com/4113649/154796076-8459e8d0-7614-4a9a-a3da-d893cb3bdcce.png">

