### PR TITLE
refactor(css/lints): Skip running rule if disabled

### DIFF
--- a/crates/swc_css_lints/src/rules/at_rule_no_unknown.rs
+++ b/crates/swc_css_lints/src/rules/at_rule_no_unknown.rs
@@ -12,7 +12,7 @@ pub struct AtRuleNoUnknownConfig {
 
 pub fn at_rule_no_unknown(ctx: LintRuleContext<AtRuleNoUnknownConfig>) -> Box<dyn LintRule> {
     let ignored = ctx.config().ignore_at_rules.clone().unwrap_or_default();
-    visitor_rule(AtRuleNoUnknown { ctx, ignored })
+    visitor_rule(ctx.reaction(), AtRuleNoUnknown { ctx, ignored })
 }
 
 #[derive(Debug, Default)]

--- a/crates/swc_css_lints/src/rules/block_no_empty.rs
+++ b/crates/swc_css_lints/src/rules/block_no_empty.rs
@@ -4,7 +4,7 @@ use swc_css_visit::{Visit, VisitWith};
 use crate::rule::{visitor_rule, LintRule, LintRuleContext};
 
 pub fn block_no_empty(ctx: LintRuleContext<()>) -> Box<dyn LintRule> {
-    visitor_rule(BlockNoEmpty { ctx })
+    visitor_rule(ctx.reaction(), BlockNoEmpty { ctx })
 }
 
 const MESSAGE: &str = "Unexpected empty block.";

--- a/crates/swc_css_lints/src/rules/color_hex_length.rs
+++ b/crates/swc_css_lints/src/rules/color_hex_length.rs
@@ -21,7 +21,7 @@ impl Default for HexForm {
 
 pub fn color_hex_length(ctx: LintRuleContext<ColorHexLengthConfig>) -> Box<dyn LintRule> {
     let form = ctx.config().clone().unwrap_or_default();
-    visitor_rule(ColorHexLength { ctx, form })
+    visitor_rule(ctx.reaction(), ColorHexLength { ctx, form })
 }
 
 #[derive(Debug, Default)]

--- a/crates/swc_css_lints/src/rules/color_no_invalid_hex.rs
+++ b/crates/swc_css_lints/src/rules/color_no_invalid_hex.rs
@@ -4,7 +4,7 @@ use swc_css_visit::{Visit, VisitWith};
 use crate::rule::{visitor_rule, LintRule, LintRuleContext};
 
 pub fn color_no_invalid_hex(ctx: LintRuleContext<()>) -> Box<dyn LintRule> {
-    visitor_rule(ColorNoInvalidHex { ctx })
+    visitor_rule(ctx.reaction(), ColorNoInvalidHex { ctx })
 }
 
 #[derive(Debug, Default)]

--- a/crates/swc_css_lints/src/rules/declaration_no_important.rs
+++ b/crates/swc_css_lints/src/rules/declaration_no_important.rs
@@ -5,10 +5,13 @@ use swc_css_visit::{Visit, VisitWith};
 use crate::rule::{visitor_rule, LintRule, LintRuleContext};
 
 pub fn declaration_no_important(ctx: LintRuleContext<()>) -> Box<dyn LintRule> {
-    visitor_rule(DeclarationNoImportant {
-        ctx,
-        keyframe_rules: vec![],
-    })
+    visitor_rule(
+        ctx.reaction(),
+        DeclarationNoImportant {
+            ctx,
+            keyframe_rules: vec![],
+        },
+    )
 }
 
 const MESSAGE: &str = "Unexpected '!important'.";

--- a/crates/swc_css_lints/src/rules/keyframe_declaration_no_important.rs
+++ b/crates/swc_css_lints/src/rules/keyframe_declaration_no_important.rs
@@ -5,10 +5,13 @@ use swc_css_visit::{Visit, VisitWith};
 use crate::rule::{visitor_rule, LintRule, LintRuleContext};
 
 pub fn keyframe_declaration_no_important(ctx: LintRuleContext<()>) -> Box<dyn LintRule> {
-    visitor_rule(KeyframeDeclarationNoImportant {
-        ctx,
-        keyframe_rules: vec![],
-    })
+    visitor_rule(
+        ctx.reaction(),
+        KeyframeDeclarationNoImportant {
+            ctx,
+            keyframe_rules: vec![],
+        },
+    )
 }
 
 const MESSAGE: &str = "Unexpected '!important'.";

--- a/crates/swc_css_lints/src/rules/mod.rs
+++ b/crates/swc_css_lints/src/rules/mod.rs
@@ -30,34 +30,21 @@ pub struct LintParams<'a> {
 }
 
 pub fn get_rules(LintParams { lint_config }: &LintParams) -> Vec<Box<dyn LintRule>> {
-    let mut rules = vec![];
     let rules_config = &lint_config.rules;
 
-    rules.push(block_no_empty((&rules_config.block_no_empty).into()));
-    rules.push(at_rule_no_unknown(
-        (&rules_config.at_rule_no_unknown).into(),
-    ));
-    rules.push(no_empty_source((&rules_config.no_empty_source).into()));
-    rules.push(declaration_no_important(
-        (&rules_config.declaration_no_important).into(),
-    ));
-    rules.push(keyframe_declaration_no_important(
-        (&rules_config.keyframe_declaration_no_important).into(),
-    ));
-    rules.push(no_invalid_position_at_import_rule(
-        (&rules_config.no_invalid_position_at_import_rule).into(),
-    ));
-    rules.push(selector_max_class(
-        (&rules_config.selector_max_class).into(),
-    ));
-    rules.push(color_hex_length((&rules_config.color_hex_length).into()));
-    rules.push(color_no_invalid_hex(
-        (&rules_config.color_no_invalid_hex).into(),
-    ));
-    rules.push(unit_no_unknown((&rules_config.unit_no_unknown).into()));
-    rules.push(selector_max_combinators(
-        (&rules_config.selector_max_combinators).into(),
-    ));
-
-    rules
+    vec![
+        block_no_empty((&rules_config.block_no_empty).into()),
+        at_rule_no_unknown((&rules_config.at_rule_no_unknown).into()),
+        no_empty_source((&rules_config.no_empty_source).into()),
+        declaration_no_important((&rules_config.declaration_no_important).into()),
+        keyframe_declaration_no_important((&rules_config.keyframe_declaration_no_important).into()),
+        no_invalid_position_at_import_rule(
+            (&rules_config.no_invalid_position_at_import_rule).into(),
+        ),
+        selector_max_class((&rules_config.selector_max_class).into()),
+        color_hex_length((&rules_config.color_hex_length).into()),
+        color_no_invalid_hex((&rules_config.color_no_invalid_hex).into()),
+        unit_no_unknown((&rules_config.unit_no_unknown).into()),
+        selector_max_combinators((&rules_config.selector_max_combinators).into()),
+    ]
 }

--- a/crates/swc_css_lints/src/rules/no_empty_source.rs
+++ b/crates/swc_css_lints/src/rules/no_empty_source.rs
@@ -4,7 +4,7 @@ use swc_css_visit::{Visit, VisitWith};
 use crate::rule::{visitor_rule, LintRule, LintRuleContext};
 
 pub fn no_empty_source(ctx: LintRuleContext<()>) -> Box<dyn LintRule> {
-    visitor_rule(NoEmptySource { ctx })
+    visitor_rule(ctx.reaction(), NoEmptySource { ctx })
 }
 
 const MESSAGE: &str = "Unexpected empty source.";

--- a/crates/swc_css_lints/src/rules/no_invalid_position_at_import_rule.rs
+++ b/crates/swc_css_lints/src/rules/no_invalid_position_at_import_rule.rs
@@ -16,7 +16,10 @@ pub fn no_invalid_position_at_import_rule(
     ctx: LintRuleContext<NoInvalidPositionAtImportRuleConfig>,
 ) -> Box<dyn LintRule> {
     let ignored = ctx.config().ignore_at_rules.clone().unwrap_or_default();
-    visitor_rule(NoInvalidPositionAtImportRule { ctx, ignored })
+    visitor_rule(
+        ctx.reaction(),
+        NoInvalidPositionAtImportRule { ctx, ignored },
+    )
 }
 
 #[derive(Debug, Default)]

--- a/crates/swc_css_lints/src/rules/selector_max_class.rs
+++ b/crates/swc_css_lints/src/rules/selector_max_class.rs
@@ -7,7 +7,7 @@ pub(crate) type SelectorMaxClassConfig = Option<usize>;
 
 pub fn selector_max_class(ctx: LintRuleContext<SelectorMaxClassConfig>) -> Box<dyn LintRule> {
     let max = ctx.config().unwrap_or(3);
-    visitor_rule(SelectorMaxClass { ctx, max })
+    visitor_rule(ctx.reaction(), SelectorMaxClass { ctx, max })
 }
 
 #[derive(Debug, Default)]

--- a/crates/swc_css_lints/src/rules/selector_max_combinators.rs
+++ b/crates/swc_css_lints/src/rules/selector_max_combinators.rs
@@ -9,7 +9,7 @@ pub fn selector_max_combinators(
     ctx: LintRuleContext<SelectorMaxCombinatorsConfig>,
 ) -> Box<dyn LintRule> {
     let max = ctx.config().unwrap_or(3);
-    visitor_rule(SelectorMaxCombinators { ctx, max })
+    visitor_rule(ctx.reaction(), SelectorMaxCombinators { ctx, max })
 }
 
 #[derive(Debug, Default)]

--- a/crates/swc_css_lints/src/rules/unit_no_unknown.rs
+++ b/crates/swc_css_lints/src/rules/unit_no_unknown.rs
@@ -12,7 +12,7 @@ pub struct UnitNoUnknownConfig {
 
 pub fn unit_no_unknown(ctx: LintRuleContext<UnitNoUnknownConfig>) -> Box<dyn LintRule> {
     let ignored_units = ctx.config().ignore_units.clone().unwrap_or_default();
-    visitor_rule(UnitNoUnknown { ctx, ignored_units })
+    visitor_rule(ctx.reaction(), UnitNoUnknown { ctx, ignored_units })
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Skip running rules that are disabled in config.

**BREAKING CHANGE:**

It seems no.
