### PR TITLE
fix(es/helpers): should export `default` for classPrivateFieldLooseKey

### DIFF
--- a/packages/swc-helpers/src/_class_private_field_loose_key.js
+++ b/packages/swc-helpers/src/_class_private_field_loose_key.js
@@ -1,5 +1,5 @@
 var id = 0;
 
-export function _classPrivateFieldLooseKey(name) {
+export default function _classPrivateFieldLooseKey(name) {
     return "__private_" + id++ + "_" + name;
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Should export `default` for `classPrivateFieldLooseKey`

I should have noticed this on previous PR 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
No
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
