### PR TITLE
#3523: Raise syntax error when rest elt is not last

### DIFF
--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -61,6 +61,7 @@ pub enum SyntaxError {
     },
     SetterParamRequired,
     RestPatInSetter,
+    RestElementNotLast,
 
     UnterminatedBlockComment,
     UnterminatedStrLit,
@@ -470,7 +471,7 @@ impl SyntaxError {
                 "A getter or a setter cannot be readonly".into()
             }
             SyntaxError::RestPatInSetter => "Rest pattern is not allowed in setter".into(),
-
+            SyntaxError::RestElementNotLast => "Rest element is not the last".into(),
             SyntaxError::GeneratorConstructor => "A constructor cannot be generator".into(),
 
             SyntaxError::ImportBindingIsString(str) => format!(


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Raises a syntax error when the rest element is not the last element.

For example,

```
var rest, b;

for ({...rest, b} of [{}
]) ;
```

will raise a syntax error like so:

```
error: Rest element is not the last
 --> <anon>:3:7
  |
3 | for ({...rest, b} of [{}
  |       ^^^^^^^
```
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

https://github.com/swc-project/swc/issues/3523