### PR TITLE
fix(es/minifier): Fix handling of `NaN`

### DIFF
--- a/crates/swc_ecma_minifier/tests/terser/compress/evaluate/issue_1760_1/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/evaluate/issue_1760_1/output.js
@@ -1,7 +1,7 @@
 !function(a) {
     try {
         throw 0;
-    } catch (NaN) {
+    } catch (NaN1) {
         a = NaN;
     }
     console.log(a);

--- a/crates/swc_ecma_minifier/tests/terser/compress/issue_597/NaN_and_Infinity_should_not_be_replaced_when_they_are_redefined_evaluate/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/issue_597/NaN_and_Infinity_should_not_be_replaced_when_they_are_redefined_evaluate/output.js
@@ -1,3 +1,3 @@
-var Infinity, NaN;
+var Infinity, NaN1;
 (1 / 0).toString();
 NaN.toString();

--- a/crates/swc_ecma_minifier/tests/terser_exec.rs
+++ b/crates/swc_ecma_minifier/tests/terser_exec.rs
@@ -34,7 +34,6 @@ use testing::assert_eq;
 #[testing::fixture(
     "tests/terser/compress/**/input.js",
     exclude(
-        "evaluate/issue_1760_1/",
         "functions/issue_2620_4/",
         "issue_1105/assorted_Infinity_NaN_undefined_in_with_scope/",
         "issue_1105/assorted_Infinity_NaN_undefined_in_with_scope_keep_infinity/",

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -733,6 +733,18 @@ impl SimplifyExpr {
                 if let Known(v) = arg.as_number() {
                     self.changed = true;
 
+                    if v.is_nan() {
+                        *expr = preserve_effects(
+                            *span,
+                            Expr::Ident(Ident::new(
+                                js_word!("NaN"),
+                                span.with_ctxt(self.unresolved_ctxt),
+                            )),
+                            iter::once(arg.take()),
+                        );
+                        return;
+                    }
+
                     *expr = preserve_effects(
                         *span,
                         Expr::Lit(Lit::Num(Number {


### PR DESCRIPTION
**Description:**

 - `expr_simplifier` now uses `NaN#unresolved` instead of f64 with `NaN` value.

**Related issue (if exists):**
