### PR TITLE
perf(es/minifier): Use fxhash for integers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3283,6 +3283,7 @@ dependencies = [
  "rayon",
  "regex",
  "retain_mut",
+ "rustc-hash",
  "serde",
  "serde_json",
  "swc_atoms",

--- a/crates/swc_ecma_minifier/Cargo.toml
+++ b/crates/swc_ecma_minifier/Cargo.toml
@@ -26,6 +26,7 @@ pretty_assertions = {version = "1.1", optional = true}
 rayon = "1.5.1"
 regex = "1.5.3"
 retain_mut = "0.1.2"
+rustc-hash = "1.1.0"
 serde = {version = "1.0.118", features = ["derive"]}
 serde_json = "1.0.61"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
@@ -1,5 +1,6 @@
+use rustc_hash::FxHashSet;
 use swc_atoms::JsWord;
-use swc_common::collections::{AHashMap, AHashSet};
+use swc_common::collections::AHashMap;
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ident::IdentLike, Id};
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
@@ -21,7 +22,7 @@ impl Analyzer {
     pub(super) fn into_rename_map(
         mut self,
         freq: &CharFreqInfo,
-        preserved: &AHashSet<Id>,
+        preserved: &FxHashSet<Id>,
     ) -> AHashMap<Id, JsWord> {
         let mut map = RenameMap::default();
 

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
@@ -14,15 +14,6 @@ pub(crate) struct Scope {
 
 #[derive(Debug, Default)]
 pub struct ScopeData {
-    // decls: AHashSet<Id>,
-
-    // /// Usages in current scope.
-    // usages: AHashSet<Id>,
-    all: AHashSet<Id>,
-    /// Usages in current scope.
-    usages: AHashSet<Id>,
-    // /// Usages in current scope.
-    // usages: AHashSet<Id>,
     all: FxHashSet<Id>,
 
     queue: Vec<(Id, u32)>,

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
@@ -1,5 +1,6 @@
+use rustc_hash::FxHashSet;
 use swc_atoms::{js_word, JsWord};
-use swc_common::{collections::AHashSet, util::take::Take};
+use swc_common::util::take::Take;
 use swc_ecma_utils::Id;
 
 use crate::pass::{compute_char_freq::CharFreqInfo, mangle_names::rename_map::RenameMap};
@@ -18,6 +19,11 @@ pub struct ScopeData {
     // /// Usages in current scope.
     // usages: AHashSet<Id>,
     all: AHashSet<Id>,
+    /// Usages in current scope.
+    usages: AHashSet<Id>,
+    // /// Usages in current scope.
+    // usages: AHashSet<Id>,
+    all: FxHashSet<Id>,
 
     queue: Vec<(Id, u32)>,
 }
@@ -56,8 +62,8 @@ impl Scope {
         &mut self,
         f: &CharFreqInfo,
         to: &mut RenameMap,
-        preserved: &AHashSet<Id>,
-        preserved_symbols: &AHashSet<JsWord>,
+        preserved: &FxHashSet<Id>,
+        preserved_symbols: &FxHashSet<JsWord>,
     ) {
         let mut n = 0;
         let mut queue = self.data.queue.take();

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
@@ -1,11 +1,11 @@
-use swc_common::collections::AHashSet;
+use rustc_hash::FxHashSet;
 use swc_ecma_ast::*;
 use swc_ecma_utils::{find_ids, ident::IdentLike, Id};
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 use crate::option::MangleOptions;
 
-pub(super) fn idents_to_preserve<N>(options: MangleOptions, n: &N) -> AHashSet<Id>
+pub(super) fn idents_to_preserve<N>(options: MangleOptions, n: &N) -> FxHashSet<Id>
 where
     N: VisitWith<Preserver>,
 {
@@ -20,7 +20,7 @@ where
 }
 pub(super) struct Preserver {
     options: MangleOptions,
-    preserved: AHashSet<Id>,
+    preserved: FxHashSet<Id>,
     should_preserve: bool,
     in_top_level: bool,
 }

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/rename_map.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/rename_map.rs
@@ -1,3 +1,4 @@
+use rustc_hash::FxHashMap;
 use swc_atoms::JsWord;
 use swc_common::collections::AHashMap;
 use swc_ecma_ast::Id;
@@ -5,7 +6,7 @@ use swc_ecma_ast::Id;
 #[derive(Default)]
 pub(super) struct RenameMap {
     map: AHashMap<Id, JsWord>,
-    rev: AHashMap<JsWord, Vec<Id>>,
+    rev: FxHashMap<JsWord, Vec<Id>>,
 }
 
 impl RenameMap {


### PR DESCRIPTION
Description:

 - `Id` is treated as integer, as `JsWord` and `SyntaxContext` are both integer.

**Related issue (if exists):**
