### PR TITLE
Export swc_ecma_utils from swc_plugin as swc_ecma_utils::utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3852,6 +3852,7 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_quote",
+ "swc_ecma_utils",
  "swc_ecma_visit",
  "swc_plugin_comments",
  "swc_plugin_macro",

--- a/crates/swc_plugin/Cargo.toml
+++ b/crates/swc_plugin/Cargo.toml
@@ -28,6 +28,7 @@ swc_ecma_ast = { version = "0.75.0", path = "../swc_ecma_ast", features = [
 ] }
 swc_ecma_quote = { version = "0.11.0", path = "../swc_ecma_quote", optional = true }
 swc_ecma_visit = { version = "0.61.0", path = "../swc_ecma_visit" }
+swc_ecma_utils = { version = "0.79.0", path = "../swc_ecma_utils" }
 swc_plugin_comments = { version = "0.1.1", path = "../swc_plugin_comments", features = [
   "plugin-mode",
 ] }

--- a/crates/swc_plugin/src/lib.rs
+++ b/crates/swc_plugin/src/lib.rs
@@ -18,6 +18,10 @@ pub mod util {
     pub use swc_ecma_quote::*;
 }
 
+pub mod utils {
+    pub use swc_ecma_utils::*;
+}
+
 pub mod ast {
     pub use swc_atoms::*;
     pub use swc_ecma_ast::*;


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
This PR exports `swc_ecma_utils` from `swc_plugin` as `utils`. 

The main reason for this change is to allow the  `swc_ecma_utils::ident::IdentLike` trait to be applied to `swc_plugin::ast::Ident`. 

So that I can use `.to_id()` like `default_specifier.local.to_id()`.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

