### PR TITLE
build(cargo): use lld for win x64 build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -49,7 +49,11 @@ rustflags = [
   "new-llvm-pass-manager=no",
 ]
 
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld"
+
 [target.aarch64-pc-windows-msvc]
+linker = "rust-lld"
 rustflags = [
   "-Z",
   "new-llvm-pass-manager=no",


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR attempts to try new linker for the builds. As first step, replaces x64 windows build to use lld. Instead of using separate llvm installation for lld which can be verbose to setup this uses out-of-the box lld comes with rustc.

Consider this as an expriment, this may not improve performance drastically. Guess we can try & see.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
- https://github.com/swc-project/swc/discussions/3637