### PR TITLE
feat(ecma/ast) Add trailing commas to AST

### DIFF
--- a/crates/swc_bundler/src/bundler/chunk/computed_key.rs
+++ b/crates/swc_bundler/src/bundler/chunk/computed_key.rs
@@ -107,6 +107,7 @@ where
             span: DUMMY_SP,
             arg: Some(Box::new(Expr::Object(ObjectLit {
                 span: DUMMY_SP,
+                trailing_comma: None,
                 props: take(&mut export_visitor.return_props),
             }))),
         });

--- a/crates/swc_bundler/src/bundler/chunk/merge.rs
+++ b/crates/swc_bundler/src/bundler/chunk/merge.rs
@@ -1405,6 +1405,7 @@ impl VisitMut for ImportMetaHandler<'_, '_> {
                                 name: Pat::Ident(self.inline_ident.clone().into()),
                                 init: Some(Box::new(Expr::Object(ObjectLit {
                                     span: n.span,
+                                    trailing_comma: None,
                                     props: key_value_props
                                         .iter()
                                         .cloned()

--- a/crates/swc_bundler/src/bundler/finalize.rs
+++ b/crates/swc_bundler/src/bundler/finalize.rs
@@ -324,6 +324,7 @@ where
             span: DUMMY_SP,
             arg: Some(Box::new(Expr::Object(ObjectLit {
                 span: DUMMY_SP,
+                trailing_comma: None,
                 props,
             }))),
         }));

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -229,6 +229,8 @@ pub struct ThisExpr {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ArrayLit {
     pub span: Span,
+    #[serde(default)]
+    pub trailing_comma: Option<Span>,
 
     #[serde(default, rename = "elements")]
     pub elems: Vec<Option<ExprOrSpread>>,
@@ -238,6 +240,7 @@ impl Take for ArrayLit {
     fn dummy() -> Self {
         ArrayLit {
             span: DUMMY_SP,
+            trailing_comma: Default::default(),
             elems: Default::default(),
         }
     }
@@ -249,6 +252,8 @@ impl Take for ArrayLit {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ObjectLit {
     pub span: Span,
+    #[serde(default)]
+    pub trailing_comma: Option<Span>,
 
     #[serde(default, rename = "properties")]
     pub props: Vec<PropOrSpread>,
@@ -258,6 +263,7 @@ impl Take for ObjectLit {
     fn dummy() -> Self {
         ObjectLit {
             span: DUMMY_SP,
+            trailing_comma: Default::default(),
             props: Default::default(),
         }
     }

--- a/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
@@ -316,7 +316,11 @@ where
                             }
                         }
 
-                        *e = Expr::Array(ArrayLit { span, elems: keys })
+                        *e = Expr::Array(ArrayLit {
+                            span,
+                            trailing_comma: None,
+                            elems: keys,
+                        })
                     }
                 }
 

--- a/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
@@ -170,6 +170,7 @@ impl Pure<'_> {
                             if start >= arr.elems.len() {
                                 *e = Expr::Array(ArrayLit {
                                     span: *span,
+                                    trailing_comma: None,
                                     elems: Default::default(),
                                 });
                                 return;
@@ -177,7 +178,11 @@ impl Pure<'_> {
 
                             let elems = arr.elems.drain(start..).collect();
 
-                            *e = Expr::Array(ArrayLit { span: *span, elems });
+                            *e = Expr::Array(ArrayLit {
+                                span: *span,
+                                trailing_comma: None,
+                                elems,
+                            });
                         }
                     }
                     _ => {
@@ -199,6 +204,7 @@ impl Pure<'_> {
                                 if start >= arr.elems.len() {
                                     *e = Expr::Array(ArrayLit {
                                         span: *span,
+                                        trailing_comma: None,
                                         elems: Default::default(),
                                     });
                                     return;
@@ -206,7 +212,11 @@ impl Pure<'_> {
 
                                 let elems = arr.elems.drain(start..end).collect();
 
-                                *e = Expr::Array(ArrayLit { span: *span, elems });
+                                *e = Expr::Array(ArrayLit {
+                                    span: *span,
+                                    trailing_comma: None,
+                                    elems,
+                                });
                             }
                         }
                     }

--- a/crates/swc_ecma_minifier/src/option/terser.rs
+++ b/crates/swc_ecma_minifier/src/option/terser.rs
@@ -522,6 +522,7 @@ fn value_to_expr(v: Value) -> Box<Expr> {
                 .collect();
             Box::new(Expr::Array(ArrayLit {
                 span: DUMMY_SP,
+                trailing_comma: None,
                 elems,
             }))
         }
@@ -545,6 +546,7 @@ fn value_to_expr(v: Value) -> Box<Expr> {
 
             Box::new(Expr::Object(ObjectLit {
                 span: DUMMY_SP,
+                trailing_comma: None,
                 props,
             }))
         }

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -436,6 +436,7 @@ impl<'a, I: Tokens> Parser<I> {
         trace_cur!(self, parse_array_lit);
 
         let start = cur_pos!(self);
+        let mut trailing_comma = None;
 
         assert_and_bump!(self, '[');
         let mut elems = vec![];
@@ -454,9 +455,7 @@ impl<'a, I: Tokens> Parser<I> {
             if !is!(self, ']') {
                 expect!(self, ',');
                 if is!(self, ']') {
-                    self.state
-                        .trailing_commas
-                        .insert(start, self.input.prev_span());
+                    trailing_comma = Some(self.input.prev_span());
                 }
             }
         }
@@ -464,7 +463,11 @@ impl<'a, I: Tokens> Parser<I> {
         expect!(self, ']');
 
         let span = span!(self, start);
-        Ok(Box::new(Expr::Array(ArrayLit { span, elems })))
+        Ok(Box::new(Expr::Array(ArrayLit {
+            span,
+            trailing_comma,
+            elems,
+        })))
     }
 
     #[allow(dead_code)]

--- a/crates/swc_ecma_parser/src/parser/expr/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/tests.rs
@@ -158,6 +158,7 @@ fn object_spread() {
             op: op!("="),
             right: Box::new(Expr::Object(ObjectLit {
                 span,
+                trailing_comma: None,
                 props: vec![
                     PropOrSpread::Prop(Box::new(Ident::new("a".into(), span).into())),
                     PropOrSpread::Spread(SpreadElement {
@@ -306,6 +307,7 @@ fn array_lit() {
         expr("[a,,,,, ...d,, e]"),
         Box::new(Expr::Array(ArrayLit {
             span,
+            trailing_comma: None,
             elems: vec![
                 Some(ExprOrSpread {
                     spread: None,

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -2,7 +2,7 @@
 use std::ops::{Deref, DerefMut};
 
 use swc_atoms::JsWord;
-use swc_common::{collections::AHashMap, comments::Comments, input::Input, BytePos, Span};
+use swc_common::{comments::Comments, input::Input, BytePos, Span};
 use swc_ecma_ast::*;
 
 pub use self::input::{Capturing, Tokens, TokensInput};
@@ -52,8 +52,6 @@ struct State {
     potential_arrow_start: Option<BytePos>,
 
     found_module_item: bool,
-    /// Start position of an AST node and the span of its trailing comma.
-    trailing_commas: AHashMap<BytePos, Span>,
 }
 
 impl<'a, I: Input> Parser<Lexer<'a, I>> {

--- a/crates/swc_ecma_parser/src/parser/object.rs
+++ b/crates/swc_ecma_parser/src/parser/object.rs
@@ -133,10 +133,11 @@ impl<I: Tokens> ParseObject<Box<Expr>> for Parser<I> {
         props: Vec<Self::Prop>,
         trailing_comma: Option<Span>,
     ) -> PResult<Box<Expr>> {
-        if let Some(trailing_comma) = trailing_comma {
-            self.state.trailing_commas.insert(span.lo, trailing_comma);
-        }
-        Ok(Box::new(Expr::Object(ObjectLit { span, props })))
+        Ok(Box::new(Expr::Object(ObjectLit {
+            span,
+            trailing_comma,
+            props,
+        })))
     }
 
     /// spec: 'PropertyDefinition'

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping/mod.rs
@@ -826,6 +826,7 @@ impl VisitMut for FlowHelper<'_> {
                     span,
                     arg: Some(Box::new(Expr::Object(ObjectLit {
                         span,
+                        trailing_comma: None,
                         props: vec![PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
                             key: PropName::Ident(Ident::new("v".into(), DUMMY_SP)),
                             value: s.arg.take().unwrap_or_else(|| {

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
@@ -828,6 +828,7 @@ where
             }
             Expr::Array(ArrayLit {
                 span: DUMMY_SP,
+                trailing_comma: None,
                 elems: props
                     .into_iter()
                     .map(|(_, data)| {
@@ -853,6 +854,7 @@ where
 
                         ObjectLit {
                             span: DUMMY_SP,
+                            trailing_comma: None,
                             props,
                         }
                         .as_arg()

--- a/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/computed_props.rs
@@ -68,7 +68,7 @@ impl VisitMut for ComputedProps {
     fn visit_mut_expr(&mut self, expr: &mut Expr) {
         expr.visit_mut_children_with(self);
 
-        if let Expr::Object(ObjectLit { props, span }) = expr {
+        if let Expr::Object(ObjectLit { props, span, .. }) = expr {
             if !is_complex(props) {
                 return;
             }
@@ -96,6 +96,7 @@ impl VisitMut for ComputedProps {
                 if !self.c.loose && props_cnt == 1 && !self.used_define_enum_props {
                     Box::new(Expr::Object(ObjectLit {
                         span: DUMMY_SP,
+                        trailing_comma: None,
                         props: obj_props,
                     }))
                 } else {
@@ -105,6 +106,7 @@ impl VisitMut for ComputedProps {
                         op: op!("="),
                         right: Box::new(Expr::Object(ObjectLit {
                             span: DUMMY_SP,
+                            trailing_comma: None,
                             props: obj_props,
                         })),
                     }))
@@ -209,6 +211,7 @@ impl VisitMut for ComputedProps {
                                     op: op!("||"),
                                     right: Box::new(Expr::Object(ObjectLit {
                                         span,
+                                        trailing_comma: None,
                                         props: vec![],
                                     })),
                                 })),
@@ -289,6 +292,7 @@ impl VisitMut for ComputedProps {
                     name: mutator_map.clone().into(),
                     init: Some(Box::new(Expr::Object(ObjectLit {
                         span: DUMMY_SP,
+                        trailing_comma: None,
                         props: vec![],
                     }))),
                     definite: false,

--- a/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/destructuring.rs
@@ -171,6 +171,7 @@ impl AssignFolder {
                                             name: *p.arg,
                                             init: Some(Box::new(Expr::Array(ArrayLit {
                                                 span: DUMMY_SP,
+                                                trailing_comma: None,
                                                 elems: arr_elems
                                                     .take()
                                                     .expect("two rest element?")
@@ -625,6 +626,7 @@ impl VisitMut for AssignFolder {
                                             op: op!("="),
                                             right: Box::new(Expr::Array(ArrayLit {
                                                 span: DUMMY_SP,
+                                                trailing_comma: None,
                                                 elems: arr_elems
                                                     .take()
                                                     .expect("two rest element?")

--- a/crates/swc_ecma_transforms_compat/src/es2015/object_super.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/object_super.rs
@@ -76,7 +76,7 @@ impl VisitMut for ObjectSuper {
 
     fn visit_mut_expr(&mut self, expr: &mut Expr) {
         expr.visit_mut_children_with(self);
-        if let Expr::Object(ObjectLit { span: _, props }) = expr {
+        if let Expr::Object(ObjectLit { props, .. }) = expr {
             let mut replacer = SuperReplacer {
                 obj: None,
                 vars: Vec::new(),

--- a/crates/swc_ecma_transforms_compat/src/es2015/regenerator/case.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/regenerator/case.rs
@@ -97,6 +97,7 @@ impl CaseHandler<'_> {
         //        let mut last_loc_value = 0;
         Some(ArrayLit {
             span: DUMMY_SP,
+            trailing_comma: None,
             elems: take(&mut self.try_entries)
                 .into_iter()
                 .map(|entry: TryEntry| {
@@ -138,6 +139,7 @@ impl CaseHandler<'_> {
                     Some(
                         ArrayLit {
                             span: DUMMY_SP,
+                            trailing_comma: None,
                             elems,
                         }
                         .as_arg(),

--- a/crates/swc_ecma_transforms_compat/src/es2015/template_literal.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/template_literal.rs
@@ -281,6 +281,7 @@ impl VisitMut for TemplateLiteral {
                                             Some(
                                                 ArrayLit {
                                                     span: DUMMY_SP,
+                                                    trailing_comma: None,
                                                     elems: quasis
                                                         .iter()
                                                         .cloned()
@@ -297,6 +298,7 @@ impl VisitMut for TemplateLiteral {
                                         iter::once(
                                             ArrayLit {
                                                 span: DUMMY_SP,
+                                                trailing_comma: None,
                                                 elems: quasis
                                                     .take()
                                                     .into_iter()

--- a/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2018/object_rest_spread.rs
@@ -385,6 +385,7 @@ impl VisitMut for ObjectRest {
                                 args: vec![
                                     ObjectLit {
                                         span: DUMMY_SP,
+                                        trailing_comma: None,
                                         props: vec![],
                                     }
                                     .as_arg(),
@@ -923,6 +924,7 @@ fn object_without_properties(
             args: vec![
                 ObjectLit {
                     span: DUMMY_SP,
+                    trailing_comma: None,
                     props: vec![],
                 }
                 .as_arg(),
@@ -964,6 +966,7 @@ fn object_without_properties(
             if is_literal(&excluded_props) {
                 ArrayLit {
                     span: DUMMY_SP,
+                    trailing_comma: None,
                     elems: excluded_props,
                 }
                 .as_arg()
@@ -972,6 +975,7 @@ fn object_without_properties(
                     span: DUMMY_SP,
                     callee: ArrayLit {
                         span: DUMMY_SP,
+                        trailing_comma: None,
                         elems: excluded_props,
                     }
                     .make_member(Ident::new("map".into(), DUMMY_SP))
@@ -1075,7 +1079,7 @@ impl VisitMut for ObjectSpread {
     fn visit_mut_expr(&mut self, expr: &mut Expr) {
         expr.visit_mut_children_with(self);
 
-        if let Expr::Object(ObjectLit { span, props }) = expr {
+        if let Expr::Object(ObjectLit { span, props, .. }) = expr {
             let has_spread = props.iter().any(|p| matches!(p, PropOrSpread::Spread(..)));
             if !has_spread {
                 return;
@@ -1088,6 +1092,7 @@ impl VisitMut for ObjectSpread {
                 let mut buf = vec![];
                 let mut obj = ObjectLit {
                     span: DUMMY_SP,
+                    trailing_comma: None,
                     props: vec![],
                 };
                 for prop in props.take() {

--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/member_init.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/member_init.rs
@@ -321,6 +321,7 @@ impl MemberInitRecord {
 fn get_value_desc(value: Box<Expr>) -> ObjectLit {
     ObjectLit {
         span: DUMMY_SP,
+        trailing_comma: None,
         props: vec![
             // writeable: true
             PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
@@ -339,6 +340,7 @@ fn get_value_desc(value: Box<Expr>) -> ObjectLit {
 fn get_accessor_desc(getter: Option<Ident>, setter: Option<Ident>) -> ObjectLit {
     ObjectLit {
         span: DUMMY_SP,
+        trailing_comma: None,
         props: vec![
             PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
                 key: PropName::Ident(quote_ident!("get")),
@@ -359,6 +361,7 @@ fn get_accessor_desc(getter: Option<Ident>, setter: Option<Ident>) -> ObjectLit 
 fn get_method_desc(value: Box<Expr>) -> ObjectLit {
     ObjectLit {
         span: DUMMY_SP,
+        trailing_comma: None,
         props: vec![
             // value: value,
             PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -481,6 +481,7 @@ impl Fold for Amd {
         let mut import_stmts = vec![];
         let mut define_deps_arg = ArrayLit {
             span: DUMMY_SP,
+            trailing_comma: None,
             elems: vec![],
         };
         let mut scope_ref_mut = self.scope.borrow_mut();
@@ -507,6 +508,7 @@ impl Fold for Amd {
                         name: exported_names.clone().into(),
                         init: Some(Box::new(Expr::Object(ObjectLit {
                             span: DUMMY_SP,
+                            trailing_comma: None,
                             props: exports
                                 .into_iter()
                                 .filter_map(|export| {
@@ -771,6 +773,7 @@ pub(super) fn handle_dynamic_import(span: Span, args: Vec<ExprOrSpread>) -> Expr
                                 args: vec![
                                     ArrayLit {
                                         span: DUMMY_SP,
+                                        trailing_comma: None,
                                         elems: args.into_iter().map(Some).collect(),
                                     }
                                     .as_arg(),

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -319,6 +319,7 @@ impl Fold for CommonJs {
                                         name: exported_names_ident.clone().into(),
                                         init: Some(Box::new(Expr::Object(ObjectLit {
                                             span: DUMMY_SP,
+                                            trailing_comma: None,
                                             props: exports
                                                 .clone()
                                                 .into_iter()

--- a/crates/swc_ecma_transforms_module/src/system_js.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js.rs
@@ -255,6 +255,7 @@ impl SystemJs {
                     callee: self.export_ident.clone().as_callee(),
                     args: vec![ObjectLit {
                         span: DUMMY_SP,
+                        trailing_comma: None,
                         props,
                     }
                     .as_arg()],
@@ -283,6 +284,7 @@ impl SystemJs {
                     name: export_obj.clone().into(),
                     init: Some(Box::new(Expr::Object(ObjectLit {
                         span: DUMMY_SP,
+                        trailing_comma: None,
                         props: vec![],
                     }))),
                     definite: false,
@@ -965,11 +967,13 @@ impl Fold for SystemJs {
 
         let mut setters = ArrayLit {
             span: DUMMY_SP,
+            trailing_comma: None,
             elems: vec![],
         };
 
         let mut dep_module_names = ArrayLit {
             span: DUMMY_SP,
+            trailing_comma: None,
             elems: vec![],
         };
 
@@ -1022,6 +1026,7 @@ impl Fold for SystemJs {
             span: DUMMY_SP,
             arg: Some(Box::new(Expr::Object(ObjectLit {
                 span: DUMMY_SP,
+                trailing_comma: None,
                 props: vec![
                     PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
                         key: quote_ident!("setters").into(),

--- a/crates/swc_ecma_transforms_module/src/umd.rs
+++ b/crates/swc_ecma_transforms_module/src/umd.rs
@@ -479,6 +479,7 @@ impl Fold for Umd {
         let mut import_stmts = vec![];
         let mut define_deps_arg = ArrayLit {
             span: DUMMY_SP,
+            trailing_comma: None,
             elems: vec![],
         };
 
@@ -511,6 +512,7 @@ impl Fold for Umd {
                         name: exported_names.clone().into(),
                         init: Some(Box::new(Expr::Object(ObjectLit {
                             span: DUMMY_SP,
+                            trailing_comma: None,
                             props: exports
                                 .into_iter()
                                 .filter_map(|export| {
@@ -706,6 +708,7 @@ impl Fold for Umd {
                                             name: quote_ident!("mod").into(),
                                             init: Some(Box::new(Expr::Object(ObjectLit {
                                                 span: DUMMY_SP,
+                                                trailing_comma: None,
                                                 props: vec![PropOrSpread::Prop(Box::new(
                                                     Prop::KeyValue(KeyValueProp {
                                                         key: PropName::Ident(quote_ident!(
@@ -713,6 +716,7 @@ impl Fold for Umd {
                                                         )),
                                                         value: Box::new(Expr::Object(ObjectLit {
                                                             span: DUMMY_SP,
+                                                            trailing_comma: None,
                                                             props: vec![],
                                                         })),
                                                     }),

--- a/crates/swc_ecma_transforms_module/src/util.rs
+++ b/crates/swc_ecma_transforms_module/src/util.rs
@@ -898,6 +898,7 @@ pub(super) fn define_es_module(exports: Ident) -> Stmt {
         Lit::Str(quote_str!("__esModule")).as_arg(),
         ObjectLit {
             span: DUMMY_SP,
+            trailing_comma: None,
             props: vec![PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
                 key: PropName::Ident(quote_ident!("value")),
                 value: true.into(),
@@ -981,6 +982,7 @@ pub(super) fn make_descriptor(get_expr: Box<Expr>) -> ObjectLit {
 
     ObjectLit {
         span: DUMMY_SP,
+        trailing_comma: None,
         props: vec![
             PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
                 key: PropName::Ident(quote_ident!("enumerable")),

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -1375,7 +1375,12 @@ fn ignore_result(e: Expr) -> Option<Expr> {
             _ => Some(Expr::Unary(UnaryExpr { span, op, arg })),
         },
 
-        Expr::Array(ArrayLit { span, elems, .. }) => {
+        Expr::Array(ArrayLit {
+            span,
+            trailing_comma,
+            elems,
+            ..
+        }) => {
             let mut has_spread = false;
             let elems = elems.move_flat_map(|v| match v {
                 Some(ExprOrSpread {
@@ -1396,7 +1401,11 @@ fn ignore_result(e: Expr) -> Option<Expr> {
             if elems.is_empty() {
                 None
             } else if has_spread {
-                Some(Expr::Array(ArrayLit { span, elems }))
+                Some(Expr::Array(ArrayLit {
+                    span,
+                    trailing_comma,
+                    elems,
+                }))
             } else {
                 ignore_result(preserve_effects(
                     span,
@@ -1406,7 +1415,12 @@ fn ignore_result(e: Expr) -> Option<Expr> {
             }
         }
 
-        Expr::Object(ObjectLit { span, props, .. }) => {
+        Expr::Object(ObjectLit {
+            span,
+            trailing_comma,
+            props,
+            ..
+        }) => {
             let props = props.move_flat_map(|v| match v {
                 PropOrSpread::Spread(..) => Some(v),
                 PropOrSpread::Prop(ref p) => {
@@ -1424,7 +1438,11 @@ fn ignore_result(e: Expr) -> Option<Expr> {
                 ignore_result(preserve_effects(
                     span,
                     *undefined(DUMMY_SP),
-                    once(Box::new(Expr::Object(ObjectLit { span, props }))),
+                    once(Box::new(Expr::Object(ObjectLit {
+                        span,
+                        trailing_comma,
+                        props,
+                    }))),
                 ))
             }
         }
@@ -1436,6 +1454,7 @@ fn ignore_result(e: Expr) -> Option<Expr> {
             ..
         }) if callee.is_pure_callee() => ignore_result(Expr::Array(ArrayLit {
             span,
+            trailing_comma: None,
             elems: args
                 .map(|args| args.into_iter().map(Some).collect())
                 .unwrap_or_else(Default::default),
@@ -1448,6 +1467,7 @@ fn ignore_result(e: Expr) -> Option<Expr> {
             ..
         }) if callee.is_pure_callee() => ignore_result(Expr::Array(ArrayLit {
             span,
+            trailing_comma: None,
             elems: args.into_iter().map(Some).collect(),
         })),
 

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/metadata.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/metadata.rs
@@ -152,6 +152,7 @@ impl Fold for Metadata<'_> {
                 "design:paramtypes",
                 ArrayLit {
                     span: DUMMY_SP,
+                    trailing_comma: None,
                     elems: constructor
                         .as_ref()
                         .unwrap()
@@ -194,6 +195,7 @@ impl Fold for Metadata<'_> {
                 "design:paramtypes",
                 ArrayLit {
                     span: DUMMY_SP,
+                    trailing_comma: None,
                     elems: m
                         .function
                         .params

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
@@ -429,6 +429,7 @@ impl Legacy {
                         // [_dec7, _dec8],
                         ArrayLit {
                             span: DUMMY_SP,
+                            trailing_comma: None,
                             elems: dec_exprs,
                         }
                         .as_arg(),
@@ -523,6 +524,7 @@ impl Legacy {
 
                 let mut property_descriptor = Expr::Object(ObjectLit {
                     span: DUMMY_SP,
+                    trailing_comma: None,
                     props: vec![
                         // configurable: true,
                         PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
@@ -629,6 +631,7 @@ impl Legacy {
                                 name.clone().as_arg(),
                                 ArrayLit {
                                     span: DUMMY_SP,
+                                    trailing_comma: None,
                                     elems: dec_exprs,
                                 }
                                 .as_arg(),
@@ -641,6 +644,7 @@ impl Legacy {
                                 name.clone().as_arg(),
                                 ArrayLit {
                                     span: DUMMY_SP,
+                                    trailing_comma: None,
                                     elems: dec_exprs,
                                 }
                                 .as_arg(),

--- a/crates/swc_ecma_transforms_proposal/src/decorators/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/mod.rs
@@ -342,6 +342,7 @@ impl Decorators {
                 Some(
                     ObjectLit {
                         span: DUMMY_SP,
+                        trailing_comma: None,
                         props: iter::once(PropOrSpread::Prop(Box::new(Prop::KeyValue(
                             KeyValueProp {
                                 key: PropName::Ident(quote_ident!("kind")),
@@ -371,6 +372,7 @@ impl Decorators {
                                     key: PropName::Ident(quote_ident!("decorators")),
                                     value: Box::new(Expr::Array(ArrayLit {
                                         span: DUMMY_SP,
+                                        trailing_comma: None,
                                         elems: method
                                             .function
                                             .decorators
@@ -454,6 +456,7 @@ impl Decorators {
                         Some(
                             ObjectLit {
                                 span: prop_span,
+                                trailing_comma: None,
                                 props: iter::once(PropOrSpread::Prop(Box::new(Prop::KeyValue(
                                     KeyValueProp {
                                         key: PropName::Ident(quote_ident!("kind")),
@@ -480,6 +483,7 @@ impl Decorators {
                                                 key: PropName::Ident(quote_ident!("decorators")),
                                                 value: Box::new(Expr::Array(ArrayLit {
                                                     span: DUMMY_SP,
+                                                    trailing_comma: None,
                                                     elems: prop
                                                         .decorators
                                                         .into_iter()
@@ -581,6 +585,7 @@ impl Decorators {
                                 span: DUMMY_SP,
                                 arg: Some(Box::new(Expr::Object(ObjectLit {
                                     span: DUMMY_SP,
+                                    trailing_comma: None,
                                     props: vec![
                                         PropOrSpread::Prop(Box::new(Prop::KeyValue(
                                             KeyValueProp {
@@ -593,6 +598,7 @@ impl Decorators {
                                                 key: PropName::Ident(quote_ident!("d")),
                                                 value: Box::new(Expr::Array(ArrayLit {
                                                     span: DUMMY_SP,
+                                                    trailing_comma: None,
                                                     elems: descriptors,
                                                 })),
                                             },
@@ -624,6 +630,7 @@ fn make_decorate_call(
         args: iter::once(
             ArrayLit {
                 span: DUMMY_SP,
+                trailing_comma: None,
                 elems: decorators
                     .into_iter()
                     .map(|dec| Some(dec.expr.as_arg()))

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -374,6 +374,7 @@ where
 
                 let mut props_obj = ObjectLit {
                     span: DUMMY_SP,
+                    trailing_comma: None,
                     props: vec![],
                 };
 
@@ -401,6 +402,7 @@ where
                                 key: PropName::Ident(quote_ident!("children")),
                                 value: Box::new(Expr::Array(ArrayLit {
                                     span: DUMMY_SP,
+                                    trailing_comma: None,
                                     elems: children,
                                 })),
                             }))));
@@ -486,6 +488,7 @@ where
 
                 let mut props_obj = ObjectLit {
                     span: DUMMY_SP,
+                    trailing_comma: None,
                     props: vec![],
                 };
 
@@ -646,6 +649,7 @@ where
                                 key: PropName::Ident(quote_ident!("children")),
                                 value: Box::new(Expr::Array(ArrayLit {
                                     span: DUMMY_SP,
+                                    trailing_comma: None,
                                     elems: children.take(),
                                 })),
                             }))));
@@ -788,6 +792,7 @@ where
 
         let obj = ObjectLit {
             span: DUMMY_SP,
+            trailing_comma: None,
             props,
         };
 
@@ -817,6 +822,7 @@ where
                         args.push(
                             ObjectLit {
                                 span: DUMMY_SP,
+                                trailing_comma: None,
                                 props: mem::take(&mut cur_obj_props),
                             }
                             .as_arg(),
@@ -853,6 +859,7 @@ where
         } else {
             Box::new(Expr::Object(ObjectLit {
                 span: DUMMY_SP,
+                trailing_comma: None,
                 props: attrs
                     .into_iter()
                     .map(|a| match a {

--- a/crates/swc_ecma_transforms_react/src/jsx_src/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx_src/mod.rs
@@ -47,6 +47,7 @@ impl VisitMut for JsxSrc {
                 expr: JSXExpr::Expr(Box::new(
                     ObjectLit {
                         span: DUMMY_SP,
+                        trailing_comma: None,
                         props: vec![
                             PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
                                 key: PropName::Ident(quote_ident!("fileName")),

--- a/crates/swc_ecma_transforms_react/src/refresh/hook.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/hook.rs
@@ -176,6 +176,7 @@ impl<'a> HookRegister<'a> {
                                 span: DUMMY_SP,
                                 arg: Some(Box::new(Expr::Array(ArrayLit {
                                     span: DUMMY_SP,
+                                    trailing_comma: None,
                                     elems,
                                 }))),
                             })],

--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -1432,6 +1432,7 @@ where
                         op: op!("="),
                         right: Box::new(Expr::Object(ObjectLit {
                             span: DUMMY_SP,
+                            trailing_comma: None,
                             props: vec![],
                         })),
                     })),
@@ -1449,6 +1450,7 @@ where
                     op: op!("="),
                     right: Box::new(Expr::Object(ObjectLit {
                         span: DUMMY_SP,
+                        trailing_comma: None,
                         props: vec![],
                     })),
                 })),

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -2039,7 +2039,10 @@ pub fn extract_side_effects_to(to: &mut Vec<Box<Expr>>, expr: Box<Expr>) {
         Expr::Paren(e) => extract_side_effects_to(to, e.expr),
 
         Expr::Object(ObjectLit {
-            span, mut props, ..
+            span,
+            trailing_comma,
+            mut props,
+            ..
         }) => {
             //
             let mut has_spread = false;
@@ -2075,7 +2078,11 @@ pub fn extract_side_effects_to(to: &mut Vec<Box<Expr>>, expr: Box<Expr>) {
             });
 
             if has_spread {
-                to.push(Box::new(Expr::Object(ObjectLit { span, props })))
+                to.push(Box::new(Expr::Object(ObjectLit {
+                    span,
+                    trailing_comma,
+                    props,
+                })))
             } else {
                 props.into_iter().for_each(|prop| match prop {
                     PropOrSpread::Prop(node) => match *node {

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -672,10 +672,12 @@ define!({
     }
     pub struct ArrayLit {
         pub span: Span,
+        pub trailing_comma: Option<Span>,
         pub elems: Vec<Option<ExprOrSpread>>,
     }
     pub struct ObjectLit {
         pub span: Span,
+        pub trailing_comma: Option<Span>,
         pub props: Vec<PropOrSpread>,
     }
     pub enum PropOrSpread {

--- a/crates/swc_estree_compat/src/swcify/expr.rs
+++ b/crates/swc_estree_compat/src/swcify/expr.rs
@@ -86,6 +86,7 @@ impl Swcify for ArrayExpression {
     fn swcify(self, ctx: &Context) -> Self::Output {
         ArrayLit {
             span: ctx.span(&self.base),
+            trailing_comma: None,
             elems: self.elements.swcify(ctx),
         }
     }
@@ -428,6 +429,7 @@ impl Swcify for ObjectExpression {
     fn swcify(self, ctx: &Context) -> Self::Output {
         ObjectLit {
             span: ctx.span(&self.base),
+            trailing_comma: None,
             props: self.properties.swcify(ctx),
         }
     }

--- a/crates/swc_estree_compat/src/swcify/stmt.rs
+++ b/crates/swc_estree_compat/src/swcify/stmt.rs
@@ -446,6 +446,7 @@ impl Swcify for ExportAllDeclaration {
                 })
                 .map(|props| ObjectLit {
                     span: DUMMY_SP,
+                    trailing_comma: None,
                     props,
                 }),
         }
@@ -535,6 +536,7 @@ impl Swcify for ExportNamedDeclaration {
                 })
                 .map(|props| ObjectLit {
                     span: DUMMY_SP,
+                    trailing_comma: None,
                     props,
                 }),
         }
@@ -629,6 +631,7 @@ impl Swcify for ImportDeclaration {
                 })
                 .map(|props| ObjectLit {
                     span: DUMMY_SP,
+                    trailing_comma: None,
                     props,
                 }),
         }


### PR DESCRIPTION
**Description:**
@alexander-akait mentioned that adding trailing commas to the AST would make it possible to improve codegen.

So far I've added trailing_comma to ArrayLit and ObjectLit. The other AST nodes that comes to mind:
- ArrayPat
- ObjectPat
- ArrowExpr
- Constructor
- ClassMethod
- PrivateMethod
- Function
- CallExpr
- ImportNamedSpecifier?
- ExportNamedSpecifier?

Does all of these make sense?

**BREAKING CHANGE:**
- trailing_comma added to ObjectLit
- trailing_comma added to ArrayLit

**Related issue (if exists):**
