### PR TITLE
perf(common): Add more methods to `Spanned`

### DIFF
--- a/crates/swc_common/src/pos.rs
+++ b/crates/swc_common/src/pos.rs
@@ -14,12 +14,12 @@ pub trait Spanned {
     fn span(&self) -> Span;
 
     #[inline]
-    fn lo(&self) -> BytePos {
+    fn span_lo(&self) -> BytePos {
         self.span().lo
     }
 
     #[inline]
-    fn hi(&self) -> BytePos {
+    fn span_hi(&self) -> BytePos {
         self.span().hi
     }
 }
@@ -34,13 +34,13 @@ where
     }
 
     #[inline]
-    fn lo(&self) -> BytePos {
-        (**self).lo()
+    fn span_lo(&self) -> BytePos {
+        (**self).span_lo()
     }
 
     #[inline]
-    fn hi(&self) -> BytePos {
-        (**self).hi()
+    fn span_hi(&self) -> BytePos {
+        (**self).span_hi()
     }
 }
 
@@ -72,17 +72,17 @@ where
     }
 
     #[inline]
-    fn lo(&self) -> BytePos {
+    fn span_lo(&self) -> BytePos {
         match *self {
-            Some(ref s) => s.lo(),
+            Some(ref s) => s.span_lo(),
             None => BytePos::DUMMY,
         }
     }
 
     #[inline]
-    fn hi(&self) -> BytePos {
+    fn span_hi(&self) -> BytePos {
         match *self {
-            Some(ref s) => s.hi(),
+            Some(ref s) => s.span_hi(),
             None => BytePos::DUMMY,
         }
     }
@@ -97,13 +97,13 @@ where
     }
 
     #[inline]
-    fn lo(&self) -> BytePos {
-        <S as Spanned>::lo(&*self)
+    fn span_lo(&self) -> BytePos {
+        <S as Spanned>::span_lo(&*self)
     }
 
     #[inline]
-    fn hi(&self) -> BytePos {
-        <S as Spanned>::hi(&*self)
+    fn span_hi(&self) -> BytePos {
+        <S as Spanned>::span_hi(&*self)
     }
 }
 
@@ -116,13 +116,13 @@ where
     }
 
     #[inline]
-    fn lo(&self) -> BytePos {
-        <S as Spanned>::lo(&*self)
+    fn span_lo(&self) -> BytePos {
+        <S as Spanned>::span_lo(&*self)
     }
 
     #[inline]
-    fn hi(&self) -> BytePos {
-        <S as Spanned>::hi(&*self)
+    fn span_hi(&self) -> BytePos {
+        <S as Spanned>::span_hi(&*self)
     }
 }
 
@@ -135,13 +135,13 @@ where
     }
 
     #[inline]
-    fn lo(&self) -> BytePos {
-        <S as Spanned>::lo(&*self)
+    fn span_lo(&self) -> BytePos {
+        <S as Spanned>::span_lo(&*self)
     }
 
     #[inline]
-    fn hi(&self) -> BytePos {
-        <S as Spanned>::hi(&*self)
+    fn span_hi(&self) -> BytePos {
+        <S as Spanned>::span_hi(&*self)
     }
 }
 
@@ -154,13 +154,13 @@ where
     }
 
     #[inline]
-    fn lo(&self) -> BytePos {
-        <S as Spanned>::lo(self)
+    fn span_lo(&self) -> BytePos {
+        <S as Spanned>::span_lo(self)
     }
 
     #[inline]
-    fn hi(&self) -> BytePos {
-        <S as Spanned>::hi(self)
+    fn span_hi(&self) -> BytePos {
+        <S as Spanned>::span_hi(self)
     }
 }
 
@@ -176,17 +176,17 @@ where
         }
     }
 
-    fn lo(&self) -> BytePos {
+    fn span_lo(&self) -> BytePos {
         match *self {
-            ::either::Either::Left(ref n) => n.lo(),
-            ::either::Either::Right(ref n) => n.lo(),
+            ::either::Either::Left(ref n) => n.span_lo(),
+            ::either::Either::Right(ref n) => n.span_lo(),
         }
     }
 
-    fn hi(&self) -> BytePos {
+    fn span_hi(&self) -> BytePos {
         match *self {
-            ::either::Either::Left(ref n) => n.hi(),
-            ::either::Either::Right(ref n) => n.hi(),
+            ::either::Either::Left(ref n) => n.span_hi(),
+            ::either::Either::Right(ref n) => n.span_hi(),
         }
     }
 }

--- a/crates/swc_common/src/pos.rs
+++ b/crates/swc_common/src/pos.rs
@@ -12,6 +12,16 @@ pub use crate::syntax_pos::{
 pub trait Spanned {
     /// Get span of `self`.
     fn span(&self) -> Span;
+
+    #[inline]
+    fn lo(&self) -> BytePos {
+        self.span().lo
+    }
+
+    #[inline]
+    fn hi(&self) -> BytePos {
+        self.span().hi
+    }
 }
 
 impl<'a, T> Spanned for Cow<'a, T>

--- a/crates/swc_common/src/pos.rs
+++ b/crates/swc_common/src/pos.rs
@@ -28,9 +28,19 @@ impl<'a, T> Spanned for Cow<'a, T>
 where
     T: Spanned + Clone,
 {
-    #[inline(always)]
+    #[inline]
     fn span(&self) -> Span {
         (**self).span()
+    }
+
+    #[inline]
+    fn lo(&self) -> BytePos {
+        (**self).lo()
+    }
+
+    #[inline]
+    fn hi(&self) -> BytePos {
+        (**self).hi()
     }
 }
 
@@ -53,10 +63,27 @@ impl<S> Spanned for Option<S>
 where
     S: Spanned,
 {
+    #[inline]
     fn span(&self) -> Span {
         match *self {
             Some(ref s) => s.span(),
             None => DUMMY_SP,
+        }
+    }
+
+    #[inline]
+    fn lo(&self) -> BytePos {
+        match *self {
+            Some(ref s) => s.lo(),
+            None => BytePos::DUMMY,
+        }
+    }
+
+    #[inline]
+    fn hi(&self) -> BytePos {
+        match *self {
+            Some(ref s) => s.hi(),
+            None => BytePos::DUMMY,
         }
     }
 }
@@ -68,6 +95,16 @@ where
     fn span(&self) -> Span {
         <S as Spanned>::span(&*self)
     }
+
+    #[inline]
+    fn lo(&self) -> BytePos {
+        <S as Spanned>::lo(&*self)
+    }
+
+    #[inline]
+    fn hi(&self) -> BytePos {
+        <S as Spanned>::hi(&*self)
+    }
 }
 
 impl<S> Spanned for Arc<S>
@@ -76,6 +113,16 @@ where
 {
     fn span(&self) -> Span {
         <S as Spanned>::span(&*self)
+    }
+
+    #[inline]
+    fn lo(&self) -> BytePos {
+        <S as Spanned>::lo(&*self)
+    }
+
+    #[inline]
+    fn hi(&self) -> BytePos {
+        <S as Spanned>::hi(&*self)
     }
 }
 
@@ -86,6 +133,16 @@ where
     fn span(&self) -> Span {
         <S as Spanned>::span(&*self)
     }
+
+    #[inline]
+    fn lo(&self) -> BytePos {
+        <S as Spanned>::lo(&*self)
+    }
+
+    #[inline]
+    fn hi(&self) -> BytePos {
+        <S as Spanned>::hi(&*self)
+    }
 }
 
 impl<'a, S> Spanned for &'a S
@@ -93,7 +150,17 @@ where
     S: ?Sized + Spanned,
 {
     fn span(&self) -> Span {
-        <S as Spanned>::span(*self)
+        <S as Spanned>::span(self)
+    }
+
+    #[inline]
+    fn lo(&self) -> BytePos {
+        <S as Spanned>::lo(self)
+    }
+
+    #[inline]
+    fn hi(&self) -> BytePos {
+        <S as Spanned>::hi(self)
     }
 }
 
@@ -106,6 +173,20 @@ where
         match *self {
             ::either::Either::Left(ref n) => n.span(),
             ::either::Either::Right(ref n) => n.span(),
+        }
+    }
+
+    fn lo(&self) -> BytePos {
+        match *self {
+            ::either::Either::Left(ref n) => n.lo(),
+            ::either::Either::Right(ref n) => n.lo(),
+        }
+    }
+
+    fn hi(&self) -> BytePos {
+        match *self {
+            ::either::Either::Left(ref n) => n.hi(),
+            ::either::Either::Right(ref n) => n.hi(),
         }
     }
 }

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -915,15 +915,15 @@ impl Spanned for ExprOrSpread {
     }
 
     #[inline]
-    fn lo(&self) -> BytePos {
+    fn span_lo(&self) -> BytePos {
         match self.spread {
             Some(s) => s.lo,
-            None => self.expr.lo(),
+            None => self.expr.span_lo(),
         }
     }
 
     #[inline]
-    fn hi(&self) -> BytePos {
+    fn span_hi(&self) -> BytePos {
         self.expr.hi()
     }
 }

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -924,7 +924,7 @@ impl Spanned for ExprOrSpread {
 
     #[inline]
     fn span_hi(&self) -> BytePos {
-        self.expr.hi()
+        self.expr.span_hi()
     }
 }
 

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -3,7 +3,7 @@ use is_macro::Is;
 use serde::{self, Deserialize, Serialize};
 use string_enum::StringEnum;
 use swc_atoms::JsWord;
-use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, Spanned, DUMMY_SP};
+use swc_common::{ast_node, util::take::Take, BytePos, EqIgnoreSpan, Span, Spanned, DUMMY_SP};
 
 use crate::{
     class::Class,
@@ -905,12 +905,26 @@ pub struct ExprOrSpread {
 }
 
 impl Spanned for ExprOrSpread {
+    #[inline]
     fn span(&self) -> Span {
         let expr = self.expr.span();
         match self.spread {
             Some(spread) => expr.with_lo(spread.lo()),
             None => expr,
         }
+    }
+
+    #[inline]
+    fn lo(&self) -> BytePos {
+        match self.spread {
+            Some(s) => s.lo,
+            None => self.expr.lo(),
+        }
+    }
+
+    #[inline]
+    fn hi(&self) -> BytePos {
+        self.expr.hi()
     }
 }
 

--- a/crates/swc_ecma_codegen/src/comments.rs
+++ b/crates/swc_ecma_codegen/src/comments.rs
@@ -67,6 +67,10 @@ where
     }
 
     pub(super) fn emit_leading_comments(&mut self, mut pos: BytePos, is_hi: bool) -> Result {
+        if pos.is_dummy() {
+            return Ok(());
+        }
+
         let comments = match self.comments {
             Some(ref comments) => comments,
             None => return Ok(()),
@@ -79,11 +83,8 @@ where
         write_comments!(self, false, comments.take_leading(pos))
     }
 
+    #[inline(always)]
     pub(super) fn emit_leading_comments_of_span(&mut self, span: Span, is_hi: bool) -> Result {
-        if span.is_dummy_ignoring_cmt() {
-            return Ok(());
-        }
-
         let pos = if is_hi { span.hi } else { span.lo };
         self.emit_leading_comments(pos, is_hi)
     }

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -2172,7 +2172,7 @@ where
                         && previous_sibling.hi != parent_node.hi()
                         && self.comments.is_some()
                     {
-                        self.emit_leading_comments(previous_sibling.span().hi(), true)?;
+                        self.emit_leading_comments(previous_sibling.hi(), true)?;
                     }
 
                     self.write_delim(format)?;
@@ -2270,11 +2270,11 @@ where
 
                 if let Some(previous_sibling) = previous_sibling {
                     if format.contains(ListFormat::DelimitersMask)
-                        && previous_sibling.span().hi() != parent_node.hi()
+                        && previous_sibling.hi() != parent_node.hi()
                         && emit_trailing_comments
                         && self.comments.is_some()
                     {
-                        self.emit_leading_comments(previous_sibling.span().hi(), true)?;
+                        self.emit_leading_comments(previous_sibling.hi(), true)?;
                     }
                 }
             }

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -3574,7 +3574,7 @@ fn is_space_require_before_rhs(rhs: &Expr) -> bool {
 }
 
 fn is_empty_comments(span: &Span, comments: &Option<&dyn Comments>) -> bool {
-    span.is_dummy() || comments.map_or(true, |c| !c.has_leading(span.hi() - BytePos(1)))
+    span.is_dummy() || comments.map_or(true, |c| !c.has_leading(span.span_hi() - BytePos(1)))
 }
 
 fn minify_number(num: f64) -> String {

--- a/crates/swc_ecma_codegen/src/macros.rs
+++ b/crates/swc_ecma_codegen/src/macros.rs
@@ -105,13 +105,13 @@ macro_rules! semi {
 /// - `srcmap!(false)` for end (span.hi)
 macro_rules! srcmap {
     ($emitter:expr, $n:expr, true) => {{
-        let lo = $n.lo();
+        let lo = $n.span_lo();
         if !lo.is_dummy() {
             $emitter.wr.add_srcmap(lo)?;
         }
     }};
     ($emitter:expr, $n:expr, false) => {
-        let hi = $n.hi();
+        let hi = $n.span_hi();
         if !hi.is_dummy() {
             $emitter.wr.add_srcmap(hi)?;
         }

--- a/crates/swc_ecma_codegen/src/macros.rs
+++ b/crates/swc_ecma_codegen/src/macros.rs
@@ -105,13 +105,13 @@ macro_rules! semi {
 /// - `srcmap!(false)` for end (span.hi)
 macro_rules! srcmap {
     ($emitter:expr, $n:expr, true) => {{
-        let bp = $n.span().lo;
-        if !bp.is_dummy() {
-            $emitter.wr.add_srcmap(bp)?;
+        let lo = $n.lo();
+        if !lo.is_dummy() {
+            $emitter.wr.add_srcmap(lo)?;
         }
     }};
     ($emitter:expr, $n:expr, false) => {
-        let hi = $n.span().hi;
+        let hi = $n.hi();
         if !hi.is_dummy() {
             $emitter.wr.add_srcmap(hi)?;
         }

--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -320,7 +320,7 @@ impl<I: Tokens> Parser<I> {
 
         let args = self.parse_args(false)?;
         Ok(Box::new(Expr::Call(CallExpr {
-            span: span!(self, expr.span().lo()),
+            span: span!(self, expr.span_lo()),
             callee: Callee::Expr(expr),
             args,
             type_args: None,

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -19,7 +19,7 @@ impl<I: Tokens> Parser<I> {
         let _tracing = debug_tracing!(self, "parse_expr");
 
         let expr = self.parse_assignment_expr()?;
-        let start = expr.span().lo();
+        let start = expr.span_lo();
 
         if is!(self, ',') {
             let mut exprs = vec![expr];
@@ -217,7 +217,7 @@ impl<I: Tokens> Parser<I> {
                 ..self.ctx()
             };
             let alt = self.with_ctx(ctx).parse_assignment_expr()?;
-            let span = Span::new(start, alt.span().hi(), Default::default());
+            let span = Span::new(start, alt.span_hi(), Default::default());
             Ok(Box::new(Expr::Cond(CondExpr {
                 span,
                 test,
@@ -915,8 +915,8 @@ impl<I: Tokens> Parser<I> {
             // span of sequence expression should not include '(', ')'
             let seq_expr = Box::new(Expr::Seq(SeqExpr {
                 span: Span::new(
-                    exprs.first().unwrap().span().lo(),
-                    exprs.last().unwrap().span().hi(),
+                    exprs.first().unwrap().span_lo(),
+                    exprs.last().unwrap().span_hi(),
                     Default::default(),
                 ),
                 exprs,
@@ -957,7 +957,7 @@ impl<I: Tokens> Parser<I> {
         tag: Box<Expr>,
         type_params: Option<TsTypeParamInstantiation>,
     ) -> PResult<TaggedTpl> {
-        let tagged_tpl_start = tag.span().lo();
+        let tagged_tpl_start = tag.span_lo();
         trace_cur!(self, parse_tagged_tpl);
 
         let tpl = self.parse_tpl(true)?;
@@ -1168,8 +1168,8 @@ impl<I: Tokens> Parser<I> {
             let bracket_lo = self.input.prev_span().lo;
             let prop = self.include_in_expr(true).parse_expr()?;
             expect!(self, ']');
-            let span = Span::new(obj.span().lo(), self.input.last_pos(), Default::default());
-            debug_assert_eq!(obj.span().lo(), span.lo());
+            let span = Span::new(obj.span_lo(), self.input.last_pos(), Default::default());
+            debug_assert_eq!(obj.span_lo(), span.lo());
             let prop = ComputedPropName {
                 span: Span::new(bracket_lo, self.input.last_pos(), Default::default()),
                 expr: prop,
@@ -1290,9 +1290,9 @@ impl<I: Tokens> Parser<I> {
                 Either::Left(p) => MemberProp::PrivateName(p),
                 Either::Right(i) => MemberProp::Ident(i),
             })?;
-            let span = span!(self, obj.span().lo());
-            debug_assert_eq!(obj.span().lo(), span.lo());
-            debug_assert_eq!(prop.span().hi(), span.hi());
+            let span = span!(self, obj.span_lo());
+            debug_assert_eq!(obj.span_lo(), span.lo());
+            debug_assert_eq!(prop.span_hi(), span.hi());
 
             let type_args = if self.syntax().typescript() && is!(self, '<') {
                 self.try_parse_ts_type_args()
@@ -1631,7 +1631,7 @@ impl<I: Tokens> Parser<I> {
                         arg = ExprOrSpread {
                             spread: None,
                             expr: Box::new(Expr::Cond(CondExpr {
-                                span: Span::new(start, alt.span().hi(), Default::default()),
+                                span: Span::new(start, alt.span_hi(), Default::default()),
 
                                 test,
                                 cons,
@@ -1838,7 +1838,7 @@ impl<I: Tokens> Parser<I> {
     fn at_possible_async(&mut self, expr: &Expr) -> PResult<bool> {
         // TODO(kdy1): !this.state.containsEsc &&
 
-        Ok(self.state.potential_arrow_start == Some(expr.span().lo())
+        Ok(self.state.potential_arrow_start == Some(expr.span_lo())
             && matches!(
                 *expr,
                 Expr::Ident(Ident {

--- a/crates/swc_ecma_parser/src/parser/expr/ops.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/ops.rs
@@ -93,7 +93,7 @@ impl<I: Tokens> Parser<I> {
             && !self.input.had_line_break_before_cur()
             && is!(self, "as")
         {
-            let start = left.span().lo();
+            let start = left.span_lo();
             let expr = left;
             let node = if peeked_is!(self, "const") {
                 bump!(self); // as
@@ -212,7 +212,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         let node = Box::new(Expr::Bin(BinExpr {
-            span: Span::new(left.span().lo(), right.span().hi(), Default::default()),
+            span: Span::new(left.span_lo(), right.span_hi(), Default::default()),
             op,
             left,
             right,
@@ -253,7 +253,7 @@ impl<I: Tokens> Parser<I> {
             };
 
             let arg = self.parse_unary_expr()?;
-            let span = Span::new(start, arg.span().hi(), Default::default());
+            let span = Span::new(start, arg.span_hi(), Default::default());
             self.check_assign_target(&arg, false);
 
             return Ok(Box::new(Expr::Update(UpdateExpr {
@@ -311,7 +311,7 @@ impl<I: Tokens> Parser<I> {
             }
 
             return Ok(Box::new(Expr::Unary(UnaryExpr {
-                span: Span::new(start, arg.span().hi(), Default::default()),
+                span: Span::new(start, arg.span_hi(), Default::default()),
                 op,
                 arg,
             })));
@@ -344,7 +344,7 @@ impl<I: Tokens> Parser<I> {
             };
 
             return Ok(Box::new(Expr::Update(UpdateExpr {
-                span: span!(self, expr.span().lo()),
+                span: span!(self, expr.span_lo()),
                 prefix: false,
                 op,
                 arg: expr,

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -2149,14 +2149,14 @@ impl<I: Tokens> Parser<I> {
         while !self.input.had_line_break_before_cur() && eat!(self, '[') {
             if eat!(self, ']') {
                 ty = Box::new(TsType::TsArrayType(TsArrayType {
-                    span: span!(self, ty.span().lo()),
+                    span: span!(self, ty.span_lo()),
                     elem_type: ty,
                 }));
             } else {
                 let index_type = self.parse_ts_type()?;
                 expect!(self, ']');
                 ty = Box::new(TsType::TsIndexedAccessType(TsIndexedAccessType {
-                    span: span!(self, ty.span().lo()),
+                    span: span!(self, ty.span_lo()),
                     readonly,
                     obj_type: ty,
                     index_type,
@@ -2259,7 +2259,7 @@ impl<I: Tokens> Parser<I> {
             return Ok(Default::default());
         }
 
-        let start = expr.span().lo();
+        let start = expr.span_lo();
 
         match &*expr.sym {
             "declare" => {


### PR DESCRIPTION
**Description:**

 - Lots of code only needs `lo` or `hi`, but they call `span()`, which is inefficient in some cases.
 - This PR only adds a trivial amount of optimization. I may add full optimization in future.
 - This PR improves codegen performance of `ExprOrSpread` and `Option<ExprOrSpread>`.

**Related issue (if exists):**
