### PR TITLE
feat(es/parser): Relax MSRV requirement

### DIFF
--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -423,7 +423,7 @@ impl SyntaxError {
                 "Classes may not have a non-static field named 'constructor'".into()
             }
             SyntaxError::PrivateNameModifier(modifier) => {
-                format!("'{modifier}' modifier cannot be used with a private identifier").into()
+                format!("'{}' modifier cannot be used with a private identifier",modifier).into()
             }
 
             SyntaxError::ReadOnlyMethod => "A method cannot be readonly".into(),

--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -422,9 +422,11 @@ impl SyntaxError {
             SyntaxError::PropertyNamedConstructor => {
                 "Classes may not have a non-static field named 'constructor'".into()
             }
-            SyntaxError::PrivateNameModifier(modifier) => {
-                format!("'{}' modifier cannot be used with a private identifier",modifier).into()
-            }
+            SyntaxError::PrivateNameModifier(modifier) => format!(
+                "'{}' modifier cannot be used with a private identifier",
+                modifier
+            )
+            .into(),
 
             SyntaxError::ReadOnlyMethod => "A method cannot be readonly".into(),
             SyntaxError::TsBindingPatCannotBeOptional => "A binding pattern parameter cannot be \


### PR DESCRIPTION
**Description:**

Seems like latest rustc has some regression.
So I reverted rustc upgrade, but it requires some fix of SWC.



**Related issue (if exists):**

 - https://github.com/vercel/next.js/pull/35133

 - https://github.com/vercel/next.js/runs/5474698598?check_suite_focus=true