### PR TITLE
build(package): bump up tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3990,9 +3990,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -4003,9 +4003,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -39,7 +39,7 @@ swc_ecma_loader = {path = "../swc_ecma_loader"}
 swc_ecma_parser = {path = "../swc_ecma_parser"}
 swc_node_base = {path = "../swc_node_base"}
 swc_node_bundler = {path = "../swc_node_bundler"}
-tracing = { version = "0.1.31", features = ["release_max_level_info"] }
+tracing = { version = "0.1.32" , features = ["release_max_level_info"] }
 tracing-chrome = "0.4.0"
 tracing-futures = "0.2.5"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -74,7 +74,7 @@ swc_ecmascript = {version = "0.129.0", path = "../swc_ecmascript"}
 swc_node_comments = {version = "0.4.0", path = "../swc_node_comments"}
 swc_plugin_runner = {version = "0.40.0", path = "../swc_plugin_runner", optional = true}
 swc_visit = {version = "0.3.0", path = "../swc_visit"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dependencies.napi-derive]
 default-features = false

--- a/crates/swc_bundler/Cargo.toml
+++ b/crates/swc_bundler/Cargo.toml
@@ -52,7 +52,7 @@ swc_ecma_utils = {version = "0.71.0", path = "../swc_ecma_utils"}
 swc_ecma_visit = {version = "0.55.0", path = "../swc_ecma_visit"}
 swc_fast_graph = {version = "0.4.0", path = "../swc_fast_graph/"}
 swc_graph_analyzer = {version = "0.4.0", path = "../swc_graph_analyzer/"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dev-dependencies]
 hex = "0.4"

--- a/crates/swc_cli/Cargo.toml
+++ b/crates/swc_cli/Cargo.toml
@@ -27,7 +27,7 @@ swc_trace_macro = {version = "0.1.0", path = "../swc_trace_macro"}
 tracing-chrome = "0.4.0"
 tracing-futures = "0.2.5"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dependencies.path-absolutize]
 version = "3.0.11"

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -46,7 +46,7 @@ string_cache = "0.8.3"
 swc_eq_ignore_macros = {version = "0.1", path = "../swc_eq_ignore_macros"}
 swc_visit = {version = "0.3.0", path = "../swc_visit"}
 termcolor = {version = "1.0", optional = true}
-tracing = "0.1.31"
+tracing = "0.1.32"
 unicode-width = "0.1.4"
 url = "2.2.2"
 

--- a/crates/swc_ecma_codegen/Cargo.toml
+++ b/crates/swc_ecma_codegen/Cargo.toml
@@ -19,7 +19,7 @@ swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.17.3", path = "../swc_common"}
 swc_ecma_ast = {version = "0.69.0", path = "../swc_ecma_ast"}
 swc_ecma_codegen_macros = {version = "0.6.0", path = "../swc_ecma_codegen_macros"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dev-dependencies]
 swc_common = {version = "0.17.3", path = "../swc_common", features = ["sourcemap"]}

--- a/crates/swc_ecma_loader/Cargo.toml
+++ b/crates/swc_ecma_loader/Cargo.toml
@@ -33,7 +33,7 @@ serde = {version = "1", features = ["derive"]}
 serde_json = {version = "1.0.64", optional = true}
 swc_cached = {version = "0.1.0", optional = true, path = "../swc_cached"}
 swc_common = {version = "0.17.0", path = "../swc_common"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dev-dependencies]
 

--- a/crates/swc_ecma_minifier/Cargo.toml
+++ b/crates/swc_ecma_minifier/Cargo.toml
@@ -39,7 +39,7 @@ swc_ecma_transforms_base = {version = "0.66.0", path = "../swc_ecma_transforms_b
 swc_ecma_utils = {version = "0.71.0", path = "../swc_ecma_utils"}
 swc_ecma_visit = {version = "0.55.0", path = "../swc_ecma_visit"}
 swc_timer = {version = "0.4.0", path = "../swc_timer"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 unicode-id = "0.3.0"
 
 [dev-dependencies]

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -31,7 +31,7 @@ swc_atoms = {version = "0.2.3", path = "../swc_atoms"}
 swc_common = {version = "0.17.0", path = "../swc_common"}
 swc_ecma_ast = {version = "0.69.0", path = "../swc_ecma_ast"}
 swc_ecma_visit = {version = "0.55.0", path = "../swc_ecma_visit", optional = true}
-tracing = "0.1.31"
+tracing = "0.1.32"
 typed-arena = "2.0.1"
 unicode-id = "0.3"
 

--- a/crates/swc_ecma_transforms_base/Cargo.toml
+++ b/crates/swc_ecma_transforms_base/Cargo.toml
@@ -27,7 +27,7 @@ swc_ecma_ast = {version = "0.69.0", path = "../swc_ecma_ast"}
 swc_ecma_parser = {version = "0.92.0", path = "../swc_ecma_parser"}
 swc_ecma_utils = {version = "0.71.0", path = "../swc_ecma_utils"}
 swc_ecma_visit = {version = "0.55.0", path = "../swc_ecma_visit"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dev-dependencies]
 swc_ecma_codegen = {version = "0.94.0", path = "../swc_ecma_codegen"}

--- a/crates/swc_ecma_transforms_compat/Cargo.toml
+++ b/crates/swc_ecma_transforms_compat/Cargo.toml
@@ -35,7 +35,7 @@ swc_ecma_transforms_macros = {version = "0.3.0", path = "../swc_ecma_transforms_
 swc_ecma_utils = {version = "0.71.0", path = "../swc_ecma_utils"}
 swc_ecma_visit = {version = "0.55.0", path = "../swc_ecma_visit"}
 swc_trace_macro = {version = "0.1.0", path = "../swc_trace_macro"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dev-dependencies]
 serde_json = "1.0.66"

--- a/crates/swc_ecma_transforms_module/Cargo.toml
+++ b/crates/swc_ecma_transforms_module/Cargo.toml
@@ -25,7 +25,7 @@ swc_ecma_parser = {version = "0.92.0", path = "../swc_ecma_parser"}
 swc_ecma_transforms_base = {version = "0.66.0", path = "../swc_ecma_transforms_base"}
 swc_ecma_utils = {version = "0.71.0", path = "../swc_ecma_utils"}
 swc_ecma_visit = {version = "0.55.0", path = "../swc_ecma_visit"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dev-dependencies]
 swc_ecma_transforms_compat = {version = "0.78.0", path = "../swc_ecma_transforms_compat"}

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -33,7 +33,7 @@ swc_ecma_transforms_base = {version = "0.66.0", path = "../swc_ecma_transforms_b
 swc_ecma_transforms_macros = {version = "0.3.0", path = "../swc_ecma_transforms_macros"}
 swc_ecma_utils = {version = "0.71.0", path = "../swc_ecma_utils"}
 swc_ecma_visit = {version = "0.55.0", path = "../swc_ecma_visit"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dev-dependencies]
 swc_ecma_transforms_compat = {version = "0.78.0", path = "../swc_ecma_transforms_compat"}

--- a/crates/swc_ecma_utils/Cargo.toml
+++ b/crates/swc_ecma_utils/Cargo.toml
@@ -27,7 +27,7 @@ swc_atoms = {version = "0.2.0", path = "../swc_atoms"}
 swc_common = {version = "0.17.0", path = "../swc_common"}
 swc_ecma_ast = {version = "0.69.0", path = "../swc_ecma_ast"}
 swc_ecma_visit = {version = "0.55.0", path = "../swc_ecma_visit"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dev-dependencies]
 swc_ecma_parser = {version = "0.92.0", path = "../swc_ecma_parser"}

--- a/crates/swc_ecma_visit/Cargo.toml
+++ b/crates/swc_ecma_visit/Cargo.toml
@@ -17,4 +17,4 @@ swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_common = {version = "0.17.0", path = "../swc_common"}
 swc_ecma_ast = {version = "0.69.0", path = "../swc_ecma_ast"}
 swc_visit = {version = "0.3.0", path = "../swc_visit"}
-tracing = "0.1.31"
+tracing = "0.1.32"

--- a/crates/swc_graph_analyzer/Cargo.toml
+++ b/crates/swc_graph_analyzer/Cargo.toml
@@ -14,7 +14,7 @@ ahash = "0.7.6"
 auto_impl = "0.5.0"
 petgraph = "0.5.0"
 swc_fast_graph = {version = "0.4.0", path = "../swc_fast_graph/"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dev-dependencies]
 testing = {version = "0.18.0", path = "../testing"}

--- a/crates/swc_node_bundler/Cargo.toml
+++ b/crates/swc_node_bundler/Cargo.toml
@@ -36,7 +36,7 @@ swc_ecma_transforms = {path = "../swc_ecma_transforms"}
 swc_ecma_utils = {path = "../swc_ecma_utils"}
 swc_ecma_visit = {path = "../swc_ecma_visit"}
 swc_node_base = {path = "../swc_node_base"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dev-dependencies]
 pretty_assertions = "0.7.2"

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -16,7 +16,7 @@ serde = {version = "1.0.126", features = ["derive"]}
 serde_json = "1.0.64"
 swc_common = {version = "0.17.0", path = "../swc_common", features = ["plugin-rt", "concurrent"]}
 swc_ecma_ast = {version = "0.69.0", path = "../swc_ecma_ast", features = ["rkyv-impl"]}
-tracing = "0.1.31"
+tracing = "0.1.32"
 wasmer = "2.2.0"
 wasmer-cache = "2.2.0"
 wasmer-wasi = "2.2.0"

--- a/crates/swc_timer/Cargo.toml
+++ b/crates/swc_timer/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dev-dependencies]
 testing = {version = "0.18.0", path = "../testing"}

--- a/crates/swc_webpack_ast/Cargo.toml
+++ b/crates/swc_webpack_ast/Cargo.toml
@@ -24,7 +24,7 @@ swc_ecma_visit = {version = "0.55.0", path = "../swc_ecma_visit"}
 swc_estree_ast = {version = "0.7.0", path = "../swc_estree_ast"}
 swc_estree_compat = {version = "0.65.0", path = "../swc_estree_compat"}
 swc_timer = {version = "0.4.0", path = "../swc_timer"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 
 [dev-dependencies]
 swc_ecma_transforms_testing = {version = "0.68.0", path = "../swc_ecma_transforms_testing"}

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -17,5 +17,5 @@ regex = "1"
 serde_json = "1.0.71"
 swc_common = {version = "0.17.0", path = "../swc_common", features = ["tty-emitter"]}
 testing_macros = {version = "0.2.0", path = "../testing_macros"}
-tracing = "0.1.31"
+tracing = "0.1.32"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -28,5 +28,5 @@ swc = {path = "../swc"}
 swc_common = {path = "../swc_common"}
 swc_ecma_lints = {path = "../swc_ecma_lints", features = ["non_critical_lints"]}
 swc_ecmascript = {path = "../swc_ecmascript"}
-tracing = {version = "0.1.31", features = ["release_max_level_off"]}
+tracing = {version = "0.1.32", features = ["release_max_level_off"]}
 wasm-bindgen = {version = "0.2", features = ["serde-serialize"]}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

https://github.com/tokio-rs/tracing/blob/v0.1.x/tracing/CHANGELOG.md#0132-march-8th-2022

> Reduced Drop overhead for disabled spans ([#1974](https://github.com/tokio-rs/tracing/pull/1974))

Related with https://github.com/swc-project/swc/pull/3911, timely upstream update we can try bump & see if it makes diff for us.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
