### PR TITLE
fix(es/optimizer): collect ident in for init first

### DIFF
--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
@@ -420,8 +420,6 @@ impl VisitMut for Inlining<'_> {
     }
 
     fn visit_mut_for_stmt(&mut self, node: &mut ForStmt) {
-        node.init.visit_mut_with(self);
-
         {
             node.init.visit_with(&mut IdentListVisitor {
                 scope: &mut self.scope,
@@ -438,6 +436,7 @@ impl VisitMut for Inlining<'_> {
             });
         }
 
+        node.init.visit_mut_with(self);
         node.test.visit_mut_with(self);
         node.update.visit_mut_with(self);
         self.visit_with_child(ScopeKind::Loop, &mut node.body);


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
Original code would collect ident at

https://github.com/swc-project/swc/blob/e77f0a2a373337181da14826097953e4f1d6b341/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs#L538

However that's only for stmts, so when branch turn
```js
if (cond) {
  aaa
}
// into
if (cond) aaa
```
declaration in `aaa` wouldn't be collected
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
closes #4173, closes #4174