### PR TITLE
feat(css/lints): Add `color-hex-alpha` rule

### DIFF
--- a/crates/swc_css_lints/src/config.rs
+++ b/crates/swc_css_lints/src/config.rs
@@ -3,7 +3,8 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
 use crate::rules::{
-    at_rule_no_unknown::AtRuleNoUnknownConfig, color_hex_length::ColorHexLengthConfig,
+    at_rule_no_unknown::AtRuleNoUnknownConfig, color_hex_alpha::ColorHexAlphaConfig,
+    color_hex_length::ColorHexLengthConfig,
     font_family_no_duplicate_names::FontFamilyNoDuplicateNamesConfig,
     no_invalid_position_at_import_rule::NoInvalidPositionAtImportRuleConfig,
     selector_max_class::SelectorMaxClassConfig,
@@ -107,6 +108,9 @@ pub struct RulesConfig {
 
     #[serde(default, alias = "fontFamilyNoDuplicateNames")]
     pub font_family_no_duplicate_names: RuleConfig<FontFamilyNoDuplicateNamesConfig>,
+
+    #[serde(default, alias = "colorHexAlpha")]
+    pub color_hex_alpha: RuleConfig<ColorHexAlphaConfig>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/swc_css_lints/src/rules/color_hex_alpha.rs
+++ b/crates/swc_css_lints/src/rules/color_hex_alpha.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+use swc_css_ast::*;
+use swc_css_visit::{Visit, VisitWith};
+
+use crate::rule::{visitor_rule, LintRule, LintRuleContext};
+
+pub type ColorHexAlphaConfig = Option<Preference>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Preference {
+    Always,
+    Never,
+}
+
+impl Default for Preference {
+    fn default() -> Self {
+        Self::Always
+    }
+}
+
+pub fn color_hex_alpha(ctx: LintRuleContext<ColorHexAlphaConfig>) -> Box<dyn LintRule> {
+    let preference = ctx.config().clone().unwrap_or_default();
+    visitor_rule(ctx.reaction(), ColorHexAlpha { ctx, preference })
+}
+
+#[derive(Debug, Default)]
+struct ColorHexAlpha {
+    ctx: LintRuleContext<ColorHexAlphaConfig>,
+    preference: Preference,
+}
+
+impl Visit for ColorHexAlpha {
+    fn visit_hex_color(&mut self, hex_color: &HexColor) {
+        let length = hex_color.value.len();
+        match self.preference {
+            Preference::Always if length == 3 || length == 6 => {
+                self.ctx.report(
+                    hex_color,
+                    format!("Expected alpha channel in '#{}'.", hex_color.value),
+                );
+            }
+            Preference::Never if length == 4 || length == 8 => {
+                self.ctx.report(
+                    hex_color,
+                    format!("Unxpected alpha channel in '#{}'.", hex_color.value),
+                );
+            }
+            _ => {}
+        }
+
+        hex_color.visit_children_with(self);
+    }
+}

--- a/crates/swc_css_lints/src/rules/mod.rs
+++ b/crates/swc_css_lints/src/rules/mod.rs
@@ -3,7 +3,8 @@ use crate::{
     rule::LintRule,
     rules::{
         at_rule_no_unknown::at_rule_no_unknown, block_no_empty::block_no_empty,
-        color_hex_length::color_hex_length, color_no_invalid_hex::color_no_invalid_hex,
+        color_hex_alpha::color_hex_alpha, color_hex_length::color_hex_length,
+        color_no_invalid_hex::color_no_invalid_hex,
         declaration_no_important::declaration_no_important,
         font_family_no_duplicate_names::font_family_no_duplicate_names,
         keyframe_declaration_no_important::keyframe_declaration_no_important,
@@ -16,6 +17,7 @@ use crate::{
 
 pub mod at_rule_no_unknown;
 pub mod block_no_empty;
+pub mod color_hex_alpha;
 pub mod color_hex_length;
 pub mod color_no_invalid_hex;
 pub mod declaration_no_important;
@@ -49,5 +51,6 @@ pub fn get_rules(LintParams { lint_config }: &LintParams) -> Vec<Box<dyn LintRul
         unit_no_unknown((&rules_config.unit_no_unknown).into()),
         selector_max_combinators((&rules_config.selector_max_combinators).into()),
         font_family_no_duplicate_names((&rules_config.font_family_no_duplicate_names).into()),
+        color_hex_alpha((&rules_config.color_hex_alpha).into()),
     ]
 }

--- a/crates/swc_css_lints/tests/rules/fail/color-hex-alpha/always/config.json
+++ b/crates/swc_css_lints/tests/rules/fail/color-hex-alpha/always/config.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "color-hex-alpha": ["error", "always"]
+    }
+}

--- a/crates/swc_css_lints/tests/rules/fail/color-hex-alpha/always/input.css
+++ b/crates/swc_css_lints/tests/rules/fail/color-hex-alpha/always/input.css
@@ -1,0 +1,3 @@
+a { color: #fff; }
+a { color: #ffffff; }
+a { background: linear-gradient(to left, #fff, #000000 100%); }

--- a/crates/swc_css_lints/tests/rules/fail/color-hex-alpha/always/output.stderr
+++ b/crates/swc_css_lints/tests/rules/fail/color-hex-alpha/always/output.stderr
@@ -1,0 +1,24 @@
+error: Expected alpha channel in '#fff'.
+ --> $DIR/tests/rules/fail/color-hex-alpha/always/input.css:1:12
+  |
+1 | a { color: #fff; }
+  |            ^^^^
+
+error: Expected alpha channel in '#ffffff'.
+ --> $DIR/tests/rules/fail/color-hex-alpha/always/input.css:2:12
+  |
+2 | a { color: #ffffff; }
+  |            ^^^^^^^
+
+error: Expected alpha channel in '#fff'.
+ --> $DIR/tests/rules/fail/color-hex-alpha/always/input.css:3:42
+  |
+3 | a { background: linear-gradient(to left, #fff, #000000 100%); }
+  |                                          ^^^^
+
+error: Expected alpha channel in '#000000'.
+ --> $DIR/tests/rules/fail/color-hex-alpha/always/input.css:3:48
+  |
+3 | a { background: linear-gradient(to left, #fff, #000000 100%); }
+  |                                                ^^^^^^^
+

--- a/crates/swc_css_lints/tests/rules/fail/color-hex-alpha/never/config.json
+++ b/crates/swc_css_lints/tests/rules/fail/color-hex-alpha/never/config.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "color-hex-alpha": ["error", "never"]
+    }
+}

--- a/crates/swc_css_lints/tests/rules/fail/color-hex-alpha/never/input.css
+++ b/crates/swc_css_lints/tests/rules/fail/color-hex-alpha/never/input.css
@@ -1,0 +1,2 @@
+a { color: #ffff; }
+a { color: #ffffffff; }

--- a/crates/swc_css_lints/tests/rules/fail/color-hex-alpha/never/output.stderr
+++ b/crates/swc_css_lints/tests/rules/fail/color-hex-alpha/never/output.stderr
@@ -1,0 +1,12 @@
+error: Unxpected alpha channel in '#ffff'.
+ --> $DIR/tests/rules/fail/color-hex-alpha/never/input.css:1:12
+  |
+1 | a { color: #ffff; }
+  |            ^^^^^
+
+error: Unxpected alpha channel in '#ffffffff'.
+ --> $DIR/tests/rules/fail/color-hex-alpha/never/input.css:2:12
+  |
+2 | a { color: #ffffffff; }
+  |            ^^^^^^^^^
+

--- a/crates/swc_css_lints/tests/rules/pass/color-hex-alpha/always/config.json
+++ b/crates/swc_css_lints/tests/rules/pass/color-hex-alpha/always/config.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "color-hex-alpha": ["error", "always"]
+    }
+}

--- a/crates/swc_css_lints/tests/rules/pass/color-hex-alpha/always/input.css
+++ b/crates/swc_css_lints/tests/rules/pass/color-hex-alpha/always/input.css
@@ -1,0 +1,4 @@
+a { color: #ffff; }
+a { color: #ffffffff; }
+a { background: linear-gradient(to left, #fffa, #000000aa 100%); }
+a { background: url(#fff); }

--- a/crates/swc_css_lints/tests/rules/pass/color-hex-alpha/never/config.json
+++ b/crates/swc_css_lints/tests/rules/pass/color-hex-alpha/never/config.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "color-hex-alpha": ["error", "never"]
+    }
+}

--- a/crates/swc_css_lints/tests/rules/pass/color-hex-alpha/never/input.css
+++ b/crates/swc_css_lints/tests/rules/pass/color-hex-alpha/never/input.css
@@ -1,0 +1,2 @@
+a { color: #fff; }
+a { color: #ffffff; }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Implemented [`color-hex-alpha`](https://stylelint.io/user-guide/rules/list/color-hex-alpha/) rule.

**BREAKING CHANGE:**

No.
