### PR TITLE
fix(es/parser): Throw syntax error for missing function expr body

### DIFF
--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -1102,15 +1102,10 @@ impl<'a, I: Tokens> Parser<I> {
                 is_async,
                 is_generator,
             )?;
-            // expect!(self, '(');
-            // let params_ctx = Context {
-            //     in_parameters: true,
-            //     ..p.ctx()
-            // };
-            // let params = p.with_ctx(params_ctx).parse_formal_params()?;
-            // expect!(self, ')');
 
-            // let body = p.parse_fn_body(is_async, is_generator)?;
+            if is_fn_expr && f.body.is_none() {
+                unexpected!(p, "{");
+            }
 
             Ok((ident, f))
         })

--- a/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/anonymous/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/anonymous/input.ts
@@ -1,0 +1,1 @@
+let f = function ()

--- a/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/anonymous/input.ts.stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/anonymous/input.ts.stderr
@@ -1,0 +1,6 @@
+
+  x Unexpected eof
+   ,-[$DIR/tests/typescript-errors/missing-fn-expr-body/anonymous/input.ts:1:1]
+ 1 | let f = function ()
+   :                    ^
+   `----

--- a/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/async/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/async/input.ts
@@ -1,0 +1,1 @@
+let f = async function ()

--- a/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/async/input.ts.stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/async/input.ts.stderr
@@ -1,0 +1,6 @@
+
+  x Unexpected eof
+   ,-[$DIR/tests/typescript-errors/missing-fn-expr-body/async/input.ts:1:1]
+ 1 | let f = async function ()
+   :                          ^
+   `----

--- a/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/named/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/named/input.ts
@@ -1,0 +1,1 @@
+let f = function f();

--- a/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/named/input.ts.stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/named/input.ts.stderr
@@ -1,0 +1,6 @@
+
+  x Unexpected eof
+   ,-[$DIR/tests/typescript-errors/missing-fn-expr-body/named/input.ts:1:1]
+ 1 | let f = function f();
+   :                      ^
+   `----

--- a/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/typed/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/typed/input.ts
@@ -1,0 +1,2 @@
+// return type is `{}`
+let f = function (): {}

--- a/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/typed/input.ts.stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/missing-fn-expr-body/typed/input.ts.stderr
@@ -1,0 +1,6 @@
+
+  x Unexpected eof
+   ,-[$DIR/tests/typescript-errors/missing-fn-expr-body/typed/input.ts:2:1]
+ 2 | let f = function (): {}
+   :                        ^
+   `----


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Throw a syntax error for the code below:

```ts
let f = function ()
```

Note that this bug is only reproducible when `syntax` is `'typescript'`; for `'ecmascript'`, it already works expectedly.

[playground](https://play.swc.rs/?version=1.2.172&code=H4sIAAAAAAAAA8tJLVGoULBVSCvNSy7JzM9T0NDkAgAMz9H4FAAAAA%3D%3D&config=H4sIAAAAAAAAA0WNSwrDMAxE76J1Fm0XpeQOPYRxleDgHxoFGozvXju4ZCfNPD0V2mBpLpSNgKVPOKKaL82kR2ZYcVlpIkWLFuPBtS1GVtaGMB63%2B6vVPiXwACYKLrrl6DKbQhYGrsrE1f%2FJ2lwhffYelPPf6XxSvRzjzuE9QJWd6w%2B6QIF4uAAAAA%3D%3D)
