### PR TITLE
fix(es/codegen): Print BigInt as object property

### DIFF
--- a/crates/swc_ecma_ast/src/prop.rs
+++ b/crates/swc_ecma_ast/src/prop.rs
@@ -104,7 +104,7 @@ pub enum PropName {
     Num(Number),
     #[tag("Computed")]
     Computed(ComputedPropName),
-    #[tag("BigInt")]
+    #[tag("BigIntLiteral")]
     BigInt(BigInt),
 }
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Fix for #4439.

Problem appears to be that node type annotation in `PropName` Enum (`#[tag("BigInt")]`) is out of sync with the annotation for `BigInt` struct (`#[ast_node("BigIntLiteral")]`).

This PR changes that, and it fixes the error.

I had trouble working out where to add a test. Fixtures in [crates/swc_ecma_codegen/tests/fixture](https://github.com/swc-project/swc/tree/main/crates/swc_ecma_codegen/tests/fixture) appear to be parsed as TypeScript, and TypeScript doesn't seem to accept this as valid code.

If someone can let me know where to put tests, I'll add them.

**Related issue (if exists):**

Closes #4439