### PR TITLE
refactor(swc/plugin): align deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3937,10 +3937,8 @@ version = "0.50.1"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
  "swc_ecma_quote",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecmascript",
  "swc_plugin_macro",
  "swc_plugin_proxy",
 ]

--- a/crates/swc_ecmascript/Cargo.toml
+++ b/crates/swc_ecmascript/Cargo.toml
@@ -25,6 +25,7 @@ preset_env = ["swc_ecma_preset_env"]
 transforms = ["swc_ecma_transforms"]
 utils = ["swc_ecma_utils"]
 visit = ["swc_ecma_visit"]
+rkyv-impl = ["swc_ecma_ast/rkyv-impl"]
 
 typescript-parser = ["swc_ecma_parser/typescript"]
 

--- a/crates/swc_plugin/Cargo.toml
+++ b/crates/swc_plugin/Cargo.toml
@@ -23,12 +23,8 @@ swc_atoms = { version = "0.2.0", path = "../swc_atoms" }
 swc_common = { version = "0.17.23", path = "../swc_common", features = [
   "plugin-mode",
 ] }
-swc_ecma_ast = { version = "0.77.0", path = "../swc_ecma_ast", features = [
-  "rkyv-impl",
-] }
 swc_ecma_quote = { version = "0.15.0", path = "../swc_ecma_quote", optional = true }
-swc_ecma_visit = { version = "0.63.0", path = "../swc_ecma_visit" }
-swc_ecma_utils = { version = "0.83.0", path = "../swc_ecma_utils" }
+swc_ecmascript = { version = "0.153.0", path = "../swc_ecmascript", features = ["utils", "visit", "rkyv-impl"] }
 swc_plugin_proxy = { version = "0.2.2", path = "../swc_plugin_proxy", features = [
   "plugin-mode",
 ] }

--- a/crates/swc_plugin/src/lib.rs
+++ b/crates/swc_plugin/src/lib.rs
@@ -27,13 +27,12 @@ pub mod utils {
     #[cfg(feature = "swc_ecma_quote")]
     #[cfg_attr(docsrs, doc(cfg(feature = "quote")))]
     pub use swc_ecma_quote::*;
-    pub use swc_ecma_utils::*;
+    pub use swc_ecmascript::utils::*;
 }
 
 pub mod ast {
     pub use swc_atoms::*;
-    pub use swc_ecma_ast::*;
-    pub use swc_ecma_visit::*;
+    pub use swc_ecmascript::{ast::*, visit::*};
 }
 
 pub mod syntax_pos {

--- a/tests/rust-plugins/swc_internal_plugin/Cargo.lock
+++ b/tests/rust-plugins/swc_internal_plugin/Cargo.lock
@@ -147,6 +147,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "enum_kind"
+version = "0.2.1"
+dependencies = [
+ "pmutil",
+ "proc-macro2",
+ "swc_macros_common",
+ "syn",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +253,79 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lexical"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd3e434c16f0164124ade12dcdee324fcc3dafb1cad0c7f1d8c2451a1aa6886"
+dependencies = [
+ "lexical-core",
+]
+
+[[package]]
+name = "lexical-core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92912c4af2e7d9075be3e5e3122c4d7263855fa6cce34fbece4dd08e5884624d"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f518eed87c3be6debe6d26b855c97358d8a11bf05acec137e5f53080f5ad2dd8"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc852ec67c6538bbb2b9911116a385b24510e879a69ab516e6a151b15a79168"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c72a9d52c5c4e62fa2cdc2cb6c694a39ae1382d9c2a17a466f18e272a0930eb1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a89ec1d062e481210c309b672f73a0567b7855f21e7d2fae636df44d12e97f9"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "094060bd2a7c2ff3a16d5304a6ae82727cb3cc9d1c70f813cc73f744c319337e"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -576,6 +659,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "ahash",
  "anyhow",
@@ -654,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -667,8 +756,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_parser"
+version = "0.103.0"
+dependencies = [
+ "either",
+ "enum_kind",
+ "lexical",
+ "num-bigint",
+ "serde",
+ "smallvec",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "tracing",
+ "typed-arena",
+ "unicode-id",
+]
+
+[[package]]
 name = "swc_ecma_utils"
-version = "0.82.0"
+version = "0.83.0"
 dependencies = [
  "indexmap",
  "once_cell",
@@ -681,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -689,6 +796,16 @@ dependencies = [
  "swc_ecma_ast",
  "swc_visit",
  "tracing",
+]
+
+[[package]]
+name = "swc_ecmascript"
+version = "0.153.0"
+dependencies = [
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -721,13 +838,11 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.49.0"
+version = "0.50.1"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecmascript",
  "swc_plugin_macro",
  "swc_plugin_proxy",
 ]
@@ -743,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -827,6 +942,12 @@ checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "unicode-bidi"


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This is minor bikeshedding for the swc_plugin's deps to use reduced number of deps instead of having individual for the reexport.

This won't make any major differences, but helps to import a visitor aims to be used for the plugin & custom pass both:

```
// visitor
- swc_ecma_script
- ...

// plugin
- swc_plugin
- visitor

// swc/custom-pass
- swc_ecma_script
- visitor

```

plugin / swc both will work by having matching version of swc_ecmascript only, instead of each (ast, visit, etcs) to avoid conflict. This is what I found while try to align versions for the https://github.com/vercel/next.js/pull/36692.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

