### PR TITLE
fix(es/minifier): Don't remove comments if `compress` is not configured

### DIFF
--- a/crates/swc/src/builder.rs
+++ b/crates/swc/src/builder.rs
@@ -343,6 +343,10 @@ impl VisitMut for MinifierPass {
                 ..Default::default()
             };
 
+            if opts.compress.is_none() && opts.mangle.is_none() {
+                return;
+            }
+
             m.map_with_mut(|m| {
                 swc_ecma_minifier::optimize(
                     m,

--- a/crates/swc_ecma_minifier/src/lib.rs
+++ b/crates/swc_ecma_minifier/src/lib.rs
@@ -91,7 +91,9 @@ pub fn optimize(
         m.visit_mut_with(&mut precompress_optimizer(options, marks));
     }
 
-    m.visit_mut_with(&mut info_marker(comments, marks, extra.top_level_mark));
+    if options.compress.is_some() {
+        m.visit_mut_with(&mut info_marker(comments, marks, extra.top_level_mark));
+    }
     m.visit_mut_with(&mut unique_scope());
 
     if options.wrap {


### PR DESCRIPTION
**Description:**

Don't invoke `info_marker` if `compress` is `None`.

**BREAKING CHANGE:**


**Related issue (if exists):**

 - Closes #3807
