### PR TITLE
build(cargo): setup plugin_runner features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,8 +887,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4328,6 +4330,7 @@ dependencies = [
  "wasmer-engine-universal",
  "wasmer-types",
  "wasmer-vm",
+ "wasmparser",
  "wat",
  "winapi",
 ]
@@ -4495,6 +4498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d9c4be9fba0cb769ae2466437d629427bb2494c9e134eacd15a6f8127a77dc2"
 dependencies = [
  "libc",
+ "slab",
  "thiserror",
  "tracing",
 ]

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -28,7 +28,7 @@ concurrent = [
 debug = ["swc_ecma_visit/debug"]
 node = ["napi", "napi-derive"]
 plugin = [
-  "swc_plugin_runner",
+  "swc_plugin_runner/default",
 ]
 
 [dependencies]
@@ -72,7 +72,7 @@ swc_ecma_utils = {version = "0.71.0", path = "../swc_ecma_utils"}
 swc_ecma_visit = {version = "0.55.0", path = "../swc_ecma_visit"}
 swc_ecmascript = {version = "0.131.0", path = "../swc_ecmascript"}
 swc_node_comments = {version = "0.4.0", path = "../swc_node_comments"}
-swc_plugin_runner = {version = "0.40.0", path = "../swc_plugin_runner", optional = true}
+swc_plugin_runner = {version = "0.40.0", path = "../swc_plugin_runner", default-features = false, optional = true}
 swc_visit = {version = "0.3.0", path = "../swc_visit"}
 tracing = "0.1.32"
 

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -30,6 +30,9 @@ node = ["napi", "napi-derive"]
 plugin = [
   "swc_plugin_runner/default",
 ]
+plugin_host_wasm_env = [
+  "swc_plugin_runner/wasm"
+]
 
 [dependencies]
 ahash = "0.7.4"

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -8,6 +8,13 @@ name = "swc_plugin_runner"
 repository = "https://github.com/swc-project/swc.git"
 version = "0.40.0"
 
+[features]
+# A feature set enables plugin runtime to work on the host binary does not have built in webassembly runtime.
+default = ["wasmer/sys-default", "wasmer-wasi/default", "wasmer-cache"]
+# A feature set enables plugin runtime to work on the host have own built in webassembly runtime.
+# This is for the @swc/wasm-* package primarily.
+wasm = ["wasmer/js-default", "wasmer-wasi/js-default"]
+
 [dependencies]
 anyhow = "1.0.42"
 once_cell = "1.10.0"
@@ -17,9 +24,9 @@ serde_json = "1.0.64"
 swc_common = {version = "0.17.0", path = "../swc_common", features = ["plugin-rt", "concurrent"]}
 swc_ecma_ast = {version = "0.69.0", path = "../swc_ecma_ast", features = ["rkyv-impl"]}
 tracing = "0.1.32"
-wasmer = "2.2.0"
-wasmer-cache = "2.2.0"
-wasmer-wasi = "2.2.0"
+wasmer = {version = "2.2.0", default-features = false, optional = true}
+wasmer-cache = {version = "2.2.0", optional = true }
+wasmer-wasi = {version = "2.2.0", default-features = false, optional = true}
 
 [dev-dependencies]
 swc_atoms = {version = "0.2.7", path = '../swc_atoms'}
@@ -28,4 +35,3 @@ swc_ecma_parser = {version = "0.92.0", path = "../swc_ecma_parser"}
 swc_ecma_visit = {version = "0.55.0", path = "../swc_ecma_visit"}
 testing = {version = "0.18.0", path = "../testing"}
 
-[features]

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -12,7 +12,7 @@ version = "1.2.153"
 crate-type = ["cdylib"]
 
 [features]
-default = ["swc_v1"]
+default = ["swc_v1", "swc/plugin_host_wasm_env"]
 swc_v1 = []
 swc_v2 = []
 
@@ -24,7 +24,7 @@ parking_lot_core = "0.9.1"
 path-clean = "0.1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
-swc = {path = "../swc"}
+swc = {path = "../swc", default-features = false, optional = true}
 swc_common = {path = "../swc_common"}
 swc_ecma_lints = {path = "../swc_ecma_lints", features = ["non_critical_lints"]}
 swc_ecmascript = {path = "../swc_ecmascript"}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

**This doesn't work currently**, opening up PR early to discuss & resolve build failures, or determine if we need some other way to workaround this instead of relying on cargo's workspace feature selection.


Basic structures of feature selection we'd like to have is

```
node
├─ swc/plugin
│  ├─ swc_plugin_runner/default
│  │  ├─ wasmer/sys

swc_cli
├─ swc/plugin
│  ├─ swc_plugin_runner/default
│  │  ├─ wasmer/sys

wasm
├─ swc/plugin_host_wasm_env
│  ├─ swc_plugin_runner/wasm
│  │  ├─ wasmer/js
```

Native entrypoint (swc_cli, node) wants to pick up wasmer/sys, and wasm target wants to pick up wasmer/js instead. However this looks like hitting https://github.com/rust-lang/cargo/issues/4463 and cargo attempts to unify all of the features at once for wasmer.

**Related issue (if exists):**

https://github.com/swc-project/swc/issues/3934