### PR TITLE
perf(es/minifier): Split frequently used functions

### DIFF
--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
@@ -100,8 +100,6 @@ impl Scope {
             loop {
                 let sym = base54::encode(&mut n, true);
 
-                let sym: JsWord = sym.into();
-
                 // TODO: Use base54::decode
                 if preserved_symbols.contains(&sym) {
                     continue;

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
@@ -69,11 +69,29 @@ impl Scope {
         preserved: &FxHashSet<Id>,
         preserved_symbols: &FxHashSet<JsWord>,
     ) {
-        let mut n = 0;
         let mut queue = self.data.queue.take();
         queue.sort_by(|a, b| b.1.cmp(&a.1));
 
         let mut cloned_reverse = reverse.clone();
+
+        self.rename_one_scope(to, &mut cloned_reverse, queue, preserved, preserved_symbols);
+
+        for child in self.children.iter_mut() {
+            child.rename(to, &cloned_reverse, preserved, preserved_symbols);
+        }
+    }
+
+    #[inline(never)]
+    fn rename_one_scope(
+        &self,
+        to: &mut AHashMap<Id, JsWord>,
+        cloned_reverse: &mut FxHashMap<JsWord, Vec<Id>>,
+        queue: Vec<(Id, u32)>,
+        preserved: &FxHashSet<Id>,
+        preserved_symbols: &FxHashSet<JsWord>,
+    ) {
+        let mut n = 0;
+
         for (id, cnt) in queue {
             if cnt == 0 || preserved.contains(&id) || to.get(&id).is_some() {
                 continue;
@@ -89,7 +107,7 @@ impl Scope {
                     continue;
                 }
 
-                if self.can_rename(&id, &sym, &cloned_reverse) {
+                if self.can_rename(&id, &sym, cloned_reverse) {
                     to.insert(id.clone(), sym.clone());
                     cloned_reverse.entry(sym).or_default().push(id.clone());
                     // self.data.decls.remove(&id);
@@ -98,10 +116,6 @@ impl Scope {
                     break;
                 }
             }
-        }
-
-        for child in self.children.iter_mut() {
-            child.rename(to, &cloned_reverse, preserved, preserved_symbols);
         }
     }
 

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/private_name.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/private_name.rs
@@ -30,8 +30,6 @@ impl PrivateNameMangler {
         } else {
             let sym = base54::encode(&mut self.private_n, true);
 
-            let sym: JsWord = sym.into();
-
             self.renamed_private.insert(id.clone(), sym.clone());
 
             sym

--- a/crates/swc_ecma_minifier/src/pass/mangle_props.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_props.rs
@@ -86,9 +86,8 @@ impl ManglePropertiesState {
             if let Some(cached) = self.cache.get(name) {
                 Some(cached.clone())
             } else {
-                let sym = base54::encode(&mut self.n, true);
+                let mangled_name = base54::encode(&mut self.n, true);
 
-                let mangled_name: JsWord = sym.into();
                 self.cache.insert(name.clone(), mangled_name.clone());
                 Some(mangled_name)
             }

--- a/crates/swc_ecma_minifier/src/util/base54.rs
+++ b/crates/swc_ecma_minifier/src/util/base54.rs
@@ -40,10 +40,12 @@ pub(crate) fn encode(init: &mut usize, skip_reserved: bool) -> JsWord {
         ret.push(c);
     }
 
-    unsafe {
+    let s = unsafe {
         // Safety: We are only using ascii characters
         String::from_utf8_unchecked(ret)
-    }
+    };
+
+    s.into()
 }
 
 #[allow(unused)]
@@ -177,7 +179,7 @@ mod tests {
 
         fn gen(&mut self, expected: &str) {
             let generated = encode(&mut self.n, true);
-            assert_eq!(generated, expected);
+            assert_eq!(&*generated, expected);
         }
     }
 
@@ -344,7 +346,7 @@ mod tests {
         let mut init = RESERVED[0];
         let target = init + 2;
         let gen = encode(&mut init, true);
-        assert_eq!(gen, "dp");
+        assert_eq!(&*gen, "dp");
         assert_eq!(init, target);
     }
 

--- a/crates/swc_ecma_minifier/src/util/base54.rs
+++ b/crates/swc_ecma_minifier/src/util/base54.rs
@@ -1,9 +1,11 @@
+use swc_atoms::JsWord;
+
 static BASE54_DEFAULT_CHARS: &[u8; 64] =
     b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_0123456789";
 
 /// givin a number, return a base54 encoded string
 /// `usize -> [a-zA-Z$_][a-zA-Z$_0-9]*`
-pub(crate) fn encode(init: &mut usize, skip_reserved: bool) -> String {
+pub(crate) fn encode(init: &mut usize, skip_reserved: bool) -> JsWord {
     if skip_reserved {
         while init.is_reserved()
             || init.is_reserved_in_strict_bind()


### PR DESCRIPTION

This improve performance a bit because of cpu cache.

**Related issue (if exists):**
