### PR TITLE
perf(es/minifier): Make `base54` use stack-allocated vector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,6 +3272,7 @@ dependencies = [
  "ahash",
  "ansi_term",
  "anyhow",
+ "arrayvec",
  "backtrace",
  "criterion",
  "indexmap",

--- a/crates/swc_ecma_minifier/Cargo.toml
+++ b/crates/swc_ecma_minifier/Cargo.toml
@@ -21,6 +21,7 @@ debug = ["backtrace", "swc_ecma_transforms_optimization/debug"]
 
 [dependencies]
 ahash = "0.7.6"
+arrayvec = "0.7.2"
 backtrace = { version = "0.3.61", optional = true }
 indexmap = "1.7.0"
 once_cell = "1.10.0"

--- a/crates/swc_ecma_minifier/src/util/base54.rs
+++ b/crates/swc_ecma_minifier/src/util/base54.rs
@@ -368,11 +368,4 @@ mod tests {
         t.incr(54 * 64 * 64 * 64 * 64 * 64 * 64 * 64);
         t.gen("_jjjjjjk")
     }
-
-    #[test]
-    fn max_len() {
-        let mut n = 54 * 64 * 64 * 64 * 64 * 64 * 64 * 64 * 64 * 64 - 1;
-
-        assert_eq!(MAX_LEN, encode(&mut n, false).len());
-    }
 }


### PR DESCRIPTION
**Description:**


**Related issue (if exists):**
