### PR TITLE
feat(html/parser): support `iframe_srcdoc`

### DIFF
--- a/crates/swc_html_codegen/tests/fixture.rs
+++ b/crates/swc_html_codegen/tests/fixture.rs
@@ -499,7 +499,10 @@ fn parser_recovery_verify(input: PathBuf) {
 fn html5lib_tests_verify(input: PathBuf) {
     let file_stem = input.file_stem().unwrap().to_str().unwrap().to_owned();
     let scripting_enabled = file_stem.contains("script_on");
-    let parser_config = ParserConfig { scripting_enabled };
+    let parser_config = ParserConfig {
+        scripting_enabled,
+        iframe_srcdoc: false,
+    };
     let codegen_config = CodegenConfig {
         minify: false,
         scripting_enabled,

--- a/crates/swc_html_parser/src/parser/mod.rs
+++ b/crates/swc_html_parser/src/parser/mod.rs
@@ -1298,14 +1298,10 @@ where
                     // In any case, switch the insertion mode to "before html", then reprocess the
                     // token.
                     _ => {
-                        // TODO handle iframe
-                        let is_iframe = false;
-
-                        if !is_iframe {
+                        if !self.config.iframe_srcdoc {
                             self.errors
                                 .push(Error::new(token_and_info.span, ErrorKind::MissingDoctype));
 
-                        if !self.config.iframe_srcdoc {
                             self.document_mode = DocumentMode::Quirks;
                         }
 

--- a/crates/swc_html_parser/src/parser/mod.rs
+++ b/crates/swc_html_parser/src/parser/mod.rs
@@ -26,6 +26,7 @@ pub type PResult<T> = Result<T, Error>;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ParserConfig {
     pub scripting_enabled: bool,
+    pub iframe_srcdoc: bool,
 }
 
 enum Bookmark<RcNode> {
@@ -1213,7 +1214,6 @@ where
                         force_quirks,
                         ..
                     } => {
-                        let is_html = matches!(name, Some(name) if name.as_ref().eq_ignore_ascii_case("html"));
                         let is_valid_doctype = matches!(
                             (
                                 name.as_ref().map(|value| &**value),
@@ -1262,21 +1262,17 @@ where
 
                         self.append_node(self.document.as_ref().unwrap(), document_type);
 
-                        // TODO handle - an iframe srcdoc document option for next entries
-                        let is_iframe = false;
-
-                        if !is_iframe {
-                            if *force_quirks
-                                || !is_html
+                        if !self.config.iframe_srcdoc
+                            && (*force_quirks
+                                || !matches!(name, Some(name) if name.as_ref().eq_ignore_ascii_case("html"))
                                 || matches!(public_id, Some(public_id) if QUIRKY_PUBLIC_MATCHES
                                     .contains(&&*public_id.to_ascii_lowercase()) || QUIRKY_PUBLIC_PREFIXES.contains(&&*public_id.to_ascii_lowercase()))
                                 || matches!(system_id, Some(system_id) if QUIRKY_SYSTEM_MATCHES
                                 .contains(&&*system_id.to_ascii_lowercase()) || HTML4_PUBLIC_PREFIXES.contains(
                                     &&*system_id.to_ascii_lowercase()
-                                ))
-                            {
-                                self.document_mode = DocumentMode::Quirks;
-                            }
+                                )))
+                        {
+                            self.document_mode = DocumentMode::Quirks;
                         } else if let Some(public_id) = public_id {
                             if LIMITED_QUIRKY_PUBLIC_PREFIXES
                                 .contains(&&*public_id.as_ref().to_ascii_lowercase())
@@ -1309,6 +1305,7 @@ where
                             self.errors
                                 .push(Error::new(token_and_info.span, ErrorKind::MissingDoctype));
 
+                        if !self.config.iframe_srcdoc {
                             self.document_mode = DocumentMode::Quirks;
                         }
 

--- a/crates/swc_html_parser/tests/fixture.rs
+++ b/crates/swc_html_parser/tests/fixture.rs
@@ -415,6 +415,17 @@ fn pass(input: PathBuf) {
     )
 }
 
+#[testing::fixture("tests/iframe_srcdoc/**/*.html")]
+fn pass_iframe_srcdoc(input: PathBuf) {
+    document_test(
+        input,
+        ParserConfig {
+            iframe_srcdoc: true,
+            ..Default::default()
+        },
+    )
+}
+
 #[testing::fixture("tests/recovery/**/*.html")]
 fn recovery(input: PathBuf) {
     document_recovery_test(
@@ -427,6 +438,7 @@ fn recovery(input: PathBuf) {
 
 #[testing::fixture("tests/fixture/**/*.html")]
 #[testing::fixture("tests/recovery/**/*.html")]
+#[testing::fixture("tests/iframe_srcdoc/**/*.html")]
 fn span_visualizer(input: PathBuf) {
     document_span_visualizer(
         input,
@@ -438,6 +450,7 @@ fn span_visualizer(input: PathBuf) {
 
 #[testing::fixture("tests/fixture/**/*.html")]
 #[testing::fixture("tests/recovery/**/*.html")]
+#[testing::fixture("tests/iframe_srcdoc/**/*.html")]
 fn dom_visualizer(input: PathBuf) {
     document_dom_visualizer(
         input,
@@ -1158,7 +1171,10 @@ fn html5lib_test_tree_construction(input: PathBuf) {
         let fm = cm.load_file(&input).unwrap();
 
         let lexer = Lexer::new(SourceFileInput::from(&*fm), Default::default());
-        let config = ParserConfig { scripting_enabled };
+        let config = ParserConfig {
+            scripting_enabled,
+            iframe_srcdoc: false,
+        };
         let mut parser = Parser::new(lexer, config);
         let document_or_document_fragment = if file_stem.contains("fragment") {
             let mut context_element_namespace = Namespace::HTML;

--- a/crates/swc_html_parser/tests/iframe_srcdoc/basic/dom.rust-debug
+++ b/crates/swc_html_parser/tests/iframe_srcdoc/basic/dom.rust-debug
@@ -1,0 +1,6 @@
+| <html>
+|   <head>
+|   <body>
+|     " "
+|     <p>
+|       "Test."

--- a/crates/swc_html_parser/tests/iframe_srcdoc/basic/input.html
+++ b/crates/swc_html_parser/tests/iframe_srcdoc/basic/input.html
@@ -1,0 +1,1 @@
+<html> <body> <p>Test.</p>

--- a/crates/swc_html_parser/tests/iframe_srcdoc/basic/output.json
+++ b/crates/swc_html_parser/tests/iframe_srcdoc/basic/output.json
@@ -1,0 +1,84 @@
+{
+  "type": "Document",
+  "span": {
+    "start": 1,
+    "end": 27,
+    "ctxt": 0
+  },
+  "mode": "no-quirks",
+  "children": [
+    {
+      "type": "Element",
+      "span": {
+        "start": 1,
+        "end": 23,
+        "ctxt": 0
+      },
+      "tagName": "html",
+      "namespace": "http://www.w3.org/1999/xhtml",
+      "attributes": [],
+      "children": [
+        {
+          "type": "Element",
+          "span": {
+            "start": 0,
+            "end": 14,
+            "ctxt": 0
+          },
+          "tagName": "head",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "attributes": [],
+          "children": [],
+          "content": null
+        },
+        {
+          "type": "Element",
+          "span": {
+            "start": 8,
+            "end": 23,
+            "ctxt": 0
+          },
+          "tagName": "body",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "attributes": [],
+          "children": [
+            {
+              "type": "Text",
+              "span": {
+                "start": 14,
+                "end": 15,
+                "ctxt": 0
+              },
+              "value": " "
+            },
+            {
+              "type": "Element",
+              "span": {
+                "start": 15,
+                "end": 23,
+                "ctxt": 0
+              },
+              "tagName": "p",
+              "namespace": "http://www.w3.org/1999/xhtml",
+              "attributes": [],
+              "children": [
+                {
+                  "type": "Text",
+                  "span": {
+                    "start": 18,
+                    "end": 23,
+                    "ctxt": 0
+                  },
+                  "value": "Test."
+                }
+              ],
+              "content": null
+            }
+          ],
+          "content": null
+        }
+      ],
+      "content": null
+    }
+  ]
+}

--- a/crates/swc_html_parser/tests/iframe_srcdoc/basic/span.rust-debug
+++ b/crates/swc_html_parser/tests/iframe_srcdoc/basic/span.rust-debug
@@ -1,0 +1,70 @@
+
+  x Document
+   ,-[$DIR/tests/iframe_srcdoc/basic/input.html:1:1]
+ 1 | <html> <body> <p>Test.</p>
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   `----
+
+  x Child
+   ,-[$DIR/tests/iframe_srcdoc/basic/input.html:1:1]
+ 1 | <html> <body> <p>Test.</p>
+   : ^^^^^^^^^^^^^^^^^^^^^^
+   `----
+
+  x Element
+   ,-[$DIR/tests/iframe_srcdoc/basic/input.html:1:1]
+ 1 | <html> <body> <p>Test.</p>
+   : ^^^^^^^^^^^^^^^^^^^^^^
+   `----
+
+  x Child
+
+  x Element
+
+  x Child
+   ,-[$DIR/tests/iframe_srcdoc/basic/input.html:1:1]
+ 1 | <html> <body> <p>Test.</p>
+   :        ^^^^^^^^^^^^^^^
+   `----
+
+  x Element
+   ,-[$DIR/tests/iframe_srcdoc/basic/input.html:1:1]
+ 1 | <html> <body> <p>Test.</p>
+   :        ^^^^^^^^^^^^^^^
+   `----
+
+  x Child
+   ,-[$DIR/tests/iframe_srcdoc/basic/input.html:1:1]
+ 1 | <html> <body> <p>Test.</p>
+   :              ^
+   `----
+
+  x Text
+   ,-[$DIR/tests/iframe_srcdoc/basic/input.html:1:1]
+ 1 | <html> <body> <p>Test.</p>
+   :              ^
+   `----
+
+  x Child
+   ,-[$DIR/tests/iframe_srcdoc/basic/input.html:1:1]
+ 1 | <html> <body> <p>Test.</p>
+   :               ^^^^^^^^
+   `----
+
+  x Element
+   ,-[$DIR/tests/iframe_srcdoc/basic/input.html:1:1]
+ 1 | <html> <body> <p>Test.</p>
+   :               ^^^^^^^^
+   `----
+
+  x Child
+   ,-[$DIR/tests/iframe_srcdoc/basic/input.html:1:1]
+ 1 | <html> <body> <p>Test.</p>
+   :                  ^^^^^
+   `----
+
+  x Text
+   ,-[$DIR/tests/iframe_srcdoc/basic/input.html:1:1]
+ 1 | <html> <body> <p>Test.</p>
+   :                  ^^^^^
+   `----


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Support `iframe_srcdoc`, i.e.

https://www.w3schools.com/tags/att_iframe_srcdoc.asp

```
<iframe srcdoc="<p>Hello world!</p>" src="demo_iframe_srcdoc.htm"></iframe>
```

Before today I don't known about this features :confused: Currently we don't parse it by default for better perf and because it has very rare usage, but we add ability to do it because it is part of spec


**BREAKING CHANGE:**

No

**Related issue (if exists):**

No