### PR TITLE
perf(es/modules): Reduce usage of generics

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1660,12 +1660,12 @@ impl Merge for HiddenTransformConfig {
     }
 }
 
-fn build_resolver(base_url: PathBuf, paths: CompiledPaths) -> SwcImportResolver {
+fn build_resolver(base_url: PathBuf, paths: CompiledPaths) -> Box<SwcImportResolver> {
     static CACHE: Lazy<DashMap<(PathBuf, CompiledPaths), SwcImportResolver, ahash::RandomState>> =
         Lazy::new(Default::default);
 
     if let Some(cached) = CACHE.get(&(base_url.clone(), paths.clone())) {
-        return (*cached).clone();
+        return Box::new((*cached).clone());
     }
 
     let r = {
@@ -1682,5 +1682,5 @@ fn build_resolver(base_url: PathBuf, paths: CompiledPaths) -> SwcImportResolver 
 
     CACHE.insert((base_url, paths), r.clone());
 
-    r
+    Box::new(r)
 }

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -33,11 +33,11 @@ pub fn amd(config: Config) -> impl Fold {
     }
 }
 
-pub fn amd_with_resolver<'a>(
-    resolver: &'a dyn ImportResolver,
+pub fn amd_with_resolver(
+    resolver: Box<dyn ImportResolver>,
     base: FileName,
     config: Config,
-) -> impl 'a + Fold {
+) -> impl Fold {
     Amd {
         config,
         in_top_level: Default::default(),
@@ -48,13 +48,13 @@ pub fn amd_with_resolver<'a>(
     }
 }
 
-struct Amd<'a> {
+struct Amd {
     config: Config,
     in_top_level: bool,
     scope: RefCell<Scope>,
     exports: Exports,
 
-    resolver: Resolver<'a>,
+    resolver: Resolver,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -68,7 +68,7 @@ pub struct Config {
 }
 
 /// TODO: VisitMut
-impl Fold for Amd<'_> {
+impl Fold for Amd {
     noop_fold_type!();
 
     mark_as_nested!();
@@ -656,7 +656,7 @@ impl Fold for Amd<'_> {
     }
 }
 
-impl ModulePass for Amd <'_>{
+impl ModulePass for Amd {
     fn config(&self) -> &util::Config {
         &self.config.config
     }

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -20,7 +20,7 @@ use super::util::{
     self, define_es_module, define_property, has_use_strict, initialize_to_undefined,
     local_name_for_src, make_descriptor, use_strict, Exports, ModulePass, Scope,
 };
-use crate::path::{ImportResolver, NoopImportResolver};
+use crate::path::{ImportResolver, NoopImportResolver, Resolver};
 
 pub fn amd(config: Config) -> impl Fold {
     Amd {
@@ -47,16 +47,13 @@ where
     }
 }
 
-struct Amd<R>
-where
-    R: ImportResolver,
-{
+struct Amd {
     config: Config,
     in_top_level: bool,
     scope: RefCell<Scope>,
     exports: Exports,
 
-    resolver: Option<(R, FileName)>,
+    resolver: Resolver,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -70,10 +67,7 @@ pub struct Config {
 }
 
 /// TODO: VisitMut
-impl<R> Fold for Amd<R>
-where
-    R: ImportResolver,
-{
+impl Fold for Amd {
     noop_fold_type!();
 
     mark_as_nested!();
@@ -661,10 +655,7 @@ where
     }
 }
 
-impl<R> ModulePass for Amd<R>
-where
-    R: ImportResolver,
-{
+impl ModulePass for Amd {
     fn config(&self) -> &util::Config {
         &self.config.config
     }

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -540,11 +540,11 @@ impl Fold for Amd<'_> {
 
             {
                 let src = match &self.resolver {
-                    Some((resolver, base)) => resolver
+                    Resolver::Real { resolver, base } => resolver
                         .resolve_import(base, &src)
                         .with_context(|| format!("failed to resolve `{}`", src))
                         .unwrap(),
-                    None => src.clone(),
+                    Resolver::Default => src.clone(),
                 };
 
                 define_deps_arg.elems.push(Some(src.as_arg()));

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -656,7 +656,7 @@ impl Fold for Amd<'_> {
     }
 }
 
-impl ModulePass for Amd {
+impl ModulePass for Amd <'_>{
     fn config(&self) -> &util::Config {
         &self.config.config
     }

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -20,7 +20,7 @@ use super::util::{
     self, define_es_module, define_property, has_use_strict, initialize_to_undefined,
     local_name_for_src, make_descriptor, use_strict, Exports, ModulePass, Scope,
 };
-use crate::path::{ImportResolver, NoopImportResolver, Resolver};
+use crate::path::{ImportResolver, Resolver};
 
 pub fn amd(config: Config) -> impl Fold {
     Amd {
@@ -29,31 +29,32 @@ pub fn amd(config: Config) -> impl Fold {
         scope: RefCell::new(Default::default()),
         exports: Default::default(),
 
-        resolver: None::<(NoopImportResolver, _)>,
+        resolver: Resolver::Default,
     }
 }
 
-pub fn amd_with_resolver<R>(resolver: R, base: FileName, config: Config) -> impl Fold
-where
-    R: ImportResolver,
-{
+pub fn amd_with_resolver<'a>(
+    resolver: &'a dyn ImportResolver,
+    base: FileName,
+    config: Config,
+) -> impl 'a + Fold {
     Amd {
         config,
         in_top_level: Default::default(),
         scope: Default::default(),
         exports: Default::default(),
 
-        resolver: Some((resolver, base)),
+        resolver: Resolver::Real { base, resolver },
     }
 }
 
-struct Amd {
+struct Amd<'a> {
     config: Config,
     in_top_level: bool,
     scope: RefCell<Scope>,
     exports: Exports,
 
-    resolver: Resolver,
+    resolver: Resolver<'a>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -67,7 +68,7 @@ pub struct Config {
 }
 
 /// TODO: VisitMut
-impl Fold for Amd {
+impl Fold for Amd<'_> {
     noop_fold_type!();
 
     mark_as_nested!();

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -39,13 +39,13 @@ pub fn common_js(
     }
 }
 
-pub fn common_js_with_resolver<'a>(
-    resolver: &'a dyn ImportResolver,
+pub fn common_js_with_resolver(
+    resolver: Box<dyn ImportResolver>,
     base: FileName,
     top_level_mark: Mark,
     config: Config,
     scope: Option<Rc<RefCell<Scope>>>,
-) -> impl 'a + Fold {
+) -> impl Fold {
     let scope = scope.unwrap_or_default();
 
     CommonJs {
@@ -130,16 +130,16 @@ impl Visit for LazyIdentifierVisitor {
     }
 }
 
-struct CommonJs<'a> {
+struct CommonJs {
     top_level_mark: Mark,
     config: Config,
     scope: Rc<RefCell<Scope>>,
     in_top_level: bool,
-    resolver: Resolver<'a>,
+    resolver: Resolver,
 }
 
 /// TODO: VisitMut
-impl Fold for CommonJs<'_> {
+impl Fold for CommonJs {
     noop_fold_type!();
 
     mark_as_nested!();
@@ -883,7 +883,7 @@ impl Fold for CommonJs<'_> {
     }
 }
 
-impl ModulePass for CommonJs<'_> {
+impl ModulePass for CommonJs {
     fn config(&self) -> &Config {
         &self.config
     }

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -22,7 +22,7 @@ use super::util::{
     define_es_module, define_property, has_use_strict, initialize_to_undefined, make_descriptor,
     make_require_call, use_strict, ModulePass, Scope,
 };
-use crate::path::{ImportResolver, NoopImportResolver};
+use crate::path::{ImportResolver, NoopImportResolver, Resolver};
 
 pub fn common_js(
     top_level_mark: Mark,
@@ -133,22 +133,16 @@ impl Visit for LazyIdentifierVisitor {
     }
 }
 
-struct CommonJs<P>
-where
-    P: ImportResolver,
-{
+struct CommonJs {
     top_level_mark: Mark,
     config: Config,
     scope: Rc<RefCell<Scope>>,
     in_top_level: bool,
-    resolver: Option<(P, FileName)>,
+    resolver: Resolver,
 }
 
 /// TODO: VisitMut
-impl<P> Fold for CommonJs<P>
-where
-    P: ImportResolver,
-{
+impl Fold for CommonJs {
     noop_fold_type!();
 
     mark_as_nested!();
@@ -890,10 +884,7 @@ where
     }
 }
 
-impl<P> ModulePass for CommonJs<P>
-where
-    P: ImportResolver,
-{
+impl ModulePass for CommonJs {
     fn config(&self) -> &Config {
         &self.config
     }

--- a/crates/swc_ecma_transforms_module/src/lib.rs
+++ b/crates/swc_ecma_transforms_module/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all)]
 #![deny(unused)]
+#![allow(clippy::needless_lifetimes)]
 
 pub use self::{amd::amd, common_js::common_js, umd::umd};
 

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -13,15 +13,15 @@ use swc_ecma_ast::*;
 use swc_ecma_loader::resolve::Resolve;
 use swc_ecma_utils::{quote_ident, ExprFactory};
 
-pub(crate) enum Resolver<'a> {
+pub(crate) enum Resolver {
     Real {
         base: FileName,
-        resolver: &'a dyn ImportResolver,
+        resolver: Box<dyn ImportResolver>,
     },
     Default,
 }
 
-impl Resolver<'_> {
+impl Resolver {
     pub(crate) fn make_require_call(&self, mark: Mark, src: JsWord) -> Expr {
         let src = match self {
             Self::Real { resolver, base } => resolver

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -11,10 +11,10 @@ use swc_atoms::JsWord;
 use swc_common::FileName;
 use swc_ecma_loader::resolve::Resolve;
 
-pub(crate) enum Resolver {
+pub(crate) enum Resolver<'a> {
     Real {
         base: FileName,
-        resolver: Box<dyn ImportResolver>,
+        resolver: &'a dyn ImportResolver,
     },
     Default,
 }

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -11,6 +11,14 @@ use swc_atoms::JsWord;
 use swc_common::FileName;
 use swc_ecma_loader::resolve::Resolve;
 
+pub(crate) enum Resolver {
+    Real {
+        base: FileName,
+        resolver: Box<dyn ImportResolver>,
+    },
+    Default,
+}
+
 pub trait ImportResolver {
     /// Resolves `target` as a string usable by the modules pass.
     ///

--- a/crates/swc_ecma_transforms_module/src/umd.rs
+++ b/crates/swc_ecma_transforms_module/src/umd.rs
@@ -15,7 +15,7 @@ use self::config::BuiltConfig;
 pub use self::config::Config;
 use super::util::{
     self, define_es_module, define_property, has_use_strict, initialize_to_undefined,
-    local_name_for_src, make_descriptor, make_require_call, use_strict, Exports, ModulePass, Scope,
+    local_name_for_src, make_descriptor, use_strict, Exports, ModulePass, Scope,
 };
 use crate::path::{ImportResolver, Resolver};
 
@@ -552,8 +552,11 @@ impl Fold for Umd<'_> {
                 decorators: Default::default(),
                 pat: ident.clone().into(),
             });
-            factory_args
-                .push(make_require_call(&self.resolver, self.root_mark, src.clone()).as_arg());
+            factory_args.push(
+                self.resolver
+                    .make_require_call(self.root_mark, src.clone())
+                    .as_arg(),
+            );
             global_factory_args.push(quote_ident!("global").make_member(global_ident).as_arg());
 
             {

--- a/crates/swc_ecma_transforms_module/src/umd.rs
+++ b/crates/swc_ecma_transforms_module/src/umd.rs
@@ -35,13 +35,13 @@ pub fn umd(cm: Lrc<SourceMap>, root_mark: Mark, config: Config) -> impl Fold {
     }
 }
 
-pub fn umd_with_resolver<'a>(
-    resolver: &'a dyn ImportResolver,
+pub fn umd_with_resolver(
+    resolver: Box<dyn ImportResolver>,
     base: FileName,
     cm: Lrc<SourceMap>,
     root_mark: Mark,
     config: Config,
-) -> impl 'a + Fold {
+) -> impl Fold {
     Umd {
         config: config.build(cm.clone()),
         root_mark,
@@ -55,7 +55,7 @@ pub fn umd_with_resolver<'a>(
     }
 }
 
-struct Umd<'a> {
+struct Umd {
     cm: Lrc<SourceMap>,
     root_mark: Mark,
     in_top_level: bool,
@@ -63,11 +63,11 @@ struct Umd<'a> {
     scope: RefCell<Scope>,
     exports: Exports,
 
-    resolver: Resolver<'a>,
+    resolver: Resolver,
 }
 
 /// TODO: VisitMut
-impl Fold for Umd<'_> {
+impl Fold for Umd {
     noop_fold_type!();
 
     mark_as_nested!();
@@ -794,7 +794,7 @@ impl Fold for Umd<'_> {
     }
 }
 
-impl ModulePass for Umd<'_> {
+impl ModulePass for Umd {
     fn config(&self) -> &util::Config {
         &self.config.config
     }

--- a/crates/swc_ecma_transforms_module/src/umd.rs
+++ b/crates/swc_ecma_transforms_module/src/umd.rs
@@ -17,7 +17,7 @@ use super::util::{
     self, define_es_module, define_property, has_use_strict, initialize_to_undefined,
     local_name_for_src, make_descriptor, make_require_call, use_strict, Exports, ModulePass, Scope,
 };
-use crate::path::{ImportResolver, NoopImportResolver};
+use crate::path::{ImportResolver, NoopImportResolver, Resolver};
 
 mod config;
 
@@ -58,10 +58,7 @@ where
     }
 }
 
-struct Umd<R>
-where
-    R: ImportResolver,
-{
+struct Umd {
     cm: Lrc<SourceMap>,
     root_mark: Mark,
     in_top_level: bool,
@@ -69,14 +66,11 @@ where
     scope: RefCell<Scope>,
     exports: Exports,
 
-    resolver: Option<(R, FileName)>,
+    resolver: Resolver,
 }
 
 /// TODO: VisitMut
-impl<R> Fold for Umd<R>
-where
-    R: ImportResolver,
-{
+impl Fold for Umd {
     noop_fold_type!();
 
     mark_as_nested!();
@@ -800,10 +794,7 @@ where
     }
 }
 
-impl<R> ModulePass for Umd<R>
-where
-    R: ImportResolver,
-{
+impl ModulePass for Umd {
     fn config(&self) -> &util::Config {
         &self.config.config
     }


### PR DESCRIPTION
**Description:**

We don't need to store the code for transforming modules twice.
 


**Related issue (if exists):**

 - https://github.com/swc-project/swc/pull/3741