### PR TITLE
build(cargo): dedupe swc_common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_comments"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "better_scoped_tls",
  "rkyv",

--- a/crates/jsdoc/Cargo.toml
+++ b/crates/jsdoc/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 nom = "7.1.0"
 serde = {version = "1", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 
 [dev-dependencies]
 anyhow = "1"

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = "1"
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_cached = {version = "0.1.0", path = "../swc_cached"}
-swc_common = {version = "0.17.0", path = "../swc_common", features = [
+swc_common = {version = "0.17.19", path = "../swc_common", features = [
   "sourcemap",
   "concurrent",
   "parking_lot",
@@ -81,7 +81,7 @@ swc_ecma_visit = {version = "0.60.0", path = "../swc_ecma_visit"}
 swc_ecmascript = {version = "0.142.0", path = "../swc_ecmascript"}
 swc_error_reporters = {version = "0.1.0", path = "../swc_error_reporters"}
 swc_node_comments = {version = "0.4.0", path = "../swc_node_comments"}
-swc_plugin_comments = {version = "0.1.0", path = "../swc_plugin_comments", optional = true}
+swc_plugin_comments = {version = "0.1.1", path = "../swc_plugin_comments", optional = true}
 swc_plugin_runner = {version = "0.49.0", path = "../swc_plugin_runner", optional = true, default-features = false}
 swc_visit = {version = "0.3.0", path = "../swc_visit"}
 tracing = "0.1.32"

--- a/crates/swc_bundler/Cargo.toml
+++ b/crates/swc_bundler/Cargo.toml
@@ -44,7 +44,7 @@ rayon = {version = "1", optional = true}
 relative-path = "1.2"
 retain_mut = "0.1.2"
 swc_atoms = {version = "0.2.4", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_codegen = {version = "0.102.0", path = "../swc_ecma_codegen"}
 swc_ecma_loader = {version = "0.29.0", path = "../swc_ecma_loader"}

--- a/crates/swc_cli/Cargo.toml
+++ b/crates/swc_cli/Cargo.toml
@@ -32,7 +32,7 @@ relative-path = "1.6.1"
 serde = {version = "1", features = ["derive"]}
 serde_json = {version = "1", features = ["unbounded_depth"]}
 swc = {version = "0.163.0", path = "../swc"}
-swc_common = {version = "0.17.5", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_plugin_runner = {version = "0.49.0", path = "../swc_plugin_runner", default-features = false, optional = true}
 swc_trace_macro = {version = "0.1.0", path = "../swc_trace_macro"}
 tracing = "0.1.32"

--- a/crates/swc_css_ast/Cargo.toml
+++ b/crates/swc_css_ast/Cargo.toml
@@ -16,4 +16,4 @@ is-macro = "0.2.0"
 serde = {version = "1.0.127", features = ["derive"]}
 string_enum = {version = "0.3.1", path = "../string_enum/"}
 swc_atoms = {version = "0.2.7", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}

--- a/crates/swc_css_codegen/Cargo.toml
+++ b/crates/swc_css_codegen/Cargo.toml
@@ -16,12 +16,12 @@ bench = false
 auto_impl = "0.5.0"
 bitflags = "1.3.2"
 swc_atoms = {version = "0.2.7", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_css_ast = {version = "0.92.0", path = "../swc_css_ast"}
 swc_css_codegen_macros = {version = "0.2.0", path = "../swc_css_codegen_macros"}
 
 [dev-dependencies]
-swc_common = {version = "0.17.3", path = "../swc_common", features = [
+swc_common = {version = "0.17.19", path = "../swc_common", features = [
   "sourcemap",
 ]}
 swc_css_parser = {version = "0.100.0", path = "../swc_css_parser"}

--- a/crates/swc_css_lints/Cargo.toml
+++ b/crates/swc_css_lints/Cargo.toml
@@ -19,7 +19,7 @@ rayon = "1.5.1"
 serde = {version = "1.0.133", features = ["derive"]}
 swc_atoms = {version = "0.2.9", path = "../swc_atoms"}
 swc_cached = {version = "0.1.0", path = "../swc_cached"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_css_ast = {version = "0.92.0", path = "../swc_css_ast"}
 swc_css_visit = {version = "0.91.0", path = "../swc_css_visit"}
 thiserror = "1.0.30"

--- a/crates/swc_css_minifier/Cargo.toml
+++ b/crates/swc_css_minifier/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 
 [dependencies]
 swc_atoms = {version = "0.2.9", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_css_ast = {version = "0.92.0", path = "../swc_css_ast"}
 swc_css_visit = {version = "0.91.0", path = "../swc_css_visit"}
 

--- a/crates/swc_css_parser/Cargo.toml
+++ b/crates/swc_css_parser/Cargo.toml
@@ -19,7 +19,7 @@ debug = []
 bitflags = "1.2.1"
 lexical = "6.1.0"
 swc_atoms = {version = "0.2.7", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_css_ast = {version = "0.92.0", path = "../swc_css_ast"}
 
 [dev-dependencies]

--- a/crates/swc_css_prefixer/Cargo.toml
+++ b/crates/swc_css_prefixer/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 
 [dependencies]
 swc_atoms = {version = "0.2.7", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_css_ast = {version = "0.92.0", path = "../swc_css_ast"}
 swc_css_utils = {version = "0.89.0", path = "../swc_css_utils/"}
 swc_css_visit = {version = "0.91.0", path = "../swc_css_visit"}

--- a/crates/swc_css_utils/Cargo.toml
+++ b/crates/swc_css_utils/Cargo.toml
@@ -13,6 +13,6 @@ bench = false
 
 [dependencies]
 swc_atoms = {version = "0.2.7", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_css_ast = {version = "0.92.0", path = "../swc_css_ast"}
 swc_css_visit = {version = "0.91.0", path = "../swc_css_visit"}

--- a/crates/swc_css_visit/Cargo.toml
+++ b/crates/swc_css_visit/Cargo.toml
@@ -13,6 +13,6 @@ bench = false
 
 [dependencies]
 swc_atoms = {version = "0.2.7", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_css_ast = {version = "0.92.0", path = "../swc_css_ast"}
 swc_visit = {version = "0.3.0", path = "../swc_visit"}

--- a/crates/swc_ecma_ast/Cargo.toml
+++ b/crates/swc_ecma_ast/Cargo.toml
@@ -28,7 +28,7 @@ rkyv = {version = "0.7.28", optional = true}
 serde = {version = "1.0.133", features = ["derive"]}
 string_enum = {version = "0.3.1", path = "../string_enum"}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 unicode-id = "0.3"
 
 [dev-dependencies]

--- a/crates/swc_ecma_codegen/Cargo.toml
+++ b/crates/swc_ecma_codegen/Cargo.toml
@@ -20,14 +20,14 @@ once_cell = "1.10.0"
 rustc-hash = "1.1.0"
 sourcemap = "6"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.3", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_codegen_macros = {version = "0.7.0", path = "../swc_ecma_codegen_macros"}
 tracing = "0.1.32"
 
 [dev-dependencies]
 criterion = "0.3"
-swc_common = {version = "0.17.3", path = "../swc_common", features = [
+swc_common = {version = "0.17.19", path = "../swc_common", features = [
   "sourcemap",
 ]}
 swc_ecma_parser = {version = "0.99.0", path = "../swc_ecma_parser"}

--- a/crates/swc_ecma_dep_graph/Cargo.toml
+++ b/crates/swc_ecma_dep_graph/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 
 [dependencies]
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_visit = {version = "0.60.0", path = "../swc_ecma_visit"}
 

--- a/crates/swc_ecma_ext_transforms/Cargo.toml
+++ b/crates/swc_ecma_ext_transforms/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 [dependencies]
 phf = {version = "0.10", features = ["macros"]}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_utils = {version = "0.78.0", path = "../swc_ecma_utils"}
 swc_ecma_visit = {version = "0.60.0", path = "../swc_ecma_visit"}

--- a/crates/swc_ecma_lints/Cargo.toml
+++ b/crates/swc_ecma_lints/Cargo.toml
@@ -21,7 +21,7 @@ rayon = "1.5.1"
 regex = "1"
 serde = {version = "1.0.133", features = ["derive"]}
 swc_atoms = {version = "0.2.9", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common", features = [
+swc_common = {version = "0.17.19", path = "../swc_common", features = [
   "concurrent",
 ]}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}

--- a/crates/swc_ecma_loader/Cargo.toml
+++ b/crates/swc_ecma_loader/Cargo.toml
@@ -35,7 +35,7 @@ path-clean = {version = "=0.1.0", optional = true}
 serde = {version = "1", features = ["derive"]}
 serde_json = {version = "1.0.64", optional = true}
 swc_cached = {version = "0.1.0", optional = true, path = "../swc_cached"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 tracing = "0.1.32"
 
 [dev-dependencies]

--- a/crates/swc_ecma_minifier/Cargo.toml
+++ b/crates/swc_ecma_minifier/Cargo.toml
@@ -34,7 +34,7 @@ serde = {version = "1.0.118", features = ["derive"]}
 serde_json = "1.0.61"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_cached = {version = "0.1.0", path = "../swc_cached"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_codegen = {version = "0.102.0", path = "../swc_ecma_codegen"}
 swc_ecma_parser = {version = "0.99.0", path = "../swc_ecma_parser"}

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -31,7 +31,7 @@ num-bigint = "0.4"
 serde = {version = "1", features = ["derive"]}
 smallvec = "1.8.0"
 swc_atoms = {version = "0.2.3", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_visit = {version = "0.60.0", path = "../swc_ecma_visit", optional = true}
 tracing = "0.1.32"

--- a/crates/swc_ecma_preset_env/Cargo.toml
+++ b/crates/swc_ecma_preset_env/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1"
 st-map = "0.1.2"
 string_enum = {version = "0.3.1", path = "../string_enum"}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_transforms = {version = "0.141.0", path = "../swc_ecma_transforms", features = [
   "compat",

--- a/crates/swc_ecma_quote/Cargo.toml
+++ b/crates/swc_ecma_quote/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 
 [dependencies]
 swc_atoms = {version = "0.2.9", path = "../swc_atoms"}
-swc_common = {version = "0.17.9", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_quote_macros = {version = "0.9.0", path = "../swc_ecma_quote_macros"}
 swc_ecma_utils = {version = "0.78.0", path = "../swc_ecma_utils"}

--- a/crates/swc_ecma_quote_macros/Cargo.toml
+++ b/crates/swc_ecma_quote_macros/Cargo.toml
@@ -18,7 +18,7 @@ pmutil = "0.5.1"
 proc-macro2 = "1"
 quote = "1"
 swc_atoms = {version = "0.2.9", path = "../swc_atoms"}
-swc_common = {version = "0.17.9", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_parser = {version = "0.99.0", path = "../swc_ecma_parser"}
 swc_macros_common = {version = "0.3.3", path = "../swc_macros_common"}

--- a/crates/swc_ecma_transforms/Cargo.toml
+++ b/crates/swc_ecma_transforms/Cargo.toml
@@ -28,7 +28,7 @@ typescript = ["swc_ecma_transforms_typescript"]
 
 [dependencies]
 swc_atoms = {version = "0.2.0", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_transforms_base = {version = "0.74.0", path = "../swc_ecma_transforms_base"}
 swc_ecma_transforms_compat = {version = "0.88.0", path = "../swc_ecma_transforms_compat", optional = true}

--- a/crates/swc_ecma_transforms_base/Cargo.toml
+++ b/crates/swc_ecma_transforms_base/Cargo.toml
@@ -23,7 +23,7 @@ rayon = {version = "1", optional = true}
 serde = {version = "1", features = ["derive"]}
 smallvec = "1.8.0"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_parser = {version = "0.99.0", path = "../swc_ecma_parser"}
 swc_ecma_utils = {version = "0.78.0", path = "../swc_ecma_utils"}

--- a/crates/swc_ecma_transforms_classes/Cargo.toml
+++ b/crates/swc_ecma_transforms_classes/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 
 [dependencies]
 swc_atoms = {version = "0.2.6", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_transforms_base = {version = "0.74.0", path = "../swc_ecma_transforms_base"}
 swc_ecma_utils = {version = "0.78.0", path = "../swc_ecma_utils"}

--- a/crates/swc_ecma_transforms_compat/Cargo.toml
+++ b/crates/swc_ecma_transforms_compat/Cargo.toml
@@ -30,7 +30,7 @@ rayon = {version = "1.5.1", optional = true}
 serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.8.0"
 swc_atoms = {version = "0.2.5", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_transforms_base = {version = "0.74.0", path = "../swc_ecma_transforms_base"}
 swc_ecma_transforms_classes = {version = "0.62.0", path = "../swc_ecma_transforms_classes"}

--- a/crates/swc_ecma_transforms_module/Cargo.toml
+++ b/crates/swc_ecma_transforms_module/Cargo.toml
@@ -21,7 +21,7 @@ pathdiff = "0.2.0"
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
 swc_cached = {version = "0.1.0", path = "../swc_cached"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_loader = {version = "0.29.0", path = "../swc_ecma_loader", features = [
   "node",

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -31,7 +31,7 @@ once_cell = "1.10.0"
 rayon = {version = "1.5.1", optional = true}
 serde_json = "1.0.61"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_parser = {version = "0.99.0", path = "../swc_ecma_parser"}
 swc_ecma_transforms_base = {version = "0.74.0", path = "../swc_ecma_transforms_base"}

--- a/crates/swc_ecma_transforms_proposal/Cargo.toml
+++ b/crates/swc_ecma_transforms_proposal/Cargo.toml
@@ -21,7 +21,7 @@ either = "1.6.1"
 serde = {version = "1.0.118", features = ["derive"]}
 smallvec = "1.8.0"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_loader = {version = "0.29.0", path = "../swc_ecma_loader", optional = true}
 swc_ecma_transforms_base = {version = "0.74.0", path = "../swc_ecma_transforms_base"}

--- a/crates/swc_ecma_transforms_react/Cargo.toml
+++ b/crates/swc_ecma_transforms_react/Cargo.toml
@@ -23,7 +23,7 @@ serde = {version = "1.0.118", features = ["derive"]}
 sha-1 = "0.10.0"
 string_enum = {version = "0.3.1", path = "../string_enum"}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_parser = {version = "0.99.0", path = "../swc_ecma_parser"}
 swc_ecma_transforms_base = {version = "0.74.0", path = "../swc_ecma_transforms_base"}

--- a/crates/swc_ecma_transforms_testing/Cargo.toml
+++ b/crates/swc_ecma_transforms_testing/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4.3"
 serde = "1"
 serde_json = "1"
 sha-1 = "0.10"
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_codegen = {version = "0.102.0", path = "../swc_ecma_codegen"}
 swc_ecma_parser = {version = "0.99.0", path = "../swc_ecma_parser"}

--- a/crates/swc_ecma_transforms_typescript/Cargo.toml
+++ b/crates/swc_ecma_transforms_typescript/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 [dependencies]
 serde = {version = "1.0.118", features = ["derive"]}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_transforms_base = {version = "0.74.0", path = "../swc_ecma_transforms_base"}
 swc_ecma_transforms_react = {version = "0.103.0", path = "../swc_ecma_transforms_react"}

--- a/crates/swc_ecma_utils/Cargo.toml
+++ b/crates/swc_ecma_utils/Cargo.toml
@@ -24,7 +24,7 @@ indexmap = "1"
 once_cell = "1.10.0"
 rayon = {version = "1.5.1", optional = true}
 swc_atoms = {version = "0.2.0", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_visit = {version = "0.60.0", path = "../swc_ecma_visit"}
 tracing = "0.1.32"

--- a/crates/swc_ecma_visit/Cargo.toml
+++ b/crates/swc_ecma_visit/Cargo.toml
@@ -17,7 +17,7 @@ debug = []
 [dependencies]
 num-bigint = {version = "0.4", features = ["serde"]}
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_visit = {version = "0.3.0", path = "../swc_visit"}
 tracing = "0.1.32"

--- a/crates/swc_error_reporters/Cargo.toml
+++ b/crates/swc_error_reporters/Cargo.toml
@@ -13,6 +13,6 @@ bench = false
 
 [dependencies]
 miette = {version = "4.2.1", features = ["fancy"]}
-swc_common = {version = "0.17.0", path = "../swc_common", features = [
+swc_common = {version = "0.17.19", path = "../swc_common", features = [
   "concurrent",
 ]}

--- a/crates/swc_estree_ast/Cargo.toml
+++ b/crates/swc_estree_ast/Cargo.toml
@@ -22,4 +22,4 @@ better_scoped_tls = {version = "0.1.0", path = "../better_scoped_tls"}
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}

--- a/crates/swc_estree_compat/Cargo.toml
+++ b/crates/swc_estree_compat/Cargo.toml
@@ -23,7 +23,7 @@ rayon = "1.5.0"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1.0.62"
 swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common", features = [
+swc_common = {version = "0.17.19", path = "../swc_common", features = [
   "concurrent",
   "sourcemap",
   "tty-emitter",

--- a/crates/swc_fast_graph/Cargo.toml
+++ b/crates/swc_fast_graph/Cargo.toml
@@ -15,4 +15,4 @@ bench = false
 ahash = "0.7.6"
 indexmap = "1.7.0"
 petgraph = "0.6"
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}

--- a/crates/swc_html_ast/Cargo.toml
+++ b/crates/swc_html_ast/Cargo.toml
@@ -16,4 +16,4 @@ is-macro = "0.2.0"
 serde = {version = "1.0.127", features = ["derive"]}
 string_enum = {version = "0.3.1", path = "../string_enum/"}
 swc_atoms = {version = "0.2.7", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}

--- a/crates/swc_html_codegen/Cargo.toml
+++ b/crates/swc_html_codegen/Cargo.toml
@@ -16,12 +16,12 @@ bench = false
 auto_impl = "0.5.0"
 bitflags = "1.3.2"
 swc_atoms = {version = "0.2.7", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_html_ast = {version = "0.1.0", path = "../swc_html_ast"}
 swc_html_codegen_macros = {version = "0.1.0", path = "../swc_html_codegen_macros"}
 
 [dev-dependencies]
-swc_common = {version = "0.17.3", path = "../swc_common", features = [
+swc_common = {version = "0.17.19", path = "../swc_common", features = [
   "sourcemap",
 ]}
 swc_html_parser = {version = "0.1.0", path = "../swc_html_parser"}

--- a/crates/swc_html_parser/Cargo.toml
+++ b/crates/swc_html_parser/Cargo.toml
@@ -19,7 +19,7 @@ debug = []
 bitflags = "1.2.1"
 lexical = "6.1.0"
 swc_atoms = {version = "0.2.7", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_html_ast = {version = "0.1.0", path = "../swc_html_ast"}
 
 [dev-dependencies]

--- a/crates/swc_html_visit/Cargo.toml
+++ b/crates/swc_html_visit/Cargo.toml
@@ -13,6 +13,6 @@ bench = false
 
 [dependencies]
 swc_atoms = {version = "0.2.7", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_html_ast = {version = "0.1.0", path = "../swc_html_ast"}
 swc_visit = {version = "0.3.0", path = "../swc_visit"}

--- a/crates/swc_node_comments/Cargo.toml
+++ b/crates/swc_node_comments/Cargo.toml
@@ -17,4 +17,4 @@ bench = false
 [dependencies]
 ahash = "0.7.6"
 dashmap = "5.1.0"
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}

--- a/crates/swc_plugin/Cargo.toml
+++ b/crates/swc_plugin/Cargo.toml
@@ -20,7 +20,7 @@ quote = ["swc_ecma_quote"]
 
 [dependencies]
 swc_atoms = {version = "0.2.0", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common", features = [
+swc_common = {version = "0.17.19", path = "../swc_common", features = [
   "plugin-mode",
 ]}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast", features = [
@@ -28,7 +28,7 @@ swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast", features = [
 ]}
 swc_ecma_quote = {version = "0.10.0", path = "../swc_ecma_quote", optional = true}
 swc_ecma_visit = {version = "0.60.0", path = "../swc_ecma_visit"}
-swc_plugin_comments = {version = "0.1.0", path = "../swc_plugin_comments", features = [
+swc_plugin_comments = {version = "0.1.1", path = "../swc_plugin_comments", features = [
   "plugin-mode",
 ]}
 swc_plugin_macro = {version = "0.4.0", path = "../swc_plugin_macro"}

--- a/crates/swc_plugin_comments/Cargo.toml
+++ b/crates/swc_plugin_comments/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "swc_plugin_comments"
 repository = "https://github.com/swc-project/swc.git"
-version = "0.1.0"
+version = "0.1.1"
 
 [lib]
 bench = false
@@ -19,6 +19,6 @@ plugin-mode = []
 [dependencies]
 better_scoped_tls = {version = "0.1.0", path = "../better_scoped_tls"}
 rkyv = "0.7.36"
-swc_common = {version = "0.17.0", path = "../swc_common", features = [
+swc_common = {version = "0.17.19", path = "../swc_common", features = [
   "plugin-base",
 ]}

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -26,14 +26,14 @@ once_cell = "1.10.0"
 parking_lot = "0.12.0"
 serde = {version = "1.0.126", features = ["derive"]}
 serde_json = "1.0.64"
-swc_common = {version = "0.17.0", path = "../swc_common", features = [
+swc_common = {version = "0.17.19", path = "../swc_common", features = [
   "plugin-rt",
   "concurrent",
 ]}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast", features = [
   "rkyv-impl",
 ]}
-swc_plugin_comments = {version = "0.1.0", path = "../swc_plugin_comments", features = [
+swc_plugin_comments = {version = "0.1.1", path = "../swc_plugin_comments", features = [
   "plugin-rt",
 ]}
 tracing = "0.1.32"

--- a/crates/swc_webpack_ast/Cargo.toml
+++ b/crates/swc_webpack_ast/Cargo.toml
@@ -17,7 +17,7 @@ rayon = "1.5.1"
 serde = {version = "1", features = ["derive", "rc"]}
 serde_json = "1.0.72"
 swc_atoms = {version = "0.2.9", path = "../swc_atoms"}
-swc_common = {version = "0.17.0", path = "../swc_common"}
+swc_common = {version = "0.17.19", path = "../swc_common"}
 swc_ecma_ast = {version = "0.74.0", path = "../swc_ecma_ast"}
 swc_ecma_parser = {version = "0.99.0", path = "../swc_ecma_parser"}
 swc_ecma_transforms_base = {version = "0.74.0", path = "../swc_ecma_transforms_base"}

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -18,7 +18,7 @@ once_cell = "1.10.0"
 pretty_assertions = "1.1"
 regex = "1"
 serde_json = "1.0.71"
-swc_common = {version = "0.17.0", path = "../swc_common", features = [
+swc_common = {version = "0.17.19", path = "../swc_common", features = [
   "tty-emitter",
 ]}
 swc_error_reporters = {version = "0.1.0", path = "../swc_error_reporters"}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR bumps up swc_plugin_comments (https://github.com/swc-project/swc/compare/main...kwonoj:dedupe-common?expand=1#diff-3e6e03a99597d39766266450bfe5b476c2988cd9fbbad61850e1dca516ca7f75R8) to get latest changes published to crates.io, also aligns version to swc_common to dedupe as much.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
