### PR TITLE
fix(es/lint): ignore type only import

### DIFF
--- a/crates/swc_ecma_lints/src/rules/duplicate_bindings.rs
+++ b/crates/swc_ecma_lints/src/rules/duplicate_bindings.rs
@@ -132,6 +132,14 @@ impl Visit for DuplicateBindings {
         d.visit_children_with(self);
     }
 
+    fn visit_import_decl(&mut self, s: &ImportDecl) {
+        if s.type_only {
+            return;
+        }
+
+        s.visit_children_with(self);
+    }
+
     fn visit_import_default_specifier(&mut self, s: &ImportDefaultSpecifier) {
         s.visit_children_with(self);
 

--- a/crates/swc_ecma_lints/tests/pass/issue-4148/1/input.ts
+++ b/crates/swc_ecma_lints/tests/pass/issue-4148/1/input.ts
@@ -1,0 +1,6 @@
+//a.ts
+import type { Foo } from "./b";
+const Foo = "hey";
+
+// b.ts
+export type Foo = string;


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Note: 

```typescript

import type { Foo } from "./b"; // fixed in this PR
import { type Foo } from "./b"; // it is OK

import { Foo } from "./b"; // cannot be fixed unless we have multifile mode

```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
- #4148 partial fixed