### PR TITLE
feat(parser): allow parsing files with missing close braces

### DIFF
--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -157,7 +157,16 @@ impl<'a, I: Tokens> Parser<I> {
                     ..p.ctx()
                 })
                 .parse_class_body()?;
-            expect!(p, '}');
+
+            if p.input.cur().is_none() {
+                let eof_text = p.input.dump_cur();
+                p.emit_err(
+                    p.input.cur_span(),
+                    SyntaxError::Expected(&Token::RBrace, eof_text),
+                );
+            } else {
+                expect!(p, '}');
+            }
             let end = last_pos!(p);
 
             Ok((

--- a/crates/swc_ecma_parser/tests/span/js/decl/class-no-close-brace.js
+++ b/crates/swc_ecma_parser/tests/span/js/decl/class-no-close-brace.js
@@ -1,0 +1,3 @@
+class Test {
+
+  method() {}

--- a/crates/swc_ecma_parser/tests/span/js/decl/class-no-close-brace.js.spans
+++ b/crates/swc_ecma_parser/tests/span/js/decl/class-no-close-brace.js.spans
@@ -1,0 +1,84 @@
+
+  x Module
+   ,-[$DIR/tests/span/js/decl/class-no-close-brace.js:1:1]
+ 1 | ,-> class Test {
+ 2 | |   
+ 3 | `->   method() {}
+   `----
+
+  x ModuleItem
+   ,-[$DIR/tests/span/js/decl/class-no-close-brace.js:1:1]
+ 1 | ,-> class Test {
+ 2 | |   
+ 3 | `->   method() {}
+   `----
+
+  x Stmt
+   ,-[$DIR/tests/span/js/decl/class-no-close-brace.js:1:1]
+ 1 | ,-> class Test {
+ 2 | |   
+ 3 | `->   method() {}
+   `----
+
+  x Decl
+   ,-[$DIR/tests/span/js/decl/class-no-close-brace.js:1:1]
+ 1 | ,-> class Test {
+ 2 | |   
+ 3 | `->   method() {}
+   `----
+
+  x ClassDecl
+   ,-[$DIR/tests/span/js/decl/class-no-close-brace.js:1:1]
+ 1 | ,-> class Test {
+ 2 | |   
+ 3 | `->   method() {}
+   `----
+
+  x Ident
+   ,-[$DIR/tests/span/js/decl/class-no-close-brace.js:1:1]
+ 1 | class Test {
+   :       ^^^^
+   `----
+
+  x Class
+   ,-[$DIR/tests/span/js/decl/class-no-close-brace.js:1:1]
+ 1 | ,-> class Test {
+ 2 | |   
+ 3 | `->   method() {}
+   `----
+
+  x ClassMember
+   ,-[$DIR/tests/span/js/decl/class-no-close-brace.js:3:3]
+ 3 | method() {}
+   : ^^^^^^^^^^^
+   `----
+
+  x ClassMethod
+   ,-[$DIR/tests/span/js/decl/class-no-close-brace.js:3:3]
+ 3 | method() {}
+   : ^^^^^^^^^^^
+   `----
+
+  x PropName
+   ,-[$DIR/tests/span/js/decl/class-no-close-brace.js:3:3]
+ 3 | method() {}
+   : ^^^^^^
+   `----
+
+  x Ident
+   ,-[$DIR/tests/span/js/decl/class-no-close-brace.js:3:3]
+ 3 | method() {}
+   : ^^^^^^
+   `----
+
+  x Function
+   ,-[$DIR/tests/span/js/decl/class-no-close-brace.js:3:3]
+ 3 | method() {}
+   : ^^^^^^^^^^^
+   `----
+
+  x BlockStmt
+   ,-[$DIR/tests/span/js/decl/class-no-close-brace.js:3:3]
+ 3 | method() {}
+   :          ^^
+   `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/021fb596db81e6d0.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/021fb596db81e6d0.js.stderr
@@ -1,6 +1,6 @@
 
-  x Unexpected eof
+  x Expected '}', got '<eof>'
    ,-[$DIR/tests/test262-parser/fail/021fb596db81e6d0.js:1:1]
  1 | {
-   :  ^
+   : ^
    `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/4d579849c75cfef9.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/4d579849c75cfef9.js.stderr
@@ -1,6 +1,6 @@
 
-  x Unexpected eof
+  x Expected '}', got '<eof>'
    ,-[$DIR/tests/test262-parser/fail/4d579849c75cfef9.js:4:1]
  4 | {
-   :  ^
+   : ^
    `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/50efa1f220e37136.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/50efa1f220e37136.js.stderr
@@ -1,6 +1,6 @@
 
-  x Unexpected eof
+  x Expected '}', got '<eof>'
    ,-[$DIR/tests/test262-parser/fail/50efa1f220e37136.js:1:1]
  1 | { ;  ;
-   :       ^
+   :      ^
    `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/77fe5a8d6ae33dd1.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/77fe5a8d6ae33dd1.js.stderr
@@ -1,6 +1,6 @@
 
-  x Unexpected eof
+  x Expected '}', got '<eof>'
    ,-[$DIR/tests/test262-parser/fail/77fe5a8d6ae33dd1.js:1:1]
  1 | function t() { ;  ;
-   :                    ^
+   :                   ^
    `----

--- a/crates/swc_ecma_parser/tests/typescript-errors/arrow-function/missing-closing-brace/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript-errors/arrow-function/missing-closing-brace/input.ts
@@ -1,0 +1,2 @@
+const t = () => {
+  console.log(5);

--- a/crates/swc_ecma_parser/tests/typescript-errors/arrow-function/missing-closing-brace/input.ts.stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/arrow-function/missing-closing-brace/input.ts.stderr
@@ -1,0 +1,6 @@
+
+  x Expected '}', got '<eof>'
+   ,-[$DIR/tests/typescript-errors/arrow-function/missing-closing-brace/input.ts:2:3]
+ 2 | console.log(5);
+   :               ^
+   `----

--- a/crates/swc_ecma_parser/tests/typescript-errors/class/missing-closing-brace/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript-errors/class/missing-closing-brace/input.ts
@@ -1,0 +1,2 @@
+class Class {
+  prop: string;

--- a/crates/swc_ecma_parser/tests/typescript-errors/class/missing-closing-brace/input.ts.stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/class/missing-closing-brace/input.ts.stderr
@@ -1,0 +1,6 @@
+
+  x Expected '}', got '<eof>'
+   ,-[$DIR/tests/typescript-errors/class/missing-closing-brace/input.ts:2:3]
+ 2 | prop: string;
+   :             ^
+   `----


### PR DESCRIPTION
**Description:**

This is a small, but huge improvement for swc to get ASTs in spite of syntax errors. Essentially, it allows parsing even if there's a missing close brace in a section of the code.

For example, the following will now parse, but have two emitted diagnostics for missing `}`:

```ts
class MyClass {
  prop: string;

  myMethod() {
    console.log(5);
```
Part of what's outlined in #1178

**BREAKING CHANGE:**

A missing close brace token will no longer be a fatal parsing error, but will instead emit diagnostics.