### PR TITLE
fix(css/lints): Allow empty `@layer` rule before `@import` rule

### DIFF
--- a/crates/swc_css_lints/src/rules/no_invalid_position_at_import_rule.rs
+++ b/crates/swc_css_lints/src/rules/no_invalid_position_at_import_rule.rs
@@ -36,7 +36,7 @@ impl Visit for NoInvalidPositionAtImportRule {
             }
 
             match rule {
-                Rule::AtRule(AtRule::Charset(..) | AtRule::Import(..)) => seen,
+                Rule::AtRule(AtRule::Charset(..) | AtRule::Import(..) | AtRule::Layer(..)) => seen,
                 Rule::AtRule(AtRule::Unknown(UnknownAtRule { name, .. })) => {
                     let name = match name {
                         AtRuleName::DashedIdent(dashed_ident) => &dashed_ident.value,

--- a/crates/swc_css_lints/src/rules/no_invalid_position_at_import_rule.rs
+++ b/crates/swc_css_lints/src/rules/no_invalid_position_at_import_rule.rs
@@ -36,7 +36,12 @@ impl Visit for NoInvalidPositionAtImportRule {
             }
 
             match rule {
-                Rule::AtRule(AtRule::Charset(..) | AtRule::Import(..) | AtRule::Layer(..)) => seen,
+                Rule::AtRule(AtRule::Charset(..) | AtRule::Import(..)) => seen,
+                Rule::AtRule(AtRule::Layer(LayerRule { block, .. })) => match block {
+                    Some(block) if block.value.is_empty() => seen,
+                    None => seen,
+                    _ => true,
+                },
                 Rule::AtRule(AtRule::Unknown(UnknownAtRule { name, .. })) => {
                     let name = match name {
                         AtRuleName::DashedIdent(dashed_ident) => &dashed_ident.value,

--- a/crates/swc_css_lints/tests/rules/fail/no-invalid-position-at-import-rule/default/at-layer-rule/config.json
+++ b/crates/swc_css_lints/tests/rules/fail/no-invalid-position-at-import-rule/default/at-layer-rule/config.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "no-invalid-position-at-import-rule": ["error"]
+    }
+}

--- a/crates/swc_css_lints/tests/rules/fail/no-invalid-position-at-import-rule/default/at-layer-rule/input.css
+++ b/crates/swc_css_lints/tests/rules/fail/no-invalid-position-at-import-rule/default/at-layer-rule/input.css
@@ -1,0 +1,6 @@
+@layer framework {
+    .title {
+    }
+}
+
+@import "kumiko.css";

--- a/crates/swc_css_lints/tests/rules/fail/no-invalid-position-at-import-rule/default/at-layer-rule/output.stderr
+++ b/crates/swc_css_lints/tests/rules/fail/no-invalid-position-at-import-rule/default/at-layer-rule/output.stderr
@@ -1,0 +1,6 @@
+error: Unexpected invalid position '@import' rule.
+ --> $DIR/tests/rules/fail/no-invalid-position-at-import-rule/default/at-layer-rule/input.css:6:1
+  |
+6 | @import "kumiko.css";
+  | ^^^^^^^^^^^^^^^^^^^^^
+

--- a/crates/swc_css_lints/tests/rules/pass/no-invalid-position-at-import-rule/default/input.css
+++ b/crates/swc_css_lints/tests/rules/pass/no-invalid-position-at-import-rule/default/input.css
@@ -1,4 +1,5 @@
 @charset "utf-8";
+@layer framework, override;
 @layer {}
 
 @import "kumiko.css";

--- a/crates/swc_css_lints/tests/rules/pass/no-invalid-position-at-import-rule/default/input.css
+++ b/crates/swc_css_lints/tests/rules/pass/no-invalid-position-at-import-rule/default/input.css
@@ -1,4 +1,5 @@
 @charset "utf-8";
+@layer {}
 
 @import "kumiko.css";
 @import "reina.css";


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

According to [spec](https://www.w3.org/TR/css-cascade-5/#at-import), this PR fixes `no-invalid-position-at-import-rule` rule, which allows:

```css
@layer {}

@import "x.css";
```

> Any [@import](https://www.w3.org/TR/css-cascade-5/#at-ruledef-import) rules must precede all other valid at-rules and style rules in a style sheet (ignoring [@charset](https://www.w3.org/TR/css-syntax-3/#at-ruledef-charset) and empty [@layer](https://www.w3.org/TR/css-cascade-5/#at-ruledef-layer) definitions).

**BREAKING CHANGE:**

No.
