### PR TITLE
fix(es): Don't create `.swc` if not required

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -449,7 +449,9 @@ impl Options {
         };
 
         #[cfg(feature = "plugin")]
-        swc_plugin_runner::cache::init_plugin_module_cache_once(&experimental.cache_root);
+        if experimental.plugins.is_some() {
+            swc_plugin_runner::cache::init_plugin_module_cache_once(&experimental.cache_root);
+        }
 
         let pass = chain!(
             lint_to_fold(swc_ecma_lints::rules::all(LintParams {


### PR DESCRIPTION
**Description:**


**BREAKING CHANGE:**


**Related issue (if exists):**
