### PR TITLE
 mod(es/ast): remove useless fields in private prop 

### DIFF
--- a/crates/swc_bundler/src/bundler/keywords.rs
+++ b/crates/swc_bundler/src/bundler/keywords.rs
@@ -118,10 +118,6 @@ impl VisitMut for KeywordRenamer {
     }
 
     fn visit_mut_private_prop(&mut self, n: &mut PrivateProp) {
-        if n.computed {
-            n.key.visit_mut_with(self);
-        }
-
         n.decorators.visit_mut_with(self);
         n.value.visit_mut_with(self);
     }

--- a/crates/swc_ecma_ast/src/class.rs
+++ b/crates/swc_ecma_ast/src/class.rs
@@ -157,16 +157,9 @@ pub struct PrivateProp {
     #[serde(default)]
     pub decorators: Vec<Decorator>,
 
-    #[serde(default)]
-    pub computed: bool,
-
     /// Typescript extension.
     #[serde(default)]
     pub accessibility: Option<Accessibility>,
-
-    /// Typescript extension.
-    #[serde(default)]
-    pub is_abstract: bool,
 
     #[serde(default)]
     pub is_optional: bool,
@@ -176,9 +169,6 @@ pub struct PrivateProp {
 
     #[serde(default)]
     pub readonly: bool,
-
-    #[serde(default)]
-    pub definite: bool,
 }
 
 macro_rules! method {

--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -166,7 +166,7 @@ pub enum SyntaxError {
 
     AsyncConstructor,
     PropertyNamedConstructor,
-    DeclarePrivateIdentifier,
+    PrivateNameModifier(JsWord),
     ReadOnlyMethod,
     GeneratorConstructor,
     TsBindingPatCannotBeOptional,
@@ -419,8 +419,8 @@ impl SyntaxError {
             SyntaxError::PropertyNamedConstructor => {
                 "Classes may not have a non-static field named 'constructor'".into()
             }
-            SyntaxError::DeclarePrivateIdentifier => {
-                "'declare' modifier cannot be used with a private identifier".into()
+            SyntaxError::PrivateNameModifier(modifier) => {
+                format!("'{modifier}' modifier cannot be used with a private identifier").into()
             }
 
             SyntaxError::ReadOnlyMethod => "A method cannot be readonly".into(),

--- a/crates/swc_ecma_parser/tests/tsc/classStaticBlock11.json
+++ b/crates/swc_ecma_parser/tests/tsc/classStaticBlock11.json
@@ -96,13 +96,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/classStaticBlock12.json
+++ b/crates/swc_ecma_parser/tests/tsc/classStaticBlock12.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "StaticBlock",

--- a/crates/swc_ecma_parser/tests/tsc/classStaticBlock13.json
+++ b/crates/swc_ecma_parser/tests/tsc/classStaticBlock13.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "StaticBlock",

--- a/crates/swc_ecma_parser/tests/tsc/classStaticBlock14.json
+++ b/crates/swc_ecma_parser/tests/tsc/classStaticBlock14.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -108,13 +105,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -153,13 +147,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "StaticBlock",

--- a/crates/swc_ecma_parser/tests/tsc/classStaticBlock15.json
+++ b/crates/swc_ecma_parser/tests/tsc/classStaticBlock15.json
@@ -96,13 +96,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -141,13 +138,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -186,13 +180,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "StaticBlock",

--- a/crates/swc_ecma_parser/tests/tsc/classStaticBlock17.json
+++ b/crates/swc_ecma_parser/tests/tsc/classStaticBlock17.json
@@ -304,13 +304,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/genericSetterInClassType.json
+++ b/crates/swc_ecma_parser/tests/tsc/genericSetterInClassType.json
@@ -481,13 +481,10 @@
                 },
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": true
+                "readonly": false
               },
               {
                 "type": "ClassMethod",

--- a/crates/swc_ecma_parser/tests/tsc/genericSetterInClassTypeJsDoc.json
+++ b/crates/swc_ecma_parser/tests/tsc/genericSetterInClassTypeJsDoc.json
@@ -55,13 +55,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/jsDeclarationsPrivateFields01.json
+++ b/crates/swc_ecma_parser/tests/tsc/jsDeclarationsPrivateFields01.json
@@ -75,13 +75,10 @@
             "typeAnnotation": null,
             "isStatic": false,
             "decorators": [],
-            "computed": false,
             "accessibility": null,
-            "isAbstract": false,
             "isOptional": false,
             "isOverride": false,
-            "readonly": false,
-            "definite": false
+            "readonly": false
           },
           {
             "type": "PrivateProperty",
@@ -120,13 +117,10 @@
             "typeAnnotation": null,
             "isStatic": false,
             "decorators": [],
-            "computed": false,
             "accessibility": null,
-            "isAbstract": false,
             "isOptional": false,
             "isOverride": false,
-            "readonly": false,
-            "definite": false
+            "readonly": false
           },
           {
             "type": "PrivateMethod",

--- a/crates/swc_ecma_parser/tests/tsc/jsdocPrivateName1.json
+++ b/crates/swc_ecma_parser/tests/tsc/jsdocPrivateName1.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNameAmbientNoImplicitAny.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameAmbientNoImplicitAny.json
@@ -55,13 +55,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,
@@ -119,13 +116,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNameAndAny.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameAndAny.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -108,13 +105,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameAndIndexSignature.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameAndIndexSignature.json
@@ -119,13 +119,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassProperty",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameAndObjectRestSpread.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameAndObjectRestSpread.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -108,13 +105,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameAndStaticInitializer.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameAndStaticInitializer.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassProperty",
@@ -156,13 +153,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNameCircularReference.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameCircularReference.json
@@ -88,13 +88,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -158,13 +155,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassProperty",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameClassExpressionLoop.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameClassExpressionLoop.json
@@ -257,13 +257,10 @@
                         "typeAnnotation": null,
                         "isStatic": false,
                         "decorators": [],
-                        "computed": false,
                         "accessibility": null,
-                        "isAbstract": false,
                         "isOptional": false,
                         "isOverride": false,
-                        "readonly": false,
-                        "definite": false
+                        "readonly": false
                       },
                       {
                         "type": "PrivateMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameComputedPropertyName1.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameComputedPropertyName1.json
@@ -68,13 +68,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -121,13 +118,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -171,13 +165,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": true,
-          "definite": false
+          "readonly": true
         },
         {
           "type": "PrivateProperty",
@@ -224,13 +215,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": true,
-          "definite": false
+          "readonly": true
         },
         {
           "type": "PrivateProperty",
@@ -274,13 +262,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameComputedPropertyName2.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameComputedPropertyName2.json
@@ -168,13 +168,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameComputedPropertyName3.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameComputedPropertyName3.json
@@ -55,13 +55,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",
@@ -327,13 +324,10 @@
                       "typeAnnotation": null,
                       "isStatic": false,
                       "decorators": [],
-                      "computed": false,
                       "accessibility": null,
-                      "isAbstract": false,
                       "isOptional": false,
                       "isOverride": false,
-                      "readonly": false,
-                      "definite": false
+                      "readonly": false
                     },
                     {
                       "type": "ClassMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameComputedPropertyName4.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameComputedPropertyName4.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",
@@ -193,13 +190,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",
@@ -323,13 +317,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassProperty",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameConstructorSignature.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameConstructorSignature.json
@@ -127,13 +127,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameDeclaration.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameDeclaration.json
@@ -71,13 +71,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -116,13 +113,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassProperty",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameDeclarationMerging.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameDeclarationMerging.json
@@ -89,13 +89,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameDuplicateField.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameDuplicateField.json
@@ -96,13 +96,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateProperty",
@@ -146,13 +143,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -223,13 +217,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateMethod",
@@ -354,13 +345,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateMethod",
@@ -508,13 +496,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateMethod",
@@ -676,13 +661,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateProperty",
@@ -726,13 +708,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -803,13 +782,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateMethod",
@@ -934,13 +910,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateMethod",
@@ -1088,13 +1061,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateMethod",
@@ -1345,13 +1315,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -1941,13 +1908,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -2595,13 +2559,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -4024,13 +3985,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -4768,13 +4726,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -5456,13 +5411,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateProperty",
@@ -5506,13 +5458,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -5583,13 +5532,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateMethod",
@@ -5714,13 +5660,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateMethod",
@@ -5868,13 +5811,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateMethod",
@@ -6036,13 +5976,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateProperty",
@@ -6086,13 +6023,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -6163,13 +6097,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateMethod",
@@ -6294,13 +6225,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateMethod",
@@ -6448,13 +6376,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "PrivateMethod",
@@ -6705,13 +6630,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -7301,13 +7223,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -7955,13 +7874,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -9384,13 +9300,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -10128,13 +10041,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNameES5Ban.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameES5Ban.json
@@ -93,13 +93,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateMethod",
@@ -197,13 +194,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameEmitHelpers.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameEmitHelpers.json
@@ -70,13 +70,10 @@
             "typeAnnotation": null,
             "isStatic": false,
             "decorators": [],
-            "computed": false,
             "accessibility": null,
-            "isAbstract": false,
             "isOptional": false,
             "isOverride": false,
-            "readonly": false,
-            "definite": false
+            "readonly": false
           },
           {
             "type": "PrivateMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassProperty",
@@ -230,13 +227,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "ClassMethod",
@@ -857,13 +851,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassProperty",
@@ -1024,13 +1015,10 @@
                 "typeAnnotation": null,
                 "isStatic": false,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               },
               {
                 "type": "ClassMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameField.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameField.json
@@ -71,13 +71,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameFieldAccess.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameFieldAccess.json
@@ -68,13 +68,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameFieldAssignment.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameFieldAssignment.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameFieldCallExpression.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameFieldCallExpression.json
@@ -131,13 +131,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -246,13 +243,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassProperty",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameFieldClassExpression.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameFieldClassExpression.json
@@ -203,13 +203,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -302,13 +299,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNameFieldDestructuredBinding.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameFieldDestructuredBinding.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassProperty",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameFieldInitializer.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameFieldInitializer.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -100,13 +97,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNameFieldUnaryMutation.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameFieldUnaryMutation.json
@@ -79,13 +79,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameFieldsESNext.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameFieldsESNext.json
@@ -100,13 +100,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassProperty",
@@ -179,13 +176,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",
@@ -509,13 +503,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -546,13 +537,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",
@@ -842,13 +830,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNameInInExpressionUnused.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameInInExpressionUnused.json
@@ -71,13 +71,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -124,13 +121,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameInLhsReceiverExpression.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameInLhsReceiverExpression.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",
@@ -322,13 +319,10 @@
                                       "typeAnnotation": null,
                                       "isStatic": false,
                                       "decorators": [],
-                                      "computed": false,
                                       "accessibility": null,
-                                      "isAbstract": false,
                                       "isOptional": false,
                                       "isOverride": false,
-                                      "readonly": false,
-                                      "definite": false
+                                      "readonly": false
                                     },
                                     {
                                       "type": "ClassProperty",
@@ -540,13 +534,10 @@
                                       "typeAnnotation": null,
                                       "isStatic": false,
                                       "decorators": [],
-                                      "computed": false,
                                       "accessibility": null,
-                                      "isAbstract": false,
                                       "isOptional": false,
                                       "isOverride": false,
-                                      "readonly": false,
-                                      "definite": false
+                                      "readonly": false
                                     },
                                     {
                                       "type": "ClassProperty",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameLateSuper.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameLateSuper.json
@@ -81,13 +81,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameLateSuperUseDefineForClassFields.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameLateSuperUseDefineForClassFields.json
@@ -81,13 +81,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameNestedClassNameConflict.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameNestedClassNameConflict.json
@@ -71,13 +71,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",
@@ -170,13 +167,10 @@
                     },
                     "isStatic": false,
                     "decorators": [],
-                    "computed": false,
                     "accessibility": null,
-                    "isAbstract": false,
                     "isOptional": false,
                     "isOverride": false,
-                    "readonly": false,
-                    "definite": false
+                    "readonly": false
                   }
                 ],
                 "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNameStaticAccessorsCallExpression.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameStaticAccessorsCallExpression.json
@@ -355,13 +355,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameStaticAndStaticInitializer.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameStaticAndStaticInitializer.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -108,13 +105,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNameStaticEmitHelpers.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameStaticEmitHelpers.json
@@ -70,13 +70,10 @@
             "typeAnnotation": null,
             "isStatic": true,
             "decorators": [],
-            "computed": false,
             "accessibility": null,
-            "isAbstract": false,
             "isOptional": false,
             "isOverride": false,
-            "readonly": false,
-            "definite": false
+            "readonly": false
           },
           {
             "type": "PrivateMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldAccess.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldAccess.json
@@ -68,13 +68,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldAssignment.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldAssignment.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldCallExpression.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldCallExpression.json
@@ -131,13 +131,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -246,13 +243,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassProperty",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldClassExpression.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldClassExpression.json
@@ -294,13 +294,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -393,13 +390,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldDestructuredBinding.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldDestructuredBinding.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassProperty",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldInitializer.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldInitializer.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -100,13 +97,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldNoInitializer.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldNoInitializer.json
@@ -73,13 +73,10 @@
                 "typeAnnotation": null,
                 "isStatic": true,
                 "decorators": [],
-                "computed": false,
                 "accessibility": null,
-                "isAbstract": false,
                 "isOptional": false,
                 "isOverride": false,
-                "readonly": false,
-                "definite": false
+                "readonly": false
               }
             ],
             "superClass": null,
@@ -141,13 +138,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldUnaryMutation.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameStaticFieldUnaryMutation.json
@@ -79,13 +79,10 @@
           },
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameStaticsAndStaticMethods.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameStaticsAndStaticMethods.json
@@ -362,13 +362,10 @@
           },
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNameUnused.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNameUnused.json
@@ -75,13 +75,10 @@
             "typeAnnotation": null,
             "isStatic": false,
             "decorators": [],
-            "computed": false,
             "accessibility": null,
-            "isAbstract": false,
             "isOptional": false,
             "isOverride": false,
-            "readonly": false,
-            "definite": false
+            "readonly": false
           },
           {
             "type": "PrivateProperty",
@@ -125,13 +122,10 @@
             "typeAnnotation": null,
             "isStatic": false,
             "decorators": [],
-            "computed": false,
             "accessibility": null,
-            "isAbstract": false,
             "isOptional": false,
             "isOverride": false,
-            "readonly": false,
-            "definite": false
+            "readonly": false
           },
           {
             "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesAndFields.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesAndFields.json
@@ -71,13 +71,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",
@@ -242,13 +239,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesAndMethods.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesAndMethods.json
@@ -362,13 +362,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesAndStaticMethods.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesAndStaticMethods.json
@@ -362,13 +362,10 @@
           },
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesAndkeyof.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesAndkeyof.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesAssertion.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesAssertion.json
@@ -267,13 +267,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesConstructorChain-1.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesConstructorChain-1.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -108,13 +105,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",
@@ -330,13 +324,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -380,13 +371,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": {

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesConstructorChain-2.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesConstructorChain-2.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -108,13 +105,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",
@@ -377,13 +371,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -427,13 +418,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": {

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesIncompatibleModifiersJs.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesIncompatibleModifiersJs.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -108,13 +105,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -153,13 +147,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesUnique-1.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesUnique-1.json
@@ -71,13 +71,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,
@@ -151,13 +148,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesUnique-2.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesUnique-2.json
@@ -62,13 +62,10 @@
             "typeAnnotation": null,
             "isStatic": false,
             "decorators": [],
-            "computed": false,
             "accessibility": null,
-            "isAbstract": false,
             "isOptional": false,
             "isOverride": false,
-            "readonly": false,
-            "definite": false
+            "readonly": false
           },
           {
             "type": "ClassMethod",
@@ -286,13 +283,10 @@
             "typeAnnotation": null,
             "isStatic": false,
             "decorators": [],
-            "computed": false,
             "accessibility": null,
-            "isAbstract": false,
             "isOptional": false,
             "isOverride": false,
-            "readonly": false,
-            "definite": false
+            "readonly": false
           }
         ],
         "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesUnique-3.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesUnique-3.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -108,13 +105,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,
@@ -180,13 +174,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "ClassMethod",

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesUnique-4.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesUnique-4.json
@@ -206,13 +206,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesUnique-5.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesUnique-5.json
@@ -71,13 +71,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,
@@ -201,13 +198,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateNamesUseBeforeDef.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateNamesUseBeforeDef.json
@@ -88,13 +88,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -133,13 +130,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,
@@ -240,13 +234,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateMethod",
@@ -417,13 +408,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateMethod",
@@ -594,13 +582,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -664,13 +649,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,

--- a/crates/swc_ecma_parser/tests/tsc/privateStaticNameShadowing.json
+++ b/crates/swc_ecma_parser/tests/tsc/privateStaticNameShadowing.json
@@ -100,13 +100,10 @@
           "typeAnnotation": null,
           "isStatic": true,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/tsc/strictPropertyInitialization.json
+++ b/crates/swc_ecma_parser/tests/tsc/strictPropertyInitialization.json
@@ -289,13 +289,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -361,13 +358,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -433,13 +427,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -486,13 +477,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": true,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,
@@ -784,13 +772,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -856,13 +841,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -928,13 +910,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -981,13 +960,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": true,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,
@@ -1446,13 +1422,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -1507,13 +1480,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -1573,13 +1543,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         }
       ],
       "superClass": null,
@@ -1698,13 +1665,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",
@@ -1966,13 +1930,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",
@@ -2309,13 +2270,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",
@@ -3264,13 +3222,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",
@@ -3838,13 +3793,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_parser/tests/typescript/class/property-private/input.ts.json
+++ b/crates/swc_ecma_parser/tests/typescript/class/property-private/input.ts.json
@@ -63,13 +63,10 @@
           "typeAnnotation": null,
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "PrivateProperty",
@@ -116,13 +113,10 @@
           },
           "isStatic": false,
           "decorators": [],
-          "computed": false,
           "accessibility": null,
-          "isAbstract": false,
           "isOptional": false,
           "isOverride": false,
-          "readonly": false,
-          "definite": false
+          "readonly": false
         },
         {
           "type": "Constructor",

--- a/crates/swc_ecma_quote_macros/src/ast/prop.rs
+++ b/crates/swc_ecma_quote_macros/src/ast/prop.rs
@@ -11,13 +11,10 @@ impl_struct!(
         type_ann,
         is_static,
         decorators,
-        computed,
         accessibility,
-        is_abstract,
         is_optional,
         is_override,
-        readonly,
-        definite
+        readonly
     ]
 );
 

--- a/crates/swc_ecma_transforms_compat/src/es2022/static_blocks.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/static_blocks.rs
@@ -49,12 +49,9 @@ impl ClassStaticBlock {
         PrivateProp {
             span: DUMMY_SP,
             is_static: true,
-            is_abstract: false,
             is_optional: false,
             is_override: false,
             readonly: false,
-            computed: false,
-            definite: false,
             type_ann: None,
             decorators: Vec::new(),
             accessibility: None,

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -543,13 +543,10 @@ define!({
         pub type_ann: Option<TsTypeAnn>,
         pub is_static: bool,
         pub decorators: Vec<Decorator>,
-        pub computed: bool,
         pub accessibility: Option<Accessibility>,
-        pub is_abstract: bool,
         pub is_optional: bool,
         pub is_override: bool,
         pub readonly: bool,
-        pub definite: bool,
     }
     pub struct ClassMethod {
         pub span: Span,

--- a/crates/swc_estree_compat/src/swcify/class.rs
+++ b/crates/swc_estree_compat/src/swcify/class.rs
@@ -159,13 +159,10 @@ impl Swcify for swc_estree_ast::ClassPrivateProperty {
             type_ann: self.type_annotation.swcify(ctx).flatten(),
             is_static: false,
             decorators: Default::default(),
-            computed: false,
             accessibility: Default::default(),
-            is_abstract: false,
             is_optional: false,
             is_override: false,
             readonly: false,
-            definite: false,
         }
     }
 }

--- a/node-swc/src/Visitor.ts
+++ b/node-swc/src/Visitor.ts
@@ -9,6 +9,7 @@ import {
   AssignmentPatternProperty,
   AssignmentProperty,
   AwaitExpression,
+  BigIntLiteral,
   BinaryExpression,
   BlockStatement,
   BooleanLiteral,
@@ -873,6 +874,8 @@ export class Visitor {
         return this.visitStringLiteral(key);
       case "NumericLiteral":
         return this.visitNumericLiteral(key);
+      case "BigIntLiteral":
+          return this.visitBigIntLiteral(key);
       default:
         return this.visitComputedPropertyKey(key);
     }
@@ -885,7 +888,7 @@ export class Visitor {
   visitClassProperty(n: ClassProperty): ClassMember {
     n.accessibility = this.visitAccessibility(n.accessibility);
     n.decorators = this.visitDecorators(n.decorators);
-    n.key = this.visitExpression(n.key);
+    n.key = this.visitPropertyName(n.key);
     n.typeAnnotation = this.visitTsTypeAnnotation(n.typeAnnotation);
     n.value = this.visitOptionalExpression(n.value);
     return n;
@@ -898,18 +901,6 @@ export class Visitor {
     return n;
   }
 
-  visitPropertName(n: PropertyName): PropertyName {
-    switch (n.type) {
-      case "Identifier":
-        return this.visitIdentifier(n);
-      case "NumericLiteral":
-        return this.visitNumericLiteral(n);
-      case "StringLiteral":
-        return this.visitStringLiteral(n);
-      case "Computed":
-        return this.visitComputedPropertyKey(n);
-    }
-  }
   visitComputedPropertyKey(n: ComputedPropName): ComputedPropName {
     n.expression = this.visitExpression(n.expression);
     return n;
@@ -1659,6 +1650,10 @@ export class Visitor {
   }
 
   visitNumericLiteral(n: NumericLiteral): NumericLiteral {
+    return n;
+  }
+
+  visitBigIntLiteral(n: BigIntLiteral): BigIntLiteral {
     return n;
   }
 

--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -1,5 +1,3 @@
-import { BigIntLiteral } from "@babel/types";
-
 export interface Plugin {
   (module: Program): Program;
 }
@@ -1466,6 +1464,12 @@ export interface NumericLiteral extends Node, HasSpan {
   type: "NumericLiteral";
 
   value: number;
+}
+
+export interface BigIntLiteral extends Node, HasSpan {
+  type: "BigIntLiteral";
+
+  value: bigint;
 }
 
 export type ModuleDeclaration =

--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -1,3 +1,5 @@
+import { BigIntLiteral } from "@babel/types";
+
 export interface Plugin {
   (module: Program): Program;
 }
@@ -889,30 +891,28 @@ export interface ClassPropertyBase extends Node, HasSpan, HasDecorator {
 
   is_static: boolean;
 
-  computed: boolean;
-
   accessibility?: Accessibility;
-
-  /// Typescript extension.
-  is_abstract: boolean;
 
   is_optional: boolean;
 
   readonly: boolean;
-
-  definite: boolean;
 }
 
 export interface ClassProperty extends ClassPropertyBase {
   type: "ClassProperty";
 
-  key: Expression;
+  key: PropertyName;
 }
 
 export interface PrivateProperty extends ClassPropertyBase {
   type: "PrivateProperty";
 
   key: PrivateName;
+
+  /// Typescript extension.
+  is_abstract: boolean;
+
+  definite: boolean;
 }
 
 export interface Param extends Node, HasSpan, HasDecorator {
@@ -1785,6 +1785,7 @@ export type PropertyName =
   | Identifier
   | StringLiteral
   | NumericLiteral
+  | BigIntLiteral
   | ComputedPropName;
 
 export interface ComputedPropName extends Node, HasSpan {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

remove `abstract` `declare` and `computed`

**BREAKING CHANGE:**
It will be a break change for rust users
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
