### PR TITLE
fix: make errorConfig.filename default to true

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1291,11 +1291,15 @@ fn default_jsonify_min_cost() -> usize {
     1024
 }
 
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ErrorConfig {
-    #[serde(default = "true_by_default")]
     pub filename: bool,
+}
+impl Default for ErrorConfig {
+    fn default() -> Self {
+        ErrorConfig { filename: true }
+    }
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/crates/swc_ecma_codegen/src/macros.rs
+++ b/crates/swc_ecma_codegen/src/macros.rs
@@ -100,6 +100,7 @@ macro_rules! semi {
     };
 }
 
+///
 /// - `srcmap!(true)` for start (span.lo)
 /// - `srcmap!(false)` for end (span.hi)
 macro_rules! srcmap {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

make errorConfig.filename default to true.
this will make @swc/cli always output error with filename, except with `-C error.filename=false`.
when using @swc/cli the value of this field in .swcrc is ignored, since swc use this value before read .swcrc

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
Closes #3950