### PR TITLE
perf(es/minifier): Use `Vec<u8>` as a buffer for `base54`

### DIFF
--- a/crates/swc_ecma_minifier/src/util/base54.rs
+++ b/crates/swc_ecma_minifier/src/util/base54.rs
@@ -38,7 +38,10 @@ pub(crate) fn encode(init: &mut usize, skip_reserved: bool) -> String {
         ret.push(c);
     }
 
-    unsafe { String::from_utf8_unchecked(ret) }
+    unsafe {
+        // Safety: We are only using ascii characters
+        String::from_utf8_unchecked(ret)
+    }
 }
 
 #[allow(unused)]

--- a/crates/swc_ecma_minifier/src/util/base54.rs
+++ b/crates/swc_ecma_minifier/src/util/base54.rs
@@ -24,21 +24,21 @@ pub(crate) fn encode(init: &mut usize, skip_reserved: bool) -> String {
         base <<= 6;
     }
 
-    let mut ret = String::new();
+    let mut ret = vec![];
 
     base /= 54;
-    let mut c = BASE54_DEFAULT_CHARS[n / base] as char;
+    let mut c = BASE54_DEFAULT_CHARS[n / base];
     ret.push(c);
 
     while base > 1 {
         n %= base;
         base >>= 6;
-        c = BASE54_DEFAULT_CHARS[n / base] as char;
+        c = BASE54_DEFAULT_CHARS[n / base];
 
         ret.push(c);
     }
 
-    ret
+    unsafe { String::from_utf8_unchecked(ret) }
 }
 
 #[allow(unused)]


### PR DESCRIPTION
Description:

We are only using ASCII characters so we can avoid utf8 logics by using `Vec<u8>` as a buffer and converting it into `String` at the end.


**Related issue (if exists):**
