### PR TITLE
test(*): Print diagnostics to stderr while testing

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -68,7 +68,7 @@ jobs:
           yarn
 
       - name: Run benchmark
-        run: cargo bench --workspace --exclude swc_plugin --exclude wasm --exclude swc_cli --exclude node | tee output.txt
+        run: cargo bench --workspace --exclude swc_plugin --exclude wasm --exclude swc_cli --exclude node --exclude swc_ecma_minifier | tee output.txt
 
       - name: Download previous benchmark results
         run: mkdir raw-data && curl -o raw-data/benchmark-data.json https://raw.githubusercontent.com/swc-project/raw-data/gh-pages/benchmark-data.json

--- a/crates/swc_ecma_parser/tests/typescript.rs
+++ b/crates/swc_ecma_parser/tests/typescript.rs
@@ -62,6 +62,7 @@ fn shifted(file: PathBuf) {
 
         Ok(())
     })
+    .map_err(|_| ())
     .unwrap();
 }
 
@@ -206,6 +207,7 @@ fn run_spec(file: &Path, output_json: &Path) {
 
         Ok(())
     })
+    .map_err(|_| ())
     .unwrap();
 }
 

--- a/crates/testing/src/errors/mod.rs
+++ b/crates/testing/src/errors/mod.rs
@@ -1,6 +1,6 @@
 use swc_common::errors::{DiagnosticBuilder, Emitter};
 
-mod stderr;
+pub(crate) mod stderr;
 
 pub(crate) fn multi_emitter(a: Box<dyn Emitter>, b: Box<dyn Emitter>) -> Box<dyn Emitter> {
     Box::new(MultiEmitter { a, b })

--- a/crates/testing/src/errors/mod.rs
+++ b/crates/testing/src/errors/mod.rs
@@ -1,0 +1,17 @@
+use swc_common::errors::{DiagnosticBuilder, Emitter};
+
+pub(crate) fn multi_emitter(a: Box<dyn Emitter>, b: Box<dyn Emitter>) -> Box<dyn Emitter> {
+    Box::new(MultiEmitter { a, b })
+}
+
+struct MultiEmitter {
+    a: Box<dyn Emitter>,
+    b: Box<dyn Emitter>,
+}
+
+impl Emitter for MultiEmitter {
+    fn emit(&mut self, db: &DiagnosticBuilder<'_>) {
+        self.a.emit(db);
+        self.b.emit(db);
+    }
+}

--- a/crates/testing/src/errors/mod.rs
+++ b/crates/testing/src/errors/mod.rs
@@ -1,5 +1,7 @@
 use swc_common::errors::{DiagnosticBuilder, Emitter};
 
+mod stderr;
+
 pub(crate) fn multi_emitter(a: Box<dyn Emitter>, b: Box<dyn Emitter>) -> Box<dyn Emitter> {
     Box::new(MultiEmitter { a, b })
 }

--- a/crates/testing/src/errors/stderr.rs
+++ b/crates/testing/src/errors/stderr.rs
@@ -1,0 +1,47 @@
+use std::fmt;
+
+use swc_common::{
+    errors::{DiagnosticBuilder, Emitter},
+    sync::Lrc,
+    SourceMap,
+};
+use swc_error_reporters::{GraphicalReportHandler, PrettyEmitter, PrettyEmitterConfig};
+use tracing::{metadata::LevelFilter, Level};
+
+/// This emitter is controlled by the env var `RUST_LOG`.
+///
+/// This emitter will print to stderr if the logging level is higher than or
+/// equal to `debug`
+pub(crate) fn stderr_emitter(cm: Lrc<SourceMap>) -> Box<dyn Emitter> {
+    if LevelFilter::current() > Level::INFO {
+        let reporter = GraphicalReportHandler::default();
+        let emitter = PrettyEmitter::new(
+            cm,
+            Box::new(TestStderr),
+            reporter,
+            PrettyEmitterConfig {
+                skip_filename: false,
+            },
+        );
+
+        Box::new(emitter)
+    } else {
+        Box::new(NoopEmitter)
+    }
+}
+
+struct TestStderr;
+
+impl fmt::Write for TestStderr {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        eprintln!("{}", s);
+
+        Ok(())
+    }
+}
+
+struct NoopEmitter;
+
+impl Emitter for NoopEmitter {
+    fn emit(&mut self, _: &DiagnosticBuilder<'_>) {}
+}

--- a/crates/testing/src/errors/stderr.rs
+++ b/crates/testing/src/errors/stderr.rs
@@ -6,7 +6,7 @@ use swc_common::{
     SourceMap,
 };
 use swc_error_reporters::{GraphicalReportHandler, PrettyEmitter, PrettyEmitterConfig};
-use tracing::{metadata::LevelFilter, Level};
+use tracing::{info, metadata::LevelFilter, Level};
 
 /// This emitter is controlled by the env var `RUST_LOG`.
 ///
@@ -14,6 +14,8 @@ use tracing::{metadata::LevelFilter, Level};
 /// equal to `debug`
 pub(crate) fn stderr_emitter(cm: Lrc<SourceMap>) -> Box<dyn Emitter> {
     if LevelFilter::current() > Level::INFO {
+        info!("Errors will be printed to stderr as logging level is trace or debug");
+
         let reporter = GraphicalReportHandler::default();
         let emitter = PrettyEmitter::new(
             cm,

--- a/crates/testing/src/errors/stderr.rs
+++ b/crates/testing/src/errors/stderr.rs
@@ -34,7 +34,7 @@ struct TestStderr;
 
 impl fmt::Write for TestStderr {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        eprintln!("{}", s);
+        eprint!("{}", s);
 
         Ok(())
     }

--- a/crates/testing/src/errors/stderr.rs
+++ b/crates/testing/src/errors/stderr.rs
@@ -14,7 +14,7 @@ use tracing::{info, metadata::LevelFilter, Level};
 /// equal to `debug`
 pub(crate) fn stderr_emitter(cm: Lrc<SourceMap>) -> Box<dyn Emitter> {
     if LevelFilter::current() > Level::INFO {
-        info!("Errors will be printed to stderr as logging level is trace or debug");
+        info!("Diagnostics will be printed to stderr as logging level is trace or debug");
 
         let reporter = GraphicalReportHandler::default();
         let emitter = PrettyEmitter::new(

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -24,6 +24,7 @@ use tracing_subscriber::EnvFilter;
 
 pub use self::output::{NormalizedOutput, StdErr, StdOut, TestOutput};
 
+mod errors;
 pub mod json;
 #[macro_use]
 mod macros;

--- a/crates/testing/src/string_errors.rs
+++ b/crates/testing/src/string_errors.rs
@@ -14,21 +14,23 @@ use swc_error_reporters::{
 };
 
 use super::StdErr;
+use crate::errors::{multi_emitter, stderr::stderr_emitter};
 
 /// Creates a new handler for testing.
 pub(crate) fn new_handler(cm: Lrc<SourceMap>, treat_err_as_bug: bool) -> (Handler, BufferedError) {
     let buf: BufferedError = Default::default();
 
     let emitter = PrettyEmitter::new(
-        cm,
+        cm.clone(),
         Box::new(buf.clone()),
         GraphicalReportHandler::default().with_theme(GraphicalTheme::none()),
         PrettyEmitterConfig {
             skip_filename: false,
         },
     );
+    let emitter = multi_emitter(Box::new(emitter), stderr_emitter(cm));
     let handler = Handler::with_emitter_and_flags(
-        Box::new(emitter),
+        emitter,
         HandlerFlags {
             treat_err_as_bug,
             ..Default::default()


### PR DESCRIPTION
**Description:**

This will make debugging stack overflow and parser issues easier because it writes to stderrr right away, instead of holding a buffer for it.


**Related issue (if exists):**
