### PR TITLE
fix(css/prefixer): Reduce the number of vars in debug build

### DIFF
--- a/crates/swc_stylis/src/prefixer.rs
+++ b/crates/swc_stylis/src/prefixer.rs
@@ -217,6 +217,25 @@ impl Prefixer {
             important: n.important.clone(),
         });
     }
+
+    fn simple(&mut self, val: JsWord, name: JsWord, n: &Declaration) {
+        let val = ComponentValue::Ident(Ident {
+            span: DUMMY_SP,
+            value: val.clone(),
+            raw: val,
+        });
+        let name = DeclarationName::Ident(Ident {
+            span: DUMMY_SP,
+            value: name.clone(),
+            raw: name,
+        });
+        self.added_declarations.push(Declaration {
+            span: n.span,
+            name,
+            value: vec![val],
+            important: n.important.clone(),
+        });
+    }
 }
 
 impl VisitMut for Prefixer {
@@ -498,22 +517,7 @@ impl VisitMut for Prefixer {
 
         macro_rules! simple {
             ($name:expr,$val:expr) => {{
-                let val = ComponentValue::Ident(Ident {
-                    span: DUMMY_SP,
-                    value: $val.into(),
-                    raw: $val.into(),
-                });
-                let name = DeclarationName::Ident(Ident {
-                    span: DUMMY_SP,
-                    value: $name.into(),
-                    raw: $name.into(),
-                });
-                self.added_declarations.push(Declaration {
-                    span: n.span,
-                    name,
-                    value: vec![val],
-                    important: n.important.clone(),
-                });
+                self.simple($name.into(), $val.into(), &n);
             }};
         }
 

--- a/crates/swc_stylis/src/prefixer.rs
+++ b/crates/swc_stylis/src/prefixer.rs
@@ -1,5 +1,6 @@
 use std::mem::take;
 
+use swc_atoms::JsWord;
 use swc_common::DUMMY_SP;
 use swc_css_ast::*;
 use swc_css_utils::{
@@ -200,6 +201,22 @@ pub enum Prefix {
     Moz,
     O,
     Ms,
+}
+
+impl Prefixer {
+    fn same_name(&mut self, name: JsWord, n: &Declaration) {
+        let val = Ident {
+            span: DUMMY_SP,
+            value: name.clone(),
+            raw: name,
+        };
+        self.added_declarations.push(Declaration {
+            span: n.span,
+            name: n.name.clone(),
+            value: vec![ComponentValue::Ident(val)],
+            important: n.important.clone(),
+        });
+    }
 }
 
 impl VisitMut for Prefixer {
@@ -502,17 +519,7 @@ impl VisitMut for Prefixer {
 
         macro_rules! same_name {
             ($name:expr) => {{
-                let val = Ident {
-                    span: DUMMY_SP,
-                    value: $name.into(),
-                    raw: $name.into(),
-                };
-                self.added_declarations.push(Declaration {
-                    span: n.span,
-                    name: n.name.clone(),
-                    value: vec![ComponentValue::Ident(val)],
-                    important: n.important.clone(),
-                });
+                self.same_name($name.into(), &n);
             }};
         }
 

--- a/crates/swc_stylis/src/prefixer.rs
+++ b/crates/swc_stylis/src/prefixer.rs
@@ -215,6 +215,20 @@ impl Prefixer {
             important: n.important.clone(),
         });
     }
+
+    fn same_name(&mut self, name: JsWord, n: &Declaration) {
+        let val = Ident {
+            span: DUMMY_SP,
+            value: name.clone(),
+            raw: name,
+        };
+        self.added_declarations.push(Declaration {
+            span: n.span,
+            name: n.name.clone(),
+            value: vec![ComponentValue::Ident(val)],
+            important: n.important.clone(),
+        });
+    }
 }
 
 pub enum Prefix {
@@ -466,17 +480,7 @@ impl VisitMut for Prefixer {
 
         macro_rules! same_name {
             ($name:expr) => {{
-                let val = Ident {
-                    span: DUMMY_SP,
-                    value: $name.into(),
-                    raw: $name.into(),
-                };
-                self.added_declarations.push(Declaration {
-                    span: n.span,
-                    name: n.name.clone(),
-                    value: vec![ComponentValue::Ident(val)],
-                    important: n.important.clone(),
-                });
+                self.same_name($name.into(), &n);
             }};
         }
 

--- a/crates/swc_stylis/src/prefixer.rs
+++ b/crates/swc_stylis/src/prefixer.rs
@@ -196,29 +196,8 @@ struct Prefixer {
     added_declarations: Vec<Declaration>,
 }
 
-pub enum Prefix {
-    Webkit,
-    Moz,
-    O,
-    Ms,
-}
-
 impl Prefixer {
-    fn same_name(&mut self, name: JsWord, n: &Declaration) {
-        let val = Ident {
-            span: DUMMY_SP,
-            value: name.clone(),
-            raw: name,
-        };
-        self.added_declarations.push(Declaration {
-            span: n.span,
-            name: n.name.clone(),
-            value: vec![ComponentValue::Ident(val)],
-            important: n.important.clone(),
-        });
-    }
-
-    fn simple(&mut self, val: JsWord, name: JsWord, n: &Declaration) {
+    fn simple(&mut self, name: JsWord, val: JsWord, n: &Declaration) {
         let val = ComponentValue::Ident(Ident {
             span: DUMMY_SP,
             value: val.clone(),
@@ -236,6 +215,13 @@ impl Prefixer {
             important: n.important.clone(),
         });
     }
+}
+
+pub enum Prefix {
+    Webkit,
+    Moz,
+    O,
+    Ms,
 }
 
 impl VisitMut for Prefixer {
@@ -450,61 +436,18 @@ impl VisitMut for Prefixer {
         let ms_new_value = n.value.clone();
 
         macro_rules! same_content {
-            (Prefix::Webkit, $name:expr) => {{
+            ($prefix:expr,$name:expr) => {{
                 let name = DeclarationName::Ident(Ident {
                     span: DUMMY_SP,
                     value: $name.into(),
                     raw: $name.into(),
                 });
-                let new_value = webkit_new_value.clone();
-
-                self.added_declarations.push(Declaration {
-                    span: n.span,
-                    name,
-                    value: new_value,
-                    important: n.important.clone(),
-                });
-            }};
-
-            (Prefix::Moz, $name:expr) => {{
-                let name = DeclarationName::Ident(Ident {
-                    span: DUMMY_SP,
-                    value: $name.into(),
-                    raw: $name.into(),
-                });
-                let new_value = moz_new_value.clone();
-
-                self.added_declarations.push(Declaration {
-                    span: n.span,
-                    name,
-                    value: new_value,
-                    important: n.important.clone(),
-                });
-            }};
-
-            (Prefix::O, $name:expr) => {{
-                let name = DeclarationName::Ident(Ident {
-                    span: DUMMY_SP,
-                    value: $name.into(),
-                    raw: $name.into(),
-                });
-                let new_value = o_new_value.clone();
-
-                self.added_declarations.push(Declaration {
-                    span: n.span,
-                    name,
-                    value: new_value,
-                    important: n.important.clone(),
-                });
-            }};
-
-            (Prefix::Ms, $name:expr) => {{
-                let name = DeclarationName::Ident(Ident {
-                    span: DUMMY_SP,
-                    value: $name.into(),
-                    raw: $name.into(),
-                });
-                let new_value = ms_new_value.clone();
+                let new_value = match $prefix {
+                    Prefix::Webkit => webkit_new_value.clone(),
+                    Prefix::Moz => moz_new_value.clone(),
+                    Prefix::O => o_new_value.clone(),
+                    Prefix::Ms => ms_new_value.clone(),
+                };
 
                 self.added_declarations.push(Declaration {
                     span: n.span,
@@ -523,7 +466,17 @@ impl VisitMut for Prefixer {
 
         macro_rules! same_name {
             ($name:expr) => {{
-                self.same_name($name.into(), &n);
+                let val = Ident {
+                    span: DUMMY_SP,
+                    value: $name.into(),
+                    raw: $name.into(),
+                };
+                self.added_declarations.push(Declaration {
+                    span: n.span,
+                    name: n.name.clone(),
+                    value: vec![ComponentValue::Ident(val)],
+                    important: n.important.clone(),
+                });
             }};
         }
 

--- a/crates/swc_stylis/src/prefixer.rs
+++ b/crates/swc_stylis/src/prefixer.rs
@@ -414,18 +414,61 @@ impl VisitMut for Prefixer {
         let ms_new_value = n.value.clone();
 
         macro_rules! same_content {
-            ($prefix:expr,$name:expr) => {{
+            (Prefix::Webkit, $name:expr) => {{
                 let name = DeclarationName::Ident(Ident {
                     span: DUMMY_SP,
                     value: $name.into(),
                     raw: $name.into(),
                 });
-                let new_value = match $prefix {
-                    Prefix::Webkit => webkit_new_value.clone(),
-                    Prefix::Moz => moz_new_value.clone(),
-                    Prefix::O => o_new_value.clone(),
-                    Prefix::Ms => ms_new_value.clone(),
-                };
+                let new_value = webkit_new_value.clone();
+
+                self.added_declarations.push(Declaration {
+                    span: n.span,
+                    name,
+                    value: new_value,
+                    important: n.important.clone(),
+                });
+            }};
+
+            (Prefix::Moz, $name:expr) => {{
+                let name = DeclarationName::Ident(Ident {
+                    span: DUMMY_SP,
+                    value: $name.into(),
+                    raw: $name.into(),
+                });
+                let new_value = moz_new_value.clone();
+
+                self.added_declarations.push(Declaration {
+                    span: n.span,
+                    name,
+                    value: new_value,
+                    important: n.important.clone(),
+                });
+            }};
+
+            (Prefix::O, $name:expr) => {{
+                let name = DeclarationName::Ident(Ident {
+                    span: DUMMY_SP,
+                    value: $name.into(),
+                    raw: $name.into(),
+                });
+                let new_value = o_new_value.clone();
+
+                self.added_declarations.push(Declaration {
+                    span: n.span,
+                    name,
+                    value: new_value,
+                    important: n.important.clone(),
+                });
+            }};
+
+            (Prefix::Ms, $name:expr) => {{
+                let name = DeclarationName::Ident(Ident {
+                    span: DUMMY_SP,
+                    value: $name.into(),
+                    raw: $name.into(),
+                });
+                let new_value = ms_new_value.clone();
 
                 self.added_declarations.push(Declaration {
                     span: n.span,


### PR DESCRIPTION
**Description:**

Too many local variables break debug wasm build.

**Related issue (if exists):**

 - https://github.com/vercel/next.js/pull/35395