### PR TITLE
fix(es/parser): Fix parsing of `const` in ambient context

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -887,7 +887,17 @@ impl Config {
     ///
     /// - typescript: `tsx` will be modified if file extension is `ts`.
     pub fn adjust(&mut self, file: &Path) {
-        if let Some(Syntax::Typescript(TsConfig { tsx, .. })) = &mut self.jsc.syntax {
+        if let Some(Syntax::Typescript(TsConfig { tsx, dts, .. })) = &mut self.jsc.syntax {
+            let is_dts = file
+                .file_name()
+                .and_then(|f| f.to_str())
+                .map(|s| s.ends_with(".d.ts"))
+                .unwrap_or(false);
+
+            if is_dts {
+                *dts = true;
+            }
+
             let is_ts = file.extension().map(|v| v == "ts").unwrap_or(false);
             if is_ts {
                 *tsx = false;

--- a/crates/swc/tests/fixture/issue-3882/input/.swcrc
+++ b/crates/swc/tests/fixture/issue-3882/input/.swcrc
@@ -1,0 +1,21 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": false,
+            "decorators": true
+        },
+        "target": "es2022",
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        }
+    },
+    "module": {
+        "type": "es6",
+        "strict": false,
+        "strictMode": false
+    },
+    "minify": false
+}

--- a/crates/swc/tests/fixture/issue-3882/input/types.d.ts
+++ b/crates/swc/tests/fixture/issue-3882/input/types.d.ts
@@ -1,0 +1,7 @@
+// filename: types.d.ts
+export const aThing: IAnInterface[];
+
+export interface IAnInterface {
+    anAttribute: string;
+    anotherAttribute: boolean;
+}

--- a/crates/swc/tests/fixture/issue-3882/output/types.d.ts
+++ b/crates/swc/tests/fixture/issue-3882/output/types.d.ts
@@ -1,0 +1,1 @@
+export const aThing;

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     error::SyntaxError,
     lexer::Lexer,
     token::{Token, Word},
-    Context, EsVersion, Syntax,
+    Context, EsVersion, Syntax, TsConfig,
 };
 #[cfg(test)]
 extern crate test;
@@ -61,7 +61,17 @@ impl<'a, I: Input> Parser<Lexer<'a, I>> {
 }
 
 impl<I: Tokens> Parser<I> {
-    pub fn new_from(input: I) -> Self {
+    pub fn new_from(mut input: I) -> Self {
+        let in_declare = matches!(
+            input.syntax(),
+            Syntax::Typescript(TsConfig { dts: true, .. })
+        );
+        let ctx = Context {
+            in_declare,
+            ..input.ctx()
+        };
+        input.set_ctx(ctx);
+
         Parser {
             state: Default::default(),
             input: Buffer::new(input),

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -809,7 +809,8 @@ impl<'a, I: Tokens> Parser<I> {
                 // typescript allows `declare` vars not to have initializers.
                 if self.ctx().in_declare {
                     None
-                } else if kind == VarDeclKind::Const && self.ctx().strict {
+                } else if kind == VarDeclKind::Const && self.ctx().strict && !self.ctx().in_declare
+                {
                     self.emit_err(
                         span!(self, start),
                         SyntaxError::ConstDeclarationsRequireInitialization,


### PR DESCRIPTION
**Description:**



**Related issue (if exists):**

 - Closes #3882
