### PR TITLE
feat(es/compiler): Make TypeScript support an opt-in option

### DIFF
--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -52,6 +52,15 @@ name = "lexer"
 
 [[example]]
 name = "typescript"
+required-features = ["typescript"]
+
+[[example]]
+name = "perf"
+required-features = ["typescript"]
+
+[[test]]
+name = "typescript"
+required-features = ["typescript"]
 
 [[bench]]
 harness = false

--- a/crates/swc_ecma_parser/src/lexer/tests.rs
+++ b/crates/swc_ecma_parser/src/lexer/tests.rs
@@ -1570,6 +1570,7 @@ fn lex_colors_js(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(feature = "typescript")]
 fn lex_colors_ts(b: &mut Bencher) {
     b.bytes = include_str!("../../colors.js").len() as _;
 
@@ -1732,6 +1733,7 @@ fn lex_semicolons(b: &mut Bencher) {
 }
 
 #[test]
+#[cfg(feature = "typescript")]
 fn issue_1272_1_ts() {
     let (tokens, errors) = lex_errors(crate::Syntax::Typescript(Default::default()), "\\u{16}");
     assert_eq!(tokens.len(), 1);
@@ -1746,6 +1748,7 @@ fn issue_1272_1_js() {
 }
 
 #[test]
+#[cfg(feature = "typescript")]
 fn issue_1272_2_ts() {
     // Not recoverable yet
     let (tokens, errors) = lex_errors(crate::Syntax::Typescript(Default::default()), "\u{16}");
@@ -1781,6 +1784,7 @@ fn issue_2853_1_js() {
 }
 
 #[test]
+#[cfg(feature = "typescript")]
 fn issue_2853_2_ts() {
     let (tokens, errors) = lex_errors(
         crate::Syntax::Typescript(Default::default()),
@@ -1825,6 +1829,7 @@ fn issue_2853_3_js() {
 }
 
 #[test]
+#[cfg(feature = "typescript")]
 fn issue_2853_4_ts() {
     let (tokens, errors) = lex_errors(
         crate::Syntax::Typescript(Default::default()),
@@ -1872,6 +1877,7 @@ fn issue_2853_5_jsx() {
 }
 
 #[test]
+#[cfg(feature = "typescript")]
 fn issue_2853_6_tsx() {
     let (tokens, errors) = lex_errors(
         crate::Syntax::Typescript(crate::TsConfig {
@@ -1922,6 +1928,7 @@ fn issue_2853_7_jsx() {
 }
 
 #[test]
+#[cfg(feature = "typescript")]
 fn issue_2853_8_tsx() {
     let (tokens, errors) = lex_errors(
         crate::Syntax::Typescript(crate::TsConfig {

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -169,10 +169,23 @@ impl Syntax {
             Syntax::Es(EsConfig {
                 import_assertions, ..
             }) => import_assertions,
+            #[cfg(feature = "typescript")]
             Syntax::Typescript(_) => true,
         }
     }
 
+    #[cfg(not(feature = "typescript"))]
+    pub fn static_blocks(self) -> bool {
+        matches!(
+            self,
+            Syntax::Es(EsConfig {
+                static_blocks: true,
+                ..
+            })
+        )
+    }
+
+    #[cfg(feature = "typescript")]
     pub fn static_blocks(self) -> bool {
         matches!(
             self,
@@ -184,6 +197,13 @@ impl Syntax {
     }
 
     /// Should we parse jsx?
+    #[cfg(not(feature = "typescript"))]
+    pub fn jsx(self) -> bool {
+        matches!(self, Syntax::Es(EsConfig { jsx: true, .. }))
+    }
+
+    /// Should we parse jsx?
+    #[cfg(feature = "typescript")]
     pub fn jsx(self) -> bool {
         matches!(
             self,
@@ -203,6 +223,18 @@ impl Syntax {
         matches!(self, Syntax::Es(EsConfig { fn_bind: true, .. }))
     }
 
+    #[cfg(not(feature = "typescript"))]
+    pub fn decorators(self) -> bool {
+        matches!(
+            self,
+            Syntax::Es(EsConfig {
+                decorators: true,
+                ..
+            })
+        )
+    }
+
+    #[cfg(feature = "typescript")]
     pub fn decorators(self) -> bool {
         matches!(
             self,
@@ -216,6 +248,18 @@ impl Syntax {
         )
     }
 
+    #[cfg(not(feature = "typescript"))]
+    pub fn decorators_before_export(self) -> bool {
+        matches!(
+            self,
+            Syntax::Es(EsConfig {
+                decorators_before_export: true,
+                ..
+            })
+        )
+    }
+
+    #[cfg(feature = "typescript")]
     pub fn decorators_before_export(self) -> bool {
         matches!(
             self,
@@ -248,10 +292,16 @@ impl Syntax {
         )
     }
 
+    #[cfg(not(feature = "typescript"))]
+    pub fn dts(self) -> bool {
+        false
+    }
+
+    #[cfg(feature = "typescript")]
     pub fn dts(self) -> bool {
         match self {
+            Syntax::Es(..) => false,
             Syntax::Typescript(t) => t.dts,
-            _ => false,
         }
     }
 
@@ -260,6 +310,7 @@ impl Syntax {
             Syntax::Es(EsConfig {
                 private_in_object, ..
             }) => private_in_object,
+            #[cfg(feature = "typescript")]
             Syntax::Typescript(_) => true,
         }
     }
@@ -270,14 +321,21 @@ impl Syntax {
                 allow_super_outside_method,
                 ..
             }) => allow_super_outside_method,
+            #[cfg(feature = "typescript")]
             Syntax::Typescript(_) => true,
         }
     }
 
+    #[cfg(not(feature = "typescript"))]
+    pub(crate) fn early_errors(self) -> bool {
+        true
+    }
+
+    #[cfg(feature = "typescript")]
     pub(crate) fn early_errors(self) -> bool {
         match self {
-            Syntax::Typescript(t) => !t.no_early_errors,
             Syntax::Es(..) => true,
+            Syntax::Typescript(t) => !t.no_early_errors,
         }
     }
 }
@@ -364,16 +422,23 @@ pub struct Context {
     in_declare: bool,
 
     /// If true, `:` should not be treated as a type annotation.
+    #[cfg(feature = "typescript")]
     in_cond_expr: bool,
+
+    #[cfg(feature = "typescript")]
     is_direct_child_of_cond: bool,
 
     in_function: bool,
 
+    #[cfg(feature = "typescript")]
     in_arrow_function: bool,
+
+    #[cfg(feature = "typescript")]
     is_direct_child_of_braceless_arrow_function: bool,
 
     in_parameters: bool,
 
+    #[cfg(feature = "typescript")]
     has_super_class: bool,
 
     in_property_name: bool,
@@ -381,6 +446,7 @@ pub struct Context {
     in_forced_jsx_context: bool,
 
     /// If true, `:` should not be treated as a type annotation.
+    #[cfg(feature = "typescript")]
     dont_parse_colon_as_type_ann: bool,
 
     // If true, allow super.x and super[x]

--- a/crates/swc_ecma_parser/src/parser/expr/ops.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/ops.rs
@@ -86,8 +86,10 @@ impl<'a, I: Tokens> Parser<I> {
         left: Box<Expr>,
         min_prec: u8,
     ) -> PResult<(Box<Expr>, Option<u8>)> {
+        #[cfg(feature = "typescript")]
         const PREC_OF_IN: u8 = 7;
 
+        #[cfg(feature = "typescript")]
         if self.input.syntax().typescript()
             && PREC_OF_IN > min_prec
             && !self.input.had_line_break_before_cur()
@@ -228,6 +230,7 @@ impl<'a, I: Tokens> Parser<I> {
         trace_cur!(self, parse_unary_expr);
         let start = cur_pos!(self);
 
+        #[cfg(feature = "typescript")]
         if !self.input.syntax().jsx() && self.input.syntax().typescript() && eat!(self, '<') {
             if eat!(self, "const") {
                 expect!(self, '>');

--- a/crates/swc_ecma_parser/src/parser/expr/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/tests.rs
@@ -491,6 +491,7 @@ fn super_expr_computed() {
 }
 
 #[test]
+#[cfg(feature = "typescript")]
 fn issue_3672_1() {
     test_parser(
         "report({
@@ -502,6 +503,7 @@ fn issue_3672_1() {
 }
 
 #[test]
+#[cfg(feature = "typescript")]
 fn issue_3672_2() {
     test_parser(
         "f(a ? (): void => { } : (): void => { })",
@@ -511,6 +513,7 @@ fn issue_3672_2() {
 }
 
 #[bench]
+#[cfg(feature = "typescript")]
 fn bench_new_expr_ts(b: &mut Bencher) {
     bench_parser(
         b,
@@ -532,6 +535,7 @@ fn bench_new_expr_es(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(feature = "typescript")]
 fn bench_member_expr_ts(b: &mut Bencher) {
     bench_parser(
         b,

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -279,6 +279,7 @@ impl<I: Tokens> Buffer<I> {
         }
     }
 
+    #[cfg(feature = "typescript")]
     pub fn store(&mut self, token: Token) {
         debug_assert!(self.next.is_none());
         debug_assert!(self.cur.is_none());
@@ -390,6 +391,7 @@ impl<I: Tokens> Buffer<I> {
     }
 
     #[inline]
+    #[cfg(feature = "typescript")]
     pub fn is(&mut self, expected: &Token) -> bool {
         match self.cur() {
             Some(t) => *expected == *t,
@@ -397,6 +399,7 @@ impl<I: Tokens> Buffer<I> {
         }
     }
 
+    #[cfg(feature = "typescript")]
     #[inline]
     pub fn eat(&mut self, expected: &Token) -> bool {
         let v = self.is(expected);
@@ -463,21 +466,25 @@ impl<I: Tokens> Buffer<I> {
     }
 
     #[inline]
+    #[cfg(feature = "typescript")]
     pub(crate) fn set_expr_allowed(&mut self, allow: bool) {
         self.iter.set_expr_allowed(allow)
     }
 
     #[inline]
+    #[cfg(feature = "typescript")]
     pub(crate) fn token_context(&self) -> &lexer::TokenContexts {
         self.iter.token_context()
     }
 
     #[inline]
+    #[cfg(feature = "typescript")]
     pub(crate) fn token_context_mut(&mut self) -> &mut lexer::TokenContexts {
         self.iter.token_context_mut()
     }
 
     #[inline]
+    #[cfg(feature = "typescript")]
     pub(crate) fn set_token_context(&mut self, c: lexer::TokenContexts) {
         self.iter.set_token_context(c)
     }

--- a/crates/swc_ecma_parser/src/parser/jsx.rs
+++ b/crates/swc_ecma_parser/src/parser/jsx.rs
@@ -209,6 +209,9 @@ impl<'a, I: Tokens> Parser<I> {
     ) -> PResult<JSXOpeningElement> {
         debug_assert!(self.input.syntax().jsx());
 
+        #[cfg(not(feature = "typescript"))]
+        let type_args = None;
+        #[cfg(feature = "typescript")]
         let type_args = if self.input.syntax().typescript() && is!(self, '<') {
             self.try_parse_ts(|p| p.parse_ts_type_args().map(Some))
         } else {

--- a/crates/swc_ecma_parser/src/parser/macros.rs
+++ b/crates/swc_ecma_parser/src/parser/macros.rs
@@ -217,6 +217,7 @@ macro_rules! expect_exact {
     }};
 }
 
+#[cfg(feature = "typescript")]
 macro_rules! store {
     ($p:expr, $t:tt) => {{
         const TOKEN: Token = token_including_semi!($t);

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -7,11 +7,13 @@ use swc_ecma_ast::*;
 
 pub use self::input::{Capturing, Tokens, TokensInput};
 use self::{input::Buffer, util::ParseObject};
+#[cfg(feature = "typescript")]
+use crate::TsConfig;
 use crate::{
     error::SyntaxError,
     lexer::Lexer,
     token::{Token, Word},
-    Context, EsVersion, Syntax, TsConfig,
+    Context, EsVersion, Syntax,
 };
 #[cfg(test)]
 extern crate test;
@@ -32,6 +34,7 @@ mod pat;
 mod stmt;
 #[cfg(test)]
 mod tests;
+#[cfg(feature = "typescript")]
 mod typescript;
 mod util;
 
@@ -62,6 +65,9 @@ impl<'a, I: Input> Parser<Lexer<'a, I>> {
 
 impl<I: Tokens> Parser<I> {
     pub fn new_from(mut input: I) -> Self {
+        #[cfg(not(feature = "typescript"))]
+        let in_declare = false;
+        #[cfg(feature = "typescript")]
         let in_declare = matches!(
             input.syntax(),
             Syntax::Typescript(TsConfig { dts: true, .. })

--- a/crates/swc_ecma_parser/src/parser/object.rs
+++ b/crates/swc_ecma_parser/src/parser/object.rs
@@ -13,7 +13,9 @@ impl<'a, I: Tokens> Parser<I> {
         Self: ParseObject<T>,
     {
         let ctx = Context {
+            #[cfg(feature = "typescript")]
             is_direct_child_of_cond: false,
+            #[cfg(feature = "typescript")]
             dont_parse_colon_as_type_ann: false,
             ..self.ctx()
         };
@@ -166,11 +168,15 @@ impl<I: Tokens> ParseObject<Box<Expr>> for Parser<I> {
                 });
         }
 
+        #[cfg(feature = "typescript")]
         let has_modifiers = self.eat_any_ts_modifier()?;
+
+        #[cfg(feature = "typescript")]
         let modifiers_span = self.input.prev_span();
 
         let key = self.parse_prop_name()?;
 
+        #[cfg(feature = "typescript")]
         if self.input.syntax().typescript()
             && !is_one_of!(self, '(', '[', ':', ',', '?', '=', '*', IdentName, Str, Num)
             && !(self.input.syntax().typescript() && is!(self, '<'))
@@ -255,6 +261,7 @@ impl<I: Tokens> ParseObject<Box<Expr>> for Parser<I> {
             js_word!("get") | js_word!("set") | js_word!("async") => {
                 trace_cur!(self, parse_object_prop__after_accessor);
 
+                #[cfg(feature = "typescript")]
                 if has_modifiers {
                     self.emit_err(modifiers_span, SyntaxError::TS1042);
                 }

--- a/crates/swc_ecma_parser/src/parser/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/tests.rs
@@ -1,7 +1,9 @@
 use swc_common::{comments::SingleThreadedComments, BytePos};
 
 use super::*;
-use crate::{test_parser, EsConfig, TsConfig};
+#[cfg(feature = "typescript")]
+use crate::TsConfig;
+use crate::{test_parser, EsConfig};
 
 fn program(src: &'static str) -> Program {
     test_parser(src, Default::default(), |p| p.parse_program())
@@ -137,6 +139,7 @@ fn parse_module_export_default_class_span() {
 }
 
 #[test]
+#[cfg(feature = "typescript")]
 fn issue_1878() {
     // file with only comments should have the comments
     // in the leading map instead of the trailing
@@ -184,6 +187,7 @@ fn issue_1878() {
 }
 
 #[test]
+#[cfg(feature = "typescript")]
 fn issue_2264_1() {
     let c = SingleThreadedComments::default();
     let s = "
@@ -232,6 +236,7 @@ fn issue_2264_2() {
 }
 
 #[test]
+#[cfg(feature = "typescript")]
 fn issue_2264_3() {
     let c = SingleThreadedComments::default();
     let s = "const foo = <h1>/* no */{/* 1 */ bar /* 2 */}/* no */</h1>;";
@@ -253,6 +258,7 @@ fn issue_2264_3() {
 }
 
 #[test]
+#[cfg(feature = "typescript")]
 fn issue_2339_1() {
     let c = SingleThreadedComments::default();
     let s = "

--- a/crates/swc_ecma_parser/src/parser/util.rs
+++ b/crates/swc_ecma_parser/src/parser/util.rs
@@ -158,6 +158,7 @@ impl<'a, I: Tokens> Parser<I> {
     }
 
     /// Original context is restored when returned guard is dropped.
+    #[cfg(feature = "typescript")]
     pub(super) fn in_type(&mut self) -> WithCtx<I> {
         let ctx = Context {
             in_type: true,

--- a/crates/swc_ecma_parser/tests/comments.rs
+++ b/crates/swc_ecma_parser/tests/comments.rs
@@ -7,7 +7,9 @@ use swc_common::{
     BytePos, Span,
 };
 use swc_ecma_ast::*;
-use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, Syntax, TsConfig};
+#[cfg(feature = "typescript")]
+use swc_ecma_parser::TsConfig;
+use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, Syntax};
 use swc_ecma_visit::{Visit, VisitWith};
 use testing::{fixture, Tester};
 
@@ -33,6 +35,7 @@ fn test(input: PathBuf) {
                     static_blocks: true,
                     ..Default::default()
                 }),
+                #[cfg(feature = "typescript")]
                 "ts" | "tsx" => Syntax::Typescript(TsConfig {
                     tsx: ext == "tsx",
                     decorators: true,


### PR DESCRIPTION
Makes the TypeScript parser in the swc_ecma_parser crate an opt-in option. Currently, the `typescript` feature flag is enabled by default and can not be disabled.

This PR should be considered as work-in-progress. It demonstrates the impact of a real implementation of the `typescript` feature flag.

After making the changes I figured out, that additional work would be required. However, by pursuing the idea the ECMAScript parser and TypeScript parser could be seperated in a clean way. This would improve the overall code quality of SWC.

For example, some JSX tests are failing at the moment when disabling the `typescript` feature flag. I'm not sure whether this is related to my changes or whether the TypeScript parser is leaking.

```
$ cargo test -p swc_ecma_parser --no-default-features
...
failures:
    references_tests__jsx__basic__custom__issue_615__input_js
    references_tests__jsx__basic__custom__unary__input_js
    references_tests__jsx__basic__custom__unary_paren__input_js
    references_tests__jsx__basic__issue_2075__case1__input_js
    references_tests__jsx__basic__issue_2075__not_keyword__input_js
    references_tests__jsx__basic__string__input_js
    references_tests__jsx__basic__template__input_js
```

Let me know what you think.

@kdy1 @Brooooooklyn @kwonoj 