### PR TITLE
perf(es/minifier): Assembly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3274,6 +3274,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "criterion",
+ "dashmap",
  "indexmap",
  "once_cell",
  "parking_lot",

--- a/crates/swc_ecma_minifier/Cargo.toml
+++ b/crates/swc_ecma_minifier/Cargo.toml
@@ -22,6 +22,7 @@ debug = ["backtrace", "swc_ecma_transforms_optimization/debug"]
 [dependencies]
 ahash = "0.7.6"
 backtrace = { version = "0.3.61", optional = true }
+dashmap = "5"
 indexmap = "1.7.0"
 once_cell = "1.10.0"
 parking_lot = "0.12.0"

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
@@ -82,8 +82,6 @@ impl Scope {
             loop {
                 let sym = base54::encode(&mut n, true);
 
-                let sym: JsWord = sym.into();
-
                 // TODO: Use base54::decode
                 if preserved_symbols.contains(&sym) {
                     continue;

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/private_name.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/private_name.rs
@@ -30,8 +30,6 @@ impl PrivateNameMangler {
         } else {
             let sym = base54::encode(&mut self.private_n, true);
 
-            let sym: JsWord = sym.into();
-
             self.renamed_private.insert(id.clone(), sym.clone());
 
             sym

--- a/crates/swc_ecma_minifier/src/pass/mangle_props.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_props.rs
@@ -86,9 +86,8 @@ impl ManglePropertiesState {
             if let Some(cached) = self.cache.get(name) {
                 Some(cached.clone())
             } else {
-                let sym = base54::encode(&mut self.n, true);
+                let mangled_name = base54::encode(&mut self.n, true);
 
-                let mangled_name: JsWord = sym.into();
                 self.cache.insert(name.clone(), mangled_name.clone());
                 Some(mangled_name)
             }

--- a/crates/swc_ecma_minifier/src/util/base54.rs
+++ b/crates/swc_ecma_minifier/src/util/base54.rs
@@ -1,9 +1,11 @@
+use swc_atoms::JsWord;
+
 static BASE54_DEFAULT_CHARS: &[u8; 64] =
     b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_0123456789";
 
 /// givin a number, return a base54 encoded string
 /// `usize -> [a-zA-Z$_][a-zA-Z$_0-9]*`
-pub(crate) fn encode(init: &mut usize, skip_reserved: bool) -> String {
+pub(crate) fn encode(init: &mut usize, skip_reserved: bool) -> JsWord {
     if skip_reserved {
         while init.is_reserved()
             || init.is_reserved_in_strict_bind()
@@ -38,10 +40,12 @@ pub(crate) fn encode(init: &mut usize, skip_reserved: bool) -> String {
         ret.push(c);
     }
 
-    unsafe {
+    let s = unsafe {
         // Safety: We are only using ascii characters
         String::from_utf8_unchecked(ret)
-    }
+    };
+
+    s.into()
 }
 
 #[allow(unused)]
@@ -175,7 +179,7 @@ mod tests {
 
         fn gen(&mut self, expected: &str) {
             let generated = encode(&mut self.n, true);
-            assert_eq!(generated, expected);
+            assert_eq!(&*generated, expected);
         }
     }
 
@@ -342,7 +346,7 @@ mod tests {
         let mut init = RESERVED[0];
         let target = init + 2;
         let gen = encode(&mut init, true);
-        assert_eq!(gen, "dp");
+        assert_eq!(&*gen, "dp");
         assert_eq!(init, target);
     }
 


### PR DESCRIPTION
**Description:**


## ARM ASM of `Expr::visit_children_with`

```asm
+0x00	stp                 x26, x25, [sp, #-80]!
+0x04	stp                 x24, x23, [sp, #16]
+0x08	stp                 x22, x21, [sp, #32]
+0x0c	stp                 x20, x19, [sp, #48]
+0x10	stp                 x29, x30, [sp, #64]
+0x14	add                 x29, sp, #64
+0x18	ldr                 w8, [x0]
+0x1c	mov                 x19, x1
+0x20	mov                 x20, x0
+0x24	adrp                x9, 960 ; 0x3c0000
+0x28	add                 x9, x9, #648
+0x2c	adr                 x10, #16
+0x30	ldrh                w11, [x9, x8, lsl #1]
+0x34	add                 x10, x10, x11, lsl #2
+0x38	br                  x10
+0x3c	ldr                 x0, [x20, #8]
+0x40	ldrb                w20, [x19, #72]
+0x44	strb                wzr, [x19, #72]
+0x48	mov                 x1, x19
+0x4c	bl                  "0x1045c9a98"
+0x50	strb                w20, [x19, #72]
+0x54	ldp                 x29, x30, [sp, #64]
+0x58	ldp                 x20, x19, [sp, #48]
+0x5c	ldp                 x22, x21, [sp, #32]
+0x60	ldp                 x24, x23, [sp, #16]
+0x64	ldp                 x26, x25, [sp], #80
+0x68	ret
+0x6c	ldr                 x8, [x20, #24]
+0x70	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x74	ldr                 x9, [x20, #8]
+0x78	add                 x8, x8, x8, lsl #1
+0x7c	lsl                 x20, x8, #3
+0x80	add                 x21, x9, #8
+0x84	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x94"
+0x88	add                 x21, x21, #24
+0x8c	subs                x20, x20, #24
+0x90	b.eq                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x94	ldr                 w8, [x21]
+0x98	cmp                 w8, #2
+0x9c	b.eq                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x88"
+0xa0	ldur                x0, [x21, #-8]
+0xa4	ldrb                w22, [x19, #72]
+0xa8	strb                wzr, [x19, #72]
+0xac	mov                 x1, x19
+0xb0	bl                  "0x1045c9a98"
+0xb4	strb                w22, [x19, #72]
+0xb8	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x88"
+0xbc	add                 x1, x20, #8
+0xc0	mov                 x0, x19
+0xc4	ldp                 x29, x30, [sp, #64]
+0xc8	ldp                 x20, x19, [sp, #48]
+0xcc	ldp                 x22, x21, [sp, #32]
+0xd0	ldp                 x24, x23, [sp, #16]
+0xd4	ldp                 x26, x25, [sp], #80
+0xd8	b                   "0x104561f98"
+0xdc	add                 x1, x20, #32
+0xe0	mov                 x0, x19
+0xe4	ldp                 x29, x30, [sp, #64]
+0xe8	ldp                 x20, x19, [sp, #48]
+0xec	ldp                 x22, x21, [sp, #32]
+0xf0	ldp                 x24, x23, [sp, #16]
+0xf4	ldp                 x26, x25, [sp], #80
+0xf8	b                   "swc_ecma_visit::visit_function::h36a65b49962bf2c5+0xe8"
+0xfc	ldr                 x0, [x20, #8]
+0x100	ldrb                w21, [x19, #72]
+0x104	strb                wzr, [x19, #72]
+0x108	mov                 x1, x19
+0x10c	bl                  "0x1045c9a98"
+0x110	ldr                 x0, [x20, #16]
+0x114	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x1f0"
+0x118	ldr                 x8, [x20, #8]
+0x11c	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x5ec"
+0x120	ldr                 x21, [x20, #16]
+0x124	mov                 x0, x21
+0x128	mov                 x1, x19
+0x12c	bl                  "_$LT$swc_ecma_ast..pat..Pat$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::hb50bf336670be9b9+0x510"
+0x130	ldrb                w22, [x19, #72]
+0x134	ldr                 w8, [x21]
+0x138	cmp                 w22, #0
+0x13c	ccmp                w8, #0, #0, ne
+0x140	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x600"
+0x144	ldr                 w8, [x19, #64]
+0x148	cmp                 w8, #1
+0x14c	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x160"
+0x150	ldr                 w8, [x19, #68]
+0x154	ldr                 w9, [x21, #24]
+0x158	cmp                 w8, w9
+0x15c	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x688"
+0x160	ldr                 x1, [x21, #8]
+0x164	tst                 x1, #0x3
+0x168	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x17c"
+0x16c	add                 x8, x1, #16
+0x170	mov                 w9, #1
+0x174	ldaddal             x9, x8, [x8]
+0x178	ldr                 x1, [x21, #8]
+0x17c	ldr                 w2, [x21, #24]
+0x180	mov                 x0, x19
+0x184	bl                  "std::collections::hash::map::HashMap$LT$K$C$V$C$S$GT$::remove::h14f2c9aca8eb186d+0x1fc"
+0x188	ldrb                w22, [x19, #72]
+0x18c	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x600"
+0x190	ldr                 x0, [x20, #8]
+0x194	ldrb                w21, [x19, #72]
+0x198	strb                wzr, [x19, #72]
+0x19c	mov                 x1, x19
+0x1a0	bl                  "0x1045c9a98"
+0x1a4	strb                w21, [x19, #72]
+0x1a8	ldr                 x8, [x20, #16]
+0x1ac	cmp                 x8, #2
+0x1b0	b.lo                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x1b4	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x1ec"
+0x1b8	ldr                 x8, [x20, #8]
+0x1bc	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x1c0	ldr                 x0, [x20, #16]
+0x1c4	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x40"
+0x1c8	ldr                 x0, [x20, #8]
+0x1cc	ldrb                w21, [x19, #72]
+0x1d0	strb                wzr, [x19, #72]
+0x1d4	mov                 x1, x19
+0x1d8	bl                  "0x1045c9a98"
+0x1dc	ldr                 x0, [x20, #16]
+0x1e0	strb                wzr, [x19, #72]
+0x1e4	mov                 x1, x19
+0x1e8	bl                  "0x1045c9a98"
+0x1ec	ldr                 x0, [x20, #24]
+0x1f0	strb                wzr, [x19, #72]
+0x1f4	mov                 x1, x19
+0x1f8	bl                  "0x1045c9a98"
+0x1fc	strb                w21, [x19, #72]
+0x200	ldp                 x29, x30, [sp, #64]
+0x204	ldp                 x20, x19, [sp, #48]
+0x208	ldp                 x22, x21, [sp, #32]
+0x20c	ldp                 x24, x23, [sp, #16]
+0x210	ldp                 x26, x25, [sp], #80
+0x214	ret
+0x218	ldr                 w8, [x20, #8]
+0x21c	cmp                 w8, #2
+0x220	b.lo                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x23c"
+0x224	ldr                 x0, [x20, #16]
+0x228	ldrb                w21, [x19, #72]
+0x22c	strb                wzr, [x19, #72]
+0x230	mov                 x1, x19
+0x234	bl                  "0x1045c9a98"
+0x238	strb                w21, [x19, #72]
+0x23c	ldr                 x8, [x20, #40]
+0x240	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x244	ldr                 x20, [x20, #24]
+0x248	ldrb                w21, [x19, #72]
+0x24c	add                 x8, x8, x8, lsl #1
+0x250	lsl                 x22, x8, #3
+0x254	ldr                 x0, [x20], #24
+0x258	strb                wzr, [x19, #72]
+0x25c	mov                 x1, x19
+0x260	bl                  "0x1045c9a98"
+0x264	strb                w21, [x19, #72]
+0x268	subs                x22, x22, #24
+0x26c	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x254"
+0x270	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x274	ldr                 x0, [x20, #8]
+0x278	ldrb                w21, [x19, #72]
+0x27c	strb                wzr, [x19, #72]
+0x280	mov                 x1, x19
+0x284	bl                  "0x1045c9a98"
+0x288	strb                w21, [x19, #72]
+0x28c	ldr                 x9, [x20, #16]!
+0x290	cmp                 x9, #0
+0x294	csel                x8, xzr, x20, eq
+0x298	cbz                 x9, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x29c	ldr                 x9, [x8, #16]
+0x2a0	add                 x9, x9, x9, lsl #1
+0x2a4	lsl                 x20, x9, #3
+0x2a8	cbz                 x20, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x2ac	ldr                 x22, [x8]
+0x2b0	ldr                 x0, [x22], #24
+0x2b4	strb                wzr, [x19, #72]
+0x2b8	mov                 x1, x19
+0x2bc	bl                  "0x1045c9a98"
+0x2c0	strb                w21, [x19, #72]
+0x2c4	subs                x20, x20, #24
+0x2c8	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x2b0"
+0x2cc	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x2d0	ldr                 x8, [x20, #24]
+0x2d4	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x2d8	ldr                 x20, [x20, #8]
+0x2dc	ldrb                w21, [x19, #72]
+0x2e0	lsl                 x22, x8, #3
+0x2e4	ldr                 x0, [x20], #8
+0x2e8	strb                wzr, [x19, #72]
+0x2ec	mov                 x1, x19
+0x2f0	bl                  "0x1045c9a98"
+0x2f4	strb                w21, [x19, #72]
+0x2f8	subs                x22, x22, #8
+0x2fc	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x2e4"
+0x300	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x304	ldr                 x8, [x20, #24]
+0x308	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x30c	ldr                 x20, [x20, #8]
+0x310	ldrb                w21, [x19, #72]
+0x314	lsl                 x22, x8, #3
+0x318	ldr                 x0, [x20], #8
+0x31c	strb                wzr, [x19, #72]
+0x320	mov                 x1, x19
+0x324	bl                  "0x1045c9a98"
+0x328	strb                w21, [x19, #72]
+0x32c	subs                x22, x22, #8
+0x330	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x318"
+0x334	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x338	ldr                 x0, [x20, #8]
+0x33c	ldrb                w21, [x19, #72]
+0x340	strb                wzr, [x19, #72]
+0x344	mov                 x1, x19
+0x348	bl                  "0x1045c9a98"
+0x34c	strb                w21, [x19, #72]
+0x350	ldr                 x8, [x20, #72]
+0x354	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x358	ldr                 x20, [x20, #56]
+0x35c	lsl                 x22, x8, #3
+0x360	ldr                 x0, [x20], #8
+0x364	strb                wzr, [x19, #72]
+0x368	mov                 x1, x19
+0x36c	bl                  "0x1045c9a98"
+0x370	strb                w21, [x19, #72]
+0x374	subs                x22, x22, #8
+0x378	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x360"
+0x37c	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x380	ldrb                w22, [x19, #72]
+0x384	ldr                 x8, [x20, #24]
+0x388	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x570"
+0x38c	ldr                 x21, [x20, #8]
+0x390	add                 x8, x8, x8, lsl #3
+0x394	lsl                 x23, x8, #3
+0x398	mov                 w24, #1
+0x39c	mov                 x25, x21
+0x3a0	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x3c8"
+0x3a4	ldr                 x1, [x21, #8]
+0x3a8	tst                 x1, #0x3
+0x3ac	b.eq                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x40c"
+0x3b0	ldr                 w2, [x21, #24]
+0x3b4	mov                 x0, x19
+0x3b8	bl                  "std::collections::hash::map::HashMap$LT$K$C$V$C$S$GT$::remove::h14f2c9aca8eb186d+0x1fc"
+0x3bc	mov                 x21, x25
+0x3c0	subs                x23, x23, #72
+0x3c4	b.eq                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x570"
+0x3c8	strb                w24, [x19, #72]
+0x3cc	mov                 x0, x21
+0x3d0	mov                 x1, x19
+0x3d4	bl                  "_$LT$swc_ecma_ast..pat..Pat$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::hb50bf336670be9b9+0x510"
+0x3d8	ldr                 w8, [x25], #72
+0x3dc	ldrb                w9, [x19, #72]
+0x3e0	cmp                 w9, #0
+0x3e4	ccmp                w8, #0, #0, ne
+0x3e8	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x3bc"
+0x3ec	ldr                 w8, [x19, #64]
+0x3f0	cmp                 w8, #1
+0x3f4	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x3a4"
+0x3f8	ldr                 w8, [x19, #68]
+0x3fc	ldr                 w9, [x21, #24]
+0x400	cmp                 w8, w9
+0x404	b.eq                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x3a4"
+0x408	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x3bc"
+0x40c	add                 x8, x1, #16
+0x410	ldaddal             x24, x8, [x8]
+0x414	ldr                 x1, [x21, #8]
+0x418	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x3b0"
+0x41c	add                 x1, x20, #32
+0x420	mov                 x0, x19
+0x424	ldp                 x29, x30, [sp, #64]
+0x428	ldp                 x20, x19, [sp, #48]
+0x42c	ldp                 x22, x21, [sp, #32]
+0x430	ldp                 x24, x23, [sp, #16]
+0x434	ldp                 x26, x25, [sp], #80
+0x438	b                   "0x10456e008"
+0x43c	ldr                 x0, [x20, #8]
+0x440	cbnz                x0, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x40"
+0x444	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x448	ldr                 x8, [x20, #8]!
+0x44c	cbnz                x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x450	ldr                 x20, [x20, #8]
+0x454	ldr                 x8, [x20]
+0x458	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x450"
+0x45c	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x460	ldr                 x21, [x20, #8]
+0x464	ldr                 x8, [x21]
+0x468	cmp                 x8, #1
+0x46c	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x488"
+0x470	mov                 x8, x21
+0x474	ldr                 x9, [x8, #8]!
+0x478	cbnz                x9, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x488"
+0x47c	ldr                 x8, [x8, #8]
+0x480	ldr                 x9, [x8]
+0x484	cbz                 x9, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x47c"
+0x488	ldr                 x8, [x21, #80]
+0x48c	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x58c"
+0x490	ldr                 x9, [x21, #64]
+0x494	mov                 w10, #152
+0x498	mul                 x22, x8, x10
+0x49c	add                 x20, x9, #64
+0x4a0	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x4c8"
+0x4a4	ldur                x0, [x20, #-56]
+0x4a8	ldrb                w23, [x19, #72]
+0x4ac	strb                wzr, [x19, #72]
+0x4b0	mov                 x1, x19
+0x4b4	bl                  "0x1045c9a98"
+0x4b8	strb                w23, [x19, #72]
+0x4bc	add                 x20, x20, #152
+0x4c0	subs                x22, x22, #152
+0x4c4	b.eq                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x58c"
+0x4c8	ldur                x8, [x20, #-64]
+0x4cc	cbnz                x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x4a4"
+0x4d0	ldr                 x8, [x20]
+0x4d4	cmp                 x8, #4
+0x4d8	b.eq                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x4bc"
+0x4dc	mov                 x0, x19
+0x4e0	mov                 x1, x20
+0x4e4	bl                  "0x104574358"
+0x4e8	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x4bc"
+0x4ec	ldr                 x8, [x20, #24]
+0x4f0	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x4f4	ldr                 x1, [x20, #8]
+0x4f8	add                 x8, x8, x8, lsl #3
+0x4fc	lsl                 x20, x8, #3
+0x500	add                 x21, x1, #72
+0x504	mov                 x0, x19
+0x508	bl                  "0x104576194"
+0x50c	mov                 x1, x21
+0x510	subs                x20, x20, #72
+0x514	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x500"
+0x518	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x51c	ldr                 x8, [x20, #8]
+0x520	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x62c"
+0x524	ldr                 x0, [x20, #16]
+0x528	ldrb                w21, [x19, #72]
+0x52c	strb                wzr, [x19, #72]
+0x530	mov                 x1, x19
+0x534	bl                  "0x1045c9a98"
+0x538	strb                w21, [x19, #72]
+0x53c	ldr                 x8, [x20, #40]
+0x540	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x544	ldr                 x20, [x20, #24]
+0x548	add                 x8, x8, x8, lsl #1
+0x54c	lsl                 x22, x8, #3
+0x550	ldr                 x0, [x20], #24
+0x554	strb                wzr, [x19, #72]
+0x558	mov                 x1, x19
+0x55c	bl                  "0x1045c9a98"
+0x560	strb                w21, [x19, #72]
+0x564	subs                x22, x22, #24
+0x568	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x550"
+0x56c	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x570	ldr                 x8, [x20, #32]
+0x574	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x658"
+0x578	ldr                 x0, [x20, #40]
+0x57c	strb                wzr, [x19, #72]
+0x580	mov                 x1, x19
+0x584	bl                  "0x1045c9a98"
+0x588	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x610"
+0x58c	ldr                 x8, [x21, #160]
+0x590	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x5b8"
+0x594	ldr                 x1, [x21, #144]
+0x598	add                 x8, x8, x8, lsl #3
+0x59c	lsl                 x20, x8, #3
+0x5a0	add                 x22, x1, #72
+0x5a4	mov                 x0, x19
+0x5a8	bl                  "0x104576194"
+0x5ac	mov                 x1, x22
+0x5b0	subs                x20, x20, #72
+0x5b4	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x5a0"
+0x5b8	ldr                 x8, [x21, #168]!
+0x5bc	cmp                 x8, #3
+0x5c0	csel                x8, xzr, x21, eq
+0x5c4	b.eq                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x5c8	ldr                 x9, [x8]
+0x5cc	cmp                 x9, #1
+0x5d0	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x5d4	ldr                 x9, [x8, #8]!
+0x5d8	cbnz                x9, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x5dc	ldr                 x8, [x8, #8]
+0x5e0	ldr                 x9, [x8]
+0x5e4	cbz                 x9, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x5dc"
+0x5e8	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x5ec	ldr                 x0, [x20, #16]
+0x5f0	ldrb                w22, [x19, #72]
+0x5f4	strb                wzr, [x19, #72]
+0x5f8	mov                 x1, x19
+0x5fc	bl                  "0x1045c9a98"
+0x600	ldr                 x0, [x20, #24]
+0x604	strb                wzr, [x19, #72]
+0x608	mov                 x1, x19
+0x60c	bl                  "0x1045c9a98"
+0x610	strb                w22, [x19, #72]
+0x614	ldp                 x29, x30, [sp, #64]
+0x618	ldp                 x20, x19, [sp, #48]
+0x61c	ldp                 x22, x21, [sp, #32]
+0x620	ldp                 x24, x23, [sp, #16]
+0x624	ldp                 x26, x25, [sp], #80
+0x628	ret
+0x62c	ldr                 x0, [x20, #16]
+0x630	ldrb                w21, [x19, #72]
+0x634	strb                wzr, [x19, #72]
+0x638	mov                 x1, x19
+0x63c	bl                  "0x1045c9a98"
+0x640	strb                w21, [x19, #72]
+0x644	ldr                 x8, [x20, #24]
+0x648	cmp                 x8, #2
+0x64c	b.lo                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x54"
+0x650	ldr                 x0, [x20, #32]
+0x654	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x1f0"
+0x658	ldr                 x8, [x20, #56]
+0x65c	cbz                 x8, "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x610"
+0x660	ldr                 x1, [x20, #40]
+0x664	mov                 w9, #232
+0x668	mul                 x20, x8, x9
+0x66c	add                 x21, x1, #232
+0x670	mov                 x0, x19
+0x674	bl                  "0x10454a8e8"
+0x678	mov                 x1, x21
+0x67c	subs                x20, x20, #232
+0x680	b.ne                "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x66c"
+0x684	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x610"
+0x688	mov                 w22, #1
+0x68c	b                   "_$LT$swc_ecma_ast..expr..Expr$u20$as$u20$swc_ecma_visit..VisitWith$LT$V$GT$$GT$::visit_children_with::h65ef2d66ef60bd67+0x600"

```

