### PR TITLE
perf(es/parser): Improve performance by using `#[cold]`

### DIFF
--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
@@ -102,7 +102,7 @@ impl Scope {
         }
     }
 
-    #[inline]
+    #[inline(never)]
     fn can_rename(&self, id: &Id, symbol: &JsWord, renamed: &RenameMap) -> bool {
         if let Some(lefts) = renamed.get_by_right(symbol) {
             for left in lefts {

--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -13,7 +13,7 @@ use crate::token::Token;
 /// Note: this struct is 8 bytes.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Error {
-    pub(crate) error: Box<(Span, SyntaxError)>,
+    error: Box<(Span, SyntaxError)>,
 }
 
 impl Spanned for Error {
@@ -23,6 +23,13 @@ impl Spanned for Error {
 }
 
 impl Error {
+    #[cold]
+    pub(crate) fn new(span: Span, error: SyntaxError) -> Self {
+        Self {
+            error: Box::new((span, error)),
+        }
+    }
+
     pub fn kind(&self) -> &SyntaxError {
         &self.error.1
     }

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -554,7 +554,7 @@ impl<'a, I: Input> Lexer<'a, I> {
             // read unicode escape sequences
             'u' => match self.read_unicode_escape(raw) {
                 Ok(chars) => return Ok(Some(chars)),
-                Err(err) => self.error(start, err.error.1)?,
+                Err(err) => self.error(start, err.into_kind())?,
             },
 
             // octal escape sequences

--- a/crates/swc_ecma_parser/src/lexer/number.rs
+++ b/crates/swc_ecma_parser/src/lexer/number.rs
@@ -341,9 +341,7 @@ impl<'a, I: Input> Lexer<'a, I> {
                     .and_then(|v| v.checked_add(val as u32))
                     .ok_or_else(|| {
                         let span = Span::new(start, start, SyntaxContext::empty());
-                        Error {
-                            error: Box::new((span, SyntaxError::InvalidUnicodeEscape)),
-                        }
+                        Error::new(span, SyntaxError::InvalidUnicodeEscape)
                     })?;
 
                 Ok((Some(total), count != len))

--- a/crates/swc_ecma_parser/src/lexer/tests.rs
+++ b/crates/swc_ecma_parser/src/lexer/tests.rs
@@ -146,9 +146,7 @@ fn module_legacy_comment_1() {
 fn module_legacy_comment_2() {
     assert_eq!(
         lex_module_errors(Syntax::default(), "-->"),
-        vec![Error {
-            error: Box::new((sp(0..3), SyntaxError::LegacyCommentInModule)),
-        }]
+        vec![Error::new(sp(0..3), SyntaxError::LegacyCommentInModule)]
     )
 }
 
@@ -259,18 +257,16 @@ fn tpl_invalid_unicode_escape() {
         vec![
             tok!('`'),
             Token::Template {
-                cooked: Err(Error {
-                    error: Box::new((
-                        Span {
-                            lo: BytePos(1),
-                            hi: BytePos(3),
-                            ctxt: SyntaxContext::empty(),
-                        },
-                        SyntaxError::BadCharacterEscapeSequence {
-                            expected: "4 hex characters"
-                        }
-                    ))
-                }),
+                cooked: Err(Error::new(
+                    Span {
+                        lo: BytePos(1),
+                        hi: BytePos(3),
+                        ctxt: SyntaxContext::empty(),
+                    },
+                    SyntaxError::BadCharacterEscapeSequence {
+                        expected: "4 hex characters"
+                    }
+                )),
                 raw: "\\unicode".into(),
             },
             tok!('`'),
@@ -281,18 +277,16 @@ fn tpl_invalid_unicode_escape() {
         vec![
             tok!('`'),
             Token::Template {
-                cooked: Err(Error {
-                    error: Box::new((
-                        Span {
-                            lo: BytePos(1),
-                            hi: BytePos(4),
-                            ctxt: SyntaxContext::empty(),
-                        },
-                        SyntaxError::BadCharacterEscapeSequence {
-                            expected: "1-6 hex characters"
-                        }
-                    ))
-                }),
+                cooked: Err(Error::new(
+                    Span {
+                        lo: BytePos(1),
+                        hi: BytePos(4),
+                        ctxt: SyntaxContext::empty(),
+                    },
+                    SyntaxError::BadCharacterEscapeSequence {
+                        expected: "1-6 hex characters"
+                    }
+                )),
                 raw: "\\u{".into(),
             },
             tok!('`'),
@@ -303,18 +297,16 @@ fn tpl_invalid_unicode_escape() {
         vec![
             tok!('`'),
             Token::Template {
-                cooked: Err(Error {
-                    error: Box::new((
-                        Span {
-                            lo: BytePos(1),
-                            hi: BytePos(3),
-                            ctxt: SyntaxContext::empty(),
-                        },
-                        SyntaxError::BadCharacterEscapeSequence {
-                            expected: "2 hex characters"
-                        }
-                    ))
-                }),
+                cooked: Err(Error::new(
+                    Span {
+                        lo: BytePos(1),
+                        hi: BytePos(3),
+                        ctxt: SyntaxContext::empty(),
+                    },
+                    SyntaxError::BadCharacterEscapeSequence {
+                        expected: "2 hex characters"
+                    }
+                )),
                 raw: "\\xhex".into(),
             },
             tok!('`'),

--- a/crates/swc_ecma_parser/src/lexer/tests.rs
+++ b/crates/swc_ecma_parser/src/lexer/tests.rs
@@ -130,9 +130,7 @@ impl WithSpan for AssignOpToken {
 fn module_legacy_decimal() {
     assert_eq!(
         lex_module_errors(Syntax::default(), "08"),
-        vec![Error {
-            error: Box::new((sp(0..2), SyntaxError::LegacyDecimal)),
-        }]
+        vec![Error::new(sp(0..2), SyntaxError::LegacyDecimal)]
     );
 }
 
@@ -140,9 +138,7 @@ fn module_legacy_decimal() {
 fn module_legacy_comment_1() {
     assert_eq!(
         lex_module_errors(Syntax::default(), "<!-- foo oo"),
-        vec![Error {
-            error: Box::new((sp(0..11), SyntaxError::LegacyCommentInModule)),
-        }]
+        vec![Error::new(sp(0..11), SyntaxError::LegacyCommentInModule)]
     )
 }
 

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -106,9 +106,7 @@ impl<'a, I: Input> Lexer<'a, I> {
     #[cold]
     #[inline(never)]
     pub(super) fn error_span<T>(&mut self, span: Span, kind: SyntaxError) -> LexResult<T> {
-        Err(Error {
-            error: Box::new((span, kind)),
-        })
+        Err(Error::new(span, kind))
     }
 
     #[cold]
@@ -126,9 +124,7 @@ impl<'a, I: Input> Lexer<'a, I> {
         }
 
         warn!("Lexer error at {:?}", span);
-        let err = Error {
-            error: Box::new((span, kind)),
-        };
+        let err = Error::new(span, kind);
         self.errors.borrow_mut().push(err);
     }
 
@@ -147,9 +143,7 @@ impl<'a, I: Input> Lexer<'a, I> {
             return;
         }
 
-        let err = Error {
-            error: Box::new((span, kind)),
-        };
+        let err = Error::new(span, kind);
 
         self.add_module_mode_error(err);
     }
@@ -166,9 +160,7 @@ impl<'a, I: Input> Lexer<'a, I> {
     #[cold]
     #[inline(never)]
     pub(super) fn emit_module_mode_error_span(&mut self, span: Span, kind: SyntaxError) {
-        let err = Error {
-            error: Box::new((span, kind)),
-        };
+        let err = Error::new(span, kind);
 
         self.add_module_mode_error(err);
     }

--- a/crates/swc_ecma_parser/src/parser/macros.rs
+++ b/crates/swc_ecma_parser/src/parser/macros.rs
@@ -346,9 +346,7 @@ macro_rules! span {
 
 macro_rules! make_error {
     ($p:expr, $span:expr, $err:expr) => {{
-        crate::error::Error {
-            error: Box::new(($span, $err)),
-        }
+        crate::error::Error::new($span, $err)
     }};
 }
 

--- a/crates/swc_ecma_parser/src/parser/macros.rs
+++ b/crates/swc_ecma_parser/src/parser/macros.rs
@@ -247,14 +247,13 @@ macro_rules! cur {
             Some(c) => Ok(c),
             None => {
                 if $required {
-                    let err = crate::error::Error {
-                        error: Box::new((last, crate::error::SyntaxError::Eof)),
-                    };
+                    let err = crate::error::Error::new(last, crate::error::SyntaxError::Eof);
                     return Err(err);
                 }
-                Err(crate::error::Error {
-                    error: Box::new((last, crate::error::SyntaxError::Eof)),
-                })
+                Err(crate::error::Error::new(
+                    last,
+                    crate::error::SyntaxError::Eof,
+                ))
             }
         }
     }};
@@ -274,9 +273,7 @@ Current token is {:?}",
         match $p.input.peek() {
             Some(c) => Ok(c),
             None => {
-                let err = crate::error::Error {
-                    error: Box::new((last, crate::error::SyntaxError::Eof)),
-                };
+                let err = crate::error::Error::new(last, crate::error::SyntaxError::Eof);
                 Err(err)
             }
         }

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -221,9 +221,7 @@ impl<I: Tokens> Parser<I> {
             return;
         }
 
-        self.emit_error(Error {
-            error: Box::new((span, error)),
-        })
+        self.emit_error(Error::new(span, error))
     }
 
     #[cold]
@@ -240,9 +238,7 @@ impl<I: Tokens> Parser<I> {
         if self.ctx().ignore_error {
             return;
         }
-        let error = Error {
-            error: Box::new((span, error)),
-        };
+        let error = Error::new(span, error);
         self.input_ref().add_module_mode_error(error);
     }
 }

--- a/crates/swc_ecma_parser/src/parser/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/tests.rs
@@ -341,16 +341,14 @@ fn illegal_language_mode_directive2() {
             let errors = p.take_errors();
             assert_eq!(
                 errors,
-                vec![Error {
-                    error: Box::new((
-                        Span {
-                            lo: BytePos(21),
-                            hi: BytePos(34),
-                            ctxt: swc_common::SyntaxContext::empty()
-                        },
-                        crate::parser::SyntaxError::IllegalLanguageModeDirective
-                    ))
-                }]
+                vec![Error::new(
+                    Span {
+                        lo: BytePos(21),
+                        hi: BytePos(34),
+                        ctxt: swc_common::SyntaxContext::empty()
+                    },
+                    crate::parser::SyntaxError::IllegalLanguageModeDirective
+                )]
             );
 
             Ok(program)

--- a/crates/swc_ecma_parser/src/parser/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/tests.rs
@@ -314,16 +314,14 @@ fn illegal_language_mode_directive1() {
             let errors = p.take_errors();
             assert_eq!(
                 errors,
-                vec![Error {
-                    error: Box::new((
-                        Span {
-                            lo: BytePos(20),
-                            hi: BytePos(33),
-                            ctxt: swc_common::SyntaxContext::empty()
-                        },
-                        crate::parser::SyntaxError::IllegalLanguageModeDirective
-                    ))
-                }]
+                vec![Error::new(
+                    Span {
+                        lo: BytePos(20),
+                        hi: BytePos(33),
+                        ctxt: swc_common::SyntaxContext::empty()
+                    },
+                    crate::parser::SyntaxError::IllegalLanguageModeDirective
+                )]
             );
 
             Ok(program)


### PR DESCRIPTION
**Description:**

We emulate `unlikely` for vairous error macros by converting `Error::new` into a cold function.

## Before

```
test angular       ... bench:   7,922,906 ns/iter (+/- 284,640) = 90 MB/s
test backbone      ... bench:   1,093,366 ns/iter (+/- 30,800) = 54 MB/s
test colors        ... bench:      14,564 ns/iter (+/- 635) = 79 MB/s
test jquery        ... bench:   6,021,029 ns/iter (+/- 209,889) = 44 MB/s
test jquery_mobile ... bench:   9,654,149 ns/iter (+/- 154,489) = 46 MB/s
test mootools      ... bench:   4,645,033 ns/iter (+/- 117,356) = 34 MB/s
test three         ... bench:  27,476,366 ns/iter (+/- 1,396,719) = 43 MB/s
test underscore    ... bench:     942,445 ns/iter (+/- 12,220) = 46 MB/s
test yui           ... bench:   4,686,897 ns/iter (+/- 180,492) = 72 MB/s
```



## After

```
test angular       ... bench:   7,823,925 ns/iter (+/- 214,984) = 91 MB/s
test backbone      ... bench:   1,077,099 ns/iter (+/- 24,427) = 55 MB/s
test colors        ... bench:      14,139 ns/iter (+/- 88) = 81 MB/s
test jquery        ... bench:   5,954,287 ns/iter (+/- 167,003) = 45 MB/s
test jquery_mobile ... bench:   9,538,154 ns/iter (+/- 266,640) = 47 MB/s
test mootools      ... bench:   4,581,866 ns/iter (+/- 112,853) = 35 MB/s
test three         ... bench:  27,164,424 ns/iter (+/- 491,544) = 43 MB/s
test underscore    ... bench:     927,293 ns/iter (+/- 14,810) = 46 MB/s
test yui           ... bench:   4,626,075 ns/iter (+/- 141,111) = 73 MB/s
```