### PR TITLE
fix(es/parser): Reject `'use strict'` with non-simple params list in TS

### DIFF
--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -1527,7 +1527,7 @@ impl<I: Tokens> FnBodyParser<BlockStmtOrExpr> for Parser<I> {
             };
             let result = self.with_ctx(ctx).parse_block(false);
             result.map(|block_stmt| {
-                if !self.input.syntax().typescript() && !is_simple_parameter_list {
+                if !is_simple_parameter_list {
                     if let Some(span) = has_use_strict(&block_stmt) {
                         self.emit_err(span, SyntaxError::IllegalLanguageModeDirective);
                     }
@@ -1558,7 +1558,7 @@ impl<I: Tokens> FnBodyParser<Option<BlockStmt>> for Parser<I> {
         }
         let block = self.include_in_expr(true).parse_block(true);
         block.map(|block_stmt| {
-            if !self.input.syntax().typescript() && !is_simple_parameter_list {
+            if !is_simple_parameter_list {
                 if let Some(span) = has_use_strict(&block_stmt) {
                     self.emit_err(span, SyntaxError::IllegalLanguageModeDirective);
                 }

--- a/crates/swc_ecma_parser/tests/typescript-errors/use-strict/arrow-fn-expr/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript-errors/use-strict/arrow-fn-expr/input.ts
@@ -1,0 +1,1 @@
+const f = ([x]: string) => { 'use strict' }

--- a/crates/swc_ecma_parser/tests/typescript-errors/use-strict/arrow-fn-expr/input.ts.stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/use-strict/arrow-fn-expr/input.ts.stderr
@@ -1,0 +1,6 @@
+
+  x Illegal 'use strict' directive in function with non-simple parameter list.
+   ,-[$DIR/tests/typescript-errors/use-strict/arrow-fn-expr/input.ts:1:1]
+ 1 | const f = ([x]: string) => { 'use strict' }
+   :                              ^^^^^^^^^^^^
+   `----

--- a/crates/swc_ecma_parser/tests/typescript-errors/use-strict/fn-block/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript-errors/use-strict/fn-block/input.ts
@@ -1,0 +1,1 @@
+function f([x]: string) { 'use strict' }

--- a/crates/swc_ecma_parser/tests/typescript-errors/use-strict/fn-block/input.ts.stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/use-strict/fn-block/input.ts.stderr
@@ -1,0 +1,6 @@
+
+  x Illegal 'use strict' directive in function with non-simple parameter list.
+   ,-[$DIR/tests/typescript-errors/use-strict/fn-block/input.ts:1:1]
+ 1 | function f([x]: string) { 'use strict' }
+   :                           ^^^^^^^^^^^^
+   `----


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR lets it check `'use strict'` with non-simple parameters list in TypeScript. Previously it only checks in JavaScript.
