### PR TITLE
mod(es/transforms/compat): use seq_expr instead of iife for class_expr

### DIFF
--- a/crates/swc/tests/fixture/issue-2011/no-minify/output/index.js
+++ b/crates/swc/tests/fixture/issue-2011/no-minify/output/index.js
@@ -1,16 +1,13 @@
+var _ClassB;
 var ClassA = function ClassA() {
     "use strict";
 };
-module.exports = (function() {
-    var ClassB = /*#__PURE__*/ function() {
-        "use strict";
-        function ClassB() {}
-        var _proto = ClassB.prototype;
-        _proto.it = function it() {
-            this.bb = new ClassB.MyA();
-        };
-        return ClassB;
-    }();
-    ClassB.MyA = ClassA;
+module.exports = (_ClassB = /*#__PURE__*/ (function() {
+    "use strict";
+    function ClassB() {}
+    var _proto = ClassB.prototype;
+    _proto.it = function it() {
+        this.bb = new ClassB.MyA();
+    };
     return ClassB;
-})();
+})(), _ClassB.MyA = ClassA, _ClassB);

--- a/crates/swc/tests/fixture/issue-2011/reduced/output/index.js
+++ b/crates/swc/tests/fixture/issue-2011/reduced/output/index.js
@@ -1,11 +1,8 @@
-var a = function() {};
-module.exports = (function() {
-    var b = function() {
-        "use strict";
-        function b() {}
-        return b.prototype.it = function() {
-            this.bb = new b.MyA();
-        }, b;
-    }();
-    return b.MyA = a, b;
-})();
+var a;
+module.exports = ((a = (function() {
+    "use strict";
+    function a() {}
+    return a.prototype.it = function() {
+        this.bb = new a.MyA();
+    }, a;
+})()).MyA = function() {}, a);

--- a/crates/swc/tests/fixture/issue-3609/1/output/index.js
+++ b/crates/swc/tests/fixture/issue-3609/1/output/index.js
@@ -11,7 +11,7 @@ function _defineProperty(obj, key, value) {
     }
     return obj;
 }
-var _ref = `lit${"lit"}`, _ref1 = `tpl${`tpl`}`, _ref2 = `lit${1 + 1}`, _ref3 = `complex${"123".length()}`;
+let _ref = `lit${"lit"}`, _ref1 = `tpl${`tpl`}`, _ref2 = `lit${1 + 1}`, _ref3 = `complex${"123".length()}`;
 class Foo {
     constructor(){
         _defineProperty(this, 1, 2);

--- a/crates/swc/tests/tsc-references/ES5For-ofTypeCheck10_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-ofTypeCheck10_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES5
 // In ES3/5, you cannot for...of over an arbitrary iterable.
 class StringIterator {
@@ -8,7 +8,7 @@ class StringIterator {
             value: ""
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/ES5For-ofTypeCheck10_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-ofTypeCheck10_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 for (var v of new class {
     next() {
         return {
@@ -6,7 +6,7 @@ for (var v of new class {
             value: ""
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/ES5For-ofTypeCheck10_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-ofTypeCheck10_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var StringIterator = //@target: ES5
 // In ES3/5, you cannot for...of over an arbitrary iterable.
 /*#__PURE__*/ function() {
@@ -36,7 +36,7 @@ var StringIterator = //@target: ES5
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -46,7 +46,7 @@ var StringIterator = //@target: ES5
 }();
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
     }
 } catch (err) {
@@ -54,8 +54,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/ES5For-ofTypeCheck10_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-ofTypeCheck10_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, StringIterator = function() {
+var _iterator = Symbol.iterator, StringIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function StringIterator() {
@@ -23,7 +23,7 @@ var tmp = Symbol.iterator, StringIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -31,12 +31,12 @@ var tmp = Symbol.iterator, StringIterator = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), StringIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator1 = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty2_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty2_es2015.1.normal.js
@@ -2,9 +2,9 @@
 var M;
 (function(M1) {
     var Symbol;
-    var tmp = Symbol.iterator;
+    let _iterator = Symbol.iterator;
     class C {
-        [tmp]() {}
+        [_iterator]() {}
     }
     M1.C = C;
     (new C)[Symbol.iterator];

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty2_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty2_es2015.2.minified.js
@@ -1,8 +1,9 @@
 var M;
 !function(M1) {
-    var Symbol, tmp = Symbol.iterator;
+    var Symbol;
+    let _iterator = Symbol.iterator;
     class C {
-        [tmp]() {}
+        [_iterator]() {}
     }
     M1.C = C, (new C)[Symbol.iterator];
 }(M || (M = {})), (new M.C)[Symbol.iterator];

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty2_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty2_es5.1.normal.js
@@ -21,7 +21,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 var M;
 (function(M1) {
     var Symbol;
-    var tmp = Symbol.iterator;
+    var _iterator = Symbol.iterator;
     var C = /*#__PURE__*/ function() {
         "use strict";
         function C() {
@@ -29,7 +29,7 @@ var M;
         }
         _createClass(C, [
             {
-                key: tmp,
+                key: _iterator,
                 value: function value() {}
             }
         ]);

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty2_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty2_es5.2.minified.js
@@ -6,7 +6,7 @@ function _defineProperties(target, props) {
     }
 }
 !function(M1) {
-    var Symbol, tmp = Symbol.iterator, C = function() {
+    var Symbol, _iterator = Symbol.iterator, C = function() {
         "use strict";
         var Constructor, protoProps, staticProps;
         function C() {
@@ -16,7 +16,7 @@ function _defineProperties(target, props) {
         }
         return Constructor = C, protoProps = [
             {
-                key: tmp,
+                key: _iterator,
                 value: function() {}
             }
         ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty3_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty3_es2015.1.normal.js
@@ -1,7 +1,7 @@
 //@target: ES5
 var Symbol;
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class C {
-    [tmp]() {}
+    [_iterator]() {}
 }
 (new C)[Symbol.iterator];

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty3_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty3_es5.1.normal.js
@@ -19,7 +19,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 }
 //@target: ES5
 var Symbol;
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -27,7 +27,7 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty3_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty3_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var Symbol, tmp = Symbol.iterator, C = function() {
+var Symbol, _iterator = Symbol.iterator, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var Symbol, tmp = Symbol.iterator, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function() {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty4_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty4_es2015.1.normal.js
@@ -1,7 +1,7 @@
 //@target: ES5
 var Symbol;
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class C {
-    [tmp]() {}
+    [_iterator]() {}
 }
 (new C)[Symbol.iterator];

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty4_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty4_es5.1.normal.js
@@ -19,7 +19,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 }
 //@target: ES5
 var Symbol;
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -27,7 +27,7 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty4_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty4_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var Symbol, tmp = Symbol.iterator, C = function() {
+var Symbol, _iterator = Symbol.iterator, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var Symbol, tmp = Symbol.iterator, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function() {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty5_es2015.1.normal.js
@@ -1,8 +1,8 @@
 //@target: ES5
 var Symbol;
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class C {
-    [tmp]() {}
+    [_iterator]() {}
 }
 (new C)[Symbol.iterator](0) // Should error
 ;

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty5_es5.1.normal.js
@@ -19,7 +19,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 }
 //@target: ES5
 var Symbol;
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -27,7 +27,7 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty5_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var Symbol, tmp = Symbol.iterator, C = function() {
+var Symbol, _iterator = Symbol.iterator, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var Symbol, tmp = Symbol.iterator, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function() {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty6_es2015.1.normal.js
@@ -1,6 +1,6 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES5
 class C {
-    [tmp]() {}
+    [_iterator]() {}
 }
 (new C)[Symbol.iterator];

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty6_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var C = //@target: ES5
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,7 +26,7 @@ var C = //@target: ES5
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty6_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, C = function() {
+var _iterator = Symbol.iterator, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var tmp = Symbol.iterator, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function() {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty7_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty7_es2015.1.normal.js
@@ -1,7 +1,7 @@
 //@target: ES5
 var Symbol;
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class C {
-    [tmp]() {}
+    [_iterator]() {}
 }
 (new C)[Symbol.iterator];

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty7_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty7_es5.1.normal.js
@@ -19,7 +19,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 }
 //@target: ES5
 var Symbol;
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -27,7 +27,7 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/ES5SymbolProperty7_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5SymbolProperty7_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var Symbol, tmp = Symbol.iterator, C = function() {
+var Symbol, _iterator = Symbol.iterator, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var Symbol, tmp = Symbol.iterator, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function() {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/MemberFunctionDeclaration3_es6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/MemberFunctionDeclaration3_es6_es2015.1.normal.js
@@ -1,5 +1,5 @@
-var tmp = foo;
+let _foo = foo;
 // @target: es6
 class C {
-    *[tmp]() {}
+    *[_foo]() {}
 }

--- a/crates/swc/tests/tsc-references/MemberFunctionDeclaration3_es6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/MemberFunctionDeclaration3_es6_es5.1.normal.js
@@ -18,7 +18,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     return Constructor;
 }
 import regeneratorRuntime from "regenerator-runtime";
-var tmp = foo;
+var _foo = foo;
 var C = // @target: es6
 /*#__PURE__*/ function() {
     "use strict";
@@ -27,7 +27,7 @@ var C = // @target: es6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _foo,
             value: regeneratorRuntime.mark(function value() {
                 return regeneratorRuntime.wrap(function value$(_ctx) {
                     while(1)switch(_ctx.prev = _ctx.next){

--- a/crates/swc/tests/tsc-references/MemberFunctionDeclaration3_es6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/MemberFunctionDeclaration3_es6_es5.2.minified.js
@@ -5,7 +5,7 @@ function _defineProperties(target, props) {
     }
 }
 import regeneratorRuntime from "regenerator-runtime";
-var tmp = foo, C = function() {
+var _foo = foo, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -15,7 +15,7 @@ var tmp = foo, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _foo,
             value: regeneratorRuntime.mark(function value() {
                 return regeneratorRuntime.wrap(function(_ctx) {
                     for(;;)switch(_ctx.prev = _ctx.next){

--- a/crates/swc/tests/tsc-references/assignParameterPropertyToPropertyDeclarationESNext_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/assignParameterPropertyToPropertyDeclarationESNext_es2015.1.normal.js
@@ -48,7 +48,7 @@ class E {
 }
 class F {
     constructor(){
-        this.Inner = class _class extends F {
+        this.Inner = class extends F {
             constructor(...args){
                 super(...args);
                 this.p2 = this.p1;
@@ -60,7 +60,7 @@ class F {
 class G {
     constructor(p1){
         this.p1 = p1;
-        this.Inner = class _class extends G {
+        this.Inner = class extends G {
             constructor(...args){
                 super(...args);
                 this.p2 = this.p1;

--- a/crates/swc/tests/tsc-references/checkSpecialPropertyAssignments_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/checkSpecialPropertyAssignments_es2015.1.normal.js
@@ -3,7 +3,7 @@
 // @allowJs: true
 // @Filename: bug24252.js
 var A = {};
-A.B = class _class {
+A.B = class {
     m() {
         /** @type {string[]} */ var x = [];
         /** @type {number[]} */ var y;

--- a/crates/swc/tests/tsc-references/classExpression3_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/classExpression3_es2015.1.normal.js
@@ -1,4 +1,4 @@
-let C = class _class extends class _class extends class _class {
+let C = class extends class extends class {
     constructor(){
         this.a = 1;
     }

--- a/crates/swc/tests/tsc-references/classExpression3_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/classExpression3_es5.1.normal.js
@@ -69,26 +69,26 @@ function _createSuper(Derived) {
         return _possibleConstructorReturn(this, result);
     };
 }
-var C = /*#__PURE__*/ function(__class) {
+var C = /*#__PURE__*/ function(_super) {
     "use strict";
-    _inherits(_class, __class);
-    var _super = _createSuper(_class);
+    _inherits(_class, _super);
+    var _super1 = _createSuper(_class);
     function _class() {
         _classCallCheck(this, _class);
         var _this;
-        _this = _super.apply(this, arguments);
+        _this = _super1.apply(this, arguments);
         _this.c = 3;
         return _this;
     }
     return _class;
-}(/*#__PURE__*/ function(__class) {
+}(/*#__PURE__*/ function(_super) {
     "use strict";
-    _inherits(_class, __class);
-    var _super = _createSuper(_class);
+    _inherits(_class, _super);
+    var _super2 = _createSuper(_class);
     function _class() {
         _classCallCheck(this, _class);
         var _this;
-        _this = _super.apply(this, arguments);
+        _this = _super2.apply(this, arguments);
         _this.b = 2;
         return _this;
     }

--- a/crates/swc/tests/tsc-references/classExpression3_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/classExpression3_es5.2.minified.js
@@ -44,22 +44,22 @@ function _createSuper(Derived) {
         })(self);
     };
 }
-var c = new (function(__class) {
+var c = new (function(_super) {
     "use strict";
-    _inherits(_class, __class);
-    var _super = _createSuper(_class);
+    _inherits(_class, _super);
+    var _super1 = _createSuper(_class);
     function _class() {
         var _this;
-        return _classCallCheck(this, _class), _this = _super.apply(this, arguments), _this.c = 3, _this;
+        return _classCallCheck(this, _class), _this = _super1.apply(this, arguments), _this.c = 3, _this;
     }
     return _class;
-}(function(__class) {
+}(function(_super) {
     "use strict";
-    _inherits(_class, __class);
-    var _super = _createSuper(_class);
+    _inherits(_class, _super);
+    var _super2 = _createSuper(_class);
     function _class() {
         var _this;
-        return _classCallCheck(this, _class), _this = _super.apply(this, arguments), _this.b = 2, _this;
+        return _classCallCheck(this, _class), _this = _super2.apply(this, arguments), _this.b = 2, _this;
     }
     return _class;
 }(function _class() {

--- a/crates/swc/tests/tsc-references/classExpression4_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/classExpression4_es2015.1.normal.js
@@ -1,4 +1,4 @@
-let C = class _class {
+let C = class {
     foo() {
         return new C();
     }

--- a/crates/swc/tests/tsc-references/classExpression5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/classExpression5_es2015.1.normal.js
@@ -1,4 +1,4 @@
-new class _class {
+new class {
     hi() {
         return "Hi!";
     }

--- a/crates/swc/tests/tsc-references/classExpressionES63_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/classExpressionES63_es2015.1.normal.js
@@ -1,5 +1,5 @@
 // @target: es6
-let C = class _class extends class _class extends class _class {
+let C = class extends class extends class {
     constructor(){
         this.a = 1;
     }

--- a/crates/swc/tests/tsc-references/classExpressionES63_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/classExpressionES63_es5.1.normal.js
@@ -70,26 +70,26 @@ function _createSuper(Derived) {
     };
 }
 // @target: es6
-var C = /*#__PURE__*/ function(__class) {
+var C = /*#__PURE__*/ function(_super) {
     "use strict";
-    _inherits(_class, __class);
-    var _super = _createSuper(_class);
+    _inherits(_class, _super);
+    var _super1 = _createSuper(_class);
     function _class() {
         _classCallCheck(this, _class);
         var _this;
-        _this = _super.apply(this, arguments);
+        _this = _super1.apply(this, arguments);
         _this.c = 3;
         return _this;
     }
     return _class;
-}(/*#__PURE__*/ function(__class) {
+}(/*#__PURE__*/ function(_super) {
     "use strict";
-    _inherits(_class, __class);
-    var _super = _createSuper(_class);
+    _inherits(_class, _super);
+    var _super2 = _createSuper(_class);
     function _class() {
         _classCallCheck(this, _class);
         var _this;
-        _this = _super.apply(this, arguments);
+        _this = _super2.apply(this, arguments);
         _this.b = 2;
         return _this;
     }

--- a/crates/swc/tests/tsc-references/classExpressionES63_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/classExpressionES63_es5.2.minified.js
@@ -44,22 +44,22 @@ function _createSuper(Derived) {
         })(self);
     };
 }
-var c = new (function(__class) {
+var c = new (function(_super) {
     "use strict";
-    _inherits(_class, __class);
-    var _super = _createSuper(_class);
+    _inherits(_class, _super);
+    var _super1 = _createSuper(_class);
     function _class() {
         var _this;
-        return _classCallCheck(this, _class), _this = _super.apply(this, arguments), _this.c = 3, _this;
+        return _classCallCheck(this, _class), _this = _super1.apply(this, arguments), _this.c = 3, _this;
     }
     return _class;
-}(function(__class) {
+}(function(_super) {
     "use strict";
-    _inherits(_class, __class);
-    var _super = _createSuper(_class);
+    _inherits(_class, _super);
+    var _super2 = _createSuper(_class);
     function _class() {
         var _this;
-        return _classCallCheck(this, _class), _this = _super.apply(this, arguments), _this.b = 2, _this;
+        return _classCallCheck(this, _class), _this = _super2.apply(this, arguments), _this.b = 2, _this;
     }
     return _class;
 }(function _class() {

--- a/crates/swc/tests/tsc-references/classStaticBlock18_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/classStaticBlock18_es2015.1.normal.js
@@ -1,25 +1,19 @@
 var _class, _class1;
 // @target: esnext, es2022, es2015, es5
 function foo() {
-    return _class1 = (function() {
-        class _class2 {
-        }
-        var __ = {
-            writable: true,
-            value: (()=>{
-                const c = (_class = function() {
-                    class _class3 {
-                    }
-                    var __ = {
-                        writable: true,
-                        value: (()=>{
-                        // do
-                        })()
-                    };
-                    return _class3;
-                }(), _class.bar = 2, _class);
-            })()
-        };
-        return _class2;
-    })(), _class1.foo = 1, _class1;
+    var _class2, __1;
+    return _class1 = (_class2 = class {
+    }, __1 = {
+        writable: true,
+        value: (()=>{
+            var _class3, __;
+            const c = (_class = (_class3 = class {
+            }, __ = {
+                writable: true,
+                value: (()=>{
+                // do
+                })()
+            }, _class3), _class.bar = 2, _class);
+        })()
+    }, _class2), _class1.foo = 1, _class1;
 }

--- a/crates/swc/tests/tsc-references/classStaticBlock18_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/classStaticBlock18_es5.1.normal.js
@@ -6,29 +6,23 @@ function _classCallCheck(instance, Constructor) {
 var _class, _class1;
 // @target: esnext, es2022, es2015, es5
 function foo() {
-    return _class1 = (function() {
-        var _class2 = function _class2() {
-            "use strict";
-            _classCallCheck(this, _class2);
-        };
-        var __ = {
-            writable: true,
-            value: function() {
-                var c = (_class = function() {
-                    var _class3 = function _class3() {
-                        "use strict";
-                        _classCallCheck(this, _class3);
-                    };
-                    var __ = {
-                        writable: true,
-                        value: function() {
-                        // do
-                        }()
-                    };
-                    return _class3;
-                }(), _class.bar = 2, _class);
-            }()
-        };
-        return _class2;
-    })(), _class1.foo = 1, _class1;
+    var _class2, __1;
+    return _class1 = (_class2 = function _class3() {
+        "use strict";
+        _classCallCheck(this, _class3);
+    }, __1 = {
+        writable: true,
+        value: (function() {
+            var _class4, __;
+            var c = (_class = (_class4 = function _class3() {
+                "use strict";
+                _classCallCheck(this, _class3);
+            }, __ = {
+                writable: true,
+                value: function() {
+                // do
+                }()
+            }, _class4), _class.bar = 2, _class);
+        })()
+    }, _class2), _class1.foo = 1, _class1;
 }

--- a/crates/swc/tests/tsc-references/classStaticBlock27_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/classStaticBlock27_es2015.1.normal.js
@@ -1,28 +1,23 @@
+var _Foo, __, __1, __2;
 var _class;
 // https://github.com/microsoft/TypeScript/issues/44872
-void (_class = function() {
-    class Foo {
-    }
-    var __ = {
-        writable: true,
-        value: (()=>{
-            console.log(Foo.prop);
-            Foo.prop++;
-        })()
-    };
-    var __1 = {
-        writable: true,
-        value: (()=>{
-            console.log(Foo.prop);
-            Foo.prop++;
-        })()
-    };
-    var __2 = {
-        writable: true,
-        value: (()=>{
-            console.log(Foo.prop);
-            Foo.prop++;
-        })()
-    };
-    return Foo;
-}(), _class.prop = 1, _class);
+void (_class = (_Foo = class Foo {
+}, __ = {
+    writable: true,
+    value: (()=>{
+        console.log(_Foo.prop);
+        _Foo.prop++;
+    })()
+}, __1 = {
+    writable: true,
+    value: (()=>{
+        console.log(_Foo.prop);
+        _Foo.prop++;
+    })()
+}, __2 = {
+    writable: true,
+    value: (()=>{
+        console.log(_Foo.prop);
+        _Foo.prop++;
+    })()
+}, _Foo), _class.prop = 1, _class);

--- a/crates/swc/tests/tsc-references/classStaticBlock27_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/classStaticBlock27_es2015.2.minified.js
@@ -1,5 +1,3 @@
-(function() {
-    class Foo {
-    }
-    return console.log(Foo.prop), Foo.prop++, console.log(Foo.prop), Foo.prop++, console.log(Foo.prop), Foo.prop++, Foo;
-})().prop = 1;
+var _Foo;
+(_Foo = class {
+}, console.log(_Foo.prop), _Foo.prop++, console.log(_Foo.prop), _Foo.prop++, console.log(_Foo.prop), _Foo.prop++, _Foo).prop = 1;

--- a/crates/swc/tests/tsc-references/classStaticBlock27_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/classStaticBlock27_es5.1.normal.js
@@ -3,33 +3,28 @@ function _classCallCheck(instance, Constructor) {
         throw new TypeError("Cannot call a class as a function");
     }
 }
+var _Foo, __, __1, __2;
 var _class;
 // https://github.com/microsoft/TypeScript/issues/44872
-void (_class = function() {
-    var Foo = function Foo() {
-        "use strict";
-        _classCallCheck(this, Foo);
-    };
-    var __ = {
-        writable: true,
-        value: function() {
-            console.log(Foo.prop);
-            Foo.prop++;
-        }()
-    };
-    var __1 = {
-        writable: true,
-        value: function() {
-            console.log(Foo.prop);
-            Foo.prop++;
-        }()
-    };
-    var __2 = {
-        writable: true,
-        value: function() {
-            console.log(Foo.prop);
-            Foo.prop++;
-        }()
-    };
-    return Foo;
-}(), _class.prop = 1, _class);
+void (_class = (_Foo = function Foo() {
+    "use strict";
+    _classCallCheck(this, Foo);
+}, __ = {
+    writable: true,
+    value: function() {
+        console.log(_Foo.prop);
+        _Foo.prop++;
+    }()
+}, __1 = {
+    writable: true,
+    value: function() {
+        console.log(_Foo.prop);
+        _Foo.prop++;
+    }()
+}, __2 = {
+    writable: true,
+    value: function() {
+        console.log(_Foo.prop);
+        _Foo.prop++;
+    }()
+}, _Foo), _class.prop = 1, _class);

--- a/crates/swc/tests/tsc-references/classStaticBlock27_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/classStaticBlock27_es5.2.minified.js
@@ -1,9 +1,7 @@
-(function() {
-    var Foo = function() {
-        "use strict";
-        !function(instance, Constructor) {
-            if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
-        }(this, Foo);
-    };
-    return console.log(Foo.prop), Foo.prop++, console.log(Foo.prop), Foo.prop++, console.log(Foo.prop), Foo.prop++, Foo;
-})().prop = 1;
+var _Foo;
+(_Foo = function Foo() {
+    "use strict";
+    (function(instance, Constructor) {
+        if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
+    })(this, Foo);
+}, console.log(_Foo.prop), _Foo.prop++, console.log(_Foo.prop), _Foo.prop++, console.log(_Foo.prop), _Foo.prop++, _Foo).prop = 1;

--- a/crates/swc/tests/tsc-references/commonJSImportNestedClassTypeReference_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/commonJSImportNestedClassTypeReference_es2015.1.normal.js
@@ -10,7 +10,7 @@ const { K  } = require("./mod1");
 }
 // @filename: mod1.js
 var NS = {};
-NS.K = class _class {
+NS.K = class {
     values() {
         return new NS.K();
     }

--- a/crates/swc/tests/tsc-references/computedPropertyNames13_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames13_ES5_es2015.1.normal.js
@@ -2,17 +2,17 @@
 var s;
 var n;
 var a;
-var tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = "", tmp6 = 0, tmp7 = a, tmp8 = true, tmp9 = `hello bye`, tmp10 = `hello ${a} bye`;
+let _s = s, _n = n, tmp = s + s, tmp1 = s + n, tmp2 = +s, _a = a, tmp3 = `hello ${a} bye`;
 class C {
-    [tmp]() {}
+    [_s]() {}
+    [_n]() {}
+    static [tmp]() {}
     [tmp1]() {}
-    static [tmp2]() {}
-    [tmp3]() {}
-    [tmp4]() {}
-    static [tmp5]() {}
-    [tmp6]() {}
-    [tmp7]() {}
-    static [tmp8]() {}
-    [tmp9]() {}
-    static [tmp10]() {}
+    [tmp2]() {}
+    static [""]() {}
+    [0]() {}
+    [_a]() {}
+    static [true]() {}
+    [`hello bye`]() {}
+    static [tmp3]() {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames13_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames13_ES5_es5.1.normal.js
@@ -21,7 +21,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 var s;
 var n;
 var a;
-var tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = "", tmp6 = 0, tmp7 = a, tmp8 = true, tmp9 = "hello bye", tmp10 = "hello ".concat(a, " bye");
+var _s = s, _n = n, tmp = s + s, tmp1 = s + n, tmp2 = +s, _a = a, tmp3 = "hello ".concat(a, " bye");
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -29,7 +29,11 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _s,
+            value: function value() {}
+        },
+        {
+            key: _n,
             value: function value() {}
         },
         {
@@ -37,40 +41,36 @@ var C = /*#__PURE__*/ function() {
             value: function value() {}
         },
         {
-            key: tmp3,
-            value: function value() {}
-        },
-        {
-            key: tmp4,
-            value: function value() {}
-        },
-        {
-            key: tmp6,
-            value: function value() {}
-        },
-        {
-            key: tmp7,
-            value: function value() {}
-        },
-        {
-            key: tmp9,
-            value: function value() {}
-        }
-    ], [
-        {
             key: tmp2,
             value: function value() {}
         },
         {
-            key: tmp5,
+            key: 0,
             value: function value() {}
         },
         {
-            key: tmp8,
+            key: _a,
             value: function value() {}
         },
         {
-            key: tmp10,
+            key: "hello bye",
+            value: function value() {}
+        }
+    ], [
+        {
+            key: tmp,
+            value: function value() {}
+        },
+        {
+            key: "",
+            value: function value() {}
+        },
+        {
+            key: true,
+            value: function value() {}
+        },
+        {
+            key: tmp3,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames13_ES5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames13_ES5_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a, tmp6 = "hello ".concat(a, " bye"), C = function() {
+var s, n, a, _s = s, _n = n, tmp = s + s, tmp1 = s + n, tmp2 = +s, _a = a, tmp3 = "hello ".concat(a, " bye"), C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,11 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _s,
+            value: function() {}
+        },
+        {
+            key: _n,
             value: function() {}
         },
         {
@@ -22,11 +26,7 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
             value: function() {}
         },
         {
-            key: tmp3,
-            value: function() {}
-        },
-        {
-            key: tmp4,
+            key: tmp2,
             value: function() {}
         },
         {
@@ -34,7 +34,7 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
             value: function() {}
         },
         {
-            key: tmp5,
+            key: _a,
             value: function() {}
         },
         {
@@ -43,7 +43,7 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
         }
     ], staticProps = [
         {
-            key: tmp2,
+            key: tmp,
             value: function() {}
         },
         {
@@ -55,7 +55,7 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
             value: function() {}
         },
         {
-            key: tmp6,
+            key: tmp3,
             value: function() {}
         }
     ], protoProps && _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/computedPropertyNames13_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames13_ES6_es2015.1.normal.js
@@ -2,17 +2,17 @@
 var s;
 var n;
 var a;
-var tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = "", tmp6 = 0, tmp7 = a, tmp8 = true, tmp9 = `hello bye`, tmp10 = `hello ${a} bye`;
+let _s = s, _n = n, tmp = s + s, tmp1 = s + n, tmp2 = +s, _a = a, tmp3 = `hello ${a} bye`;
 class C {
-    [tmp]() {}
+    [_s]() {}
+    [_n]() {}
+    static [tmp]() {}
     [tmp1]() {}
-    static [tmp2]() {}
-    [tmp3]() {}
-    [tmp4]() {}
-    static [tmp5]() {}
-    [tmp6]() {}
-    [tmp7]() {}
-    static [tmp8]() {}
-    [tmp9]() {}
-    static [tmp10]() {}
+    [tmp2]() {}
+    static [""]() {}
+    [0]() {}
+    [_a]() {}
+    static [true]() {}
+    [`hello bye`]() {}
+    static [tmp3]() {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames13_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames13_ES6_es5.1.normal.js
@@ -21,7 +21,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 var s;
 var n;
 var a;
-var tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = "", tmp6 = 0, tmp7 = a, tmp8 = true, tmp9 = "hello bye", tmp10 = "hello ".concat(a, " bye");
+var _s = s, _n = n, tmp = s + s, tmp1 = s + n, tmp2 = +s, _a = a, tmp3 = "hello ".concat(a, " bye");
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -29,7 +29,11 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _s,
+            value: function value() {}
+        },
+        {
+            key: _n,
             value: function value() {}
         },
         {
@@ -37,40 +41,36 @@ var C = /*#__PURE__*/ function() {
             value: function value() {}
         },
         {
-            key: tmp3,
-            value: function value() {}
-        },
-        {
-            key: tmp4,
-            value: function value() {}
-        },
-        {
-            key: tmp6,
-            value: function value() {}
-        },
-        {
-            key: tmp7,
-            value: function value() {}
-        },
-        {
-            key: tmp9,
-            value: function value() {}
-        }
-    ], [
-        {
             key: tmp2,
             value: function value() {}
         },
         {
-            key: tmp5,
+            key: 0,
             value: function value() {}
         },
         {
-            key: tmp8,
+            key: _a,
             value: function value() {}
         },
         {
-            key: tmp10,
+            key: "hello bye",
+            value: function value() {}
+        }
+    ], [
+        {
+            key: tmp,
+            value: function value() {}
+        },
+        {
+            key: "",
+            value: function value() {}
+        },
+        {
+            key: true,
+            value: function value() {}
+        },
+        {
+            key: tmp3,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames13_ES6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames13_ES6_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a, tmp6 = "hello ".concat(a, " bye"), C = function() {
+var s, n, a, _s = s, _n = n, tmp = s + s, tmp1 = s + n, tmp2 = +s, _a = a, tmp3 = "hello ".concat(a, " bye"), C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,11 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _s,
+            value: function() {}
+        },
+        {
+            key: _n,
             value: function() {}
         },
         {
@@ -22,11 +26,7 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
             value: function() {}
         },
         {
-            key: tmp3,
-            value: function() {}
-        },
-        {
-            key: tmp4,
+            key: tmp2,
             value: function() {}
         },
         {
@@ -34,7 +34,7 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
             value: function() {}
         },
         {
-            key: tmp5,
+            key: _a,
             value: function() {}
         },
         {
@@ -43,7 +43,7 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
         }
     ], staticProps = [
         {
-            key: tmp2,
+            key: tmp,
             value: function() {}
         },
         {
@@ -55,7 +55,7 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
             value: function() {}
         },
         {
-            key: tmp6,
+            key: tmp3,
             value: function() {}
         }
     ], protoProps && _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/computedPropertyNames14_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames14_ES5_es2015.1.normal.js
@@ -1,11 +1,11 @@
 // @target: es5
 var b;
-var tmp = b, tmp1 = true, tmp2 = [], tmp3 = {}, tmp4 = undefined, tmp5 = null;
+let _b = b, _undefined = undefined;
 class C {
-    [tmp]() {}
-    static [tmp1]() {}
-    [tmp2]() {}
-    static [tmp3]() {}
-    [tmp4]() {}
-    static [tmp5]() {}
+    [_b]() {}
+    static [true]() {}
+    [[]]() {}
+    static [{}]() {}
+    [_undefined]() {}
+    static [null]() {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames14_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames14_ES5_es5.1.normal.js
@@ -19,7 +19,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 }
 // @target: es5
 var b;
-var tmp = b, tmp1 = true, tmp2 = [], tmp3 = {}, tmp4 = undefined, tmp5 = null;
+var _b = b, _undefined = undefined;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -27,28 +27,28 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _b,
             value: function value() {}
         },
         {
-            key: tmp2,
+            key: [],
             value: function value() {}
         },
         {
-            key: tmp4,
+            key: _undefined,
             value: function value() {}
         }
     ], [
         {
-            key: tmp1,
+            key: true,
             value: function value() {}
         },
         {
-            key: tmp3,
+            key: {},
             value: function value() {}
         },
         {
-            key: tmp5,
+            key: null,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames14_ES5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames14_ES5_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = void 0, tmp1 = [], tmp2 = {}, tmp3 = void 0, C = function() {
+var _b = void 0, _undefined = void 0, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -12,31 +12,31 @@ var tmp = void 0, tmp1 = [], tmp2 = {}, tmp3 = void 0, C = function() {
             if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
         }(this, C);
     }
-    return Constructor = C, protoProps = [
-        {
-            key: tmp,
-            value: function() {}
-        },
-        {
-            key: tmp1,
-            value: function() {}
-        },
-        {
-            key: tmp3,
-            value: function() {}
-        }
-    ], staticProps = [
+    return Constructor = C, staticProps = [
         {
             key: !0,
             value: function() {}
         },
         {
-            key: tmp2,
+            key: {},
             value: function() {}
         },
         {
             key: null,
             value: function() {}
         }
-    ], protoProps && _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;
+    ], protoProps = [
+        {
+            key: _b,
+            value: function() {}
+        },
+        {
+            key: [],
+            value: function() {}
+        },
+        {
+            key: _undefined,
+            value: function() {}
+        }
+    ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;
 }();

--- a/crates/swc/tests/tsc-references/computedPropertyNames14_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames14_ES6_es2015.1.normal.js
@@ -1,11 +1,11 @@
 // @target: es6
 var b;
-var tmp = b, tmp1 = true, tmp2 = [], tmp3 = {}, tmp4 = undefined, tmp5 = null;
+let _b = b, _undefined = undefined;
 class C {
-    [tmp]() {}
-    static [tmp1]() {}
-    [tmp2]() {}
-    static [tmp3]() {}
-    [tmp4]() {}
-    static [tmp5]() {}
+    [_b]() {}
+    static [true]() {}
+    [[]]() {}
+    static [{}]() {}
+    [_undefined]() {}
+    static [null]() {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames14_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames14_ES6_es5.1.normal.js
@@ -19,7 +19,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 }
 // @target: es6
 var b;
-var tmp = b, tmp1 = true, tmp2 = [], tmp3 = {}, tmp4 = undefined, tmp5 = null;
+var _b = b, _undefined = undefined;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -27,28 +27,28 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _b,
             value: function value() {}
         },
         {
-            key: tmp2,
+            key: [],
             value: function value() {}
         },
         {
-            key: tmp4,
+            key: _undefined,
             value: function value() {}
         }
     ], [
         {
-            key: tmp1,
+            key: true,
             value: function value() {}
         },
         {
-            key: tmp3,
+            key: {},
             value: function value() {}
         },
         {
-            key: tmp5,
+            key: null,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames14_ES6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames14_ES6_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = void 0, tmp1 = [], tmp2 = {}, tmp3 = void 0, C = function() {
+var _b = void 0, _undefined = void 0, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -12,31 +12,31 @@ var tmp = void 0, tmp1 = [], tmp2 = {}, tmp3 = void 0, C = function() {
             if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
         }(this, C);
     }
-    return Constructor = C, protoProps = [
-        {
-            key: tmp,
-            value: function() {}
-        },
-        {
-            key: tmp1,
-            value: function() {}
-        },
-        {
-            key: tmp3,
-            value: function() {}
-        }
-    ], staticProps = [
+    return Constructor = C, staticProps = [
         {
             key: !0,
             value: function() {}
         },
         {
-            key: tmp2,
+            key: {},
             value: function() {}
         },
         {
             key: null,
             value: function() {}
         }
-    ], protoProps && _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;
+    ], protoProps = [
+        {
+            key: _b,
+            value: function() {}
+        },
+        {
+            key: [],
+            value: function() {}
+        },
+        {
+            key: _undefined,
+            value: function() {}
+        }
+    ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;
 }();

--- a/crates/swc/tests/tsc-references/computedPropertyNames15_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames15_ES5_es2015.1.normal.js
@@ -2,9 +2,9 @@
 var p1;
 var p2;
 var p3;
-var tmp = p1, tmp1 = p2, tmp2 = p3;
+let _p1 = p1, _p2 = p2, _p3 = p3;
 class C {
-    [tmp]() {}
-    [tmp1]() {}
-    [tmp2]() {}
+    [_p1]() {}
+    [_p2]() {}
+    [_p3]() {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames15_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames15_ES5_es5.1.normal.js
@@ -21,7 +21,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 var p1;
 var p2;
 var p3;
-var tmp = p1, tmp1 = p2, tmp2 = p3;
+var _p1 = p1, _p2 = p2, _p3 = p3;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -29,15 +29,15 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _p1,
             value: function value() {}
         },
         {
-            key: tmp1,
+            key: _p2,
             value: function value() {}
         },
         {
-            key: tmp2,
+            key: _p3,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames15_ES5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames15_ES5_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var p2, p3, tmp = void 0, tmp1 = p2, tmp2 = p3, C = function() {
+var p2, p3, _p1 = void 0, _p2 = p2, _p3 = p3, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,15 +14,15 @@ var p2, p3, tmp = void 0, tmp1 = p2, tmp2 = p3, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _p1,
             value: function() {}
         },
         {
-            key: tmp1,
+            key: _p2,
             value: function() {}
         },
         {
-            key: tmp2,
+            key: _p3,
             value: function() {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/computedPropertyNames15_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames15_ES6_es2015.1.normal.js
@@ -2,9 +2,9 @@
 var p1;
 var p2;
 var p3;
-var tmp = p1, tmp1 = p2, tmp2 = p3;
+let _p1 = p1, _p2 = p2, _p3 = p3;
 class C {
-    [tmp]() {}
-    [tmp1]() {}
-    [tmp2]() {}
+    [_p1]() {}
+    [_p2]() {}
+    [_p3]() {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames15_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames15_ES6_es5.1.normal.js
@@ -21,7 +21,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 var p1;
 var p2;
 var p3;
-var tmp = p1, tmp1 = p2, tmp2 = p3;
+var _p1 = p1, _p2 = p2, _p3 = p3;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -29,15 +29,15 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _p1,
             value: function value() {}
         },
         {
-            key: tmp1,
+            key: _p2,
             value: function value() {}
         },
         {
-            key: tmp2,
+            key: _p3,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames15_ES6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames15_ES6_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var p2, p3, tmp = void 0, tmp1 = p2, tmp2 = p3, C = function() {
+var p2, p3, _p1 = void 0, _p2 = p2, _p3 = p3, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,15 +14,15 @@ var p2, p3, tmp = void 0, tmp1 = p2, tmp2 = p3, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _p1,
             value: function() {}
         },
         {
-            key: tmp1,
+            key: _p2,
             value: function() {}
         },
         {
-            key: tmp2,
+            key: _p3,
             value: function() {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/computedPropertyNames16_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames16_ES5_es2015.1.normal.js
@@ -2,29 +2,29 @@
 var s;
 var n;
 var a;
-var tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = "", tmp6 = 0, tmp7 = a, tmp8 = true, tmp9 = `hello bye`, tmp10 = `hello ${a} bye`;
+let _s = s, _n = n, tmp = s + s, tmp1 = s + n, tmp2 = +s, _a = a, tmp3 = `hello ${a} bye`;
 class C {
-    get [tmp]() {
+    get [_s]() {
+        return 0;
+    }
+    set [_n](v) {}
+    static get [tmp]() {
         return 0;
     }
     set [tmp1](v) {}
-    static get [tmp2]() {
+    get [tmp2]() {
         return 0;
     }
-    set [tmp3](v) {}
-    get [tmp4]() {
+    static set [""](v) {}
+    get [0]() {
         return 0;
     }
-    static set [tmp5](v) {}
-    get [tmp6]() {
+    set [_a](v) {}
+    static get [true]() {
         return 0;
     }
-    set [tmp7](v) {}
-    static get [tmp8]() {
-        return 0;
-    }
-    set [tmp9](v) {}
-    get [tmp10]() {
+    set [`hello bye`](v) {}
+    get [tmp3]() {
         return 0;
     }
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames16_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames16_ES5_es5.1.normal.js
@@ -21,7 +21,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 var s;
 var n;
 var a;
-var tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = "", tmp6 = 0, tmp7 = a, tmp8 = true, tmp9 = "hello bye", tmp10 = "hello ".concat(a, " bye");
+var _s = s, _n = n, tmp = s + s, tmp1 = s + n, tmp2 = +s, _a = a, tmp3 = "hello ".concat(a, " bye");
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -29,46 +29,19 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _s,
             get: function get() {
                 return 0;
             }
+        },
+        {
+            key: _n,
+            set: function set(v) {}
         },
         {
             key: tmp1,
             set: function set(v) {}
         },
-        {
-            key: tmp3,
-            set: function set(v) {}
-        },
-        {
-            key: tmp4,
-            get: function get() {
-                return 0;
-            }
-        },
-        {
-            key: tmp6,
-            get: function get() {
-                return 0;
-            }
-        },
-        {
-            key: tmp7,
-            set: function set(v) {}
-        },
-        {
-            key: tmp9,
-            set: function set(v) {}
-        },
-        {
-            key: tmp10,
-            get: function get() {
-                return 0;
-            }
-        }
-    ], [
         {
             key: tmp2,
             get: function get() {
@@ -76,11 +49,38 @@ var C = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp5,
+            key: 0,
+            get: function get() {
+                return 0;
+            }
+        },
+        {
+            key: _a,
             set: function set(v) {}
         },
         {
-            key: tmp8,
+            key: "hello bye",
+            set: function set(v) {}
+        },
+        {
+            key: tmp3,
+            get: function get() {
+                return 0;
+            }
+        }
+    ], [
+        {
+            key: tmp,
+            get: function get() {
+                return 0;
+            }
+        },
+        {
+            key: "",
+            set: function set(v) {}
+        },
+        {
+            key: true,
             get: function get() {
                 return 0;
             }

--- a/crates/swc/tests/tsc-references/computedPropertyNames16_ES5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames16_ES5_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a, tmp6 = "hello ".concat(a, " bye"), C = function() {
+var s, n, a, _s = s, _n = n, tmp = s + s, tmp1 = s + n, tmp2 = +s, _a = a, tmp3 = "hello ".concat(a, " bye"), C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,21 +14,21 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _s,
             get: function() {
                 return 0;
             }
+        },
+        {
+            key: _n,
+            set: function(v) {}
         },
         {
             key: tmp1,
             set: function(v) {}
         },
         {
-            key: tmp3,
-            set: function(v) {}
-        },
-        {
-            key: tmp4,
+            key: tmp2,
             get: function() {
                 return 0;
             }
@@ -40,7 +40,7 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
             }
         },
         {
-            key: tmp5,
+            key: _a,
             set: function(v) {}
         },
         {
@@ -48,14 +48,14 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
             set: function(v) {}
         },
         {
-            key: tmp6,
+            key: tmp3,
             get: function() {
                 return 0;
             }
         }
     ], staticProps = [
         {
-            key: tmp2,
+            key: tmp,
             get: function() {
                 return 0;
             }

--- a/crates/swc/tests/tsc-references/computedPropertyNames16_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames16_ES6_es2015.1.normal.js
@@ -2,29 +2,29 @@
 var s;
 var n;
 var a;
-var tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = "", tmp6 = 0, tmp7 = a, tmp8 = true, tmp9 = `hello bye`, tmp10 = `hello ${a} bye`;
+let _s = s, _n = n, tmp = s + s, tmp1 = s + n, tmp2 = +s, _a = a, tmp3 = `hello ${a} bye`;
 class C {
-    get [tmp]() {
+    get [_s]() {
+        return 0;
+    }
+    set [_n](v) {}
+    static get [tmp]() {
         return 0;
     }
     set [tmp1](v) {}
-    static get [tmp2]() {
+    get [tmp2]() {
         return 0;
     }
-    set [tmp3](v) {}
-    get [tmp4]() {
+    static set [""](v) {}
+    get [0]() {
         return 0;
     }
-    static set [tmp5](v) {}
-    get [tmp6]() {
+    set [_a](v) {}
+    static get [true]() {
         return 0;
     }
-    set [tmp7](v) {}
-    static get [tmp8]() {
-        return 0;
-    }
-    set [tmp9](v) {}
-    get [tmp10]() {
+    set [`hello bye`](v) {}
+    get [tmp3]() {
         return 0;
     }
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames16_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames16_ES6_es5.1.normal.js
@@ -21,7 +21,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 var s;
 var n;
 var a;
-var tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = "", tmp6 = 0, tmp7 = a, tmp8 = true, tmp9 = "hello bye", tmp10 = "hello ".concat(a, " bye");
+var _s = s, _n = n, tmp = s + s, tmp1 = s + n, tmp2 = +s, _a = a, tmp3 = "hello ".concat(a, " bye");
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -29,46 +29,19 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _s,
             get: function get() {
                 return 0;
             }
+        },
+        {
+            key: _n,
+            set: function set(v) {}
         },
         {
             key: tmp1,
             set: function set(v) {}
         },
-        {
-            key: tmp3,
-            set: function set(v) {}
-        },
-        {
-            key: tmp4,
-            get: function get() {
-                return 0;
-            }
-        },
-        {
-            key: tmp6,
-            get: function get() {
-                return 0;
-            }
-        },
-        {
-            key: tmp7,
-            set: function set(v) {}
-        },
-        {
-            key: tmp9,
-            set: function set(v) {}
-        },
-        {
-            key: tmp10,
-            get: function get() {
-                return 0;
-            }
-        }
-    ], [
         {
             key: tmp2,
             get: function get() {
@@ -76,11 +49,38 @@ var C = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp5,
+            key: 0,
+            get: function get() {
+                return 0;
+            }
+        },
+        {
+            key: _a,
             set: function set(v) {}
         },
         {
-            key: tmp8,
+            key: "hello bye",
+            set: function set(v) {}
+        },
+        {
+            key: tmp3,
+            get: function get() {
+                return 0;
+            }
+        }
+    ], [
+        {
+            key: tmp,
+            get: function get() {
+                return 0;
+            }
+        },
+        {
+            key: "",
+            set: function set(v) {}
+        },
+        {
+            key: true,
             get: function get() {
                 return 0;
             }

--- a/crates/swc/tests/tsc-references/computedPropertyNames16_ES6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames16_ES6_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a, tmp6 = "hello ".concat(a, " bye"), C = function() {
+var s, n, a, _s = s, _n = n, tmp = s + s, tmp1 = s + n, tmp2 = +s, _a = a, tmp3 = "hello ".concat(a, " bye"), C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,21 +14,21 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _s,
             get: function() {
                 return 0;
             }
+        },
+        {
+            key: _n,
+            set: function(v) {}
         },
         {
             key: tmp1,
             set: function(v) {}
         },
         {
-            key: tmp3,
-            set: function(v) {}
-        },
-        {
-            key: tmp4,
+            key: tmp2,
             get: function() {
                 return 0;
             }
@@ -40,7 +40,7 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
             }
         },
         {
-            key: tmp5,
+            key: _a,
             set: function(v) {}
         },
         {
@@ -48,14 +48,14 @@ var s, n, a, tmp = s, tmp1 = n, tmp2 = s + s, tmp3 = s + n, tmp4 = +s, tmp5 = a,
             set: function(v) {}
         },
         {
-            key: tmp6,
+            key: tmp3,
             get: function() {
                 return 0;
             }
         }
     ], staticProps = [
         {
-            key: tmp2,
+            key: tmp,
             get: function() {
                 return 0;
             }

--- a/crates/swc/tests/tsc-references/computedPropertyNames17_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames17_ES5_es2015.1.normal.js
@@ -1,17 +1,17 @@
 // @target: es5
 var b;
-var tmp = b, tmp1 = true, tmp2 = [], tmp3 = {}, tmp4 = undefined, tmp5 = null;
+let _b = b, _undefined = undefined;
 class C {
-    get [tmp]() {
+    get [_b]() {
         return 0;
     }
-    static set [tmp1](v) {}
-    get [tmp2]() {
+    static set [true](v) {}
+    get [[]]() {
         return 0;
     }
-    set [tmp3](v) {}
-    static get [tmp4]() {
+    set [{}](v) {}
+    static get [_undefined]() {
         return 0;
     }
-    set [tmp5](v) {}
+    set [null](v) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames17_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames17_ES5_es5.1.normal.js
@@ -19,7 +19,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 }
 // @target: es5
 var b;
-var tmp = b, tmp1 = true, tmp2 = [], tmp3 = {}, tmp4 = undefined, tmp5 = null;
+var _b = b, _undefined = undefined;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -27,32 +27,32 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _b,
             get: function get() {
                 return 0;
             }
         },
         {
-            key: tmp2,
+            key: [],
             get: function get() {
                 return 0;
             }
         },
         {
-            key: tmp3,
+            key: {},
             set: function set(v) {}
         },
         {
-            key: tmp5,
+            key: null,
             set: function set(v) {}
         }
     ], [
         {
-            key: tmp1,
+            key: true,
             set: function set(v) {}
         },
         {
-            key: tmp4,
+            key: _undefined,
             get: function get() {
                 return 0;
             }

--- a/crates/swc/tests/tsc-references/computedPropertyNames17_ES5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames17_ES5_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = void 0, tmp1 = [], tmp2 = {}, tmp3 = void 0, C = function() {
+var _b = void 0, _undefined = void 0, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,19 +14,19 @@ var tmp = void 0, tmp1 = [], tmp2 = {}, tmp3 = void 0, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _b,
             get: function() {
                 return 0;
             }
         },
         {
-            key: tmp1,
+            key: [],
             get: function() {
                 return 0;
             }
         },
         {
-            key: tmp2,
+            key: {},
             set: function(v) {}
         },
         {
@@ -39,7 +39,7 @@ var tmp = void 0, tmp1 = [], tmp2 = {}, tmp3 = void 0, C = function() {
             set: function(v) {}
         },
         {
-            key: tmp3,
+            key: _undefined,
             get: function() {
                 return 0;
             }

--- a/crates/swc/tests/tsc-references/computedPropertyNames17_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames17_ES6_es2015.1.normal.js
@@ -1,17 +1,17 @@
 // @target: es6
 var b;
-var tmp = b, tmp1 = true, tmp2 = [], tmp3 = {}, tmp4 = undefined, tmp5 = null;
+let _b = b, _undefined = undefined;
 class C {
-    get [tmp]() {
+    get [_b]() {
         return 0;
     }
-    static set [tmp1](v) {}
-    get [tmp2]() {
+    static set [true](v) {}
+    get [[]]() {
         return 0;
     }
-    set [tmp3](v) {}
-    static get [tmp4]() {
+    set [{}](v) {}
+    static get [_undefined]() {
         return 0;
     }
-    set [tmp5](v) {}
+    set [null](v) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames17_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames17_ES6_es5.1.normal.js
@@ -19,7 +19,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 }
 // @target: es6
 var b;
-var tmp = b, tmp1 = true, tmp2 = [], tmp3 = {}, tmp4 = undefined, tmp5 = null;
+var _b = b, _undefined = undefined;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -27,32 +27,32 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _b,
             get: function get() {
                 return 0;
             }
         },
         {
-            key: tmp2,
+            key: [],
             get: function get() {
                 return 0;
             }
         },
         {
-            key: tmp3,
+            key: {},
             set: function set(v) {}
         },
         {
-            key: tmp5,
+            key: null,
             set: function set(v) {}
         }
     ], [
         {
-            key: tmp1,
+            key: true,
             set: function set(v) {}
         },
         {
-            key: tmp4,
+            key: _undefined,
             get: function get() {
                 return 0;
             }

--- a/crates/swc/tests/tsc-references/computedPropertyNames17_ES6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames17_ES6_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = void 0, tmp1 = [], tmp2 = {}, tmp3 = void 0, C = function() {
+var _b = void 0, _undefined = void 0, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,19 +14,19 @@ var tmp = void 0, tmp1 = [], tmp2 = {}, tmp3 = void 0, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _b,
             get: function() {
                 return 0;
             }
         },
         {
-            key: tmp1,
+            key: [],
             get: function() {
                 return 0;
             }
         },
         {
-            key: tmp2,
+            key: {},
             set: function(v) {}
         },
         {
@@ -39,7 +39,7 @@ var tmp = void 0, tmp1 = [], tmp2 = {}, tmp3 = void 0, C = function() {
             set: function(v) {}
         },
         {
-            key: tmp3,
+            key: _undefined,
             get: function() {
                 return 0;
             }

--- a/crates/swc/tests/tsc-references/computedPropertyNames21_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames21_ES5_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = this.bar();
+let tmp = this.bar();
 // @target: es5
 class C {
     bar() {

--- a/crates/swc/tests/tsc-references/computedPropertyNames21_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames21_ES6_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = this.bar();
+let tmp = this.bar();
 // @target: es6
 class C {
     bar() {

--- a/crates/swc/tests/tsc-references/computedPropertyNames23_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames23_ES5_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = {
+let tmp = {
     [this.bar()]: 1
 }[0];
 // @target: es5

--- a/crates/swc/tests/tsc-references/computedPropertyNames23_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames23_ES6_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = {
+let tmp = {
     [this.bar()]: 1
 }[0];
 // @target: es6

--- a/crates/swc/tests/tsc-references/computedPropertyNames24_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames24_ES5_es2015.1.normal.js
@@ -4,7 +4,7 @@ class Base {
         return 0;
     }
 }
-var tmp = super.bar();
+let tmp = super.bar();
 class C extends Base {
     [tmp]() {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames24_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames24_ES6_es2015.1.normal.js
@@ -4,7 +4,7 @@ class Base {
         return 0;
     }
 }
-var tmp = super.bar();
+let tmp = super.bar();
 class C extends Base {
     // Gets emitted as super, not _super, which is consistent with
     // use of super in static properties initializers.

--- a/crates/swc/tests/tsc-references/computedPropertyNames26_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames26_ES5_es2015.1.normal.js
@@ -4,7 +4,7 @@ class Base {
         return 0;
     }
 }
-var tmp = {
+let tmp = {
     [super.bar()]: 1
 }[0];
 class C extends Base {

--- a/crates/swc/tests/tsc-references/computedPropertyNames26_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames26_ES6_es2015.1.normal.js
@@ -4,7 +4,7 @@ class Base {
         return 0;
     }
 }
-var tmp = {
+let tmp = {
     [super.bar()]: 1
 }[0];
 class C extends Base {

--- a/crates/swc/tests/tsc-references/computedPropertyNames27_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames27_ES5_es2015.1.normal.js
@@ -1,7 +1,7 @@
 // @target: es5
 class Base {
 }
-var tmp = (super(), "prop");
+let tmp = (super(), "prop");
 class C extends Base {
     [tmp]() {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames27_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames27_ES6_es2015.1.normal.js
@@ -1,7 +1,7 @@
 // @target: es6
 class Base {
 }
-var tmp = (super(), "prop");
+let tmp = (super(), "prop");
 class C extends Base {
     [tmp]() {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames2_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames2_ES5_es2015.1.normal.js
@@ -1,12 +1,12 @@
 // @target: es5
 var methodName = "method";
 var accessorName = "accessor";
-var tmp = methodName, tmp1 = methodName, tmp2 = accessorName, tmp3 = accessorName, tmp4 = accessorName, tmp5 = accessorName;
+let _methodName = methodName, _methodName1 = methodName, _accessorName = accessorName, _accessorName1 = accessorName, _accessorName2 = accessorName, _accessorName3 = accessorName;
 class C {
-    [tmp]() {}
-    static [tmp1]() {}
-    get [tmp2]() {}
-    set [tmp3](v) {}
-    static get [tmp4]() {}
-    static set [tmp5](v) {}
+    [_methodName]() {}
+    static [_methodName1]() {}
+    get [_accessorName]() {}
+    set [_accessorName1](v) {}
+    static get [_accessorName2]() {}
+    static set [_accessorName3](v) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames2_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames2_ES5_es5.1.normal.js
@@ -20,7 +20,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 // @target: es5
 var methodName = "method";
 var accessorName = "accessor";
-var tmp = methodName, tmp1 = methodName, tmp2 = accessorName, tmp3 = accessorName, tmp4 = accessorName, tmp5 = accessorName;
+var _methodName = methodName, _methodName1 = methodName, _accessorName = accessorName, _accessorName1 = accessorName, _accessorName2 = accessorName, _accessorName3 = accessorName;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -28,28 +28,28 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _methodName,
             value: function value() {}
         },
         {
-            key: tmp2,
+            key: _accessorName,
             get: function get() {}
         },
         {
-            key: tmp3,
+            key: _accessorName1,
             set: function set(v) {}
         }
     ], [
         {
-            key: tmp1,
+            key: _methodName1,
             value: function value() {}
         },
         {
-            key: tmp4,
+            key: _accessorName2,
             get: function get() {}
         },
         {
-            key: tmp5,
+            key: _accessorName3,
             set: function set(v) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames2_ES5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames2_ES5_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var methodName = "method", accessorName = "accessor", tmp = methodName, tmp1 = methodName, tmp2 = accessorName, tmp3 = accessorName, tmp4 = accessorName, tmp5 = accessorName, C = function() {
+var methodName = "method", accessorName = "accessor", _methodName = methodName, _methodName1 = methodName, _accessorName = accessorName, _accessorName1 = accessorName, _accessorName2 = accessorName, _accessorName3 = accessorName, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,28 +14,28 @@ var methodName = "method", accessorName = "accessor", tmp = methodName, tmp1 = m
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _methodName,
             value: function() {}
         },
         {
-            key: tmp2,
+            key: _accessorName,
             get: function() {}
         },
         {
-            key: tmp3,
+            key: _accessorName1,
             set: function(v) {}
         }
     ], staticProps = [
         {
-            key: tmp1,
+            key: _methodName1,
             value: function() {}
         },
         {
-            key: tmp4,
+            key: _accessorName2,
             get: function() {}
         },
         {
-            key: tmp5,
+            key: _accessorName3,
             set: function(v) {}
         }
     ], protoProps && _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/computedPropertyNames2_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames2_ES6_es2015.1.normal.js
@@ -1,12 +1,12 @@
 // @target: es6
 var methodName = "method";
 var accessorName = "accessor";
-var tmp = methodName, tmp1 = methodName, tmp2 = accessorName, tmp3 = accessorName, tmp4 = accessorName, tmp5 = accessorName;
+let _methodName = methodName, _methodName1 = methodName, _accessorName = accessorName, _accessorName1 = accessorName, _accessorName2 = accessorName, _accessorName3 = accessorName;
 class C {
-    [tmp]() {}
-    static [tmp1]() {}
-    get [tmp2]() {}
-    set [tmp3](v) {}
-    static get [tmp4]() {}
-    static set [tmp5](v) {}
+    [_methodName]() {}
+    static [_methodName1]() {}
+    get [_accessorName]() {}
+    set [_accessorName1](v) {}
+    static get [_accessorName2]() {}
+    static set [_accessorName3](v) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames2_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames2_ES6_es5.1.normal.js
@@ -20,7 +20,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 // @target: es6
 var methodName = "method";
 var accessorName = "accessor";
-var tmp = methodName, tmp1 = methodName, tmp2 = accessorName, tmp3 = accessorName, tmp4 = accessorName, tmp5 = accessorName;
+var _methodName = methodName, _methodName1 = methodName, _accessorName = accessorName, _accessorName1 = accessorName, _accessorName2 = accessorName, _accessorName3 = accessorName;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -28,28 +28,28 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _methodName,
             value: function value() {}
         },
         {
-            key: tmp2,
+            key: _accessorName,
             get: function get() {}
         },
         {
-            key: tmp3,
+            key: _accessorName1,
             set: function set(v) {}
         }
     ], [
         {
-            key: tmp1,
+            key: _methodName1,
             value: function value() {}
         },
         {
-            key: tmp4,
+            key: _accessorName2,
             get: function get() {}
         },
         {
-            key: tmp5,
+            key: _accessorName3,
             set: function set(v) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames2_ES6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames2_ES6_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var methodName = "method", accessorName = "accessor", tmp = methodName, tmp1 = methodName, tmp2 = accessorName, tmp3 = accessorName, tmp4 = accessorName, tmp5 = accessorName, C = function() {
+var methodName = "method", accessorName = "accessor", _methodName = methodName, _methodName1 = methodName, _accessorName = accessorName, _accessorName1 = accessorName, _accessorName2 = accessorName, _accessorName3 = accessorName, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,28 +14,28 @@ var methodName = "method", accessorName = "accessor", tmp = methodName, tmp1 = m
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _methodName,
             value: function() {}
         },
         {
-            key: tmp2,
+            key: _accessorName,
             get: function() {}
         },
         {
-            key: tmp3,
+            key: _accessorName1,
             set: function(v) {}
         }
     ], staticProps = [
         {
-            key: tmp1,
+            key: _methodName1,
             value: function() {}
         },
         {
-            key: tmp4,
+            key: _accessorName2,
             get: function() {}
         },
         {
-            key: tmp5,
+            key: _accessorName3,
             set: function(v) {}
         }
     ], protoProps && _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/computedPropertyNames32_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames32_ES5_es2015.1.normal.js
@@ -2,7 +2,7 @@
 function foo() {
     return '';
 }
-var tmp = foo();
+let tmp = foo();
 class C {
     bar() {
         return 0;

--- a/crates/swc/tests/tsc-references/computedPropertyNames32_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames32_ES6_es2015.1.normal.js
@@ -2,7 +2,7 @@
 function foo() {
     return '';
 }
-var tmp = foo();
+let tmp = foo();
 class C {
     bar() {
         return 0;

--- a/crates/swc/tests/tsc-references/computedPropertyNames36_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames36_ES5_es2015.1.normal.js
@@ -3,11 +3,10 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = "get1", tmp1 = "set1";
 class C {
     // Computed properties
-    get [tmp]() {
+    get ["get1"]() {
         return new Foo;
     }
-    set [tmp1](p) {}
+    set ["set1"](p) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames36_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames36_ES5_es5.1.normal.js
@@ -25,7 +25,6 @@ var Foo2 = function Foo2() {
     "use strict";
     _classCallCheck(this, Foo2);
 };
-var tmp = "get1", tmp1 = "set1";
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -33,14 +32,14 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: "get1",
             get: // Computed properties
             function get() {
                 return new Foo;
             }
         },
         {
-            key: tmp1,
+            key: "set1",
             set: function set(p) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames36_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames36_ES6_es2015.1.normal.js
@@ -3,11 +3,10 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = "get1", tmp1 = "set1";
 class C {
     // Computed properties
-    get [tmp]() {
+    get ["get1"]() {
         return new Foo;
     }
-    set [tmp1](p) {}
+    set ["set1"](p) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames36_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames36_ES6_es5.1.normal.js
@@ -25,7 +25,6 @@ var Foo2 = function Foo2() {
     "use strict";
     _classCallCheck(this, Foo2);
 };
-var tmp = "get1", tmp1 = "set1";
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -33,14 +32,14 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: "get1",
             get: // Computed properties
             function get() {
                 return new Foo;
             }
         },
         {
-            key: tmp1,
+            key: "set1",
             set: function set(p) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames37_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames37_ES5_es2015.1.normal.js
@@ -3,11 +3,10 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = "get1", tmp1 = "set1";
 class C {
     // Computed properties
-    get [tmp]() {
+    get ["get1"]() {
         return new Foo;
     }
-    set [tmp1](p) {}
+    set ["set1"](p) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames37_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames37_ES5_es5.1.normal.js
@@ -25,7 +25,6 @@ var Foo2 = function Foo2() {
     "use strict";
     _classCallCheck(this, Foo2);
 };
-var tmp = "get1", tmp1 = "set1";
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -33,14 +32,14 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: "get1",
             get: // Computed properties
             function get() {
                 return new Foo;
             }
         },
         {
-            key: tmp1,
+            key: "set1",
             set: function set(p) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames37_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames37_ES6_es2015.1.normal.js
@@ -3,11 +3,10 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = "get1", tmp1 = "set1";
 class C {
     // Computed properties
-    get [tmp]() {
+    get ["get1"]() {
         return new Foo;
     }
-    set [tmp1](p) {}
+    set ["set1"](p) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames37_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames37_ES6_es5.1.normal.js
@@ -25,7 +25,6 @@ var Foo2 = function Foo2() {
     "use strict";
     _classCallCheck(this, Foo2);
 };
-var tmp = "get1", tmp1 = "set1";
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -33,14 +32,14 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: "get1",
             get: // Computed properties
             function get() {
                 return new Foo;
             }
         },
         {
-            key: tmp1,
+            key: "set1",
             set: function set(p) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames38_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames38_ES5_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = 1 << 6, tmp1 = 1 << 6;
+let tmp = 1 << 6, tmp1 = 1 << 6;
 class C {
     // Computed properties
     get [tmp]() {

--- a/crates/swc/tests/tsc-references/computedPropertyNames38_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames38_ES6_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = 1 << 6, tmp1 = 1 << 6;
+let tmp = 1 << 6, tmp1 = 1 << 6;
 class C {
     // Computed properties
     get [tmp]() {

--- a/crates/swc/tests/tsc-references/computedPropertyNames39_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames39_ES5_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = 1 << 6, tmp1 = 1 << 6;
+let tmp = 1 << 6, tmp1 = 1 << 6;
 class C {
     // Computed properties
     get [tmp]() {

--- a/crates/swc/tests/tsc-references/computedPropertyNames39_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames39_ES6_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = 1 << 6, tmp1 = 1 << 6;
+let tmp = 1 << 6, tmp1 = 1 << 6;
 class C {
     // Computed properties
     get [tmp]() {

--- a/crates/swc/tests/tsc-references/computedPropertyNames40_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames40_ES5_es2015.1.normal.js
@@ -3,13 +3,12 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = "", tmp1 = "";
 class C {
     // Computed properties
-    [tmp]() {
+    [""]() {
         return new Foo;
     }
-    [tmp1]() {
+    [""]() {
         return new Foo2;
     }
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames40_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames40_ES5_es5.1.normal.js
@@ -25,7 +25,6 @@ var Foo2 = function Foo2() {
     "use strict";
     _classCallCheck(this, Foo2);
 };
-var tmp = "", tmp1 = "";
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -34,13 +33,13 @@ var C = /*#__PURE__*/ function() {
     _createClass(C, [
         {
             // Computed properties
-            key: tmp,
+            key: "",
             value: function value() {
                 return new Foo;
             }
         },
         {
-            key: tmp1,
+            key: "",
             value: function value() {
                 return new Foo2;
             }

--- a/crates/swc/tests/tsc-references/computedPropertyNames40_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames40_ES6_es2015.1.normal.js
@@ -3,13 +3,12 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = "", tmp1 = "";
 class C {
     // Computed properties
-    [tmp]() {
+    [""]() {
         return new Foo;
     }
-    [tmp1]() {
+    [""]() {
         return new Foo2;
     }
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames40_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames40_ES6_es5.1.normal.js
@@ -25,7 +25,6 @@ var Foo2 = function Foo2() {
     "use strict";
     _classCallCheck(this, Foo2);
 };
-var tmp = "", tmp1 = "";
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -34,13 +33,13 @@ var C = /*#__PURE__*/ function() {
     _createClass(C, [
         {
             // Computed properties
-            key: tmp,
+            key: "",
             value: function value() {
                 return new Foo;
             }
         },
         {
-            key: tmp1,
+            key: "",
             value: function value() {
                 return new Foo2;
             }

--- a/crates/swc/tests/tsc-references/computedPropertyNames41_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames41_ES5_es2015.1.normal.js
@@ -3,10 +3,9 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = "";
 class C {
     // Computed properties
-    static [tmp]() {
+    static [""]() {
         return new Foo;
     }
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames41_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames41_ES5_es5.1.normal.js
@@ -25,7 +25,6 @@ var Foo2 = function Foo2() {
     "use strict";
     _classCallCheck(this, Foo2);
 };
-var tmp = "";
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -33,7 +32,7 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, null, [
         {
-            key: tmp,
+            key: "",
             value: // Computed properties
             function value() {
                 return new Foo;

--- a/crates/swc/tests/tsc-references/computedPropertyNames41_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames41_ES6_es2015.1.normal.js
@@ -3,10 +3,9 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = "";
 class C {
     // Computed properties
-    static [tmp]() {
+    static [""]() {
         return new Foo;
     }
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames41_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames41_ES6_es5.1.normal.js
@@ -25,7 +25,6 @@ var Foo2 = function Foo2() {
     "use strict";
     _classCallCheck(this, Foo2);
 };
-var tmp = "";
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -33,7 +32,7 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, null, [
         {
-            key: tmp,
+            key: "",
             value: // Computed properties
             function value() {
                 return new Foo;

--- a/crates/swc/tests/tsc-references/computedPropertyNames43_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames43_ES5_es2015.1.normal.js
@@ -5,11 +5,10 @@ class Foo2 {
 }
 class C {
 }
-var tmp = "get1", tmp1 = "set1";
 class D extends C {
     // Computed properties
-    get [tmp]() {
+    get ["get1"]() {
         return new Foo;
     }
-    set [tmp1](p) {}
+    set ["set1"](p) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames43_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames43_ES5_es5.1.normal.js
@@ -95,7 +95,6 @@ var C = function C() {
     "use strict";
     _classCallCheck(this, C);
 };
-var tmp = "get1", tmp1 = "set1";
 var D = /*#__PURE__*/ function(C) {
     "use strict";
     _inherits(D, C);
@@ -106,14 +105,14 @@ var D = /*#__PURE__*/ function(C) {
     }
     _createClass(D, [
         {
-            key: tmp,
+            key: "get1",
             get: // Computed properties
             function get() {
                 return new Foo;
             }
         },
         {
-            key: tmp1,
+            key: "set1",
             set: function set(p) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames43_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames43_ES6_es2015.1.normal.js
@@ -5,11 +5,10 @@ class Foo2 {
 }
 class C {
 }
-var tmp = "get1", tmp1 = "set1";
 class D extends C {
     // Computed properties
-    get [tmp]() {
+    get ["get1"]() {
         return new Foo;
     }
-    set [tmp1](p) {}
+    set ["set1"](p) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames43_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames43_ES6_es5.1.normal.js
@@ -95,7 +95,6 @@ var C = function C() {
     "use strict";
     _classCallCheck(this, C);
 };
-var tmp = "get1", tmp1 = "set1";
 var D = /*#__PURE__*/ function(C) {
     "use strict";
     _inherits(D, C);
@@ -106,14 +105,14 @@ var D = /*#__PURE__*/ function(C) {
     }
     _createClass(D, [
         {
-            key: tmp,
+            key: "get1",
             get: // Computed properties
             function get() {
                 return new Foo;
             }
         },
         {
-            key: tmp1,
+            key: "set1",
             set: function set(p) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames44_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames44_ES5_es2015.1.normal.js
@@ -3,13 +3,11 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = "get1";
 class C {
-    get [tmp]() {
+    get ["get1"]() {
         return new Foo;
     }
 }
-var tmp1 = "set1";
 class D extends C {
-    set [tmp1](p) {}
+    set ["set1"](p) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames44_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames44_ES5_es5.1.normal.js
@@ -91,7 +91,6 @@ var Foo2 = function Foo2() {
     "use strict";
     _classCallCheck(this, Foo2);
 };
-var tmp = "get1";
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -99,7 +98,7 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: "get1",
             get: function get() {
                 return new Foo;
             }
@@ -107,7 +106,6 @@ var C = /*#__PURE__*/ function() {
     ]);
     return C;
 }();
-var tmp1 = "set1";
 var D = /*#__PURE__*/ function(C) {
     "use strict";
     _inherits(D, C);
@@ -118,7 +116,7 @@ var D = /*#__PURE__*/ function(C) {
     }
     _createClass(D, [
         {
-            key: tmp1,
+            key: "set1",
             set: function set(p) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames44_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames44_ES6_es2015.1.normal.js
@@ -3,13 +3,11 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = "get1";
 class C {
-    get [tmp]() {
+    get ["get1"]() {
         return new Foo;
     }
 }
-var tmp1 = "set1";
 class D extends C {
-    set [tmp1](p) {}
+    set ["set1"](p) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames44_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames44_ES6_es5.1.normal.js
@@ -91,7 +91,6 @@ var Foo2 = function Foo2() {
     "use strict";
     _classCallCheck(this, Foo2);
 };
-var tmp = "get1";
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -99,7 +98,7 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: "get1",
             get: function get() {
                 return new Foo;
             }
@@ -107,7 +106,6 @@ var C = /*#__PURE__*/ function() {
     ]);
     return C;
 }();
-var tmp1 = "set1";
 var D = /*#__PURE__*/ function(C) {
     "use strict";
     _inherits(D, C);
@@ -118,7 +116,7 @@ var D = /*#__PURE__*/ function(C) {
     }
     _createClass(D, [
         {
-            key: tmp1,
+            key: "set1",
             set: function set(p) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames45_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames45_ES5_es2015.1.normal.js
@@ -3,13 +3,11 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = "get1";
 class C {
-    get [tmp]() {
+    get ["get1"]() {
         return new Foo;
     }
 }
-var tmp1 = "set1";
 class D extends C {
-    set [tmp1](p) {}
+    set ["set1"](p) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames45_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames45_ES5_es5.1.normal.js
@@ -91,7 +91,6 @@ var Foo2 = function Foo2() {
     "use strict";
     _classCallCheck(this, Foo2);
 };
-var tmp = "get1";
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -99,7 +98,7 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: "get1",
             get: function get() {
                 return new Foo;
             }
@@ -107,7 +106,6 @@ var C = /*#__PURE__*/ function() {
     ]);
     return C;
 }();
-var tmp1 = "set1";
 var D = /*#__PURE__*/ function(C) {
     "use strict";
     _inherits(D, C);
@@ -118,7 +116,7 @@ var D = /*#__PURE__*/ function(C) {
     }
     _createClass(D, [
         {
-            key: tmp1,
+            key: "set1",
             set: function set(p) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNames45_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames45_ES6_es2015.1.normal.js
@@ -3,13 +3,11 @@ class Foo {
 }
 class Foo2 {
 }
-var tmp = "get1";
 class C {
-    get [tmp]() {
+    get ["get1"]() {
         return new Foo;
     }
 }
-var tmp1 = "set1";
 class D extends C {
-    set [tmp1](p) {}
+    set ["set1"](p) {}
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNames45_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNames45_ES6_es5.1.normal.js
@@ -91,7 +91,6 @@ var Foo2 = function Foo2() {
     "use strict";
     _classCallCheck(this, Foo2);
 };
-var tmp = "get1";
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -99,7 +98,7 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: "get1",
             get: function get() {
                 return new Foo;
             }
@@ -107,7 +106,6 @@ var C = /*#__PURE__*/ function() {
     ]);
     return C;
 }();
-var tmp1 = "set1";
 var D = /*#__PURE__*/ function(C) {
     "use strict";
     _inherits(D, C);
@@ -118,7 +116,7 @@ var D = /*#__PURE__*/ function(C) {
     }
     _createClass(D, [
         {
-            key: tmp1,
+            key: "set1",
             set: function set(p) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNamesDeclarationEmit1_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNamesDeclarationEmit1_ES5_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = "" + "", tmp1 = "" + "", tmp2 = "" + "";
+let tmp = "" + "", tmp1 = "" + "", tmp2 = "" + "";
 // @target: es5
 // @declaration: true
 class C {

--- a/crates/swc/tests/tsc-references/computedPropertyNamesDeclarationEmit1_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNamesDeclarationEmit1_ES6_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = "" + "", tmp1 = "" + "", tmp2 = "" + "";
+let tmp = "" + "", tmp1 = "" + "", tmp2 = "" + "";
 // @target: es6
 // @declaration: true
 class C {

--- a/crates/swc/tests/tsc-references/computedPropertyNamesDeclarationEmit2_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNamesDeclarationEmit2_ES5_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = "" + "", tmp1 = "" + "", tmp2 = "" + "";
+let tmp = "" + "", tmp1 = "" + "", tmp2 = "" + "";
 // @target: es5
 // @declaration: true
 class C {

--- a/crates/swc/tests/tsc-references/computedPropertyNamesDeclarationEmit2_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNamesDeclarationEmit2_ES6_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = "" + "", tmp1 = "" + "", tmp2 = "" + "";
+let tmp = "" + "", tmp1 = "" + "", tmp2 = "" + "";
 // @target: es6
 // @declaration: true
 class C {

--- a/crates/swc/tests/tsc-references/computedPropertyNamesSourceMap1_ES5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNamesSourceMap1_ES5_es2015.1.normal.js
@@ -1,11 +1,10 @@
-var tmp = "hello", tmp1 = "goodbye";
 // @target: es5
 // @sourceMap: true
 class C {
-    [tmp]() {
+    ["hello"]() {
         debugger;
     }
-    get [tmp1]() {
+    get ["goodbye"]() {
         return 0;
     }
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNamesSourceMap1_ES5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNamesSourceMap1_ES5_es5.1.normal.js
@@ -17,7 +17,6 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = "hello", tmp1 = "goodbye";
 var C = // @target: es5
 // @sourceMap: true
 /*#__PURE__*/ function() {
@@ -27,13 +26,13 @@ var C = // @target: es5
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: "hello",
             value: function value() {
                 debugger;
             }
         },
         {
-            key: tmp1,
+            key: "goodbye",
             get: function get() {
                 return 0;
             }

--- a/crates/swc/tests/tsc-references/computedPropertyNamesSourceMap1_ES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNamesSourceMap1_ES6_es2015.1.normal.js
@@ -1,11 +1,10 @@
-var tmp = "hello", tmp1 = "goodbye";
 // @target: es6
 // @sourceMap: true
 class C {
-    [tmp]() {
+    ["hello"]() {
         debugger;
     }
-    get [tmp1]() {
+    get ["goodbye"]() {
         return 0;
     }
 }

--- a/crates/swc/tests/tsc-references/computedPropertyNamesSourceMap1_ES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNamesSourceMap1_ES6_es5.1.normal.js
@@ -17,7 +17,6 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = "hello", tmp1 = "goodbye";
 var C = // @target: es6
 // @sourceMap: true
 /*#__PURE__*/ function() {
@@ -27,13 +26,13 @@ var C = // @target: es6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: "hello",
             value: function value() {
                 debugger;
             }
         },
         {
-            key: tmp1,
+            key: "goodbye",
             get: function get() {
                 return 0;
             }

--- a/crates/swc/tests/tsc-references/computedPropertyNamesWithStaticProperty_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNamesWithStaticProperty_es2015.1.normal.js
@@ -1,15 +1,15 @@
 function _classNameTDZError(name) {
     throw new Error("Class \"" + name + "\" cannot be referenced in computed property keys.");
 }
-var tmp = (_classNameTDZError("C"), C).staticProp, tmp1 = (_classNameTDZError("C"), C).staticProp, tmp2 = (_classNameTDZError("C"), C).staticProp;
+let _staticProp = (_classNameTDZError("C"), C).staticProp, _staticProp1 = (_classNameTDZError("C"), C).staticProp, _staticProp2 = (_classNameTDZError("C"), C).staticProp;
 // @target: es6
 class C {
-    get [tmp]() {
+    get [_staticProp]() {
         return "hello";
     }
-    set [tmp1](x) {
+    set [_staticProp1](x) {
         var y = x;
     }
-    [tmp2]() {}
+    [_staticProp2]() {}
 }
 C.staticProp = 10;

--- a/crates/swc/tests/tsc-references/computedPropertyNamesWithStaticProperty_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNamesWithStaticProperty_es2015.2.minified.js
@@ -1,12 +1,12 @@
 function _classNameTDZError(name) {
     throw new Error("Class \"" + name + "\" cannot be referenced in computed property keys.");
 }
-var tmp = (_classNameTDZError("C"), C).staticProp, tmp1 = (_classNameTDZError("C"), C).staticProp, tmp2 = (_classNameTDZError("C"), C).staticProp;
+let _staticProp = (_classNameTDZError("C"), C).staticProp, _staticProp1 = (_classNameTDZError("C"), C).staticProp, _staticProp2 = (_classNameTDZError("C"), C).staticProp;
 class C {
-    get [tmp]() {
+    get [_staticProp]() {
         return "hello";
     }
-    set [tmp1](x) {}
-    [tmp2]() {}
+    set [_staticProp1](x) {}
+    [_staticProp2]() {}
 }
 C.staticProp = 10;

--- a/crates/swc/tests/tsc-references/computedPropertyNamesWithStaticProperty_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNamesWithStaticProperty_es5.1.normal.js
@@ -20,7 +20,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = (_classNameTDZError("C"), C).staticProp, tmp1 = (_classNameTDZError("C"), C).staticProp, tmp2 = (_classNameTDZError("C"), C).staticProp;
+var _staticProp = (_classNameTDZError("C"), C).staticProp, _staticProp1 = (_classNameTDZError("C"), C).staticProp, _staticProp2 = (_classNameTDZError("C"), C).staticProp;
 var C = // @target: es6
 /*#__PURE__*/ function() {
     "use strict";
@@ -29,19 +29,19 @@ var C = // @target: es6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _staticProp,
             get: function get() {
                 return "hello";
             }
         },
         {
-            key: tmp1,
+            key: _staticProp1,
             set: function set(x) {
                 var y = x;
             }
         },
         {
-            key: tmp2,
+            key: _staticProp2,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/computedPropertyNamesWithStaticProperty_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/computedPropertyNamesWithStaticProperty_es5.2.minified.js
@@ -7,7 +7,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = (_classNameTDZError("C"), C).staticProp, tmp1 = (_classNameTDZError("C"), C).staticProp, tmp2 = (_classNameTDZError("C"), C).staticProp, C = function() {
+var _staticProp = (_classNameTDZError("C"), C).staticProp, _staticProp1 = (_classNameTDZError("C"), C).staticProp, _staticProp2 = (_classNameTDZError("C"), C).staticProp, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -17,17 +17,17 @@ var tmp = (_classNameTDZError("C"), C).staticProp, tmp1 = (_classNameTDZError("C
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _staticProp,
             get: function() {
                 return "hello";
             }
         },
         {
-            key: tmp1,
+            key: _staticProp1,
             set: function(x) {}
         },
         {
-            key: tmp2,
+            key: _staticProp2,
             value: function() {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/constEnumPropertyAccess1_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/constEnumPropertyAccess1_es2015.1.normal.js
@@ -16,11 +16,10 @@ var o = {
 var a = 1;
 var a1 = 1;
 var g = o[1];
-var tmp = 1, tmp1 = 2, tmp2 = 2;
 class C {
-    [tmp]() {}
-    get [tmp1]() {
+    [1]() {}
+    get [2]() {
         return true;
     }
-    set [tmp2](x) {}
+    set [2](x) {}
 }

--- a/crates/swc/tests/tsc-references/constEnumPropertyAccess1_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/constEnumPropertyAccess1_es5.1.normal.js
@@ -35,7 +35,6 @@ var o = {
 var a = 1;
 var a1 = 1;
 var g = o[1];
-var tmp = 1, tmp1 = 2, tmp2 = 2;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -43,17 +42,17 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: 1,
             value: function value() {}
         },
         {
-            key: tmp1,
+            key: 2,
             get: function get() {
                 return true;
             }
         },
         {
-            key: tmp2,
+            key: 2,
             set: function set(x) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/contextuallyTypedClassExpressionMethodDeclaration01_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/contextuallyTypedClassExpressionMethodDeclaration01_es2015.1.normal.js
@@ -1,6 +1,6 @@
 var _class, _class1;
 function getFoo1() {
-    return class _class {
+    return class {
         static method1(arg) {
             arg.numProp = 10;
         }

--- a/crates/swc/tests/tsc-references/contextuallyTypedClassExpressionMethodDeclaration01_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/contextuallyTypedClassExpressionMethodDeclaration01_es5.1.normal.js
@@ -42,9 +42,9 @@ function getFoo1() {
     })();
 }
 function getFoo2() {
-    return _class = function _class3() {
+    return _class = function _class2() {
         "use strict";
-        _classCallCheck(this, _class3);
+        _classCallCheck(this, _class2);
     }, _class.method1 = function(arg) {
         arg.numProp = 10;
     }, _class.method2 = function(arg) {
@@ -52,9 +52,9 @@ function getFoo2() {
     }, _class;
 }
 function getFoo3() {
-    return _class1 = function _class3() {
+    return _class1 = function _class2() {
         "use strict";
-        _classCallCheck(this, _class3);
+        _classCallCheck(this, _class2);
     }, _class1.method1 = function(arg) {
         arg.numProp = 10;
     }, _class1.method2 = function(arg) {

--- a/crates/swc/tests/tsc-references/contextuallyTypedClassExpressionMethodDeclaration02_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/contextuallyTypedClassExpressionMethodDeclaration02_es2015.1.normal.js
@@ -1,5 +1,5 @@
 function getFoo1() {
-    return class _class {
+    return class {
         method1(arg) {
             arg.numProp = 10;
         }
@@ -9,7 +9,7 @@ function getFoo1() {
     };
 }
 function getFoo2() {
-    return class _class {
+    return class {
         constructor(){
             this.method1 = (arg)=>{
                 arg.numProp = 10;
@@ -21,7 +21,7 @@ function getFoo2() {
     };
 }
 function getFoo3() {
-    return class _class {
+    return class {
         constructor(){
             this.method1 = function(arg) {
                 arg.numProp = 10;

--- a/crates/swc/tests/tsc-references/emitClassDeclarationWithGetterSetterInES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/emitClassDeclarationWithGetterSetterInES6_es2015.1.normal.js
@@ -1,4 +1,3 @@
-var tmp = "computedname", tmp1 = "computedname1", tmp2 = "computedname2", tmp3 = "computedname3", tmp4 = "computedname4", tmp5 = "computedname";
 // @target:es6
 class C {
     get name() {
@@ -7,18 +6,18 @@ class C {
     static get name2() {
         return "BYE";
     }
-    static get [tmp]() {
+    static get ["computedname"]() {
         return "";
     }
-    get [tmp1]() {
+    get ["computedname1"]() {
         return "";
     }
-    get [tmp2]() {
+    get ["computedname2"]() {
         return "";
     }
-    set [tmp3](x) {}
-    set [tmp4](y) {}
+    set ["computedname3"](x) {}
+    set ["computedname4"](y) {}
     set foo(a) {}
     static set bar(b) {}
-    static set [tmp5](b) {}
+    static set ["computedname"](b) {}
 }

--- a/crates/swc/tests/tsc-references/emitClassDeclarationWithGetterSetterInES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/emitClassDeclarationWithGetterSetterInES6_es5.1.normal.js
@@ -17,7 +17,6 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = "computedname", tmp1 = "computedname1", tmp2 = "computedname2", tmp3 = "computedname3", tmp4 = "computedname4", tmp5 = "computedname";
 var C = // @target:es6
 /*#__PURE__*/ function() {
     "use strict";
@@ -32,23 +31,23 @@ var C = // @target:es6
             }
         },
         {
-            key: tmp1,
+            key: "computedname1",
             get: function get() {
                 return "";
             }
         },
         {
-            key: tmp2,
+            key: "computedname2",
             get: function get() {
                 return "";
             }
         },
         {
-            key: tmp3,
+            key: "computedname3",
             set: function set(x) {}
         },
         {
-            key: tmp4,
+            key: "computedname4",
             set: function set(y) {}
         },
         {
@@ -63,7 +62,7 @@ var C = // @target:es6
             }
         },
         {
-            key: tmp,
+            key: "computedname",
             get: function get() {
                 return "";
             }
@@ -73,7 +72,7 @@ var C = // @target:es6
             set: function set(b) {}
         },
         {
-            key: tmp5,
+            key: "computedname",
             set: function set(b) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/emitClassDeclarationWithMethodInES6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/emitClassDeclarationWithMethodInES6_es2015.1.normal.js
@@ -1,10 +1,9 @@
-var tmp = "computedName1", tmp1 = "computedName2", tmp2 = "computedName3", tmp3 = "computedname4", tmp4 = "computedname5", tmp5 = "computedname6";
 // @target:es6
 class D {
     foo() {}
-    [tmp]() {}
-    [tmp1](a) {}
-    [tmp2](a) {
+    ["computedName1"]() {}
+    ["computedName2"](a) {}
+    ["computedName3"](a) {
         return 1;
     }
     bar() {
@@ -13,9 +12,9 @@ class D {
     baz(a, x) {
         return "HELLO";
     }
-    static [tmp3]() {}
-    static [tmp4](a) {}
-    static [tmp5](a) {
+    static ["computedname4"]() {}
+    static ["computedname5"](a) {}
+    static ["computedname6"](a) {
         return true;
     }
     static staticMethod() {

--- a/crates/swc/tests/tsc-references/emitClassDeclarationWithMethodInES6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/emitClassDeclarationWithMethodInES6_es5.1.normal.js
@@ -17,7 +17,6 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = "computedName1", tmp1 = "computedName2", tmp2 = "computedName3", tmp3 = "computedname4", tmp4 = "computedname5", tmp5 = "computedname6";
 var D = // @target:es6
 /*#__PURE__*/ function() {
     "use strict";
@@ -30,15 +29,15 @@ var D = // @target:es6
             value: function foo() {}
         },
         {
-            key: tmp,
+            key: "computedName1",
             value: function value() {}
         },
         {
-            key: tmp1,
+            key: "computedName2",
             value: function value(a) {}
         },
         {
-            key: tmp2,
+            key: "computedName3",
             value: function value(a) {
                 return 1;
             }
@@ -57,15 +56,15 @@ var D = // @target:es6
         }
     ], [
         {
-            key: tmp3,
+            key: "computedname4",
             value: function value() {}
         },
         {
-            key: tmp4,
+            key: "computedname5",
             value: function value(a) {}
         },
         {
-            key: tmp5,
+            key: "computedname6",
             value: function value(a) {
                 return true;
             }

--- a/crates/swc/tests/tsc-references/exportNestedNamespaces_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/exportNestedNamespaces_es2015.1.normal.js
@@ -8,7 +8,7 @@ exports.n = {};
 exports.n.K = function() {
     this.x = 10;
 };
-exports.Classic = class _class {
+exports.Classic = class {
     constructor(){
         this.p = 1;
     }

--- a/crates/swc/tests/tsc-references/for-of15_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of15_es2015.1.normal.js
@@ -1,10 +1,10 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class StringIterator {
     next() {
         return "";
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of15_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of15_es2015.2.minified.js
@@ -1,9 +1,10 @@
-var v, tmp = Symbol.iterator;
+var v;
+let _iterator = Symbol.iterator;
 for (v of new class {
     next() {
         return "";
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of15_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of15_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var StringIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -32,7 +32,7 @@ var StringIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -43,7 +43,7 @@ var StringIterator = //@target: ES6
 var v;
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         v = _step.value;
     } // Should fail
 } catch (err) {
@@ -51,8 +51,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of15_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of15_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, StringIterator = function() {
+var _iterator = Symbol.iterator, StringIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function StringIterator() {
@@ -20,7 +20,7 @@ var tmp = Symbol.iterator, StringIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -28,13 +28,13 @@ var tmp = Symbol.iterator, StringIterator = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), StringIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator1 = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
      // Should fail
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of16_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of16_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class StringIterator {
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of16_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of16_es2015.2.minified.js
@@ -1,6 +1,7 @@
-var v, tmp = Symbol.iterator;
+var v;
+let _iterator = Symbol.iterator;
 for (v of new class {
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of16_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of16_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var StringIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,7 +26,7 @@ var StringIterator = //@target: ES6
     }
     _createClass(StringIterator, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -37,7 +37,7 @@ var StringIterator = //@target: ES6
 var v;
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         v = _step.value;
     } // Should fail
 } catch (err) {
@@ -45,8 +45,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of16_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of16_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, StringIterator = function() {
+var _iterator = Symbol.iterator, StringIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function StringIterator() {
@@ -14,7 +14,7 @@ var tmp = Symbol.iterator, StringIterator = function() {
     }
     return Constructor = StringIterator, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -22,13 +22,13 @@ var tmp = Symbol.iterator, StringIterator = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), StringIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator1 = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
      // Should fail
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of17_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of17_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class NumberIterator {
     next() {
@@ -7,7 +7,7 @@ class NumberIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of17_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of17_es2015.2.minified.js
@@ -1,4 +1,5 @@
-var v, tmp = Symbol.iterator;
+var v;
+let _iterator = Symbol.iterator;
 for (v of new class {
     next() {
         return {
@@ -6,7 +7,7 @@ for (v of new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of17_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of17_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var NumberIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -35,7 +35,7 @@ var NumberIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -46,7 +46,7 @@ var NumberIterator = //@target: ES6
 var v;
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new NumberIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new NumberIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         v = _step.value;
     } // Should succeed
 } catch (err) {
@@ -54,8 +54,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of17_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of17_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, NumberIterator = function() {
+var _iterator = Symbol.iterator, NumberIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function NumberIterator() {
@@ -23,7 +23,7 @@ var tmp = Symbol.iterator, NumberIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -31,13 +31,13 @@ var tmp = Symbol.iterator, NumberIterator = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), NumberIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new NumberIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator1 = (new NumberIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
      // Should succeed
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of18_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of18_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class StringIterator {
     next() {
@@ -7,7 +7,7 @@ class StringIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of18_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of18_es2015.2.minified.js
@@ -1,4 +1,5 @@
-var v, tmp = Symbol.iterator;
+var v;
+let _iterator = Symbol.iterator;
 for (v of new class {
     next() {
         return {
@@ -6,7 +7,7 @@ for (v of new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of18_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of18_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var StringIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -35,7 +35,7 @@ var StringIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -46,7 +46,7 @@ var StringIterator = //@target: ES6
 var v;
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         v = _step.value;
     } // Should succeed
 } catch (err) {
@@ -54,8 +54,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of18_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of18_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, StringIterator = function() {
+var _iterator = Symbol.iterator, StringIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function StringIterator() {
@@ -23,7 +23,7 @@ var tmp = Symbol.iterator, StringIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -31,13 +31,13 @@ var tmp = Symbol.iterator, StringIterator = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), StringIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator1 = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
      // Should succeed
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of19_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of19_es2015.1.normal.js
@@ -1,7 +1,7 @@
 //@target: ES6
 class Foo {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -9,7 +9,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of19_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of19_es2015.2.minified.js
@@ -1,6 +1,6 @@
 class Foo {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 for (var v of new class {
     next() {
         return {
@@ -8,7 +8,7 @@ for (var v of new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of19_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of19_es5.1.normal.js
@@ -21,7 +21,7 @@ var Foo = function Foo() {
     "use strict";
     _classCallCheck(this, Foo);
 };
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -38,7 +38,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -48,7 +48,7 @@ var FooIterator = /*#__PURE__*/ function() {
 }();
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new FooIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new FooIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
         v;
     }
@@ -57,8 +57,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of19_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of19_es5.2.minified.js
@@ -10,7 +10,7 @@ function _defineProperties(target, props) {
 var Foo = function() {
     "use strict";
     _classCallCheck(this, Foo);
-}, tmp = Symbol.iterator, FooIterator = function() {
+}, _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -27,7 +27,7 @@ var Foo = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -35,12 +35,12 @@ var Foo = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), FooIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new FooIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator1 = (new FooIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of20_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of20_es2015.1.normal.js
@@ -1,7 +1,7 @@
 //@target: ES6
 class Foo {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -9,7 +9,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of20_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of20_es2015.2.minified.js
@@ -1,6 +1,6 @@
 class Foo {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 for (let v of new class {
     next() {
         return {
@@ -8,7 +8,7 @@ for (let v of new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of20_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of20_es5.1.normal.js
@@ -21,7 +21,7 @@ var Foo = function Foo() {
     "use strict";
     _classCallCheck(this, Foo);
 };
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -38,7 +38,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -48,7 +48,7 @@ var FooIterator = /*#__PURE__*/ function() {
 }();
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new FooIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new FooIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
         v;
     }
@@ -57,8 +57,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of20_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of20_es5.2.minified.js
@@ -10,7 +10,7 @@ function _defineProperties(target, props) {
 var Foo = function() {
     "use strict";
     _classCallCheck(this, Foo);
-}, tmp = Symbol.iterator, FooIterator = function() {
+}, _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -27,7 +27,7 @@ var Foo = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -35,12 +35,12 @@ var Foo = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), FooIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new FooIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator1 = (new FooIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of21_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of21_es2015.1.normal.js
@@ -1,7 +1,7 @@
 //@target: ES6
 class Foo {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -9,7 +9,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of21_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of21_es2015.2.minified.js
@@ -1,6 +1,6 @@
 class Foo {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 for (const v of new class {
     next() {
         return {
@@ -8,7 +8,7 @@ for (const v of new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of21_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of21_es5.1.normal.js
@@ -21,7 +21,7 @@ var Foo = function Foo() {
     "use strict";
     _classCallCheck(this, Foo);
 };
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -38,7 +38,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -48,7 +48,7 @@ var FooIterator = /*#__PURE__*/ function() {
 }();
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new FooIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new FooIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
         v;
     }
@@ -57,8 +57,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of21_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of21_es5.2.minified.js
@@ -10,7 +10,7 @@ function _defineProperties(target, props) {
 var Foo = function() {
     "use strict";
     _classCallCheck(this, Foo);
-}, tmp = Symbol.iterator, FooIterator = function() {
+}, _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -27,7 +27,7 @@ var Foo = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -35,12 +35,12 @@ var Foo = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), FooIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new FooIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator1 = (new FooIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of22_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of22_es2015.1.normal.js
@@ -1,7 +1,7 @@
 //@target: ES6
 class Foo {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -9,7 +9,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of22_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of22_es2015.2.minified.js
@@ -1,6 +1,6 @@
 class Foo {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 for (var v of new class {
     next() {
         return {
@@ -8,7 +8,7 @@ for (var v of new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of22_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of22_es5.1.normal.js
@@ -21,7 +21,7 @@ var Foo = function Foo() {
     "use strict";
     _classCallCheck(this, Foo);
 };
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -38,7 +38,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -49,7 +49,7 @@ var FooIterator = /*#__PURE__*/ function() {
 v;
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new FooIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new FooIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
     }
 } catch (err) {
@@ -57,8 +57,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of22_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of22_es5.2.minified.js
@@ -10,7 +10,7 @@ function _defineProperties(target, props) {
 var Foo = function() {
     "use strict";
     _classCallCheck(this, Foo);
-}, tmp = Symbol.iterator, FooIterator = function() {
+}, _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -27,7 +27,7 @@ var Foo = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -35,12 +35,12 @@ var Foo = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), FooIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new FooIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator1 = (new FooIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of23_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of23_es2015.1.normal.js
@@ -1,7 +1,7 @@
 //@target: ES6
 class Foo {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -9,7 +9,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of23_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of23_es2015.2.minified.js
@@ -1,6 +1,6 @@
 class Foo {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 for (const v of new class {
     next() {
         return {
@@ -8,7 +8,7 @@ for (const v of new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of23_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of23_es5.1.normal.js
@@ -21,7 +21,7 @@ var Foo = function Foo() {
     "use strict";
     _classCallCheck(this, Foo);
 };
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -38,7 +38,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -48,7 +48,7 @@ var FooIterator = /*#__PURE__*/ function() {
 }();
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new FooIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new FooIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
         var v1 = 0; // new scope
     }
@@ -57,8 +57,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of23_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of23_es5.2.minified.js
@@ -10,7 +10,7 @@ function _defineProperties(target, props) {
 var Foo = function() {
     "use strict";
     _classCallCheck(this, Foo);
-}, tmp = Symbol.iterator, FooIterator = function() {
+}, _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -27,7 +27,7 @@ var Foo = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -35,12 +35,12 @@ var Foo = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), FooIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new FooIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator1 = (new FooIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of25_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of25_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class StringIterator {
-    [tmp]() {
+    [_iterator]() {
         return x;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of25_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of25_es2015.2.minified.js
@@ -1,6 +1,7 @@
-var x, tmp = Symbol.iterator;
+var x;
+let _iterator = Symbol.iterator;
 for (var v of new class {
-    [tmp]() {
+    [_iterator]() {
         return x;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of25_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of25_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var StringIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,7 +26,7 @@ var StringIterator = //@target: ES6
     }
     _createClass(StringIterator, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return x;
             }
@@ -37,7 +37,7 @@ var StringIterator = //@target: ES6
 var x;
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
     }
 } catch (err) {
@@ -45,8 +45,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of25_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of25_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, StringIterator = function() {
+var _iterator = Symbol.iterator, StringIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function StringIterator() {
@@ -14,7 +14,7 @@ var tmp = Symbol.iterator, StringIterator = function() {
     }
     return Constructor = StringIterator, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return x;
             }
@@ -22,12 +22,12 @@ var tmp = Symbol.iterator, StringIterator = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), StringIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var x, _step, _iterator = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var x, _step, _iterator1 = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of26_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of26_es2015.1.normal.js
@@ -1,10 +1,10 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class StringIterator {
     next() {
         return x;
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of26_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of26_es2015.2.minified.js
@@ -1,9 +1,10 @@
-var x, tmp = Symbol.iterator;
+var x;
+let _iterator = Symbol.iterator;
 for (var v of new class {
     next() {
         return x;
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of26_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of26_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var StringIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -32,7 +32,7 @@ var StringIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -43,7 +43,7 @@ var StringIterator = //@target: ES6
 var x;
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
     }
 } catch (err) {
@@ -51,8 +51,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of26_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of26_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, StringIterator = function() {
+var _iterator = Symbol.iterator, StringIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function StringIterator() {
@@ -20,7 +20,7 @@ var tmp = Symbol.iterator, StringIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -28,12 +28,12 @@ var tmp = Symbol.iterator, StringIterator = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), StringIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var x, _step, _iterator = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var x, _step, _iterator1 = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of28_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of28_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class StringIterator {
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of28_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of28_es2015.2.minified.js
@@ -1,6 +1,6 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 for (var v of new class {
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of28_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of28_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var StringIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,7 +26,7 @@ var StringIterator = //@target: ES6
     }
     _createClass(StringIterator, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -36,7 +36,7 @@ var StringIterator = //@target: ES6
 }();
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
     }
 } catch (err) {
@@ -44,8 +44,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of28_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of28_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, StringIterator = function() {
+var _iterator = Symbol.iterator, StringIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function StringIterator() {
@@ -14,7 +14,7 @@ var tmp = Symbol.iterator, StringIterator = function() {
     }
     return Constructor = StringIterator, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -22,12 +22,12 @@ var tmp = Symbol.iterator, StringIterator = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), StringIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator1 = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of30_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of30_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class StringIterator {
     next() {
@@ -7,7 +7,7 @@ class StringIterator {
             value: ""
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
     constructor(){

--- a/crates/swc/tests/tsc-references/for-of30_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of30_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 for (var v of new class {
     next() {
         return {
@@ -6,7 +6,7 @@ for (var v of new class {
             value: ""
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
     constructor(){

--- a/crates/swc/tests/tsc-references/for-of30_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of30_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var StringIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -36,7 +36,7 @@ var StringIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -46,7 +46,7 @@ var StringIterator = //@target: ES6
 }();
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
     }
 } catch (err) {
@@ -54,8 +54,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of30_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of30_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, StringIterator = function() {
+var _iterator = Symbol.iterator, StringIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function StringIterator() {
@@ -23,7 +23,7 @@ var tmp = Symbol.iterator, StringIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -31,12 +31,12 @@ var tmp = Symbol.iterator, StringIterator = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), StringIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator1 = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of31_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of31_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class StringIterator {
     next() {
@@ -7,7 +7,7 @@ class StringIterator {
             value: ""
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of31_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of31_es2015.2.minified.js
@@ -1,11 +1,11 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 for (var v of new class {
     next() {
         return {
             value: ""
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of31_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of31_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var StringIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -35,7 +35,7 @@ var StringIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -45,7 +45,7 @@ var StringIterator = //@target: ES6
 }();
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
     }
 } catch (err) {
@@ -53,8 +53,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of31_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of31_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, StringIterator = function() {
+var _iterator = Symbol.iterator, StringIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function StringIterator() {
@@ -22,7 +22,7 @@ var tmp = Symbol.iterator, StringIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -30,12 +30,12 @@ var tmp = Symbol.iterator, StringIterator = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), StringIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator1 = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)_step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of33_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of33_es2015.1.normal.js
@@ -1,8 +1,8 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 //@noImplicitAny: true
 class StringIterator {
-    [tmp]() {
+    [_iterator]() {
         return v;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of33_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of33_es2015.2.minified.js
@@ -1,6 +1,6 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 for (var v of new class {
-    [tmp]() {
+    [_iterator]() {
         return v;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of33_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of33_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var StringIterator = //@target: ES6
 //@noImplicitAny: true
 /*#__PURE__*/ function() {
@@ -27,7 +27,7 @@ var StringIterator = //@target: ES6
     }
     _createClass(StringIterator, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return v;
             }
@@ -37,7 +37,7 @@ var StringIterator = //@target: ES6
 }();
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
     }
 } catch (err) {
@@ -45,8 +45,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of33_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of33_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, StringIterator = function() {
+var _iterator = Symbol.iterator, StringIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function StringIterator() {
@@ -14,7 +14,7 @@ var tmp = Symbol.iterator, StringIterator = function() {
     }
     return Constructor = StringIterator, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return v;
             }
@@ -22,12 +22,12 @@ var tmp = Symbol.iterator, StringIterator = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), StringIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)var v = _step.value;
+    for(var _step, _iterator1 = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)var v = _step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of34_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of34_es2015.1.normal.js
@@ -1,11 +1,11 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 //@noImplicitAny: true
 class StringIterator {
     next() {
         return v;
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of34_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of34_es2015.2.minified.js
@@ -1,9 +1,9 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 for (var v of new class {
     next() {
         return v;
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of34_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of34_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var StringIterator = //@target: ES6
 //@noImplicitAny: true
 /*#__PURE__*/ function() {
@@ -33,7 +33,7 @@ var StringIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -43,7 +43,7 @@ var StringIterator = //@target: ES6
 }();
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
     }
 } catch (err) {
@@ -51,8 +51,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of34_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of34_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, StringIterator = function() {
+var _iterator = Symbol.iterator, StringIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function StringIterator() {
@@ -20,7 +20,7 @@ var tmp = Symbol.iterator, StringIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -28,12 +28,12 @@ var tmp = Symbol.iterator, StringIterator = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), StringIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)var v = _step.value;
+    for(var _step, _iterator1 = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)var v = _step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/for-of35_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of35_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 //@noImplicitAny: true
 class StringIterator {
@@ -8,7 +8,7 @@ class StringIterator {
             value: v
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/for-of35_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of35_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 for (var v of new class {
     next() {
         return {
@@ -6,7 +6,7 @@ for (var v of new class {
             value: v
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/for-of35_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of35_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var StringIterator = //@target: ES6
 //@noImplicitAny: true
 /*#__PURE__*/ function() {
@@ -36,7 +36,7 @@ var StringIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -46,7 +46,7 @@ var StringIterator = //@target: ES6
 }();
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator1 = (new StringIterator)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = true){
         var v = _step.value;
     }
 } catch (err) {
@@ -54,8 +54,8 @@ try {
     _iteratorError = err;
 } finally{
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        if (!_iteratorNormalCompletion && _iterator1.return != null) {
+            _iterator1.return();
         }
     } finally{
         if (_didIteratorError) {

--- a/crates/swc/tests/tsc-references/for-of35_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of35_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, StringIterator = function() {
+var _iterator = Symbol.iterator, StringIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function StringIterator() {
@@ -23,7 +23,7 @@ var tmp = Symbol.iterator, StringIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
@@ -31,12 +31,12 @@ var tmp = Symbol.iterator, StringIterator = function() {
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), StringIterator;
 }(), _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)var v = _step.value;
+    for(var _step, _iterator1 = (new StringIterator)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator1.next()).done); _iteratorNormalCompletion = !0)var v = _step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
+        _iteratorNormalCompletion || null == _iterator1.return || _iterator1.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
     }

--- a/crates/swc/tests/tsc-references/generatorTypeCheck56_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/generatorTypeCheck56_es2015.1.normal.js
@@ -1,12 +1,9 @@
 //@target: ES6
 function* g() {
-    var x = function() {
-        var tmp = yield 0;
-        class C {
-            *[tmp]() {
-                yield 0;
-            }
+    let tmp;
+    var x = (tmp = yield 0, class C {
+        *[tmp]() {
+            yield 0;
         }
-        return C;
-    }();
+    });
 }

--- a/crates/swc/tests/tsc-references/generatorTypeCheck56_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/generatorTypeCheck56_es5.1.normal.js
@@ -21,39 +21,40 @@ import regeneratorRuntime from "regenerator-runtime";
 var _marked = regeneratorRuntime.mark(g);
 //@target: ES6
 function g() {
-    var x;
+    var tmp, x;
     return regeneratorRuntime.wrap(function g$(_ctx1) {
         while(1)switch(_ctx1.prev = _ctx1.next){
             case 0:
-                x = (function() {
-                    var tmp = yield 0;
-                    var C = /*#__PURE__*/ function() {
-                        "use strict";
-                        function C() {
-                            _classCallCheck(this, C);
+                ;
+                _ctx1.next = 3;
+                return 0;
+            case 3:
+                tmp = _ctx1.sent;
+                x = (0, /*#__PURE__*/ (function() {
+                    "use strict";
+                    function C() {
+                        _classCallCheck(this, C);
+                    }
+                    _createClass(C, [
+                        {
+                            key: tmp,
+                            value: regeneratorRuntime.mark(function value() {
+                                return regeneratorRuntime.wrap(function value$(_ctx) {
+                                    while(1)switch(_ctx.prev = _ctx.next){
+                                        case 0:
+                                            _ctx.next = 2;
+                                            return 0;
+                                        case 2:
+                                        case "end":
+                                            return _ctx.stop();
+                                    }
+                                }, value);
+                            })
                         }
-                        _createClass(C, [
-                            {
-                                key: tmp,
-                                value: regeneratorRuntime.mark(function value() {
-                                    return regeneratorRuntime.wrap(function value$(_ctx) {
-                                        while(1)switch(_ctx.prev = _ctx.next){
-                                            case 0:
-                                                _ctx.next = 2;
-                                                return 0;
-                                            case 2:
-                                            case "end":
-                                                return _ctx.stop();
-                                        }
-                                    }, value);
-                                })
-                            }
-                        ]);
-                        return C;
-                    }();
+                    ]);
                     return C;
-                })();
-            case 1:
+                })());
+            case 5:
             case "end":
                 return _ctx1.stop();
         }

--- a/crates/swc/tests/tsc-references/generatorTypeCheck56_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/generatorTypeCheck56_es5.2.minified.js
@@ -12,36 +12,35 @@ function _createClass(Constructor, protoProps, staticProps) {
 }
 import regeneratorRuntime from "regenerator-runtime";
 var _marked = regeneratorRuntime.mark(function() {
-    var x;
+    var tmp, x;
     return regeneratorRuntime.wrap(function(_ctx1) {
         for(;;)switch(_ctx1.prev = _ctx1.next){
             case 0:
-                x = (function() {
-                    var tmp = yield 0, C = function() {
-                        "use strict";
-                        function C() {
-                            _classCallCheck(this, C);
+                return _ctx1.next = 3, 0;
+            case 3:
+                tmp = _ctx1.sent, x = (function() {
+                    "use strict";
+                    function C() {
+                        _classCallCheck(this, C);
+                    }
+                    return _createClass(C, [
+                        {
+                            key: tmp,
+                            value: regeneratorRuntime.mark(function value() {
+                                return regeneratorRuntime.wrap(function(_ctx) {
+                                    for(;;)switch(_ctx.prev = _ctx.next){
+                                        case 0:
+                                            return _ctx.next = 2, 0;
+                                        case 2:
+                                        case "end":
+                                            return _ctx.stop();
+                                    }
+                                }, value);
+                            })
                         }
-                        return _createClass(C, [
-                            {
-                                key: tmp,
-                                value: regeneratorRuntime.mark(function value() {
-                                    return regeneratorRuntime.wrap(function(_ctx) {
-                                        for(;;)switch(_ctx.prev = _ctx.next){
-                                            case 0:
-                                                return _ctx.next = 2, 0;
-                                            case 2:
-                                            case "end":
-                                                return _ctx.stop();
-                                        }
-                                    }, value);
-                                })
-                            }
-                        ]), C;
-                    }();
-                    return C;
+                    ]), C;
                 })();
-            case 1:
+            case 5:
             case "end":
                 return _ctx1.stop();
         }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern10_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern10_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern10_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern10_es5.1.normal.js
@@ -143,7 +143,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -160,7 +160,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern10_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern10_es5.2.minified.js
@@ -61,7 +61,7 @@ var Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -78,7 +78,7 @@ var Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern11_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern11_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern11_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern11_es2015.2.minified.js
@@ -2,7 +2,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -10,7 +10,7 @@ class FooIterator {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern11_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern11_es5.1.normal.js
@@ -143,7 +143,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -160,7 +160,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern11_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern11_es5.2.minified.js
@@ -61,7 +61,7 @@ var Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -78,7 +78,7 @@ var Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern12_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern12_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern12_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern12_es2015.2.minified.js
@@ -2,7 +2,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -10,7 +10,7 @@ class FooIterator {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern12_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern12_es5.1.normal.js
@@ -122,7 +122,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -139,7 +139,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern12_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern12_es5.2.minified.js
@@ -61,7 +61,7 @@ var Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -78,7 +78,7 @@ var Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern13_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern13_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern13_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern13_es5.1.normal.js
@@ -122,7 +122,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -139,7 +139,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern13_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern13_es5.2.minified.js
@@ -61,7 +61,7 @@ var Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -78,7 +78,7 @@ var Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern14_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern14_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern14_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern14_es5.1.normal.js
@@ -122,7 +122,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -139,7 +139,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern14_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern14_es5.2.minified.js
@@ -61,7 +61,7 @@ var Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -78,7 +78,7 @@ var Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern15_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern15_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern15_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern15_es5.1.normal.js
@@ -155,7 +155,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -172,7 +172,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern15_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern15_es5.2.minified.js
@@ -69,7 +69,7 @@ var Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -86,7 +86,7 @@ var Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern16_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern16_es2015.1.normal.js
@@ -5,7 +5,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -13,11 +13,11 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }
-var tmp1 = Symbol.iterator;
+let _iterator1 = Symbol.iterator;
 class FooIteratorIterator {
     next() {
         return {
@@ -25,7 +25,7 @@ class FooIteratorIterator {
             done: false
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern16_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern16_es2015.2.minified.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,11 +11,11 @@ class FooIterator {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }
-var tmp1 = Symbol.iterator;
+let _iterator1 = Symbol.iterator;
 class FooIteratorIterator {
     next() {
         return {
@@ -23,7 +23,7 @@ class FooIteratorIterator {
             done: !1
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern16_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern16_es5.1.normal.js
@@ -163,7 +163,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -180,7 +180,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -188,7 +188,7 @@ var FooIterator = /*#__PURE__*/ function() {
     ]);
     return FooIterator;
 }();
-var tmp1 = Symbol.iterator;
+var _iterator1 = Symbol.iterator;
 var FooIteratorIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIteratorIterator() {
@@ -205,7 +205,7 @@ var FooIteratorIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern16_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern16_es5.2.minified.js
@@ -106,7 +106,7 @@ var Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     function FooIterator() {
         _classCallCheck(this, FooIterator);
@@ -122,13 +122,13 @@ var Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
         }
     ]), FooIterator;
-}(), tmp1 = Symbol.iterator, FooIteratorIterator = function() {
+}(), _iterator1 = Symbol.iterator, FooIteratorIterator = function() {
     "use strict";
     function FooIteratorIterator() {
         _classCallCheck(this, FooIteratorIterator);
@@ -144,7 +144,7 @@ var Bar = function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern17_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern17_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern17_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern17_es5.1.normal.js
@@ -143,7 +143,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -160,7 +160,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern17_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern17_es5.2.minified.js
@@ -61,7 +61,7 @@ var Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -78,7 +78,7 @@ var Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern18_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern18_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern18_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern18_es5.1.normal.js
@@ -143,7 +143,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -160,7 +160,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern18_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern18_es5.2.minified.js
@@ -61,7 +61,7 @@ var Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -78,7 +78,7 @@ var Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern19_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern19_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooArrayIterator {
     next() {
         return {
@@ -13,7 +13,7 @@ class FooArrayIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern19_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern19_es5.1.normal.js
@@ -143,7 +143,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooArrayIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooArrayIterator() {
@@ -162,7 +162,7 @@ var FooArrayIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern19_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern19_es5.2.minified.js
@@ -93,7 +93,7 @@ var Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooArrayIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooArrayIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooArrayIterator() {
@@ -112,7 +112,7 @@ var Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern1_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern1_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class SymbolIterator {
     next() {
@@ -7,7 +7,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern1_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern1_es2015.2.minified.js
@@ -1,11 +1,12 @@
-var tmp = Symbol.iterator, [a, b] = new class {
+let _iterator = Symbol.iterator;
+var [a, b] = new class {
     next() {
         return {
             value: Symbol(),
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iterableArrayPattern1_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern1_es5.1.normal.js
@@ -63,7 +63,7 @@ function _unsupportedIterableToArray(o, minLen) {
     if (n === "Map" || n === "Set") return Array.from(n);
     if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -81,7 +81,7 @@ var SymbolIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern1_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern1_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -28,7 +28,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern20_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern20_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooArrayIterator {
     next() {
         return {
@@ -13,7 +13,7 @@ class FooArrayIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern20_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern20_es5.1.normal.js
@@ -155,7 +155,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooArrayIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooArrayIterator() {
@@ -174,7 +174,7 @@ var FooArrayIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -186,7 +186,7 @@ function fun() {
     for(var _len = arguments.length, _tmp = new Array(_len), _key = 0; _key < _len; _key++){
         _tmp[_key] = arguments[_key];
     }
-    var __tmp = _slicedToArray(_tmp, 2), ref = _slicedToArray(__tmp[0], 1), tmp2 = ref[0], a = tmp2 === void 0 ? new Foo : tmp2, tmp1 = __tmp[1], b = tmp1 === void 0 ? [
+    var __tmp = _slicedToArray(_tmp, 2), ref = _slicedToArray(__tmp[0], 1), tmp = ref[0], a = tmp === void 0 ? new Foo : tmp, tmp1 = __tmp[1], b = tmp1 === void 0 ? [
         new Foo
     ] : tmp1;
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern20_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern20_es5.2.minified.js
@@ -93,7 +93,7 @@ var Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooArrayIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooArrayIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooArrayIterator() {
@@ -112,7 +112,7 @@ var Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern2_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern2_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class SymbolIterator {
     next() {
@@ -7,7 +7,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern2_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern2_es2015.2.minified.js
@@ -1,11 +1,12 @@
-var tmp = Symbol.iterator, [a, ...b] = new class {
+let _iterator = Symbol.iterator;
+var [a, ...b] = new class {
     next() {
         return {
             value: Symbol(),
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iterableArrayPattern2_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern2_es5.1.normal.js
@@ -42,7 +42,7 @@ function _unsupportedIterableToArray(o, minLen) {
     if (n === "Map" || n === "Set") return Array.from(n);
     if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -60,7 +60,7 @@ var SymbolIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern2_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern2_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -28,7 +28,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern3_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern3_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern3_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern3_es2015.2.minified.js
@@ -1,8 +1,9 @@
+var a, b;
 class Bar {
 }
 class Foo extends Bar {
 }
-var a, b, tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 [a, b] = new class {
     next() {
         return {
@@ -10,7 +11,7 @@ var a, b, tmp = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iterableArrayPattern3_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern3_es5.1.normal.js
@@ -143,7 +143,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -160,7 +160,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern3_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern3_es5.2.minified.js
@@ -61,7 +61,7 @@ var ref, Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -78,7 +78,7 @@ var ref, Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern4_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern4_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern4_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern4_es2015.2.minified.js
@@ -1,8 +1,9 @@
+var a, b;
 class Bar {
 }
 class Foo extends Bar {
 }
-var a, b, tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 [a, ...b] = new class {
     next() {
         return {
@@ -10,7 +11,7 @@ var a, b, tmp = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iterableArrayPattern4_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern4_es5.1.normal.js
@@ -122,7 +122,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -139,7 +139,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern4_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern4_es5.2.minified.js
@@ -61,7 +61,7 @@ var ref, Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -78,7 +78,7 @@ var ref, Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern5_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern5_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern5_es2015.2.minified.js
@@ -1,8 +1,9 @@
+var a, b;
 class Bar {
 }
 class Foo extends Bar {
 }
-var a, b, tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 [a, b] = new class {
     next() {
         return {
@@ -10,7 +11,7 @@ var a, b, tmp = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iterableArrayPattern5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern5_es5.1.normal.js
@@ -143,7 +143,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -160,7 +160,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern5_es5.2.minified.js
@@ -61,7 +61,7 @@ var ref, Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -78,7 +78,7 @@ var ref, Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern6_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern6_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern6_es2015.2.minified.js
@@ -1,8 +1,9 @@
+var a, b;
 class Bar {
 }
 class Foo extends Bar {
 }
-var a, b, tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 [a, ...b] = new class {
     next() {
         return {
@@ -10,7 +11,7 @@ var a, b, tmp = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iterableArrayPattern6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern6_es5.1.normal.js
@@ -122,7 +122,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -139,7 +139,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern6_es5.2.minified.js
@@ -61,7 +61,7 @@ var ref, Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -78,7 +78,7 @@ var ref, Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern7_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern7_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern7_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern7_es2015.2.minified.js
@@ -1,8 +1,9 @@
+var a, b;
 class Bar {
 }
 class Foo extends Bar {
 }
-var a, b, tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 [a, b] = new class {
     next() {
         return {
@@ -10,7 +11,7 @@ var a, b, tmp = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iterableArrayPattern7_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern7_es5.1.normal.js
@@ -143,7 +143,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -160,7 +160,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern7_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern7_es5.2.minified.js
@@ -61,7 +61,7 @@ var ref, Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -78,7 +78,7 @@ var ref, Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern8_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern8_es2015.1.normal.js
@@ -3,7 +3,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -11,7 +11,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern8_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern8_es2015.2.minified.js
@@ -1,8 +1,9 @@
+var a, b;
 class Bar {
 }
 class Foo extends Bar {
 }
-var a, b, tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 [a, ...b] = new class {
     next() {
         return {
@@ -10,7 +11,7 @@ var a, b, tmp = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iterableArrayPattern8_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern8_es5.1.normal.js
@@ -122,7 +122,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -139,7 +139,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern8_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern8_es5.2.minified.js
@@ -61,7 +61,7 @@ var ref, Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -78,7 +78,7 @@ var ref, Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern9_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern9_es2015.1.normal.js
@@ -4,7 +4,7 @@ class Bar {
 }
 class Foo extends Bar {
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class FooIterator {
     next() {
         return {
@@ -12,7 +12,7 @@ class FooIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern9_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern9_es5.1.normal.js
@@ -147,7 +147,7 @@ var Foo = /*#__PURE__*/ function(Bar) {
     }
     return Foo;
 }(Bar);
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var FooIterator = /*#__PURE__*/ function() {
     "use strict";
     function FooIterator() {
@@ -164,7 +164,7 @@ var FooIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iterableArrayPattern9_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iterableArrayPattern9_es5.2.minified.js
@@ -56,7 +56,7 @@ var Bar = function() {
         return _classCallCheck(this, Foo), _super.apply(this, arguments);
     }
     return Foo;
-}(Bar), tmp = Symbol.iterator, FooIterator = function() {
+}(Bar), _iterator = Symbol.iterator, FooIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function FooIterator() {
@@ -73,7 +73,7 @@ var Bar = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray10_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray10_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class SymbolIterator {
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray10_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray10_es5.1.normal.js
@@ -42,7 +42,7 @@ function _unsupportedIterableToArray(o, minLen) {
     if (n === "Map" || n === "Set") return Array.from(n);
     if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -51,7 +51,7 @@ var SymbolIterator = //@target: ES6
     }
     _createClass(SymbolIterator, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray10_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray10_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -19,7 +19,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
     }
     return Constructor = SymbolIterator, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray2_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray2_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class SymbolIterator {
     next() {
@@ -7,11 +7,11 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }
-var tmp1 = Symbol.iterator;
+let _iterator1 = Symbol.iterator;
 class NumberIterator {
     next() {
         return {
@@ -19,7 +19,7 @@ class NumberIterator {
             done: false
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray2_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray2_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
+let _iterator = Symbol.iterator, _iterator1 = Symbol.iterator;
 new class {
     next() {
         return {
@@ -6,7 +6,7 @@ new class {
             done: !1
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 }, new class {
@@ -16,7 +16,7 @@ new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray2_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray2_es5.1.normal.js
@@ -42,7 +42,7 @@ function _unsupportedIterableToArray(o, minLen) {
     if (n === "Map" || n === "Set") return Array.from(n);
     if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -60,7 +60,7 @@ var SymbolIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -68,7 +68,7 @@ var SymbolIterator = //@target: ES6
     ]);
     return SymbolIterator;
 }();
-var tmp1 = Symbol.iterator;
+var _iterator1 = Symbol.iterator;
 var NumberIterator = /*#__PURE__*/ function() {
     "use strict";
     function NumberIterator() {
@@ -85,7 +85,7 @@ var NumberIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray2_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray2_es5.2.minified.js
@@ -32,7 +32,7 @@ function _unsupportedIterableToArray(o, minLen) {
         if ("Arguments" === n || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     function SymbolIterator() {
         _classCallCheck(this, SymbolIterator);
@@ -48,13 +48,13 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
         }
     ]), SymbolIterator;
-}(), tmp1 = Symbol.iterator, NumberIterator = function() {
+}(), _iterator1 = Symbol.iterator, NumberIterator = function() {
     "use strict";
     function NumberIterator() {
         _classCallCheck(this, NumberIterator);
@@ -70,7 +70,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray3_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray3_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class SymbolIterator {
     next() {
@@ -7,7 +7,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray3_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray3_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 new class {
     next() {
         return {
@@ -6,7 +6,7 @@ new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray3_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray3_es5.1.normal.js
@@ -42,7 +42,7 @@ function _unsupportedIterableToArray(o, minLen) {
     if (n === "Map" || n === "Set") return Array.from(n);
     if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -60,7 +60,7 @@ var SymbolIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray3_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray3_es5.2.minified.js
@@ -26,7 +26,7 @@ function _unsupportedIterableToArray(o, minLen) {
         if ("Arguments" === n || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -45,7 +45,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray4_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray4_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class SymbolIterator {
     next() {
@@ -7,7 +7,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray4_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray4_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 new class {
     next() {
         return {
@@ -6,7 +6,7 @@ new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray4_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray4_es5.1.normal.js
@@ -42,7 +42,7 @@ function _unsupportedIterableToArray(o, minLen) {
     if (n === "Map" || n === "Set") return Array.from(n);
     if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -60,7 +60,7 @@ var SymbolIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray4_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray4_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -28,7 +28,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray5_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class SymbolIterator {
     next() {
@@ -7,7 +7,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray5_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray5_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 new class {
     next() {
         return {
@@ -6,7 +6,7 @@ new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray5_es5.1.normal.js
@@ -42,7 +42,7 @@ function _unsupportedIterableToArray(o, minLen) {
     if (n === "Map" || n === "Set") return Array.from(n);
     if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -60,7 +60,7 @@ var SymbolIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray5_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -28,7 +28,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray6_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class SymbolIterator {
     next() {
@@ -7,7 +7,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray6_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray6_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 [
     0,
     1
@@ -10,7 +10,7 @@ var tmp = Symbol.iterator;
                 done: !1
             };
         }
-        [tmp]() {
+        [_iterator]() {
             return this;
         }
     }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray6_es5.1.normal.js
@@ -42,7 +42,7 @@ function _unsupportedIterableToArray(o, minLen) {
     if (n === "Map" || n === "Set") return Array.from(n);
     if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -60,7 +60,7 @@ var SymbolIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray6_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -28,7 +28,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray7_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray7_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class SymbolIterator {
     next() {
@@ -7,7 +7,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray7_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray7_es2015.2.minified.js
@@ -1,4 +1,5 @@
-var array, tmp = Symbol.iterator;
+var array;
+let _iterator = Symbol.iterator;
 array.concat([
     ...new class {
         next() {
@@ -7,7 +8,7 @@ array.concat([
                 done: !1
             };
         }
-        [tmp]() {
+        [_iterator]() {
             return this;
         }
     }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray7_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray7_es5.1.normal.js
@@ -42,7 +42,7 @@ function _unsupportedIterableToArray(o, minLen) {
     if (n === "Map" || n === "Set") return Array.from(n);
     if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -60,7 +60,7 @@ var SymbolIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray7_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray7_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var array, tmp = Symbol.iterator, SymbolIterator = function() {
+var array, _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -28,7 +28,7 @@ var array, tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray9_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray9_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class SymbolIterator {
     next() {
@@ -6,7 +6,7 @@ class SymbolIterator {
             value: Symbol()
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray9_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray9_es2015.2.minified.js
@@ -1,11 +1,11 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 new class {
     next() {
         return {
             value: Symbol()
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray9_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray9_es5.1.normal.js
@@ -42,7 +42,7 @@ function _unsupportedIterableToArray(o, minLen) {
     if (n === "Map" || n === "Set") return Array.from(n);
     if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -59,7 +59,7 @@ var SymbolIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray9_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray9_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -27,7 +27,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class SymbolIterator {
     next() {
@@ -7,7 +7,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 new class {
     next() {
         return {
@@ -6,7 +6,7 @@ new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 };

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray_es5.1.normal.js
@@ -42,7 +42,7 @@ function _unsupportedIterableToArray(o, minLen) {
     if (n === "Map" || n === "Set") return Array.from(n);
     if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -60,7 +60,7 @@ var SymbolIterator = //@target: ES6
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInArray_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInArray_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -28,7 +28,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall10_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall10_es2015.1.normal.js
@@ -2,7 +2,7 @@
 function foo(s) {
     return s[0];
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class SymbolIterator {
     next() {
         return {
@@ -10,7 +10,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall10_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall10_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 !function(s) {
     return s[0];
 }(...new class {
@@ -8,7 +8,7 @@ var tmp = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall10_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall10_es5.1.normal.js
@@ -46,7 +46,7 @@ function _unsupportedIterableToArray(o, minLen) {
 function foo(s) {
     return s[0];
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = /*#__PURE__*/ function() {
     "use strict";
     function SymbolIterator() {
@@ -63,7 +63,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall10_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall10_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -28,7 +28,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall11_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall11_es2015.1.normal.js
@@ -2,7 +2,7 @@
 function foo(...s) {
     return s[0];
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class SymbolIterator {
     next() {
         return {
@@ -10,7 +10,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall11_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall11_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 !function(...s) {
     return s[0];
 }(...new class {
@@ -8,7 +8,7 @@ var tmp = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall11_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall11_es5.1.normal.js
@@ -49,7 +49,7 @@ function foo() {
     }
     return s[0];
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = /*#__PURE__*/ function() {
     "use strict";
     function SymbolIterator() {
@@ -66,7 +66,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall11_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall11_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -28,7 +28,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall12_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall12_es2015.1.normal.js
@@ -2,7 +2,7 @@
 class Foo {
     constructor(...s){}
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class SymbolIterator {
     next() {
         return {
@@ -10,11 +10,11 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }
-var tmp1 = Symbol.iterator;
+let _iterator1 = Symbol.iterator;
 class _StringIterator {
     next() {
         return {
@@ -22,7 +22,7 @@ class _StringIterator {
             done: false
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall12_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall12_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
+let _iterator = Symbol.iterator, _iterator1 = Symbol.iterator;
 new class {
     constructor(...s){}
 }(...[
@@ -9,7 +9,7 @@ new class {
                 done: !1
             };
         }
-        [tmp]() {
+        [_iterator]() {
             return this;
         }
     },
@@ -20,7 +20,7 @@ new class {
                 done: !1
             };
         }
-        [tmp1]() {
+        [_iterator1]() {
             return this;
         }
     }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall12_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall12_es5.1.normal.js
@@ -84,7 +84,7 @@ var Foo = function Foo() {
     }
     _classCallCheck(this, Foo);
 };
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = /*#__PURE__*/ function() {
     "use strict";
     function SymbolIterator() {
@@ -101,7 +101,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -109,7 +109,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
     ]);
     return SymbolIterator;
 }();
-var tmp1 = Symbol.iterator;
+var _iterator1 = Symbol.iterator;
 var _StringIterator = /*#__PURE__*/ function() {
     "use strict";
     function _StringIterator() {
@@ -126,7 +126,7 @@ var _StringIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall12_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall12_es5.2.minified.js
@@ -60,7 +60,7 @@ var Foo = function() {
     "use strict";
     for(var _len = arguments.length, s = new Array(_len), _key = 0; _key < _len; _key++)s[_key] = arguments[_key];
     _classCallCheck(this, Foo);
-}, tmp = Symbol.iterator, SymbolIterator = function() {
+}, _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     function SymbolIterator() {
         _classCallCheck(this, SymbolIterator);
@@ -76,13 +76,13 @@ var Foo = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
         }
     ]), SymbolIterator;
-}(), tmp1 = Symbol.iterator, _StringIterator = function() {
+}(), _iterator1 = Symbol.iterator, _StringIterator = function() {
     "use strict";
     function _StringIterator() {
         _classCallCheck(this, _StringIterator);
@@ -98,7 +98,7 @@ var Foo = function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall2_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall2_es2015.1.normal.js
@@ -1,6 +1,6 @@
 //@target: ES6
 function foo(s) {}
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class SymbolIterator {
     next() {
         return {
@@ -8,7 +8,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall2_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall2_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 !function(s) {}(...new class {
     next() {
         return {
@@ -6,7 +6,7 @@ var tmp = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall2_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall2_es5.1.normal.js
@@ -44,7 +44,7 @@ function _unsupportedIterableToArray(o, minLen) {
 }
 //@target: ES6
 function foo(s) {}
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = /*#__PURE__*/ function() {
     "use strict";
     function SymbolIterator() {
@@ -61,7 +61,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall2_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall2_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -28,7 +28,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall3_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall3_es2015.1.normal.js
@@ -1,6 +1,6 @@
 //@target: ES6
 function foo(...s) {}
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class SymbolIterator {
     next() {
         return {
@@ -8,7 +8,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall3_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall3_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 !function(...s) {}(...new class {
     next() {
         return {
@@ -6,7 +6,7 @@ var tmp = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall3_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall3_es5.1.normal.js
@@ -48,7 +48,7 @@ function foo() {
         s[_key] = arguments[_key];
     }
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = /*#__PURE__*/ function() {
     "use strict";
     function SymbolIterator() {
@@ -65,7 +65,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall3_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall3_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -28,7 +28,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall4_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall4_es2015.1.normal.js
@@ -1,6 +1,6 @@
 //@target: ES6
 function foo(s1, ...s) {}
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class SymbolIterator {
     next() {
         return {
@@ -8,7 +8,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall4_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall4_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 !function(s1, ...s) {}(...new class {
     next() {
         return {
@@ -6,7 +6,7 @@ var tmp = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall4_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall4_es5.1.normal.js
@@ -48,7 +48,7 @@ function foo(s1) {
         s[_key - 1] = arguments[_key];
     }
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = /*#__PURE__*/ function() {
     "use strict";
     function SymbolIterator() {
@@ -65,7 +65,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall4_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall4_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -28,7 +28,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall5_es2015.1.normal.js
@@ -1,6 +1,6 @@
 //@target: ES6
 function foo(...s) {}
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class SymbolIterator {
     next() {
         return {
@@ -8,11 +8,11 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }
-var tmp1 = Symbol.iterator;
+let _iterator1 = Symbol.iterator;
 class _StringIterator {
     next() {
         return {
@@ -20,7 +20,7 @@ class _StringIterator {
             done: false
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall5_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall5_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
+let _iterator = Symbol.iterator, _iterator1 = Symbol.iterator;
 !function(...s) {}(...new class {
     next() {
         return {
@@ -6,7 +6,7 @@ var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }, ...new class {
@@ -16,7 +16,7 @@ var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
             done: !1
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall5_es5.1.normal.js
@@ -48,7 +48,7 @@ function foo() {
         s[_key] = arguments[_key];
     }
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = /*#__PURE__*/ function() {
     "use strict";
     function SymbolIterator() {
@@ -65,7 +65,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -73,7 +73,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
     ]);
     return SymbolIterator;
 }();
-var tmp1 = Symbol.iterator;
+var _iterator1 = Symbol.iterator;
 var _StringIterator = /*#__PURE__*/ function() {
     "use strict";
     function _StringIterator() {
@@ -90,7 +90,7 @@ var _StringIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall5_es5.2.minified.js
@@ -32,7 +32,7 @@ function _unsupportedIterableToArray(o, minLen) {
         if ("Arguments" === n || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     function SymbolIterator() {
         _classCallCheck(this, SymbolIterator);
@@ -48,13 +48,13 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
         }
     ]), SymbolIterator;
-}(), tmp1 = Symbol.iterator, _StringIterator = function() {
+}(), _iterator1 = Symbol.iterator, _StringIterator = function() {
     "use strict";
     function _StringIterator() {
         _classCallCheck(this, _StringIterator);
@@ -70,7 +70,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall6_es2015.1.normal.js
@@ -1,6 +1,6 @@
 //@target: ES6
 function foo(...s) {}
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class SymbolIterator {
     next() {
         return {
@@ -8,11 +8,11 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }
-var tmp1 = Symbol.iterator;
+let _iterator1 = Symbol.iterator;
 class _StringIterator {
     next() {
         return {
@@ -20,7 +20,7 @@ class _StringIterator {
             done: false
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall6_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall6_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
+let _iterator = Symbol.iterator, _iterator1 = Symbol.iterator;
 !function(...s) {}(...new class {
     next() {
         return {
@@ -6,7 +6,7 @@ var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }, ...new class {
@@ -16,7 +16,7 @@ var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
             done: !1
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall6_es5.1.normal.js
@@ -48,7 +48,7 @@ function foo() {
         s[_key] = arguments[_key];
     }
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = /*#__PURE__*/ function() {
     "use strict";
     function SymbolIterator() {
@@ -65,7 +65,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -73,7 +73,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
     ]);
     return SymbolIterator;
 }();
-var tmp1 = Symbol.iterator;
+var _iterator1 = Symbol.iterator;
 var _StringIterator = /*#__PURE__*/ function() {
     "use strict";
     function _StringIterator() {
@@ -90,7 +90,7 @@ var _StringIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall6_es5.2.minified.js
@@ -32,7 +32,7 @@ function _unsupportedIterableToArray(o, minLen) {
         if ("Arguments" === n || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     function SymbolIterator() {
         _classCallCheck(this, SymbolIterator);
@@ -48,13 +48,13 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
         }
     ]), SymbolIterator;
-}(), tmp1 = Symbol.iterator, _StringIterator = function() {
+}(), _iterator1 = Symbol.iterator, _StringIterator = function() {
     "use strict";
     function _StringIterator() {
         _classCallCheck(this, _StringIterator);
@@ -70,7 +70,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall7_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall7_es2015.1.normal.js
@@ -2,7 +2,7 @@
 function foo(...s) {
     return s[0];
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class SymbolIterator {
     next() {
         return {
@@ -10,11 +10,11 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }
-var tmp1 = Symbol.iterator;
+let _iterator1 = Symbol.iterator;
 class _StringIterator {
     next() {
         return {
@@ -22,7 +22,7 @@ class _StringIterator {
             done: false
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall7_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall7_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
+let _iterator = Symbol.iterator, _iterator1 = Symbol.iterator;
 !function(...s) {
     return s[0];
 }(...new class {
@@ -8,7 +8,7 @@ var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }, ...new class {
@@ -18,7 +18,7 @@ var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
             done: !1
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall7_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall7_es5.1.normal.js
@@ -49,7 +49,7 @@ function foo() {
     }
     return s[0];
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = /*#__PURE__*/ function() {
     "use strict";
     function SymbolIterator() {
@@ -66,7 +66,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -74,7 +74,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
     ]);
     return SymbolIterator;
 }();
-var tmp1 = Symbol.iterator;
+var _iterator1 = Symbol.iterator;
 var _StringIterator = /*#__PURE__*/ function() {
     "use strict";
     function _StringIterator() {
@@ -91,7 +91,7 @@ var _StringIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall7_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall7_es5.2.minified.js
@@ -32,7 +32,7 @@ function _unsupportedIterableToArray(o, minLen) {
         if ("Arguments" === n || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     function SymbolIterator() {
         _classCallCheck(this, SymbolIterator);
@@ -48,13 +48,13 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
         }
     ]), SymbolIterator;
-}(), tmp1 = Symbol.iterator, _StringIterator = function() {
+}(), _iterator1 = Symbol.iterator, _StringIterator = function() {
     "use strict";
     function _StringIterator() {
         _classCallCheck(this, _StringIterator);
@@ -70,7 +70,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall8_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall8_es2015.1.normal.js
@@ -2,7 +2,7 @@
 class Foo {
     constructor(...s){}
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class SymbolIterator {
     next() {
         return {
@@ -10,11 +10,11 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }
-var tmp1 = Symbol.iterator;
+let _iterator1 = Symbol.iterator;
 class _StringIterator {
     next() {
         return {
@@ -22,7 +22,7 @@ class _StringIterator {
             done: false
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall8_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall8_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
+let _iterator = Symbol.iterator, _iterator1 = Symbol.iterator;
 new class {
     constructor(...s){}
 }(...new class {
@@ -8,7 +8,7 @@ new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }, ...new class {
@@ -18,7 +18,7 @@ new class {
             done: !1
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall8_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall8_es5.1.normal.js
@@ -84,7 +84,7 @@ var Foo = function Foo() {
     }
     _classCallCheck(this, Foo);
 };
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = /*#__PURE__*/ function() {
     "use strict";
     function SymbolIterator() {
@@ -101,7 +101,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -109,7 +109,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
     ]);
     return SymbolIterator;
 }();
-var tmp1 = Symbol.iterator;
+var _iterator1 = Symbol.iterator;
 var _StringIterator = /*#__PURE__*/ function() {
     "use strict";
     function _StringIterator() {
@@ -126,7 +126,7 @@ var _StringIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall8_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall8_es5.2.minified.js
@@ -60,7 +60,7 @@ var Foo = function() {
     "use strict";
     for(var _len = arguments.length, s = new Array(_len), _key = 0; _key < _len; _key++)s[_key] = arguments[_key];
     _classCallCheck(this, Foo);
-}, tmp = Symbol.iterator, SymbolIterator = function() {
+}, _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     function SymbolIterator() {
         _classCallCheck(this, SymbolIterator);
@@ -76,13 +76,13 @@ var Foo = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
         }
     ]), SymbolIterator;
-}(), tmp1 = Symbol.iterator, _StringIterator = function() {
+}(), _iterator1 = Symbol.iterator, _StringIterator = function() {
     "use strict";
     function _StringIterator() {
         _classCallCheck(this, _StringIterator);
@@ -98,7 +98,7 @@ var Foo = function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall9_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall9_es2015.1.normal.js
@@ -2,7 +2,7 @@
 class Foo {
     constructor(...s){}
 }
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class SymbolIterator {
     next() {
         return {
@@ -10,11 +10,11 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }
-var tmp1 = Symbol.iterator;
+let _iterator1 = Symbol.iterator;
 class _StringIterator {
     next() {
         return {
@@ -22,7 +22,7 @@ class _StringIterator {
             done: false
         };
     }
-    [tmp1]() {
+    [_iterator1]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall9_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall9_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
+let _iterator = Symbol.iterator, _iterator1 = Symbol.iterator;
 new class {
     constructor(...s){}
 }(...new class {
@@ -8,7 +8,7 @@ new class {
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }, ...[
@@ -19,7 +19,7 @@ new class {
                 done: !1
             };
         }
-        [tmp1]() {
+        [_iterator1]() {
             return this;
         }
     }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall9_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall9_es5.1.normal.js
@@ -84,7 +84,7 @@ var Foo = function Foo() {
     }
     _classCallCheck(this, Foo);
 };
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = /*#__PURE__*/ function() {
     "use strict";
     function SymbolIterator() {
@@ -101,7 +101,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }
@@ -109,7 +109,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
     ]);
     return SymbolIterator;
 }();
-var tmp1 = Symbol.iterator;
+var _iterator1 = Symbol.iterator;
 var _StringIterator = /*#__PURE__*/ function() {
     "use strict";
     function _StringIterator() {
@@ -126,7 +126,7 @@ var _StringIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall9_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall9_es5.2.minified.js
@@ -60,7 +60,7 @@ var Foo = function() {
     "use strict";
     for(var _len = arguments.length, s = new Array(_len), _key = 0; _key < _len; _key++)s[_key] = arguments[_key];
     _classCallCheck(this, Foo);
-}, tmp = Symbol.iterator, SymbolIterator = function() {
+}, _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     function SymbolIterator() {
         _classCallCheck(this, SymbolIterator);
@@ -76,13 +76,13 @@ var Foo = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }
         }
     ]), SymbolIterator;
-}(), tmp1 = Symbol.iterator, _StringIterator = function() {
+}(), _iterator1 = Symbol.iterator, _StringIterator = function() {
     "use strict";
     function _StringIterator() {
         _classCallCheck(this, _StringIterator);
@@ -98,7 +98,7 @@ var Foo = function() {
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall_es2015.1.normal.js
@@ -1,6 +1,6 @@
 //@target: ES6
 function foo(s) {}
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 class SymbolIterator {
     next() {
         return {
@@ -8,7 +8,7 @@ class SymbolIterator {
             done: false
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall_es2015.2.minified.js
@@ -1,4 +1,4 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 !function(s) {}(...new class {
     next() {
         return {
@@ -6,7 +6,7 @@ var tmp = Symbol.iterator;
             done: !1
         };
     }
-    [tmp]() {
+    [_iterator]() {
         return this;
     }
 });

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall_es5.1.normal.js
@@ -44,7 +44,7 @@ function _unsupportedIterableToArray(o, minLen) {
 }
 //@target: ES6
 function foo(s) {}
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var SymbolIterator = /*#__PURE__*/ function() {
     "use strict";
     function SymbolIterator() {
@@ -61,7 +61,7 @@ var SymbolIterator = /*#__PURE__*/ function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function value() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/iteratorSpreadInCall_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/iteratorSpreadInCall_es5.2.minified.js
@@ -9,7 +9,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, SymbolIterator = function() {
+var _iterator = Symbol.iterator, SymbolIterator = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function SymbolIterator() {
@@ -28,7 +28,7 @@ var tmp = Symbol.iterator, SymbolIterator = function() {
             }
         },
         {
-            key: tmp,
+            key: _iterator,
             value: function() {
                 return this;
             }

--- a/crates/swc/tests/tsc-references/jsDeclarationsExportAssignedClassExpressionAnonymousWithSub_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/jsDeclarationsExportAssignedClassExpressionAnonymousWithSub_es2015.1.normal.js
@@ -4,14 +4,14 @@
 // @outDir: ./out
 // @declaration: true
 // @filename: index.js
-module.exports = class _class {
+module.exports = class {
     /**
      * @param {number} p
      */ constructor(p){
         this.t = 12 + p;
     }
 };
-module.exports.Sub = class _class {
+module.exports.Sub = class {
     constructor(){
         this.instance = new module.exports(10);
     }

--- a/crates/swc/tests/tsc-references/jsDeclarationsExportAssignedClassExpressionAnonymous_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/jsDeclarationsExportAssignedClassExpressionAnonymous_es2015.1.normal.js
@@ -4,7 +4,7 @@
 // @outDir: ./out
 // @declaration: true
 // @filename: index.js
-module.exports = class _class {
+module.exports = class {
     /**
      * @param {number} p
      */ constructor(p){

--- a/crates/swc/tests/tsc-references/mixinClassesAnonymous_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/mixinClassesAnonymous_es2015.1.normal.js
@@ -53,7 +53,7 @@ class Thing3 extends Thing2 {
 }
 // Repro from #13805
 const Timestamped = (Base1)=>{
-    return class _class extends Base1 {
+    return class extends Base1 {
         constructor(...args){
             super(...args);
             this.timestamp = new Date();

--- a/crates/swc/tests/tsc-references/moduleExportNestedNamespaces_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/moduleExportNestedNamespaces_es2015.1.normal.js
@@ -8,7 +8,7 @@ module.exports.n = {};
 module.exports.n.K = function C() {
     this.x = 10;
 };
-module.exports.Classic = class _class {
+module.exports.Classic = class {
     constructor(){
         this.p = 1;
     }

--- a/crates/swc/tests/tsc-references/override20_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/override20_es2015.1.normal.js
@@ -1,6 +1,6 @@
 // @target: esnext
 // @noImplicitOverride: true
-const Foo = class _class {
+const Foo = class {
     m1() {}
     m2() {}
 };

--- a/crates/swc/tests/tsc-references/parserComputedPropertyName12_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/parserComputedPropertyName12_es2015.1.normal.js
@@ -1,5 +1,5 @@
-var tmp = e;
+let _e = e;
 //@target: ES6
 class C {
-    [tmp]() {}
+    [_e]() {}
 }

--- a/crates/swc/tests/tsc-references/parserComputedPropertyName12_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/parserComputedPropertyName12_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = e;
+var _e = e;
 var C = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,7 +26,7 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _e,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/parserComputedPropertyName12_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/parserComputedPropertyName12_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = e, C = function() {
+var _e = e, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var tmp = e, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _e,
             value: function() {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/parserComputedPropertyName24_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/parserComputedPropertyName24_es2015.1.normal.js
@@ -1,5 +1,5 @@
-var tmp = e;
+let _e = e;
 //@target: ES6
 class C {
-    set [tmp](v) {}
+    set [_e](v) {}
 }

--- a/crates/swc/tests/tsc-references/parserComputedPropertyName24_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/parserComputedPropertyName24_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = e;
+var _e = e;
 var C = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,7 +26,7 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _e,
             set: function set(v) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/parserComputedPropertyName24_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/parserComputedPropertyName24_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = e, C = function() {
+var _e = e, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var tmp = e, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _e,
             set: function(v) {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/parserComputedPropertyName40_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/parserComputedPropertyName40_es2015.1.normal.js
@@ -1,4 +1,4 @@
-var tmp = a ? "" : "";
+let tmp = a ? "" : "";
 //@target: ES6
 class C {
     [tmp]() {}

--- a/crates/swc/tests/tsc-references/parserES5SymbolProperty7_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/parserES5SymbolProperty7_es2015.1.normal.js
@@ -1,5 +1,5 @@
-var tmp = Symbol.toStringTag;
+let _toStringTag = Symbol.toStringTag;
 //@target: ES5
 class C {
-    [tmp]() {}
+    [_toStringTag]() {}
 }

--- a/crates/swc/tests/tsc-references/parserES5SymbolProperty7_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/parserES5SymbolProperty7_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.toStringTag;
+var _toStringTag = Symbol.toStringTag;
 var C = //@target: ES5
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,7 +26,7 @@ var C = //@target: ES5
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/parserES5SymbolProperty7_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/parserES5SymbolProperty7_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.toStringTag, C = function() {
+var _toStringTag = Symbol.toStringTag, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var tmp = Symbol.toStringTag, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function() {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/parserSymbolProperty7_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/parserSymbolProperty7_es2015.1.normal.js
@@ -1,5 +1,5 @@
-var tmp = Symbol.toStringTag;
+let _toStringTag = Symbol.toStringTag;
 //@target: ES6
 class C {
-    [tmp]() {}
+    [_toStringTag]() {}
 }

--- a/crates/swc/tests/tsc-references/parserSymbolProperty7_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/parserSymbolProperty7_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.toStringTag;
+var _toStringTag = Symbol.toStringTag;
 var C = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,7 +26,7 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/parserSymbolProperty7_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/parserSymbolProperty7_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.toStringTag, C = function() {
+var _toStringTag = Symbol.toStringTag, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var tmp = Symbol.toStringTag, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function() {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/privateNameClassExpressionLoop_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameClassExpressionLoop_es2015.1.normal.js
@@ -14,26 +14,23 @@ function _classPrivateMethodInit(obj, privateSet) {
 // @target: es2015
 const array = [];
 for(let i = 0; i < 10; ++i){
-    array.push(function() {
-        var _myField = new WeakMap(), _method = new WeakSet(), _accessor = new WeakMap();
-        class C {
-            constructor(){
-                _classPrivateMethodInit(this, _method);
-                _classPrivateFieldInit(this, _accessor, {
-                    get: get_accessor,
-                    set: set_accessor
-                });
-                _classPrivateFieldInit(this, _myField, {
-                    writable: true,
-                    value: "hello"
-                });
-            }
+    var _myField, _method, _accessor, _C;
+    array.push((_myField = new WeakMap(), _method = new WeakSet(), _accessor = new WeakMap(), _C = class C {
+        constructor(){
+            _classPrivateMethodInit(this, _method);
+            _classPrivateFieldInit(this, _accessor, {
+                get: get_accessor,
+                set: set_accessor
+            });
+            _classPrivateFieldInit(this, _myField, {
+                writable: true,
+                value: "hello"
+            });
         }
-        function method() {}
-        function get_accessor() {
-            return 42;
-        }
-        function set_accessor(val) {}
-        return C;
-    }());
+    }, _C));
+    function method() {}
+    function get_accessor() {
+        return 42;
+    }
+    function set_accessor(val) {}
 }

--- a/crates/swc/tests/tsc-references/privateNameClassExpressionLoop_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNameClassExpressionLoop_es2015.2.minified.js
@@ -8,11 +8,12 @@ function _classPrivateMethodInit(obj, privateSet) {
     _checkPrivateRedeclaration(obj, privateSet), privateSet.add(obj);
 }
 const array = [];
-for(let i = 0; i < 10; ++i)array.push(function() {
-    var _myField = new WeakMap(), _method = new WeakSet(), _accessor = new WeakMap();
-    class C {
+for(let i = 0; i < 10; ++i){
+    var _myField;
+    function set_accessor(val) {}
+    array.push((_myField = new WeakMap(), class {
         constructor(){
-            _classPrivateMethodInit(this, _method), _classPrivateFieldInit(this, _accessor, {
+            _classPrivateMethodInit(this, new WeakSet()), _classPrivateFieldInit(this, new WeakMap(), {
                 get: function() {
                     return 42;
                 },
@@ -22,7 +23,5 @@ for(let i = 0; i < 10; ++i)array.push(function() {
                 value: "hello"
             });
         }
-    }
-    function set_accessor(val) {}
-    return C;
-}());
+    }));
+}

--- a/crates/swc/tests/tsc-references/privateNameClassExpressionLoop_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameClassExpressionLoop_es5.1.normal.js
@@ -19,26 +19,23 @@ function _classPrivateMethodInit(obj, privateSet) {
 // @target: es2015
 var array = [];
 for(var i = 0; i < 10; ++i){
-    array.push(function() {
-        var method = function method() {};
-        var get_accessor = function get_accessor() {
-            return 42;
-        };
-        var set_accessor = function set_accessor(val) {};
-        var _myField = new WeakMap(), _method = new WeakSet(), _accessor = new WeakMap();
-        var C = function C() {
-            "use strict";
-            _classCallCheck(this, C);
-            _classPrivateMethodInit(this, _method);
-            _classPrivateFieldInit(this, _accessor, {
-                get: get_accessor,
-                set: set_accessor
-            });
-            _classPrivateFieldInit(this, _myField, {
-                writable: true,
-                value: "hello"
-            });
-        };
-        return C;
-    }());
+    var method = function method() {};
+    var get_accessor = function get_accessor() {
+        return 42;
+    };
+    var set_accessor = function set_accessor(val) {};
+    var _myField, _method, _accessor, _C;
+    array.push((_myField = new WeakMap(), _method = new WeakSet(), _accessor = new WeakMap(), _C = function C() {
+        "use strict";
+        _classCallCheck(this, C);
+        _classPrivateMethodInit(this, _method);
+        _classPrivateFieldInit(this, _accessor, {
+            get: get_accessor,
+            set: set_accessor
+        });
+        _classPrivateFieldInit(this, _myField, {
+            writable: true,
+            value: "hello"
+        });
+    }, _C));
 }

--- a/crates/swc/tests/tsc-references/privateNameClassExpressionLoop_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNameClassExpressionLoop_es5.2.minified.js
@@ -10,10 +10,11 @@ function _classPrivateFieldInit(obj, privateMap, value) {
 function _classPrivateMethodInit(obj, privateSet) {
     _checkPrivateRedeclaration(obj, privateSet), privateSet.add(obj);
 }
-for(var array = [], i = 0; i < 10; ++i)array.push(function() {
-    var get_accessor = function() {
+for(var array = [], i = 0; i < 10; ++i){
+    var _myField, _method, _accessor, get_accessor = function() {
         return 42;
-    }, set_accessor = function(val) {}, _myField = new WeakMap(), _method = new WeakSet(), _accessor = new WeakMap(), C = function() {
+    }, set_accessor = function(val) {};
+    array.push((_myField = new WeakMap(), _method = new WeakSet(), _accessor = new WeakMap(), function C() {
         "use strict";
         _classCallCheck(this, C), _classPrivateMethodInit(this, _method), _classPrivateFieldInit(this, _accessor, {
             get: get_accessor,
@@ -22,6 +23,5 @@ for(var array = [], i = 0; i < 10; ++i)array.push(function() {
             writable: !0,
             value: "hello"
         });
-    };
-    return C;
-}());
+    }));
+}

--- a/crates/swc/tests/tsc-references/privateNameComputedPropertyName2_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameComputedPropertyName2_es2015.1.normal.js
@@ -25,7 +25,8 @@ function _classPrivateFieldInit(obj, privateMap, value) {
 }
 // @target: esnext, es2022, es2015
 let getX;
-var _x = new WeakMap(), tmp = (getX = (a)=>_classPrivateFieldGet(a, _x)
+var _x = new WeakMap();
+let tmp = (getX = (a)=>_classPrivateFieldGet(a, _x)
 , "_");
 class A {
     [tmp]() {}

--- a/crates/swc/tests/tsc-references/privateNameComputedPropertyName2_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNameComputedPropertyName2_es2015.2.minified.js
@@ -1,5 +1,6 @@
 let getX;
-var _x = new WeakMap(), tmp = (getX = (a)=>(function(receiver, privateMap) {
+var _x = new WeakMap();
+let tmp = (getX = (a)=>(function(receiver, privateMap) {
         var receiver, descriptor, descriptor = function(receiver, privateMap, action) {
             if (!privateMap.has(receiver)) throw new TypeError("attempted to get private field on non-instance");
             return privateMap.get(receiver);

--- a/crates/swc/tests/tsc-references/privateNameComputedPropertyName2_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameComputedPropertyName2_es5.1.normal.js
@@ -44,7 +44,8 @@ function _createClass(Constructor, protoProps, staticProps) {
 }
 // @target: esnext, es2022, es2015
 var getX;
-var _x = new WeakMap(), tmp = (getX = function(a) {
+var _x = new WeakMap();
+var tmp = (getX = function(a) {
     return _classPrivateFieldGet(a, _x);
 }, "_");
 var A = /*#__PURE__*/ function() {

--- a/crates/swc/tests/tsc-references/privateNameComputedPropertyName3_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameComputedPropertyName3_es2015.1.normal.js
@@ -43,7 +43,8 @@ var _name = new WeakMap();
 class Foo {
     getValue(x) {
         const obj = this;
-        var _y = new WeakMap(), tmp = _classPrivateFieldGet(obj, _name);
+        var _y = new WeakMap();
+        let tmp = _classPrivateFieldGet(obj, _name);
         class Bar {
             [tmp]() {
                 return x + _classPrivateFieldGet(this, _y);

--- a/crates/swc/tests/tsc-references/privateNameComputedPropertyName3_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNameComputedPropertyName3_es2015.2.minified.js
@@ -14,7 +14,8 @@ function _classPrivateFieldInit(obj, privateMap, value) {
 var _name = new WeakMap();
 console.log(new class {
     getValue(x) {
-        var _y = new WeakMap(), tmp = _classPrivateFieldGet(this, _name);
+        var _y = new WeakMap();
+        let tmp = _classPrivateFieldGet(this, _name);
         return new class {
             [tmp]() {
                 return x + _classPrivateFieldGet(this, _y);

--- a/crates/swc/tests/tsc-references/privateNameComputedPropertyName3_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameComputedPropertyName3_es5.1.normal.js
@@ -74,7 +74,8 @@ var Foo = // @target: esnext, es2022, es2015
             key: "getValue",
             value: function getValue(x) {
                 var obj = this;
-                var _y = new WeakMap(), tmp = _classPrivateFieldGet(obj, _name);
+                var _y = new WeakMap();
+                var tmp = _classPrivateFieldGet(obj, _name);
                 var Bar = /*#__PURE__*/ function() {
                     function Bar() {
                         _classCallCheck(this, Bar);

--- a/crates/swc/tests/tsc-references/privateNameComputedPropertyName4_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameComputedPropertyName4_es2015.1.normal.js
@@ -1,19 +1,17 @@
 var _key;
-var tmp = "bar";
 // @target: esnext, es2022, es2015
 // @useDefineForClassFields: true
 // @noTypesAndSymbols: true
 // https://github.com/microsoft/TypeScript/issues/44113
 class C1 {
-    [tmp]() {}
+    ["bar"]() {}
 }
 var _qux = {
     writable: true,
     value: 42
 };
-var tmp1 = "bar";
 class C2 {
-    static [tmp1]() {}
+    static ["bar"]() {}
 }
 var _qux1 = {
     writable: true,

--- a/crates/swc/tests/tsc-references/privateNameComputedPropertyName4_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameComputedPropertyName4_es5.1.normal.js
@@ -18,7 +18,6 @@ function _createClass(Constructor, protoProps, staticProps) {
     return Constructor;
 }
 var _key;
-var tmp = "bar";
 var C1 = // @target: esnext, es2022, es2015
 // @useDefineForClassFields: true
 // @noTypesAndSymbols: true
@@ -30,7 +29,7 @@ var C1 = // @target: esnext, es2022, es2015
     }
     _createClass(C1, [
         {
-            key: tmp,
+            key: "bar",
             value: function value() {}
         }
     ]);
@@ -40,7 +39,6 @@ var _qux = {
     writable: true,
     value: 42
 };
-var tmp1 = "bar";
 var C2 = /*#__PURE__*/ function() {
     "use strict";
     function C2() {
@@ -48,7 +46,7 @@ var C2 = /*#__PURE__*/ function() {
     }
     _createClass(C2, null, [
         {
-            key: tmp1,
+            key: "bar",
             value: function value() {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/privateNameFieldClassExpression_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameFieldClassExpression_es2015.1.normal.js
@@ -14,7 +14,7 @@ class B {
     constructor(){
         _classPrivateFieldInit(this, _foo, {
             writable: true,
-            value: (_class = class _class {
+            value: (_class = class {
                 constructor(){
                     console.log("hello");
                 }

--- a/crates/swc/tests/tsc-references/privateNameInLhsReceiverExpression_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameInLhsReceiverExpression_es2015.1.normal.js
@@ -43,32 +43,25 @@ var _y = new WeakMap();
 class Test {
     static something(obj) {
         var _s;
-        _classPrivateFieldSet(obj[(new (function() {
-            var _x = new WeakMap();
-            class _class {
-                constructor(){
-                    _classPrivateFieldInit(this, _x, {
-                        writable: true,
-                        value: 1
-                    });
-                    this.s = "prop";
-                }
+        var _x, _x1;
+        _classPrivateFieldSet(obj[(new (_x = new WeakMap(), class {
+            constructor(){
+                _classPrivateFieldInit(this, _x, {
+                    writable: true,
+                    value: 1
+                });
+                this.s = "prop";
             }
-            return _class;
-        }())).s], _y, 1);
-        _classPrivateFieldSet(_s = obj[(new (function() {
-            var _x = new WeakMap();
-            class _class {
-                constructor(){
-                    _classPrivateFieldInit(this, _x, {
-                        writable: true,
-                        value: 1
-                    });
-                    this.s = "prop";
-                }
+        })).s], _y, 1);
+        _classPrivateFieldSet(_s = obj[(new (_x1 = new WeakMap(), class {
+            constructor(){
+                _classPrivateFieldInit(this, _x1, {
+                    writable: true,
+                    value: 1
+                });
+                this.s = "prop";
             }
-            return _class;
-        }())).s], _y, _classPrivateFieldGet(_s, _y) + 1);
+        })).s], _y, _classPrivateFieldGet(_s, _y) + 1);
     }
     constructor(){
         _classPrivateFieldInit(this, _y, {

--- a/crates/swc/tests/tsc-references/privateNameInLhsReceiverExpression_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameInLhsReceiverExpression_es5.1.normal.js
@@ -73,30 +73,23 @@ var Test = // @target: es2015
             key: "something",
             value: function something(obj) {
                 var _s;
-                _classPrivateFieldSet(obj[(new (function() {
-                    var _x = new WeakMap();
-                    var _class = function _class() {
-                        _classCallCheck(this, _class);
-                        _classPrivateFieldInit(this, _x, {
-                            writable: true,
-                            value: 1
-                        });
-                        this.s = "prop";
-                    };
-                    return _class;
-                }())).s], _y, 1);
-                _classPrivateFieldSet(_s = obj[(new (function() {
-                    var _x = new WeakMap();
-                    var _class = function _class() {
-                        _classCallCheck(this, _class);
-                        _classPrivateFieldInit(this, _x, {
-                            writable: true,
-                            value: 1
-                        });
-                        this.s = "prop";
-                    };
-                    return _class;
-                }())).s], _y, _classPrivateFieldGet(_s, _y) + 1);
+                var _x, _x1;
+                _classPrivateFieldSet(obj[(new (_x = new WeakMap(), function _class() {
+                    _classCallCheck(this, _class);
+                    _classPrivateFieldInit(this, _x, {
+                        writable: true,
+                        value: 1
+                    });
+                    this.s = "prop";
+                })).s], _y, 1);
+                _classPrivateFieldSet(_s = obj[(new (_x1 = new WeakMap(), function _class() {
+                    _classCallCheck(this, _class);
+                    _classPrivateFieldInit(this, _x1, {
+                        writable: true,
+                        value: 1
+                    });
+                    this.s = "prop";
+                })).s], _y, _classPrivateFieldGet(_s, _y) + 1);
             }
         }
     ]);

--- a/crates/swc/tests/tsc-references/privateNameInLhsReceiverExpression_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNameInLhsReceiverExpression_es5.2.minified.js
@@ -39,14 +39,14 @@ var _y = new WeakMap(), Test = function() {
         {
             key: "something",
             value: function(obj) {
-                var _s, _x, _class, _x1, _class1, receiver, privateMap, descriptor, receiver, descriptor;
-                _classPrivateFieldSet(obj[(new (_x = new WeakMap(), _class = function() {
+                var _s, _x, _x1, receiver, privateMap, descriptor, receiver, descriptor;
+                _classPrivateFieldSet(obj[(new (_x = new WeakMap(), function _class() {
                     _classCallCheck(this, _class), _classPrivateFieldInit(this, _x, {
                         writable: !0,
                         value: 1
                     }), this.s = "prop";
-                })).s], _y, 1), _classPrivateFieldSet(_s = obj[(new (_x1 = new WeakMap(), _class1 = function() {
-                    _classCallCheck(this, _class1), _classPrivateFieldInit(this, _x1, {
+                })).s], _y, 1), _classPrivateFieldSet(_s = obj[(new (_x1 = new WeakMap(), function _class() {
+                    _classCallCheck(this, _class), _classPrivateFieldInit(this, _x1, {
                         writable: !0,
                         value: 1
                     }), this.s = "prop";

--- a/crates/swc/tests/tsc-references/privateNameMethodAsync_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameMethodAsync_es2015.1.normal.js
@@ -134,44 +134,41 @@ function _wrapAsyncGenerator(fn) {
         return new AsyncGenerator(fn.apply(this, arguments));
     };
 }
+var _bar, _baz, _qux, _class;
 // @target: es2019
-const C = function() {
-    var _bar = new WeakSet(), _baz = new WeakSet(), _qux = new WeakSet();
-    class _class {
-        foo() {
-            var _this = this;
-            return _asyncToGenerator(function*() {
-                const b = yield _classPrivateMethodGet(_this, _bar, bar).call(_this);
-                return b + (_classPrivateMethodGet(_this, _baz, baz).call(_this).next().value || 0) + ((yield _classPrivateMethodGet(_this, _qux, qux).call(_this).next()).value || 0);
-            })();
-        }
-        constructor(){
-            _classPrivateMethodInit(this, _bar);
-            _classPrivateMethodInit(this, _baz);
-            _classPrivateMethodInit(this, _qux);
-        }
+const C = (_bar = new WeakSet(), _baz = new WeakSet(), _qux = new WeakSet(), _class = class {
+    foo() {
+        var _this = this;
+        return _asyncToGenerator(function*() {
+            const b = yield _classPrivateMethodGet(_this, _bar, bar).call(_this);
+            return b + (_classPrivateMethodGet(_this, _baz, baz).call(_this).next().value || 0) + ((yield _classPrivateMethodGet(_this, _qux, qux).call(_this).next()).value || 0);
+        })();
     }
-    function bar() {
-        return _bar1.apply(this, arguments);
+    constructor(){
+        _classPrivateMethodInit(this, _bar);
+        _classPrivateMethodInit(this, _baz);
+        _classPrivateMethodInit(this, _qux);
     }
-    function _bar1() {
-        _bar1 = _asyncToGenerator(function*() {
-            return yield Promise.resolve(42);
-        });
-        return _bar1.apply(this, arguments);
-    }
-    function* baz() {
-        yield 42;
-    }
-    function qux() {
-        return _qux1.apply(this, arguments);
-    }
-    function _qux1() {
-        _qux1 = _wrapAsyncGenerator(function*() {
-            yield yield _awaitAsyncGenerator(Promise.resolve(42));
-        });
-        return _qux1.apply(this, arguments);
-    }
-    return _class;
-}();
+}, _class);
 new C().foo().then(console.log);
+function bar() {
+    return _bar1.apply(this, arguments);
+}
+function _bar1() {
+    _bar1 = _asyncToGenerator(function*() {
+        return yield Promise.resolve(42);
+    });
+    return _bar1.apply(this, arguments);
+}
+function* baz() {
+    yield 42;
+}
+function qux() {
+    return _qux1.apply(this, arguments);
+}
+function _qux1() {
+    _qux1 = _wrapAsyncGenerator(function*() {
+        yield yield _awaitAsyncGenerator(Promise.resolve(42));
+    });
+    return _qux1.apply(this, arguments);
+}

--- a/crates/swc/tests/tsc-references/privateNameMethodAsync_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNameMethodAsync_es2015.2.minified.js
@@ -1,3 +1,4 @@
+var _bar, _baz, _qux;
 function AsyncGenerator(gen) {
     var front, back;
     function resume(key, arg) {
@@ -94,43 +95,40 @@ function _classPrivateMethodInit(obj, privateSet) {
 }, AsyncGenerator.prototype.return = function(arg) {
     return this._invoke("return", arg);
 };
-const C = function() {
-    var _bar = new WeakSet(), _baz = new WeakSet(), _qux = new WeakSet();
-    function bar() {
-        return _bar1.apply(this, arguments);
+const C = (_bar = new WeakSet(), _baz = new WeakSet(), _qux = new WeakSet(), class {
+    foo() {
+        var _this = this;
+        return _asyncToGenerator(function*() {
+            const b = yield _classPrivateMethodGet(_this, _bar, bar).call(_this);
+            return b + (_classPrivateMethodGet(_this, _baz, baz).call(_this).next().value || 0) + ((yield _classPrivateMethodGet(_this, _qux, qux).call(_this).next()).value || 0);
+        })();
     }
-    function _bar1() {
-        return (_bar1 = _asyncToGenerator(function*() {
-            return yield Promise.resolve(42);
-        })).apply(this, arguments);
+    constructor(){
+        _classPrivateMethodInit(this, _bar), _classPrivateMethodInit(this, _baz), _classPrivateMethodInit(this, _qux);
     }
-    function* baz() {
-        yield 42;
-    }
-    function qux() {
-        return _qux1.apply(this, arguments);
-    }
-    function _qux1() {
-        return (_qux1 = (function(fn) {
-            return function() {
-                return new AsyncGenerator(fn.apply(this, arguments));
-            };
-        })(function*() {
-            var value;
-            yield yield value = Promise.resolve(42), new _AwaitValue(value);
-        })).apply(this, arguments);
-    }
-    return class {
-        foo() {
-            var _this = this;
-            return _asyncToGenerator(function*() {
-                const b = yield _classPrivateMethodGet(_this, _bar, bar).call(_this);
-                return b + (_classPrivateMethodGet(_this, _baz, baz).call(_this).next().value || 0) + ((yield _classPrivateMethodGet(_this, _qux, qux).call(_this).next()).value || 0);
-            })();
-        }
-        constructor(){
-            _classPrivateMethodInit(this, _bar), _classPrivateMethodInit(this, _baz), _classPrivateMethodInit(this, _qux);
-        }
-    };
-}();
+});
+function bar() {
+    return _bar1.apply(this, arguments);
+}
+function _bar1() {
+    return (_bar1 = _asyncToGenerator(function*() {
+        return yield Promise.resolve(42);
+    })).apply(this, arguments);
+}
+function* baz() {
+    yield 42;
+}
+function qux() {
+    return _qux1.apply(this, arguments);
+}
+function _qux1() {
+    return (_qux1 = (function(fn) {
+        return function() {
+            return new AsyncGenerator(fn.apply(this, arguments));
+        };
+    })(function*() {
+        var value;
+        yield yield value = Promise.resolve(42), new _AwaitValue(value);
+    })).apply(this, arguments);
+}
 new C().foo().then(console.log);

--- a/crates/swc/tests/tsc-references/privateNameMethodAsync_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameMethodAsync_es5.1.normal.js
@@ -154,108 +154,106 @@ function _wrapAsyncGenerator(fn) {
     };
 }
 import regeneratorRuntime from "regenerator-runtime";
+var _marked = regeneratorRuntime.mark(baz);
+var _bar, _baz, _qux, _class;
 // @target: es2019
-var C = function() {
-    var baz = regeneratorRuntime.mark(function baz() {
-        return regeneratorRuntime.wrap(function baz$(_ctx) {
+var C = (_bar = new WeakSet(), _baz = new WeakSet(), _qux = new WeakSet(), _class = /*#__PURE__*/ function() {
+    "use strict";
+    function _class1() {
+        _classCallCheck(this, _class1);
+        _classPrivateMethodInit(this, _bar);
+        _classPrivateMethodInit(this, _baz);
+        _classPrivateMethodInit(this, _qux);
+    }
+    _createClass(_class1, [
+        {
+            key: "foo",
+            value: function foo() {
+                var _this = this;
+                return _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
+                    var b;
+                    return regeneratorRuntime.wrap(function _callee$(_ctx) {
+                        while(1)switch(_ctx.prev = _ctx.next){
+                            case 0:
+                                _ctx.next = 2;
+                                return _classPrivateMethodGet(_this, _bar, bar).call(_this);
+                            case 2:
+                                b = _ctx.sent;
+                                _ctx.t0 = b + (_classPrivateMethodGet(_this, _baz, baz).call(_this).next().value || 0);
+                                _ctx.next = 6;
+                                return _classPrivateMethodGet(_this, _qux, qux).call(_this).next();
+                            case 6:
+                                _ctx.t1 = _ctx.sent.value;
+                                if (_ctx.t1) {
+                                    _ctx.next = 9;
+                                    break;
+                                }
+                                _ctx.t1 = 0;
+                            case 9:
+                                _ctx.t2 = _ctx.t1;
+                                return _ctx.abrupt("return", _ctx.t0 + _ctx.t2);
+                            case 11:
+                            case "end":
+                                return _ctx.stop();
+                        }
+                    }, _callee);
+                }))();
+            }
+        }
+    ]);
+    return _class1;
+}(), _class);
+new C().foo().then(console.log);
+function bar() {
+    return _bar1.apply(this, arguments);
+}
+function _bar1() {
+    _bar1 = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
+        return regeneratorRuntime.wrap(function _callee$(_ctx) {
             while(1)switch(_ctx.prev = _ctx.next){
                 case 0:
                     _ctx.next = 2;
-                    return 42;
+                    return Promise.resolve(42);
                 case 2:
+                    return _ctx.abrupt("return", _ctx.sent);
+                case 3:
                 case "end":
                     return _ctx.stop();
             }
-        }, baz);
-    });
-    var _bar = new WeakSet(), _baz = new WeakSet(), _qux = new WeakSet();
-    var _class = /*#__PURE__*/ function() {
-        "use strict";
-        function _class() {
-            _classCallCheck(this, _class);
-            _classPrivateMethodInit(this, _bar);
-            _classPrivateMethodInit(this, _baz);
-            _classPrivateMethodInit(this, _qux);
+        }, _callee);
+    }));
+    return _bar1.apply(this, arguments);
+}
+function baz() {
+    return regeneratorRuntime.wrap(function baz$(_ctx) {
+        while(1)switch(_ctx.prev = _ctx.next){
+            case 0:
+                _ctx.next = 2;
+                return 42;
+            case 2:
+            case "end":
+                return _ctx.stop();
         }
-        _createClass(_class, [
-            {
-                key: "foo",
-                value: function foo() {
-                    var _this = this;
-                    return _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
-                        var b;
-                        return regeneratorRuntime.wrap(function _callee$(_ctx) {
-                            while(1)switch(_ctx.prev = _ctx.next){
-                                case 0:
-                                    _ctx.next = 2;
-                                    return _classPrivateMethodGet(_this, _bar, bar).call(_this);
-                                case 2:
-                                    b = _ctx.sent;
-                                    _ctx.t0 = b + (_classPrivateMethodGet(_this, _baz, baz).call(_this).next().value || 0);
-                                    _ctx.next = 6;
-                                    return _classPrivateMethodGet(_this, _qux, qux).call(_this).next();
-                                case 6:
-                                    _ctx.t1 = _ctx.sent.value;
-                                    if (_ctx.t1) {
-                                        _ctx.next = 9;
-                                        break;
-                                    }
-                                    _ctx.t1 = 0;
-                                case 9:
-                                    _ctx.t2 = _ctx.t1;
-                                    return _ctx.abrupt("return", _ctx.t0 + _ctx.t2);
-                                case 11:
-                                case "end":
-                                    return _ctx.stop();
-                            }
-                        }, _callee);
-                    }))();
-                }
+    }, _marked);
+}
+function qux() {
+    return _qux1.apply(this, arguments);
+}
+function _qux1() {
+    _qux1 = _wrapAsyncGenerator(regeneratorRuntime.mark(function _callee() {
+        return regeneratorRuntime.wrap(function _callee$(_ctx) {
+            while(1)switch(_ctx.prev = _ctx.next){
+                case 0:
+                    _ctx.next = 2;
+                    return _awaitAsyncGenerator(Promise.resolve(42));
+                case 2:
+                    _ctx.next = 4;
+                    return _ctx.sent;
+                case 4:
+                case "end":
+                    return _ctx.stop();
             }
-        ]);
-        return _class;
-    }();
-    function bar() {
-        return _bar1.apply(this, arguments);
-    }
-    function _bar1() {
-        _bar1 = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
-            return regeneratorRuntime.wrap(function _callee$(_ctx) {
-                while(1)switch(_ctx.prev = _ctx.next){
-                    case 0:
-                        _ctx.next = 2;
-                        return Promise.resolve(42);
-                    case 2:
-                        return _ctx.abrupt("return", _ctx.sent);
-                    case 3:
-                    case "end":
-                        return _ctx.stop();
-                }
-            }, _callee);
-        }));
-        return _bar1.apply(this, arguments);
-    }
-    function qux() {
-        return _qux1.apply(this, arguments);
-    }
-    function _qux1() {
-        _qux1 = _wrapAsyncGenerator(regeneratorRuntime.mark(function _callee() {
-            return regeneratorRuntime.wrap(function _callee$(_ctx) {
-                while(1)switch(_ctx.prev = _ctx.next){
-                    case 0:
-                        _ctx.next = 2;
-                        return _awaitAsyncGenerator(Promise.resolve(42));
-                    case 2:
-                        _ctx.next = 4;
-                        return _ctx.sent;
-                    case 4:
-                    case "end":
-                        return _ctx.stop();
-                }
-            }, _callee);
-        }));
-        return _qux1.apply(this, arguments);
-    }
-    return _class;
-}();
-new C().foo().then(console.log);
+        }, _callee);
+    }));
+    return _qux1.apply(this, arguments);
+}

--- a/crates/swc/tests/tsc-references/privateNameMethodAsync_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNameMethodAsync_es5.2.minified.js
@@ -104,94 +104,93 @@ function _defineProperties(target, props) {
     return this._invoke("return", arg);
 };
 import regeneratorRuntime from "regenerator-runtime";
-new (function() {
-    var baz = regeneratorRuntime.mark(function() {
+var _bar, _baz, _qux, _marked = regeneratorRuntime.mark(baz);
+function bar() {
+    return _bar1.apply(this, arguments);
+}
+function _bar1() {
+    return (_bar1 = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
         return regeneratorRuntime.wrap(function(_ctx) {
             for(;;)switch(_ctx.prev = _ctx.next){
                 case 0:
-                    return _ctx.next = 2, 42;
+                    return _ctx.next = 2, Promise.resolve(42);
                 case 2:
+                    return _ctx.abrupt("return", _ctx.sent);
+                case 3:
                 case "end":
                     return _ctx.stop();
             }
-        }, baz);
-    }), _bar = new WeakSet(), _baz = new WeakSet(), _qux = new WeakSet(), _class = function() {
-        "use strict";
-        var Constructor, protoProps, staticProps;
-        function _class() {
-            !function(instance, Constructor) {
-                if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
-            }(this, _class), _classPrivateMethodInit(this, _bar), _classPrivateMethodInit(this, _baz), _classPrivateMethodInit(this, _qux);
+        }, _callee);
+    }))).apply(this, arguments);
+}
+function baz() {
+    return regeneratorRuntime.wrap(function(_ctx) {
+        for(;;)switch(_ctx.prev = _ctx.next){
+            case 0:
+                return _ctx.next = 2, 42;
+            case 2:
+            case "end":
+                return _ctx.stop();
         }
-        return Constructor = _class, protoProps = [
-            {
-                key: "foo",
-                value: function() {
-                    var _this = this;
-                    return _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
-                        var b;
-                        return regeneratorRuntime.wrap(function(_ctx) {
-                            for(;;)switch(_ctx.prev = _ctx.next){
-                                case 0:
-                                    return _ctx.next = 2, _classPrivateMethodGet(_this, _bar, bar).call(_this);
-                                case 2:
-                                    return b = _ctx.sent, _ctx.t0 = b + (_classPrivateMethodGet(_this, _baz, baz).call(_this).next().value || 0), _ctx.next = 6, _classPrivateMethodGet(_this, _qux, qux).call(_this).next();
-                                case 6:
-                                    if (_ctx.t1 = _ctx.sent.value, _ctx.t1) {
-                                        _ctx.next = 9;
-                                        break;
-                                    }
-                                    _ctx.t1 = 0;
-                                case 9:
-                                    return _ctx.t2 = _ctx.t1, _ctx.abrupt("return", _ctx.t0 + _ctx.t2);
-                                case 11:
-                                case "end":
-                                    return _ctx.stop();
-                            }
-                        }, _callee);
-                    }))();
-                }
+    }, _marked);
+}
+function qux() {
+    return _qux1.apply(this, arguments);
+}
+function _qux1() {
+    var fn;
+    return (_qux1 = (fn = regeneratorRuntime.mark(function _callee() {
+        return regeneratorRuntime.wrap(function(_ctx) {
+            for(;;)switch(_ctx.prev = _ctx.next){
+                case 0:
+                    return _ctx.next = 2, _awaitAsyncGenerator(Promise.resolve(42));
+                case 2:
+                    return _ctx.next = 4, _ctx.sent;
+                case 4:
+                case "end":
+                    return _ctx.stop();
             }
-        ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), _class;
-    }();
-    function bar() {
-        return _bar1.apply(this, arguments);
+        }, _callee);
+    }), function() {
+        return new AsyncGenerator(fn.apply(this, arguments));
+    })).apply(this, arguments);
+}
+new (_bar = new WeakSet(), _baz = new WeakSet(), _qux = new WeakSet(), (function() {
+    "use strict";
+    var Constructor, protoProps, staticProps;
+    function _class() {
+        (function(instance, Constructor) {
+            if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
+        })(this, _class), _classPrivateMethodInit(this, _bar), _classPrivateMethodInit(this, _baz), _classPrivateMethodInit(this, _qux);
     }
-    function _bar1() {
-        return (_bar1 = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
-            return regeneratorRuntime.wrap(function(_ctx) {
-                for(;;)switch(_ctx.prev = _ctx.next){
-                    case 0:
-                        return _ctx.next = 2, Promise.resolve(42);
-                    case 2:
-                        return _ctx.abrupt("return", _ctx.sent);
-                    case 3:
-                    case "end":
-                        return _ctx.stop();
-                }
-            }, _callee);
-        }))).apply(this, arguments);
-    }
-    function qux() {
-        return _qux1.apply(this, arguments);
-    }
-    function _qux1() {
-        var fn;
-        return (_qux1 = (fn = regeneratorRuntime.mark(function _callee() {
-            return regeneratorRuntime.wrap(function(_ctx) {
-                for(;;)switch(_ctx.prev = _ctx.next){
-                    case 0:
-                        return _ctx.next = 2, _awaitAsyncGenerator(Promise.resolve(42));
-                    case 2:
-                        return _ctx.next = 4, _ctx.sent;
-                    case 4:
-                    case "end":
-                        return _ctx.stop();
-                }
-            }, _callee);
-        }), function() {
-            return new AsyncGenerator(fn.apply(this, arguments));
-        })).apply(this, arguments);
-    }
-    return _class;
-}())().foo().then(console.log);
+    return Constructor = _class, protoProps = [
+        {
+            key: "foo",
+            value: function() {
+                var _this = this;
+                return _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
+                    var b;
+                    return regeneratorRuntime.wrap(function(_ctx) {
+                        for(;;)switch(_ctx.prev = _ctx.next){
+                            case 0:
+                                return _ctx.next = 2, _classPrivateMethodGet(_this, _bar, bar).call(_this);
+                            case 2:
+                                return b = _ctx.sent, _ctx.t0 = b + (_classPrivateMethodGet(_this, _baz, baz).call(_this).next().value || 0), _ctx.next = 6, _classPrivateMethodGet(_this, _qux, qux).call(_this).next();
+                            case 6:
+                                if (_ctx.t1 = _ctx.sent.value, _ctx.t1) {
+                                    _ctx.next = 9;
+                                    break;
+                                }
+                                _ctx.t1 = 0;
+                            case 9:
+                                return _ctx.t2 = _ctx.t1, _ctx.abrupt("return", _ctx.t0 + _ctx.t2);
+                            case 11:
+                            case "end":
+                                return _ctx.stop();
+                        }
+                    }, _callee);
+                }))();
+            }
+        }
+    ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), _class;
+}()))().foo().then(console.log);

--- a/crates/swc/tests/tsc-references/privateNameReadonly_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameReadonly_es2015.1.normal.js
@@ -28,18 +28,15 @@ function _classPrivateMethodInit(obj, privateSet) {
     _checkPrivateRedeclaration(obj, privateSet);
     privateSet.add(obj);
 }
+var _bar, _class;
 // @target: es2015
-const C = function() {
-    var _bar = new WeakSet();
-    class _class {
-        foo() {
-            _classPrivateFieldSet(this, _bar, console.log("should log this then throw"));
-        }
-        constructor(){
-            _classPrivateMethodInit(this, _bar);
-        }
+const C = (_bar = new WeakSet(), _class = class {
+    foo() {
+        _classPrivateFieldSet(this, _bar, console.log("should log this then throw"));
     }
-    function bar() {}
-    return _class;
-}();
+    constructor(){
+        _classPrivateMethodInit(this, _bar);
+    }
+}, _class);
 console.log(new C().foo());
+function bar() {}

--- a/crates/swc/tests/tsc-references/privateNameReadonly_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNameReadonly_es2015.2.minified.js
@@ -1,25 +1,24 @@
-const C = function() {
-    var _bar = new WeakSet();
-    return class {
-        foo() {
-            var receiver, privateMap, value, descriptor;
-            receiver = this, privateMap = _bar, value = console.log("should log this then throw"), descriptor = (function(receiver, privateMap, action) {
-                if (!privateMap.has(receiver)) throw new TypeError("attempted to set private field on non-instance");
-                return privateMap.get(receiver);
-            })(receiver, privateMap, "set"), (function(receiver, descriptor, value) {
-                if (descriptor.set) descriptor.set.call(receiver, value);
-                else {
-                    if (!descriptor.writable) throw new TypeError("attempted to set read only private field");
-                    descriptor.value = value;
-                }
-            })(receiver, descriptor, value);
-        }
-        constructor(){
-            var obj, privateSet;
-            obj = this, (function(obj, privateCollection) {
+var _bar;
+const C = (_bar = new WeakSet(), class {
+    foo() {
+        var receiver, privateMap, value, descriptor;
+        receiver = this, privateMap = _bar, value = console.log("should log this then throw"), descriptor = (function(receiver, privateMap, action) {
+            if (!privateMap.has(receiver)) throw new TypeError("attempted to set private field on non-instance");
+            return privateMap.get(receiver);
+        })(receiver, privateMap, "set"), (function(receiver, descriptor, value) {
+            if (descriptor.set) descriptor.set.call(receiver, value);
+            else {
+                if (!descriptor.writable) throw new TypeError("attempted to set read only private field");
+                descriptor.value = value;
+            }
+        })(receiver, descriptor, value);
+    }
+    constructor(){
+        (function(obj, privateSet) {
+            (function(obj, privateCollection) {
                 if (privateCollection.has(obj)) throw new TypeError("Cannot initialize the same private elements twice on an object");
-            })(obj, privateSet = _bar), privateSet.add(obj);
-        }
-    };
-}();
+            })(obj, privateSet), privateSet.add(obj);
+        })(this, _bar);
+    }
+});
 console.log(new C().foo());

--- a/crates/swc/tests/tsc-references/privateNameReadonly_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameReadonly_es5.1.normal.js
@@ -47,26 +47,23 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
+var _bar, _class;
 // @target: es2015
-var C = function() {
-    var bar = function bar() {};
-    var _bar = new WeakSet();
-    var _class = /*#__PURE__*/ function() {
-        "use strict";
-        function _class() {
-            _classCallCheck(this, _class);
-            _classPrivateMethodInit(this, _bar);
-        }
-        _createClass(_class, [
-            {
-                key: "foo",
-                value: function foo() {
-                    _classPrivateFieldSet(this, _bar, console.log("should log this then throw"));
-                }
+var C = (_bar = new WeakSet(), _class = /*#__PURE__*/ function() {
+    "use strict";
+    function _class1() {
+        _classCallCheck(this, _class1);
+        _classPrivateMethodInit(this, _bar);
+    }
+    _createClass(_class1, [
+        {
+            key: "foo",
+            value: function foo() {
+                _classPrivateFieldSet(this, _bar, console.log("should log this then throw"));
             }
-        ]);
-        return _class;
-    }();
-    return _class;
-}();
+        }
+    ]);
+    return _class1;
+}(), _class);
 console.log(new C().foo());
+function bar() {}

--- a/crates/swc/tests/tsc-references/privateNameReadonly_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNameReadonly_es5.2.minified.js
@@ -4,37 +4,34 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var C = function() {
-    var _bar = new WeakSet(), _class = function() {
-        "use strict";
-        var Constructor, protoProps, staticProps;
-        function _class() {
-            var obj, privateSet;
-            !function(instance, Constructor) {
-                if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
-            }(this, _class), obj = this, (function(obj, privateCollection) {
-                if (privateCollection.has(obj)) throw new TypeError("Cannot initialize the same private elements twice on an object");
-            })(obj, privateSet = _bar), privateSet.add(obj);
-        }
-        return Constructor = _class, protoProps = [
-            {
-                key: "foo",
-                value: function() {
-                    var receiver, privateMap, value, descriptor;
-                    receiver = this, privateMap = _bar, value = console.log("should log this then throw"), descriptor = (function(receiver, privateMap, action) {
-                        if (!privateMap.has(receiver)) throw new TypeError("attempted to set private field on non-instance");
-                        return privateMap.get(receiver);
-                    })(receiver, privateMap, "set"), (function(receiver, descriptor, value) {
-                        if (descriptor.set) descriptor.set.call(receiver, value);
-                        else {
-                            if (!descriptor.writable) throw new TypeError("attempted to set read only private field");
-                            descriptor.value = value;
-                        }
-                    })(receiver, descriptor, value);
-                }
+var _bar, C = (_bar = new WeakSet(), function() {
+    "use strict";
+    var Constructor, protoProps, staticProps;
+    function _class() {
+        var obj, privateSet;
+        (function(instance, Constructor) {
+            if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
+        })(this, _class), obj = this, (function(obj, privateCollection) {
+            if (privateCollection.has(obj)) throw new TypeError("Cannot initialize the same private elements twice on an object");
+        })(obj, privateSet = _bar), privateSet.add(obj);
+    }
+    return Constructor = _class, protoProps = [
+        {
+            key: "foo",
+            value: function() {
+                var receiver, privateMap, value, descriptor;
+                receiver = this, privateMap = _bar, value = console.log("should log this then throw"), descriptor = (function(receiver, privateMap, action) {
+                    if (!privateMap.has(receiver)) throw new TypeError("attempted to set private field on non-instance");
+                    return privateMap.get(receiver);
+                })(receiver, privateMap, "set"), (function(receiver, descriptor, value) {
+                    if (descriptor.set) descriptor.set.call(receiver, value);
+                    else {
+                        if (!descriptor.writable) throw new TypeError("attempted to set read only private field");
+                        descriptor.value = value;
+                    }
+                })(receiver, descriptor, value);
             }
-        ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), _class;
-    }();
-    return _class;
-}();
+        }
+    ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), _class;
+}());
 console.log(new C().foo());

--- a/crates/swc/tests/tsc-references/privateNameSetterNoGetter_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameSetterNoGetter_es2015.1.normal.js
@@ -38,21 +38,18 @@ function _classPrivateFieldSet(receiver, privateMap, value) {
     _classApplyDescriptorSet(receiver, descriptor, value);
     return value;
 }
+var _x, _class;
 // @target: es2015
-const C = function() {
-    var _x = new WeakMap();
-    class _class {
-        m() {
-            _classPrivateFieldSet(this, _x, _classPrivateFieldGet(this, _x) + 2); // Error
-        }
-        constructor(){
-            _classPrivateFieldInit(this, _x, {
-                get: void 0,
-                set: set_x
-            });
-        }
+const C = (_x = new WeakMap(), _class = class {
+    m() {
+        _classPrivateFieldSet(this, _x, _classPrivateFieldGet(this, _x) + 2); // Error
     }
-    function set_x(x) {}
-    return _class;
-}();
+    constructor(){
+        _classPrivateFieldInit(this, _x, {
+            get: void 0,
+            set: set_x
+        });
+    }
+}, _class);
 console.log(new C().m());
+function set_x(x) {}

--- a/crates/swc/tests/tsc-references/privateNameSetterNoGetter_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNameSetterNoGetter_es2015.2.minified.js
@@ -1,29 +1,28 @@
+var _x;
 function _classExtractFieldDescriptor(receiver, privateMap, action) {
     if (!privateMap.has(receiver)) throw new TypeError("attempted to " + action + " private field on non-instance");
     return privateMap.get(receiver);
 }
-const C = function() {
-    var _x = new WeakMap();
-    return class {
-        m() {
-            var receiver, privateMap, descriptor, receiver, descriptor, receiver, privateMap, value, descriptor;
-            receiver = this, privateMap = _x, receiver = this, value = ((descriptor = _classExtractFieldDescriptor(receiver, privateMap = _x, "get")).get ? descriptor.get.call(receiver) : descriptor.value) + 2, descriptor = _classExtractFieldDescriptor(receiver, privateMap, "set"), (function(receiver, descriptor, value) {
-                if (descriptor.set) descriptor.set.call(receiver, value);
-                else {
-                    if (!descriptor.writable) throw new TypeError("attempted to set read only private field");
-                    descriptor.value = value;
-                }
-            })(receiver, descriptor, value);
-        }
-        constructor(){
-            var obj, privateMap, value;
-            obj = this, privateMap = _x, value = {
-                get: void 0,
-                set: function(x) {}
-            }, (function(obj, privateCollection) {
+const C = (_x = new WeakMap(), class {
+    m() {
+        var receiver, privateMap, descriptor, receiver, descriptor, receiver, privateMap, value, descriptor;
+        receiver = this, privateMap = _x, receiver = this, value = ((descriptor = _classExtractFieldDescriptor(receiver, privateMap = _x, "get")).get ? descriptor.get.call(receiver) : descriptor.value) + 2, descriptor = _classExtractFieldDescriptor(receiver, privateMap, "set"), (function(receiver, descriptor, value) {
+            if (descriptor.set) descriptor.set.call(receiver, value);
+            else {
+                if (!descriptor.writable) throw new TypeError("attempted to set read only private field");
+                descriptor.value = value;
+            }
+        })(receiver, descriptor, value);
+    }
+    constructor(){
+        (function(obj, privateMap, value) {
+            (function(obj, privateCollection) {
                 if (privateCollection.has(obj)) throw new TypeError("Cannot initialize the same private elements twice on an object");
             })(obj, privateMap), privateMap.set(obj, value);
-        }
-    };
-}();
+        })(this, _x, {
+            get: void 0,
+            set: function(x) {}
+        });
+    }
+});
 console.log(new C().m());

--- a/crates/swc/tests/tsc-references/privateNameSetterNoGetter_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameSetterNoGetter_es5.1.normal.js
@@ -57,29 +57,26 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
+var _x, _class;
 // @target: es2015
-var C = function() {
-    var set_x = function set_x(x) {};
-    var _x = new WeakMap();
-    var _class = /*#__PURE__*/ function() {
-        "use strict";
-        function _class() {
-            _classCallCheck(this, _class);
-            _classPrivateFieldInit(this, _x, {
-                get: void 0,
-                set: set_x
-            });
-        }
-        _createClass(_class, [
-            {
-                key: "m",
-                value: function m() {
-                    _classPrivateFieldSet(this, _x, _classPrivateFieldGet(this, _x) + 2); // Error
-                }
+var C = (_x = new WeakMap(), _class = /*#__PURE__*/ function() {
+    "use strict";
+    function _class1() {
+        _classCallCheck(this, _class1);
+        _classPrivateFieldInit(this, _x, {
+            get: void 0,
+            set: set_x
+        });
+    }
+    _createClass(_class1, [
+        {
+            key: "m",
+            value: function m() {
+                _classPrivateFieldSet(this, _x, _classPrivateFieldGet(this, _x) + 2); // Error
             }
-        ]);
-        return _class;
-    }();
-    return _class;
-}();
+        }
+    ]);
+    return _class1;
+}(), _class);
 console.log(new C().m());
+function set_x(x) {}

--- a/crates/swc/tests/tsc-references/privateNameSetterNoGetter_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNameSetterNoGetter_es5.2.minified.js
@@ -8,37 +8,35 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var C = function() {
-    var set_x = function(x) {}, _x = new WeakMap(), _class = function() {
-        "use strict";
-        var Constructor, protoProps, staticProps;
-        function _class() {
-            var obj, privateMap, value;
-            !function(instance, Constructor) {
-                if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
-            }(this, _class), obj = this, privateMap = _x, value = {
-                get: void 0,
-                set: set_x
-            }, (function(obj, privateCollection) {
-                if (privateCollection.has(obj)) throw new TypeError("Cannot initialize the same private elements twice on an object");
-            })(obj, privateMap), privateMap.set(obj, value);
-        }
-        return Constructor = _class, protoProps = [
-            {
-                key: "m",
-                value: function() {
-                    var receiver, privateMap, descriptor, receiver, descriptor, receiver, privateMap, value, descriptor;
-                    receiver = this, privateMap = _x, receiver = this, value = ((descriptor = _classExtractFieldDescriptor(receiver, privateMap = _x, "get")).get ? descriptor.get.call(receiver) : descriptor.value) + 2, descriptor = _classExtractFieldDescriptor(receiver, privateMap, "set"), (function(receiver, descriptor, value) {
-                        if (descriptor.set) descriptor.set.call(receiver, value);
-                        else {
-                            if (!descriptor.writable) throw new TypeError("attempted to set read only private field");
-                            descriptor.value = value;
-                        }
-                    })(receiver, descriptor, value);
-                }
+var _x, C = (_x = new WeakMap(), function() {
+    "use strict";
+    var Constructor, protoProps, staticProps;
+    function _class() {
+        var obj, privateMap, value;
+        (function(instance, Constructor) {
+            if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
+        })(this, _class), obj = this, privateMap = _x, value = {
+            get: void 0,
+            set: set_x
+        }, (function(obj, privateCollection) {
+            if (privateCollection.has(obj)) throw new TypeError("Cannot initialize the same private elements twice on an object");
+        })(obj, privateMap), privateMap.set(obj, value);
+    }
+    return Constructor = _class, protoProps = [
+        {
+            key: "m",
+            value: function() {
+                var receiver, privateMap, descriptor, receiver, descriptor, receiver, privateMap, value, descriptor;
+                receiver = this, privateMap = _x, receiver = this, value = ((descriptor = _classExtractFieldDescriptor(receiver, privateMap = _x, "get")).get ? descriptor.get.call(receiver) : descriptor.value) + 2, descriptor = _classExtractFieldDescriptor(receiver, privateMap, "set"), (function(receiver, descriptor, value) {
+                    if (descriptor.set) descriptor.set.call(receiver, value);
+                    else {
+                        if (!descriptor.writable) throw new TypeError("attempted to set read only private field");
+                        descriptor.value = value;
+                    }
+                })(receiver, descriptor, value);
             }
-        ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), _class;
-    }();
-    return _class;
-}();
+        }
+    ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), _class;
+}());
+function set_x(x) {}
 console.log(new C().m());

--- a/crates/swc/tests/tsc-references/privateNameStaticFieldClassExpression_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameStaticFieldClassExpression_es2015.1.normal.js
@@ -30,7 +30,7 @@ class B {
 }
 var _foo = {
     writable: true,
-    value: (_class = class _class {
+    value: (_class = class {
         constructor(){
             this.field = 10;
             console.log("hello");

--- a/crates/swc/tests/tsc-references/privateNameStaticFieldNoInitializer_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameStaticFieldNoInitializer_es2015.1.normal.js
@@ -1,16 +1,13 @@
+var _class, _x;
 // @target: es2015, es2022, esnext
-const C = function() {
-    class _class {
-    }
-    var _x = {
-        writable: true,
-        value: void 0
-    };
-    return _class;
-}();
+const C = (_class = class {
+}, _x = {
+    writable: true,
+    value: void 0
+}, _class);
 class C2 {
 }
-var _x = {
+var _x1 = {
     writable: true,
     value: void 0
 };

--- a/crates/swc/tests/tsc-references/privateNameStaticFieldNoInitializer_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameStaticFieldNoInitializer_es5.1.normal.js
@@ -3,23 +3,20 @@ function _classCallCheck(instance, Constructor) {
         throw new TypeError("Cannot call a class as a function");
     }
 }
+var _class, _x;
 // @target: es2015, es2022, esnext
-var C = function() {
-    var _class = function _class() {
-        "use strict";
-        _classCallCheck(this, _class);
-    };
-    var _x = {
-        writable: true,
-        value: void 0
-    };
-    return _class;
-}();
+var C = (_class = function _class1() {
+    "use strict";
+    _classCallCheck(this, _class1);
+}, _x = {
+    writable: true,
+    value: void 0
+}, _class);
 var C2 = function C2() {
     "use strict";
     _classCallCheck(this, C2);
 };
-var _x = {
+var _x1 = {
     writable: true,
     value: void 0
 };

--- a/crates/swc/tests/tsc-references/privateNameStaticFieldNoInitializer_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNameStaticFieldNoInitializer_es5.2.minified.js
@@ -1,13 +1,6 @@
-function _classCallCheck(instance, Constructor) {
-    if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
-}
-!function() {
-    var _class = function() {
-        "use strict";
-        _classCallCheck(this, _class);
-    };
-}();
 var C2 = function() {
     "use strict";
-    _classCallCheck(this, C2);
+    !function(instance, Constructor) {
+        if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
+    }(this, C2);
 };

--- a/crates/swc/tests/tsc-references/quotedConstructors_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/quotedConstructors_es2015.1.normal.js
@@ -8,13 +8,12 @@ class D {
         console.log(this);
     }
 }
-var tmp = 'constructor';
 class E {
-    [tmp]() {
+    ['constructor']() {
         console.log(this);
     }
 }
-new class _class {
+new class {
     constructor(){
         console.log(this);
     }

--- a/crates/swc/tests/tsc-references/quotedConstructors_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/quotedConstructors_es5.1.normal.js
@@ -27,7 +27,6 @@ var D = function D() {
     _classCallCheck(this, D);
     console.log(this);
 };
-var tmp = 'constructor';
 var E = /*#__PURE__*/ function() {
     "use strict";
     function E() {
@@ -35,7 +34,7 @@ var E = /*#__PURE__*/ function() {
     }
     _createClass(E, [
         {
-            key: tmp,
+            key: 'constructor',
             value: function value() {
                 console.log(this);
             }

--- a/crates/swc/tests/tsc-references/staticIndexSignature6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/staticIndexSignature6_es2015.1.normal.js
@@ -1,6 +1,6 @@
 // @strict: true
 function foo() {
-    return class _class {
+    return class {
         foo(v) {
             return v;
         }

--- a/crates/swc/tests/tsc-references/superInStaticMembers1_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/superInStaticMembers1_es2015.1.normal.js
@@ -11,7 +11,7 @@ class _class {
 export { _class as default };
 class C extends B {
 }
-var __ = {
+var __32 = {
     writable: true,
     value: (()=>{
         var { Reflect  } = {
@@ -400,37 +400,30 @@ var __30 = {
         super.w();
     })()
 };
-(function() {
-    class Reflect {
-    }
-    var __ = {
-        writable: true,
-        value: (()=>{
-            class C1 extends B {
-            }
-            C1._ = super.w();
-        })()
-    };
-    return Reflect;
-})();
-(function() {
-    class Reflect {
-    }
-    var __ = {
-        writable: true,
-        value: (()=>{
-            class C extends B {
-            }
-            var __ = {
-                writable: true,
-                value: (()=>{
-                    super.w();
-                })()
-            };
-        })()
-    };
-    return Reflect;
-})();
+_Reflect = class Reflect {
+}, __ = {
+    writable: true,
+    value: (()=>{
+        class C1 extends B {
+        }
+        C1._ = super.w();
+    })()
+}, _Reflect;
+_Reflect = class Reflect {
+}, __ = {
+    writable: true,
+    value: (()=>{
+        var _Reflect, __;
+        class C extends B {
+        }
+        var __33 = {
+            writable: true,
+            value: (()=>{
+                super.w();
+            })()
+        };
+    })()
+}, _Reflect;
 (function Reflect() {}); // no collision
 class C extends B {
 }
@@ -450,9 +443,10 @@ var __31 = {
     C2._ = super.w();
 });
 (function Reflect() {
+    var _Reflect, __;
     class C extends B {
     }
-    var __ = {
+    var __34 = {
         writable: true,
         value: (()=>{
             super.w();

--- a/crates/swc/tests/tsc-references/superInStaticMembers1_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/superInStaticMembers1_es2015.2.minified.js
@@ -169,8 +169,19 @@ class C extends B {
 C._ = super.w();
 class C extends B {
 }
-super.w(), (class extends B {
-})._ = super.w(), super.w();
+super.w(), _Reflect = class {
+}, __ = {
+    writable: !0,
+    value: void ((class extends B {
+    })._ = super.w())
+}, _Reflect = class {
+}, __ = {
+    writable: !0,
+    value: (()=>{
+        var _Reflect, __;
+        super.w();
+    })()
+};
 class C extends B {
 }
 C._ = super.w();

--- a/crates/swc/tests/tsc-references/superInStaticMembers1_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/superInStaticMembers1_es5.1.normal.js
@@ -96,7 +96,7 @@ var C = /*#__PURE__*/ function(B) {
     }
     return C;
 }(B);
-var __ = {
+var __32 = {
     writable: true,
     value: function() {
         var Reflect = {
@@ -815,63 +815,52 @@ var __30 = {
         _superprop_get_w().call(_this);
     }()
 };
-(function() {
-    var _this1 = this, _superprop_get_w1 = ()=>super.w
-    ;
-    var Reflect = function Reflect() {
-        "use strict";
-        _classCallCheck(this, Reflect);
-    };
-    var __ = {
-        writable: true,
-        value: function() {
-            var C = /*#__PURE__*/ function(B) {
-                "use strict";
-                _inherits(C, B);
-                var _super = _createSuper(C);
-                function C() {
-                    _classCallCheck(this, C);
-                    return _super.apply(this, arguments);
-                }
-                return C;
-            }(B);
-            C._ = _superprop_get_w1().call(_this1);
-        }()
-    };
-    return Reflect;
-})();
-(function() {
-    var _this3 = this, _superprop_get_w3 = ()=>super.w
-    ;
-    var Reflect = function Reflect() {
-        "use strict";
-        _classCallCheck(this, Reflect);
-    };
-    var __ = {
-        writable: true,
-        value: function() {
-            var _this2 = _this3, _superprop_get_w2 = ()=>_superprop_get_w3()
-            ;
-            var C = /*#__PURE__*/ function(B) {
-                "use strict";
-                _inherits(C, B);
-                var _super = _createSuper(C);
-                function C() {
-                    _classCallCheck(this, C);
-                    return _super.apply(this, arguments);
-                }
-                return C;
-            }(B);
-            var __ = {
-                writable: true,
-                value: function() {
-                    _superprop_get_w2().call(_this2);
-                }()
-            };
-        }()
-    };
-    return Reflect;
-})();
+_Reflect = function Reflect() {
+    "use strict";
+    _classCallCheck(this, Reflect);
+}, __ = {
+    writable: true,
+    value: (function() {
+        var C = /*#__PURE__*/ function(B) {
+            "use strict";
+            _inherits(C, B);
+            var _super = _createSuper(C);
+            function C() {
+                _classCallCheck(this, C);
+                return _super.apply(this, arguments);
+            }
+            return C;
+        }(B);
+        C._ = _superprop_get_w().call(_this);
+    })()
+}, _Reflect;
+_Reflect = function Reflect() {
+    "use strict";
+    _classCallCheck(this, Reflect);
+}, __ = {
+    writable: true,
+    value: (function() {
+        var _this1 = _this, _superprop_get_w1 = ()=>_superprop_get_w()
+        ;
+        var _Reflect, __;
+        var C = /*#__PURE__*/ function(B) {
+            "use strict";
+            _inherits(C, B);
+            var _super = _createSuper(C);
+            function C() {
+                _classCallCheck(this, C);
+                return _super.apply(this, arguments);
+            }
+            return C;
+        }(B);
+        var __33 = {
+            writable: true,
+            value: function() {
+                _superprop_get_w1().call(_this1);
+            }()
+        };
+    })()
+}, _Reflect;
 (function Reflect() {}); // no collision
 var C = /*#__PURE__*/ function(B) {
     "use strict";
@@ -915,8 +904,9 @@ var __31 = {
     C._ = super.w();
 });
 (function Reflect() {
-    var _this4 = this, _superprop_get_w4 = ()=>super.w
+    var _this2 = this, _superprop_get_w2 = ()=>super.w
     ;
+    var _Reflect, __;
     var C = /*#__PURE__*/ function(B) {
         "use strict";
         _inherits(C, B);
@@ -927,10 +917,10 @@ var __31 = {
         }
         return C;
     }(B);
-    var __ = {
+    var __34 = {
         writable: true,
         value: function() {
-            _superprop_get_w4().call(_this4);
+            _superprop_get_w2().call(_this2);
         }()
     };
 });

--- a/crates/swc/tests/tsc-references/superInStaticMembers1_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/superInStaticMembers1_es5.2.minified.js
@@ -496,37 +496,41 @@ var C = function(B) {
     }
     return C;
 }(B);
-_superprop_get_w().call(_this), (function() {
-    var C, Reflect = function() {
-        "use strict";
-        _classCallCheck(this, Reflect);
-    };
-    (C = (function(B) {
-        "use strict";
-        _inherits(C, B);
-        var _super = _createSuper(C);
-        function C() {
-            return _classCallCheck(this, C), _super.apply(this, arguments);
-        }
-        return C;
-    })(B))._ = super.w.call(this);
-})(), (function() {
-    var _this1, _superprop_get_w2, C, _superprop_get_w1 = ()=>super.w
-    , Reflect = function() {
-        "use strict";
-        _classCallCheck(this, Reflect);
-    };
-    _this1 = this, _superprop_get_w2 = ()=>_superprop_get_w1()
-    , C = (function(B) {
-        "use strict";
-        _inherits(C, B);
-        var _super = _createSuper(C);
-        function C() {
-            return _classCallCheck(this, C), _super.apply(this, arguments);
-        }
-        return C;
-    })(B), _superprop_get_w2().call(_this1);
-})();
+_superprop_get_w().call(_this), _Reflect = function Reflect() {
+    "use strict";
+    _classCallCheck(this, Reflect);
+}, __ = {
+    writable: !0,
+    value: (function() {
+        var C = function(B) {
+            "use strict";
+            _inherits(C, B);
+            var _super = _createSuper(C);
+            function C() {
+                return _classCallCheck(this, C), _super.apply(this, arguments);
+            }
+            return C;
+        }(B);
+        C._ = _superprop_get_w().call(_this);
+    })()
+}, _Reflect = function Reflect() {
+    "use strict";
+    _classCallCheck(this, Reflect);
+}, __ = {
+    writable: !0,
+    value: (function() {
+        var _Reflect, __, C = function(B) {
+            "use strict";
+            _inherits(C, B);
+            var _super = _createSuper(C);
+            function C() {
+                return _classCallCheck(this, C), _super.apply(this, arguments);
+            }
+            return C;
+        }(B);
+        _superprop_get_w().call(_this);
+    })()
+};
 var C = function(B) {
     "use strict";
     _inherits(C, B);

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess1_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess1_es2015.1.normal.js
@@ -1,14 +1,14 @@
 //@target: ES6
 var symbol = Symbol.for('myThing');
-var tmp = symbol;
+let _symbol = symbol;
 class Foo {
-    [tmp]() {
+    [_symbol]() {
         return 0;
     }
 }
-var tmp1 = symbol;
+let _symbol1 = symbol;
 class Bar extends Foo {
-    [tmp1]() {
+    [_symbol1]() {
         return super[symbol]();
     }
 }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess1_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess1_es5.1.normal.js
@@ -108,7 +108,7 @@ function _createSuper(Derived) {
 }
 //@target: ES6
 var symbol = Symbol.for('myThing');
-var tmp = symbol;
+var _symbol = symbol;
 var Foo = /*#__PURE__*/ function() {
     "use strict";
     function Foo() {
@@ -116,7 +116,7 @@ var Foo = /*#__PURE__*/ function() {
     }
     _createClass(Foo, [
         {
-            key: tmp,
+            key: _symbol,
             value: function value() {
                 return 0;
             }
@@ -124,7 +124,7 @@ var Foo = /*#__PURE__*/ function() {
     ]);
     return Foo;
 }();
-var tmp1 = symbol;
+var _symbol1 = symbol;
 var Bar = /*#__PURE__*/ function(Foo) {
     "use strict";
     _inherits(Bar, Foo);
@@ -135,7 +135,7 @@ var Bar = /*#__PURE__*/ function(Foo) {
     }
     _createClass(Bar, [
         {
-            key: tmp1,
+            key: _symbol1,
             value: function value() {
                 return _get(_getPrototypeOf(Bar.prototype), symbol, this).call(this);
             }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess1_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess1_es5.2.minified.js
@@ -33,20 +33,20 @@ function _superPropBase(object, property) {
     for(; !Object.prototype.hasOwnProperty.call(object, property) && null !== (object = _getPrototypeOf(object)););
     return object;
 }
-var symbol = Symbol.for("myThing"), tmp = symbol, Foo = function() {
+var symbol = Symbol.for("myThing"), _symbol = symbol, Foo = function() {
     "use strict";
     function Foo() {
         _classCallCheck(this, Foo);
     }
     return _createClass(Foo, [
         {
-            key: tmp,
+            key: _symbol,
             value: function() {
                 return 0;
             }
         }
     ]), Foo;
-}(), tmp1 = symbol, Bar = function(Foo) {
+}(), _symbol1 = symbol, Bar = function(Foo) {
     "use strict";
     !function(subClass, superClass) {
         if ("function" != typeof superClass && null !== superClass) throw new TypeError("Super expression must either be null or a function");
@@ -83,7 +83,7 @@ var symbol = Symbol.for("myThing"), tmp = symbol, Foo = function() {
     }
     return _createClass(Bar, [
         {
-            key: tmp1,
+            key: _symbol1,
             value: function() {
                 return _get(_getPrototypeOf(Bar.prototype), symbol, this).call(this);
             }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess2_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess2_es2015.1.normal.js
@@ -1,13 +1,13 @@
-var tmp = Symbol.isConcatSpreadable;
+let _isConcatSpreadable = Symbol.isConcatSpreadable;
 //@target: ES6
 class Foo {
-    [tmp]() {
+    [_isConcatSpreadable]() {
         return 0;
     }
 }
-var tmp1 = Symbol.isConcatSpreadable;
+let _isConcatSpreadable1 = Symbol.isConcatSpreadable;
 class Bar extends Foo {
-    [tmp1]() {
+    [_isConcatSpreadable1]() {
         return super[Symbol.isConcatSpreadable]();
     }
 }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess2_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess2_es5.1.normal.js
@@ -106,7 +106,7 @@ function _createSuper(Derived) {
         return _possibleConstructorReturn(this, result);
     };
 }
-var tmp = Symbol.isConcatSpreadable;
+var _isConcatSpreadable = Symbol.isConcatSpreadable;
 var Foo = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -115,7 +115,7 @@ var Foo = //@target: ES6
     }
     _createClass(Foo, [
         {
-            key: tmp,
+            key: _isConcatSpreadable,
             value: function value() {
                 return 0;
             }
@@ -123,7 +123,7 @@ var Foo = //@target: ES6
     ]);
     return Foo;
 }();
-var tmp1 = Symbol.isConcatSpreadable;
+var _isConcatSpreadable1 = Symbol.isConcatSpreadable;
 var Bar = /*#__PURE__*/ function(Foo) {
     "use strict";
     _inherits(Bar, Foo);
@@ -134,7 +134,7 @@ var Bar = /*#__PURE__*/ function(Foo) {
     }
     _createClass(Bar, [
         {
-            key: tmp1,
+            key: _isConcatSpreadable1,
             value: function value() {
                 return _get(_getPrototypeOf(Bar.prototype), Symbol.isConcatSpreadable, this).call(this);
             }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess2_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess2_es5.2.minified.js
@@ -33,20 +33,20 @@ function _superPropBase(object, property) {
     for(; !Object.prototype.hasOwnProperty.call(object, property) && null !== (object = _getPrototypeOf(object)););
     return object;
 }
-var tmp = Symbol.isConcatSpreadable, Foo = function() {
+var _isConcatSpreadable = Symbol.isConcatSpreadable, Foo = function() {
     "use strict";
     function Foo() {
         _classCallCheck(this, Foo);
     }
     return _createClass(Foo, [
         {
-            key: tmp,
+            key: _isConcatSpreadable,
             value: function() {
                 return 0;
             }
         }
     ]), Foo;
-}(), tmp1 = Symbol.isConcatSpreadable, Bar = function(Foo) {
+}(), _isConcatSpreadable1 = Symbol.isConcatSpreadable, Bar = function(Foo) {
     "use strict";
     !function(subClass, superClass) {
         if ("function" != typeof superClass && null !== superClass) throw new TypeError("Super expression must either be null or a function");
@@ -83,7 +83,7 @@ var tmp = Symbol.isConcatSpreadable, Foo = function() {
     }
     return _createClass(Bar, [
         {
-            key: tmp1,
+            key: _isConcatSpreadable1,
             value: function() {
                 return _get(_getPrototypeOf(Bar.prototype), Symbol.isConcatSpreadable, this).call(this);
             }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess3_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess3_es2015.1.normal.js
@@ -1,14 +1,14 @@
 //@target: ES6
 var symbol = Symbol.for('myThing');
-var tmp = symbol;
+let _symbol = symbol;
 class Foo {
-    [tmp]() {
+    [_symbol]() {
         return 0;
     }
 }
-var tmp1 = symbol;
+let _symbol1 = symbol;
 class Bar extends Foo {
-    [tmp1]() {
+    [_symbol1]() {
         return super[Bar]();
     }
 }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess3_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess3_es5.1.normal.js
@@ -108,7 +108,7 @@ function _createSuper(Derived) {
 }
 //@target: ES6
 var symbol = Symbol.for('myThing');
-var tmp = symbol;
+var _symbol = symbol;
 var Foo = /*#__PURE__*/ function() {
     "use strict";
     function Foo() {
@@ -116,7 +116,7 @@ var Foo = /*#__PURE__*/ function() {
     }
     _createClass(Foo, [
         {
-            key: tmp,
+            key: _symbol,
             value: function value() {
                 return 0;
             }
@@ -124,7 +124,7 @@ var Foo = /*#__PURE__*/ function() {
     ]);
     return Foo;
 }();
-var tmp1 = symbol;
+var _symbol1 = symbol;
 var Bar = /*#__PURE__*/ function(Foo) {
     "use strict";
     _inherits(Bar, Foo);
@@ -135,7 +135,7 @@ var Bar = /*#__PURE__*/ function(Foo) {
     }
     _createClass(Bar, [
         {
-            key: tmp1,
+            key: _symbol1,
             value: function value() {
                 return _get(_getPrototypeOf(Bar.prototype), Bar, this).call(this);
             }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess3_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess3_es5.2.minified.js
@@ -33,20 +33,20 @@ function _superPropBase(object, property) {
     for(; !Object.prototype.hasOwnProperty.call(object, property) && null !== (object = _getPrototypeOf(object)););
     return object;
 }
-var symbol = Symbol.for("myThing"), tmp = symbol, Foo = function() {
+var symbol = Symbol.for("myThing"), _symbol = symbol, Foo = function() {
     "use strict";
     function Foo() {
         _classCallCheck(this, Foo);
     }
     return _createClass(Foo, [
         {
-            key: tmp,
+            key: _symbol,
             value: function() {
                 return 0;
             }
         }
     ]), Foo;
-}(), tmp1 = symbol, Bar = function(Foo) {
+}(), _symbol1 = symbol, Bar = function(Foo) {
     "use strict";
     !function(subClass, superClass) {
         if ("function" != typeof superClass && null !== superClass) throw new TypeError("Super expression must either be null or a function");
@@ -83,7 +83,7 @@ var symbol = Symbol.for("myThing"), tmp = symbol, Foo = function() {
     }
     return _createClass(Bar, [
         {
-            key: tmp1,
+            key: _symbol1,
             value: function() {
                 return _get(_getPrototypeOf(Bar.prototype), Bar, this).call(this);
             }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess4_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess4_es2015.1.normal.js
@@ -1,8 +1,8 @@
 //@target: ES6
 var symbol = Symbol.for('myThing');
-var tmp = symbol;
+let _symbol = symbol;
 class Bar {
-    [tmp]() {
+    [_symbol]() {
         return super[symbol]();
     }
 }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess4_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess4_es5.1.normal.js
@@ -48,7 +48,7 @@ function _superPropBase(object, property) {
 }
 //@target: ES6
 var symbol = Symbol.for('myThing');
-var tmp = symbol;
+var _symbol = symbol;
 var Bar = /*#__PURE__*/ function() {
     "use strict";
     function Bar() {
@@ -56,7 +56,7 @@ var Bar = /*#__PURE__*/ function() {
     }
     _createClass(Bar, [
         {
-            key: tmp,
+            key: _symbol,
             value: function value() {
                 return _get(_getPrototypeOf(Bar.prototype), symbol, this).call(this);
             }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess4_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess4_es5.2.minified.js
@@ -22,7 +22,7 @@ function _superPropBase(object, property) {
     for(; !Object.prototype.hasOwnProperty.call(object, property) && null !== (object = _getPrototypeOf(object)););
     return object;
 }
-var symbol = Symbol.for("myThing"), tmp = symbol, Bar = function() {
+var symbol = Symbol.for("myThing"), _symbol = symbol, Bar = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function Bar() {
@@ -32,7 +32,7 @@ var symbol = Symbol.for("myThing"), tmp = symbol, Bar = function() {
     }
     return Constructor = Bar, protoProps = [
         {
-            key: tmp,
+            key: _symbol,
             value: function() {
                 return _get(_getPrototypeOf(Bar.prototype), symbol, this).call(this);
             }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess5_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess5_es2015.1.normal.js
@@ -1,14 +1,14 @@
 //@target: ES5
 var symbol;
-var tmp = symbol;
+let _symbol = symbol;
 class Foo {
-    [tmp]() {
+    [_symbol]() {
         return 0;
     }
 }
-var tmp1 = symbol;
+let _symbol1 = symbol;
 class Bar extends Foo {
-    [tmp1]() {
+    [_symbol1]() {
         return super[symbol]();
     }
 }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess5_es5.1.normal.js
@@ -108,7 +108,7 @@ function _createSuper(Derived) {
 }
 //@target: ES5
 var symbol;
-var tmp = symbol;
+var _symbol = symbol;
 var Foo = /*#__PURE__*/ function() {
     "use strict";
     function Foo() {
@@ -116,7 +116,7 @@ var Foo = /*#__PURE__*/ function() {
     }
     _createClass(Foo, [
         {
-            key: tmp,
+            key: _symbol,
             value: function value() {
                 return 0;
             }
@@ -124,7 +124,7 @@ var Foo = /*#__PURE__*/ function() {
     ]);
     return Foo;
 }();
-var tmp1 = symbol;
+var _symbol1 = symbol;
 var Bar = /*#__PURE__*/ function(Foo) {
     "use strict";
     _inherits(Bar, Foo);
@@ -135,7 +135,7 @@ var Bar = /*#__PURE__*/ function(Foo) {
     }
     _createClass(Bar, [
         {
-            key: tmp1,
+            key: _symbol1,
             value: function value() {
                 return _get(_getPrototypeOf(Bar.prototype), symbol, this).call(this);
             }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess5_es5.2.minified.js
@@ -33,20 +33,20 @@ function _superPropBase(object, property) {
     for(; !Object.prototype.hasOwnProperty.call(object, property) && null !== (object = _getPrototypeOf(object)););
     return object;
 }
-var symbol, tmp = symbol, Foo = function() {
+var symbol, _symbol = symbol, Foo = function() {
     "use strict";
     function Foo() {
         _classCallCheck(this, Foo);
     }
     return _createClass(Foo, [
         {
-            key: tmp,
+            key: _symbol,
             value: function() {
                 return 0;
             }
         }
     ]), Foo;
-}(), tmp1 = symbol, Bar = function(Foo) {
+}(), _symbol1 = symbol, Bar = function(Foo) {
     "use strict";
     !function(subClass, superClass) {
         if ("function" != typeof superClass && null !== superClass) throw new TypeError("Super expression must either be null or a function");
@@ -83,7 +83,7 @@ var symbol, tmp = symbol, Foo = function() {
     }
     return _createClass(Bar, [
         {
-            key: tmp1,
+            key: _symbol1,
             value: function() {
                 return _get(_getPrototypeOf(Bar.prototype), symbol, this).call(this);
             }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess6_es2015.1.normal.js
@@ -1,14 +1,14 @@
 //@target: ES5
 var symbol;
-var tmp = symbol;
+let _symbol = symbol;
 class Foo {
-    static [tmp]() {
+    static [_symbol]() {
         return 0;
     }
 }
-var tmp1 = symbol;
+let _symbol1 = symbol;
 class Bar extends Foo {
-    static [tmp1]() {
+    static [_symbol1]() {
         return super[symbol]();
     }
 }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess6_es5.1.normal.js
@@ -108,7 +108,7 @@ function _createSuper(Derived) {
 }
 //@target: ES5
 var symbol;
-var tmp = symbol;
+var _symbol = symbol;
 var Foo = /*#__PURE__*/ function() {
     "use strict";
     function Foo() {
@@ -116,7 +116,7 @@ var Foo = /*#__PURE__*/ function() {
     }
     _createClass(Foo, null, [
         {
-            key: tmp,
+            key: _symbol,
             value: function value() {
                 return 0;
             }
@@ -124,7 +124,7 @@ var Foo = /*#__PURE__*/ function() {
     ]);
     return Foo;
 }();
-var tmp1 = symbol;
+var _symbol1 = symbol;
 var Bar = /*#__PURE__*/ function(Foo) {
     "use strict";
     _inherits(Bar, Foo);
@@ -135,7 +135,7 @@ var Bar = /*#__PURE__*/ function(Foo) {
     }
     _createClass(Bar, null, [
         {
-            key: tmp1,
+            key: _symbol1,
             value: function value() {
                 return _get(_getPrototypeOf(Bar), symbol, this).call(this);
             }

--- a/crates/swc/tests/tsc-references/superSymbolIndexedAccess6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/superSymbolIndexedAccess6_es5.2.minified.js
@@ -33,20 +33,20 @@ function _superPropBase(object, property) {
     for(; !Object.prototype.hasOwnProperty.call(object, property) && null !== (object = _getPrototypeOf(object)););
     return object;
 }
-var symbol, tmp = symbol, Foo = function() {
+var symbol, _symbol = symbol, Foo = function() {
     "use strict";
     function Foo() {
         _classCallCheck(this, Foo);
     }
     return _createClass(Foo, null, [
         {
-            key: tmp,
+            key: _symbol,
             value: function() {
                 return 0;
             }
         }
     ]), Foo;
-}(), tmp1 = symbol, Bar = function(Foo) {
+}(), _symbol1 = symbol, Bar = function(Foo) {
     "use strict";
     !function(subClass, superClass) {
         if ("function" != typeof superClass && null !== superClass) throw new TypeError("Super expression must either be null or a function");
@@ -83,7 +83,7 @@ var symbol, tmp = symbol, Foo = function() {
     }
     return _createClass(Bar, null, [
         {
-            key: tmp1,
+            key: _symbol1,
             value: function() {
                 return _get(_getPrototypeOf(Bar), symbol, this).call(this);
             }

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit11_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit11_es2015.1.normal.js
@@ -1,12 +1,12 @@
 var _key;
-var tmp = (_key = Symbol.iterator, Symbol.isConcatSpreadable), tmp1 = Symbol.toPrimitive, tmp2 = Symbol.toPrimitive;
+let tmp = (_key = Symbol.iterator, Symbol.isConcatSpreadable), _toPrimitive = Symbol.toPrimitive, _toPrimitive1 = Symbol.toPrimitive;
 //@target: ES6
 //@declaration: true
 class C {
     static [tmp]() {}
-    static get [tmp1]() {
+    static get [_toPrimitive]() {
         return "";
     }
-    static set [tmp2](x) {}
+    static set [_toPrimitive1](x) {}
 }
 C[_key] = 0;

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit11_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit11_es2015.2.minified.js
@@ -1,8 +1,9 @@
-var _key, tmp = (_key = Symbol.iterator, Symbol.isConcatSpreadable), tmp1 = Symbol.toPrimitive, tmp2 = Symbol.toPrimitive;
+var _key;
+let tmp = (_key = Symbol.iterator, Symbol.isConcatSpreadable), _toPrimitive = Symbol.toPrimitive, _toPrimitive1 = Symbol.toPrimitive;
 (class {
     static [tmp]() {}
-    static get [tmp1]() {
+    static get [_toPrimitive]() {
         return "";
     }
-    static set [tmp2](x) {}
+    static set [_toPrimitive1](x) {}
 })[_key] = 0;

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit11_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit11_es5.1.normal.js
@@ -18,7 +18,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     return Constructor;
 }
 var _key;
-var tmp = (_key = Symbol.iterator, Symbol.isConcatSpreadable), tmp1 = Symbol.toPrimitive, tmp2 = Symbol.toPrimitive;
+var tmp = (_key = Symbol.iterator, Symbol.isConcatSpreadable), _toPrimitive = Symbol.toPrimitive, _toPrimitive1 = Symbol.toPrimitive;
 var C = //@target: ES6
 //@declaration: true
 /*#__PURE__*/ function() {
@@ -32,13 +32,13 @@ var C = //@target: ES6
             value: function value() {}
         },
         {
-            key: tmp1,
+            key: _toPrimitive,
             get: function get() {
                 return "";
             }
         },
         {
-            key: tmp2,
+            key: _toPrimitive1,
             set: function set(x) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit11_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit11_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var _key, tmp = (_key = Symbol.iterator, Symbol.isConcatSpreadable), tmp1 = Symbol.toPrimitive, tmp2 = Symbol.toPrimitive, C = function() {
+var _key, tmp = (_key = Symbol.iterator, Symbol.isConcatSpreadable), _toPrimitive = Symbol.toPrimitive, _toPrimitive1 = Symbol.toPrimitive, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -18,13 +18,13 @@ var _key, tmp = (_key = Symbol.iterator, Symbol.isConcatSpreadable), tmp1 = Symb
             value: function() {}
         },
         {
-            key: tmp1,
+            key: _toPrimitive,
             get: function() {
                 return "";
             }
         },
         {
-            key: tmp2,
+            key: _toPrimitive1,
             set: function(x) {}
         }
     ], protoProps && _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit12_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit12_es2015.1.normal.js
@@ -2,16 +2,16 @@
 //@declaration: true
 var M;
 (function(M1) {
-    var tmp = Symbol.toPrimitive, tmp1 = Symbol.isConcatSpreadable, tmp2 = Symbol.toPrimitive, tmp3 = Symbol.toPrimitive;
+    let _toPrimitive = Symbol.toPrimitive, _isConcatSpreadable = Symbol.isConcatSpreadable, _toPrimitive1 = Symbol.toPrimitive, _toPrimitive2 = Symbol.toPrimitive;
     class C {
-        [tmp](x) {}
-        [tmp1]() {
+        [_toPrimitive](x) {}
+        [_isConcatSpreadable]() {
             return undefined;
         }
-        get [tmp2]() {
+        get [_toPrimitive1]() {
             return undefined;
         }
-        set [tmp3](x) {}
+        set [_toPrimitive2](x) {}
     }
     M1.C = C;
 })(M || (M = {}));

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit12_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit12_es2015.2.minified.js
@@ -1,10 +1,10 @@
 var M;
 !function(M1) {
-    var tmp = Symbol.toPrimitive, tmp1 = Symbol.isConcatSpreadable, tmp2 = Symbol.toPrimitive, tmp3 = Symbol.toPrimitive;
+    let _toPrimitive = Symbol.toPrimitive, _isConcatSpreadable = Symbol.isConcatSpreadable, _toPrimitive1 = Symbol.toPrimitive, _toPrimitive2 = Symbol.toPrimitive;
     M1.C = class {
-        [tmp](x) {}
-        [tmp1]() {}
-        get [tmp2]() {}
-        set [tmp3](x) {}
+        [_toPrimitive](x) {}
+        [_isConcatSpreadable]() {}
+        get [_toPrimitive1]() {}
+        set [_toPrimitive2](x) {}
     };
 }(M || (M = {}));

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit12_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit12_es5.1.normal.js
@@ -21,7 +21,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 //@declaration: true
 var M;
 (function(M1) {
-    var tmp = Symbol.toPrimitive, tmp1 = Symbol.isConcatSpreadable, tmp2 = Symbol.toPrimitive, tmp3 = Symbol.toPrimitive;
+    var _toPrimitive = Symbol.toPrimitive, _isConcatSpreadable = Symbol.isConcatSpreadable, _toPrimitive1 = Symbol.toPrimitive, _toPrimitive2 = Symbol.toPrimitive;
     var C = /*#__PURE__*/ function() {
         "use strict";
         function C() {
@@ -29,23 +29,23 @@ var M;
         }
         _createClass(C, [
             {
-                key: tmp,
+                key: _toPrimitive,
                 value: function value(x) {}
             },
             {
-                key: tmp1,
+                key: _isConcatSpreadable,
                 value: function value() {
                     return undefined;
                 }
             },
             {
-                key: tmp2,
+                key: _toPrimitive1,
                 get: function get() {
                     return undefined;
                 }
             },
             {
-                key: tmp3,
+                key: _toPrimitive2,
                 set: function set(x) {}
             }
         ]);

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit12_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit12_es5.2.minified.js
@@ -6,7 +6,7 @@ function _defineProperties(target, props) {
     }
 }
 !function(M1) {
-    var tmp = Symbol.toPrimitive, tmp1 = Symbol.isConcatSpreadable, tmp2 = Symbol.toPrimitive, tmp3 = Symbol.toPrimitive, C = function() {
+    var _toPrimitive = Symbol.toPrimitive, _isConcatSpreadable = Symbol.isConcatSpreadable, _toPrimitive1 = Symbol.toPrimitive, _toPrimitive2 = Symbol.toPrimitive, C = function() {
         "use strict";
         var Constructor, protoProps, staticProps;
         function C() {
@@ -16,19 +16,19 @@ function _defineProperties(target, props) {
         }
         return Constructor = C, protoProps = [
             {
-                key: tmp,
+                key: _toPrimitive,
                 value: function(x) {}
             },
             {
-                key: tmp1,
+                key: _isConcatSpreadable,
                 value: function() {}
             },
             {
-                key: tmp2,
+                key: _toPrimitive1,
                 get: function() {}
             },
             {
-                key: tmp3,
+                key: _toPrimitive2,
                 set: function(x) {}
             }
         ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit13_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit13_es2015.1.normal.js
@@ -1,9 +1,9 @@
-var tmp = Symbol.toPrimitive, tmp1 = Symbol.toStringTag;
+let _toPrimitive = Symbol.toPrimitive, _toStringTag = Symbol.toStringTag;
 //@target: ES6
 //@declaration: true
 class C {
-    get [tmp]() {
+    get [_toPrimitive]() {
         return "";
     }
-    set [tmp1](x) {}
+    set [_toStringTag](x) {}
 }

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit13_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit13_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.toPrimitive, tmp1 = Symbol.toStringTag;
+var _toPrimitive = Symbol.toPrimitive, _toStringTag = Symbol.toStringTag;
 var C = //@target: ES6
 //@declaration: true
 /*#__PURE__*/ function() {
@@ -27,13 +27,13 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _toPrimitive,
             get: function get() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _toStringTag,
             set: function set(x) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit13_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit13_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.toPrimitive, tmp1 = Symbol.toStringTag, C = function() {
+var _toPrimitive = Symbol.toPrimitive, _toStringTag = Symbol.toStringTag, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,13 +14,13 @@ var tmp = Symbol.toPrimitive, tmp1 = Symbol.toStringTag, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _toPrimitive,
             get: function() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _toStringTag,
             set: function(x) {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit14_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit14_es2015.1.normal.js
@@ -1,11 +1,11 @@
-var tmp = Symbol.toPrimitive, tmp1 = Symbol.toStringTag;
+let _toPrimitive = Symbol.toPrimitive, _toStringTag = Symbol.toStringTag;
 //@target: ES6
 //@declaration: true
 class C {
-    get [tmp]() {
+    get [_toPrimitive]() {
         return "";
     }
-    get [tmp1]() {
+    get [_toStringTag]() {
         return "";
     }
 }

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit14_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit14_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.toPrimitive, tmp1 = Symbol.toStringTag;
+var _toPrimitive = Symbol.toPrimitive, _toStringTag = Symbol.toStringTag;
 var C = //@target: ES6
 //@declaration: true
 /*#__PURE__*/ function() {
@@ -27,13 +27,13 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _toPrimitive,
             get: function get() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _toStringTag,
             get: function get() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit14_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit14_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.toPrimitive, tmp1 = Symbol.toStringTag, C = function() {
+var _toPrimitive = Symbol.toPrimitive, _toStringTag = Symbol.toStringTag, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,13 +14,13 @@ var tmp = Symbol.toPrimitive, tmp1 = Symbol.toStringTag, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _toPrimitive,
             get: function() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _toStringTag,
             get: function() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit3_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit3_es2015.1.normal.js
@@ -1,6 +1,6 @@
-var tmp = Symbol.toPrimitive;
+let _toPrimitive = Symbol.toPrimitive;
 //@target: ES6
 //@declaration: true
 class C {
-    [tmp](x) {}
+    [_toPrimitive](x) {}
 }

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit3_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit3_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.toPrimitive;
+var _toPrimitive = Symbol.toPrimitive;
 var C = //@target: ES6
 //@declaration: true
 /*#__PURE__*/ function() {
@@ -27,7 +27,7 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _toPrimitive,
             value: function value(x) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit3_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit3_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.toPrimitive, C = function() {
+var _toPrimitive = Symbol.toPrimitive, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var tmp = Symbol.toPrimitive, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _toPrimitive,
             value: function(x) {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit4_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit4_es2015.1.normal.js
@@ -1,9 +1,9 @@
-var tmp = Symbol.toPrimitive, tmp1 = Symbol.toPrimitive;
+let _toPrimitive = Symbol.toPrimitive, _toPrimitive1 = Symbol.toPrimitive;
 //@target: ES6
 //@declaration: true
 class C {
-    get [tmp]() {
+    get [_toPrimitive]() {
         return "";
     }
-    set [tmp1](x) {}
+    set [_toPrimitive1](x) {}
 }

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit4_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit4_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.toPrimitive, tmp1 = Symbol.toPrimitive;
+var _toPrimitive = Symbol.toPrimitive, _toPrimitive1 = Symbol.toPrimitive;
 var C = //@target: ES6
 //@declaration: true
 /*#__PURE__*/ function() {
@@ -27,13 +27,13 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _toPrimitive,
             get: function get() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _toPrimitive1,
             set: function set(x) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/symbolDeclarationEmit4_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolDeclarationEmit4_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.toPrimitive, tmp1 = Symbol.toPrimitive, C = function() {
+var _toPrimitive = Symbol.toPrimitive, _toPrimitive1 = Symbol.toPrimitive, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,13 +14,13 @@ var tmp = Symbol.toPrimitive, tmp1 = Symbol.toPrimitive, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _toPrimitive,
             get: function() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _toPrimitive1,
             set: function(x) {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolProperty23_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty23_es2015.1.normal.js
@@ -1,6 +1,6 @@
-var tmp = Symbol.toPrimitive;
+let _toPrimitive = Symbol.toPrimitive;
 class C {
-    [tmp]() {
+    [_toPrimitive]() {
         return true;
     }
 }

--- a/crates/swc/tests/tsc-references/symbolProperty23_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty23_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.toPrimitive;
+var _toPrimitive = Symbol.toPrimitive;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -25,7 +25,7 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _toPrimitive,
             value: function value() {
                 return true;
             }

--- a/crates/swc/tests/tsc-references/symbolProperty23_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty23_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.toPrimitive, C = function() {
+var _toPrimitive = Symbol.toPrimitive, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var tmp = Symbol.toPrimitive, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _toPrimitive,
             value: function() {
                 return !0;
             }

--- a/crates/swc/tests/tsc-references/symbolProperty24_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty24_es2015.1.normal.js
@@ -1,6 +1,6 @@
-var tmp = Symbol.toPrimitive;
+let _toPrimitive = Symbol.toPrimitive;
 class C {
-    [tmp]() {
+    [_toPrimitive]() {
         return "";
     }
 }

--- a/crates/swc/tests/tsc-references/symbolProperty24_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty24_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.toPrimitive;
+var _toPrimitive = Symbol.toPrimitive;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -25,7 +25,7 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _toPrimitive,
             value: function value() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolProperty24_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty24_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.toPrimitive, C = function() {
+var _toPrimitive = Symbol.toPrimitive, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var tmp = Symbol.toPrimitive, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _toPrimitive,
             value: function() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolProperty25_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty25_es2015.1.normal.js
@@ -1,6 +1,6 @@
-var tmp = Symbol.toStringTag;
+let _toStringTag = Symbol.toStringTag;
 class C {
-    [tmp]() {
+    [_toStringTag]() {
         return "";
     }
 }

--- a/crates/swc/tests/tsc-references/symbolProperty25_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty25_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.toStringTag;
+var _toStringTag = Symbol.toStringTag;
 var C = /*#__PURE__*/ function() {
     "use strict";
     function C() {
@@ -25,7 +25,7 @@ var C = /*#__PURE__*/ function() {
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function value() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolProperty25_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty25_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.toStringTag, C = function() {
+var _toStringTag = Symbol.toStringTag, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var tmp = Symbol.toStringTag, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolProperty26_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty26_es2015.1.normal.js
@@ -1,13 +1,13 @@
-var tmp = Symbol.toStringTag;
+let _toStringTag = Symbol.toStringTag;
 //@target: ES6
 class C1 {
-    [tmp]() {
+    [_toStringTag]() {
         return "";
     }
 }
-var tmp1 = Symbol.toStringTag;
+let _toStringTag1 = Symbol.toStringTag;
 class C2 extends C1 {
-    [tmp1]() {
+    [_toStringTag1]() {
         return "";
     }
 }

--- a/crates/swc/tests/tsc-references/symbolProperty26_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty26_es5.1.normal.js
@@ -83,7 +83,7 @@ function _createSuper(Derived) {
         return _possibleConstructorReturn(this, result);
     };
 }
-var tmp = Symbol.toStringTag;
+var _toStringTag = Symbol.toStringTag;
 var C1 = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -92,7 +92,7 @@ var C1 = //@target: ES6
     }
     _createClass(C1, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function value() {
                 return "";
             }
@@ -100,7 +100,7 @@ var C1 = //@target: ES6
     ]);
     return C1;
 }();
-var tmp1 = Symbol.toStringTag;
+var _toStringTag1 = Symbol.toStringTag;
 var C2 = /*#__PURE__*/ function(C1) {
     "use strict";
     _inherits(C2, C1);
@@ -111,7 +111,7 @@ var C2 = /*#__PURE__*/ function(C1) {
     }
     _createClass(C2, [
         {
-            key: tmp1,
+            key: _toStringTag1,
             value: function value() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolProperty26_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty26_es5.2.minified.js
@@ -20,20 +20,20 @@ function _setPrototypeOf(o, p) {
         return o.__proto__ = p, o;
     }, _setPrototypeOf(o, p);
 }
-var tmp = Symbol.toStringTag, C1 = function() {
+var _toStringTag = Symbol.toStringTag, C1 = function() {
     "use strict";
     function C1() {
         _classCallCheck(this, C1);
     }
     return _createClass(C1, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function() {
                 return "";
             }
         }
     ]), C1;
-}(), tmp1 = Symbol.toStringTag, C2 = function(C1) {
+}(), _toStringTag1 = Symbol.toStringTag, C2 = function(C1) {
     "use strict";
     !function(subClass, superClass) {
         if ("function" != typeof superClass && null !== superClass) throw new TypeError("Super expression must either be null or a function");
@@ -70,7 +70,7 @@ var tmp = Symbol.toStringTag, C1 = function() {
     }
     return _createClass(C2, [
         {
-            key: tmp1,
+            key: _toStringTag1,
             value: function() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolProperty27_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty27_es2015.1.normal.js
@@ -1,13 +1,13 @@
-var tmp = Symbol.toStringTag;
+let _toStringTag = Symbol.toStringTag;
 //@target: ES6
 class C1 {
-    [tmp]() {
+    [_toStringTag]() {
         return {};
     }
 }
-var tmp1 = Symbol.toStringTag;
+let _toStringTag1 = Symbol.toStringTag;
 class C2 extends C1 {
-    [tmp1]() {
+    [_toStringTag1]() {
         return "";
     }
 }

--- a/crates/swc/tests/tsc-references/symbolProperty27_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty27_es5.1.normal.js
@@ -83,7 +83,7 @@ function _createSuper(Derived) {
         return _possibleConstructorReturn(this, result);
     };
 }
-var tmp = Symbol.toStringTag;
+var _toStringTag = Symbol.toStringTag;
 var C1 = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -92,7 +92,7 @@ var C1 = //@target: ES6
     }
     _createClass(C1, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function value() {
                 return {};
             }
@@ -100,7 +100,7 @@ var C1 = //@target: ES6
     ]);
     return C1;
 }();
-var tmp1 = Symbol.toStringTag;
+var _toStringTag1 = Symbol.toStringTag;
 var C2 = /*#__PURE__*/ function(C1) {
     "use strict";
     _inherits(C2, C1);
@@ -111,7 +111,7 @@ var C2 = /*#__PURE__*/ function(C1) {
     }
     _createClass(C2, [
         {
-            key: tmp1,
+            key: _toStringTag1,
             value: function value() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolProperty27_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty27_es5.2.minified.js
@@ -20,20 +20,20 @@ function _setPrototypeOf(o, p) {
         return o.__proto__ = p, o;
     }, _setPrototypeOf(o, p);
 }
-var tmp = Symbol.toStringTag, C1 = function() {
+var _toStringTag = Symbol.toStringTag, C1 = function() {
     "use strict";
     function C1() {
         _classCallCheck(this, C1);
     }
     return _createClass(C1, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function() {
                 return {};
             }
         }
     ]), C1;
-}(), tmp1 = Symbol.toStringTag, C2 = function(C1) {
+}(), _toStringTag1 = Symbol.toStringTag, C2 = function(C1) {
     "use strict";
     !function(subClass, superClass) {
         if ("function" != typeof superClass && null !== superClass) throw new TypeError("Super expression must either be null or a function");
@@ -70,7 +70,7 @@ var tmp = Symbol.toStringTag, C1 = function() {
     }
     return _createClass(C2, [
         {
-            key: tmp1,
+            key: _toStringTag1,
             value: function() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolProperty28_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty28_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.toStringTag;
+let _toStringTag = Symbol.toStringTag;
 //@target: ES6
 class C1 {
-    [tmp]() {
+    [_toStringTag]() {
         return {
             x: ""
         };

--- a/crates/swc/tests/tsc-references/symbolProperty28_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty28_es2015.2.minified.js
@@ -1,1 +1,2 @@
-Symbol.toStringTag, (void 0)[Symbol.toStringTag]().x;
+var c;
+Symbol.toStringTag, c[Symbol.toStringTag]().x;

--- a/crates/swc/tests/tsc-references/symbolProperty28_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty28_es5.1.normal.js
@@ -83,7 +83,7 @@ function _createSuper(Derived) {
         return _possibleConstructorReturn(this, result);
     };
 }
-var tmp = Symbol.toStringTag;
+var _toStringTag = Symbol.toStringTag;
 var C1 = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -92,7 +92,7 @@ var C1 = //@target: ES6
     }
     _createClass(C1, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function value() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty28_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty28_es5.2.minified.js
@@ -17,7 +17,7 @@ function _setPrototypeOf(o, p) {
         return o.__proto__ = p, o;
     }, _setPrototypeOf(o, p);
 }
-var c, tmp = Symbol.toStringTag, C1 = function() {
+var c, _toStringTag = Symbol.toStringTag, C1 = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C1() {
@@ -25,7 +25,7 @@ var c, tmp = Symbol.toStringTag, C1 = function() {
     }
     return Constructor = C1, protoProps = [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty29_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty29_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.toStringTag;
+let _toStringTag = Symbol.toStringTag;
 //@target: ES6
 class C1 {
-    [tmp]() {
+    [_toStringTag]() {
         return {
             x: ""
         };

--- a/crates/swc/tests/tsc-references/symbolProperty29_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty29_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.toStringTag;
+var _toStringTag = Symbol.toStringTag;
 var C1 = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,7 +26,7 @@ var C1 = //@target: ES6
     }
     _createClass(C1, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function value() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty29_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty29_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.toStringTag, C1 = function() {
+var _toStringTag = Symbol.toStringTag, C1 = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C1() {
@@ -14,7 +14,7 @@ var tmp = Symbol.toStringTag, C1 = function() {
     }
     return Constructor = C1, protoProps = [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty30_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty30_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.toStringTag;
+let _toStringTag = Symbol.toStringTag;
 //@target: ES6
 class C1 {
-    [tmp]() {
+    [_toStringTag]() {
         return {
             x: ""
         };

--- a/crates/swc/tests/tsc-references/symbolProperty30_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty30_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.toStringTag;
+var _toStringTag = Symbol.toStringTag;
 var C1 = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,7 +26,7 @@ var C1 = //@target: ES6
     }
     _createClass(C1, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function value() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty30_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty30_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.toStringTag, C1 = function() {
+var _toStringTag = Symbol.toStringTag, C1 = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C1() {
@@ -14,7 +14,7 @@ var tmp = Symbol.toStringTag, C1 = function() {
     }
     return Constructor = C1, protoProps = [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty31_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty31_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.toStringTag;
+let _toStringTag = Symbol.toStringTag;
 //@target: ES6
 class C1 {
-    [tmp]() {
+    [_toStringTag]() {
         return {
             x: ""
         };

--- a/crates/swc/tests/tsc-references/symbolProperty31_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty31_es5.1.normal.js
@@ -83,7 +83,7 @@ function _createSuper(Derived) {
         return _possibleConstructorReturn(this, result);
     };
 }
-var tmp = Symbol.toStringTag;
+var _toStringTag = Symbol.toStringTag;
 var C1 = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -92,7 +92,7 @@ var C1 = //@target: ES6
     }
     _createClass(C1, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function value() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty31_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty31_es5.2.minified.js
@@ -17,7 +17,7 @@ function _setPrototypeOf(o, p) {
         return o.__proto__ = p, o;
     }, _setPrototypeOf(o, p);
 }
-var tmp = Symbol.toStringTag, C1 = function() {
+var _toStringTag = Symbol.toStringTag, C1 = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C1() {
@@ -25,7 +25,7 @@ var tmp = Symbol.toStringTag, C1 = function() {
     }
     return Constructor = C1, protoProps = [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty32_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty32_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.toStringTag;
+let _toStringTag = Symbol.toStringTag;
 //@target: ES6
 class C1 {
-    [tmp]() {
+    [_toStringTag]() {
         return {
             x: ""
         };

--- a/crates/swc/tests/tsc-references/symbolProperty32_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty32_es5.1.normal.js
@@ -83,7 +83,7 @@ function _createSuper(Derived) {
         return _possibleConstructorReturn(this, result);
     };
 }
-var tmp = Symbol.toStringTag;
+var _toStringTag = Symbol.toStringTag;
 var C1 = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -92,7 +92,7 @@ var C1 = //@target: ES6
     }
     _createClass(C1, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function value() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty32_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty32_es5.2.minified.js
@@ -17,7 +17,7 @@ function _setPrototypeOf(o, p) {
         return o.__proto__ = p, o;
     }, _setPrototypeOf(o, p);
 }
-var tmp = Symbol.toStringTag, C1 = function() {
+var _toStringTag = Symbol.toStringTag, C1 = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C1() {
@@ -25,7 +25,7 @@ var tmp = Symbol.toStringTag, C1 = function() {
     }
     return Constructor = C1, protoProps = [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty33_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty33_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.toStringTag;
+let _toStringTag = Symbol.toStringTag;
 //@target: ES6
 class C1 extends C2 {
-    [tmp]() {
+    [_toStringTag]() {
         return {
             x: ""
         };

--- a/crates/swc/tests/tsc-references/symbolProperty33_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty33_es5.1.normal.js
@@ -83,7 +83,7 @@ function _createSuper(Derived) {
         return _possibleConstructorReturn(this, result);
     };
 }
-var tmp = Symbol.toStringTag;
+var _toStringTag = Symbol.toStringTag;
 var C1 = //@target: ES6
 /*#__PURE__*/ function(C21) {
     "use strict";
@@ -95,7 +95,7 @@ var C1 = //@target: ES6
     }
     _createClass(C1, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function value() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty33_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty33_es5.2.minified.js
@@ -17,7 +17,7 @@ function _setPrototypeOf(o, p) {
         return o.__proto__ = p, o;
     }, _setPrototypeOf(o, p);
 }
-var tmp = Symbol.toStringTag, C1 = function(C21) {
+var _toStringTag = Symbol.toStringTag, C1 = function(C21) {
     "use strict";
     !function(subClass, superClass) {
         if ("function" != typeof superClass && null !== superClass) throw new TypeError("Super expression must either be null or a function");
@@ -54,7 +54,7 @@ var tmp = Symbol.toStringTag, C1 = function(C21) {
     }
     return Constructor = C1, protoProps = [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty34_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty34_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.toStringTag;
+let _toStringTag = Symbol.toStringTag;
 //@target: ES6
 class C1 extends C2 {
-    [tmp]() {
+    [_toStringTag]() {
         return {
             x: ""
         };

--- a/crates/swc/tests/tsc-references/symbolProperty34_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty34_es5.1.normal.js
@@ -83,7 +83,7 @@ function _createSuper(Derived) {
         return _possibleConstructorReturn(this, result);
     };
 }
-var tmp = Symbol.toStringTag;
+var _toStringTag = Symbol.toStringTag;
 var C1 = //@target: ES6
 /*#__PURE__*/ function(C21) {
     "use strict";
@@ -95,7 +95,7 @@ var C1 = //@target: ES6
     }
     _createClass(C1, [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function value() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty34_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty34_es5.2.minified.js
@@ -17,7 +17,7 @@ function _setPrototypeOf(o, p) {
         return o.__proto__ = p, o;
     }, _setPrototypeOf(o, p);
 }
-var tmp = Symbol.toStringTag, C1 = function(C21) {
+var _toStringTag = Symbol.toStringTag, C1 = function(C21) {
     "use strict";
     !function(subClass, superClass) {
         if ("function" != typeof superClass && null !== superClass) throw new TypeError("Super expression must either be null or a function");
@@ -54,7 +54,7 @@ var tmp = Symbol.toStringTag, C1 = function(C21) {
     }
     return Constructor = C1, protoProps = [
         {
-            key: tmp,
+            key: _toStringTag,
             value: function() {
                 return {
                     x: ""

--- a/crates/swc/tests/tsc-references/symbolProperty39_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty39_es2015.1.normal.js
@@ -1,10 +1,10 @@
-var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
+let _iterator = Symbol.iterator, _iterator1 = Symbol.iterator;
 //@target: ES6
 class C {
-    [tmp](x) {
+    [_iterator](x) {
         return undefined;
     }
-    [tmp1](x) {
+    [_iterator1](x) {
         return undefined;
     }
 }

--- a/crates/swc/tests/tsc-references/symbolProperty39_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty39_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator, tmp1 = Symbol.iterator;
+var _iterator = Symbol.iterator, _iterator1 = Symbol.iterator;
 var C = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,13 +26,13 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value(x) {
                 return undefined;
             }
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function value(x) {
                 return undefined;
             }

--- a/crates/swc/tests/tsc-references/symbolProperty39_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty39_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, tmp1 = Symbol.iterator, C = function() {
+var _iterator = Symbol.iterator, _iterator1 = Symbol.iterator, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,11 +14,11 @@ var tmp = Symbol.iterator, tmp1 = Symbol.iterator, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function(x) {}
         },
         {
-            key: tmp1,
+            key: _iterator1,
             value: function(x) {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolProperty40_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty40_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class C {
-    [tmp](x) {
+    [_iterator](x) {
         return undefined;
     }
 }

--- a/crates/swc/tests/tsc-references/symbolProperty40_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty40_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var C = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,7 +26,7 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value(x) {
                 return undefined;
             }

--- a/crates/swc/tests/tsc-references/symbolProperty40_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty40_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, C = function() {
+var _iterator = Symbol.iterator, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var tmp = Symbol.iterator, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function(x) {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolProperty41_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty41_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class C {
-    [tmp](x) {
+    [_iterator](x) {
         return undefined;
     }
 }

--- a/crates/swc/tests/tsc-references/symbolProperty41_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty41_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var C = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,7 +26,7 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value(x) {
                 return undefined;
             }

--- a/crates/swc/tests/tsc-references/symbolProperty41_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty41_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, C = function() {
+var _iterator = Symbol.iterator, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var tmp = Symbol.iterator, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function(x) {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolProperty42_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty42_es2015.1.normal.js
@@ -1,7 +1,7 @@
-var tmp = Symbol.iterator;
+let _iterator = Symbol.iterator;
 //@target: ES6
 class C {
-    [tmp](x) {
+    [_iterator](x) {
         return undefined;
     }
 }

--- a/crates/swc/tests/tsc-references/symbolProperty42_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty42_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.iterator;
+var _iterator = Symbol.iterator;
 var C = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,7 +26,7 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _iterator,
             value: function value(x) {
                 return undefined;
             }

--- a/crates/swc/tests/tsc-references/symbolProperty42_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty42_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.iterator, C = function() {
+var _iterator = Symbol.iterator, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,7 +14,7 @@ var tmp = Symbol.iterator, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _iterator,
             value: function(x) {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolProperty44_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty44_es2015.1.normal.js
@@ -1,10 +1,10 @@
-var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance;
+let _hasInstance = Symbol.hasInstance, _hasInstance1 = Symbol.hasInstance;
 //@target: ES6
 class C {
-    get [tmp]() {
+    get [_hasInstance]() {
         return "";
     }
-    get [tmp1]() {
+    get [_hasInstance1]() {
         return "";
     }
 }

--- a/crates/swc/tests/tsc-references/symbolProperty44_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty44_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance;
+var _hasInstance = Symbol.hasInstance, _hasInstance1 = Symbol.hasInstance;
 var C = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,13 +26,13 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _hasInstance,
             get: function get() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _hasInstance1,
             get: function get() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolProperty44_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty44_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance, C = function() {
+var _hasInstance = Symbol.hasInstance, _hasInstance1 = Symbol.hasInstance, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,13 +14,13 @@ var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _hasInstance,
             get: function() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _hasInstance1,
             get: function() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolProperty45_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty45_es2015.1.normal.js
@@ -1,10 +1,10 @@
-var tmp = Symbol.hasInstance, tmp1 = Symbol.toPrimitive;
+let _hasInstance = Symbol.hasInstance, _toPrimitive = Symbol.toPrimitive;
 //@target: ES6
 class C {
-    get [tmp]() {
+    get [_hasInstance]() {
         return "";
     }
-    get [tmp1]() {
+    get [_toPrimitive]() {
         return "";
     }
 }

--- a/crates/swc/tests/tsc-references/symbolProperty45_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty45_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.hasInstance, tmp1 = Symbol.toPrimitive;
+var _hasInstance = Symbol.hasInstance, _toPrimitive = Symbol.toPrimitive;
 var C = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,13 +26,13 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _hasInstance,
             get: function get() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _toPrimitive,
             get: function get() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolProperty45_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty45_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.hasInstance, tmp1 = Symbol.toPrimitive, C = function() {
+var _hasInstance = Symbol.hasInstance, _toPrimitive = Symbol.toPrimitive, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,13 +14,13 @@ var tmp = Symbol.hasInstance, tmp1 = Symbol.toPrimitive, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _hasInstance,
             get: function() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _toPrimitive,
             get: function() {
                 return "";
             }

--- a/crates/swc/tests/tsc-references/symbolProperty46_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty46_es2015.1.normal.js
@@ -1,11 +1,11 @@
-var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance;
+let _hasInstance = Symbol.hasInstance, _hasInstance1 = Symbol.hasInstance;
 //@target: ES6
 class C {
-    get [tmp]() {
+    get [_hasInstance]() {
         return "";
     }
     // Should take a string
-    set [tmp1](x) {}
+    set [_hasInstance1](x) {}
 }
 (new C)[Symbol.hasInstance] = 0;
 (new C)[Symbol.hasInstance] = "";

--- a/crates/swc/tests/tsc-references/symbolProperty46_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty46_es2015.2.minified.js
@@ -1,8 +1,8 @@
-var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance;
+let _hasInstance = Symbol.hasInstance, _hasInstance1 = Symbol.hasInstance;
 class C {
-    get [tmp]() {
+    get [_hasInstance]() {
         return "";
     }
-    set [tmp1](x) {}
+    set [_hasInstance1](x) {}
 }
 (new C)[Symbol.hasInstance] = 0, (new C)[Symbol.hasInstance] = "";

--- a/crates/swc/tests/tsc-references/symbolProperty46_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty46_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance;
+var _hasInstance = Symbol.hasInstance, _hasInstance1 = Symbol.hasInstance;
 var C = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,13 +26,13 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _hasInstance,
             get: function get() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _hasInstance1,
             set: // Should take a string
             function set(x) {}
         }

--- a/crates/swc/tests/tsc-references/symbolProperty46_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty46_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance, C = function() {
+var _hasInstance = Symbol.hasInstance, _hasInstance1 = Symbol.hasInstance, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,13 +14,13 @@ var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _hasInstance,
             get: function() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _hasInstance1,
             set: function(x) {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolProperty47_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty47_es2015.1.normal.js
@@ -1,11 +1,11 @@
-var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance;
+let _hasInstance = Symbol.hasInstance, _hasInstance1 = Symbol.hasInstance;
 //@target: ES6
 class C {
-    get [tmp]() {
+    get [_hasInstance]() {
         return "";
     }
     // Should take a string
-    set [tmp1](x) {}
+    set [_hasInstance1](x) {}
 }
 (new C)[Symbol.hasInstance] = 0;
 (new C)[Symbol.hasInstance] = "";

--- a/crates/swc/tests/tsc-references/symbolProperty47_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty47_es2015.2.minified.js
@@ -1,8 +1,8 @@
-var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance;
+let _hasInstance = Symbol.hasInstance, _hasInstance1 = Symbol.hasInstance;
 class C {
-    get [tmp]() {
+    get [_hasInstance]() {
         return "";
     }
-    set [tmp1](x) {}
+    set [_hasInstance1](x) {}
 }
 (new C)[Symbol.hasInstance] = 0, (new C)[Symbol.hasInstance] = "";

--- a/crates/swc/tests/tsc-references/symbolProperty47_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty47_es5.1.normal.js
@@ -17,7 +17,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
 }
-var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance;
+var _hasInstance = Symbol.hasInstance, _hasInstance1 = Symbol.hasInstance;
 var C = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -26,13 +26,13 @@ var C = //@target: ES6
     }
     _createClass(C, [
         {
-            key: tmp,
+            key: _hasInstance,
             get: function get() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _hasInstance1,
             set: // Should take a string
             function set(x) {}
         }

--- a/crates/swc/tests/tsc-references/symbolProperty47_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty47_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance, C = function() {
+var _hasInstance = Symbol.hasInstance, _hasInstance1 = Symbol.hasInstance, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -14,13 +14,13 @@ var tmp = Symbol.hasInstance, tmp1 = Symbol.hasInstance, C = function() {
     }
     return Constructor = C, protoProps = [
         {
-            key: tmp,
+            key: _hasInstance,
             get: function() {
                 return "";
             }
         },
         {
-            key: tmp1,
+            key: _hasInstance1,
             set: function(x) {}
         }
     ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolProperty48_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty48_es2015.1.normal.js
@@ -2,8 +2,8 @@
 var M;
 (function(M) {
     var Symbol;
-    var tmp = Symbol.iterator;
+    let _iterator = Symbol.iterator;
     class C {
-        [tmp]() {}
+        [_iterator]() {}
     }
 })(M || (M = {}));

--- a/crates/swc/tests/tsc-references/symbolProperty48_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty48_es5.1.normal.js
@@ -21,7 +21,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 var M;
 (function(M) {
     var Symbol;
-    var tmp = Symbol.iterator;
+    var _iterator = Symbol.iterator;
     var C = /*#__PURE__*/ function() {
         "use strict";
         function C() {
@@ -29,7 +29,7 @@ var M;
         }
         _createClass(C, [
             {
-                key: tmp,
+                key: _iterator,
                 value: function value() {}
             }
         ]);

--- a/crates/swc/tests/tsc-references/symbolProperty48_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty48_es5.2.minified.js
@@ -6,7 +6,7 @@ function _defineProperties(target, props) {
     }
 }
 !function(M) {
-    var tmp = (void 0).iterator, C = function() {
+    var _iterator = (void 0).iterator, C = function() {
         "use strict";
         var Constructor, protoProps, staticProps;
         function C() {
@@ -16,7 +16,7 @@ function _defineProperties(target, props) {
         }
         return Constructor = C, protoProps = [
             {
-                key: tmp,
+                key: _iterator,
                 value: function() {}
             }
         ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolProperty49_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty49_es2015.1.normal.js
@@ -2,9 +2,9 @@
 var M;
 (function(M1) {
     var Symbol;
-    var tmp = Symbol.iterator;
+    let _iterator = Symbol.iterator;
     class C {
-        [tmp]() {}
+        [_iterator]() {}
     }
     M1.Symbol = Symbol;
 })(M || (M = {}));

--- a/crates/swc/tests/tsc-references/symbolProperty49_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty49_es5.1.normal.js
@@ -21,7 +21,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 var M;
 (function(M1) {
     var Symbol;
-    var tmp = Symbol.iterator;
+    var _iterator = Symbol.iterator;
     var C = /*#__PURE__*/ function() {
         "use strict";
         function C() {
@@ -29,7 +29,7 @@ var M;
         }
         _createClass(C, [
             {
-                key: tmp,
+                key: _iterator,
                 value: function value() {}
             }
         ]);

--- a/crates/swc/tests/tsc-references/symbolProperty49_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty49_es5.2.minified.js
@@ -6,7 +6,7 @@ function _defineProperties(target, props) {
     }
 }
 !function(M1) {
-    var Symbol, tmp = Symbol.iterator, C = function() {
+    var Symbol, _iterator = Symbol.iterator, C = function() {
         "use strict";
         var Constructor, protoProps, staticProps;
         function C() {
@@ -16,7 +16,7 @@ function _defineProperties(target, props) {
         }
         return Constructor = C, protoProps = [
             {
-                key: tmp,
+                key: _iterator,
                 value: function() {}
             }
         ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolProperty50_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty50_es2015.1.normal.js
@@ -1,8 +1,8 @@
 //@target: ES6
 var M;
 (function(M) {
-    var tmp = Symbol.iterator;
+    let _iterator = Symbol.iterator;
     class C {
-        [tmp]() {}
+        [_iterator]() {}
     }
 })(M || (M = {}));

--- a/crates/swc/tests/tsc-references/symbolProperty50_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty50_es5.1.normal.js
@@ -20,7 +20,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 //@target: ES6
 var M;
 (function(M) {
-    var tmp = Symbol.iterator;
+    var _iterator = Symbol.iterator;
     var C = /*#__PURE__*/ function() {
         "use strict";
         function C() {
@@ -28,7 +28,7 @@ var M;
         }
         _createClass(C, [
             {
-                key: tmp,
+                key: _iterator,
                 value: function value() {}
             }
         ]);

--- a/crates/swc/tests/tsc-references/symbolProperty50_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty50_es5.2.minified.js
@@ -6,7 +6,7 @@ function _defineProperties(target, props) {
     }
 }
 !function(M) {
-    var tmp = Symbol.iterator, C = function() {
+    var _iterator = Symbol.iterator, C = function() {
         "use strict";
         var Constructor, protoProps, staticProps;
         function C() {
@@ -16,7 +16,7 @@ function _defineProperties(target, props) {
         }
         return Constructor = C, protoProps = [
             {
-                key: tmp,
+                key: _iterator,
                 value: function() {}
             }
         ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolProperty51_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty51_es2015.1.normal.js
@@ -1,8 +1,8 @@
 //@target: ES6
 var M;
 (function(M) {
-    var tmp = Symbol.iterator;
+    let _iterator = Symbol.iterator;
     class C {
-        [tmp]() {}
+        [_iterator]() {}
     }
 })(M || (M = {}));

--- a/crates/swc/tests/tsc-references/symbolProperty51_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty51_es5.1.normal.js
@@ -20,7 +20,7 @@ function _createClass(Constructor, protoProps, staticProps) {
 //@target: ES6
 var M;
 (function(M) {
-    var tmp = Symbol.iterator;
+    var _iterator = Symbol.iterator;
     var C = /*#__PURE__*/ function() {
         "use strict";
         function C() {
@@ -28,7 +28,7 @@ var M;
         }
         _createClass(C, [
             {
-                key: tmp,
+                key: _iterator,
                 value: function value() {}
             }
         ]);

--- a/crates/swc/tests/tsc-references/symbolProperty51_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty51_es5.2.minified.js
@@ -6,7 +6,7 @@ function _defineProperties(target, props) {
     }
 }
 !function(M) {
-    var tmp = Symbol.iterator, C = function() {
+    var _iterator = Symbol.iterator, C = function() {
         "use strict";
         var Constructor, protoProps, staticProps;
         function C() {
@@ -16,7 +16,7 @@ function _defineProperties(target, props) {
         }
         return Constructor = C, protoProps = [
             {
-                key: tmp,
+                key: _iterator,
                 value: function() {}
             }
         ], _defineProperties(Constructor.prototype, protoProps), staticProps && _defineProperties(Constructor, staticProps), C;

--- a/crates/swc/tests/tsc-references/symbolProperty6_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty6_es2015.1.normal.js
@@ -1,9 +1,9 @@
 var _key;
-var tmp = (_key = Symbol.iterator, Symbol.toPrimitive), tmp1 = Symbol.toStringTag;
+let tmp = (_key = Symbol.iterator, Symbol.toPrimitive), _toStringTag = Symbol.toStringTag;
 //@target: ES6
 class C {
     [tmp]() {}
-    get [tmp1]() {
+    get [_toStringTag]() {
         return 0;
     }
     constructor(){

--- a/crates/swc/tests/tsc-references/symbolProperty6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/symbolProperty6_es5.1.normal.js
@@ -18,7 +18,7 @@ function _createClass(Constructor, protoProps, staticProps) {
     return Constructor;
 }
 var _key;
-var tmp = (_key = Symbol.iterator, Symbol.toPrimitive), tmp1 = Symbol.toStringTag;
+var tmp = (_key = Symbol.iterator, Symbol.toPrimitive), _toStringTag = Symbol.toStringTag;
 var C = //@target: ES6
 /*#__PURE__*/ function() {
     "use strict";
@@ -32,7 +32,7 @@ var C = //@target: ES6
             value: function value() {}
         },
         {
-            key: tmp1,
+            key: _toStringTag,
             get: function get() {
                 return 0;
             }

--- a/crates/swc/tests/tsc-references/symbolProperty6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/symbolProperty6_es5.2.minified.js
@@ -4,7 +4,7 @@ function _defineProperties(target, props) {
         descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
 }
-var _key, tmp = (_key = Symbol.iterator, Symbol.toPrimitive), tmp1 = Symbol.toStringTag, C = function() {
+var _key, tmp = (_key = Symbol.iterator, Symbol.toPrimitive), _toStringTag = Symbol.toStringTag, C = function() {
     "use strict";
     var Constructor, protoProps, staticProps;
     function C() {
@@ -18,7 +18,7 @@ var _key, tmp = (_key = Symbol.iterator, Symbol.toPrimitive), tmp1 = Symbol.toSt
             value: function() {}
         },
         {
-            key: tmp1,
+            key: _toStringTag,
             get: function() {
                 return 0;
             }

--- a/crates/swc/tests/tsc-references/tsxGenericAttributesType9_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxGenericAttributesType9_es2015.1.normal.js
@@ -19,7 +19,7 @@ function _extends() {
 // @libFiles: react.d.ts,lib.d.ts
 const React = require('react');
 export function makeP(Ctor) {
-    return class _class extends React.PureComponent {
+    return class extends React.PureComponent {
         render() {
             return(/*#__PURE__*/ React.createElement(Ctor, _extends({}, this.props)));
         }

--- a/crates/swc/tests/tsc-references/typeArgumentInferenceWithClassExpression3_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeArgumentInferenceWithClassExpression3_es2015.1.normal.js
@@ -2,7 +2,7 @@ function foo(x = class {
 }) {
     return undefined;
 }
-foo(class _class {
+foo(class {
     constructor(){
         this.prop = "hello";
     }

--- a/crates/swc/tests/tsc-references/typeFromParamTagForFunction_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeFromParamTagForFunction_es2015.1.normal.js
@@ -8,7 +8,7 @@ const { A  } = require("./a-ext");
     p.x;
 }
 // @filename: b-ext.js
-exports.B = class _class {
+exports.B = class {
     constructor(){
         this.x = 1;
     }

--- a/crates/swc/tests/tsc-references/typeFromPropertyAssignment10_1_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeFromPropertyAssignment10_1_es2015.1.normal.js
@@ -13,7 +13,7 @@ Outer.app.SomeView = (function() {
     };
     return SomeView;
 })();
-Outer.app.Inner = class _class {
+Outer.app.Inner = class {
     constructor(){
         /** @type {number} */ this.y = 12;
     }

--- a/crates/swc/tests/tsc-references/typeFromPropertyAssignment10_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeFromPropertyAssignment10_es2015.1.normal.js
@@ -12,7 +12,7 @@ Outer.app.SomeView = (function() {
     };
     return SomeView;
 })();
-Outer.app.Inner = class _class {
+Outer.app.Inner = class {
     constructor(){
         /** @type {number} */ this.y = 12;
     }

--- a/crates/swc/tests/tsc-references/typeFromPropertyAssignment15_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeFromPropertyAssignment15_es2015.1.normal.js
@@ -3,7 +3,7 @@
 // @checkJs: true
 // @Filename: a.js
 var Outer = {};
-Outer.Inner = class _class {
+Outer.Inner = class {
     m() {}
     constructor(){
         this.x = 1;

--- a/crates/swc/tests/tsc-references/typeFromPropertyAssignment24_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeFromPropertyAssignment24_es2015.1.normal.js
@@ -10,7 +10,7 @@ y.name;
 x.name;
 // @Filename: def.js
 var Outer = {};
-Outer.Inner = class _class {
+Outer.Inner = class {
     name() {
         return 'hi';
     }

--- a/crates/swc/tests/tsc-references/typeFromPropertyAssignment25_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeFromPropertyAssignment25_es2015.1.normal.js
@@ -3,12 +3,12 @@
 // @allowJs: true
 // @Filename: bug24703.js
 var Common = {};
-Common.I = class _class {
+Common.I = class {
     constructor(){
         this.i = 1;
     }
 };
-Common.O = class _class extends Common.I {
+Common.O = class extends Common.I {
     constructor(){
         super();
         this.o = 2;

--- a/crates/swc/tests/tsc-references/typeFromPropertyAssignment26_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeFromPropertyAssignment26_es2015.1.normal.js
@@ -4,7 +4,7 @@
 // @allowJs: true
 // @Filename: bug24730.js
 var UI = {};
-UI.TreeElement = class _class {
+UI.TreeElement = class {
     constructor(){
         this.treeOutline = 12;
     }

--- a/crates/swc/tests/tsc-references/typeFromPropertyAssignment29_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeFromPropertyAssignment29_es2015.1.normal.js
@@ -75,7 +75,7 @@ ExpandoClass.m = function(n11) {
 };
 var n = ExpandoClass.prop + ExpandoClass.m(12) + new ExpandoClass().n;
 // Class expressions shouldn't work in typescript either
-var ExpandoExpr3 = class _class {
+var ExpandoExpr3 = class {
     constructor(){
         this.n = 10001;
     }

--- a/crates/swc/tests/tsc-references/typeFromPropertyAssignment35_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeFromPropertyAssignment35_es2015.1.normal.js
@@ -7,7 +7,7 @@
     const y = new Emu.D();
     const z = Emu.D._wrapperInstance;
 }
-Emu.D = class _class {
+Emu.D = class {
     constructor(){
         this._model = 1;
     }

--- a/crates/swc/tests/tsc-references/typeFromPropertyAssignment4_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeFromPropertyAssignment4_es2015.1.normal.js
@@ -4,7 +4,7 @@
 // @Filename: def.js
 var Outer = {};
 // @Filename: a.js
-Outer.Inner = class _class {
+Outer.Inner = class {
     constructor(){
         /** @type {number} */ this.y = 12;
     }

--- a/crates/swc/tests/tsc-references/typeFromPropertyAssignment9_1_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeFromPropertyAssignment9_1_es2015.1.normal.js
@@ -26,7 +26,7 @@ var _sort;
  */ my.predicate.sort = (_sort = my.predicate.sort) !== null && _sort !== void 0 ? _sort : function(first, second) {
     return first > second ? first : second;
 };
-my.predicate.type = class _class {
+my.predicate.type = class {
     m() {
         return 101;
     }

--- a/crates/swc/tests/tsc-references/typeFromPropertyAssignment9_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeFromPropertyAssignment9_es2015.1.normal.js
@@ -24,7 +24,7 @@ my.predicate.query.result = 'none';
  */ my.predicate.sort = my.predicate.sort || function(first, second) {
     return first > second ? first : second;
 };
-my.predicate.type = class _class {
+my.predicate.type = class {
     m() {
         return 101;
     }

--- a/crates/swc/tests/tsc-references/typeGuardInClass_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeGuardInClass_es2015.1.normal.js
@@ -1,12 +1,12 @@
 let x;
 if (typeof x === "string") {
-    let n = class _class {
+    let n = class {
         constructor(){
             let y = x;
         }
     };
 } else {
-    let m = class _class {
+    let m = class {
         constructor(){
             let y = x;
         }

--- a/crates/swc/tests/tsc-references/typeOfThisInStaticMembers8_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeOfThisInStaticMembers8_es2015.1.normal.js
@@ -7,7 +7,7 @@ C.arrowFunctionBoundary = ()=>C.f + 1
 C.functionExprBoundary = function() {
     return this.f + 2;
 };
-C.classExprBoundary = class _class {
+C.classExprBoundary = class {
     constructor(){
         this.a = this.f + 3;
     }

--- a/crates/swc/tests/tsc-references/typeOfThisInStaticMembers9_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeOfThisInStaticMembers9_es2015.1.normal.js
@@ -9,7 +9,7 @@ D.arrowFunctionBoundary = ()=>super.f + 1
 D.functionExprBoundary = function() {
     return super.f + 2;
 };
-D.classExprBoundary = class _class {
+D.classExprBoundary = class {
     constructor(){
         this.a = super.f + 3;
     }

--- a/crates/swc/tests/tsc-references/uniqueSymbolsDeclarationsErrors_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/uniqueSymbolsDeclarationsErrors_es2015.1.normal.js
@@ -7,7 +7,7 @@ export const obj = {
         return p;
     }
 };
-export const classExpression = class _class {
+export const classExpression = class {
     method1(p) {
         return p;
     }
@@ -20,19 +20,19 @@ export function funcInferredReturnType(obj1) {
 }
 export class ClassWithPrivateNamedProperties {
 }
-var tmp = s, tmp1 = s;
+let _s = s, _s1 = s;
 export class ClassWithPrivateNamedMethods {
-    [tmp]() {}
-    static [tmp1]() {}
+    [_s]() {}
+    static [_s1]() {}
 }
-var tmp2 = s, tmp3 = s, tmp4 = s, tmp5 = s;
+let _s2 = s, _s3 = s, _s4 = s, _s5 = s;
 export class ClassWithPrivateNamedAccessors {
-    get [tmp2]() {
+    get [_s2]() {
         return undefined;
     }
-    set [tmp3](v) {}
-    static get [tmp4]() {
+    set [_s3](v) {}
+    static get [_s4]() {
         return undefined;
     }
-    static set [tmp5](v) {}
+    static set [_s5](v) {}
 }

--- a/crates/swc/tests/tsc-references/uniqueSymbolsDeclarationsErrors_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/uniqueSymbolsDeclarationsErrors_es5.1.normal.js
@@ -54,7 +54,7 @@ export var ClassWithPrivateNamedProperties = function ClassWithPrivateNamedPrope
     "use strict";
     _classCallCheck(this, ClassWithPrivateNamedProperties);
 };
-var tmp = s, tmp1 = s;
+var _s = s, _s1 = s;
 export var ClassWithPrivateNamedMethods = /*#__PURE__*/ function() {
     "use strict";
     function ClassWithPrivateNamedMethods() {
@@ -62,18 +62,18 @@ export var ClassWithPrivateNamedMethods = /*#__PURE__*/ function() {
     }
     _createClass(ClassWithPrivateNamedMethods, [
         {
-            key: tmp,
+            key: _s,
             value: function value() {}
         }
     ], [
         {
-            key: tmp1,
+            key: _s1,
             value: function value() {}
         }
     ]);
     return ClassWithPrivateNamedMethods;
 }();
-var tmp2 = s, tmp3 = s, tmp4 = s, tmp5 = s;
+var _s2 = s, _s3 = s, _s4 = s, _s5 = s;
 export var ClassWithPrivateNamedAccessors = /*#__PURE__*/ function() {
     "use strict";
     function ClassWithPrivateNamedAccessors() {
@@ -81,24 +81,24 @@ export var ClassWithPrivateNamedAccessors = /*#__PURE__*/ function() {
     }
     _createClass(ClassWithPrivateNamedAccessors, [
         {
-            key: tmp2,
+            key: _s2,
             get: function get() {
                 return undefined;
             }
         },
         {
-            key: tmp3,
+            key: _s3,
             set: function set(v) {}
         }
     ], [
         {
-            key: tmp4,
+            key: _s4,
             get: function get() {
                 return undefined;
             }
         },
         {
-            key: tmp5,
+            key: _s5,
             set: function set(v) {}
         }
     ]);

--- a/crates/swc/tests/tsc-references/uniqueSymbolsDeclarationsErrors_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/uniqueSymbolsDeclarationsErrors_es5.2.minified.js
@@ -45,7 +45,7 @@ export var ClassWithPrivateNamedProperties = function() {
     "use strict";
     _classCallCheck(this, ClassWithPrivateNamedProperties);
 };
-var tmp = s, tmp1 = s;
+var _s = s, _s1 = s;
 export var ClassWithPrivateNamedMethods = function() {
     "use strict";
     function ClassWithPrivateNamedMethods() {
@@ -53,17 +53,17 @@ export var ClassWithPrivateNamedMethods = function() {
     }
     return _createClass(ClassWithPrivateNamedMethods, [
         {
-            key: tmp,
+            key: _s,
             value: function() {}
         }
     ], [
         {
-            key: tmp1,
+            key: _s1,
             value: function() {}
         }
     ]), ClassWithPrivateNamedMethods;
 }();
-var tmp2 = s, tmp3 = s, tmp4 = s, tmp5 = s;
+var _s2 = s, _s3 = s, _s4 = s, _s5 = s;
 export var ClassWithPrivateNamedAccessors = function() {
     "use strict";
     function ClassWithPrivateNamedAccessors() {
@@ -71,20 +71,20 @@ export var ClassWithPrivateNamedAccessors = function() {
     }
     return _createClass(ClassWithPrivateNamedAccessors, [
         {
-            key: tmp2,
+            key: _s2,
             get: function() {}
         },
         {
-            key: tmp3,
+            key: _s3,
             set: function(v) {}
         }
     ], [
         {
-            key: tmp4,
+            key: _s4,
             get: function() {}
         },
         {
-            key: tmp5,
+            key: _s5,
             set: function(v) {}
         }
     ]), ClassWithPrivateNamedAccessors;

--- a/crates/swc/tests/tsc-references/uniqueSymbols_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/uniqueSymbols_es2015.1.normal.js
@@ -400,7 +400,7 @@ const o4 = {
         return p;
     }
 };
-const ce0 = class _class {
+const ce0 = class {
     method1(p) {
         return p;
     }

--- a/crates/swc_ecma_transforms/tests/decorators.rs
+++ b/crates/swc_ecma_transforms/tests/decorators.rs
@@ -3178,7 +3178,7 @@ export default class {
 "#,
     r#"
     var _class;
-    let _class1 = ((_class = class _class {
+    let _class1 = ((_class = class {
         bar() {
         }
     }) || _class, _applyDecoratedDescriptor(_class.prototype, "bar", [

--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
@@ -48,7 +48,7 @@ pub fn class_properties(config: Config) -> impl Fold + VisitMut {
     as_folder(ClassProperties {
         c: config,
         private: PrivateRecord::new(),
-        extra: ClassExtra::new(),
+        extra: ClassExtra::default(),
     })
 }
 
@@ -66,22 +66,15 @@ struct ClassProperties {
     private: PrivateRecord,
 }
 
-#[swc_trace]
+#[derive(Default)]
 struct ClassExtra {
     lets: Vec<VarDeclarator>,
     vars: Vec<VarDeclarator>,
     stmts: Vec<Stmt>,
 }
 
+#[swc_trace]
 impl ClassExtra {
-    fn new() -> Self {
-        Self {
-            lets: Vec::new(),
-            vars: Vec::new(),
-            stmts: Vec::new(),
-        }
-    }
-
     fn prepend_with<T: StmtLike + From<Stmt>>(self, stmts: &mut Vec<T>) {
         if !self.vars.is_empty() {
             prepend(
@@ -145,10 +138,11 @@ impl ClassExtra {
 
 impl Take for ClassExtra {
     fn dummy() -> Self {
-        Self::new()
+        Self::default()
     }
 }
 
+#[swc_trace]
 #[fast_path(ShouldWork)]
 impl VisitMut for ClassProperties {
     noop_visit_mut_type!();

--- a/crates/swc_ecma_transforms_compat/tests/es2022_class_properties.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2022_class_properties.rs
@@ -49,14 +49,13 @@ var Foo = class {
 
 "#,
     r#"
-var Foo = function() {
-    var Foo = function Foo() {
+var Foo;
+var Foo = (Foo = function Foo() {
         'use strict';
         _classCallCheck(this, Foo);
-    };
-    _defineProperty(Foo, 'num', 0);
-    return Foo;
-}();
+    },
+    _defineProperty(Foo, 'num', 0),
+    Foo)
 "#
 );
 
@@ -409,8 +408,8 @@ function withContext(ComposedComponent) {
 "#,
     r#"
 function withContext(ComposedComponent) {
-  return (function() {
-    var WithContext = function(Component) {
+  var WithContext
+  return WithContext = (function(Component) {
       'use strict';
       _inherits(WithContext, Component);
       var _super = _createSuper(WithContext);
@@ -419,16 +418,15 @@ function withContext(ComposedComponent) {
         return _super.apply(this, arguments);
       }
       return WithContext;
-    }(Component);
+    })(Component),
     _defineProperty(WithContext, 'propTypes', {
       context: PropTypes.shape({
         addCss: PropTypes.func,
         setTitle: PropTypes.func,
         setMeta: PropTypes.func
       })
-    });
-    return WithContext;
-  })();
+    }),
+    WithContext;
 }
 
 "#
@@ -748,20 +746,20 @@ export default class {
 
 "#,
     r#"
-  call(function() {
-      var _class1 = function _class1() {
+  var _class
+  call((_class = function _class2() {
           "use strict";
-          _classCallCheck(this, _class1);
-      };
-      _defineProperty(_class1, "test", true);
-      return _class1;
-  }());
-  var _class = function _class() {
+          _classCallCheck(this, _class2);
+      },
+      _defineProperty(_class, "test", true),
+      _class
+  ));
+  var _class1 = function _class1() {
       "use strict";
-      _classCallCheck(this, _class);
+      _classCallCheck(this, _class1);
   };
-  _defineProperty(_class, "test", true);
-  export { _class as default };
+  _defineProperty(_class1, "test", true);
+  export { _class1 as default };
 "#
 );
 
@@ -1043,12 +1041,9 @@ var _ref = one(),
     _ref3 = 2 * four + seven,
     _undefined = undefined,
     _ref4 = void 0,
-    tmp = "whatever",
-    tmp1 = "whatever",
-    tmp2 = computed(),
-    tmp3 = computed(),
-    tmp4 = "test" + one,
-    tmp5 = 10,
+    tmp = computed(),
+    tmp1 = computed(),
+    tmp2 = "test" + one,
     _ref5 = /regex/,
     _foo = foo,
     _bar = bar,
@@ -1071,22 +1066,22 @@ var MyClass = function() {
         _defineProperty(this, _ref6, "template-with-expression");
     }
     _createClass(MyClass, [{
+             key: "whatever", get: function () {
+                }
+        }, {
+             key: "whatever", set: function (value) {
+                }
+        }, {
              key: tmp, get: function () {
                 }
         }, {
              key: tmp1, set: function (value) {
                 }
         }, {
-             key: tmp2, get: function () {
-                }
-        }, {
-             key: tmp3, set: function (value) {
-                }
-        }, {
-             key: tmp4, value: function () {
+             key: tmp2, value: function () {
                 }
         }], [{
-             key: tmp5, value: function () {
+             key: 10, value: function () {
                 }
         }]);
     return MyClass;
@@ -2965,10 +2960,9 @@ function withContext(ComposedComponent) {
 "#,
     r#"
 function withContext(ComposedComponent) {
-    return (function() {
-        class WithContext extends Component{
-        }
-        var _propTypes = {
+    var WithContext, _propTypes;
+    return WithContext = class WithContext extends Component{
+        }, _propTypes = {
             writable: true,
             value: {
                 context: PropTypes.shape({
@@ -2977,9 +2971,8 @@ function withContext(ComposedComponent) {
                     setMeta: PropTypes.func
                 })
             }
-        };
-        return WithContext;
-    })();
+        },
+        WithContext;
 }
 
 
@@ -3059,10 +3052,9 @@ function classFactory() {
 "#,
     r#"
 function classFactory() {
-    return (function() {
-        var _foo = new WeakMap();
-        class Foo{
-             instance() {
+    var _foo, Foo, _bar;
+    return _foo = new WeakMap(), Foo = class Foo{
+            instance() {
                 return _classPrivateFieldGet(this, _foo);
             }
              static() {
@@ -3080,13 +3072,11 @@ function classFactory() {
                     value: 'foo'
                 });
             }
-        }
-        var _bar = {
+        }, _bar = {
             writable: true,
             value: 'bar'
-        };
-        return Foo;
-    })();
+        },
+        Foo;
 }
 "#
 );
@@ -3375,22 +3365,20 @@ export default class {
 
 "#,
     r#"
-call(function() {
-    class _class1{
-    }
-    var _test = {
+var _class, _test;
+call((_class = class {
+    }, _test = {
         writable: true,
         value: true
-    };
-    return _class1;
-}());
-class _class{
+    }, _class
+  ));
+class _class1{
 }
-var _test = {
+var _test1 = {
     writable: true,
     value: true
 };
-export { _class as default }
+export { _class1 as default }
 
 
 "#
@@ -3426,8 +3414,21 @@ export default class MyClass3 {
 
 "#,
     r#"
-var _myAsyncMethod = new WeakMap();
+var _myAsyncMethod;
+var _myAsyncMethod1 = new WeakMap();
 class MyClass {
+    constructor(){
+        var _this = this;
+        _classPrivateFieldInit(this, _myAsyncMethod1, {
+            writable: true,
+            value: _asyncToGenerator(function*() {
+                console.log(_this);
+            })
+        });
+    }
+}
+_myAsyncMethod = new WeakMap(),
+class MyClass2 {
     constructor(){
         var _this = this;
         _classPrivateFieldInit(this, _myAsyncMethod, {
@@ -3437,27 +3438,12 @@ class MyClass {
             })
         });
     }
-}
-(function() {
-    var _myAsyncMethod2 = new WeakMap();
-    class MyClass2 {
-        constructor(){
-            var _this = this;
-            _classPrivateFieldInit(this, _myAsyncMethod2, {
-                writable: true,
-                value: _asyncToGenerator(function*() {
-                    console.log(_this);
-                })
-            });
-        }
-    }
-    return MyClass2;
-})();
-var _myAsyncMethod1 = new WeakMap();
+};
+var _myAsyncMethod2 = new WeakMap();
 class MyClass3 {
     constructor(){
         var _this = this;
-        _classPrivateFieldInit(this, _myAsyncMethod1, {
+        _classPrivateFieldInit(this, _myAsyncMethod2, {
             writable: true,
             value: _asyncToGenerator(function*() {
                 console.log(_this);
@@ -3524,6 +3510,37 @@ for (let i = 0; i <= 10; ++i) {
       }
     }
   );
+}
+
+for(let i=0; i<= 10; ++i) {
+  const clazz = classes[i];
+  expect(clazz.foo).toBe('static field ' + i);
+
+  const instance = new clazz();
+  expect(Object.getOwnPropertyNames(instance)).toEqual([String(i)])
+  expect(instance[i]).toBe('computed field ' + i);
+  expect(instance.getBar()).toBe('private field ' + i);
+}
+"#
+);
+
+test_exec!(
+    syntax(),
+    |_| class_properties(Default::default()),
+    regression_8882_exec_2,
+    r#"
+const classes = [];
+for (let i = 0; i <= 10; ++i) {
+  class A {
+    [i] = `computed field ${i}`;
+    static foo = `static field ${i}`;
+    #bar = `private field ${i}`;
+    getBar() {
+      return this.#bar;
+    }
+  }
+  
+  classes.push(A)
 }
 
 for(let i=0; i<= 10; ++i) {
@@ -3711,7 +3728,7 @@ class A {
 
 "#,
     r#"
-var _x = {
+let _x = {
   x: (_classNameTDZError("A"), A) || 0
 }.x;
 
@@ -4016,7 +4033,7 @@ new SuperClass(); // ensure ComputedKey Method is still transformed
 class ComputedMethod extends Obj {
   constructor() {
     var _temp;
-    var tmp = (_temp = super(), _defineProperty(this, "field", 1), _temp);
+    let tmp = (_temp = super(), _defineProperty(this, "field", 1), _temp);
     class B extends Obj {
       [tmp]() {}
 
@@ -4040,7 +4057,7 @@ class ComputedField extends Obj {
   constructor() {
     var _temp;
 
-    var _ref = (_temp = super(), _defineProperty(this, "field", 1), _temp);
+    let _ref = (_temp = super(), _defineProperty(this, "field", 1), _temp);
 
     class B extends Obj {
       constructor() {
@@ -4439,14 +4456,12 @@ class A {
 "#,
     r#"
 const field = Symbol('field');
-var _field = field;
+let _field = field;
 class A{
     constructor(){
         _defineProperty(this, _field, 10);
     }
 }
-
-
 "#
 );
 
@@ -4510,7 +4525,7 @@ class C {
 
 "#,
     r#"
-var _ref = (_classNameTDZError('C'), C) + 3;
+let _ref = (_classNameTDZError('C'), C) + 3;
 
 let C = function C() {
   "use strict";
@@ -5306,7 +5321,7 @@ test!(
     console.log(class { run() { } });
     ",
     "
-    console.log(class _class {
+    console.log(class {
         run() {
         }
     });
@@ -5697,16 +5712,17 @@ test!(
     }
     ",
     "
+    var TestClass;
     var _class;
-    let TestClass = _class = someClassDecorator((_class = function() {
+    let TestClass = _class = someClassDecorator((_class = (TestClass =
         class TestClass {
-        }
-        _defineProperty(TestClass, 'Something', 'hello');
+        },
+        _defineProperty(TestClass, 'Something', 'hello'),
         _defineProperty(TestClass, 'SomeProperties', {
             firstProp: TestClass.Something
-        });
-        return TestClass;
-    }()) || _class) || _class;
+        }),
+        TestClass
+    )) || _class) || _class;
     function someClassDecorator(c) {
         return c;
     }
@@ -6074,14 +6090,14 @@ class MyClass {
 const foo = "foo";
 const bar = ()=>{};
 const four = 4;
-var _ref = one(), _ref1 = 2 * 4 + 7, _ref2 = 2 * four + 7, _ref3 = 2 * four + seven, _undefined = undefined, _ref4 = void 0, tmp = "whatever", tmp1 = "whatever", tmp2 = computed(), tmp3 = computed(), tmp4 = "test" + one, tmp5 = 10, _ref5 = /regex/, _foo = foo, _bar = bar, _baz = baz, _ref6 = `template${expression}`;
+let _ref = one(), _ref1 = 2 * 4 + 7, _ref2 = 2 * four + 7, _ref3 = 2 * four + seven, _undefined = undefined, _ref4 = void 0, tmp = computed(), tmp1 = computed(), tmp2 = "test" + one, _ref5 = /regex/, _foo = foo, _bar = bar, _baz = baz, _ref6 = `template${expression}`;
 class MyClass {
+    get ["whatever"]() {}
+    set ["whatever"](value) {}
     get [tmp]() {}
     set [tmp1](value) {}
-    get [tmp2]() {}
-    set [tmp3](value) {}
-    [tmp4]() {}
-    static [tmp5]() {}
+    [tmp2]() {}
+    static [10]() {}
     constructor(){
         this[null] = "null";
         this[_undefined] = "undefined";

--- a/crates/swc_ecma_transforms_compat/tests/es2022_class_properties.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2022_class_properties.rs
@@ -49,13 +49,13 @@ var Foo = class {
 
 "#,
     r#"
-var Foo;
-var Foo = (Foo = function Foo() {
+var _Foo;
+var Foo = (_Foo = function Foo() {
         'use strict';
         _classCallCheck(this, Foo);
     },
-    _defineProperty(Foo, 'num', 0),
-    Foo)
+    _defineProperty(_Foo, 'num', 0),
+    _Foo);
 "#
 );
 
@@ -408,8 +408,8 @@ function withContext(ComposedComponent) {
 "#,
     r#"
 function withContext(ComposedComponent) {
-  var WithContext
-  return WithContext = (function(Component) {
+  var _WithContext
+  return _WithContext = (function(Component) {
       'use strict';
       _inherits(WithContext, Component);
       var _super = _createSuper(WithContext);
@@ -419,14 +419,14 @@ function withContext(ComposedComponent) {
       }
       return WithContext;
     })(Component),
-    _defineProperty(WithContext, 'propTypes', {
+    _defineProperty(_WithContext, 'propTypes', {
       context: PropTypes.shape({
         addCss: PropTypes.func,
         setTitle: PropTypes.func,
         setMeta: PropTypes.func
       })
     }),
-    WithContext;
+    _WithContext;
 }
 
 "#
@@ -2960,8 +2960,8 @@ function withContext(ComposedComponent) {
 "#,
     r#"
 function withContext(ComposedComponent) {
-    var WithContext, _propTypes;
-    return WithContext = class WithContext extends Component{
+    var _WithContext, _propTypes;
+    return _WithContext = class WithContext extends Component{
         }, _propTypes = {
             writable: true,
             value: {
@@ -2972,7 +2972,7 @@ function withContext(ComposedComponent) {
                 })
             }
         },
-        WithContext;
+        _WithContext;
 }
 
 
@@ -3052,19 +3052,19 @@ function classFactory() {
 "#,
     r#"
 function classFactory() {
-    var _foo, Foo, _bar;
-    return _foo = new WeakMap(), Foo = class Foo{
+    var _foo, _Foo, _bar;
+    return _foo = new WeakMap(), _Foo = class Foo {
             instance() {
                 return _classPrivateFieldGet(this, _foo);
             }
-             static() {
-                return _classStaticPrivateFieldSpecGet(Foo, Foo, _bar);
+            static() {
+                return _classStaticPrivateFieldSpecGet(Foo, _Foo, _bar);
             }
             static  instance(inst) {
                 return _classPrivateFieldGet(inst, _foo);
             }
             static  static() {
-                return _classStaticPrivateFieldSpecGet(Foo, Foo, _bar);
+                return _classStaticPrivateFieldSpecGet(Foo, _Foo, _bar);
             }
             constructor(){
                 _classPrivateFieldInit(this, _foo, {
@@ -3076,7 +3076,7 @@ function classFactory() {
             writable: true,
             value: 'bar'
         },
-        Foo;
+        _Foo;
 }
 "#
 );
@@ -5712,16 +5712,16 @@ test!(
     }
     ",
     "
-    var TestClass;
+    var _TestClass;
     var _class;
-    let TestClass = _class = someClassDecorator((_class = (TestClass =
+    let TestClass = _class = someClassDecorator((_class = (_TestClass =
         class TestClass {
         },
-        _defineProperty(TestClass, 'Something', 'hello'),
-        _defineProperty(TestClass, 'SomeProperties', {
-            firstProp: TestClass.Something
+        _defineProperty(_TestClass, 'Something', 'hello'),
+        _defineProperty(_TestClass, 'SomeProperties', {
+            firstProp: _TestClass.Something
         }),
-        TestClass
+        _TestClass
     )) || _class) || _class;
     function someClassDecorator(c) {
         return c;

--- a/crates/swc_ecma_transforms_compat/tests/fixture/new-target/general/class-properties-loose/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/fixture/new-target/general/class-properties-loose/output.js
@@ -6,28 +6,21 @@ class Foo {
         this.test2 = function() {
             void 0;
         };
-        this.Bar = (function _target() {
-            class _class {
-                constructor(){
-                    this.q = void 0;
-                }
+        var _class;
+        this.Bar = (_class = class {
+            constructor(){
+                this.q = void 0;
             }
-            _class.p = void 0;
-            _class.p1 = class _class {
-                constructor(){
-                    this.constructor;
-                }
-            };
-            _class.p2 = new function _target() {
-                this.constructor;
-            };
-            _class.p3 = function() {
-                void 0;
-            };
-            _class.p4 = function _target() {
-                this.constructor;
-            };
-            return _class;
-        })();
+        }, _class.p = void 0, _class.p1 = class {
+            constructor(){
+                new.target;
+            }
+        }, _class.p2 = new function _target() {
+            this.constructor;
+        }, _class.p3 = function() {
+            void 0;
+        }, _class.p4 = function _target() {
+            this.constructor;
+        }, _class);
     }
 }

--- a/crates/swc_ecma_transforms_compat/tests/fixture/new-target/general/class-properties/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/fixture/new-target/general/class-properties/output.js
@@ -6,28 +6,21 @@ class Foo {
         _defineProperty(this, "test2", function() {
             void 0;
         });
-        this.Bar = (function _target() {
-            class _class {
-                constructor(){
-                    _defineProperty(this, "q", void 0);
-                }
+        var _class;
+        this.Bar = (_class = class {
+            constructor(){
+                _defineProperty(this, "q", void 0);
             }
-            _defineProperty(_class, "p", void 0);
-            _defineProperty(_class, "p1", class _class {
-                constructor(){
-                    this.constructor;
-                }
-            });
-            _defineProperty(_class, "p2", new function _target() {
-                this.constructor;
-            });
-            _defineProperty(_class, "p3", function() {
-                void 0;
-            });
-            _defineProperty(_class, "p4", function _target() {
-                this.constructor;
-            });
-            return _class;
-        })();
+        }, _defineProperty(_class, "p", void 0), _defineProperty(_class, "p1", class {
+            constructor(){
+                new.target;
+            }
+        }), _defineProperty(_class, "p2", new function _target() {
+            this.constructor;
+        }), _defineProperty(_class, "p3", function() {
+            void 0;
+        }), _defineProperty(_class, "p4", function _target() {
+            this.constructor;
+        }), _class);
     }
 }

--- a/crates/swc_ecma_transforms_compat/tests/static-blocks/class-properties/in-class-heritage/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/static-blocks/class-properties/in-class-heritage/output.js
@@ -1,25 +1,21 @@
-class Foo extends (function () {
-    class _class extends (function () {
-        class Base {}
-        var __ = {
-            writable: true,
-            value: (() => {
-                Base.qux = 21;
-            })(),
-        };
-        return Base;
-    })() {}
-    var __ = {
-        writable: true,
-        value: (() => {
-            _class.bar = 21;
-        })(),
-    };
-    return _class;
-})() {}
-var __ = {
+var _Base, __, _class, __1;
+class Foo extends (_class = class extends (_Base = class Base {
+}, __ = {
     writable: true,
-    value: (() => {
+    value: (()=>{
+        _Base.qux = 21;
+    })()
+}, _Base) {
+}, __1 = {
+    writable: true,
+    value: (()=>{
+        _class.bar = 21;
+    })()
+}, _class) {
+}
+var __2 = {
+    writable: true,
+    value: (()=>{
         Foo.foo = Foo.bar + Foo.qux;
-    })(),
+    })()
 };

--- a/crates/swc_ecma_transforms_compat/tests/static-blocks/class-properties/new-target/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/static-blocks/class-properties/new-target/output.js
@@ -1,15 +1,12 @@
 class Base {
     constructor(){
-        this.Foo = (function() {
-            class _class {
-            }
-            var __ = {
-                writable: true,
-                value: (()=>{
-                    _class.foo = void 0;
-                })()
-            };
-            return _class;
-        })();
+        var _class, __;
+        this.Foo = (_class = class {
+        }, __ = {
+            writable: true,
+            value: (()=>{
+                _class.foo = void 0;
+            })()
+        }, _class);
     }
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

And also:
1. don't memorize computed method name if it's a literal
2. fix [this bug](https://play.swc.rs/?version=1.2.144&code=H4sIAAAAAAAAA0vOzysuUUjOSSwuTi1WsFWIjuXiSssvUtDISS1RyAQKGFhn2hgCCW1tTYVqLgUgACtWcITyQCA6MxaoMhPMr%2BVCKEot1isoLc7QcNTkAgoTNBfolPycVL2c%2FHSNvNRymBFAw4HaATgF0YGoAAAA&config=H4sIAAAAAAAAA0WNOwrDMBBE7zK1isRFCt0hh1iUtVHQj10ZIoTunsjYpBvm86bjrQ62o5Aoy1TaUqUPLNhFUie%2BVAyDSrJxnbYut%2BUOg5CzMuxKQdkg%2BuTXNgEuxyKs%2Bo8obeFqjh8r5tc%2BjY7aCh%2FMx%2Fy4GOfO6%2FMsVtl5fAGaNFAarAAAAA%3D%3D). This would require change cached computed keys variable from `var` to `let`, and it would cause thousands of snapshot changes

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
