### PR TITLE
fix(es/helpers): Fix the name of `_classPrivateFieldLooseBase`

### DIFF
--- a/crates/swc_ecma_transforms_base/src/helpers/_class_private_field_loose_base.js
+++ b/crates/swc_ecma_transforms_base/src/helpers/_class_private_field_loose_base.js
@@ -1,4 +1,4 @@
-function _classPrivateFieldBase(receiver, privateKey) {
+function _classPrivateFieldLooseBase(receiver, privateKey) {
   if (!Object.prototype.hasOwnProperty.call(receiver, privateKey)) {
     throw new TypeError("attempted to use private field on non-instance");
   }


### PR DESCRIPTION
**Description:**

Function name was wrong.

**Related issue (if exists):**


 - Closes https://github.com/swc-project/swc/issues/4048