### PR TITLE
build(swc): Remove unused dependencies

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,4 +3,9 @@
 
 # yarn run cspell "**/src/**/*.rs"
 cargo fmt --all -- --check
-cargo clippy
+
+
+if [ -z ${SWC_SKIP_CLIPPY+x} ];
+then
+    cargo clippy
+fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,15 +1664,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owning_ref"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2761,7 +2752,6 @@ dependencies = [
  "from_variant",
  "num-bigint",
  "once_cell",
- "owning_ref",
  "parking_lot 0.12.0",
  "rayon",
  "rkyv",
@@ -3069,7 +3059,6 @@ dependencies = [
  "swc_ecma_utils",
  "swc_ecma_visit",
  "testing",
- "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,7 +3504,6 @@ name = "swc_plugin_runner"
 version = "0.38.0"
 dependencies = [
  "anyhow",
- "libloading",
  "once_cell",
  "parking_lot 0.12.0",
  "serde",

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -39,7 +39,6 @@ either = "1.5"
 from_variant = {version = "0.1.3", path = "../from_variant"}
 num-bigint = "0.2"
 once_cell = "1.9.0"
-owning_ref = "0.4"
 parking_lot = {version = "0.12.0", optional = true}
 rkyv = {version = "0.7.28", optional = true}
 rustc-hash = "1.1.0"

--- a/crates/swc_ecma_codegen/Cargo.toml
+++ b/crates/swc_ecma_codegen/Cargo.toml
@@ -19,10 +19,10 @@ swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.17.3", path = "../swc_common"}
 swc_ecma_ast = {version = "0.68.0", path = "../swc_ecma_ast"}
 swc_ecma_codegen_macros = {version = "0.6.0", path = "../swc_ecma_codegen_macros"}
-swc_ecma_parser = {version = "0.91.0", path = "../swc_ecma_parser"}
 tracing = "0.1"
 
 [dev-dependencies]
 swc_common = {version = "0.17.3", path = "../swc_common", features = ["sourcemap"]}
+swc_ecma_parser = {version = "0.91.0", path = "../swc_ecma_parser"}
 swc_node_base = {version = "0.5.0", path = "../swc_node_base"}
 testing = {version = "0.18.0", path = "../testing"}

--- a/crates/swc_ecma_preset_env/Cargo.toml
+++ b/crates/swc_ecma_preset_env/Cargo.toml
@@ -27,7 +27,6 @@ swc_ecma_ast = {version = "0.68.0", path = "../swc_ecma_ast"}
 swc_ecma_transforms = {version = "0.120.0", path = "../swc_ecma_transforms", features = ["compat", "proposal"]}
 swc_ecma_utils = {version = "0.68.0", path = "../swc_ecma_utils"}
 swc_ecma_visit = {version = "0.54.0", path = "../swc_ecma_visit"}
-walkdir = "2"
 
 [dev-dependencies]
 pretty_assertions = "0.7.2"

--- a/crates/swc_ecma_preset_env/tests/test.rs
+++ b/crates/swc_ecma_preset_env/tests/test.rs
@@ -112,7 +112,6 @@ impl Default for UseBuiltIns {
 enum Error {
     Io(io::Error),
     Var(env::VarError),
-    WalkDir(walkdir::Error),
     Json(serde_json::Error),
     Msg(String),
 }

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -10,7 +10,6 @@ version = "0.38.0"
 
 [dependencies]
 anyhow = "1.0.42"
-libloading = "0.7.0"
 once_cell = "1.9.0"
 parking_lot = "0.12.0"
 serde = {version = "1.0.126", features = ["derive"]}
@@ -18,14 +17,14 @@ serde_json = "1.0.64"
 swc_atoms = {version = "0.2.7", path = '../swc_atoms'}
 swc_common = {version = "0.17.0", path = "../swc_common", features = ["plugin-rt", "concurrent"]}
 swc_ecma_ast = {version = "0.68.0", path = "../swc_ecma_ast", features = ["rkyv-impl"]}
-swc_ecma_loader = { version = "0.28.0", path = "../swc_ecma_loader" }
+swc_ecma_loader = {version = "0.28.0", path = "../swc_ecma_loader"}
 swc_ecma_parser = {version = "0.91.0", path = "../swc_ecma_parser"}
 wasmer = "2.1.1"
 wasmer-cache = "2.1.1"
 wasmer-wasi = "2.1.1"
 
 [dev-dependencies]
+swc_ecma_visit = {version = "0.54.0", path = "../swc_ecma_visit"}
 testing = {version = "0.18.0", path = "../testing"}
-swc_ecma_visit = { version = "0.54.0", path = "../swc_ecma_visit" }
 
 [features]

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -14,16 +14,16 @@ once_cell = "1.9.0"
 parking_lot = "0.12.0"
 serde = {version = "1.0.126", features = ["derive"]}
 serde_json = "1.0.64"
-swc_atoms = {version = "0.2.7", path = '../swc_atoms'}
 swc_common = {version = "0.17.0", path = "../swc_common", features = ["plugin-rt", "concurrent"]}
-swc_ecma_ast = {version = "0.68.0", path = "../swc_ecma_ast", features = ["rkyv-impl"]}
-swc_ecma_loader = {version = "0.28.0", path = "../swc_ecma_loader"}
-swc_ecma_parser = {version = "0.91.0", path = "../swc_ecma_parser"}
 wasmer = "2.1.1"
 wasmer-cache = "2.1.1"
 wasmer-wasi = "2.1.1"
 
 [dev-dependencies]
+swc_atoms = {version = "0.2.7", path = '../swc_atoms'}
+swc_ecma_ast = {version = "0.68.0", path = "../swc_ecma_ast", features = ["rkyv-impl"]}
+swc_ecma_loader = {version = "0.28.0", path = "../swc_ecma_loader"}
+swc_ecma_parser = {version = "0.91.0", path = "../swc_ecma_parser"}
 swc_ecma_visit = {version = "0.54.0", path = "../swc_ecma_visit"}
 testing = {version = "0.18.0", path = "../testing"}
 

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -15,13 +15,13 @@ parking_lot = "0.12.0"
 serde = {version = "1.0.126", features = ["derive"]}
 serde_json = "1.0.64"
 swc_common = {version = "0.17.0", path = "../swc_common", features = ["plugin-rt", "concurrent"]}
+swc_ecma_ast = {version = "0.68.0", path = "../swc_ecma_ast", features = ["rkyv-impl"]}
 wasmer = "2.1.1"
 wasmer-cache = "2.1.1"
 wasmer-wasi = "2.1.1"
 
 [dev-dependencies]
 swc_atoms = {version = "0.2.7", path = '../swc_atoms'}
-swc_ecma_ast = {version = "0.68.0", path = "../swc_ecma_ast", features = ["rkyv-impl"]}
 swc_ecma_loader = {version = "0.28.0", path = "../swc_ecma_loader"}
 swc_ecma_parser = {version = "0.91.0", path = "../swc_ecma_parser"}
 swc_ecma_visit = {version = "0.54.0", path = "../swc_ecma_visit"}


### PR DESCRIPTION
**Description:**

git/push-hook:
 - Allow skipping `cargo clippy` while pushing.




**Related issue (if exists):**
