### PR TITLE
node-swc: add `isTypeOnly` memebr to missing interfaces

### DIFF
--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -1575,6 +1575,7 @@ export interface NamedImportSpecifier extends Node, HasSpan {
   type: "ImportSpecifier";
   local: Identifier;
   imported: Identifier | null;
+  isTypeOnly?: boolean;
 }
 
 export type ExportSpecifier =
@@ -1605,6 +1606,7 @@ export interface NamedExportSpecifier extends Node, HasSpan {
    * `Some(bar)` in `export { foo as bar }`
    */
   exported: Identifier | null;
+  isTypeOnly?: boolean;
 }
 
 interface HasInterpreter {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Type definitions(`isTypeOnly`) are not getting updated at #2309, this PR tries to fix that.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

No breaking change, just a bug fix for typescript usage.

**Related issue (if exists):**

 #2309

**Workaround without this**

```ts
type PatchedNamedExportSpecifier = {
  isTypeOnly: boolean,
} & NamedExportSpecifier;

// some code...
(specifier as unknown as PatchedNamedExportSpecifier).isTypeOnly
```

