### PR TITLE
fix(es/lints): Don't visit types while collecting `const`

### DIFF
--- a/crates/swc_css_codegen/tests/fixture.rs
+++ b/crates/swc_css_codegen/tests/fixture.rs
@@ -405,7 +405,7 @@ fn linefeed_lf(input: PathBuf) {
 
         let fm_output = cm.load_file(&output).unwrap();
 
-        assert_eq!(false, css_str.contains("\r\n"));
+        assert!(!css_str.contains("\r\n"));
 
         NormalizedOutput::from(css_str)
             .compare_to_file(output)
@@ -484,7 +484,7 @@ fn linefeed_crlf(input: PathBuf) {
 
         let fm_output = cm.load_file(&output).unwrap();
 
-        assert_eq!(true, css_str.contains("\r\n"));
+        assert!(css_str.contains("\r\n"));
 
         NormalizedOutput::from(css_str)
             .compare_to_file(output)

--- a/crates/swc_ecma_lints/src/rules/const_assign.rs
+++ b/crates/swc_ecma_lints/src/rules/const_assign.rs
@@ -92,6 +92,8 @@ struct Collector<'a> {
 }
 
 impl Visit for Collector<'_> {
+    noop_visit_type!();
+
     fn visit_assign_pat_prop(&mut self, p: &AssignPatProp) {
         p.visit_children_with(self);
 

--- a/crates/swc_ecma_lints/tests/pass/issue-3956/1/input.ts
+++ b/crates/swc_ecma_lints/tests/pass/issue-3956/1/input.ts
@@ -1,0 +1,8 @@
+function fn1({ x, y }: { x: string, y: string }): string {
+    return x + y
+}
+
+function fn2({ x, y }: { x: string, y: string }): string {
+    const fn3: ({ x, y }: { x: string, y: string }) => string = fn1
+    return fn3({ x, y })
+}


### PR DESCRIPTION
**Description:**


**Related issue (if exists):**


 - Closes #3956