### PR TITLE
fix(es/codegen): Fix sourcemap issue caused by reserved `BytePos` values

### DIFF
--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1131,6 +1131,11 @@ impl SourceMap {
 
         for (pos, lc) in mappings.iter() {
             let pos = *pos;
+
+            if pos.is_reserved_for_comments() {
+                continue;
+            }
+
             let lc = *lc;
 
             if pos == BytePos(u32::MAX) {

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -830,6 +830,13 @@ pub trait Pos {
 
 /// A byte offset. Keep this small (currently 32-bits), as AST contains
 /// a lot of them.
+///
+///
+/// # Reserved
+///
+///  - Values larger than 2^16 are reserved for the comments.
+///
+/// `u32::MAX` is special value used to generate source map entries.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -840,10 +847,10 @@ pub trait Pos {
 pub struct BytePos(#[cfg_attr(feature = "rkyv", omit_bounds)] pub u32);
 
 impl BytePos {
-    const RESERVED: Self = BytePos(DUMMY_RESERVE);
+    const MIN_RESERVED: Self = BytePos(DUMMY_RESERVE);
 
-    pub const fn is_reserved(self) -> bool {
-        self.0 >= Self::RESERVED.0
+    pub const fn is_reserved_for_comments(self) -> bool {
+        self.0 >= Self::MIN_RESERVED.0 && self.0 != u32::MAX
     }
 }
 

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -834,7 +834,7 @@ pub trait Pos {
 ///
 /// # Reserved
 ///
-///  - Values larger than 2^16 are reserved for the comments.
+///  - Values larger than `u32::MAX - 2^16` are reserved for the comments.
 ///
 /// `u32::MAX` is special value used to generate source map entries.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Serialize, Deserialize)]

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -839,6 +839,14 @@ pub trait Pos {
 )]
 pub struct BytePos(#[cfg_attr(feature = "rkyv", omit_bounds)] pub u32);
 
+impl BytePos {
+    const RESERVED: Self = BytePos(DUMMY_RESERVE);
+
+    pub const fn is_reserved(self) -> bool {
+        self.0 >= Self::RESERVED.0
+    }
+}
+
 /// A character offset. Because of multibyte utf8 characters, a byte offset
 /// is not equivalent to a character offset. The SourceMap will convert BytePos
 /// values to CharPos values as necessary.

--- a/crates/swc_ecma_codegen/src/text_writer/basic_impl.rs
+++ b/crates/swc_ecma_codegen/src/text_writer/basic_impl.rs
@@ -96,6 +96,10 @@ impl<'a, W: Write> JsWriter<'a, W> {
     }
 
     fn srcmap(&mut self, byte_pos: BytePos) {
+        if byte_pos.is_reserved_for_comments() {
+            return;
+        }
+
         if let Some(ref mut srcmap) = self.srcmap {
             srcmap.push((
                 byte_pos,


### PR DESCRIPTION
**Description:**


**Related issue (if exists):**
