### PR TITLE
perf(es/minifier): Add some fast-path to the `MultiReplacer`

### DIFF
--- a/crates/swc_ecma_minifier/examples/minify-all.rs
+++ b/crates/swc_ecma_minifier/examples/minify-all.rs
@@ -23,8 +23,8 @@ fn main() {
 
     testing::run_test2(false, |cm, handler| {
         GLOBALS.with(|globals| {
-            files
-                .into_par_iter()
+            let _ = files
+                .into_iter()
                 .map(|path| -> Result<_> {
                     GLOBALS.set(globals, || {
                         let fm = cm.load_file(&path).expect("failed to load file");

--- a/crates/swc_ecma_minifier/scripts/instrument/all.sh
+++ b/crates/swc_ecma_minifier/scripts/instrument/all.sh
@@ -8,4 +8,4 @@
 
 
 export RUST_LOG=off
-cargo profile instruments -t time --example minify-all --release -- $@
+cargo profile instruments -t time --example minify-all --features swc_common/perf --release -- $@

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -286,19 +286,21 @@ impl VisitMut for MultiReplacer<'_> {
     fn visit_mut_prop(&mut self, p: &mut Prop) {
         p.visit_mut_children_with(self);
 
-        if let Prop::Shorthand(i) = p {
-            if let Some(value) = self.var(&i.to_id()) {
-                debug!("multi-replacer: Replaced `{}` as shorthand", i);
-                *self.worked = true;
-                self.changed = true;
+        if matches!(self.mode, MultiReplacerMode::Normal) {
+            if let Prop::Shorthand(i) = p {
+                if let Some(value) = self.var(&i.to_id()) {
+                    debug!("multi-replacer: Replaced `{}` as shorthand", i);
+                    *self.worked = true;
+                    self.changed = true;
 
-                *p = Prop::KeyValue(KeyValueProp {
-                    key: PropName::Ident(Ident::new(
-                        i.sym.clone(),
-                        i.span.with_ctxt(Default::default()),
-                    )),
-                    value,
-                });
+                    *p = Prop::KeyValue(KeyValueProp {
+                        key: PropName::Ident(Ident::new(
+                            i.sym.clone(),
+                            i.span.with_ctxt(Default::default()),
+                        )),
+                        value,
+                    });
+                }
             }
         }
     }

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -250,7 +250,14 @@ impl VisitMut for MultiReplacer<'_> {
     }
 
     fn visit_mut_expr(&mut self, e: &mut Expr) {
+        if self.vars.is_empty() {
+            return;
+        }
         e.visit_mut_children_with(self);
+
+        if self.vars.is_empty() {
+            return;
+        }
 
         if matches!(self.mode, MultiReplacerMode::Normal) {
             if let Expr::Ident(i) = e {


### PR DESCRIPTION
**Description:**

This improves performance in some cases.

```

es/minify/libraries/antd
                        time:   [722.83 ms 724.42 ms 726.21 ms]
                        change: [-2.6626% -2.1874% -1.7210%] (p = 0.00 < 0.05)
                        Performance has improved.
es/minify/libraries/d3  time:   [205.47 ms 205.84 ms 206.23 ms]
                        change: [-0.1453% +0.8473% +1.5925%] (p = 0.09 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.4s.
es/minify/libraries/echarts
                        time:   [838.60 ms 840.63 ms 843.00 ms]
                        change: [-1.1146% -0.8510% -0.5331%] (p = 0.00 < 0.05)
                        Change within noise threshold.
es/minify/libraries/jquery
                        time:   [45.964 ms 46.044 ms 46.104 ms]
                        change: [-0.4046% +0.1915% +0.8415%] (p = 0.59 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
es/minify/libraries/lodash
                        time:   [53.870 ms 53.915 ms 53.989 ms]
                        change: [-1.0360% -0.6616% -0.3626%] (p = 0.00 < 0.05)
                        Change within noise threshold.
es/minify/libraries/moment
                        time:   [26.990 ms 27.032 ms 27.074 ms]
                        change: [+0.0172% +0.3518% +0.7199%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
es/minify/libraries/react
                        time:   [9.3490 ms 9.5497 ms 9.6836 ms]
                        change: [-5.4959% -4.2533% -2.6815%] (p = 0.00 < 0.05)
                        Performance has improved.
es/minify/libraries/terser
                        time:   [335.50 ms 336.70 ms 337.85 ms]
                        change: [+0.4835% +0.9732% +1.4543%] (p = 0.00 < 0.05)
                        Change within noise threshold.
es/minify/libraries/three
                        time:   [242.65 ms 243.20 ms 243.75 ms]
                        change: [+0.8298% +1.1339% +1.4423%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 16.6s.
es/minify/libraries/typescript
                        time:   [1.6499 s 1.6530 s 1.6560 s]
                        change: [-3.9252% -3.6394% -3.3638%] (p = 0.00 < 0.05)
                        Performance has improved.
es/minify/libraries/victory
                        time:   [314.49 ms 314.87 ms 315.24 ms]
                        change: [-0.2916% -0.0344% +0.2025%] (p = 0.80 > 0.05)
                        No change in performance detected.
es/minify/libraries/vue time:   [65.643 ms 65.705 ms 65.798 ms]
                        change: [-1.6684% -1.1719% -0.7178%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```

**Related issue (if exists):**
