### PR TITLE
chore(plugin): expose optional features for wasm plugin test

### DIFF
--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -29,6 +29,8 @@ concurrent = [
 debug = ["swc_ecma_visit/debug"]
 node = ["napi", "napi-derive"]
 plugin = ["swc_plugin_runner", "swc_plugin_proxy/plugin-rt"]
+# For developers who use the `plugin` feature directly in rust:
+plugin-dev = ["plugin", "swc_plugin_runner/filesystem_cache", "swc_plugin_runner/plugin-dev"]
 
 [dependencies]
 ahash = "0.7.4"

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -19,6 +19,7 @@ filesystem_cache = ["wasmer-cache"]
 # Supports a cache allow to store wasm module in-memory. This avoids recompilation
 # to the same module in a single procress lifecycle.
 memory_cache = []
+plugin-dev = ["wasmer/default", "wasmer-wasi/default"]
 
 [dependencies]
 anyhow = "1.0.42"


### PR DESCRIPTION
**Description:**

At present, the default features of `wasmer` are not exposed by default, so if third-party plugin developers want to use the swc to write some test code, it will be difficult.

For example, if there is no default feature of `wasmer`, developers using related capabilities will report errors like the following:

```
error: At least the `host-fs` or the `mem-fs` feature must be enabled. Please, pick one.
 --> /Users/xxx/.cargo/registry/src/mirrors.tuna.tsinghua.edu.cn-df7c3c540f42cdbd/wasmer-vfs-2.2.1/src/lib.rs:9:1
  |
9 | compile_error!("At least the `host-fs` or the `mem-fs` feature must be enabled. Please, pick one.");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Moreover, I haven't found a way to directly specify the dependency's dependency features in rust, so I think adding some optional features to swc may be a solution. This will not affect normal use.

Of course, if there are other ways to accomplish this ability, it is also OK

> Here's an my test code example based on other developers' versions in the community(
The test now fails to compile): https://github.com/aircloud/swc-plugin-console-prefix/blob/feat/swc_2022_04/src/lib.rs

**BREAKING CHANGE:**

None

**Related issue (if exists):**

None
