### PR TITLE
feat(swc/plugin): support trace for plugin execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ pkg/
 
 # Used to see output of babel.
 /lab
+
+*.mm_profdata

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3549,6 +3549,7 @@ dependencies = [
  "swc_ecma_parser",
  "swc_ecma_visit",
  "testing",
+ "tracing",
  "wasmer",
  "wasmer-cache",
  "wasmer-wasi",

--- a/crates/node/src/util.rs
+++ b/crates/node/src/util.rs
@@ -34,9 +34,11 @@ pub fn init_trace_once(
     FLUSH_GUARD.get_or_init(|| {
         if enable_chrome_trace {
             let layer = if let Some(trace_out_file) = trace_out_file {
-                ChromeLayerBuilder::new().file(trace_out_file)
-            } else {
                 ChromeLayerBuilder::new()
+                    .file(trace_out_file)
+                    .include_args(true)
+            } else {
+                ChromeLayerBuilder::new().include_args(true)
             };
 
             let (chrome_layer, guard) = layer.build();

--- a/crates/swc/src/plugin.rs
+++ b/crates/swc/src/plugin.rs
@@ -68,6 +68,7 @@ struct RustPlugins {
 }
 
 impl RustPlugins {
+    #[tracing::instrument(level = "trace", skip_all, name = "apply_plugins")]
     #[cfg(feature = "plugin")]
     fn apply(&mut self, n: Program) -> Result<Program, anyhow::Error> {
         use std::{path::PathBuf, sync::Arc};
@@ -86,6 +87,13 @@ impl RustPlugins {
         // transform.
         if let Some(plugins) = &self.plugins {
             for p in plugins {
+                let span = tracing::span!(
+                    tracing::Level::TRACE,
+                    "serialize_context",
+                    plugin_module = p.0.as_str()
+                );
+                let context_span_guard = span.enter();
+
                 let config_json = serde_json::to_string(&p.1)
                     .context("Failed to serialize plugin config as json")
                     .and_then(|value| Serialized::serialize(&value))?;
@@ -103,7 +111,14 @@ impl RustPlugins {
                 } else {
                     anyhow::bail!("Failed to resolve plugin path: {:?}", resolved_path);
                 };
+                drop(context_span_guard);
 
+                let span = tracing::span!(
+                    tracing::Level::TRACE,
+                    "execute_plugin_runner",
+                    plugin_module = p.0.as_str()
+                );
+                let transform_span_guard = span.enter();
                 serialized = swc_plugin_runner::apply_js_plugin(
                     &p.0,
                     &path,
@@ -112,6 +127,7 @@ impl RustPlugins {
                     config_json,
                     context_json,
                 )?;
+                drop(transform_span_guard);
             }
         }
 

--- a/crates/swc_ecma_transforms_compat/Cargo.toml
+++ b/crates/swc_ecma_transforms_compat/Cargo.toml
@@ -34,7 +34,7 @@ swc_ecma_transforms_classes = {version = "0.50.0", path = "../swc_ecma_transform
 swc_ecma_transforms_macros = {version = "0.3.0", path = "../swc_ecma_transforms_macros"}
 swc_ecma_utils = {version = "0.68.0", path = "../swc_ecma_utils"}
 swc_ecma_visit = {version = "0.54.0", path = "../swc_ecma_visit"}
-swc_trace_macro = {versio = "0.1.0", path = "../swc_trace_macro"}
+swc_trace_macro = {version = "0.1.0", path = "../swc_trace_macro"}
 tracing = "0.1.31"
 
 [dev-dependencies]

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -16,6 +16,7 @@ serde = {version = "1.0.126", features = ["derive"]}
 serde_json = "1.0.64"
 swc_common = {version = "0.17.0", path = "../swc_common", features = ["plugin-rt", "concurrent"]}
 swc_ecma_ast = {version = "0.68.0", path = "../swc_ecma_ast", features = ["rkyv-impl"]}
+tracing = "0.1.31"
 wasmer = "2.1.1"
 wasmer-cache = "2.1.1"
 wasmer-wasi = "2.1.1"

--- a/crates/swc_plugin_runner/src/lib.rs
+++ b/crates/swc_plugin_runner/src/lib.rs
@@ -195,6 +195,7 @@ struct HostEnvironment {
     transform_result: Arc<Mutex<Vec<u8>>>,
 }
 
+#[tracing::instrument(level = "trace", skip_all)]
 fn load_plugin(
     plugin_path: &Path,
     cache: &Lazy<PluginModuleCache>,
@@ -347,6 +348,7 @@ struct PluginTransformTracker {
 }
 
 impl PluginTransformTracker {
+    #[tracing::instrument(level = "trace", skip(cache))]
     fn new(path: &Path, cache: &Lazy<PluginModuleCache>) -> Result<PluginTransformTracker, Error> {
         let (instance, transform_result) = load_plugin(path, cache)?;
 
@@ -414,6 +416,7 @@ impl PluginTransformTracker {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip_all)]
     fn transform(
         &mut self,
         program: &Serialized,


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Finally, I can connect the pieces together. 🎉 

One of the major reason I tried to push forward runtime tracing support is to diagnost user-level execution. Plugin is an exact fit, I wanted to have some answers like `swc is being slow cause plugin xxxx taking too long`. I added initial trace for those in this PR.

![image](https://user-images.githubusercontent.com/1210596/155784066-d1de06c6-b222-4b5d-8696-5de08c60a50b.png)

This tells us

- What plugin module takes X time for total execution
- Serialization cost (loading, json serialization for config, context..)
- Actual plugin transformation cost

and we can add more gradually.

**Related issue (if exists):**
