### PR TITLE
feat(es/parser): Support 'extends' clause to 'infer' type

### DIFF
--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -387,6 +387,8 @@ pub struct Context {
     allow_direct_super: bool,
 
     ignore_else_clause: bool,
+
+    disallow_conditional_types: bool,
 }
 
 #[cfg(test)]

--- a/crates/swc_ecma_parser/tests/typescript/types/conditional-infer-extends/basic/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript/types/conditional-infer-extends/basic/input.ts
@@ -1,0 +1,29 @@
+type X1<T extends any[]> =
+    T extends [infer U extends string] ? ["string", U] :
+    T extends [infer U extends number] ? ["number", U] :
+    never;
+
+type X2<T extends (...args: any[]) => void> =
+    T extends (a: infer U extends string) => void ? ["string", U] :
+    T extends (a: infer U extends number) => void ? ["number", U] :
+    never;
+
+type X3<T extends (...args: any[]) => any> =
+    T extends (...args: any[]) => (infer U extends string) ? ["string", U] :
+    T extends (...args: any[]) => (infer U extends number) ? ["number", U] :
+    never;
+
+type X4<T extends new (...args: any[]) => any> =
+    T extends new (...args: any[]) => (infer U extends { a: string }) ? ["string", U] :
+    T extends new (...args: any[]) => (infer U extends { a: number }) ? ["number", U] :
+    never;
+
+type X5<T> =
+    T extends Promise<infer U extends string> ? ["string", U] :
+    T extends Promise<infer U extends number> ? ["number", U] :
+    never;
+
+type X6<T> =
+    T extends { a: infer U extends string } ? ["string", U] :
+    T extends { a: infer U extends number } ? ["number", U] :
+    never;

--- a/crates/swc_ecma_parser/tests/typescript/types/conditional-infer-extends/basic/input.ts.json
+++ b/crates/swc_ecma_parser/tests/typescript/types/conditional-infer-extends/basic/input.ts.json
@@ -1,0 +1,2836 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 0,
+    "end": 1095,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 0,
+        "end": 151,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 5,
+          "end": 7,
+          "ctxt": 0
+        },
+        "value": "X1",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 7,
+          "end": 24,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 8,
+              "end": 23,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 8,
+                "end": 9,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": {
+              "type": "TsArrayType",
+              "span": {
+                "start": 18,
+                "end": 23,
+                "ctxt": 0
+              },
+              "elemType": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 18,
+                  "end": 21,
+                  "ctxt": 0
+                },
+                "kind": "any"
+              }
+            },
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 31,
+          "end": 150,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 31,
+            "end": 32,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 31,
+              "end": 32,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsTupleType",
+          "span": {
+            "start": 41,
+            "end": 65,
+            "ctxt": 0
+          },
+          "elemTypes": [
+            {
+              "type": "TsTupleElement",
+              "span": {
+                "start": 42,
+                "end": 64,
+                "ctxt": 0
+              },
+              "label": null,
+              "ty": {
+                "type": "TsInferType",
+                "span": {
+                  "start": 42,
+                  "end": 64,
+                  "ctxt": 0
+                },
+                "typeParam": {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 48,
+                    "end": 49,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 48,
+                      "end": 49,
+                      "ctxt": 0
+                    },
+                    "value": "U",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "constraint": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 58,
+                      "end": 64,
+                      "ctxt": 0
+                    },
+                    "kind": "string"
+                  },
+                  "default": null
+                }
+              }
+            }
+          ]
+        },
+        "trueType": {
+          "type": "TsTupleType",
+          "span": {
+            "start": 68,
+            "end": 81,
+            "ctxt": 0
+          },
+          "elemTypes": [
+            {
+              "type": "TsTupleElement",
+              "span": {
+                "start": 69,
+                "end": 77,
+                "ctxt": 0
+              },
+              "label": null,
+              "ty": {
+                "type": "TsLiteralType",
+                "span": {
+                  "start": 69,
+                  "end": 77,
+                  "ctxt": 0
+                },
+                "literal": {
+                  "type": "StringLiteral",
+                  "span": {
+                    "start": 69,
+                    "end": 77,
+                    "ctxt": 0
+                  },
+                  "value": "string",
+                  "raw": "\"string\""
+                }
+              }
+            },
+            {
+              "type": "TsTupleElement",
+              "span": {
+                "start": 79,
+                "end": 80,
+                "ctxt": 0
+              },
+              "label": null,
+              "ty": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 79,
+                  "end": 80,
+                  "ctxt": 0
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 79,
+                    "end": 80,
+                    "ctxt": 0
+                  },
+                  "value": "U",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            }
+          ]
+        },
+        "falseType": {
+          "type": "TsConditionalType",
+          "span": {
+            "start": 88,
+            "end": 150,
+            "ctxt": 0
+          },
+          "checkType": {
+            "type": "TsTypeReference",
+            "span": {
+              "start": 88,
+              "end": 89,
+              "ctxt": 0
+            },
+            "typeName": {
+              "type": "Identifier",
+              "span": {
+                "start": 88,
+                "end": 89,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "typeParams": null
+          },
+          "extendsType": {
+            "type": "TsTupleType",
+            "span": {
+              "start": 98,
+              "end": 122,
+              "ctxt": 0
+            },
+            "elemTypes": [
+              {
+                "type": "TsTupleElement",
+                "span": {
+                  "start": 99,
+                  "end": 121,
+                  "ctxt": 0
+                },
+                "label": null,
+                "ty": {
+                  "type": "TsInferType",
+                  "span": {
+                    "start": 99,
+                    "end": 121,
+                    "ctxt": 0
+                  },
+                  "typeParam": {
+                    "type": "TsTypeParameter",
+                    "span": {
+                      "start": 105,
+                      "end": 106,
+                      "ctxt": 0
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 105,
+                        "end": 106,
+                        "ctxt": 0
+                      },
+                      "value": "U",
+                      "optional": false
+                    },
+                    "in": false,
+                    "out": false,
+                    "constraint": {
+                      "type": "TsKeywordType",
+                      "span": {
+                        "start": 115,
+                        "end": 121,
+                        "ctxt": 0
+                      },
+                      "kind": "number"
+                    },
+                    "default": null
+                  }
+                }
+              }
+            ]
+          },
+          "trueType": {
+            "type": "TsTupleType",
+            "span": {
+              "start": 125,
+              "end": 138,
+              "ctxt": 0
+            },
+            "elemTypes": [
+              {
+                "type": "TsTupleElement",
+                "span": {
+                  "start": 126,
+                  "end": 134,
+                  "ctxt": 0
+                },
+                "label": null,
+                "ty": {
+                  "type": "TsLiteralType",
+                  "span": {
+                    "start": 126,
+                    "end": 134,
+                    "ctxt": 0
+                  },
+                  "literal": {
+                    "type": "StringLiteral",
+                    "span": {
+                      "start": 126,
+                      "end": 134,
+                      "ctxt": 0
+                    },
+                    "value": "number",
+                    "raw": "\"number\""
+                  }
+                }
+              },
+              {
+                "type": "TsTupleElement",
+                "span": {
+                  "start": 136,
+                  "end": 137,
+                  "ctxt": 0
+                },
+                "label": null,
+                "ty": {
+                  "type": "TsTypeReference",
+                  "span": {
+                    "start": 136,
+                    "end": 137,
+                    "ctxt": 0
+                  },
+                  "typeName": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 136,
+                      "end": 137,
+                      "ctxt": 0
+                    },
+                    "value": "U",
+                    "optional": false
+                  },
+                  "typeParams": null
+                }
+              }
+            ]
+          },
+          "falseType": {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 145,
+              "end": 150,
+              "ctxt": 0
+            },
+            "kind": "never"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 153,
+        "end": 345,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 158,
+          "end": 160,
+          "ctxt": 0
+        },
+        "value": "X2",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 160,
+          "end": 196,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 161,
+              "end": 195,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 161,
+                "end": 162,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": {
+              "type": "TsFunctionType",
+              "span": {
+                "start": 171,
+                "end": 195,
+                "ctxt": 0
+              },
+              "params": [
+                {
+                  "type": "RestElement",
+                  "span": {
+                    "start": 172,
+                    "end": 186,
+                    "ctxt": 0
+                  },
+                  "rest": {
+                    "start": 172,
+                    "end": 175,
+                    "ctxt": 0
+                  },
+                  "argument": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 175,
+                      "end": 179,
+                      "ctxt": 0
+                    },
+                    "value": "args",
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 179,
+                      "end": 186,
+                      "ctxt": 0
+                    },
+                    "typeAnnotation": {
+                      "type": "TsArrayType",
+                      "span": {
+                        "start": 181,
+                        "end": 186,
+                        "ctxt": 0
+                      },
+                      "elemType": {
+                        "type": "TsKeywordType",
+                        "span": {
+                          "start": 181,
+                          "end": 184,
+                          "ctxt": 0
+                        },
+                        "kind": "any"
+                      }
+                    }
+                  }
+                }
+              ],
+              "typeParams": null,
+              "typeAnnotation": {
+                "type": "TsTypeAnnotation",
+                "span": {
+                  "start": 188,
+                  "end": 195,
+                  "ctxt": 0
+                },
+                "typeAnnotation": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 191,
+                    "end": 195,
+                    "ctxt": 0
+                  },
+                  "kind": "void"
+                }
+              }
+            },
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 203,
+          "end": 344,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 203,
+            "end": 204,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 203,
+              "end": 204,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsFunctionType",
+          "span": {
+            "start": 213,
+            "end": 248,
+            "ctxt": 0
+          },
+          "params": [
+            {
+              "type": "Identifier",
+              "span": {
+                "start": 214,
+                "end": 239,
+                "ctxt": 0
+              },
+              "value": "a",
+              "optional": false,
+              "typeAnnotation": {
+                "type": "TsTypeAnnotation",
+                "span": {
+                  "start": 215,
+                  "end": 239,
+                  "ctxt": 0
+                },
+                "typeAnnotation": {
+                  "type": "TsInferType",
+                  "span": {
+                    "start": 217,
+                    "end": 239,
+                    "ctxt": 0
+                  },
+                  "typeParam": {
+                    "type": "TsTypeParameter",
+                    "span": {
+                      "start": 223,
+                      "end": 224,
+                      "ctxt": 0
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 223,
+                        "end": 224,
+                        "ctxt": 0
+                      },
+                      "value": "U",
+                      "optional": false
+                    },
+                    "in": false,
+                    "out": false,
+                    "constraint": {
+                      "type": "TsKeywordType",
+                      "span": {
+                        "start": 233,
+                        "end": 239,
+                        "ctxt": 0
+                      },
+                      "kind": "string"
+                    },
+                    "default": null
+                  }
+                }
+              }
+            }
+          ],
+          "typeParams": null,
+          "typeAnnotation": {
+            "type": "TsTypeAnnotation",
+            "span": {
+              "start": 241,
+              "end": 248,
+              "ctxt": 0
+            },
+            "typeAnnotation": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 244,
+                "end": 248,
+                "ctxt": 0
+              },
+              "kind": "void"
+            }
+          }
+        },
+        "trueType": {
+          "type": "TsTupleType",
+          "span": {
+            "start": 251,
+            "end": 264,
+            "ctxt": 0
+          },
+          "elemTypes": [
+            {
+              "type": "TsTupleElement",
+              "span": {
+                "start": 252,
+                "end": 260,
+                "ctxt": 0
+              },
+              "label": null,
+              "ty": {
+                "type": "TsLiteralType",
+                "span": {
+                  "start": 252,
+                  "end": 260,
+                  "ctxt": 0
+                },
+                "literal": {
+                  "type": "StringLiteral",
+                  "span": {
+                    "start": 252,
+                    "end": 260,
+                    "ctxt": 0
+                  },
+                  "value": "string",
+                  "raw": "\"string\""
+                }
+              }
+            },
+            {
+              "type": "TsTupleElement",
+              "span": {
+                "start": 262,
+                "end": 263,
+                "ctxt": 0
+              },
+              "label": null,
+              "ty": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 262,
+                  "end": 263,
+                  "ctxt": 0
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 262,
+                    "end": 263,
+                    "ctxt": 0
+                  },
+                  "value": "U",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            }
+          ]
+        },
+        "falseType": {
+          "type": "TsConditionalType",
+          "span": {
+            "start": 271,
+            "end": 344,
+            "ctxt": 0
+          },
+          "checkType": {
+            "type": "TsTypeReference",
+            "span": {
+              "start": 271,
+              "end": 272,
+              "ctxt": 0
+            },
+            "typeName": {
+              "type": "Identifier",
+              "span": {
+                "start": 271,
+                "end": 272,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "typeParams": null
+          },
+          "extendsType": {
+            "type": "TsFunctionType",
+            "span": {
+              "start": 281,
+              "end": 316,
+              "ctxt": 0
+            },
+            "params": [
+              {
+                "type": "Identifier",
+                "span": {
+                  "start": 282,
+                  "end": 307,
+                  "ctxt": 0
+                },
+                "value": "a",
+                "optional": false,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 283,
+                    "end": 307,
+                    "ctxt": 0
+                  },
+                  "typeAnnotation": {
+                    "type": "TsInferType",
+                    "span": {
+                      "start": 285,
+                      "end": 307,
+                      "ctxt": 0
+                    },
+                    "typeParam": {
+                      "type": "TsTypeParameter",
+                      "span": {
+                        "start": 291,
+                        "end": 292,
+                        "ctxt": 0
+                      },
+                      "name": {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 291,
+                          "end": 292,
+                          "ctxt": 0
+                        },
+                        "value": "U",
+                        "optional": false
+                      },
+                      "in": false,
+                      "out": false,
+                      "constraint": {
+                        "type": "TsKeywordType",
+                        "span": {
+                          "start": 301,
+                          "end": 307,
+                          "ctxt": 0
+                        },
+                        "kind": "number"
+                      },
+                      "default": null
+                    }
+                  }
+                }
+              }
+            ],
+            "typeParams": null,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 309,
+                "end": 316,
+                "ctxt": 0
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 312,
+                  "end": 316,
+                  "ctxt": 0
+                },
+                "kind": "void"
+              }
+            }
+          },
+          "trueType": {
+            "type": "TsTupleType",
+            "span": {
+              "start": 319,
+              "end": 332,
+              "ctxt": 0
+            },
+            "elemTypes": [
+              {
+                "type": "TsTupleElement",
+                "span": {
+                  "start": 320,
+                  "end": 328,
+                  "ctxt": 0
+                },
+                "label": null,
+                "ty": {
+                  "type": "TsLiteralType",
+                  "span": {
+                    "start": 320,
+                    "end": 328,
+                    "ctxt": 0
+                  },
+                  "literal": {
+                    "type": "StringLiteral",
+                    "span": {
+                      "start": 320,
+                      "end": 328,
+                      "ctxt": 0
+                    },
+                    "value": "number",
+                    "raw": "\"number\""
+                  }
+                }
+              },
+              {
+                "type": "TsTupleElement",
+                "span": {
+                  "start": 330,
+                  "end": 331,
+                  "ctxt": 0
+                },
+                "label": null,
+                "ty": {
+                  "type": "TsTypeReference",
+                  "span": {
+                    "start": 330,
+                    "end": 331,
+                    "ctxt": 0
+                  },
+                  "typeName": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 330,
+                      "end": 331,
+                      "ctxt": 0
+                    },
+                    "value": "U",
+                    "optional": false
+                  },
+                  "typeParams": null
+                }
+              }
+            ]
+          },
+          "falseType": {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 339,
+              "end": 344,
+              "ctxt": 0
+            },
+            "kind": "never"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 347,
+        "end": 556,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 352,
+          "end": 354,
+          "ctxt": 0
+        },
+        "value": "X3",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 354,
+          "end": 389,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 355,
+              "end": 388,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 355,
+                "end": 356,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": {
+              "type": "TsFunctionType",
+              "span": {
+                "start": 365,
+                "end": 388,
+                "ctxt": 0
+              },
+              "params": [
+                {
+                  "type": "RestElement",
+                  "span": {
+                    "start": 366,
+                    "end": 380,
+                    "ctxt": 0
+                  },
+                  "rest": {
+                    "start": 366,
+                    "end": 369,
+                    "ctxt": 0
+                  },
+                  "argument": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 369,
+                      "end": 373,
+                      "ctxt": 0
+                    },
+                    "value": "args",
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 373,
+                      "end": 380,
+                      "ctxt": 0
+                    },
+                    "typeAnnotation": {
+                      "type": "TsArrayType",
+                      "span": {
+                        "start": 375,
+                        "end": 380,
+                        "ctxt": 0
+                      },
+                      "elemType": {
+                        "type": "TsKeywordType",
+                        "span": {
+                          "start": 375,
+                          "end": 378,
+                          "ctxt": 0
+                        },
+                        "kind": "any"
+                      }
+                    }
+                  }
+                }
+              ],
+              "typeParams": null,
+              "typeAnnotation": {
+                "type": "TsTypeAnnotation",
+                "span": {
+                  "start": 382,
+                  "end": 388,
+                  "ctxt": 0
+                },
+                "typeAnnotation": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 385,
+                    "end": 388,
+                    "ctxt": 0
+                  },
+                  "kind": "any"
+                }
+              }
+            },
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 396,
+          "end": 555,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 396,
+            "end": 397,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 396,
+              "end": 397,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsFunctionType",
+          "span": {
+            "start": 406,
+            "end": 450,
+            "ctxt": 0
+          },
+          "params": [
+            {
+              "type": "RestElement",
+              "span": {
+                "start": 407,
+                "end": 421,
+                "ctxt": 0
+              },
+              "rest": {
+                "start": 407,
+                "end": 410,
+                "ctxt": 0
+              },
+              "argument": {
+                "type": "Identifier",
+                "span": {
+                  "start": 410,
+                  "end": 414,
+                  "ctxt": 0
+                },
+                "value": "args",
+                "optional": false,
+                "typeAnnotation": null
+              },
+              "typeAnnotation": {
+                "type": "TsTypeAnnotation",
+                "span": {
+                  "start": 414,
+                  "end": 421,
+                  "ctxt": 0
+                },
+                "typeAnnotation": {
+                  "type": "TsArrayType",
+                  "span": {
+                    "start": 416,
+                    "end": 421,
+                    "ctxt": 0
+                  },
+                  "elemType": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 416,
+                      "end": 419,
+                      "ctxt": 0
+                    },
+                    "kind": "any"
+                  }
+                }
+              }
+            }
+          ],
+          "typeParams": null,
+          "typeAnnotation": {
+            "type": "TsTypeAnnotation",
+            "span": {
+              "start": 423,
+              "end": 450,
+              "ctxt": 0
+            },
+            "typeAnnotation": {
+              "type": "TsParenthesizedType",
+              "span": {
+                "start": 426,
+                "end": 450,
+                "ctxt": 0
+              },
+              "typeAnnotation": {
+                "type": "TsInferType",
+                "span": {
+                  "start": 427,
+                  "end": 449,
+                  "ctxt": 0
+                },
+                "typeParam": {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 433,
+                    "end": 434,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 433,
+                      "end": 434,
+                      "ctxt": 0
+                    },
+                    "value": "U",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "constraint": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 443,
+                      "end": 449,
+                      "ctxt": 0
+                    },
+                    "kind": "string"
+                  },
+                  "default": null
+                }
+              }
+            }
+          }
+        },
+        "trueType": {
+          "type": "TsTupleType",
+          "span": {
+            "start": 453,
+            "end": 466,
+            "ctxt": 0
+          },
+          "elemTypes": [
+            {
+              "type": "TsTupleElement",
+              "span": {
+                "start": 454,
+                "end": 462,
+                "ctxt": 0
+              },
+              "label": null,
+              "ty": {
+                "type": "TsLiteralType",
+                "span": {
+                  "start": 454,
+                  "end": 462,
+                  "ctxt": 0
+                },
+                "literal": {
+                  "type": "StringLiteral",
+                  "span": {
+                    "start": 454,
+                    "end": 462,
+                    "ctxt": 0
+                  },
+                  "value": "string",
+                  "raw": "\"string\""
+                }
+              }
+            },
+            {
+              "type": "TsTupleElement",
+              "span": {
+                "start": 464,
+                "end": 465,
+                "ctxt": 0
+              },
+              "label": null,
+              "ty": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 464,
+                  "end": 465,
+                  "ctxt": 0
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 464,
+                    "end": 465,
+                    "ctxt": 0
+                  },
+                  "value": "U",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            }
+          ]
+        },
+        "falseType": {
+          "type": "TsConditionalType",
+          "span": {
+            "start": 473,
+            "end": 555,
+            "ctxt": 0
+          },
+          "checkType": {
+            "type": "TsTypeReference",
+            "span": {
+              "start": 473,
+              "end": 474,
+              "ctxt": 0
+            },
+            "typeName": {
+              "type": "Identifier",
+              "span": {
+                "start": 473,
+                "end": 474,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "typeParams": null
+          },
+          "extendsType": {
+            "type": "TsFunctionType",
+            "span": {
+              "start": 483,
+              "end": 527,
+              "ctxt": 0
+            },
+            "params": [
+              {
+                "type": "RestElement",
+                "span": {
+                  "start": 484,
+                  "end": 498,
+                  "ctxt": 0
+                },
+                "rest": {
+                  "start": 484,
+                  "end": 487,
+                  "ctxt": 0
+                },
+                "argument": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 487,
+                    "end": 491,
+                    "ctxt": 0
+                  },
+                  "value": "args",
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 491,
+                    "end": 498,
+                    "ctxt": 0
+                  },
+                  "typeAnnotation": {
+                    "type": "TsArrayType",
+                    "span": {
+                      "start": 493,
+                      "end": 498,
+                      "ctxt": 0
+                    },
+                    "elemType": {
+                      "type": "TsKeywordType",
+                      "span": {
+                        "start": 493,
+                        "end": 496,
+                        "ctxt": 0
+                      },
+                      "kind": "any"
+                    }
+                  }
+                }
+              }
+            ],
+            "typeParams": null,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 500,
+                "end": 527,
+                "ctxt": 0
+              },
+              "typeAnnotation": {
+                "type": "TsParenthesizedType",
+                "span": {
+                  "start": 503,
+                  "end": 527,
+                  "ctxt": 0
+                },
+                "typeAnnotation": {
+                  "type": "TsInferType",
+                  "span": {
+                    "start": 504,
+                    "end": 526,
+                    "ctxt": 0
+                  },
+                  "typeParam": {
+                    "type": "TsTypeParameter",
+                    "span": {
+                      "start": 510,
+                      "end": 511,
+                      "ctxt": 0
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 510,
+                        "end": 511,
+                        "ctxt": 0
+                      },
+                      "value": "U",
+                      "optional": false
+                    },
+                    "in": false,
+                    "out": false,
+                    "constraint": {
+                      "type": "TsKeywordType",
+                      "span": {
+                        "start": 520,
+                        "end": 526,
+                        "ctxt": 0
+                      },
+                      "kind": "number"
+                    },
+                    "default": null
+                  }
+                }
+              }
+            }
+          },
+          "trueType": {
+            "type": "TsTupleType",
+            "span": {
+              "start": 530,
+              "end": 543,
+              "ctxt": 0
+            },
+            "elemTypes": [
+              {
+                "type": "TsTupleElement",
+                "span": {
+                  "start": 531,
+                  "end": 539,
+                  "ctxt": 0
+                },
+                "label": null,
+                "ty": {
+                  "type": "TsLiteralType",
+                  "span": {
+                    "start": 531,
+                    "end": 539,
+                    "ctxt": 0
+                  },
+                  "literal": {
+                    "type": "StringLiteral",
+                    "span": {
+                      "start": 531,
+                      "end": 539,
+                      "ctxt": 0
+                    },
+                    "value": "number",
+                    "raw": "\"number\""
+                  }
+                }
+              },
+              {
+                "type": "TsTupleElement",
+                "span": {
+                  "start": 541,
+                  "end": 542,
+                  "ctxt": 0
+                },
+                "label": null,
+                "ty": {
+                  "type": "TsTypeReference",
+                  "span": {
+                    "start": 541,
+                    "end": 542,
+                    "ctxt": 0
+                  },
+                  "typeName": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 541,
+                      "end": 542,
+                      "ctxt": 0
+                    },
+                    "value": "U",
+                    "optional": false
+                  },
+                  "typeParams": null
+                }
+              }
+            ]
+          },
+          "falseType": {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 550,
+              "end": 555,
+              "ctxt": 0
+            },
+            "kind": "never"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 558,
+        "end": 793,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 563,
+          "end": 565,
+          "ctxt": 0
+        },
+        "value": "X4",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 565,
+          "end": 604,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 566,
+              "end": 603,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 566,
+                "end": 567,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": {
+              "type": "TsConstructorType",
+              "span": {
+                "start": 576,
+                "end": 603,
+                "ctxt": 0
+              },
+              "params": [
+                {
+                  "type": "RestElement",
+                  "span": {
+                    "start": 581,
+                    "end": 595,
+                    "ctxt": 0
+                  },
+                  "rest": {
+                    "start": 581,
+                    "end": 584,
+                    "ctxt": 0
+                  },
+                  "argument": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 584,
+                      "end": 588,
+                      "ctxt": 0
+                    },
+                    "value": "args",
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 588,
+                      "end": 595,
+                      "ctxt": 0
+                    },
+                    "typeAnnotation": {
+                      "type": "TsArrayType",
+                      "span": {
+                        "start": 590,
+                        "end": 595,
+                        "ctxt": 0
+                      },
+                      "elemType": {
+                        "type": "TsKeywordType",
+                        "span": {
+                          "start": 590,
+                          "end": 593,
+                          "ctxt": 0
+                        },
+                        "kind": "any"
+                      }
+                    }
+                  }
+                }
+              ],
+              "typeParams": null,
+              "typeAnnotation": {
+                "type": "TsTypeAnnotation",
+                "span": {
+                  "start": 597,
+                  "end": 603,
+                  "ctxt": 0
+                },
+                "typeAnnotation": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 600,
+                    "end": 603,
+                    "ctxt": 0
+                  },
+                  "kind": "any"
+                }
+              },
+              "isAbstract": false
+            },
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 611,
+          "end": 792,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 611,
+            "end": 612,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 611,
+              "end": 612,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsConstructorType",
+          "span": {
+            "start": 621,
+            "end": 676,
+            "ctxt": 0
+          },
+          "params": [
+            {
+              "type": "RestElement",
+              "span": {
+                "start": 626,
+                "end": 640,
+                "ctxt": 0
+              },
+              "rest": {
+                "start": 626,
+                "end": 629,
+                "ctxt": 0
+              },
+              "argument": {
+                "type": "Identifier",
+                "span": {
+                  "start": 629,
+                  "end": 633,
+                  "ctxt": 0
+                },
+                "value": "args",
+                "optional": false,
+                "typeAnnotation": null
+              },
+              "typeAnnotation": {
+                "type": "TsTypeAnnotation",
+                "span": {
+                  "start": 633,
+                  "end": 640,
+                  "ctxt": 0
+                },
+                "typeAnnotation": {
+                  "type": "TsArrayType",
+                  "span": {
+                    "start": 635,
+                    "end": 640,
+                    "ctxt": 0
+                  },
+                  "elemType": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 635,
+                      "end": 638,
+                      "ctxt": 0
+                    },
+                    "kind": "any"
+                  }
+                }
+              }
+            }
+          ],
+          "typeParams": null,
+          "typeAnnotation": {
+            "type": "TsTypeAnnotation",
+            "span": {
+              "start": 642,
+              "end": 676,
+              "ctxt": 0
+            },
+            "typeAnnotation": {
+              "type": "TsParenthesizedType",
+              "span": {
+                "start": 645,
+                "end": 676,
+                "ctxt": 0
+              },
+              "typeAnnotation": {
+                "type": "TsInferType",
+                "span": {
+                  "start": 646,
+                  "end": 675,
+                  "ctxt": 0
+                },
+                "typeParam": {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 652,
+                    "end": 653,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 652,
+                      "end": 653,
+                      "ctxt": 0
+                    },
+                    "value": "U",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "constraint": {
+                    "type": "TsTypeLiteral",
+                    "span": {
+                      "start": 662,
+                      "end": 675,
+                      "ctxt": 0
+                    },
+                    "members": [
+                      {
+                        "type": "TsPropertySignature",
+                        "span": {
+                          "start": 664,
+                          "end": 673,
+                          "ctxt": 0
+                        },
+                        "readonly": false,
+                        "key": {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 664,
+                            "end": 665,
+                            "ctxt": 0
+                          },
+                          "value": "a",
+                          "optional": false
+                        },
+                        "computed": false,
+                        "optional": false,
+                        "init": null,
+                        "params": [],
+                        "typeAnnotation": {
+                          "type": "TsTypeAnnotation",
+                          "span": {
+                            "start": 665,
+                            "end": 673,
+                            "ctxt": 0
+                          },
+                          "typeAnnotation": {
+                            "type": "TsKeywordType",
+                            "span": {
+                              "start": 667,
+                              "end": 673,
+                              "ctxt": 0
+                            },
+                            "kind": "string"
+                          }
+                        },
+                        "typeParams": null
+                      }
+                    ]
+                  },
+                  "default": null
+                }
+              }
+            }
+          },
+          "isAbstract": false
+        },
+        "trueType": {
+          "type": "TsTupleType",
+          "span": {
+            "start": 679,
+            "end": 692,
+            "ctxt": 0
+          },
+          "elemTypes": [
+            {
+              "type": "TsTupleElement",
+              "span": {
+                "start": 680,
+                "end": 688,
+                "ctxt": 0
+              },
+              "label": null,
+              "ty": {
+                "type": "TsLiteralType",
+                "span": {
+                  "start": 680,
+                  "end": 688,
+                  "ctxt": 0
+                },
+                "literal": {
+                  "type": "StringLiteral",
+                  "span": {
+                    "start": 680,
+                    "end": 688,
+                    "ctxt": 0
+                  },
+                  "value": "string",
+                  "raw": "\"string\""
+                }
+              }
+            },
+            {
+              "type": "TsTupleElement",
+              "span": {
+                "start": 690,
+                "end": 691,
+                "ctxt": 0
+              },
+              "label": null,
+              "ty": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 690,
+                  "end": 691,
+                  "ctxt": 0
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 690,
+                    "end": 691,
+                    "ctxt": 0
+                  },
+                  "value": "U",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            }
+          ]
+        },
+        "falseType": {
+          "type": "TsConditionalType",
+          "span": {
+            "start": 699,
+            "end": 792,
+            "ctxt": 0
+          },
+          "checkType": {
+            "type": "TsTypeReference",
+            "span": {
+              "start": 699,
+              "end": 700,
+              "ctxt": 0
+            },
+            "typeName": {
+              "type": "Identifier",
+              "span": {
+                "start": 699,
+                "end": 700,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "typeParams": null
+          },
+          "extendsType": {
+            "type": "TsConstructorType",
+            "span": {
+              "start": 709,
+              "end": 764,
+              "ctxt": 0
+            },
+            "params": [
+              {
+                "type": "RestElement",
+                "span": {
+                  "start": 714,
+                  "end": 728,
+                  "ctxt": 0
+                },
+                "rest": {
+                  "start": 714,
+                  "end": 717,
+                  "ctxt": 0
+                },
+                "argument": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 717,
+                    "end": 721,
+                    "ctxt": 0
+                  },
+                  "value": "args",
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 721,
+                    "end": 728,
+                    "ctxt": 0
+                  },
+                  "typeAnnotation": {
+                    "type": "TsArrayType",
+                    "span": {
+                      "start": 723,
+                      "end": 728,
+                      "ctxt": 0
+                    },
+                    "elemType": {
+                      "type": "TsKeywordType",
+                      "span": {
+                        "start": 723,
+                        "end": 726,
+                        "ctxt": 0
+                      },
+                      "kind": "any"
+                    }
+                  }
+                }
+              }
+            ],
+            "typeParams": null,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 730,
+                "end": 764,
+                "ctxt": 0
+              },
+              "typeAnnotation": {
+                "type": "TsParenthesizedType",
+                "span": {
+                  "start": 733,
+                  "end": 764,
+                  "ctxt": 0
+                },
+                "typeAnnotation": {
+                  "type": "TsInferType",
+                  "span": {
+                    "start": 734,
+                    "end": 763,
+                    "ctxt": 0
+                  },
+                  "typeParam": {
+                    "type": "TsTypeParameter",
+                    "span": {
+                      "start": 740,
+                      "end": 741,
+                      "ctxt": 0
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 740,
+                        "end": 741,
+                        "ctxt": 0
+                      },
+                      "value": "U",
+                      "optional": false
+                    },
+                    "in": false,
+                    "out": false,
+                    "constraint": {
+                      "type": "TsTypeLiteral",
+                      "span": {
+                        "start": 750,
+                        "end": 763,
+                        "ctxt": 0
+                      },
+                      "members": [
+                        {
+                          "type": "TsPropertySignature",
+                          "span": {
+                            "start": 752,
+                            "end": 761,
+                            "ctxt": 0
+                          },
+                          "readonly": false,
+                          "key": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 752,
+                              "end": 753,
+                              "ctxt": 0
+                            },
+                            "value": "a",
+                            "optional": false
+                          },
+                          "computed": false,
+                          "optional": false,
+                          "init": null,
+                          "params": [],
+                          "typeAnnotation": {
+                            "type": "TsTypeAnnotation",
+                            "span": {
+                              "start": 753,
+                              "end": 761,
+                              "ctxt": 0
+                            },
+                            "typeAnnotation": {
+                              "type": "TsKeywordType",
+                              "span": {
+                                "start": 755,
+                                "end": 761,
+                                "ctxt": 0
+                              },
+                              "kind": "number"
+                            }
+                          },
+                          "typeParams": null
+                        }
+                      ]
+                    },
+                    "default": null
+                  }
+                }
+              }
+            },
+            "isAbstract": false
+          },
+          "trueType": {
+            "type": "TsTupleType",
+            "span": {
+              "start": 767,
+              "end": 780,
+              "ctxt": 0
+            },
+            "elemTypes": [
+              {
+                "type": "TsTupleElement",
+                "span": {
+                  "start": 768,
+                  "end": 776,
+                  "ctxt": 0
+                },
+                "label": null,
+                "ty": {
+                  "type": "TsLiteralType",
+                  "span": {
+                    "start": 768,
+                    "end": 776,
+                    "ctxt": 0
+                  },
+                  "literal": {
+                    "type": "StringLiteral",
+                    "span": {
+                      "start": 768,
+                      "end": 776,
+                      "ctxt": 0
+                    },
+                    "value": "number",
+                    "raw": "\"number\""
+                  }
+                }
+              },
+              {
+                "type": "TsTupleElement",
+                "span": {
+                  "start": 778,
+                  "end": 779,
+                  "ctxt": 0
+                },
+                "label": null,
+                "ty": {
+                  "type": "TsTypeReference",
+                  "span": {
+                    "start": 778,
+                    "end": 779,
+                    "ctxt": 0
+                  },
+                  "typeName": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 778,
+                      "end": 779,
+                      "ctxt": 0
+                    },
+                    "value": "U",
+                    "optional": false
+                  },
+                  "typeParams": null
+                }
+              }
+            ]
+          },
+          "falseType": {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 787,
+              "end": 792,
+              "ctxt": 0
+            },
+            "kind": "never"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 795,
+        "end": 946,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 800,
+          "end": 802,
+          "ctxt": 0
+        },
+        "value": "X5",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 802,
+          "end": 805,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 803,
+              "end": 804,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 803,
+                "end": 804,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 812,
+          "end": 945,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 812,
+            "end": 813,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 812,
+              "end": 813,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 822,
+            "end": 853,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 822,
+              "end": 829,
+              "ctxt": 0
+            },
+            "value": "Promise",
+            "optional": false
+          },
+          "typeParams": {
+            "type": "TsTypeParameterInstantiation",
+            "span": {
+              "start": 829,
+              "end": 853,
+              "ctxt": 0
+            },
+            "params": [
+              {
+                "type": "TsInferType",
+                "span": {
+                  "start": 830,
+                  "end": 852,
+                  "ctxt": 0
+                },
+                "typeParam": {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 836,
+                    "end": 837,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 836,
+                      "end": 837,
+                      "ctxt": 0
+                    },
+                    "value": "U",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "constraint": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 846,
+                      "end": 852,
+                      "ctxt": 0
+                    },
+                    "kind": "string"
+                  },
+                  "default": null
+                }
+              }
+            ]
+          }
+        },
+        "trueType": {
+          "type": "TsTupleType",
+          "span": {
+            "start": 856,
+            "end": 869,
+            "ctxt": 0
+          },
+          "elemTypes": [
+            {
+              "type": "TsTupleElement",
+              "span": {
+                "start": 857,
+                "end": 865,
+                "ctxt": 0
+              },
+              "label": null,
+              "ty": {
+                "type": "TsLiteralType",
+                "span": {
+                  "start": 857,
+                  "end": 865,
+                  "ctxt": 0
+                },
+                "literal": {
+                  "type": "StringLiteral",
+                  "span": {
+                    "start": 857,
+                    "end": 865,
+                    "ctxt": 0
+                  },
+                  "value": "string",
+                  "raw": "\"string\""
+                }
+              }
+            },
+            {
+              "type": "TsTupleElement",
+              "span": {
+                "start": 867,
+                "end": 868,
+                "ctxt": 0
+              },
+              "label": null,
+              "ty": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 867,
+                  "end": 868,
+                  "ctxt": 0
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 867,
+                    "end": 868,
+                    "ctxt": 0
+                  },
+                  "value": "U",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            }
+          ]
+        },
+        "falseType": {
+          "type": "TsConditionalType",
+          "span": {
+            "start": 876,
+            "end": 945,
+            "ctxt": 0
+          },
+          "checkType": {
+            "type": "TsTypeReference",
+            "span": {
+              "start": 876,
+              "end": 877,
+              "ctxt": 0
+            },
+            "typeName": {
+              "type": "Identifier",
+              "span": {
+                "start": 876,
+                "end": 877,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "typeParams": null
+          },
+          "extendsType": {
+            "type": "TsTypeReference",
+            "span": {
+              "start": 886,
+              "end": 917,
+              "ctxt": 0
+            },
+            "typeName": {
+              "type": "Identifier",
+              "span": {
+                "start": 886,
+                "end": 893,
+                "ctxt": 0
+              },
+              "value": "Promise",
+              "optional": false
+            },
+            "typeParams": {
+              "type": "TsTypeParameterInstantiation",
+              "span": {
+                "start": 893,
+                "end": 917,
+                "ctxt": 0
+              },
+              "params": [
+                {
+                  "type": "TsInferType",
+                  "span": {
+                    "start": 894,
+                    "end": 916,
+                    "ctxt": 0
+                  },
+                  "typeParam": {
+                    "type": "TsTypeParameter",
+                    "span": {
+                      "start": 900,
+                      "end": 901,
+                      "ctxt": 0
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 900,
+                        "end": 901,
+                        "ctxt": 0
+                      },
+                      "value": "U",
+                      "optional": false
+                    },
+                    "in": false,
+                    "out": false,
+                    "constraint": {
+                      "type": "TsKeywordType",
+                      "span": {
+                        "start": 910,
+                        "end": 916,
+                        "ctxt": 0
+                      },
+                      "kind": "number"
+                    },
+                    "default": null
+                  }
+                }
+              ]
+            }
+          },
+          "trueType": {
+            "type": "TsTupleType",
+            "span": {
+              "start": 920,
+              "end": 933,
+              "ctxt": 0
+            },
+            "elemTypes": [
+              {
+                "type": "TsTupleElement",
+                "span": {
+                  "start": 921,
+                  "end": 929,
+                  "ctxt": 0
+                },
+                "label": null,
+                "ty": {
+                  "type": "TsLiteralType",
+                  "span": {
+                    "start": 921,
+                    "end": 929,
+                    "ctxt": 0
+                  },
+                  "literal": {
+                    "type": "StringLiteral",
+                    "span": {
+                      "start": 921,
+                      "end": 929,
+                      "ctxt": 0
+                    },
+                    "value": "number",
+                    "raw": "\"number\""
+                  }
+                }
+              },
+              {
+                "type": "TsTupleElement",
+                "span": {
+                  "start": 931,
+                  "end": 932,
+                  "ctxt": 0
+                },
+                "label": null,
+                "ty": {
+                  "type": "TsTypeReference",
+                  "span": {
+                    "start": 931,
+                    "end": 932,
+                    "ctxt": 0
+                  },
+                  "typeName": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 931,
+                      "end": 932,
+                      "ctxt": 0
+                    },
+                    "value": "U",
+                    "optional": false
+                  },
+                  "typeParams": null
+                }
+              }
+            ]
+          },
+          "falseType": {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 940,
+              "end": 945,
+              "ctxt": 0
+            },
+            "kind": "never"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 948,
+        "end": 1095,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 953,
+          "end": 955,
+          "ctxt": 0
+        },
+        "value": "X6",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 955,
+          "end": 958,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 956,
+              "end": 957,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 956,
+                "end": 957,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 965,
+          "end": 1094,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 965,
+            "end": 966,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 965,
+              "end": 966,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsTypeLiteral",
+          "span": {
+            "start": 975,
+            "end": 1004,
+            "ctxt": 0
+          },
+          "members": [
+            {
+              "type": "TsPropertySignature",
+              "span": {
+                "start": 977,
+                "end": 1002,
+                "ctxt": 0
+              },
+              "readonly": false,
+              "key": {
+                "type": "Identifier",
+                "span": {
+                  "start": 977,
+                  "end": 978,
+                  "ctxt": 0
+                },
+                "value": "a",
+                "optional": false
+              },
+              "computed": false,
+              "optional": false,
+              "init": null,
+              "params": [],
+              "typeAnnotation": {
+                "type": "TsTypeAnnotation",
+                "span": {
+                  "start": 978,
+                  "end": 1002,
+                  "ctxt": 0
+                },
+                "typeAnnotation": {
+                  "type": "TsInferType",
+                  "span": {
+                    "start": 980,
+                    "end": 1002,
+                    "ctxt": 0
+                  },
+                  "typeParam": {
+                    "type": "TsTypeParameter",
+                    "span": {
+                      "start": 986,
+                      "end": 987,
+                      "ctxt": 0
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 986,
+                        "end": 987,
+                        "ctxt": 0
+                      },
+                      "value": "U",
+                      "optional": false
+                    },
+                    "in": false,
+                    "out": false,
+                    "constraint": {
+                      "type": "TsKeywordType",
+                      "span": {
+                        "start": 996,
+                        "end": 1002,
+                        "ctxt": 0
+                      },
+                      "kind": "string"
+                    },
+                    "default": null
+                  }
+                }
+              },
+              "typeParams": null
+            }
+          ]
+        },
+        "trueType": {
+          "type": "TsTupleType",
+          "span": {
+            "start": 1007,
+            "end": 1020,
+            "ctxt": 0
+          },
+          "elemTypes": [
+            {
+              "type": "TsTupleElement",
+              "span": {
+                "start": 1008,
+                "end": 1016,
+                "ctxt": 0
+              },
+              "label": null,
+              "ty": {
+                "type": "TsLiteralType",
+                "span": {
+                  "start": 1008,
+                  "end": 1016,
+                  "ctxt": 0
+                },
+                "literal": {
+                  "type": "StringLiteral",
+                  "span": {
+                    "start": 1008,
+                    "end": 1016,
+                    "ctxt": 0
+                  },
+                  "value": "string",
+                  "raw": "\"string\""
+                }
+              }
+            },
+            {
+              "type": "TsTupleElement",
+              "span": {
+                "start": 1018,
+                "end": 1019,
+                "ctxt": 0
+              },
+              "label": null,
+              "ty": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 1018,
+                  "end": 1019,
+                  "ctxt": 0
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 1018,
+                    "end": 1019,
+                    "ctxt": 0
+                  },
+                  "value": "U",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            }
+          ]
+        },
+        "falseType": {
+          "type": "TsConditionalType",
+          "span": {
+            "start": 1027,
+            "end": 1094,
+            "ctxt": 0
+          },
+          "checkType": {
+            "type": "TsTypeReference",
+            "span": {
+              "start": 1027,
+              "end": 1028,
+              "ctxt": 0
+            },
+            "typeName": {
+              "type": "Identifier",
+              "span": {
+                "start": 1027,
+                "end": 1028,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "typeParams": null
+          },
+          "extendsType": {
+            "type": "TsTypeLiteral",
+            "span": {
+              "start": 1037,
+              "end": 1066,
+              "ctxt": 0
+            },
+            "members": [
+              {
+                "type": "TsPropertySignature",
+                "span": {
+                  "start": 1039,
+                  "end": 1064,
+                  "ctxt": 0
+                },
+                "readonly": false,
+                "key": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 1039,
+                    "end": 1040,
+                    "ctxt": 0
+                  },
+                  "value": "a",
+                  "optional": false
+                },
+                "computed": false,
+                "optional": false,
+                "init": null,
+                "params": [],
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 1040,
+                    "end": 1064,
+                    "ctxt": 0
+                  },
+                  "typeAnnotation": {
+                    "type": "TsInferType",
+                    "span": {
+                      "start": 1042,
+                      "end": 1064,
+                      "ctxt": 0
+                    },
+                    "typeParam": {
+                      "type": "TsTypeParameter",
+                      "span": {
+                        "start": 1048,
+                        "end": 1049,
+                        "ctxt": 0
+                      },
+                      "name": {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 1048,
+                          "end": 1049,
+                          "ctxt": 0
+                        },
+                        "value": "U",
+                        "optional": false
+                      },
+                      "in": false,
+                      "out": false,
+                      "constraint": {
+                        "type": "TsKeywordType",
+                        "span": {
+                          "start": 1058,
+                          "end": 1064,
+                          "ctxt": 0
+                        },
+                        "kind": "number"
+                      },
+                      "default": null
+                    }
+                  }
+                },
+                "typeParams": null
+              }
+            ]
+          },
+          "trueType": {
+            "type": "TsTupleType",
+            "span": {
+              "start": 1069,
+              "end": 1082,
+              "ctxt": 0
+            },
+            "elemTypes": [
+              {
+                "type": "TsTupleElement",
+                "span": {
+                  "start": 1070,
+                  "end": 1078,
+                  "ctxt": 0
+                },
+                "label": null,
+                "ty": {
+                  "type": "TsLiteralType",
+                  "span": {
+                    "start": 1070,
+                    "end": 1078,
+                    "ctxt": 0
+                  },
+                  "literal": {
+                    "type": "StringLiteral",
+                    "span": {
+                      "start": 1070,
+                      "end": 1078,
+                      "ctxt": 0
+                    },
+                    "value": "number",
+                    "raw": "\"number\""
+                  }
+                }
+              },
+              {
+                "type": "TsTupleElement",
+                "span": {
+                  "start": 1080,
+                  "end": 1081,
+                  "ctxt": 0
+                },
+                "label": null,
+                "ty": {
+                  "type": "TsTypeReference",
+                  "span": {
+                    "start": 1080,
+                    "end": 1081,
+                    "ctxt": 0
+                  },
+                  "typeName": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 1080,
+                      "end": 1081,
+                      "ctxt": 0
+                    },
+                    "value": "U",
+                    "optional": false
+                  },
+                  "typeParams": null
+                }
+              }
+            ]
+          },
+          "falseType": {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 1089,
+              "end": 1094,
+              "ctxt": 0
+            },
+            "kind": "never"
+          }
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/typescript/types/conditional-infer-extends/distinguishing/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript/types/conditional-infer-extends/distinguishing/input.ts
@@ -1,0 +1,9 @@
+type X10<T> = T extends (infer U extends number ? 1 : 0) ? 1 : 0; // ok, parsed as conditional
+type X11<T> = T extends ((infer U) extends number ? 1 : 0) ? 1 : 0; // ok, parsed as conditional
+type X12<T> = T extends (infer U extends number) ? 1 : 0; // ok, parsed as `infer..extends` (no trailing `?`)
+type X13<T> = T extends infer U extends number ? 1 : 0; // ok, parsed as `infer..extends` (conditional types not allowed in 'extends type')
+type X14<T> = T extends keyof infer U extends number ? 1 : 0; // ok, parsed as `infer..extends` (precedence wouldn't have parsed the `?` as part of a type operator)
+type X15<T> = T extends { [P in infer U extends keyof T ? 1 : 0]: 1; } ? 1 : 0; // ok, parsed as conditional
+type X16<T> = T extends { [P in infer U extends keyof T]: 1; } ? 1 : 0; // ok, parsed as `infer..extends` (no trailing `?`)
+type X17<T> = T extends { [P in keyof T as infer U extends P ? 1 : 0]: 1; } ? 1 : 0; // ok, parsed as conditional
+type X18<T> = T extends { [P in keyof T as infer U extends P]: 1; } ? 1 : 0; // ok, parsed as `infer..extends` (no trailing `?`)

--- a/crates/swc_ecma_parser/tests/typescript/types/conditional-infer-extends/distinguishing/input.ts.json
+++ b/crates/swc_ecma_parser/tests/typescript/types/conditional-infer-extends/distinguishing/input.ts.json
@@ -1,0 +1,1912 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 0,
+    "end": 1030,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 0,
+        "end": 65,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 5,
+          "end": 8,
+          "ctxt": 0
+        },
+        "value": "X10",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 8,
+          "end": 11,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 9,
+              "end": 10,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 9,
+                "end": 10,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 14,
+          "end": 64,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 14,
+            "end": 15,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 14,
+              "end": 15,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsParenthesizedType",
+          "span": {
+            "start": 24,
+            "end": 56,
+            "ctxt": 0
+          },
+          "typeAnnotation": {
+            "type": "TsConditionalType",
+            "span": {
+              "start": 25,
+              "end": 55,
+              "ctxt": 0
+            },
+            "checkType": {
+              "type": "TsInferType",
+              "span": {
+                "start": 25,
+                "end": 32,
+                "ctxt": 0
+              },
+              "typeParam": {
+                "type": "TsTypeParameter",
+                "span": {
+                  "start": 31,
+                  "end": 32,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 31,
+                    "end": 32,
+                    "ctxt": 0
+                  },
+                  "value": "U",
+                  "optional": false
+                },
+                "in": false,
+                "out": false,
+                "constraint": null,
+                "default": null
+              }
+            },
+            "extendsType": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 41,
+                "end": 47,
+                "ctxt": 0
+              },
+              "kind": "number"
+            },
+            "trueType": {
+              "type": "TsLiteralType",
+              "span": {
+                "start": 50,
+                "end": 51,
+                "ctxt": 0
+              },
+              "literal": {
+                "type": "NumericLiteral",
+                "span": {
+                  "start": 50,
+                  "end": 51,
+                  "ctxt": 0
+                },
+                "value": 1.0,
+                "raw": "1"
+              }
+            },
+            "falseType": {
+              "type": "TsLiteralType",
+              "span": {
+                "start": 54,
+                "end": 55,
+                "ctxt": 0
+              },
+              "literal": {
+                "type": "NumericLiteral",
+                "span": {
+                  "start": 54,
+                  "end": 55,
+                  "ctxt": 0
+                },
+                "value": 0.0,
+                "raw": "0"
+              }
+            }
+          }
+        },
+        "trueType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 59,
+            "end": 60,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 59,
+              "end": 60,
+              "ctxt": 0
+            },
+            "value": 1.0,
+            "raw": "1"
+          }
+        },
+        "falseType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 63,
+            "end": 64,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 63,
+              "end": 64,
+              "ctxt": 0
+            },
+            "value": 0.0,
+            "raw": "0"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 95,
+        "end": 162,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 100,
+          "end": 103,
+          "ctxt": 0
+        },
+        "value": "X11",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 103,
+          "end": 106,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 104,
+              "end": 105,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 104,
+                "end": 105,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 109,
+          "end": 161,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 109,
+            "end": 110,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 109,
+              "end": 110,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsParenthesizedType",
+          "span": {
+            "start": 119,
+            "end": 153,
+            "ctxt": 0
+          },
+          "typeAnnotation": {
+            "type": "TsConditionalType",
+            "span": {
+              "start": 120,
+              "end": 152,
+              "ctxt": 0
+            },
+            "checkType": {
+              "type": "TsParenthesizedType",
+              "span": {
+                "start": 120,
+                "end": 129,
+                "ctxt": 0
+              },
+              "typeAnnotation": {
+                "type": "TsInferType",
+                "span": {
+                  "start": 121,
+                  "end": 128,
+                  "ctxt": 0
+                },
+                "typeParam": {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 127,
+                    "end": 128,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 127,
+                      "end": 128,
+                      "ctxt": 0
+                    },
+                    "value": "U",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "constraint": null,
+                  "default": null
+                }
+              }
+            },
+            "extendsType": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 138,
+                "end": 144,
+                "ctxt": 0
+              },
+              "kind": "number"
+            },
+            "trueType": {
+              "type": "TsLiteralType",
+              "span": {
+                "start": 147,
+                "end": 148,
+                "ctxt": 0
+              },
+              "literal": {
+                "type": "NumericLiteral",
+                "span": {
+                  "start": 147,
+                  "end": 148,
+                  "ctxt": 0
+                },
+                "value": 1.0,
+                "raw": "1"
+              }
+            },
+            "falseType": {
+              "type": "TsLiteralType",
+              "span": {
+                "start": 151,
+                "end": 152,
+                "ctxt": 0
+              },
+              "literal": {
+                "type": "NumericLiteral",
+                "span": {
+                  "start": 151,
+                  "end": 152,
+                  "ctxt": 0
+                },
+                "value": 0.0,
+                "raw": "0"
+              }
+            }
+          }
+        },
+        "trueType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 156,
+            "end": 157,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 156,
+              "end": 157,
+              "ctxt": 0
+            },
+            "value": 1.0,
+            "raw": "1"
+          }
+        },
+        "falseType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 160,
+            "end": 161,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 160,
+              "end": 161,
+              "ctxt": 0
+            },
+            "value": 0.0,
+            "raw": "0"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 192,
+        "end": 249,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 197,
+          "end": 200,
+          "ctxt": 0
+        },
+        "value": "X12",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 200,
+          "end": 203,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 201,
+              "end": 202,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 201,
+                "end": 202,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 206,
+          "end": 248,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 206,
+            "end": 207,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 206,
+              "end": 207,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsParenthesizedType",
+          "span": {
+            "start": 216,
+            "end": 240,
+            "ctxt": 0
+          },
+          "typeAnnotation": {
+            "type": "TsInferType",
+            "span": {
+              "start": 217,
+              "end": 239,
+              "ctxt": 0
+            },
+            "typeParam": {
+              "type": "TsTypeParameter",
+              "span": {
+                "start": 223,
+                "end": 224,
+                "ctxt": 0
+              },
+              "name": {
+                "type": "Identifier",
+                "span": {
+                  "start": 223,
+                  "end": 224,
+                  "ctxt": 0
+                },
+                "value": "U",
+                "optional": false
+              },
+              "in": false,
+              "out": false,
+              "constraint": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 233,
+                  "end": 239,
+                  "ctxt": 0
+                },
+                "kind": "number"
+              },
+              "default": null
+            }
+          }
+        },
+        "trueType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 243,
+            "end": 244,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 243,
+              "end": 244,
+              "ctxt": 0
+            },
+            "value": 1.0,
+            "raw": "1"
+          }
+        },
+        "falseType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 247,
+            "end": 248,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 247,
+              "end": 248,
+              "ctxt": 0
+            },
+            "value": 0.0,
+            "raw": "0"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 302,
+        "end": 357,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 307,
+          "end": 310,
+          "ctxt": 0
+        },
+        "value": "X13",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 310,
+          "end": 313,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 311,
+              "end": 312,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 311,
+                "end": 312,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 316,
+          "end": 356,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 316,
+            "end": 317,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 316,
+              "end": 317,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsInferType",
+          "span": {
+            "start": 326,
+            "end": 348,
+            "ctxt": 0
+          },
+          "typeParam": {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 332,
+              "end": 333,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 332,
+                "end": 333,
+                "ctxt": 0
+              },
+              "value": "U",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 342,
+                "end": 348,
+                "ctxt": 0
+              },
+              "kind": "number"
+            },
+            "default": null
+          }
+        },
+        "trueType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 351,
+            "end": 352,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 351,
+              "end": 352,
+              "ctxt": 0
+            },
+            "value": 1.0,
+            "raw": "1"
+          }
+        },
+        "falseType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 355,
+            "end": 356,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 355,
+              "end": 356,
+              "ctxt": 0
+            },
+            "value": 0.0,
+            "raw": "0"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 442,
+        "end": 503,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 447,
+          "end": 450,
+          "ctxt": 0
+        },
+        "value": "X14",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 450,
+          "end": 453,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 451,
+              "end": 452,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 451,
+                "end": 452,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 456,
+          "end": 502,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 456,
+            "end": 457,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 456,
+              "end": 457,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsTypeOperator",
+          "span": {
+            "start": 466,
+            "end": 494,
+            "ctxt": 0
+          },
+          "op": "keyof",
+          "typeAnnotation": {
+            "type": "TsInferType",
+            "span": {
+              "start": 472,
+              "end": 494,
+              "ctxt": 0
+            },
+            "typeParam": {
+              "type": "TsTypeParameter",
+              "span": {
+                "start": 478,
+                "end": 479,
+                "ctxt": 0
+              },
+              "name": {
+                "type": "Identifier",
+                "span": {
+                  "start": 478,
+                  "end": 479,
+                  "ctxt": 0
+                },
+                "value": "U",
+                "optional": false
+              },
+              "in": false,
+              "out": false,
+              "constraint": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 488,
+                  "end": 494,
+                  "ctxt": 0
+                },
+                "kind": "number"
+              },
+              "default": null
+            }
+          }
+        },
+        "trueType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 497,
+            "end": 498,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 497,
+              "end": 498,
+              "ctxt": 0
+            },
+            "value": 1.0,
+            "raw": "1"
+          }
+        },
+        "falseType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 501,
+            "end": 502,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 501,
+              "end": 502,
+              "ctxt": 0
+            },
+            "value": 0.0,
+            "raw": "0"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 607,
+        "end": 686,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 612,
+          "end": 615,
+          "ctxt": 0
+        },
+        "value": "X15",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 615,
+          "end": 618,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 616,
+              "end": 617,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 616,
+                "end": 617,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 621,
+          "end": 685,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 621,
+            "end": 622,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 621,
+              "end": 622,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsMappedType",
+          "span": {
+            "start": 631,
+            "end": 677,
+            "ctxt": 0
+          },
+          "readonly": null,
+          "typeParam": {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 634,
+              "end": 670,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 634,
+                "end": 635,
+                "ctxt": 0
+              },
+              "value": "P",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": {
+              "type": "TsConditionalType",
+              "span": {
+                "start": 639,
+                "end": 670,
+                "ctxt": 0
+              },
+              "checkType": {
+                "type": "TsInferType",
+                "span": {
+                  "start": 639,
+                  "end": 646,
+                  "ctxt": 0
+                },
+                "typeParam": {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 645,
+                    "end": 646,
+                    "ctxt": 0
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 645,
+                      "end": 646,
+                      "ctxt": 0
+                    },
+                    "value": "U",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "constraint": null,
+                  "default": null
+                }
+              },
+              "extendsType": {
+                "type": "TsTypeOperator",
+                "span": {
+                  "start": 655,
+                  "end": 662,
+                  "ctxt": 0
+                },
+                "op": "keyof",
+                "typeAnnotation": {
+                  "type": "TsTypeReference",
+                  "span": {
+                    "start": 661,
+                    "end": 662,
+                    "ctxt": 0
+                  },
+                  "typeName": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 661,
+                      "end": 662,
+                      "ctxt": 0
+                    },
+                    "value": "T",
+                    "optional": false
+                  },
+                  "typeParams": null
+                }
+              },
+              "trueType": {
+                "type": "TsLiteralType",
+                "span": {
+                  "start": 665,
+                  "end": 666,
+                  "ctxt": 0
+                },
+                "literal": {
+                  "type": "NumericLiteral",
+                  "span": {
+                    "start": 665,
+                    "end": 666,
+                    "ctxt": 0
+                  },
+                  "value": 1.0,
+                  "raw": "1"
+                }
+              },
+              "falseType": {
+                "type": "TsLiteralType",
+                "span": {
+                  "start": 669,
+                  "end": 670,
+                  "ctxt": 0
+                },
+                "literal": {
+                  "type": "NumericLiteral",
+                  "span": {
+                    "start": 669,
+                    "end": 670,
+                    "ctxt": 0
+                  },
+                  "value": 0.0,
+                  "raw": "0"
+                }
+              }
+            },
+            "default": null
+          },
+          "nameType": null,
+          "optional": null,
+          "typeAnnotation": {
+            "type": "TsLiteralType",
+            "span": {
+              "start": 673,
+              "end": 674,
+              "ctxt": 0
+            },
+            "literal": {
+              "type": "NumericLiteral",
+              "span": {
+                "start": 673,
+                "end": 674,
+                "ctxt": 0
+              },
+              "value": 1.0,
+              "raw": "1"
+            }
+          }
+        },
+        "trueType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 680,
+            "end": 681,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 680,
+              "end": 681,
+              "ctxt": 0
+            },
+            "value": 1.0,
+            "raw": "1"
+          }
+        },
+        "falseType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 684,
+            "end": 685,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 684,
+              "end": 685,
+              "ctxt": 0
+            },
+            "value": 0.0,
+            "raw": "0"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 716,
+        "end": 787,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 721,
+          "end": 724,
+          "ctxt": 0
+        },
+        "value": "X16",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 724,
+          "end": 727,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 725,
+              "end": 726,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 725,
+                "end": 726,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 730,
+          "end": 786,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 730,
+            "end": 731,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 730,
+              "end": 731,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsMappedType",
+          "span": {
+            "start": 740,
+            "end": 778,
+            "ctxt": 0
+          },
+          "readonly": null,
+          "typeParam": {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 743,
+              "end": 771,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 743,
+                "end": 744,
+                "ctxt": 0
+              },
+              "value": "P",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": {
+              "type": "TsInferType",
+              "span": {
+                "start": 748,
+                "end": 771,
+                "ctxt": 0
+              },
+              "typeParam": {
+                "type": "TsTypeParameter",
+                "span": {
+                  "start": 754,
+                  "end": 755,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 754,
+                    "end": 755,
+                    "ctxt": 0
+                  },
+                  "value": "U",
+                  "optional": false
+                },
+                "in": false,
+                "out": false,
+                "constraint": {
+                  "type": "TsTypeOperator",
+                  "span": {
+                    "start": 764,
+                    "end": 771,
+                    "ctxt": 0
+                  },
+                  "op": "keyof",
+                  "typeAnnotation": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 770,
+                      "end": 771,
+                      "ctxt": 0
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 770,
+                        "end": 771,
+                        "ctxt": 0
+                      },
+                      "value": "T",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  }
+                },
+                "default": null
+              }
+            },
+            "default": null
+          },
+          "nameType": null,
+          "optional": null,
+          "typeAnnotation": {
+            "type": "TsLiteralType",
+            "span": {
+              "start": 774,
+              "end": 775,
+              "ctxt": 0
+            },
+            "literal": {
+              "type": "NumericLiteral",
+              "span": {
+                "start": 774,
+                "end": 775,
+                "ctxt": 0
+              },
+              "value": 1.0,
+              "raw": "1"
+            }
+          }
+        },
+        "trueType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 781,
+            "end": 782,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 781,
+              "end": 782,
+              "ctxt": 0
+            },
+            "value": 1.0,
+            "raw": "1"
+          }
+        },
+        "falseType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 785,
+            "end": 786,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 785,
+              "end": 786,
+              "ctxt": 0
+            },
+            "value": 0.0,
+            "raw": "0"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 840,
+        "end": 924,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 845,
+          "end": 848,
+          "ctxt": 0
+        },
+        "value": "X17",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 848,
+          "end": 851,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 849,
+              "end": 850,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 849,
+                "end": 850,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 854,
+          "end": 923,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 854,
+            "end": 855,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 854,
+              "end": 855,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsMappedType",
+          "span": {
+            "start": 864,
+            "end": 915,
+            "ctxt": 0
+          },
+          "readonly": null,
+          "typeParam": {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 867,
+              "end": 879,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 867,
+                "end": 868,
+                "ctxt": 0
+              },
+              "value": "P",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": {
+              "type": "TsTypeOperator",
+              "span": {
+                "start": 872,
+                "end": 879,
+                "ctxt": 0
+              },
+              "op": "keyof",
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 878,
+                  "end": 879,
+                  "ctxt": 0
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 878,
+                    "end": 879,
+                    "ctxt": 0
+                  },
+                  "value": "T",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            },
+            "default": null
+          },
+          "nameType": {
+            "type": "TsConditionalType",
+            "span": {
+              "start": 883,
+              "end": 908,
+              "ctxt": 0
+            },
+            "checkType": {
+              "type": "TsInferType",
+              "span": {
+                "start": 883,
+                "end": 890,
+                "ctxt": 0
+              },
+              "typeParam": {
+                "type": "TsTypeParameter",
+                "span": {
+                  "start": 889,
+                  "end": 890,
+                  "ctxt": 0
+                },
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 889,
+                    "end": 890,
+                    "ctxt": 0
+                  },
+                  "value": "U",
+                  "optional": false
+                },
+                "in": false,
+                "out": false,
+                "constraint": null,
+                "default": null
+              }
+            },
+            "extendsType": {
+              "type": "TsTypeReference",
+              "span": {
+                "start": 899,
+                "end": 900,
+                "ctxt": 0
+              },
+              "typeName": {
+                "type": "Identifier",
+                "span": {
+                  "start": 899,
+                  "end": 900,
+                  "ctxt": 0
+                },
+                "value": "P",
+                "optional": false
+              },
+              "typeParams": null
+            },
+            "trueType": {
+              "type": "TsLiteralType",
+              "span": {
+                "start": 903,
+                "end": 904,
+                "ctxt": 0
+              },
+              "literal": {
+                "type": "NumericLiteral",
+                "span": {
+                  "start": 903,
+                  "end": 904,
+                  "ctxt": 0
+                },
+                "value": 1.0,
+                "raw": "1"
+              }
+            },
+            "falseType": {
+              "type": "TsLiteralType",
+              "span": {
+                "start": 907,
+                "end": 908,
+                "ctxt": 0
+              },
+              "literal": {
+                "type": "NumericLiteral",
+                "span": {
+                  "start": 907,
+                  "end": 908,
+                  "ctxt": 0
+                },
+                "value": 0.0,
+                "raw": "0"
+              }
+            }
+          },
+          "optional": null,
+          "typeAnnotation": {
+            "type": "TsLiteralType",
+            "span": {
+              "start": 911,
+              "end": 912,
+              "ctxt": 0
+            },
+            "literal": {
+              "type": "NumericLiteral",
+              "span": {
+                "start": 911,
+                "end": 912,
+                "ctxt": 0
+              },
+              "value": 1.0,
+              "raw": "1"
+            }
+          }
+        },
+        "trueType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 918,
+            "end": 919,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 918,
+              "end": 919,
+              "ctxt": 0
+            },
+            "value": 1.0,
+            "raw": "1"
+          }
+        },
+        "falseType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 922,
+            "end": 923,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 922,
+              "end": 923,
+              "ctxt": 0
+            },
+            "value": 0.0,
+            "raw": "0"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 954,
+        "end": 1030,
+        "ctxt": 0
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 959,
+          "end": 962,
+          "ctxt": 0
+        },
+        "value": "X18",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 962,
+          "end": 965,
+          "ctxt": 0
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 963,
+              "end": 964,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 963,
+                "end": 964,
+                "ctxt": 0
+              },
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsConditionalType",
+        "span": {
+          "start": 968,
+          "end": 1029,
+          "ctxt": 0
+        },
+        "checkType": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 968,
+            "end": 969,
+            "ctxt": 0
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 968,
+              "end": 969,
+              "ctxt": 0
+            },
+            "value": "T",
+            "optional": false
+          },
+          "typeParams": null
+        },
+        "extendsType": {
+          "type": "TsMappedType",
+          "span": {
+            "start": 978,
+            "end": 1021,
+            "ctxt": 0
+          },
+          "readonly": null,
+          "typeParam": {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 981,
+              "end": 993,
+              "ctxt": 0
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 981,
+                "end": 982,
+                "ctxt": 0
+              },
+              "value": "P",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "constraint": {
+              "type": "TsTypeOperator",
+              "span": {
+                "start": 986,
+                "end": 993,
+                "ctxt": 0
+              },
+              "op": "keyof",
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 992,
+                  "end": 993,
+                  "ctxt": 0
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 992,
+                    "end": 993,
+                    "ctxt": 0
+                  },
+                  "value": "T",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            },
+            "default": null
+          },
+          "nameType": {
+            "type": "TsInferType",
+            "span": {
+              "start": 997,
+              "end": 1014,
+              "ctxt": 0
+            },
+            "typeParam": {
+              "type": "TsTypeParameter",
+              "span": {
+                "start": 1003,
+                "end": 1004,
+                "ctxt": 0
+              },
+              "name": {
+                "type": "Identifier",
+                "span": {
+                  "start": 1003,
+                  "end": 1004,
+                  "ctxt": 0
+                },
+                "value": "U",
+                "optional": false
+              },
+              "in": false,
+              "out": false,
+              "constraint": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 1013,
+                  "end": 1014,
+                  "ctxt": 0
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 1013,
+                    "end": 1014,
+                    "ctxt": 0
+                  },
+                  "value": "P",
+                  "optional": false
+                },
+                "typeParams": null
+              },
+              "default": null
+            }
+          },
+          "optional": null,
+          "typeAnnotation": {
+            "type": "TsLiteralType",
+            "span": {
+              "start": 1017,
+              "end": 1018,
+              "ctxt": 0
+            },
+            "literal": {
+              "type": "NumericLiteral",
+              "span": {
+                "start": 1017,
+                "end": 1018,
+                "ctxt": 0
+              },
+              "value": 1.0,
+              "raw": "1"
+            }
+          }
+        },
+        "trueType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 1024,
+            "end": 1025,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 1024,
+              "end": 1025,
+              "ctxt": 0
+            },
+            "value": 1.0,
+            "raw": "1"
+          }
+        },
+        "falseType": {
+          "type": "TsLiteralType",
+          "span": {
+            "start": 1028,
+            "end": 1029,
+            "ctxt": 0
+          },
+          "literal": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 1028,
+              "end": 1029,
+              "ctxt": 0
+            },
+            "value": 0.0,
+            "raw": "0"
+          }
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Support the new TypeScript syntax below:

```ts
type X3<T> = T extends [infer U extends number] ? MustBeNumber<U> : never;
```
Reference: https://github.com/microsoft/TypeScript/pull/48112
