### PR TITLE
fix(es/parser): Reject await expr with exponentiation op

### DIFF
--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -320,7 +320,9 @@ impl SyntaxError {
             SyntaxError::IllegalLanguageModeDirective => {
                 "Illegal 'use strict' directive in function with non-simple parameter list.".into()
             }
-            SyntaxError::UnaryInExp { .. } => "** cannot be applied to unary expression".into(),
+            SyntaxError::UnaryInExp { .. } => {
+                "'**' cannot be applied to unary/await expression.".into()
+            }
             SyntaxError::Hash => "Unexpected token '#'".into(),
             SyntaxError::LineBreakInThrow => "LineBreak cannot follow 'throw'".into(),
             SyntaxError::LineBreakBeforeArrow => {

--- a/crates/swc_ecma_parser/src/parser/expr/ops.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/ops.rs
@@ -154,7 +154,7 @@ impl<'a, I: Tokens> Parser<I> {
         }
         match *left {
             // This is invalid syntax.
-            Expr::Unary { .. } if op == op!("**") => {
+            Expr::Unary { .. } | Expr::Await(..) if op == op!("**") => {
                 // Correct implementation would be returning Ok(left) and
                 // returning "unexpected token '**'" on next.
                 // But it's not useful error message.

--- a/crates/swc_ecma_parser/tests/typescript-errors/await-with-exponentiation/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript-errors/await-with-exponentiation/input.ts
@@ -1,0 +1,1 @@
+async () => await a ** b;

--- a/crates/swc_ecma_parser/tests/typescript-errors/await-with-exponentiation/input.ts.stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/await-with-exponentiation/input.ts.stderr
@@ -1,0 +1,6 @@
+
+  x '**' cannot be applied to unary/await expression.
+   ,-[$DIR/tests/typescript-errors/await-with-exponentiation/input.ts:1:1]
+ 1 | async () => await a ** b;
+   :                     ^^
+   `----


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Reject the code below:

```js
async () => await a ** b;
```

[Current behavior](https://play.swc.rs/?version=1.2.170&code=H4sIAAAAAAAAA0ssrsxLVtDQVLC1U0gsT8wsUUhU0NJSSLIGAEmKHsUZAAAA&config=H4sIAAAAAAAAA0WNSwrDMAxE76J1FsWLLnKHHsK4SnDxD40CDcZ3rx1cspNmnp4qfeBorVSsgGVMOJPaL62kZ2E48UVpIUWPNhvArS9WdtaOMMzDmF6HnMETWCj65LdzyFyORRi4K5v28Cdbd8X8PkZQr3%2BX80ntdsw7j9cEVQ5uPx%2Bqcl%2B4AAAA)

[Babel REPL](https://babel.dev/repl#?browsers=&build=&builtIns=false&corejs=3.6&spec=false&loose=false&code_lz=IYZwngdgxgBAFAShgXgHw2Ad2ASwC4YwBURMARgNxA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=&prettier=false&targets=&version=7.17.9&externalPlugins=&assumptions=%7B%7D)