### PR TITLE
feat(swc/wasm): initial plugin support interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4511,6 +4511,7 @@ dependencies = [
  "swc_common",
  "swc_ecma_lints",
  "swc_ecmascript",
+ "swc_plugin_runner",
  "tracing",
  "wasm-bindgen",
  "wasmer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,6 +3080,7 @@ dependencies = [
  "serde_json",
  "swc",
  "swc_common",
+ "swc_plugin_runner",
  "swc_trace_macro",
  "tracing",
  "tracing-chrome",

--- a/crates/swc/src/plugin.rs
+++ b/crates/swc/src/plugin.rs
@@ -41,12 +41,12 @@ pub struct PluginContext {
     pub env_name: String,
 }
 
+#[cfg(all(feature = "plugin", not(target_arch = "wasm32")))]
 pub fn plugins(
     resolver: CachingResolver<NodeModulesResolver>,
     config: crate::config::JscExperimental,
     plugin_context: PluginContext,
 ) -> impl Fold {
-    #[cfg(feature = "plugin")]
     {
         RustPlugins {
             resolver,
@@ -54,11 +54,16 @@ pub fn plugins(
             plugin_context,
         }
     }
+}
 
-    #[cfg(not(feature = "plugin"))]
-    {
-        noop()
-    }
+#[cfg(all(feature = "plugin", target_arch = "wasm32"))]
+pub fn plugins(config: crate::config::JscExperimental, plugin_context: PluginContext) -> impl Fold {
+    swc_ecma_transforms::pass::noop()
+}
+
+#[cfg(not(feature = "plugin"))]
+pub fn plugins() -> impl Fold {
+    noop()
 }
 
 struct RustPlugins {

--- a/crates/swc_cli/Cargo.toml
+++ b/crates/swc_cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "./src/main.rs"
 
 [features]
 default = []
-plugin = ["swc/plugin", "wasmer/default", "wasmer-wasi/default"]
+plugin = ["swc/plugin", "swc_plugin_runner/filesystem_cache", "wasmer/default", "wasmer-wasi/default"]
 
 [dependencies]
 anyhow = "1.0.53"
@@ -27,6 +27,7 @@ serde_json = { version = "1", features = ["unbounded_depth"] }
 swc = { version = "0.159.0", path = "../swc" }
 swc_common = { version = "0.17.5", path = "../swc_common" }
 swc_trace_macro = { version = "0.1.0", path = "../swc_trace_macro" }
+swc_plugin_runner = { version = "0.46.0", path = "../swc_plugin_runner", default-features = false, optional = true }
 tracing = "0.1.32"
 tracing-chrome = "0.4.0"
 tracing-futures = "0.2.5"

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -10,7 +10,12 @@ version = "0.46.0"
 
 [features]
 default = ["filesystem_cache"]
+# Supports a cache allow to store compiled bytecode into filesystem location.
+# This feature implies in-memory cache enabled always.
 filesystem_cache = ["wasmer-cache"]
+# Supports a cache allow to store wasm module in-memory. This avoids recompilation
+# to the same module in a single procress lifecycle.
+memory_cache = []
 
 [dependencies]
 anyhow = "1.0.42"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -18,6 +18,7 @@ swc_v2 = []
 # This feature exists to allow cargo operations
 plugin = [
   "swc/plugin",
+  "swc_plugin_runner/memory_cache",
   "wasmer",
   "wasmer-wasi",
   "wasmer/js-default",
@@ -38,6 +39,7 @@ swc_ecma_lints = { path = "../swc_ecma_lints", features = [
   "non_critical_lints",
 ] }
 swc_ecmascript = { path = "../swc_ecmascript" }
+swc_plugin_runner = { version = "0.45.0", path = "../swc_plugin_runner", default-features = false }
 tracing = { version = "0.1.32", features = ["release_max_level_off"] }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasmer = { version = "2.2.1", optional = true, default-features = false }

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -39,7 +39,7 @@ swc_ecma_lints = { path = "../swc_ecma_lints", features = [
   "non_critical_lints",
 ] }
 swc_ecmascript = { path = "../swc_ecmascript" }
-swc_plugin_runner = { version = "0.45.0", path = "../swc_plugin_runner", default-features = false }
+swc_plugin_runner = { version = "0.46.0", path = "../swc_plugin_runner", default-features = false, optional = true }
 tracing = { version = "0.1.32", features = ["release_max_level_off"] }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasmer = { version = "2.2.1", optional = true, default-features = false }

--- a/crates/wasm/scripts/build.sh
+++ b/crates/wasm/scripts/build.sh
@@ -1,1 +1,1 @@
-wasm-pack build --debug --scope swc -t nodejs $@
+wasm-pack build --debug --scope swc -t nodejs --features plugin $@

--- a/crates/wasm/scripts/build_nodejs_release.sh
+++ b/crates/wasm/scripts/build_nodejs_release.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # run this script from the wasm folder ./scripts/build_nodejs_release.sh
-npx wasm-pack build --scope swc -t nodejs
+npx wasm-pack build --scope swc -t nodejs --features plugin

--- a/crates/wasm/scripts/build_web_release.sh
+++ b/crates/wasm/scripts/build_web_release.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # run this script from the wasm folder ./scripts/build_web_release.sh
-npx wasm-pack build --scope swc 
+npx wasm-pack build --scope swc --features plugin


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This is the initial groundwork for #3934. Mainly, PR attempts to introduce interface to `transformSync` in wasm to accept another param for the plugin's module bytes.

I'm not a huge fan of current approach, honestly. But also wasm-* target is pretty limited to access external system resources - for example, @swc/wasm cannot access filesystem also can't easily use remote-ish interfaces since it implies node.js target.

For now, I'll focus for the primary goal to enable end-to-end workflow to make plugin work in the wasm target. Once it's done, I can come up with proposal for consolidating all interface stablization.

**Related issue (if exists):**

- relates with https://github.com/swc-project/swc/issues/3934