### PR TITLE
feat(es/minifier): Implement more evaluation rules

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
@@ -582,6 +582,13 @@ fn to_trivial_exprs(e: &mut Expr) -> Vec<&mut Expr> {
 
 /// Evaluation of strings.
 impl Pure<'_> {
+    pub(super) fn eval_tpl_as_str(&mut self, e: &mut Expr) {
+        let tpl = match e {
+            Expr::Tpl(e) => e,
+            _ => return,
+        };
+    }
+
     /// Handle calls on string literals, like `'foo'.toUpperCase()`.
     pub(super) fn eval_str_method_call(&mut self, e: &mut Expr) {
         if !self.options.evaluate {

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -82,6 +82,12 @@ impl Pure<'_> {
             return;
         }
 
+        if let Some(new_expr) = self.compress_array_join_as_tpl(&mut arr.elems, &separator) {
+            self.changed = true;
+            *e = new_expr;
+            return;
+        }
+
         let cannot_join_as_str_lit = arr
             .elems
             .iter()
@@ -249,6 +255,14 @@ impl Pure<'_> {
         } else {
             false
         }
+    }
+
+    fn compress_array_join_as_tpl(
+        &mut self,
+        elems: &mut Vec<Option<ExprOrSpread>>,
+        sep: &str,
+    ) -> Option<Expr> {
+        None
     }
 
     /// Returns true if something is modified.

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -328,6 +328,14 @@ impl Pure<'_> {
             }
         }
 
+        let s = JsWord::from(&*cur_str_value);
+        new_tpl.quasis.push(TplElement {
+            span: DUMMY_SP,
+            tail: false,
+            cooked: Some(s.clone()),
+            raw: s,
+        });
+
         Some(Expr::Tpl(new_tpl))
     }
 

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -262,6 +262,18 @@ impl Pure<'_> {
         elems: &mut Vec<Option<ExprOrSpread>>,
         sep: &str,
     ) -> Option<Expr> {
+        if elems.iter().flatten().any(|elem| {
+            !matches!(
+                &*elem.expr,
+                Expr::Tpl(Tpl {
+                    value: Some(..),
+                    ..
+                }) | Expr::Lit(Lit::Str(..))
+            )
+        }) {
+            return None;
+        }
+
         None
     }
 

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -306,6 +306,7 @@ impl Pure<'_> {
                             cur_str_value.push_str(&e.cooked.unwrap());
                         } else {
                             let s = JsWord::from(&*cur_str_value);
+                            cur_str_value.clear();
                             new_tpl.quasis.push(TplElement {
                                 span: DUMMY_SP,
                                 tail: false,

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -1,6 +1,7 @@
-use std::num::FpCategory;
+use std::{fmt::Write, num::FpCategory};
 
-use swc_common::{util::take::Take, DUMMY_SP};
+use swc_atoms::js_word;
+use swc_common::{iter::IdentifyLast, util::take::Take, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_utils::ident::IdentLike;
 
@@ -21,6 +22,176 @@ impl Pure<'_> {
                 self.remove_invalid(e);
             }
         }
+    }
+
+    pub(super) fn compress_array_join(&mut self, e: &mut Expr) {
+        let call = match e {
+            Expr::Call(e) => e,
+            _ => return,
+        };
+
+        let callee = match &mut call.callee {
+            Callee::Super(_) | Callee::Import(_) => return,
+            Callee::Expr(callee) => &mut **callee,
+        };
+
+        let separator = if call.args.is_empty() {
+            ",".into()
+        } else if call.args.len() == 1 {
+            if call.args[0].spread.is_some() {
+                return;
+            }
+
+            if is_pure_undefined(&call.args[0].expr) {
+                ",".into()
+            } else {
+                match &*call.args[0].expr {
+                    Expr::Lit(Lit::Str(s)) => s.value.clone(),
+                    Expr::Lit(Lit::Null(..)) => js_word!("null"),
+                    _ => return,
+                }
+            }
+        } else {
+            return;
+        };
+
+        let arr = match callee {
+            Expr::Member(MemberExpr {
+                obj,
+                prop: MemberProp::Ident(Ident { sym, .. }),
+                ..
+            }) if *sym == *"join" => {
+                if let Expr::Array(arr) = &mut **obj {
+                    arr
+                } else {
+                    return;
+                }
+            }
+            _ => return,
+        };
+
+        if arr.elems.iter().any(|elem| {
+            matches!(
+                elem,
+                Some(ExprOrSpread {
+                    spread: Some(..),
+                    ..
+                })
+            )
+        }) {
+            return;
+        }
+
+        let cannot_join_as_str_lit = arr
+            .elems
+            .iter()
+            .filter_map(|v| v.as_ref())
+            .any(|v| match &*v.expr {
+                e if is_pure_undefined(e) => false,
+                Expr::Lit(lit) => !matches!(lit, Lit::Str(..) | Lit::Num(..) | Lit::Null(..)),
+                _ => true,
+            });
+
+        if cannot_join_as_str_lit {
+            if !self.options.unsafe_passes {
+                return;
+            }
+
+            // TODO: Partial join
+
+            if arr
+                .elems
+                .iter()
+                .filter_map(|v| v.as_ref())
+                .any(|v| match &*v.expr {
+                    e if is_pure_undefined(e) => false,
+                    Expr::Lit(lit) => !matches!(lit, Lit::Str(..) | Lit::Num(..) | Lit::Null(..)),
+                    // This can change behavior if the value is `undefined` or `null`.
+                    Expr::Ident(..) => false,
+                    _ => true,
+                })
+            {
+                return;
+            }
+
+            let sep = Box::new(Expr::Lit(Lit::Str(Str {
+                span: DUMMY_SP,
+                raw: None,
+                value: separator,
+            })));
+            let mut res = Expr::Lit(Lit::Str(Str {
+                span: DUMMY_SP,
+                raw: None,
+                value: js_word!(""),
+            }));
+
+            fn add(to: &mut Expr, right: Box<Expr>) {
+                let lhs = to.take();
+                *to = Expr::Bin(BinExpr {
+                    span: DUMMY_SP,
+                    left: Box::new(lhs),
+                    op: op!(bin, "+"),
+                    right,
+                });
+            }
+
+            for (last, elem) in arr.elems.take().into_iter().identify_last() {
+                if let Some(ExprOrSpread { spread: None, expr }) = elem {
+                    match &*expr {
+                        e if is_pure_undefined(e) => {}
+                        Expr::Lit(Lit::Null(..)) => {}
+                        _ => {
+                            add(&mut res, expr);
+                        }
+                    }
+                }
+
+                if !last {
+                    add(&mut res, sep.clone());
+                }
+            }
+
+            *e = res;
+
+            return;
+        }
+
+        let mut res = String::new();
+        for (last, elem) in arr.elems.iter().identify_last() {
+            if let Some(elem) = elem {
+                debug_assert_eq!(elem.spread, None);
+
+                match &*elem.expr {
+                    Expr::Lit(Lit::Str(s)) => {
+                        res.push_str(&s.value);
+                    }
+                    Expr::Lit(Lit::Num(n)) => {
+                        write!(res, "{}", n.value).unwrap();
+                    }
+                    e if is_pure_undefined(e) => {}
+                    Expr::Lit(Lit::Null(..)) => {}
+                    _ => {
+                        unreachable!(
+                            "Expression {:#?} cannot be joined and it should be filtered out",
+                            elem.expr
+                        )
+                    }
+                }
+            }
+
+            if !last {
+                res.push_str(&separator);
+            }
+        }
+
+        report_change!("Compressing array.join()");
+
+        self.changed = true;
+        *e = Expr::Lit(Lit::Str(Str {
+            span: call.span,
+            raw: None,
+            value: res.into(),
+        }))
     }
 
     pub(super) fn drop_undefined_from_return_arg(&mut self, s: &mut ReturnStmt) {

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -309,6 +309,8 @@ impl VisitMut for Pure<'_> {
             }
         }
 
+        self.compress_array_join(e);
+
         self.unsafe_optimize_fn_as_arrow(e);
 
         self.eval_opt_chain(e);

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -290,6 +290,8 @@ impl VisitMut for Pure<'_> {
             }
         }
 
+        self.eval_tpl_as_str(e);
+
         self.eval_trivial_values_in_expr(e);
 
         self.remove_invalid(e);

--- a/crates/swc_ecma_minifier/tests/TODO.txt
+++ b/crates/swc_ecma_minifier/tests/TODO.txt
@@ -722,8 +722,6 @@ sequences/lift_sequences_2/input.js
 sequences/lift_sequences_5/input.js
 sequences/side_effects_cascade_3/input.js
 switch/if_switch_typeof/input.js
-template_string/array_join/input.js
-template_string/coerce_to_string/input.js
 template_string/evaluate_nested_templates/input.js
 template_string/regex_2/input.js
 template_string/side_effects/input.js

--- a/crates/swc_ecma_minifier/tests/TODO.txt
+++ b/crates/swc_ecma_minifier/tests/TODO.txt
@@ -702,6 +702,8 @@ reduce_vars/unsafe_evaluate_modified/input.js
 reduce_vars/unsafe_evaluate_side_effect_free_1/input.js
 reduce_vars/unsafe_evaluate_side_effect_free_2/input.js
 reduce_vars/unused_modified/input.js
+reduce_vars/var_assign_1/input.js
+reduce_vars/var_assign_2/input.js
 reduce_vars/variables_collision_in_immediately_invoked_func/input.js
 regexp/unsafe_slashes/input.js
 rename/function_iife_catch/input.js

--- a/crates/swc_ecma_minifier/tests/TODO.txt
+++ b/crates/swc_ecma_minifier/tests/TODO.txt
@@ -702,8 +702,6 @@ reduce_vars/unsafe_evaluate_modified/input.js
 reduce_vars/unsafe_evaluate_side_effect_free_1/input.js
 reduce_vars/unsafe_evaluate_side_effect_free_2/input.js
 reduce_vars/unused_modified/input.js
-reduce_vars/var_assign_1/input.js
-reduce_vars/var_assign_2/input.js
 reduce_vars/variables_collision_in_immediately_invoked_func/input.js
 regexp/unsafe_slashes/input.js
 rename/function_iife_catch/input.js

--- a/crates/swc_ecma_minifier/tests/golden.txt
+++ b/crates/swc_ecma_minifier/tests/golden.txt
@@ -1306,6 +1306,7 @@ switch/keep_case/input.js
 switch/keep_default/input.js
 template_string/allow_chained_templates/input.js
 template_string/allow_null_character/input.js
+template_string/array_join/input.js
 template_string/check_escaped_chars/input.js
 template_string/do_not_optimize_tagged_template_1/input.js
 template_string/do_not_optimize_tagged_template_2/input.js

--- a/crates/swc_ecma_minifier/tests/golden.txt
+++ b/crates/swc_ecma_minifier/tests/golden.txt
@@ -1308,6 +1308,7 @@ template_string/allow_chained_templates/input.js
 template_string/allow_null_character/input.js
 template_string/array_join/input.js
 template_string/check_escaped_chars/input.js
+template_string/coerce_to_string/input.js
 template_string/do_not_optimize_tagged_template_1/input.js
 template_string/do_not_optimize_tagged_template_2/input.js
 template_string/equality/input.js


### PR DESCRIPTION
**Description:**

 - We now handle `array.join` in parallel optimizer.
 - We now handle `[].join` of template literals.
 - We now optimize a template literal as a string addition, in unsafe mode.

**Related issue (if exists):**
