### PR TITLE
fix(swc): init custom trace subscriber once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4166,8 +4166,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-chrome"
-version = "0.4.0"
-source = "git+https://github.com/kwonoj/tracing-chrome?rev=a345d8e#a345d8e8b0db52911711d01c9d44b1bdb7be2901"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb13184244c7cd22758b79e7c993c515ad67a8e730edcb7e05fe7bcabb283c7"
 dependencies = [
  "json",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,5 +61,3 @@ opt-level = 3
 [patch.crates-io]
 cranelift-codegen = { git = "https://github.com/kdy1/wasmtime", branch = "tls" }
 cranelift-entity = { git = "https://github.com/kdy1/wasmtime", branch = "tls" }
-# https://github.com/thoren-d/tracing-chrome/pull/6
-tracing-chrome = { git = "https://github.com/kwonoj/tracing-chrome", rev = "a345d8e" }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -53,7 +53,7 @@ swc_node_base = { path = "../swc_node_base" }
 swc_node_bundler = { path = "../swc_node_bundler" }
 swc_plugin_runner = { path = "../swc_plugin_runner", optional = true, default-features = false }
 tracing = { version = "0.1.32", features = ["release_max_level_info"] }
-tracing-chrome = "0.4.0"
+tracing-chrome = "0.5.0"
 tracing-futures = "0.2.5"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 wasmer = { version = "2.2.1", optional = true, default-features = false }

--- a/crates/node/src/util.rs
+++ b/crates/node/src/util.rs
@@ -7,7 +7,11 @@ use anyhow::{anyhow, Context, Error};
 use napi::{Env, Status};
 use serde::de::DeserializeOwned;
 use swc::try_with_handler;
-use swc_common::{errors::Handler, sync::Lrc, SourceMap};
+use swc_common::{
+    errors::Handler,
+    sync::{Lrc, OnceCell},
+    SourceMap,
+};
 use tracing::instrument;
 use tracing_chrome::ChromeLayerBuilder;
 use tracing_subscriber::{
@@ -15,6 +19,7 @@ use tracing_subscriber::{
 };
 
 static TARGET_TRIPLE: &str = include_str!(concat!(env!("OUT_DIR"), "/triple.txt"));
+static CUSTOM_TRACE_SUBSCRIBER: OnceCell<bool> = OnceCell::new();
 
 #[napi]
 pub fn get_target_triple() -> napi::Result<String> {
@@ -26,23 +31,28 @@ pub fn init_custom_trace_subscriber(
     mut env: Env,
     trace_out_file_path: Option<String>,
 ) -> napi::Result<()> {
-    let mut layer = ChromeLayerBuilder::new().include_args(true);
-    if let Some(trace_out_file) = trace_out_file_path {
-        layer = layer.file(trace_out_file);
-    }
+    CUSTOM_TRACE_SUBSCRIBER.get_or_init(|| {
+        let mut layer = ChromeLayerBuilder::new().include_args(true);
+        if let Some(trace_out_file) = trace_out_file_path {
+            layer = layer.file(trace_out_file);
+        }
 
-    let (chrome_layer, guard) = layer.build();
-    tracing_subscriber::registry()
-        .with(chrome_layer.with_filter(filter::filter_fn(|metadata| {
-            !metadata.target().contains("cranelift") && !metadata.name().contains("log ")
-        })))
-        .try_init()
-        .expect("Failed to register tracing subscriber");
+        let (chrome_layer, guard) = layer.build();
+        tracing_subscriber::registry()
+            .with(chrome_layer.with_filter(filter::filter_fn(|metadata| {
+                !metadata.target().contains("cranelift") && !metadata.name().contains("log ")
+            })))
+            .try_init()
+            .expect("Failed to register tracing subscriber");
 
-    env.add_env_cleanup_hook(guard, |flush_guard| {
-        flush_guard.flush();
-        drop(flush_guard);
-    })?;
+        env.add_env_cleanup_hook(guard, |flush_guard| {
+            flush_guard.flush();
+            drop(flush_guard);
+        })
+        .expect("Should able to initialize cleanup for custom trace subscriber");
+
+        true
+    });
 
     Ok(())
 }

--- a/crates/swc_cli/Cargo.toml
+++ b/crates/swc_cli/Cargo.toml
@@ -34,7 +34,7 @@ swc_common = { version = "0.17.5", path = "../swc_common" }
 swc_trace_macro = { version = "0.1.0", path = "../swc_trace_macro" }
 swc_plugin_runner = { version = "0.48.0", path = "../swc_plugin_runner", default-features = false, optional = true }
 tracing = "0.1.32"
-tracing-chrome = "0.4.0"
+tracing-chrome = "0.5.0"
 tracing-futures = "0.2.5"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 walkdir = "2"


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

When fix dropping flush guard global static was removed, and also removed init once logic. PR fixes to init once only, subsequent call do nothing.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
