### PR TITLE
refactor(swc/cli): alias plugin build with wasm target instead of

### DIFF
--- a/crates/swc_cli/src/commands/plugin.rs
+++ b/crates/swc_cli/src/commands/plugin.rs
@@ -173,8 +173,10 @@ swc_plugin = "*""#,
         fs::write(
             &cargo_config_path.join("config"),
             format!(
-                r#"[build]
-target = "{}""#,
+                r#"# These command aliases are not final, may change
+[alias]
+# Alias to build actual plugin binary for the specified target.
+prepublish = "build --target {}""#,
                 build_target
             )
             .as_bytes(),


### PR DESCRIPTION
override

<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

PR replaces plugin scaffolding config to not override build to specific target, instead introduce aliased one. This is due to overriding target defeats all other commands (i.e cargo `test` doesn't work out of the box). 

Name of new alias will likely change.

**BREAKING CHANGE:**

New plugin template created via cli now need to specify target for `cargo build` or use new alias.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
