### PR TITLE
build(cargo): skip unnecessary package for the benchmark

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -58,7 +58,7 @@ jobs:
           override: true
 
       - name: Run benchmark
-        run: cargo bench --all --exclude swc_plugin | tee output.txt
+        run: cargo bench --workspace --exclude swc_plugin --exclude wasm --exclude swc_cli --exclude node | tee output.txt
 
       - name: Download previous benchmark results
         run: mkdir raw-data && curl -o raw-data/benchmark-data.json https://raw.githubusercontent.com/swc-project/raw-data/gh-pages/benchmark-data.json

--- a/crates/swc/benches/typescript.rs
+++ b/crates/swc/benches/typescript.rs
@@ -59,59 +59,64 @@ fn as_es(c: &swc::Compiler) -> Program {
 #[bench]
 fn base_tr_fixer(b: &mut Bencher) {
     let c = mk();
-    let module = as_es(&c);
+    c.run(|| {
+        let module = as_es(&c);
 
-    b.iter(|| {
-        let handler = Handler::with_emitter_writer(Box::new(stderr()), Some(c.cm.clone()));
-
-        black_box(c.run_transform(&handler, true, || {
-            module.clone().fold_with(&mut fixer(Some(c.comments())))
-        }))
+        b.iter(|| {
+            let handler = Handler::with_emitter_writer(Box::new(stderr()), Some(c.cm.clone()));
+            black_box(c.run_transform(&handler, true, || {
+                module.clone().fold_with(&mut fixer(Some(c.comments())))
+            }))
+        });
     });
 }
 
 #[bench]
 fn base_tr_resolver_and_hygiene(b: &mut Bencher) {
     let c = mk();
-    let module = as_es(&c);
+    c.run(|| {
+        let module = as_es(&c);
 
-    b.iter(|| {
-        let handler = Handler::with_emitter_writer(Box::new(stderr()), Some(c.cm.clone()));
-
-        black_box(c.run_transform(&handler, true, || {
-            module
-                .clone()
-                .fold_with(&mut resolver())
-                .fold_with(&mut hygiene())
-        }))
-    });
+        b.iter(|| {
+            let handler = Handler::with_emitter_writer(Box::new(stderr()), Some(c.cm.clone()));
+            black_box(c.run_transform(&handler, true, || {
+                module
+                    .clone()
+                    .fold_with(&mut resolver())
+                    .fold_with(&mut hygiene())
+            }))
+        });
+    })
 }
 
 /// This benchmark exists to know exact execution time of each pass.
 
 fn bench_codegen(b: &mut Bencher, _target: EsVersion) {
     let c = mk();
-    let module = as_es(&c);
 
-    //TODO: Use target
+    c.run(|| {
+        let module = as_es(&c);
 
-    b.iter(|| {
-        black_box(
-            c.print(
-                &module,
-                None,
-                None,
-                false,
-                EsVersion::Es2020,
-                SourceMapsConfig::Bool(false),
-                &Default::default(),
-                None,
-                false,
-                None,
-            )
-            .unwrap(),
-        );
-    })
+        //TODO: Use target
+
+        b.iter(|| {
+            black_box(
+                c.print(
+                    &module,
+                    None,
+                    None,
+                    false,
+                    EsVersion::Es2020,
+                    SourceMapsConfig::Bool(false),
+                    &Default::default(),
+                    None,
+                    false,
+                    None,
+                )
+                .unwrap(),
+            );
+        })
+    });
 }
 
 macro_rules! codegen {

--- a/crates/swc_webpack_ast/benches/webpack_ast.rs
+++ b/crates/swc_webpack_ast/benches/webpack_ast.rs
@@ -15,6 +15,14 @@ extern crate test;
 fn total(b: &mut Bencher) {
     let input = Path::new("tests/fixture/real/input.js");
 
+    if !input.exists() {
+        println!(
+            "Skipping webpack_ast benchmark due to missing input fixture at {}",
+            input.display()
+        );
+        return;
+    }
+
     b.iter(|| {
         testing::run_test(false, |cm, handler| {
             let fm = cm.load_file(input).unwrap();


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

There are few packages we don't need to build run benchmark, updated gh workflow to skip it.

Also, not sure if this is intended or not - but there are failing benchmark cases with `--all`. PR attempts to fix it to run the benchmark properly.

