### PR TITLE
feat(css/lints): Implement `property-no-vendor-prefix` rule

### DIFF
--- a/crates/swc_css_lints/src/config.rs
+++ b/crates/swc_css_lints/src/config.rs
@@ -7,6 +7,7 @@ use crate::rules::{
     color_hex_length::ColorHexLengthConfig,
     font_family_no_duplicate_names::FontFamilyNoDuplicateNamesConfig,
     no_invalid_position_at_import_rule::NoInvalidPositionAtImportRuleConfig,
+    property_no_vendor_prefix::PropertyNoVendorPrefixConfig,
     selector_max_class::SelectorMaxClassConfig,
     selector_max_combinators::SelectorMaxCombinatorsConfig, unit_no_unknown::UnitNoUnknownConfig,
 };
@@ -114,6 +115,9 @@ pub struct RulesConfig {
 
     #[serde(default, alias = "customPropertyNoMissingVarFunction")]
     pub custom_property_no_missing_var_function: RuleConfig<()>,
+
+    #[serde(default, alias = "propertyNoVendorPrefix")]
+    pub property_no_vendor_prefix: RuleConfig<PropertyNoVendorPrefixConfig>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/swc_css_lints/src/dataset.rs
+++ b/crates/swc_css_lints/src/dataset.rs
@@ -7,3 +7,12 @@ pub(crate) fn is_generic_font_keyword<S: AsRef<str>>(name: S) -> bool {
         || name.eq_ignore_ascii_case("monospace")
         || name.eq_ignore_ascii_case("system-ui")
 }
+
+/// This function doesn't convert case,
+/// so you may need to convert string to lowercase manually.
+pub(crate) fn strip_vendor_prefix(s: &str) -> Option<&str> {
+    s.strip_prefix("-webkit-")
+        .or_else(|| s.strip_prefix("-moz-"))
+        .or_else(|| s.strip_prefix("-ms-"))
+        .or_else(|| s.strip_prefix("-o-"))
+}

--- a/crates/swc_css_lints/src/rules/mod.rs
+++ b/crates/swc_css_lints/src/rules/mod.rs
@@ -28,6 +28,7 @@ pub mod font_family_no_duplicate_names;
 pub mod keyframe_declaration_no_important;
 pub mod no_empty_source;
 pub mod no_invalid_position_at_import_rule;
+pub mod property_no_vendor_prefix;
 pub mod selector_max_class;
 pub mod selector_max_combinators;
 pub mod unit_no_unknown;
@@ -60,6 +61,9 @@ pub fn get_rules(
         custom_property_no_missing_var_function(
             (&rules_config.custom_property_no_missing_var_function).into(),
         ),
+        property_no_vendor_prefix::property_no_vendor_prefix(
+            (&rules_config.property_no_vendor_prefix).into(),
+        )?,
     ];
 
     Ok(rules)

--- a/crates/swc_css_lints/src/rules/property_no_vendor_prefix.rs
+++ b/crates/swc_css_lints/src/rules/property_no_vendor_prefix.rs
@@ -1,0 +1,57 @@
+use serde::{Deserialize, Serialize};
+use swc_css_ast::*;
+use swc_css_visit::{Visit, VisitWith};
+
+use crate::{
+    dataset::strip_vendor_prefix,
+    error::ConfigError,
+    pattern::NamePattern,
+    rule::{visitor_rule, LintRule, LintRuleContext},
+};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PropertyNoVendorPrefixConfig {
+    ignore_properties: Option<Vec<String>>,
+}
+
+pub fn property_no_vendor_prefix(
+    ctx: LintRuleContext<PropertyNoVendorPrefixConfig>,
+) -> Result<Box<dyn LintRule>, ConfigError> {
+    let ignored = ctx
+        .config()
+        .ignore_properties
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .map(NamePattern::try_from)
+        .collect::<Result<_, _>>()?;
+    Ok(visitor_rule(
+        ctx.reaction(),
+        PropertyNoVendorPrefix { ctx, ignored },
+    ))
+}
+
+#[derive(Debug, Default)]
+struct PropertyNoVendorPrefix {
+    ctx: LintRuleContext<PropertyNoVendorPrefixConfig>,
+
+    ignored: Vec<NamePattern>,
+}
+
+impl Visit for PropertyNoVendorPrefix {
+    fn visit_declaration(&mut self, declaration: &Declaration) {
+        if let DeclarationName::Ident(Ident { value, .. }) = &declaration.name {
+            match strip_vendor_prefix(&value.to_lowercase()) {
+                Some(unprefix) if self.ignored.iter().all(|pat| !pat.is_match(unprefix)) => {
+                    self.ctx.report(
+                        &declaration.name,
+                        format!("Unexpected vendor-prefix '{}'.", value),
+                    );
+                }
+                _ => {}
+            }
+        }
+        declaration.visit_children_with(self);
+    }
+}

--- a/crates/swc_css_lints/tests/rules/fail/property-no-vendor-prefix/default/config.json
+++ b/crates/swc_css_lints/tests/rules/fail/property-no-vendor-prefix/default/config.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "property-no-vendor-prefix": ["error"]
+    }
+}

--- a/crates/swc_css_lints/tests/rules/fail/property-no-vendor-prefix/default/input.css
+++ b/crates/swc_css_lints/tests/rules/fail/property-no-vendor-prefix/default/input.css
@@ -1,0 +1,9 @@
+a { -webkit-transform: scale(1); }
+a { -wEbKiT-tRaNsFoRm: scale(1); }
+a { -WEBKIT-TRANSFORM: scale(1); }
+a { -webkit-transform: scale(1); transform: scale(1); }
+a { transform: scale(1); -webkit-transform: scale(1); }
+a { -moz-transition: all 3s; }
+a { -moz-columns: 2; }
+a { -o-columns: 2; }
+a { -ms-interpolation-mode: nearest-neighbor; }

--- a/crates/swc_css_lints/tests/rules/fail/property-no-vendor-prefix/default/output.stderr
+++ b/crates/swc_css_lints/tests/rules/fail/property-no-vendor-prefix/default/output.stderr
@@ -1,0 +1,54 @@
+error: Unexpected vendor-prefix '-webkit-transform'.
+ --> $DIR/tests/rules/fail/property-no-vendor-prefix/default/input.css:1:5
+  |
+1 | a { -webkit-transform: scale(1); }
+  |     ^^^^^^^^^^^^^^^^^
+
+error: Unexpected vendor-prefix '-wEbKiT-tRaNsFoRm'.
+ --> $DIR/tests/rules/fail/property-no-vendor-prefix/default/input.css:2:5
+  |
+2 | a { -wEbKiT-tRaNsFoRm: scale(1); }
+  |     ^^^^^^^^^^^^^^^^^
+
+error: Unexpected vendor-prefix '-WEBKIT-TRANSFORM'.
+ --> $DIR/tests/rules/fail/property-no-vendor-prefix/default/input.css:3:5
+  |
+3 | a { -WEBKIT-TRANSFORM: scale(1); }
+  |     ^^^^^^^^^^^^^^^^^
+
+error: Unexpected vendor-prefix '-webkit-transform'.
+ --> $DIR/tests/rules/fail/property-no-vendor-prefix/default/input.css:4:5
+  |
+4 | a { -webkit-transform: scale(1); transform: scale(1); }
+  |     ^^^^^^^^^^^^^^^^^
+
+error: Unexpected vendor-prefix '-webkit-transform'.
+ --> $DIR/tests/rules/fail/property-no-vendor-prefix/default/input.css:5:26
+  |
+5 | a { transform: scale(1); -webkit-transform: scale(1); }
+  |                          ^^^^^^^^^^^^^^^^^
+
+error: Unexpected vendor-prefix '-moz-transition'.
+ --> $DIR/tests/rules/fail/property-no-vendor-prefix/default/input.css:6:5
+  |
+6 | a { -moz-transition: all 3s; }
+  |     ^^^^^^^^^^^^^^^
+
+error: Unexpected vendor-prefix '-moz-columns'.
+ --> $DIR/tests/rules/fail/property-no-vendor-prefix/default/input.css:7:5
+  |
+7 | a { -moz-columns: 2; }
+  |     ^^^^^^^^^^^^
+
+error: Unexpected vendor-prefix '-o-columns'.
+ --> $DIR/tests/rules/fail/property-no-vendor-prefix/default/input.css:8:5
+  |
+8 | a { -o-columns: 2; }
+  |     ^^^^^^^^^^
+
+error: Unexpected vendor-prefix '-ms-interpolation-mode'.
+ --> $DIR/tests/rules/fail/property-no-vendor-prefix/default/input.css:9:5
+  |
+9 | a { -ms-interpolation-mode: nearest-neighbor; }
+  |     ^^^^^^^^^^^^^^^^^^^^^^
+

--- a/crates/swc_css_lints/tests/rules/fail/property-no-vendor-prefix/ignored/config.json
+++ b/crates/swc_css_lints/tests/rules/fail/property-no-vendor-prefix/ignored/config.json
@@ -1,0 +1,8 @@
+{
+    "rules": {
+        "property-no-vendor-prefix": [
+            "error",
+            { "ignoreProperties": ["transform", "columns", "/^animation-/"] }
+        ]
+    }
+}

--- a/crates/swc_css_lints/tests/rules/fail/property-no-vendor-prefix/ignored/input.css
+++ b/crates/swc_css_lints/tests/rules/fail/property-no-vendor-prefix/ignored/input.css
@@ -1,0 +1,3 @@
+a { -webkit-border-radius: 10px; }
+a { -moz-background-size: cover; }
+a { -WEBKIT-tranSFoRM: translateY(-50%); }

--- a/crates/swc_css_lints/tests/rules/fail/property-no-vendor-prefix/ignored/output.stderr
+++ b/crates/swc_css_lints/tests/rules/fail/property-no-vendor-prefix/ignored/output.stderr
@@ -1,0 +1,12 @@
+error: Unexpected vendor-prefix '-webkit-border-radius'.
+ --> $DIR/tests/rules/fail/property-no-vendor-prefix/ignored/input.css:1:5
+  |
+1 | a { -webkit-border-radius: 10px; }
+  |     ^^^^^^^^^^^^^^^^^^^^^
+
+error: Unexpected vendor-prefix '-moz-background-size'.
+ --> $DIR/tests/rules/fail/property-no-vendor-prefix/ignored/input.css:2:5
+  |
+2 | a { -moz-background-size: cover; }
+  |     ^^^^^^^^^^^^^^^^^^^^
+

--- a/crates/swc_css_lints/tests/rules/pass/property-no-vendor-prefix/default/config.json
+++ b/crates/swc_css_lints/tests/rules/pass/property-no-vendor-prefix/default/config.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "property-no-vendor-prefix": ["error"]
+    }
+}

--- a/crates/swc_css_lints/tests/rules/pass/property-no-vendor-prefix/default/input.css
+++ b/crates/swc_css_lints/tests/rules/pass/property-no-vendor-prefix/default/input.css
@@ -1,0 +1,4 @@
+:root { --foo-bar: 1px; }
+a { color: pink; --webkit-transform: 1px; }
+a { transform: scale(1); }
+a { box-sizing: border-box; }

--- a/crates/swc_css_lints/tests/rules/pass/property-no-vendor-prefix/ignored/config.json
+++ b/crates/swc_css_lints/tests/rules/pass/property-no-vendor-prefix/ignored/config.json
@@ -1,0 +1,8 @@
+{
+    "rules": {
+        "property-no-vendor-prefix": [
+            "error",
+            { "ignoreProperties": ["transform", "columns", "/^animation-/"] }
+        ]
+    }
+}

--- a/crates/swc_css_lints/tests/rules/pass/property-no-vendor-prefix/ignored/input.css
+++ b/crates/swc_css_lints/tests/rules/pass/property-no-vendor-prefix/ignored/input.css
@@ -1,0 +1,5 @@
+a { -webkit-transform: scale(1); }
+a { -moz-columns: 2; }
+a { -webkit-animation-delay: 0.5s; }
+a { -webkit-ANIMATION-DeLaY: 0.5s; }
+a { width: 320px; }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Implemented [`property-no-vendor-prefix`](https://stylelint.io/user-guide/rules/list/property-no-vendor-prefix) rule.

**BREAKING CHANGE:**

No.
