### PR TITLE
Fix: Issue 2224

### DIFF
--- a/crates/swc/tests/projects.rs
+++ b/crates/swc/tests/projects.rs
@@ -901,6 +901,37 @@ fn opt_source_file_name_1() {
 }
 
 #[test]
+fn issue_2224() {
+    let output = str_with_opt(
+        r#"
+        const Injectable = () => {};
+
+        @Injectable
+        export class TestClass {
+            private readonly property = TestClass.name;
+        }"#,
+        Options {
+            is_module: IsModule::Bool(true),
+            config: Config {
+                jsc: JscConfig {
+                    syntax: Some(Syntax::Typescript(TsConfig {
+                        decorators: true,
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    println!("{}", output);
+
+    assert!(output.contains("this.property = TestClass.name"));
+}
+
+#[test]
 fn bom() {
     project("tests/projects/bom")
 }

--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -411,8 +411,10 @@ where
         } else {
             for m in class.body.iter_mut() {
                 if let ClassMember::ClassProp(m) = m {
-                    if let Some(orig_ident) = &orig_ident {
-                        replace_ident(&mut m.value, orig_ident.to_id(), &ident)
+                    if m.is_static {
+                        if let Some(orig_ident) = &orig_ident {
+                            replace_ident(&mut m.value, orig_ident.to_id(), &ident)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Description

In fixing issue https://github.com/swc-project/swc/issues/1869 in PR https://github.com/swc-project/swc/pull/1950, class-name identifiers of decorated
classes were renamed to the `_class` hard-coded identifier.

https://github.com/swc-project/swc/pull/1950/files#diff-aee7604a9d35c517e7e1637b34d66b7ce8de17cc407ba6236d314471d00d4b5eR265-R267

For decorated classes, the generated code is a class expression

This makes sense for static attributes of decorated classes, since the
generated code is a class expression, such that

```js
@dec
class TestClass {}
```

would produce, roughly:

```js
var _class;
let TestClass = _class = dec(_class = class TestClass {})
```

In function expressions, the right-hand class is only available within
the class block.

Adding static properties would show the issue:

```js
var _class;
var _class1;
let TestClass = _class1 = dec(
    _class1 = (
        _class = class TestClass {},
        _class.foo = _class.name,
        _class
    )
)
```

The `TestClass` from the class expression doesn't live long enough to be used
to assign `_class.foo`, and the `TestClass` from the let assignment
doesn't exist yet. Therefore, for static properties, it's imperative to
use the `_class` identifier.

We've seen why static properties identifiers must be renamed, but for
non-static properties, it's the opposite.

Non-static properties are assigned as part of the constructor function.

```js
@dec
class TestClass {
    readonly property = TestClass.name;
}
```

becomes roughly:

```js
var _class1;
let TestClass = _class1 = dec(_class1 =
    class TestClass {
        constructor(){
            this.property = TestClass.name;
        }
    }
);
```

We can see that within the constructor, the `TestClass` from the class
expression is available. Moreover, we can see that no `_class`
identifier has been generated.

Prior to this PR, the assignment would have been performed by the
invalid code:

```js
this.property = _class.name;
```

**Related issue (if exists):**

 - Closes #2224 
