### PR TITLE
fix(tests): rename all `inclidesStr` to `includesStr`

### DIFF
--- a/crates/swc_ecma_preset_env/tests/fixtures/corejs2/.usage-evaluated-class-methods/input.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/corejs2/.usage-evaluated-class-methods/input.mjs
@@ -3,7 +3,7 @@ var arrayInstance = [];
 var assignStr = "assign";
 var entriesStr = "entries";
 var valuesStr = "values";
-var inclidesStr = "includes";
+var includesStr = "includes";
 var findStr = "find";
 
 // Allow static methods be assigned to variables only directly in the module.

--- a/crates/swc_ecma_preset_env/tests/fixtures/corejs2/.usage-evaluated-class-methods/output.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/corejs2/.usage-evaluated-class-methods/output.mjs
@@ -7,7 +7,7 @@ var arrayInstance = [];
 var assignStr = "assign";
 var entriesStr = "entries";
 var valuesStr = "values";
-var inclidesStr = "includes";
+var includesStr = "includes";
 var findStr = "find"; // Allow static methods be assigned to variables only directly in the module.
 
 externalVar[valuesStr]; // don't include

--- a/crates/swc_ecma_preset_env/tests/fixtures/corejs2/.usage-evaluated-instance-methods/input.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/corejs2/.usage-evaluated-instance-methods/input.mjs
@@ -1,8 +1,8 @@
 var arrayInstance = [];
-var inclidesStr = "includes";
+var includesStr = "includes";
 var findStr = "find";
 
 // Allow instance methods be assigned to variables.
-arrayInstance[inclidesStr](); // include
+arrayInstance[includesStr](); // include
 externalVar[findStr]; // include
 

--- a/crates/swc_ecma_preset_env/tests/fixtures/corejs2/.usage-evaluated-instance-methods/output.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/corejs2/.usage-evaluated-instance-methods/output.mjs
@@ -1,9 +1,9 @@
 import "core-js/modules/es6.array.find";
 import "core-js/modules/es7.array.includes";
 var arrayInstance = [];
-var inclidesStr = "includes";
+var includesStr = "includes";
 var findStr = "find"; // Allow instance methods be assigned to variables.
 
-arrayInstance[inclidesStr](); // include
+arrayInstance[includesStr](); // include
 
 externalVar[findStr]; // include

--- a/crates/swc_ecma_preset_env/tests/fixtures/corejs3/.usage-evaluated-class-methods/input.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/corejs3/.usage-evaluated-class-methods/input.mjs
@@ -3,7 +3,7 @@ var arrayInstance = [];
 var assignStr = "assign";
 var entriesStr = "entries";
 var valuesStr = "values";
-var inclidesStr = "includes";
+var includesStr = "includes";
 var findStr = "find";
 
 // Allow static methods be assigned to variables only directly in the module.

--- a/crates/swc_ecma_preset_env/tests/fixtures/corejs3/.usage-evaluated-class-methods/output.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/corejs3/.usage-evaluated-class-methods/output.mjs
@@ -7,7 +7,7 @@ var arrayInstance = [];
 var assignStr = "assign";
 var entriesStr = "entries";
 var valuesStr = "values";
-var inclidesStr = "includes";
+var includesStr = "includes";
 var findStr = "find"; // Allow static methods be assigned to variables only directly in the module.
 
 externalVar[valuesStr]; // don't include

--- a/crates/swc_ecma_preset_env/tests/fixtures/corejs3/.usage-evaluated-instance-methods/input.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/corejs3/.usage-evaluated-instance-methods/input.mjs
@@ -1,8 +1,8 @@
 var arrayInstance = [];
-var inclidesStr = "includes";
+var includesStr = "includes";
 var findStr = "find";
 
 // Allow instance methods be assigned to variables.
-arrayInstance[inclidesStr](); // include
+arrayInstance[includesStr](); // include
 externalVar[findStr]; // include
 

--- a/crates/swc_ecma_preset_env/tests/fixtures/corejs3/.usage-evaluated-instance-methods/output.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/corejs3/.usage-evaluated-instance-methods/output.mjs
@@ -1,9 +1,9 @@
 import "core-js/modules/es.array.find";
 import "core-js/modules/es.array.includes";
 var arrayInstance = [];
-var inclidesStr = "includes";
+var includesStr = "includes";
 var findStr = "find"; // Allow instance methods be assigned to variables.
 
-arrayInstance[inclidesStr](); // include
+arrayInstance[includesStr](); // include
 
 externalVar[findStr]; // include


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

When I read the code of swc, I found that many places in the test code use the `inclidesStr` variable to define a string of `'includes'`, I tried to find the reason for this definition, but I didn't find it, so I think it may be a spelling bugs and I fixed them.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

No

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
