### PR TITLE
perf(common): Improve performance of `StringInput`

### DIFF
--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -9,7 +9,7 @@ pub type SourceFileInput<'a> = StringInput<'a>;
 /// Implementation of [Input].
 #[derive(Clone)]
 pub struct StringInput<'a> {
-    start_pos: BytePos,
+    cur_pos: BytePos,
     last_pos: BytePos,
     /// Current cursor
     iter: str::CharIndices<'a>,
@@ -31,7 +31,7 @@ impl<'a> StringInput<'a> {
         assert!(start <= end);
 
         StringInput {
-            start_pos: start,
+            cur_pos: start,
             last_pos: start,
             orig: src,
             iter: src.char_indices(),
@@ -70,7 +70,7 @@ impl<'a> Input for StringInput<'a> {
     #[inline]
     fn bump(&mut self) {
         if let Some((i, c)) = self.iter.next() {
-            self.last_pos = self.start_pos + BytePos((i + c.len_utf8()) as u32);
+            self.last_pos = self.cur_pos + BytePos((i + c.len_utf8()) as u32);
         } else {
             unsafe {
                 debug_unreachable!("bump should not be called when cur() == None");
@@ -87,7 +87,7 @@ impl<'a> Input for StringInput<'a> {
         self.iter
             .clone()
             .next()
-            .map_or(self.last_pos, |(p, _)| self.start_pos + BytePos(p as u32))
+            .map_or(self.last_pos, |(p, _)| self.cur_pos + BytePos(p as u32))
     }
 
     #[inline]
@@ -107,7 +107,7 @@ impl<'a> Input for StringInput<'a> {
 
         self.iter = s[end_idx..].char_indices();
         self.last_pos = end;
-        self.start_pos = end;
+        self.cur_pos = end;
 
         ret
     }
@@ -129,7 +129,7 @@ impl<'a> Input for StringInput<'a> {
         let ret = &s[..last];
 
         self.last_pos = self.last_pos + BytePos(last as _);
-        self.start_pos = self.last_pos;
+        self.cur_pos = self.last_pos;
         self.iter = s[last..].char_indices();
 
         ret
@@ -153,7 +153,7 @@ impl<'a> Input for StringInput<'a> {
         }
 
         self.last_pos = self.last_pos + BytePos(last as _);
-        self.start_pos = self.last_pos;
+        self.cur_pos = self.last_pos;
         self.iter = s[last..].char_indices();
 
         Some(self.last_pos)
@@ -166,7 +166,7 @@ impl<'a> Input for StringInput<'a> {
 
         let s = &orig[idx..];
         self.iter = s.char_indices();
-        self.start_pos = to;
+        self.cur_pos = to;
         self.last_pos = to;
     }
 
@@ -184,7 +184,7 @@ impl<'a> Input for StringInput<'a> {
     fn eat_byte(&mut self, c: u8) -> bool {
         if self.is_byte(c) {
             if let Some((i, _)) = self.iter.next() {
-                self.last_pos = self.start_pos + BytePos((i + 1) as u32);
+                self.last_pos = self.cur_pos + BytePos((i + 1) as u32);
             } else {
                 unsafe {
                     debug_unreachable!(
@@ -274,13 +274,13 @@ mod tests {
         with_test_sess("foo/d", |mut i| {
             assert_eq!(i.slice(BytePos(1), BytePos(2)), "f");
             assert_eq!(i.last_pos, BytePos(2));
-            assert_eq!(i.start_pos, BytePos(2));
+            assert_eq!(i.cur_pos, BytePos(2));
             assert_eq!(i.cur(), Some('o'));
 
             assert_eq!(i.slice(BytePos(2), BytePos(4)), "oo");
             assert_eq!(i.slice(BytePos(1), BytePos(4)), "foo");
             assert_eq!(i.last_pos, BytePos(4));
-            assert_eq!(i.start_pos, BytePos(4));
+            assert_eq!(i.cur_pos, BytePos(4));
             assert_eq!(i.cur(), Some('/'));
         });
     }
@@ -290,13 +290,13 @@ mod tests {
         with_test_sess("load", |mut i| {
             assert_eq!(i.slice(BytePos(1), BytePos(3)), "lo");
             assert_eq!(i.last_pos, BytePos(3));
-            assert_eq!(i.start_pos, BytePos(3));
+            assert_eq!(i.cur_pos, BytePos(3));
             assert_eq!(i.cur(), Some('a'));
             i.reset_to(BytePos(1));
 
             assert_eq!(i.cur(), Some('l'));
             assert_eq!(i.last_pos, BytePos(1));
-            assert_eq!(i.start_pos, BytePos(1));
+            assert_eq!(i.cur_pos, BytePos(1));
         });
     }
 
@@ -305,12 +305,12 @@ mod tests {
         with_test_sess("foo/d", |mut i| {
             assert_eq!(i.cur_pos(), BytePos(1));
             assert_eq!(i.last_pos, BytePos(1));
-            assert_eq!(i.start_pos, BytePos(1));
+            assert_eq!(i.cur_pos, BytePos(1));
             assert_eq!(i.uncons_while(|c| c.is_alphabetic()), "foo");
 
             // assert_eq!(i.cur_pos(), BytePos(4));
             assert_eq!(i.last_pos, BytePos(4));
-            assert_eq!(i.start_pos, BytePos(4));
+            assert_eq!(i.cur_pos, BytePos(4));
             assert_eq!(i.cur(), Some('/'));
 
             i.bump();
@@ -328,10 +328,10 @@ mod tests {
         with_test_sess("foo/d", |mut i| {
             assert_eq!(i.cur_pos(), BytePos(1));
             assert_eq!(i.last_pos, BytePos(1));
-            assert_eq!(i.start_pos, BytePos(1));
+            assert_eq!(i.cur_pos, BytePos(1));
 
             assert_eq!(i.find(|c| c == '/'), Some(BytePos(5)));
-            assert_eq!(i.start_pos, BytePos(5));
+            assert_eq!(i.cur_pos, BytePos(5));
             assert_eq!(i.last_pos, BytePos(5));
             assert_eq!(i.cur(), Some('d'));
         });

--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -83,11 +83,10 @@ impl<'a> Input for StringInput<'a> {
         self.orig_start == self.last_pos
     }
 
+    /// TODO(kdy1): Remove this?
+    #[inline]
     fn cur_pos(&mut self) -> BytePos {
-        self.iter
-            .clone()
-            .next()
-            .map_or(self.last_pos, |(p, _)| self.cur_pos + BytePos(p as u32))
+        self.last_pos
     }
 
     #[inline]

--- a/crates/swc_ecma_parser/scripts/instrument.sh
+++ b/crates/swc_ecma_parser/scripts/instrument.sh
@@ -4,4 +4,4 @@ set -eu
 export RUST_LOG=off
 export MIMALLOC_SHOW_STATS=1
 
-cargo profile instruments --release -t time --features tracing/release_max_level_info --features swc_common/concurrent --features swc_common/parking_lot --bench parser -- --bench
+cargo profile instruments --release -t time --features tracing/release_max_level_info --features swc_common/concurrent --features swc_common/parking_lot --bench parser -- --bench --color


### PR DESCRIPTION
**Description:**

```
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
Benchmarking es/parser/colors
Benchmarking es/parser/colors: Warming up for 3.0000 s
Benchmarking es/parser/colors: Collecting 100 samples in estimated 5.0671 s (333k iterations)
Benchmarking es/parser/colors: Analyzing
es/parser/colors        time:   [14.951 us 14.962 us 14.973 us]
                        change: [-0.0124% +0.2115% +0.4430%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) low severe
  3 (3.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe

Benchmarking es/parser/angular
Benchmarking es/parser/angular: Warming up for 3.0000 s
Benchmarking es/parser/angular: Collecting 100 samples in estimated 5.5768 s (700 iterations)
Benchmarking es/parser/angular: Analyzing
es/parser/angular       time:   [7.7097 ms 7.7253 ms 7.7452 ms]
                        change: [+0.7741% +1.1070% +1.4259%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

Benchmarking es/parser/backbone
Benchmarking es/parser/backbone: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.4s, enable flat sampling, or reduce sample count to 60.
Benchmarking es/parser/backbone: Collecting 100 samples in estimated 5.4292 s (5050 iterations)
Benchmarking es/parser/backbone: Analyzing
es/parser/backbone      time:   [1.0616 ms 1.0628 ms 1.0642 ms]
                        change: [-3.4465% -2.5919% -1.7528%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

Benchmarking es/parser/jquery
Benchmarking es/parser/jquery: Warming up for 3.0000 s
Benchmarking es/parser/jquery: Collecting 100 samples in estimated 5.3679 s (900 iterations)
Benchmarking es/parser/jquery: Analyzing
es/parser/jquery        time:   [5.9311 ms 5.9434 ms 5.9583 ms]
                        change: [-2.2919% -2.0471% -1.7916%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

Benchmarking es/parser/jquery mobile
Benchmarking es/parser/jquery mobile: Warming up for 3.0000 s
Benchmarking es/parser/jquery mobile: Collecting 100 samples in estimated 5.6712 s (600 iterations)
Benchmarking es/parser/jquery mobile: Analyzing
es/parser/jquery mobile time:   [9.3627 ms 9.3709 ms 9.3803 ms]
                        change: [-2.2032% -2.0293% -1.8711%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  10 (10.00%) high severe

Benchmarking es/parser/mootools
Benchmarking es/parser/mootools: Warming up for 3.0000 s
Benchmarking es/parser/mootools: Collecting 100 samples in estimated 5.0748 s (1100 iterations)
Benchmarking es/parser/mootools: Analyzing
es/parser/mootools      time:   [4.5845 ms 4.5923 ms 4.6019 ms]
                        change: [-2.0457% -1.7616% -1.4742%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) high mild
  9 (9.00%) high severe

Benchmarking es/parser/underscore
Benchmarking es/parser/underscore: Warming up for 3.0000 s
Benchmarking es/parser/underscore: Collecting 100 samples in estimated 9.4091 s (10k iterations)
Benchmarking es/parser/underscore: Analyzing
es/parser/underscore    time:   [926.62 us 927.06 us 927.51 us]
                        change: [-2.3427% -2.0605% -1.7839%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high severe

Benchmarking es/parser/three
Benchmarking es/parser/three: Warming up for 3.0000 s
Benchmarking es/parser/three: Collecting 100 samples in estimated 5.3973 s (200 iterations)
Benchmarking es/parser/three: Analyzing
es/parser/three         time:   [26.757 ms 26.806 ms 26.867 ms]
                        change: [-1.9068% -1.6520% -1.3446%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  4 (4.00%) high mild
  14 (14.00%) high severe

Benchmarking es/parser/yui
Benchmarking es/parser/yui: Warming up for 3.0000 s
Benchmarking es/parser/yui: Collecting 100 samples in estimated 5.0808 s (1100 iterations)
Benchmarking es/parser/yui: Analyzing
es/parser/yui           time:   [4.5685 ms 4.5727 ms 4.5780 ms]
                        change: [-1.1193% -0.9325% -0.7622%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) high mild
  6 (6.00%) high severe

heap stats:    peak      total      freed    current       unit      count
  reserved:  512.1 MiB  512.1 MiB  256.0 MiB  256.1 MiB                        not all freed!
 committed:  512.1 MiB  512.1 MiB  256.0 MiB  256.1 MiB                        not all freed!
     reset:    8.4 MiB  554.2 MiB  666.1 MiB -111.8 MiB                        ok
   touched:      0          0       55.8 GiB  -55.8 GiB                        ok
  segments:     41        3.3 Ki     3.3 Ki       4                            not all freed!
-abandoned:      0          0          0          0                            ok
   -cached:      0          0          0          0                            ok
     pages:    1.9 Ki   999.5 Ki   999.4 Ki      27                            not all freed!
-abandoned:      0          0          0          0                            ok
 -extended:      0
 -noretire:      0
     mmaps:      0
   commits:      0
   threads:     10         10          0         10                            not all freed!
  searches:     0.0 avg
numa nodes:       1
   elapsed:      92.639 s
   process: user: 117.333 s, system: 1.152 s, faults: 0, rss: 349.9 MiB, commit: 512.1 MiB
```

**Related issue (if exists):**
