### PR TITLE
fix(css/prefixer): fix more bugs

### DIFF
--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -459,15 +459,17 @@ impl VisitMut for Prefixer {
         for mut n in take(&mut n.rules) {
             n.visit_mut_children_with(self);
 
-            new.append(&mut self.added_rules);
-            new.push(n);
-        }
+            let mut added_rules = take(&mut self.added_rules);
 
-        // TODO only for added_rules
-        new.dedup_by(|a, b| match (a, b) {
-            (Rule::AtRule(a), Rule::AtRule(b)) => a.eq_ignore_span(b),
-            _ => false,
-        });
+            new.append(&mut added_rules);
+            new.push(n);
+
+            // Avoid duplicate prefixed at-rules
+            new.dedup_by(|a, b| match (a, b) {
+                (Rule::AtRule(a), Rule::AtRule(b)) => a.eq_ignore_span(b),
+                _ => false,
+            });
+        }
 
         n.rules = new;
     }

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -960,12 +960,14 @@ impl VisitMut for Prefixer {
         // TODO lazy
         let property_names: Vec<&str> = declarations
             .iter()
-            .filter(|declaration| match declaration {
-                Declaration {
-                    name: DeclarationName::DashedIdent(_),
-                    ..
-                } => false,
-                _ => true,
+            .filter(|declaration| {
+                !matches!(
+                    declaration,
+                    Declaration {
+                        name: DeclarationName::DashedIdent(_),
+                        ..
+                    }
+                )
             })
             .map(|declaration| match declaration {
                 Declaration {

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -867,87 +867,93 @@ impl VisitMut for Prefixer {
         // TODO make it lazy?
         let mut webkit_value = n.value.clone();
 
-        replace_function_name(&mut webkit_value, "filter", "-webkit-filter");
-        replace_image_set_function_on_legacy_variant(
-            &mut webkit_value,
-            "image-set",
-            "-webkit-image-set",
-        );
-        replace_function_name(&mut webkit_value, "calc", "-webkit-calc");
-        replace_cross_fade_function_on_legacy_variant(
-            &mut webkit_value,
-            "cross-fade",
-            "-webkit-cross-fade",
-        );
+        if self.rule_prefix == Some(Prefix::Webkit) || self.rule_prefix.is_none() {
+            replace_function_name(&mut webkit_value, "filter", "-webkit-filter");
+            replace_image_set_function_on_legacy_variant(
+                &mut webkit_value,
+                "image-set",
+                "-webkit-image-set",
+            );
+            replace_function_name(&mut webkit_value, "calc", "-webkit-calc");
+            replace_cross_fade_function_on_legacy_variant(
+                &mut webkit_value,
+                "cross-fade",
+                "-webkit-cross-fade",
+            );
 
-        replace_gradient_function_on_legacy_variant(
-            &mut webkit_value,
-            "linear-gradient",
-            "-webkit-linear-gradient",
-        );
-        replace_gradient_function_on_legacy_variant(
-            &mut webkit_value,
-            "repeating-linear-gradient",
-            "-webkit-repeating-linear-gradient",
-        );
-        replace_gradient_function_on_legacy_variant(
-            &mut webkit_value,
-            "radial-gradient",
-            "-webkit-radial-gradient",
-        );
-        replace_gradient_function_on_legacy_variant(
-            &mut webkit_value,
-            "repeating-radial-gradient",
-            "-webkit-repeating-radial-gradient",
-        );
+            replace_gradient_function_on_legacy_variant(
+                &mut webkit_value,
+                "linear-gradient",
+                "-webkit-linear-gradient",
+            );
+            replace_gradient_function_on_legacy_variant(
+                &mut webkit_value,
+                "repeating-linear-gradient",
+                "-webkit-repeating-linear-gradient",
+            );
+            replace_gradient_function_on_legacy_variant(
+                &mut webkit_value,
+                "radial-gradient",
+                "-webkit-radial-gradient",
+            );
+            replace_gradient_function_on_legacy_variant(
+                &mut webkit_value,
+                "repeating-radial-gradient",
+                "-webkit-repeating-radial-gradient",
+            );
+        }
 
         let mut moz_value = n.value.clone();
 
-        replace_function_name(&mut moz_value, "element", "-moz-element");
-        replace_function_name(&mut moz_value, "calc", "-moz-calc");
-        replace_gradient_function_on_legacy_variant(
-            &mut moz_value,
-            "linear-gradient",
-            "-moz-linear-gradient",
-        );
-        replace_gradient_function_on_legacy_variant(
-            &mut moz_value,
-            "repeating-linear-gradient",
-            "-moz-repeating-linear-gradient",
-        );
-        replace_gradient_function_on_legacy_variant(
-            &mut moz_value,
-            "radial-gradient",
-            "-moz-radial-gradient",
-        );
-        replace_gradient_function_on_legacy_variant(
-            &mut moz_value,
-            "repeating-radial-gradient",
-            "-moz-repeating-linear-gradient",
-        );
+        if self.rule_prefix == Some(Prefix::Moz) || self.rule_prefix.is_none() {
+            replace_function_name(&mut moz_value, "element", "-moz-element");
+            replace_function_name(&mut moz_value, "calc", "-moz-calc");
+            replace_gradient_function_on_legacy_variant(
+                &mut moz_value,
+                "linear-gradient",
+                "-moz-linear-gradient",
+            );
+            replace_gradient_function_on_legacy_variant(
+                &mut moz_value,
+                "repeating-linear-gradient",
+                "-moz-repeating-linear-gradient",
+            );
+            replace_gradient_function_on_legacy_variant(
+                &mut moz_value,
+                "radial-gradient",
+                "-moz-radial-gradient",
+            );
+            replace_gradient_function_on_legacy_variant(
+                &mut moz_value,
+                "repeating-radial-gradient",
+                "-moz-repeating-linear-gradient",
+            );
+        }
 
         let mut o_value = n.value.clone();
 
-        replace_gradient_function_on_legacy_variant(
-            &mut o_value,
-            "linear-gradient",
-            "-o-linear-gradient",
-        );
-        replace_gradient_function_on_legacy_variant(
-            &mut o_value,
-            "repeating-linear-gradient",
-            "-o-repeating-linear-gradient",
-        );
-        replace_gradient_function_on_legacy_variant(
-            &mut o_value,
-            "radial-gradient",
-            "-o-radial-gradient",
-        );
-        replace_gradient_function_on_legacy_variant(
-            &mut o_value,
-            "repeating-radial-gradient",
-            "-o-repeating-radial-gradient",
-        );
+        if self.rule_prefix == Some(Prefix::O) || self.rule_prefix.is_none() {
+            replace_gradient_function_on_legacy_variant(
+                &mut o_value,
+                "linear-gradient",
+                "-o-linear-gradient",
+            );
+            replace_gradient_function_on_legacy_variant(
+                &mut o_value,
+                "repeating-linear-gradient",
+                "-o-repeating-linear-gradient",
+            );
+            replace_gradient_function_on_legacy_variant(
+                &mut o_value,
+                "radial-gradient",
+                "-o-radial-gradient",
+            );
+            replace_gradient_function_on_legacy_variant(
+                &mut o_value,
+                "repeating-radial-gradient",
+                "-o-repeating-radial-gradient",
+            );
+        }
 
         let ms_value = n.value.clone();
 
@@ -989,8 +995,7 @@ impl VisitMut for Prefixer {
             })
             .collect();
 
-        // TODO avoid insert values with `-webkit`/etc prefixes in `-moz` prefixed
-        // declaration and versa vice
+        // TODO avoid insert moz/etc prefixes for `appearance: -webkit-button;`
         // TODO avoid duplication insert
         macro_rules! add_declaration {
             ($prefix:expr,$name:expr) => {{

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -1302,44 +1302,56 @@ impl VisitMut for Prefixer {
             }
 
             "cursor" => {
-                replace_ident(&mut webkit_value, "zoom-in", "-webkit-zoom-in");
-                replace_ident(&mut webkit_value, "zoom-out", "-webkit-zoom-out");
-                replace_ident(&mut webkit_value, "grab", "-webkit-grab");
-                replace_ident(&mut webkit_value, "grabbing", "-webkit-grabbing");
+                if self.rule_prefix == Some(Prefix::Webkit) || self.rule_prefix.is_none() {
+                    replace_ident(&mut webkit_value, "zoom-in", "-webkit-zoom-in");
+                    replace_ident(&mut webkit_value, "zoom-out", "-webkit-zoom-out");
+                    replace_ident(&mut webkit_value, "grab", "-webkit-grab");
+                    replace_ident(&mut webkit_value, "grabbing", "-webkit-grabbing");
+                }
 
-                replace_ident(&mut moz_value, "zoom-in", "-moz-zoom-in");
-                replace_ident(&mut moz_value, "zoom-out", "-moz-zoom-out");
-                replace_ident(&mut moz_value, "grab", "-moz-grab");
-                replace_ident(&mut moz_value, "grabbing", "-moz-grabbing");
+                if self.rule_prefix == Some(Prefix::Moz) || self.rule_prefix.is_none() {
+                    replace_ident(&mut moz_value, "zoom-in", "-moz-zoom-in");
+                    replace_ident(&mut moz_value, "zoom-out", "-moz-zoom-out");
+                    replace_ident(&mut moz_value, "grab", "-moz-grab");
+                    replace_ident(&mut moz_value, "grabbing", "-moz-grabbing");
+                }
             }
 
             "display" if n.value.len() == 1 => {
-                let mut old_spec_webkit_value = webkit_value.clone();
+                if self.rule_prefix == Some(Prefix::Webkit) || self.rule_prefix.is_none() {
+                    let mut old_spec_webkit_value = webkit_value.clone();
 
-                replace_ident(&mut old_spec_webkit_value, "flex", "-webkit-box");
-                replace_ident(
-                    &mut old_spec_webkit_value,
-                    "inline-flex",
-                    "-webkit-inline-box",
-                );
+                    replace_ident(&mut old_spec_webkit_value, "flex", "-webkit-box");
+                    replace_ident(
+                        &mut old_spec_webkit_value,
+                        "inline-flex",
+                        "-webkit-inline-box",
+                    );
 
-                if n.value != old_spec_webkit_value {
-                    self.added_declarations.push(Declaration {
-                        span: n.span,
-                        name: n.name.clone(),
-                        value: old_spec_webkit_value,
-                        important: n.important.clone(),
-                    });
+                    if n.value != old_spec_webkit_value {
+                        self.added_declarations.push(Declaration {
+                            span: n.span,
+                            name: n.name.clone(),
+                            value: old_spec_webkit_value,
+                            important: n.important.clone(),
+                        });
+                    }
                 }
 
-                replace_ident(&mut webkit_value, "flex", "-webkit-flex");
-                replace_ident(&mut webkit_value, "inline-flex", "-webkit-inline-flex");
+                if self.rule_prefix == Some(Prefix::Webkit) || self.rule_prefix.is_none() {
+                    replace_ident(&mut webkit_value, "flex", "-webkit-flex");
+                    replace_ident(&mut webkit_value, "inline-flex", "-webkit-inline-flex");
+                }
 
-                replace_ident(&mut moz_value, "flex", "-moz-box");
-                replace_ident(&mut moz_value, "inline-flex", "-moz-inline-box");
+                if self.rule_prefix == Some(Prefix::Moz) || self.rule_prefix.is_none() {
+                    replace_ident(&mut moz_value, "flex", "-moz-box");
+                    replace_ident(&mut moz_value, "inline-flex", "-moz-inline-box");
+                }
 
-                replace_ident(&mut ms_value, "flex", "-ms-flexbox");
-                replace_ident(&mut ms_value, "inline-flex", "-ms-inline-flexbox");
+                if self.rule_prefix == Some(Prefix::Ms) || self.rule_prefix.is_none() {
+                    replace_ident(&mut ms_value, "flex", "-ms-flexbox");
+                    replace_ident(&mut ms_value, "inline-flex", "-ms-inline-flexbox");
+                }
             }
 
             "flex" => {
@@ -1567,7 +1579,9 @@ impl VisitMut for Prefixer {
                     _ => true,
                 };
 
-                if need_old_spec {
+                if need_old_spec
+                    && (self.rule_prefix == Some(Prefix::Webkit) || self.rule_prefix.is_none())
+                {
                     let mut old_spec_webkit_new_value = webkit_value.clone();
 
                     replace_ident(&mut old_spec_webkit_new_value, "flex-start", "start");
@@ -1583,7 +1597,9 @@ impl VisitMut for Prefixer {
 
                 add_declaration!(Prefix::Webkit, "-webkit-justify-content");
 
-                if need_old_spec {
+                if need_old_spec
+                    && (self.rule_prefix == Some(Prefix::Moz) || self.rule_prefix.is_none())
+                {
                     let mut old_spec_moz_value = moz_value.clone();
 
                     replace_ident(&mut old_spec_moz_value, "flex-start", "start");
@@ -1593,14 +1609,16 @@ impl VisitMut for Prefixer {
                     add_declaration!(Prefix::Moz, "-moz-box-pack", old_spec_moz_value);
                 }
 
-                let mut old_spec_ms_value = ms_value.clone();
+                if self.rule_prefix == Some(Prefix::Ms) || self.rule_prefix.is_none() {
+                    let mut old_spec_ms_value = ms_value.clone();
 
-                replace_ident(&mut old_spec_ms_value, "flex-start", "start");
-                replace_ident(&mut old_spec_ms_value, "flex-end", "end");
-                replace_ident(&mut old_spec_ms_value, "space-between", "justify");
-                replace_ident(&mut old_spec_ms_value, "space-around", "distribute");
+                    replace_ident(&mut old_spec_ms_value, "flex-start", "start");
+                    replace_ident(&mut old_spec_ms_value, "flex-end", "end");
+                    replace_ident(&mut old_spec_ms_value, "space-between", "justify");
+                    replace_ident(&mut old_spec_ms_value, "space-around", "distribute");
 
-                add_declaration!(Prefix::Ms, "-ms-flex-pack", old_spec_ms_value);
+                    add_declaration!(Prefix::Ms, "-ms-flex-pack", old_spec_ms_value);
+                }
             }
 
             "order" => {
@@ -1641,78 +1659,97 @@ impl VisitMut for Prefixer {
             }
 
             "align-items" => {
-                let mut old_spec_webkit_new_value = webkit_value.clone();
+                if self.rule_prefix == Some(Prefix::Webkit) || self.rule_prefix.is_none() {
+                    let mut old_spec_webkit_new_value = webkit_value.clone();
 
-                replace_ident(&mut old_spec_webkit_new_value, "flex-end", "end");
-                replace_ident(&mut old_spec_webkit_new_value, "flex-start", "start");
+                    replace_ident(&mut old_spec_webkit_new_value, "flex-end", "end");
+                    replace_ident(&mut old_spec_webkit_new_value, "flex-start", "start");
 
-                add_declaration!(
-                    Prefix::Webkit,
-                    "-webkit-box-align",
-                    old_spec_webkit_new_value
-                );
+                    add_declaration!(
+                        Prefix::Webkit,
+                        "-webkit-box-align",
+                        old_spec_webkit_new_value
+                    );
+                }
+
                 add_declaration!(Prefix::Webkit, "-webkit-align-items");
 
-                let mut old_spec_moz_value = moz_value.clone();
+                if self.rule_prefix == Some(Prefix::Moz) || self.rule_prefix.is_none() {
+                    let mut old_spec_moz_value = moz_value.clone();
 
-                replace_ident(&mut old_spec_moz_value, "flex-end", "end");
-                replace_ident(&mut old_spec_moz_value, "flex-start", "start");
+                    replace_ident(&mut old_spec_moz_value, "flex-end", "end");
+                    replace_ident(&mut old_spec_moz_value, "flex-start", "start");
 
-                add_declaration!(Prefix::Moz, "-moz-box-align", old_spec_moz_value);
+                    add_declaration!(Prefix::Moz, "-moz-box-align", old_spec_moz_value);
+                }
 
-                let mut old_spec_ms_value = ms_value.clone();
+                if self.rule_prefix == Some(Prefix::Ms) || self.rule_prefix.is_none() {
+                    let mut old_spec_ms_value = ms_value.clone();
 
-                replace_ident(&mut old_spec_ms_value, "flex-end", "end");
-                replace_ident(&mut old_spec_ms_value, "flex-start", "start");
+                    replace_ident(&mut old_spec_ms_value, "flex-end", "end");
+                    replace_ident(&mut old_spec_ms_value, "flex-start", "start");
 
-                add_declaration!(Prefix::Ms, "-ms-flex-align", old_spec_ms_value);
+                    add_declaration!(Prefix::Ms, "-ms-flex-align", old_spec_ms_value);
+                }
             }
 
             "align-self" => {
                 add_declaration!(Prefix::Webkit, "-webkit-align-self");
 
-                let mut spec_2012_ms_value = ms_value.clone();
+                if self.rule_prefix == Some(Prefix::Ms) || self.rule_prefix.is_none() {
+                    let mut spec_2012_ms_value = ms_value.clone();
 
-                replace_ident(&mut spec_2012_ms_value, "flex-end", "end");
-                replace_ident(&mut spec_2012_ms_value, "flex-start", "start");
+                    replace_ident(&mut spec_2012_ms_value, "flex-end", "end");
+                    replace_ident(&mut spec_2012_ms_value, "flex-start", "start");
 
-                add_declaration!(Prefix::Ms, "-ms-flex-item-align", spec_2012_ms_value);
+                    add_declaration!(Prefix::Ms, "-ms-flex-item-align", spec_2012_ms_value);
+                }
             }
 
             "align-content" => {
                 add_declaration!(Prefix::Webkit, "-webkit-align-content");
 
-                let mut spec_2012_ms_value = ms_value.clone();
+                if self.rule_prefix == Some(Prefix::Ms) || self.rule_prefix.is_none() {
+                    let mut spec_2012_ms_value = ms_value.clone();
 
-                replace_ident(&mut spec_2012_ms_value, "flex-end", "end");
-                replace_ident(&mut spec_2012_ms_value, "flex-start", "start");
-                replace_ident(&mut spec_2012_ms_value, "space-between", "justify");
-                replace_ident(&mut spec_2012_ms_value, "space-around", "distribute");
+                    replace_ident(&mut spec_2012_ms_value, "flex-end", "end");
+                    replace_ident(&mut spec_2012_ms_value, "flex-start", "start");
+                    replace_ident(&mut spec_2012_ms_value, "space-between", "justify");
+                    replace_ident(&mut spec_2012_ms_value, "space-around", "distribute");
 
-                add_declaration!(Prefix::Ms, "-ms-flex-line-pack", spec_2012_ms_value);
+                    add_declaration!(Prefix::Ms, "-ms-flex-line-pack", spec_2012_ms_value);
+                }
             }
 
             "image-rendering" => {
-                // Fallback to nearest-neighbor algorithm
-                replace_ident(&mut webkit_value, "pixelated", "-webkit-optimize-contrast");
-                replace_ident(
-                    &mut webkit_value,
-                    "crisp-edges",
-                    "-webkit-optimize-contrast",
-                );
+                if self.rule_prefix == Some(Prefix::Webkit) || self.rule_prefix.is_none() {
+                    // Fallback to nearest-neighbor algorithm
+                    replace_ident(&mut webkit_value, "pixelated", "-webkit-optimize-contrast");
+                    replace_ident(
+                        &mut webkit_value,
+                        "crisp-edges",
+                        "-webkit-optimize-contrast",
+                    );
+                }
 
-                // Fallback to nearest-neighbor algorithm
-                replace_ident(&mut moz_value, "pixelated", "-moz-crisp-edges");
-                replace_ident(&mut moz_value, "crisp-edges", "-moz-crisp-edges");
+                if self.rule_prefix == Some(Prefix::Moz) || self.rule_prefix.is_none() {
+                    // Fallback to nearest-neighbor algorithm
+                    replace_ident(&mut moz_value, "pixelated", "-moz-crisp-edges");
+                    replace_ident(&mut moz_value, "crisp-edges", "-moz-crisp-edges");
+                }
 
-                replace_ident(&mut o_value, "pixelated", "-o-pixelated");
+                if self.rule_prefix == Some(Prefix::O) || self.rule_prefix.is_none() {
+                    replace_ident(&mut o_value, "pixelated", "-o-pixelated");
+                }
 
-                let mut old_spec_ms_value = ms_value.clone();
+                if self.rule_prefix == Some(Prefix::Ms) || self.rule_prefix.is_none() {
+                    let mut old_spec_ms_value = ms_value.clone();
 
-                replace_ident(&mut old_spec_ms_value, "pixelated", "nearest-neighbor");
+                    replace_ident(&mut old_spec_ms_value, "pixelated", "nearest-neighbor");
 
-                if ms_value != old_spec_ms_value {
-                    add_declaration!(Prefix::Ms, "-ms-interpolation-mode", old_spec_ms_value);
+                    if ms_value != old_spec_ms_value {
+                        add_declaration!(Prefix::Ms, "-ms-interpolation-mode", old_spec_ms_value);
+                    }
                 }
             }
 
@@ -1851,7 +1888,9 @@ impl VisitMut for Prefixer {
             }
 
             "position" if n.value.len() == 1 => {
-                replace_ident(&mut webkit_value, "sticky", "-webkit-sticky");
+                if self.rule_prefix == Some(Prefix::Webkit) || self.rule_prefix.is_none() {
+                    replace_ident(&mut webkit_value, "sticky", "-webkit-sticky");
+                }
             }
 
             "user-select" => {
@@ -2011,24 +2050,38 @@ impl VisitMut for Prefixer {
             // TODO improve me for `filter` values https://github.com/postcss/autoprefixer/blob/main/test/cases/transition.css#L6
             // TODO https://github.com/postcss/autoprefixer/blob/main/lib/transition.js
             "transition" => {
-                replace_ident(&mut webkit_value, "transform", "-webkit-transform");
-                replace_ident(&mut webkit_value, "filter", "-webkit-filter");
+                if self.rule_prefix == Some(Prefix::Webkit) || self.rule_prefix.is_none() {
+                    replace_ident(&mut webkit_value, "transform", "-webkit-transform");
+                    replace_ident(&mut webkit_value, "filter", "-webkit-filter");
+                }
 
                 add_declaration!(Prefix::Webkit, "-webkit-transition");
 
-                replace_ident(&mut moz_value, "transform", "-moz-transform");
+                if self.rule_prefix == Some(Prefix::Moz) || self.rule_prefix.is_none() {
+                    replace_ident(&mut moz_value, "transform", "-moz-transform");
+                }
 
                 add_declaration!(Prefix::Moz, "-moz-transition");
 
-                replace_ident(&mut o_value, "transform", "-o-transform");
+                if self.rule_prefix == Some(Prefix::O) || self.rule_prefix.is_none() {
+                    replace_ident(&mut o_value, "transform", "-o-transform");
+                }
 
                 add_declaration!(Prefix::O, "-o-transition");
             }
 
             "transition-property" => {
-                replace_ident(&mut webkit_value, "transform", "-webkit-transform");
-                replace_ident(&mut moz_value, "transform", "-moz-transform");
-                replace_ident(&mut o_value, "transform", "-o-transform");
+                if self.rule_prefix == Some(Prefix::Webkit) || self.rule_prefix.is_none() {
+                    replace_ident(&mut webkit_value, "transform", "-webkit-transform");
+                }
+
+                if self.rule_prefix == Some(Prefix::Moz) || self.rule_prefix.is_none() {
+                    replace_ident(&mut moz_value, "transform", "-moz-transform");
+                }
+
+                if self.rule_prefix == Some(Prefix::O) || self.rule_prefix.is_none() {
+                    replace_ident(&mut o_value, "transform", "-o-transform");
+                }
 
                 add_declaration!(Prefix::Webkit, "-webkit-transition-property");
                 add_declaration!(Prefix::Moz, "-moz-transition-timing-function");
@@ -2179,18 +2232,22 @@ impl VisitMut for Prefixer {
                         | "grid-auto-rows"
                 );
 
-                replace_ident(&mut webkit_value, "fit-content", "-webkit-fit-content");
-                replace_ident(&mut webkit_value, "max-content", "-webkit-max-content");
-                replace_ident(&mut webkit_value, "min-content", "-webkit-min-content");
-                replace_ident(
-                    &mut webkit_value,
-                    "fill-available",
-                    "-webkit-fill-available",
-                );
-                replace_ident(&mut webkit_value, "fill", "-webkit-fill-available");
-                replace_ident(&mut webkit_value, "stretch", "-webkit-fill-available");
+                if self.rule_prefix == Some(Prefix::Webkit) || self.rule_prefix.is_none() {
+                    replace_ident(&mut webkit_value, "fit-content", "-webkit-fit-content");
+                    replace_ident(&mut webkit_value, "max-content", "-webkit-max-content");
+                    replace_ident(&mut webkit_value, "min-content", "-webkit-min-content");
+                    replace_ident(
+                        &mut webkit_value,
+                        "fill-available",
+                        "-webkit-fill-available",
+                    );
+                    replace_ident(&mut webkit_value, "fill", "-webkit-fill-available");
+                    replace_ident(&mut webkit_value, "stretch", "-webkit-fill-available");
+                }
 
-                if !is_grid_property {
+                if !is_grid_property
+                    && (self.rule_prefix == Some(Prefix::Moz) || self.rule_prefix.is_none())
+                {
                     replace_ident(&mut moz_value, "fit-content", "-moz-fit-content");
                     replace_ident(&mut moz_value, "max-content", "-moz-max-content");
                     replace_ident(&mut moz_value, "min-content", "-moz-min-content");
@@ -2201,16 +2258,19 @@ impl VisitMut for Prefixer {
             }
 
             "touch-action" => {
-                let mut value = ms_value.clone();
+                if self.rule_prefix == Some(Prefix::Ms) || self.rule_prefix.is_none() {
+                    let mut new_ms_value = ms_value.clone();
 
-                replace_ident(&mut value, "pan-x", "-ms-pan-x");
-                replace_ident(&mut value, "pan-y", "-ms-pan-y");
-                replace_ident(&mut value, "double-tap-zoom", "-ms-double-tap-zoom");
-                replace_ident(&mut value, "manipulation", "-ms-manipulation");
-                replace_ident(&mut value, "none", "-ms-none");
-                replace_ident(&mut value, "pinch-zoom", "-ms-pinch-zoom");
+                    replace_ident(&mut new_ms_value, "pan-x", "-ms-pan-x");
+                    replace_ident(&mut new_ms_value, "pan-y", "-ms-pan-y");
+                    replace_ident(&mut new_ms_value, "double-tap-zoom", "-ms-double-tap-zoom");
+                    replace_ident(&mut new_ms_value, "manipulation", "-ms-manipulation");
+                    replace_ident(&mut new_ms_value, "none", "-ms-none");
+                    replace_ident(&mut new_ms_value, "pinch-zoom", "-ms-pinch-zoom");
 
-                add_declaration!(Prefix::Ms, "-ms-touch-action", value);
+                    add_declaration!(Prefix::Ms, "-ms-touch-action", new_ms_value);
+                }
+
                 add_declaration!(Prefix::Ms, "-ms-touch-action");
             }
 
@@ -2219,17 +2279,19 @@ impl VisitMut for Prefixer {
             }
 
             "unicode-bidi" => {
-                replace_ident(&mut moz_value, "isolate", "-moz-isolate");
-                replace_ident(&mut moz_value, "isolate-override", "-moz-isolate-override");
-                replace_ident(&mut moz_value, "plaintext", "-moz-plaintext");
+                if self.rule_prefix == Some(Prefix::Webkit) || self.rule_prefix.is_none() {
+                    replace_ident(&mut moz_value, "isolate", "-moz-isolate");
+                    replace_ident(&mut moz_value, "isolate-override", "-moz-isolate-override");
+                    replace_ident(&mut moz_value, "plaintext", "-moz-plaintext");
 
-                replace_ident(&mut webkit_value, "isolate", "-webkit-isolate");
-                replace_ident(
-                    &mut webkit_value,
-                    "isolate-override",
-                    "-webpack-isolate-override",
-                );
-                replace_ident(&mut webkit_value, "plaintext", "-webpack-plaintext");
+                    replace_ident(&mut webkit_value, "isolate", "-webkit-isolate");
+                    replace_ident(
+                        &mut webkit_value,
+                        "isolate-override",
+                        "-webpack-isolate-override",
+                    );
+                    replace_ident(&mut webkit_value, "plaintext", "-webpack-plaintext");
+                }
             }
 
             "text-spacing" => {

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -1053,17 +1053,7 @@ impl VisitMut for Prefixer {
             ($prefix:expr,$name:expr) => {{
                 // Use only specific prefix in prefixed at-rules or rule, i.e.
                 // don't use `-moz` prefix for properties in `@-webkit-keyframes` at-rule
-                let need_prefix = if let Some(rule_prefix) = &self.rule_prefix {
-                    if $prefix != *rule_prefix {
-                        false
-                    } else {
-                        true
-                    }
-                } else {
-                    true
-                };
-
-                if need_prefix {
+                if self.rule_prefix == Some($prefix) || self.rule_prefix.is_none() {
                     self.same_name($name.into(), &n);
                 }
             }};

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -1065,8 +1065,22 @@ impl VisitMut for Prefixer {
         }
 
         macro_rules! same_name {
-            ($name:expr) => {{
-                self.same_name($name.into(), &n);
+            ($prefix:expr,$name:expr) => {{
+                // Use only specific prefix in prefixed at-rules or rule, i.e.
+                // don't use `-moz` prefix for properties in `@-webkit-keyframes` at-rule
+                let need_prefix = if let Some(rule_prefix) = &self.rule_prefix {
+                    if $prefix != *rule_prefix {
+                        false
+                    } else {
+                        true
+                    }
+                } else {
+                    true
+                };
+
+                if need_prefix {
+                    self.same_name($name.into(), &n);
+                }
             }};
         }
 
@@ -1237,17 +1251,17 @@ impl VisitMut for Prefixer {
                 if let ComponentValue::Ident(Ident { value, .. }) = &n.value[0] {
                     match &*value.to_lowercase() {
                         "flex" => {
-                            same_name!("-webkit-box");
-                            same_name!("-webkit-flex");
-                            same_name!("-moz-box");
-                            same_name!("-ms-flexbox");
+                            same_name!(Prefix::Webkit, "-webkit-box");
+                            same_name!(Prefix::Webkit, "-webkit-flex");
+                            same_name!(Prefix::Moz, "-moz-box");
+                            same_name!(Prefix::Ms, "-ms-flexbox");
                         }
 
                         "inline-flex" => {
-                            same_name!("-webkit-inline-box");
-                            same_name!("-webkit-inline-flex");
-                            same_name!("-moz-inline-box");
-                            same_name!("-ms-inline-flexbox");
+                            same_name!(Prefix::Webkit, "-webkit-inline-box");
+                            same_name!(Prefix::Webkit, "-webkit-inline-flex");
+                            same_name!(Prefix::Moz, "-moz-inline-box");
+                            same_name!(Prefix::Ms, "-ms-inline-flexbox");
                         }
 
                         _ => {}

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -825,12 +825,26 @@ impl VisitMut for Prefixer {
         for mut n in take(&mut simple_block.value) {
             n.visit_mut_children_with(self);
 
-            new.extend(
-                self.added_declarations
-                    .drain(..)
-                    .map(DeclarationOrAtRule::Declaration)
-                    .map(ComponentValue::DeclarationOrAtRule),
-            );
+            match n {
+                ComponentValue::StyleBlock(_) => {
+                    new.extend(
+                        self.added_declarations
+                            .drain(..)
+                            .map(StyleBlock::Declaration)
+                            .map(ComponentValue::StyleBlock),
+                    );
+                }
+                ComponentValue::DeclarationOrAtRule(_) => {
+                    new.extend(
+                        self.added_declarations
+                            .drain(..)
+                            .map(DeclarationOrAtRule::Declaration)
+                            .map(ComponentValue::DeclarationOrAtRule),
+                    );
+                }
+                _ => {}
+            }
+
             new.push(n);
         }
 

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -1001,17 +1001,7 @@ impl VisitMut for Prefixer {
             ($prefix:expr,$name:expr) => {{
                 // Use only specific prefix in prefixed at-rules or rule, i.e.
                 // don't use `-moz` prefix for properties in `@-webkit-keyframes` at-rule
-                let need_prefix = if let Some(rule_prefix) = &self.rule_prefix {
-                    if $prefix != *rule_prefix {
-                        false
-                    } else {
-                        true
-                    }
-                } else {
-                    true
-                };
-
-                if need_prefix {
+                if self.rule_prefix == Some($prefix) || self.rule_prefix.is_none() {
                     // Check we don't have prefixed property
                     if !property_names.contains(&$name) {
                         let name = DeclarationName::Ident(Ident {
@@ -1039,17 +1029,7 @@ impl VisitMut for Prefixer {
             ($prefix:expr,$name:expr,$value:expr) => {{
                 // Use only specific prefix in prefixed at-rules or rule, i.e.
                 // don't use `-moz` prefix for properties in `@-webkit-keyframes` at-rule
-                let need_prefix = if let Some(rule_prefix) = &self.rule_prefix {
-                    if $prefix != *rule_prefix {
-                        false
-                    } else {
-                        true
-                    }
-                } else {
-                    true
-                };
-
-                if need_prefix {
+                if self.rule_prefix == Some($prefix) || self.rule_prefix.is_none() {
                     // Check we don't have prefixed property
                     if !property_names.contains(&$name) {
                         let name = DeclarationName::Ident(Ident {

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -461,7 +461,7 @@ impl VisitMut for Prefixer {
             n.visit_mut_children_with(self);
 
             for mut n in take(&mut self.added_top_rules) {
-                let old_rule_prefix = self.rule_prefix.clone();
+                let old_rule_prefix = self.rule_prefix.take();
 
                 self.rule_prefix = Some(n.0);
 
@@ -841,7 +841,7 @@ impl VisitMut for Prefixer {
     }
 
     fn visit_mut_simple_block(&mut self, simple_block: &mut SimpleBlock) {
-        let old_simple_block = self.simple_block.clone();
+        let old_simple_block = self.simple_block.take();
 
         self.simple_block = Some(simple_block.clone());
 
@@ -860,7 +860,7 @@ impl VisitMut for Prefixer {
                     );
 
                     for mut n in take(&mut self.added_at_rules) {
-                        let old_rule_prefix = self.rule_prefix.clone();
+                        let old_rule_prefix = self.rule_prefix.take();
 
                         self.rule_prefix = Some(n.0);
 
@@ -873,7 +873,7 @@ impl VisitMut for Prefixer {
                 }
                 ComponentValue::Rule(_) => {
                     for mut n in take(&mut self.added_qualified_rules) {
-                        let old_rule_prefix = self.rule_prefix.clone();
+                        let old_rule_prefix = self.rule_prefix.take();
 
                         self.rule_prefix = Some(n.0);
 
@@ -885,7 +885,7 @@ impl VisitMut for Prefixer {
                     }
 
                     for mut n in take(&mut self.added_at_rules) {
-                        let old_rule_prefix = self.rule_prefix.clone();
+                        let old_rule_prefix = self.rule_prefix.take();
 
                         self.rule_prefix = Some(n.0);
 
@@ -905,7 +905,7 @@ impl VisitMut for Prefixer {
                     );
 
                     for mut n in take(&mut self.added_qualified_rules) {
-                        let old_rule_prefix = self.rule_prefix.clone();
+                        let old_rule_prefix = self.rule_prefix.take();
 
                         self.rule_prefix = Some(n.0);
 
@@ -917,7 +917,7 @@ impl VisitMut for Prefixer {
                     }
 
                     for mut n in take(&mut self.added_at_rules) {
-                        let old_rule_prefix = self.rule_prefix.clone();
+                        let old_rule_prefix = self.rule_prefix.take();
 
                         self.rule_prefix = Some(n.0);
 

--- a/crates/swc_css_prefixer/tests/fixture/display/input.css
+++ b/crates/swc_css_prefixer/tests/fixture/display/input.css
@@ -13,3 +13,7 @@
 .class {
     display: flex;
 }
+
+:fullscreen a {
+    display: flex;
+}

--- a/crates/swc_css_prefixer/tests/fixture/display/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/display/output.css
@@ -25,13 +25,21 @@
 :-webkit-full-screen a {
   display: -webkit-box;
   display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
   display: flex;
 }
 :-moz-full-screen a {
+  display: -webkit-box;
+  display: -webkit-flex;
   display: -moz-box;
+  display: -ms-flexbox;
   display: flex;
 }
 :-ms-fullscreen a {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
   display: -ms-flexbox;
   display: flex;
 }

--- a/crates/swc_css_prefixer/tests/fixture/display/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/display/output.css
@@ -25,21 +25,13 @@
 :-webkit-full-screen a {
   display: -webkit-box;
   display: -webkit-flex;
-  display: -moz-box;
-  display: -ms-flexbox;
   display: flex;
 }
 :-moz-full-screen a {
-  display: -webkit-box;
-  display: -webkit-flex;
   display: -moz-box;
-  display: -ms-flexbox;
   display: flex;
 }
 :-ms-fullscreen a {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -moz-box;
   display: -ms-flexbox;
   display: flex;
 }

--- a/crates/swc_css_prefixer/tests/fixture/display/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/display/output.css
@@ -22,3 +22,23 @@
   display: -ms-flexbox;
   display: flex;
 }
+:-webkit-full-screen a {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: flex;
+}
+:-moz-full-screen a {
+  display: -moz-box;
+  display: flex;
+}
+:-ms-fullscreen a {
+  display: -ms-flexbox;
+  display: flex;
+}
+:fullscreen a {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+}

--- a/crates/swc_css_prefixer/tests/fixture/duplicate-at-rule/input.css
+++ b/crates/swc_css_prefixer/tests/fixture/duplicate-at-rule/input.css
@@ -1,0 +1,2 @@
+@-webkit-keyframes anim {}
+@keyframes anim {}

--- a/crates/swc_css_prefixer/tests/fixture/duplicate-at-rule/input.css
+++ b/crates/swc_css_prefixer/tests/fixture/duplicate-at-rule/input.css
@@ -1,2 +1,13 @@
 @-webkit-keyframes anim {}
 @keyframes anim {}
+
+@-webkit-keyframes anim {
+    0% {
+        color: red
+    }
+}
+@keyframes anim {
+    0% {
+        color: red
+    }
+}

--- a/crates/swc_css_prefixer/tests/fixture/duplicate-at-rule/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/duplicate-at-rule/output.css
@@ -1,0 +1,4 @@
+@-webkit-keyframes anim {}
+@-moz-keyframes anim {}
+@-o-keyframes anim {}
+@keyframes anim {}

--- a/crates/swc_css_prefixer/tests/fixture/duplicate-at-rule/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/duplicate-at-rule/output.css
@@ -2,3 +2,23 @@
 @-moz-keyframes anim {}
 @-o-keyframes anim {}
 @keyframes anim {}
+@-webkit-keyframes anim {
+  0% {
+    color: red;
+  }
+}
+@-moz-keyframes anim {
+  0% {
+    color: red;
+  }
+}
+@-o-keyframes anim {
+  0% {
+    color: red;
+  }
+}
+@keyframes anim {
+  0% {
+    color: red;
+  }
+}

--- a/crates/swc_css_prefixer/tests/fixture/grouping-rule/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/grouping-rule/output.css
@@ -81,7 +81,6 @@
   background-color: red;
 }
 .c::-moz-selection {
-  -webkit-backface-visibility: visible;
   -moz-backface-visibility: visible;
   backface-visibility: visible;
 }

--- a/crates/swc_css_prefixer/tests/fixture/keyframes/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/keyframes/output.css
@@ -90,10 +90,10 @@
     transform: rotate(0);
   }
 }
-@-webkit-keyframes inside {}
-@-moz-keyframes inside {}
-@-o-keyframes inside {}
 @media screen {
+  @-webkit-keyframes inside {}
+  @-moz-keyframes inside {}
+  @-o-keyframes inside {}
   @keyframes inside {}
 }
 @-webkit-keyframes spaces {

--- a/crates/swc_css_prefixer/tests/fixture/keyframes/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/keyframes/output.css
@@ -9,8 +9,6 @@
     top: 0;
     display: -webkit-box;
     display: -webkit-flex;
-    display: -moz-box;
-    display: -ms-flexbox;
     display: flex;
   }
   to {
@@ -29,10 +27,7 @@
   }
   50% {
     top: 0;
-    display: -webkit-box;
-    display: -webkit-flex;
     display: -moz-box;
-    display: -ms-flexbox;
     display: flex;
   }
   to {
@@ -50,10 +45,6 @@
   }
   50% {
     top: 0;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -moz-box;
-    display: -ms-flexbox;
     display: flex;
   }
   to {

--- a/crates/swc_css_prefixer/tests/fixture/keyframes/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/keyframes/output.css
@@ -9,6 +9,8 @@
     top: 0;
     display: -webkit-box;
     display: -webkit-flex;
+    display: -moz-box;
+    display: -ms-flexbox;
     display: flex;
   }
   to {
@@ -27,7 +29,10 @@
   }
   50% {
     top: 0;
+    display: -webkit-box;
+    display: -webkit-flex;
     display: -moz-box;
+    display: -ms-flexbox;
     display: flex;
   }
   to {
@@ -45,6 +50,10 @@
   }
   50% {
     top: 0;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -moz-box;
+    display: -ms-flexbox;
     display: flex;
   }
   to {

--- a/crates/swc_css_prefixer/tests/fixture/keyframes/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/keyframes/output.css
@@ -10,8 +10,6 @@
     top: 0;
     display: -webkit-box;
     display: -webkit-flex;
-    display: -moz-box;
-    display: -ms-flexbox;
     display: flex;
   }
   to {
@@ -32,10 +30,7 @@
   }
   50% {
     top: 0;
-    display: -webkit-box;
-    display: -webkit-flex;
     display: -moz-box;
-    display: -ms-flexbox;
     display: flex;
   }
   to {
@@ -56,10 +51,6 @@
   }
   50% {
     top: 0;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -moz-box;
-    display: -ms-flexbox;
     display: flex;
   }
   to {

--- a/crates/swc_css_prefixer/tests/fixture/keyframes/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/keyframes/output.css
@@ -1,7 +1,6 @@
 @-webkit-keyframes anim {
   from {
     top: -webkit-calc(10% + 10px);
-    top: -moz-calc(10% + 10px);
     top: calc(10% + 10px);
     -webkit-transform: rotate(10deg);
     transform: rotate(10deg);
@@ -14,7 +13,6 @@
   }
   to {
     top: -webkit-calc(10%);
-    top: -moz-calc(10%);
     top: calc(10%);
     -webkit-transform: rotate(0);
     transform: rotate(0);
@@ -22,7 +20,6 @@
 }
 @-moz-keyframes anim {
   from {
-    top: -webkit-calc(10% + 10px);
     top: -moz-calc(10% + 10px);
     top: calc(10% + 10px);
     -moz-transform: rotate(10deg);
@@ -34,7 +31,6 @@
     display: flex;
   }
   to {
-    top: -webkit-calc(10%);
     top: -moz-calc(10%);
     top: calc(10%);
     -moz-transform: rotate(0);
@@ -43,8 +39,6 @@
 }
 @-o-keyframes anim {
   from {
-    top: -webkit-calc(10% + 10px);
-    top: -moz-calc(10% + 10px);
     top: calc(10% + 10px);
     -o-transform: rotate(10deg);
     transform: rotate(10deg);
@@ -54,8 +48,6 @@
     display: flex;
   }
   to {
-    top: -webkit-calc(10%);
-    top: -moz-calc(10%);
     top: calc(10%);
     -o-transform: rotate(0);
     transform: rotate(0);

--- a/crates/swc_css_prefixer/tests/fixture/nested/input.css
+++ b/crates/swc_css_prefixer/tests/fixture/nested/input.css
@@ -72,3 +72,37 @@
         appearance: auto;
     }
 }
+
+@media (orientation: landscape) {
+    .test {
+        &.class::placeholder {
+             appearance: auto;
+        }
+    }
+}
+
+@media (orientation: landscape) {
+    .test {
+        appearance: auto;
+
+        &.class {
+            appearance: auto;
+        }
+    }
+}
+
+.test {
+    appearance: none;
+
+    &.class {
+        appearance: auto;
+
+        &.class {
+            appearance: menulist-button;
+
+            &.class {
+                appearance: button;
+            }
+        }
+    }
+}

--- a/crates/swc_css_prefixer/tests/fixture/nested/input.css
+++ b/crates/swc_css_prefixer/tests/fixture/nested/input.css
@@ -1,0 +1,74 @@
+@keyframes test {
+    0% {
+        color: red;
+    }
+}
+
+@supports (flex-wrap: wrap) {
+    @keyframes test {
+        0% {
+            color: red;
+        }
+    }
+}
+
+@supports (flex-wrap: wrap) {
+    @supports (flex-wrap: wrap) {
+        @keyframes test {
+            0% {
+                color: red;
+            }
+        }
+    }
+}
+
+.test {
+    &.class::placeholder {
+        color: red;
+    }
+}
+
+.test {
+    &.class::placeholder {
+         appearance: auto;
+    }
+}
+
+.test {
+    appearance: auto;
+
+    &.class {
+        color: red;
+    }
+}
+
+.test {
+    appearance: auto;
+
+    &.class {
+         appearance: auto;
+    }
+}
+
+.test {
+    @supports (foo: bar) {
+        appearance: auto;
+    }
+}
+
+.test {
+    @media (orientation: landscape) {
+        appearance: auto;
+    }
+}
+
+.test {
+    appearance: auto;
+
+    &.class::placeholder {
+        appearance: auto;
+    }
+    @media (orientation: landscape) {
+        appearance: auto;
+    }
+}

--- a/crates/swc_css_prefixer/tests/fixture/nested/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/nested/output.css
@@ -67,19 +67,19 @@
   }
 }
 .test {
+  &.class::-webkit-input-placeholder {
+    color: red;
+  }
+  &.class:-moz-placeholder {
+    color: red;
+  }
+  &.class::-moz-placeholder {
+    color: red;
+  }
+  &.class:-ms-input-placeholder {
+    color: red;
+  }
   &.class::-ms-input-placeholder {
-    &.class:-ms-input-placeholder {
-      &.class::-moz-placeholder {
-        &.class:-moz-placeholder {
-          &.class::-webkit-input-placeholder {
-            color: red;
-          }
-          color: red;
-        }
-        color: red;
-      }
-      color: red;
-    }
     color: red;
   }
   &.class::placeholder {
@@ -87,24 +87,24 @@
   }
 }
 .test {
+  &.class::-webkit-input-placeholder {
+    -webkit-appearance: auto;
+    appearance: auto;
+  }
+  &.class:-moz-placeholder {
+    -moz-appearance: auto;
+    appearance: auto;
+  }
+  &.class::-moz-placeholder {
+    -moz-appearance: auto;
+    appearance: auto;
+  }
+  &.class:-ms-input-placeholder {
+    -ms-appearance: auto;
+    appearance: auto;
+  }
   &.class::-ms-input-placeholder {
     -ms-appearance: auto;
-    &.class:-ms-input-placeholder {
-      -ms-appearance: auto;
-      &.class::-moz-placeholder {
-        -moz-appearance: auto;
-        &.class:-moz-placeholder {
-          -moz-appearance: auto;
-          &.class::-webkit-input-placeholder {
-            -webkit-appearance: auto;
-            appearance: auto;
-          }
-          appearance: auto;
-        }
-        appearance: auto;
-      }
-      appearance: auto;
-    }
     appearance: auto;
   }
   &.class::placeholder {
@@ -156,24 +156,24 @@
   -moz-appearance: auto;
   -ms-appearance: auto;
   appearance: auto;
+  &.class::-webkit-input-placeholder {
+    -webkit-appearance: auto;
+    appearance: auto;
+  }
+  &.class:-moz-placeholder {
+    -moz-appearance: auto;
+    appearance: auto;
+  }
+  &.class::-moz-placeholder {
+    -moz-appearance: auto;
+    appearance: auto;
+  }
+  &.class:-ms-input-placeholder {
+    -ms-appearance: auto;
+    appearance: auto;
+  }
   &.class::-ms-input-placeholder {
     -ms-appearance: auto;
-    &.class:-ms-input-placeholder {
-      -ms-appearance: auto;
-      &.class::-moz-placeholder {
-        -moz-appearance: auto;
-        &.class:-moz-placeholder {
-          -moz-appearance: auto;
-          &.class::-webkit-input-placeholder {
-            -webkit-appearance: auto;
-            appearance: auto;
-          }
-          appearance: auto;
-        }
-        appearance: auto;
-      }
-      appearance: auto;
-    }
     appearance: auto;
   }
   &.class::placeholder {

--- a/crates/swc_css_prefixer/tests/fixture/nested/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/nested/output.css
@@ -1,0 +1,191 @@
+@-webkit-keyframes test {
+  0% {
+    color: red;
+  }
+}
+@-moz-keyframes test {
+  0% {
+    color: red;
+  }
+}
+@-o-keyframes test {
+  0% {
+    color: red;
+  }
+}
+@keyframes test {
+  0% {
+    color: red;
+  }
+}
+@supports (flex-wrap: wrap) {
+  @-webkit-keyframes test {
+    0% {
+      color: red;
+    }
+  }
+  @-moz-keyframes test {
+    0% {
+      color: red;
+    }
+  }
+  @-o-keyframes test {
+    0% {
+      color: red;
+    }
+  }
+  @keyframes test {
+    0% {
+      color: red;
+    }
+  }
+}
+@supports (flex-wrap: wrap) {
+  @supports (flex-wrap: wrap) {
+    @-webkit-keyframes test {
+      0% {
+        color: red;
+      }
+    }
+    @-moz-keyframes test {
+      0% {
+        color: red;
+      }
+    }
+    @-o-keyframes test {
+      0% {
+        color: red;
+      }
+    }
+    @keyframes test {
+      0% {
+        -webkit-flex-wrap: wrap;
+        -ms-flex-wrap: wrap;
+        color: red;
+      }
+    }
+  }
+}
+.test {
+  &.class::-ms-input-placeholder {
+    &.class:-ms-input-placeholder {
+      &.class::-moz-placeholder {
+        &.class:-moz-placeholder {
+          &.class::-webkit-input-placeholder {
+            color: red;
+          }
+          color: red;
+        }
+        color: red;
+      }
+      color: red;
+    }
+    color: red;
+  }
+  &.class::placeholder {
+    color: red;
+  }
+}
+.test {
+  &.class::-ms-input-placeholder {
+    -ms-appearance: auto;
+    &.class:-ms-input-placeholder {
+      -ms-appearance: auto;
+      &.class::-moz-placeholder {
+        -moz-appearance: auto;
+        &.class:-moz-placeholder {
+          -moz-appearance: auto;
+          &.class::-webkit-input-placeholder {
+            -webkit-appearance: auto;
+            appearance: auto;
+          }
+          appearance: auto;
+        }
+        appearance: auto;
+      }
+      appearance: auto;
+    }
+    appearance: auto;
+  }
+  &.class::placeholder {
+    -webkit-appearance: auto;
+    -moz-appearance: auto;
+    -ms-appearance: auto;
+    appearance: auto;
+  }
+}
+.test {
+  -webkit-appearance: auto;
+  -moz-appearance: auto;
+  -ms-appearance: auto;
+  appearance: auto;
+  &.class {
+    color: red;
+  }
+}
+.test {
+  -webkit-appearance: auto;
+  -moz-appearance: auto;
+  -ms-appearance: auto;
+  appearance: auto;
+  &.class {
+    -webkit-appearance: auto;
+    -moz-appearance: auto;
+    -ms-appearance: auto;
+    appearance: auto;
+  }
+}
+.test {
+  @supports (foo: bar) {
+    -webkit-appearance: auto;
+    -moz-appearance: auto;
+    -ms-appearance: auto;
+    appearance: auto;
+  }
+}
+.test {
+  @media (orientation: landscape) {
+    -webkit-appearance: auto;
+    -moz-appearance: auto;
+    -ms-appearance: auto;
+    appearance: auto;
+  }
+}
+.test {
+  -webkit-appearance: auto;
+  -moz-appearance: auto;
+  -ms-appearance: auto;
+  appearance: auto;
+  &.class::-ms-input-placeholder {
+    -ms-appearance: auto;
+    &.class:-ms-input-placeholder {
+      -ms-appearance: auto;
+      &.class::-moz-placeholder {
+        -moz-appearance: auto;
+        &.class:-moz-placeholder {
+          -moz-appearance: auto;
+          &.class::-webkit-input-placeholder {
+            -webkit-appearance: auto;
+            appearance: auto;
+          }
+          appearance: auto;
+        }
+        appearance: auto;
+      }
+      appearance: auto;
+    }
+    appearance: auto;
+  }
+  &.class::placeholder {
+    -webkit-appearance: auto;
+    -moz-appearance: auto;
+    -ms-appearance: auto;
+    appearance: auto;
+  }
+  @media (orientation: landscape) {
+    -webkit-appearance: auto;
+    -moz-appearance: auto;
+    -ms-appearance: auto;
+    appearance: auto;
+  }
+}

--- a/crates/swc_css_prefixer/tests/fixture/nested/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/nested/output.css
@@ -189,3 +189,71 @@
     appearance: auto;
   }
 }
+@media (orientation: landscape) {
+  .test {
+    &.class::-webkit-input-placeholder {
+      -webkit-appearance: auto;
+      appearance: auto;
+    }
+    &.class:-moz-placeholder {
+      -moz-appearance: auto;
+      appearance: auto;
+    }
+    &.class::-moz-placeholder {
+      -moz-appearance: auto;
+      appearance: auto;
+    }
+    &.class:-ms-input-placeholder {
+      -ms-appearance: auto;
+      appearance: auto;
+    }
+    &.class::-ms-input-placeholder {
+      -ms-appearance: auto;
+      appearance: auto;
+    }
+    &.class::placeholder {
+      -webkit-appearance: auto;
+      -moz-appearance: auto;
+      -ms-appearance: auto;
+      appearance: auto;
+    }
+  }
+}
+@media (orientation: landscape) {
+  .test {
+    -webkit-appearance: auto;
+    -moz-appearance: auto;
+    -ms-appearance: auto;
+    appearance: auto;
+    &.class {
+      -webkit-appearance: auto;
+      -moz-appearance: auto;
+      -ms-appearance: auto;
+      appearance: auto;
+    }
+  }
+}
+.test {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  &.class {
+    -webkit-appearance: auto;
+    -moz-appearance: auto;
+    -ms-appearance: auto;
+    appearance: auto;
+    &.class {
+      -webkit-appearance: menulist-button;
+      -moz-appearance: menulist-button;
+      -ms-appearance: menulist-button;
+      appearance: menulist-button;
+      &.class {
+        -webkit-appearance: button;
+        -moz-appearance: button;
+        -ms-appearance: button;
+        appearance: button;
+      }
+    }
+  }
+}

--- a/crates/swc_css_prefixer/tests/fixture/placeholder/input.css
+++ b/crates/swc_css_prefixer/tests/fixture/placeholder/input.css
@@ -5,3 +5,11 @@ input::placeholder {
 input::placeholder, #fs-toggle:fullscreen {
     color: red;
 }
+
+input::placeholder {
+    backdrop-filter: blur(2px);
+}
+
+input.appearance::placeholder {
+    appearance: none;
+}

--- a/crates/swc_css_prefixer/tests/fixture/placeholder/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/placeholder/output.css
@@ -40,3 +40,49 @@ input::placeholder,
 #fs-toggle:fullscreen {
   color: red;
 }
+input::-webkit-input-placeholder {
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
+}
+input:-moz-placeholder {
+  backdrop-filter: blur(2px);
+}
+input::-moz-placeholder {
+  backdrop-filter: blur(2px);
+}
+input:-ms-input-placeholder {
+  backdrop-filter: blur(2px);
+}
+input::-ms-input-placeholder {
+  backdrop-filter: blur(2px);
+}
+input::placeholder {
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
+}
+input.appearance::-webkit-input-placeholder {
+  -webkit-appearance: none;
+  appearance: none;
+}
+input.appearance:-moz-placeholder {
+  -moz-appearance: none;
+  appearance: none;
+}
+input.appearance::-moz-placeholder {
+  -moz-appearance: none;
+  appearance: none;
+}
+input.appearance:-ms-input-placeholder {
+  -ms-appearance: none;
+  appearance: none;
+}
+input.appearance::-ms-input-placeholder {
+  -ms-appearance: none;
+  appearance: none;
+}
+input.appearance::placeholder {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+}

--- a/crates/swc_css_prefixer/tests/fixture/prefixed/input.css
+++ b/crates/swc_css_prefixer/tests/fixture/prefixed/input.css
@@ -95,3 +95,12 @@
     -ms-flex-line-pack: end;
     align-content: flex-start;
 }
+
+.class-19 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: flex;
+}
+

--- a/crates/swc_css_prefixer/tests/fixture/prefixed/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/prefixed/output.css
@@ -120,3 +120,14 @@
   -webkit-align-content: flex-start;
   align-content: flex-start;
 }
+.class-19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+}

--- a/crates/swc_css_prefixer/tests/fixture/style-block/input.css
+++ b/crates/swc_css_prefixer/tests/fixture/style-block/input.css
@@ -1,0 +1,33 @@
+.class {
+    &.foo {
+         appearance: auto;
+    }
+
+    @media all {
+        appearance: auto;
+    }
+}
+
+@media (min-width: 50em) {
+    .foo {
+        appearance: auto;
+    }
+
+    @supports (flex-wrap: wrap) {
+        .foo {
+            appearance: auto;
+        }
+    }
+}
+
+@supports (flex-wrap: wrap) {
+    .foo {
+        appearance: auto;
+    }
+
+    @media (min-width: 50em) {
+        .foo {
+            appearance: auto;
+        }
+    }
+}

--- a/crates/swc_css_prefixer/tests/fixture/style-block/output.css
+++ b/crates/swc_css_prefixer/tests/fixture/style-block/output.css
@@ -1,0 +1,48 @@
+.class {
+  &.foo {
+    -webkit-appearance: auto;
+    -moz-appearance: auto;
+    -ms-appearance: auto;
+    appearance: auto;
+  }
+  @media all {
+    -webkit-appearance: auto;
+    -moz-appearance: auto;
+    -ms-appearance: auto;
+    appearance: auto;
+  }
+}
+@media (min-width: 50em) {
+  .foo {
+    -webkit-appearance: auto;
+    -moz-appearance: auto;
+    -ms-appearance: auto;
+    appearance: auto;
+  }
+  @supports (flex-wrap: wrap) {
+    .foo {
+      -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+      -webkit-appearance: auto;
+      -moz-appearance: auto;
+      -ms-appearance: auto;
+      appearance: auto;
+    }
+  }
+}
+@supports (flex-wrap: wrap) {
+  .foo {
+    -webkit-appearance: auto;
+    -moz-appearance: auto;
+    -ms-appearance: auto;
+    appearance: auto;
+  }
+  @media (min-width: 50em) {
+    .foo {
+      -webkit-appearance: auto;
+      -moz-appearance: auto;
+      -ms-appearance: auto;
+      appearance: auto;
+    }
+  }
+}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Fixed:
- don't add unnecessary prefixes
- avoid invalid prefixes in prefixed at-rule/rule
- fix perf
- fix prefixes in nested at-rules/rule
- and big code refactor

Autoprefixer mostly ported, currently I want to focus:
1. Adding browserslist option to generate only necessary prefixes
2. Remove outdated prefixes based on browserslist (after first)
3. Finish small TODOs

Hope I will finish it on this/next week

**BREAKING CHANGE:**

No

**Related issue (if exists):**

No