### PR TITLE
fix(trace): adjust tracing span level

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -48,7 +48,7 @@ pub struct JsCompiler {
 impl JsCompiler {
     #[napi(constructor)]
     #[allow(clippy::new_without_default)]
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "info", skip_all)]
     pub fn new() -> Self {
         Self {
             _compiler: COMPILER.clone(),

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -728,7 +728,7 @@ impl Compiler {
         }
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "info", skip_all)]
     pub fn read_config(&self, opts: &Options, name: &FileName) -> Result<Option<Config>, Error> {
         static CUR_DIR: Lazy<PathBuf> = Lazy::new(|| {
             if cfg!(target_arch = "wasm32") {
@@ -834,7 +834,7 @@ impl Compiler {
     /// This method handles merging of config.
     ///
     /// This method does **not** parse module.
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "info", skip_all)]
     pub fn parse_js_as_input<'a, P>(
         &'a self,
         fm: Lrc<SourceFile>,
@@ -890,7 +890,7 @@ impl Compiler {
         })
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "info", skip_all)]
     pub fn transform(
         &self,
         handler: &Handler,
@@ -918,7 +918,7 @@ impl Compiler {
     ///
     /// This means, you can use `noop_visit_type`, `noop_fold_type` and
     /// `noop_visit_mut_type` in your visitor to reduce the binary size.
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "info", skip_all)]
     pub fn process_js_with_custom_pass<P1, P2>(
         &self,
         fm: Arc<SourceFile>,
@@ -982,7 +982,7 @@ impl Compiler {
         .context("failed to process js file")
     }
 
-    #[tracing::instrument(level = "trace", skip(self, handler, opts))]
+    #[tracing::instrument(level = "info", skip(self, handler, opts))]
     pub fn process_js_file(
         &self,
         fm: Arc<SourceFile>,
@@ -992,7 +992,7 @@ impl Compiler {
         self.process_js_with_custom_pass(fm, None, handler, opts, |_| noop(), |_| noop())
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "info", skip_all)]
     pub fn minify(
         &self,
         fm: Arc<SourceFile>,
@@ -1117,7 +1117,7 @@ impl Compiler {
     /// You can use custom pass with this method.
     ///
     /// There exists a [PassBuilder] to help building custom passes.
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "info", skip_all)]
     pub fn process_js(
         &self,
         handler: &Handler,
@@ -1130,7 +1130,7 @@ impl Compiler {
         self.process_js_with_custom_pass(fm, Some(program), handler, opts, |_| noop(), |_| noop())
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "info", skip_all)]
     fn process_js_inner(
         &self,
         handler: &Handler,
@@ -1177,7 +1177,7 @@ impl Compiler {
     }
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn load_swcrc(path: &Path) -> Result<Rc, Error> {
     fn convert_json_err(e: serde_json::Error) -> Error {
         let line = e.line();

--- a/crates/swc/src/plugin.rs
+++ b/crates/swc/src/plugin.rs
@@ -68,7 +68,7 @@ struct RustPlugins {
 }
 
 impl RustPlugins {
-    #[tracing::instrument(level = "trace", skip_all, name = "apply_plugins")]
+    #[tracing::instrument(level = "info", skip_all, name = "apply_plugins")]
     #[cfg(feature = "plugin")]
     fn apply(&mut self, n: Program) -> Result<Program, anyhow::Error> {
         use std::{path::PathBuf, sync::Arc};
@@ -88,7 +88,7 @@ impl RustPlugins {
         if let Some(plugins) = &self.plugins {
             for p in plugins {
                 let span = tracing::span!(
-                    tracing::Level::TRACE,
+                    tracing::Level::INFO,
                     "serialize_context",
                     plugin_module = p.0.as_str()
                 );
@@ -114,7 +114,7 @@ impl RustPlugins {
                 drop(context_span_guard);
 
                 let span = tracing::span!(
-                    tracing::Level::TRACE,
+                    tracing::Level::INFO,
                     "execute_plugin_runner",
                     plugin_module = p.0.as_str()
                 );

--- a/crates/swc_cli/src/commands/compile.rs
+++ b/crates/swc_cli/src/commands/compile.rs
@@ -110,7 +110,7 @@ static DEFAULT_EXTENSIONS: &[&str] = &["js", "jsx", "es6", "es", "mjs", "ts", "t
 /// Infer list of files to be transformed from cli arguments.
 /// If given input is a directory, it'll traverse it and collect all supported
 /// files.
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn get_files_list(
     raw_files_input: &[PathBuf],
     extensions: &[String],
@@ -274,7 +274,7 @@ impl CompileOptions {
         }
 
         if let Some(stdin_input) = stdin_input {
-            let span = tracing::span!(tracing::Level::TRACE, "compile_stdin");
+            let span = tracing::span!(tracing::Level::INFO, "compile_stdin");
             let stdin_span_guard = span.enter();
             let comp = COMPILER.clone();
 
@@ -308,7 +308,7 @@ impl CompileOptions {
         }
 
         if !self.files.is_empty() {
-            let span = tracing::span!(tracing::Level::TRACE, "compile_files");
+            let span = tracing::span!(tracing::Level::INFO, "compile_files");
             let files_span_guard = span.enter();
             let included_extensions = if let Some(extensions) = &self.extensions {
                 extensions.clone()

--- a/crates/swc_ecma_transforms_compat/src/bugfixes/async_arrows_in_class.rs
+++ b/crates/swc_ecma_transforms_compat/src/bugfixes/async_arrows_in_class.rs
@@ -11,7 +11,7 @@ use crate::es2015::arrow;
 /// instance via `this` within those methods would also throw. This is fixed by
 /// converting arrow functions in class methods into equivalent function
 /// expressions. See https://bugs.webkit.org/show_bug.cgi?id=166879
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn async_arrows_in_class() -> impl Fold {
     AsyncArrowsInClass::default()
 }

--- a/crates/swc_ecma_transforms_compat/src/bugfixes/edge_default_param.rs
+++ b/crates/swc_ecma_transforms_compat/src/bugfixes/edge_default_param.rs
@@ -6,7 +6,7 @@ use swc_trace_macro::swc_trace;
 /// syntax. This fixes the only arguments-related bug in ES Modules-supporting
 /// browsers (Edge 16 & 17). Use this plugin instead of
 /// @babel/plugin-transform-parameters when targeting ES Modules.
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn edge_default_param() -> impl Fold + VisitMut {
     as_folder(EdgeDefaultParam::default())
 }

--- a/crates/swc_ecma_transforms_compat/src/bugfixes/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/bugfixes/mod.rs
@@ -12,7 +12,7 @@ mod edge_default_param;
 mod safari_id_destructuring_collision_in_function_expression;
 mod template_literal_caching;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn bugfixes() -> impl Fold {
     chain!(
         async_arrows_in_class(),

--- a/crates/swc_ecma_transforms_compat/src/bugfixes/safari_id_destructuring_collision_in_function_expression.rs
+++ b/crates/swc_ecma_transforms_compat/src/bugfixes/safari_id_destructuring_collision_in_function_expression.rs
@@ -8,7 +8,7 @@ use swc_ecma_transforms_base::hygiene::rename;
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 use swc_trace_macro::swc_trace;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn safari_id_destructuring_collision_in_function_expression() -> impl Fold + VisitMut {
     as_folder(SafariIdDestructuringCollisionInFunctionExpression::default())
 }

--- a/crates/swc_ecma_transforms_compat/src/bugfixes/template_literal_caching.rs
+++ b/crates/swc_ecma_transforms_compat/src/bugfixes/template_literal_caching.rs
@@ -19,7 +19,7 @@ use swc_trace_macro::swc_trace;
 //   Object``===Object``  // true, should be false.
 //
 // Benchmarks: https://jsperf.com/compiled-tagged-template-performance
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn template_literal_caching() -> impl Fold {
     TemplateLiteralCaching::default()
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/arrow.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/arrow.rs
@@ -57,7 +57,7 @@ use swc_trace_macro::swc_trace;
 /// };
 /// console.log(bob.printFriends());
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn arrow() -> impl Fold + VisitMut + InjectVars {
     as_folder(Arrow::default())
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoped_fn.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoped_fn.rs
@@ -4,7 +4,7 @@ use swc_ecma_utils::UsageFinder;
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 use swc_trace_macro::swc_trace;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn block_scoped_functions() -> impl Fold + VisitMut {
     as_folder(BlockScopedFns)
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping/mod.rs
@@ -33,7 +33,7 @@ mod vars;
 ///    });
 /// }
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn block_scoping() -> impl VisitMut + Fold {
     as_folder(chain!(
         self::vars::block_scoped_vars(),

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
@@ -27,7 +27,7 @@ use self::{
 mod constructor;
 mod prop_name;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn classes<C>(comments: Option<C>, config: Config) -> impl Fold + VisitMut
 where
     C: Comments,
@@ -1058,7 +1058,7 @@ where
     }
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn inject_class_call_check(c: &mut Vec<Stmt>, name: Ident) {
     let mut class_name_sym = name.clone();
     class_name_sym.span = DUMMY_SP;
@@ -1079,7 +1079,7 @@ fn inject_class_call_check(c: &mut Vec<Stmt>, name: Ident) {
 }
 
 /// Returns true if no `super` is used before `super()` call.
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn is_always_initialized(body: &[Stmt]) -> bool {
     struct SuperFinder {
         found: bool,

--- a/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
@@ -39,7 +39,7 @@ use swc_trace_macro::swc_trace;
 ///
 /// TODO(kdy1): cache reference like (_f = f, mutatorMap[_f].get = function(){})
 ///     instead of (mutatorMap[f].get = function(){}
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn computed_properties(c: Config) -> impl Fold {
     as_folder(ComputedProps {
         c,

--- a/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
@@ -36,7 +36,7 @@ use swc_trace_macro::swc_trace;
 ///     b = _arr2[1],
 ///     rest = _arr2.slice(2);
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn destructuring(c: Config) -> impl Fold + VisitMut {
     as_folder(Destructuring { c })
 }
@@ -1047,7 +1047,7 @@ fn make_ref_ident(c: Config, decls: &mut Vec<VarDeclarator>, init: Option<Box<Ex
     make_ref_ident_for_array(c, decls, init, None)
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn make_ref_ident_for_array(
     c: Config,
     decls: &mut Vec<VarDeclarator>,

--- a/crates/swc_ecma_transforms_compat/src/es2015/for_of.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/for_of.rs
@@ -46,7 +46,7 @@ use swc_trace_macro::swc_trace;
 ///   }
 /// }
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn for_of(c: Config) -> impl Fold + VisitMut {
     as_folder(ForOf {
         c,
@@ -395,7 +395,7 @@ impl ForOf {
 ///     }
 ///   }
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn make_finally_block(
     iterator_return: Box<Expr>,
     normal_completion_ident: &Ident,

--- a/crates/swc_ecma_transforms_compat/src/es2015/function_name.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/function_name.rs
@@ -23,7 +23,7 @@ use swc_trace_macro::swc_trace;
 /// }
 /// var Foo = (class Foo {});
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn function_name() -> impl 'static + Copy + Fold + VisitMut {
     as_folder(FnName)
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/instanceof.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/instanceof.rs
@@ -31,7 +31,7 @@ use swc_trace_macro::swc_trace;
 ///
 /// _instanceof(foo, Bar);
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn instance_of() -> impl Fold + VisitMut {
     as_folder(InstanceOf)
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/mod.rs
@@ -32,7 +32,7 @@ mod sticky_regex;
 pub mod template_literal;
 mod typeof_symbol;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn exprs() -> impl Fold {
     chain!(
         arrow(),
@@ -44,7 +44,7 @@ fn exprs() -> impl Fold {
 }
 
 /// Compiles es2015 to es5.
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn es2015<C>(global_mark: Mark, comments: Option<C>, c: Config) -> impl Fold
 where
     C: Comments,

--- a/crates/swc_ecma_transforms_compat/src/es2015/new_target.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/new_target.rs
@@ -9,7 +9,7 @@ use swc_ecma_visit::{
 };
 use swc_trace_macro::swc_trace;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn new_target() -> impl Fold + VisitMut + CompilerPass {
     as_folder(NewTarget::default())
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/object_super.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/object_super.rs
@@ -13,7 +13,7 @@ struct ObjectSuper {
     extra_vars: Vec<Ident>,
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn object_super() -> impl Fold + VisitMut {
     as_folder(ObjectSuper {
         extra_vars: Vec::new(),

--- a/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/parameters.rs
@@ -15,7 +15,7 @@ use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWit
 use swc_trace_macro::swc_trace;
 use tracing::trace;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn parameters(c: Config) -> impl 'static + Fold {
     as_folder(Params {
         c,

--- a/crates/swc_ecma_transforms_compat/src/es2015/regenerator/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/regenerator/mod.rs
@@ -27,7 +27,7 @@ pub struct Config {
     pub import_path: Option<JsWord>,
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn regenerator(config: Config, top_level_mark: Mark) -> impl Fold + VisitMut {
     as_folder(Regenerator {
         config,

--- a/crates/swc_ecma_transforms_compat/src/es2015/shorthand_property.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/shorthand_property.rs
@@ -40,7 +40,7 @@ use swc_trace_macro::swc_trace;
 ///   }
 /// };
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn shorthand() -> impl 'static + Fold + VisitMut {
     as_folder(Shorthand)
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/spread.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/spread.rs
@@ -393,7 +393,7 @@ impl Spread {
     }
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn expand_literal_args(
     args: impl ExactSizeIterator + Iterator<Item = Option<ExprOrSpread>>,
 ) -> Vec<Option<ExprOrSpread>> {

--- a/crates/swc_ecma_transforms_compat/src/es2015/sticky_regex.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/sticky_regex.rs
@@ -21,7 +21,7 @@ use swc_trace_macro::swc_trace;
 /// ```js
 /// new RegExp("o+", "y")
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn sticky_regex() -> impl 'static + Fold + VisitMut {
     as_folder(StickyRegex)
 }

--- a/crates/swc_ecma_transforms_compat/src/es2015/template_literal.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/template_literal.rs
@@ -12,7 +12,7 @@ use swc_ecma_utils::{
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 use swc_trace_macro::swc_trace;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn template_literal(c: Config) -> impl Fold + VisitMut {
     as_folder(TemplateLiteral {
         c,

--- a/crates/swc_ecma_transforms_compat/src/es2015/typeof_symbol.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/typeof_symbol.rs
@@ -7,7 +7,7 @@ use swc_ecma_utils::{quote_str, ExprFactory};
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 use swc_trace_macro::swc_trace;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn typeof_symbol() -> impl VisitMut + Fold {
     as_folder(TypeOfSymbol)
 }
@@ -144,7 +144,7 @@ impl VisitMut for TypeOfSymbol {
     }
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn is_non_symbol_literal(e: &Expr) -> bool {
     matches!(
         *e,

--- a/crates/swc_ecma_transforms_compat/src/es2016/exponentation.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2016/exponentation.rs
@@ -25,7 +25,7 @@ use swc_trace_macro::swc_trace;
 ///
 /// x = Math.pow(x, 3);
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn exponentation() -> impl Fold + VisitMut {
     as_folder(Exponentation::default())
 }
@@ -128,7 +128,7 @@ impl VisitMut for Exponentation {
     }
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn mk_call(span: Span, left: Box<Expr>, right: Box<Expr>) -> Expr {
     // Math.pow()
     Expr::Call(CallExpr {

--- a/crates/swc_ecma_transforms_compat/src/es2016/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2016/mod.rs
@@ -4,7 +4,7 @@ pub use self::exponentation::exponentation;
 
 mod exponentation;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn es2016() -> impl Fold {
     exponentation()
 }

--- a/crates/swc_ecma_transforms_compat/src/es2017/async_to_generator.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2017/async_to_generator.rs
@@ -35,7 +35,7 @@ use swc_trace_macro::swc_trace;
 ///   yield bar();
 /// });
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn async_to_generator(c: Config) -> impl Fold + VisitMut {
     as_folder(AsyncToGenerator { c })
 }
@@ -350,7 +350,7 @@ impl Actual {
 /// Creates
 ///
 /// `_asyncToGenerator(function*() {})` from `async function() {}`;
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn make_fn_ref(mut expr: FnExpr) -> Expr {
     expr.function.body.visit_mut_with(&mut AsyncFnBodyHandler {
         is_async_generator: expr.function.is_generator,
@@ -468,7 +468,7 @@ impl Check for ShouldWork {
     }
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
     let s = match stmt {
         Stmt::ForOf(

--- a/crates/swc_ecma_transforms_compat/src/es2017/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2017/mod.rs
@@ -5,7 +5,7 @@ pub use self::async_to_generator::async_to_generator;
 
 pub mod async_to_generator;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn es2017(c: Config) -> impl Fold {
     async_to_generator(c.async_to_generator)
 }

--- a/crates/swc_ecma_transforms_compat/src/es2018/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2018/mod.rs
@@ -5,7 +5,7 @@ pub use self::object_rest_spread::object_rest_spread;
 
 pub mod object_rest_spread;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn es2018(c: Config) -> impl Fold {
     object_rest_spread(c.object_rest_spread)
 }

--- a/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
@@ -21,7 +21,7 @@ use swc_trace_macro::swc_trace;
 // `ignoreFunctionLength` and `pureGetters` on
 
 /// `@babel/plugin-proposal-object-rest-spread`
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn object_rest_spread(c: Config) -> impl Fold + VisitMut {
     chain!(
         as_folder(ObjectRest {
@@ -910,7 +910,7 @@ impl ObjectRest {
     }
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn object_without_properties(
     obj: Box<Expr>,
     excluded_props: Vec<Option<ExprOrSpread>>,
@@ -987,7 +987,7 @@ fn object_without_properties(
     })
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn excluded_props(props: &[ObjectPatProp]) -> Vec<Option<ExprOrSpread>> {
     props
         .iter()

--- a/crates/swc_ecma_transforms_compat/src/es2019/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2019/mod.rs
@@ -4,7 +4,7 @@ pub use self::optional_catch_binding::optional_catch_binding;
 
 mod optional_catch_binding;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn es2019() -> impl Fold {
     optional_catch_binding()
 }

--- a/crates/swc_ecma_transforms_compat/src/es2019/optional_catch_binding.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2019/optional_catch_binding.rs
@@ -5,7 +5,7 @@ use swc_trace_macro::swc_trace;
 
 struct OptionalCatchBinding;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn optional_catch_binding() -> impl Fold + VisitMut {
     as_folder(OptionalCatchBinding)
 }

--- a/crates/swc_ecma_transforms_compat/src/es2020/export_namespace_from.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2020/export_namespace_from.rs
@@ -4,7 +4,7 @@ use swc_ecma_utils::{IdentExt, IsDirective};
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut};
 use swc_trace_macro::swc_trace;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn export_namespace_from() -> impl Fold + VisitMut {
     as_folder(ExportNamespaceFrom)
 }

--- a/crates/swc_ecma_transforms_compat/src/es2020/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2020/mod.rs
@@ -11,7 +11,7 @@ mod export_namespace_from;
 pub mod nullish_coalescing;
 pub mod opt_chaining;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn es2020(config: Config) -> impl Fold {
     chain!(
         nullish_coalescing(config.nullish_coalescing),

--- a/crates/swc_ecma_transforms_compat/src/es2020/nullish_coalescing/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2020/nullish_coalescing/mod.rs
@@ -10,7 +10,7 @@ use swc_trace_macro::swc_trace;
 #[cfg(test)]
 mod tests;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn nullish_coalescing(c: Config) -> impl Fold + VisitMut + 'static {
     as_folder(NullishCoalescing {
         c,
@@ -193,7 +193,7 @@ impl VisitMut for NullishCoalescing {
     }
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn make_cond(c: Config, span: Span, alias: &Ident, var_expr: Expr, init: Box<Expr>) -> Expr {
     Expr::Cond(if c.no_document_all {
         CondExpr {

--- a/crates/swc_ecma_transforms_compat/src/es2020/opt_chaining.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2020/opt_chaining.rs
@@ -15,7 +15,7 @@ use swc_ecma_visit::{
 };
 use swc_trace_macro::swc_trace;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn optional_chaining(c: Config) -> impl Fold + VisitMut {
     as_folder(OptChaining {
         c,
@@ -611,7 +611,7 @@ impl Check for ShouldWork {
 }
 
 // TODO: skip transparent wrapper
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn is_simple_expr(expr: &Expr) -> bool {
     match expr {
         Expr::Ident(_) => true,

--- a/crates/swc_ecma_transforms_compat/src/es2021/logical_assignments.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2021/logical_assignments.rs
@@ -6,7 +6,7 @@ use swc_ecma_utils::{alias_ident_for, prepend};
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 use swc_trace_macro::swc_trace;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn logical_assignments() -> impl Fold + VisitMut {
     as_folder(Operators::default())
 }

--- a/crates/swc_ecma_transforms_compat/src/es2021/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2021/mod.rs
@@ -4,7 +4,7 @@ pub use self::logical_assignments::logical_assignments;
 
 mod logical_assignments;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn es2021() -> impl Fold + VisitMut {
     logical_assignments()
 }

--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
@@ -46,6 +46,8 @@ mod used_name;
 /// We use custom helper to handle export default class
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn class_properties<C: Comments>(cm: Option<C>, config: Config) -> impl Fold + VisitMut {
+#[tracing::instrument(level = "info", skip_all)]
+pub fn class_properties(config: Config) -> impl Fold + VisitMut {
     as_folder(ClassProperties {
         c: config,
         cm,

--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
@@ -44,10 +44,8 @@ mod used_name;
 /// # Impl note
 ///
 /// We use custom helper to handle export default class
-#[tracing::instrument(level = "trace", skip_all)]
-pub fn class_properties<C: Comments>(cm: Option<C>, config: Config) -> impl Fold + VisitMut {
 #[tracing::instrument(level = "info", skip_all)]
-pub fn class_properties(config: Config) -> impl Fold + VisitMut {
+pub fn class_properties<C: Comments>(cm: Option<C>, config: Config) -> impl Fold + VisitMut {
     as_folder(ClassProperties {
         c: config,
         cm,

--- a/crates/swc_ecma_transforms_compat/src/es2022/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/mod.rs
@@ -12,6 +12,8 @@ pub mod static_blocks;
 
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn es2022<C: Comments>(cm: Option<C>, config: Config) -> impl Fold {
+#[tracing::instrument(level = "info", skip_all)]
+pub fn es2022(config: Config) -> impl Fold {
     chain!(
         static_blocks(),
         class_properties(cm, config.class_properties),

--- a/crates/swc_ecma_transforms_compat/src/es2022/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/mod.rs
@@ -10,10 +10,8 @@ pub mod class_properties;
 pub mod private_in_object;
 pub mod static_blocks;
 
-#[tracing::instrument(level = "trace", skip_all)]
-pub fn es2022<C: Comments>(cm: Option<C>, config: Config) -> impl Fold {
 #[tracing::instrument(level = "info", skip_all)]
-pub fn es2022(config: Config) -> impl Fold {
+pub fn es2022<C: Comments>(cm: Option<C>, config: Config) -> impl Fold {
     chain!(
         static_blocks(),
         class_properties(cm, config.class_properties),

--- a/crates/swc_ecma_transforms_compat/src/es2022/static_blocks.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/static_blocks.rs
@@ -7,7 +7,7 @@ use swc_trace_macro::swc_trace;
 
 struct ClassStaticBlock;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn static_blocks() -> impl Fold + VisitMut {
     as_folder(ClassStaticBlock)
 }

--- a/crates/swc_ecma_transforms_compat/src/es3/member_expr_lits.rs
+++ b/crates/swc_ecma_transforms_compat/src/es3/member_expr_lits.rs
@@ -20,7 +20,7 @@ use swc_trace_macro::swc_trace;
 /// obj["const"] = "isKeyword";
 /// obj["var"] = "isKeyword";
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn member_expression_literals() -> impl Fold {
     MemberExprLit
 }

--- a/crates/swc_ecma_transforms_compat/src/es3/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es3/mod.rs
@@ -11,7 +11,7 @@ mod prop_lits;
 mod reserved_word;
 
 /// Make output es3-compatible.
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn es3(preserve_import: bool) -> impl Fold {
     chain!(
         property_literals(),

--- a/crates/swc_ecma_transforms_compat/src/es3/prop_lits.rs
+++ b/crates/swc_ecma_transforms_compat/src/es3/prop_lits.rs
@@ -30,7 +30,7 @@ use swc_trace_macro::swc_trace;
 ///   foo: 1
 /// };
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn property_literals() -> impl Fold {
     PropertyLiteral
 }

--- a/crates/swc_ecma_transforms_compat/src/es3/reserved_word.rs
+++ b/crates/swc_ecma_transforms_compat/src/es3/reserved_word.rs
@@ -19,7 +19,7 @@ use swc_trace_macro::swc_trace;
 /// var _abstract = 1;
 /// var x = _abstract + 1;
 /// ```
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn reserved_words(preserve_import: bool) -> impl Fold {
     ReservedWord { preserve_import }
 }

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -284,7 +284,7 @@ where
         #[cfg(all(debug_assertions, feature = "debug"))]
         let _tracing = {
             let visitor_name = std::any::type_name::<V>();
-            tracing::span!(tracing::Level::TRACE, "as_folder", visitor = visitor_name).entered()
+            tracing::span!(tracing::Level::INFO, "as_folder", visitor = visitor_name).entered()
         };
         n.visit_mut_with(&mut self.0);
         n

--- a/crates/swc_plugin_runner/src/cache.rs
+++ b/crates/swc_plugin_runner/src/cache.rs
@@ -48,7 +48,7 @@ pub struct PluginModuleCache {
     instantiation_lock: Mutex<()>,
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn create_filesystem_cache(filesystem_cache_root: &Option<String>) -> Option<FileSystemCache> {
     let mut root_path = if let Some(root) = filesystem_cache_root {
         Some(PathBuf::from(root))
@@ -106,7 +106,7 @@ impl PluginModuleCache {
     /// [This code](https://github.com/swc-project/swc/blob/fc4c6708f24cda39640fbbfe56123f2f6eeb2474/crates/swc/src/plugin.rs#L19-L44)
     /// includes previous incorrect attempt to workaround file read issues.
     /// In actual transform, `plugins` is also being called per each transform.
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "info", skip_all)]
     pub fn load_module(&self, binary_path: &Path) -> Result<Module, Error> {
         let binary_path = binary_path.to_path_buf();
         let mut inner_cache = self.inner.get().expect("Cache should be available").lock();
@@ -127,7 +127,7 @@ impl PluginModuleCache {
 
         let load_cold_wasm_bytes = || {
             let span = tracing::span!(
-                tracing::Level::TRACE,
+                tracing::Level::INFO,
                 "load_cold_wasm_bytes",
                 plugin_module = binary_path.to_str()
             );

--- a/crates/swc_plugin_runner/src/lib.rs
+++ b/crates/swc_plugin_runner/src/lib.rs
@@ -15,7 +15,7 @@ use wasmer_wasi::{is_wasi_module, WasiState};
 
 pub mod cache;
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn copy_bytes_into_host(memory: &Memory, bytes_ptr: i32, bytes_ptr_len: i32) -> Vec<u8> {
     let ptr: WasmPtr<u8, Array> = WasmPtr::new(bytes_ptr as _);
 
@@ -33,7 +33,7 @@ fn copy_bytes_into_host(memory: &Memory, bytes_ptr: i32, bytes_ptr_len: i32) -> 
 }
 
 /// Locate a view from given memory, write serialized bytes into.
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn write_into_memory_view<F>(
     memory: &Memory,
     serialized_bytes: &Serialized,
@@ -203,7 +203,7 @@ struct HostEnvironment {
     transform_result: Arc<Mutex<Vec<u8>>>,
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "info", skip_all)]
 fn load_plugin(
     plugin_path: &Path,
     cache: &Lazy<PluginModuleCache>,
@@ -356,7 +356,7 @@ struct PluginTransformTracker {
 }
 
 impl PluginTransformTracker {
-    #[tracing::instrument(level = "trace", skip(cache))]
+    #[tracing::instrument(level = "info", skip(cache))]
     fn new(path: &Path, cache: &Lazy<PluginModuleCache>) -> Result<PluginTransformTracker, Error> {
         let (instance, transform_result) = load_plugin(path, cache)?;
 
@@ -424,7 +424,7 @@ impl PluginTransformTracker {
         }
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "info", skip_all)]
     fn transform(
         &mut self,
         program: &Serialized,

--- a/crates/swc_trace_macro/src/lib.rs
+++ b/crates/swc_trace_macro/src/lib.rs
@@ -3,7 +3,7 @@ extern crate proc_macro;
 use quote::ToTokens;
 use syn::{parse_quote, AttrStyle, Attribute, ImplItem, ItemImpl};
 
-/// Utility proc macro to add `#[tracing::instrument(level = "trace",
+/// Utility proc macro to add `#[tracing::instrument(level = "info",
 /// skip_all)]` to all methods in an impl block.
 ///
 /// This attribute macro is typically applied on an `VisitMut` impl block.
@@ -19,13 +19,13 @@ pub fn swc_trace(
     item.items.iter_mut().for_each(|item| {
         // We only handle methods
         if let ImplItem::Method(m) = item {
-            // #[tracing::instrument(level = "trace", skip_all)]
+            // #[tracing::instrument(level = "info", skip_all)]
             let attr = Attribute {
                 pound_token: Default::default(),
                 style: AttrStyle::Outer,
                 bracket_token: Default::default(),
                 path: parse_quote!(tracing::instrument),
-                tokens: parse_quote!((level = "trace", skip_all)),
+                tokens: parse_quote!((level = "info", skip_all)),
             };
             m.attrs.push(attr);
         }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

- closes https://github.com/swc-project/swc/issues/3863.

I tried various approach to preserve compile time trace level but only enable Level::TRACE for `span` only. However, it simply not seems possible. The reason I choose trace level at the moment is I was under assumption it's the only level tracing spans will try to use and would possible to enable it selectively. Both seems incorrect - first, trace level can be used for logging any span-less event, or other places. Secondly, as said above we can't opt in to enable span's trace level.

PR changes span's level into `info`. This is not a regression or defeating back: https://tracing.rs/tracing_attributes/attr.instrument.html# If we didn't choose level intentionally it would been `info` all the time and we won't hit this problem from beginning.

> instruments a function to create and enter a tracing [span](https://docs.rs/tracing/latest/tracing/span/index.html) every time the function is called.
> Unless overriden, a span with info level will be generated.

WIth this PR, only tracing `spans` will be recorded as info. Any other traces, logs, or events can use TRACE | DEBUG level and `@swc/core` release binary will not emit those at all.


**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
