### PR TITLE
feat(es/minifier): Introduce concept of epoch in the analyzer

### DIFF
--- a/crates/swc_ecma_minifier/tests/TODO.txt
+++ b/crates/swc_ecma_minifier/tests/TODO.txt
@@ -357,12 +357,6 @@ hoist_props/toplevel_const/input.js
 hoist_props/toplevel_let/input.js
 hoist_props/toplevel_var/input.js
 hoist_props/undefined_key/input.js
-identity/inline_identity_dont_lose_this_when_arg/input.js
-identity/inline_identity_duplicate_arg_var/input.js
-identity/inline_identity_extra_params/input.js
-identity/inline_identity_function/input.js
-identity/inline_identity_inline_function/input.js
-identity/inline_identity_lose_this/input.js
 ie8/do_screw_try_catch/input.js
 ie8/do_screw_try_catch_undefined/input.js
 ie8/dont_screw_try_catch/input.js


### PR DESCRIPTION
**Description:**


 - Concept of `epoch` in analyzer

Rust does not have GC, so we can't store the value of expression without cloning, if we are not sure it will be used exactly only once.
But this is problematic for code like

```js
"use strict";
const id = (x)=>x
;
const func_bag = {
    func: function() {
        return void 0 === this ? "PASS" : "FAIL";
    }
};
func_bag.func2 = function() {
    return void 0 === this ? "PASS" : "FAIL";
};
var x;
console.log((x = func_bag.func)());
var x;
console.log((x = func_bag.func2)());

```

because the analyzer has the same restriction. (It's rust)
We can workaround this by attaching epoch to all accesses.

**Related issue (if exists):**
