### PR TITLE
fix(node-swc): Disable logging of `warn` level by default

### DIFF
--- a/crates/node/src/util.rs
+++ b/crates/node/src/util.rs
@@ -49,7 +49,7 @@ pub fn init_default_trace_subscriber() {
         .with_target(false)
         .with_ansi(true)
         .with_env_filter(EnvFilter::from_env("SWC_LOG"))
-        .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::WARN.into()))
+        .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::ERROR.into()))
         .try_init();
 }
 


### PR DESCRIPTION
**Description:**

As swc started using logging in more places, we should adjust logging levels.


**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/4032