### PR TITLE
fix(swc/transforms/react): catch refresh directive comment widely

### DIFF
--- a/crates/swc_ecma_transforms_react/src/refresh/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/mod.rs
@@ -246,12 +246,37 @@ where
 
         let mut should_refresh = self.should_reset;
         if let Some(comments) = &self.comments {
-            if n.hi != BytePos(0) {
-                comments.with_leading(n.hi - BytePos(1), |comments| {
-                    if comments.iter().any(|c| c.text.contains("@refresh reset")) {
-                        should_refresh = true
-                    }
-                });
+            comments.with_leading(n.hi - BytePos(1), |comments| {
+                if comments.iter().any(|c| c.text.contains("@refresh reset")) {
+                    should_refresh = true
+                }
+            });
+
+            if should_refresh {
+                self.should_reset = true;
+                return;
+            }
+
+            comments.with_trailing(n.hi, |comments| {
+                if comments.iter().any(|c| c.text.contains("@refresh reset")) {
+                    should_refresh = true
+                }
+            });
+
+            if should_refresh {
+                self.should_reset = true;
+                return;
+            }
+
+            comments.with_leading(n.lo, |comments| {
+                if comments.iter().any(|c| c.text.contains("@refresh reset")) {
+                    should_refresh = true
+                }
+            });
+
+            if should_refresh {
+                self.should_reset = true;
+                return;
             }
 
             comments.with_trailing(n.lo, |comments| {

--- a/crates/swc_ecma_transforms_react/src/refresh/tests.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/tests.rs
@@ -1340,6 +1340,62 @@ test!(
         ..Default::default()
     }),
     tr,
+    should_refresh_when_has_top_level_comment,
+    r#"
+  // @refresh reset
+
+  export function Foo() {
+    const [foo, setFoo] = useState(0);
+    React.useEffect(() => {});
+    return <h1>{foo}</h1>;
+  }
+  function Bar() {
+    const [foo, setFoo] = useState(0);
+    React.useEffect(() => {
+    });
+    return <h1>{foo}</h1>;
+  }
+"#,
+    r#"
+  var _s = $RefreshSig$(), _s1 = $RefreshSig$();
+
+  export function Foo() {
+    _s();
+
+    const [foo, setFoo] = useState(0);
+    React.useEffect(() => {});
+    return <h1>{foo}</h1>;
+  }
+
+  _s(Foo, "useState{[foo, setFoo](0)}\nuseEffect{}", true);
+
+  _c = Foo;
+
+  function Bar() {
+    _s1();
+
+    const [foo, setFoo] = useState(0);
+    React.useEffect(() => {});
+    return <h1>{foo}</h1>;
+  }
+
+  _s1(Bar, "useState{[foo, setFoo](0)}\nuseEffect{}", true);
+
+  _c1 = Bar;
+
+  var _c, _c1;
+
+  $RefreshReg$(_c, "Foo");
+  $RefreshReg$(_c1, "Bar");
+"#
+);
+
+test!(
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+        jsx: true,
+        ..Default::default()
+    }),
+    tr,
     dont_consider_iife_as_hoc,
     r#"
     while (item) {
@@ -1465,7 +1521,7 @@ test!(
     "
     export function App() {
       console.log(useState())
-    
+
       return null;
     }
   ",
@@ -1475,7 +1531,7 @@ test!(
     export function App() {
       _s();
       console.log(useState())
-    
+
       return null;
     }
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR attempts to fix react-refresh comment directive `@refresh reset` behavior, catch it more widely if it's placed in top-level comment, or per-component level.

I applied pretty much brute way similar to https://github.com/swc-project/swc/blob/main/crates/swc_ecma_parser/tests/comments.rs#L86 by checking comments across span's hi/lo positions. 

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
