### PR TITLE
perf(es/minifier): Merge hashmap for scoping before checking

### DIFF
--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
@@ -26,6 +26,8 @@ impl Analyzer {
     ) -> AHashMap<Id, JsWord> {
         let mut map = RenameMap::default();
 
+        self.scope.prepare_renaming();
+
         let preserved_symbols = preserved.iter().cloned().map(|v| v.0).collect();
         self.scope
             .rename(freq, &mut map, preserved, &preserved_symbols);

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
@@ -78,7 +78,6 @@ impl Scope {
                     to.insert(id.clone(), sym);
                     // self.data.decls.remove(&id);
                     // self.data.usages.remove(&id);
-                    self.data.all.remove(&id);
 
                     break;
                 }


### PR DESCRIPTION
**Description:**

Currently, we check for child scopes by doing a recursive call, like https://github.com/swc-project/swc/blob/2ad0d801a2a9d84ae2c6df2d15ff8a215f296eec/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs#L112-L114

But this is slow because it results in an enormous amount of calls.

We can optimize this by merging information of child scopes beforehand.


This makes huge difference, so I decided to include this in v1.2.154



**Related issue (if exists):**
