### PR TITLE
feature(lazy): Allow more lazy configurations, enabling local and external dependencies to be lazy

### DIFF
--- a/crates/swc_ecma_transforms_module/tests/common_js.rs
+++ b/crates/swc_ecma_transforms_module/tests/common_js.rs
@@ -19,7 +19,7 @@ use swc_ecma_transforms_module::{
     common_js::common_js,
     hoist::module_hoister,
     import_analysis::import_analyzer,
-    util::{Config, Lazy, Scope},
+    util::{Config, Lazy, LazyObjectConfig, Scope},
 };
 use swc_ecma_transforms_testing::{test, test_exec, test_fixture};
 use swc_ecma_visit::Fold;
@@ -3758,6 +3758,91 @@ function _foo() {
 
 function use() {
   console.log(_foo().default);
+}
+"#
+);
+
+// lazy_import_all_from_object_config
+test!(
+    syntax(),
+    |_| tr(Config {
+        lazy: Lazy::Object(LazyObjectConfig {
+            all_external: true,
+            all_local: true,
+            allowed: vec![],
+        }),
+        ..Default::default()
+    }),
+    lazy_import_all_from_object_config,
+    r#"
+import { local } from "./local";
+import { external } from "external";
+
+function use() {
+  local(external);
+}
+"#,
+    r#"
+"use strict";
+
+function _local() {
+  const data = require("./local");
+  _local = function () {
+    return data;
+  };
+  return data;
+}
+
+function _external() {
+  const data = require("external");
+  _external = function () {
+    return data;
+  };
+  return data;
+}
+
+function use() {
+  _local().local(_external().external);
+}
+"#
+);
+
+// lazy_import_only_allowed_from_object_config
+test!(
+    syntax(),
+    |_| tr(Config {
+        lazy: Lazy::Object(LazyObjectConfig {
+            all_external: false,
+            all_local: false,
+            allowed: vec!["test".into()],
+        }),
+        ..Default::default()
+    }),
+    lazy_import_only_allowed_from_object_config,
+    r#"
+import { local } from "./local";
+import { external } from "external";
+import { test } from "test";
+
+function use() {
+  local(external(test));
+}
+"#,
+    r#"
+"use strict";
+var _local = require("./local");
+var _external = require("external");
+
+function _test() {
+  const data = require("test");
+  _test = function () {
+    return data;
+  };
+  return data;
+}
+
+function use() {
+  (0, _local).local((0, _external).external(_test().test));
 }
 "#
 );


### PR DESCRIPTION
# Description

(edited from Discord)

We've been liking lazy module loading a lot (it cut down or load times by over 30%), but I was wondering if we can push this even further.
Right now, there are 3 possible values for lazy:
- `false`: no lazy-loading at all
- `true`: external dependencies are lazy-loaded (not prefixed by `./` ?)
- `Array<string>`: Allow-list of paths that can be lazy loaded.

Our application contains many different packages that are not all required to perform any given task. At this time, we're running on `true`. In addition to having all external deps loaded lazily, we'd like either all local deps be lazy loaded, or an allow-list. 

With this change, I was thinking adding a new possible config value:

```
{
  all_external: bool,
  all_local: bool,
  allowed: Array<string>,
}
```

This create an ambiguity if `all_external: true, all_local: true, allowed: not_empty_list`, but for now it's the best I can think of.

# Questions

- [ ] How can I test these changes on my app before merging, to make sure it produces a statistically significant improvement?
- [ ] Do I need to update the documentation and/or other repos such as the npm package?