### PR TITLE
chore(react): add example for transforms_react

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3394,6 +3394,7 @@ dependencies = [
  "serde",
  "sha-1",
  "string_enum",
+ "swc",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",

--- a/crates/swc_ecma_transforms_react/Cargo.toml
+++ b/crates/swc_ecma_transforms_react/Cargo.toml
@@ -35,3 +35,4 @@ swc_ecma_transforms_compat = {version = "0.78.0", path = "../swc_ecma_transforms
 swc_ecma_transforms_module = {version = "0.89.0", path = "../swc_ecma_transforms_module"}
 swc_ecma_transforms_testing = {version = "0.68.0", path = "../swc_ecma_transforms_testing"}
 testing = {version = "0.18.0", path = "../testing"}
+swc = {version = "0.145.1", path = "../swc"}

--- a/crates/swc_ecma_transforms_react/examples/app.jsx
+++ b/crates/swc_ecma_transforms_react/examples/app.jsx
@@ -1,0 +1,20 @@
+import React, {useState} from 'react';
+import ReactDOM from 'react-dom';
+
+const App = () => {
+  const [counter, setCounter] = useState(0);
+
+  return (
+    <div>
+      <h1>Counter App</h1>
+      <p>I'm at {counter}</p>
+      <div>
+        <button onClick={() => setCounter(counter => counter + 1)}>Increment</button>
+        <button onClick={() => setCounter(counter => counter - 1)}>Decrement</button>
+      </div>
+    </div>
+  )
+}
+
+ReactDOM.render(<App />, document.body.appendChild(document.createElement('div')));
+

--- a/crates/swc_ecma_transforms_react/examples/transform_react_app.rs
+++ b/crates/swc_ecma_transforms_react/examples/transform_react_app.rs
@@ -1,0 +1,84 @@
+//! Usage: cargo run --example transform_react_app
+//!
+//! This program will emit output to stdout.
+
+use std::{path::Path, sync::Arc};
+
+use swc::config::{IsModule, Options};
+use swc_common::{
+    comments::SingleThreadedComments,
+    errors::{ColorConfig, Handler},
+    Globals, Mark, SourceMap, GLOBALS,
+};
+use swc_ecma_ast::EsVersion;
+use swc_ecma_parser::{EsConfig, Syntax};
+use swc_ecma_transforms_react::{react, Options as ReactOptions};
+
+fn main() {
+    let cm = Arc::<SourceMap>::default();
+
+    let handler = Arc::new(Handler::with_tty_emitter(
+        ColorConfig::Auto,
+        true,
+        false,
+        Some(cm.clone()),
+    ));
+
+    let compiler = swc::Compiler::new(cm.clone());
+
+    let fm = cm
+        .load_file(Path::new(
+            "crates/swc_ecma_transforms_react/examples/app.jsx",
+        ))
+        .expect("Failed to load the js file");
+
+    let parse_result = compiler.parse_js(
+        fm,
+        &handler,
+        EsVersion::Es2015,
+        Syntax::Es(EsConfig {
+            jsx: true,
+            ..Default::default()
+        }),
+        IsModule::Bool(true),
+        None,
+    );
+
+    let parsed = parse_result.expect("Failed to parse the js module");
+
+    let comments = SingleThreadedComments::default();
+    let globals = Globals::default();
+
+    GLOBALS.set(&globals, || {
+        let top_level_mark = Mark::fresh(Mark::root());
+
+        // applies the react transformer
+        let program = compiler.transform(
+            &handler,
+            parsed,
+            false,
+            react(
+                cm.clone(),
+                Some(&comments),
+                ReactOptions {
+                    ..Default::default()
+                },
+                top_level_mark,
+            ),
+        );
+
+        // generates the final JS code
+        let output = compiler
+            .process_js(
+                &handler,
+                program,
+                &Options {
+                    is_module: IsModule::Bool(true),
+                    ..Default::default()
+                },
+            )
+            .expect("failed to process file");
+
+        print!("{}", output.code);
+    });
+}


### PR DESCRIPTION
**Description:**

Adds an example script to the `swc_ecma_transforms_react` that
demonstrates how to parse and transform a JavaScript file that uses React and JSX.

Also adds a test jsx file, and the `swc` package to the dev-dependency
list of `swc_ecma_transforms_react` as that's needed to run the example
script.

