### PR TITLE
fix(es/compat): use define for non-spread props

### DIFF
--- a/crates/swc/src/builder.rs
+++ b/crates/swc/src/builder.rs
@@ -232,7 +232,8 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
                     compat::es2018(compat::es2018::Config {
                         object_rest_spread: compat::es2018::object_rest_spread::Config {
                             no_symbol: assumptions.object_rest_no_symbols,
-                            set_property: assumptions.set_spread_properties
+                            set_property: assumptions.set_spread_properties,
+                            pure_getters: assumptions.pure_getters
                         }
                     }),
                     should_enable(self.target, EsVersion::Es2018)

--- a/crates/swc/tests/exec.rs
+++ b/crates/swc/tests/exec.rs
@@ -74,52 +74,49 @@ fn create_matrix(entry: &Path) -> Vec<Options> {
     })
     .matrix_bool()
     .matrix_bool()
-    .matrix_bool()
     .into_iter()
-    .map(
-        |((((target, syntax), minify), source_map), external_helpers)| {
-            // Actual
-            Options {
-                config: Config {
-                    jsc: JscConfig {
-                        syntax: Some(syntax),
-                        transform: None.into(),
-                        external_helpers: external_helpers.into(),
-                        target: Some(target),
-                        minify: if minify {
-                            Some(JsMinifyOptions {
-                                compress: BoolOrDataConfig::from_bool(true),
-                                mangle: BoolOrDataConfig::from_bool(true),
-                                format: Default::default(),
-                                ecma: Default::default(),
-                                keep_classnames: Default::default(),
-                                keep_fnames: Default::default(),
-                                module: Default::default(),
-                                safari10: Default::default(),
-                                toplevel: Default::default(),
-                                source_map: Default::default(),
-                                output_path: Default::default(),
-                                inline_sources_content: Default::default(),
-                                emit_source_map_columns: Default::default(),
-                            })
-                        } else {
-                            None
-                        },
-                        ..Default::default()
+    .map(|(((target, syntax), minify), source_map)| {
+        // Actual
+        Options {
+            config: Config {
+                jsc: JscConfig {
+                    syntax: Some(syntax),
+                    transform: None.into(),
+                    external_helpers: false.into(),
+                    target: Some(target),
+                    minify: if minify {
+                        Some(JsMinifyOptions {
+                            compress: BoolOrDataConfig::from_bool(true),
+                            mangle: BoolOrDataConfig::from_bool(true),
+                            format: Default::default(),
+                            ecma: Default::default(),
+                            keep_classnames: Default::default(),
+                            keep_fnames: Default::default(),
+                            module: Default::default(),
+                            safari10: Default::default(),
+                            toplevel: Default::default(),
+                            source_map: Default::default(),
+                            output_path: Default::default(),
+                            inline_sources_content: Default::default(),
+                            emit_source_map_columns: Default::default(),
+                        })
+                    } else {
+                        None
                     },
-                    module: Some(ModuleConfig::CommonJs(Default::default())),
-                    minify: minify.into(),
                     ..Default::default()
                 },
-                source_maps: if source_map {
-                    Some(SourceMapsConfig::Str("inline".into()))
-                } else {
-                    None
-                },
+                module: Some(ModuleConfig::CommonJs(Default::default())),
+                minify: minify.into(),
                 ..Default::default()
-            }
-        },
-    )
+            },
+            source_maps: if source_map {
+                Some(SourceMapsConfig::Str("inline".into()))
+            } else {
+                None
+            },
+            ..Default::default()
+        }
+    })
     .collect::<Vec<_>>()
 }
 

--- a/crates/swc/tests/tsc-references/destructuringSpread_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/destructuringSpread_es2015.1.normal.js
@@ -1,5 +1,6 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-const { x  } = _object_spread({}, {}, {
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+const { x  } = _object_spread_props(_object_spread({}, {}), {
     x: 0
 });
 const { y  } = _object_spread({
@@ -11,12 +12,12 @@ const { z , a , b  } = _object_spread({
     a: 0,
     b: 0
 });
-const { c , d , e , f , g  } = _object_spread({}, _object_spread({}, _object_spread({}, {
+const { c , d , e , f , g  } = _object_spread_props(_object_spread({}, _object_spread_props(_object_spread({}, _object_spread_props(_object_spread({}, {
     c: 0
-}, {
+}), {
     d: 0
-}), {
+})), {
     e: 0
-}), {
+})), {
     f: 0
 });

--- a/crates/swc/tests/tsc-references/destructuringSpread_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/destructuringSpread_es2015.2.minified.js
@@ -1,5 +1,6 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-let { x  } = _object_spread({}, {}, {
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+let { x  } = _object_spread_props(_object_spread({}, {}), {
     x: 0
 }), { y  } = _object_spread({
     y: 0
@@ -8,12 +9,12 @@ let { x  } = _object_spread({}, {}, {
 }, {
     a: 0,
     b: 0
-}), { c , d , e , f , g  } = _object_spread({}, _object_spread({}, _object_spread({}, {
+}), { c , d , e , f , g  } = _object_spread_props(_object_spread({}, _object_spread_props(_object_spread({}, _object_spread_props(_object_spread({}, {
     c: 0
-}, {
+}), {
     d: 0
-}), {
+})), {
     e: 0
-}), {
+})), {
     f: 0
 });

--- a/crates/swc/tests/tsc-references/destructuringSpread_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/destructuringSpread_es5.1.normal.js
@@ -1,5 +1,6 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-var x = _object_spread({}, {}, {
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+var x = _object_spread_props(_object_spread({}, {}), {
     x: 0
 }).x;
 var y = _object_spread({
@@ -11,12 +12,12 @@ var ref = _object_spread({
     a: 0,
     b: 0
 }), z = ref.z, a = ref.a, b = ref.b;
-var ref1 = _object_spread({}, _object_spread({}, _object_spread({}, {
+var ref1 = _object_spread_props(_object_spread({}, _object_spread_props(_object_spread({}, _object_spread_props(_object_spread({}, {
     c: 0
-}, {
+}), {
     d: 0
-}), {
+})), {
     e: 0
-}), {
+})), {
     f: 0
 }), c = ref1.c, d = ref1.d, e = ref1.e, f = ref1.f, g = ref1.g;

--- a/crates/swc/tests/tsc-references/destructuringSpread_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/destructuringSpread_es5.2.minified.js
@@ -1,5 +1,6 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-_object_spread({}, {}, {
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+_object_spread_props(_object_spread({}, {}), {
     x: 0
 }).x, _object_spread({
     y: 0
@@ -11,13 +12,13 @@ var ref = _object_spread({
     b: 0
 });
 ref.z, ref.a, ref.b;
-var ref1 = _object_spread({}, _object_spread({}, _object_spread({}, {
+var ref1 = _object_spread_props(_object_spread({}, _object_spread_props(_object_spread({}, _object_spread_props(_object_spread({}, {
     c: 0
-}, {
+}), {
     d: 0
-}), {
+})), {
     e: 0
-}), {
+})), {
     f: 0
 });
 ref1.c, ref1.d, ref1.e, ref1.f, ref1.g;

--- a/crates/swc/tests/tsc-references/jsxJsxsCjsTransformKeyPropCustomImportPragma_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/jsxJsxsCjsTransformKeyPropCustomImportPragma_es2015.1.normal.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 import { jsx as _jsx } from "preact/jsx-runtime";
 import { createElement as _createElement } from "react";
 // @filename: react.tsx
@@ -12,18 +13,18 @@ import { createElement as _createElement } from "react";
 /* @jsxImportSource preact */ const props = {
     answer: 42
 };
-const a = /*#__PURE__*/ _jsx("div", _object_spread({}, props, {
+const a = /*#__PURE__*/ _jsx("div", _object_spread_props(_object_spread({}, props), {
     children: "text"
 }), "foo");
-const b = /*#__PURE__*/ _createElement("div", _object_spread({}, props, {
+const b = /*#__PURE__*/ _createElement("div", _object_spread_props(_object_spread({}, props), {
     key: "bar"
 }), "text");
 const props2 = {
     answer: 42
 };
-const a2 = /*#__PURE__*/ _jsx("div", _object_spread({}, props2, {
+const a2 = /*#__PURE__*/ _jsx("div", _object_spread_props(_object_spread({}, props2), {
     children: "text"
 }), "foo");
-const b2 = /*#__PURE__*/ _createElement("div", _object_spread({}, props2, {
+const b2 = /*#__PURE__*/ _createElement("div", _object_spread_props(_object_spread({}, props2), {
     key: "bar"
 }), "text");

--- a/crates/swc/tests/tsc-references/jsxJsxsCjsTransformKeyPropCustomImportPragma_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/jsxJsxsCjsTransformKeyPropCustomImportPragma_es2015.2.minified.js
@@ -1,20 +1,21 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 import { jsx as _jsx } from "preact/jsx-runtime";
 import { createElement as _createElement } from "react";
 import "./preact";
 let props = {
     answer: 42
 };
-_object_spread({}, props, {
+_object_spread_props(_object_spread({}, props), {
     children: "text"
-}), _object_spread({}, props, {
+}), _object_spread_props(_object_spread({}, props), {
     key: "bar"
 });
 let props2 = {
     answer: 42
 };
-_object_spread({}, props2, {
+_object_spread_props(_object_spread({}, props2), {
     children: "text"
-}), _object_spread({}, props2, {
+}), _object_spread_props(_object_spread({}, props2), {
     key: "bar"
 });

--- a/crates/swc/tests/tsc-references/jsxJsxsCjsTransformKeyPropCustomImportPragma_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/jsxJsxsCjsTransformKeyPropCustomImportPragma_es5.1.normal.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 import { jsx as _jsx } from "preact/jsx-runtime";
 import { createElement as _createElement } from "react";
 // @filename: react.tsx
@@ -12,18 +13,18 @@ import { createElement as _createElement } from "react";
 /* @jsxImportSource preact */ var props = {
     answer: 42
 };
-var a = /*#__PURE__*/ _jsx("div", _object_spread({}, props, {
+var a = /*#__PURE__*/ _jsx("div", _object_spread_props(_object_spread({}, props), {
     children: "text"
 }), "foo");
-var b = /*#__PURE__*/ _createElement("div", _object_spread({}, props, {
+var b = /*#__PURE__*/ _createElement("div", _object_spread_props(_object_spread({}, props), {
     key: "bar"
 }), "text");
 var props2 = {
     answer: 42
 };
-var a2 = /*#__PURE__*/ _jsx("div", _object_spread({}, props2, {
+var a2 = /*#__PURE__*/ _jsx("div", _object_spread_props(_object_spread({}, props2), {
     children: "text"
 }), "foo");
-var b2 = /*#__PURE__*/ _createElement("div", _object_spread({}, props2, {
+var b2 = /*#__PURE__*/ _createElement("div", _object_spread_props(_object_spread({}, props2), {
     key: "bar"
 }), "text");

--- a/crates/swc/tests/tsc-references/jsxJsxsCjsTransformKeyPropCustomImportPragma_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/jsxJsxsCjsTransformKeyPropCustomImportPragma_es5.2.minified.js
@@ -1,20 +1,21 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 import { jsx as _jsx } from "preact/jsx-runtime";
 import { createElement as _createElement } from "react";
 import "./preact";
 var props = {
     answer: 42
 };
-_object_spread({}, props, {
+_object_spread_props(_object_spread({}, props), {
     children: "text"
-}), _object_spread({}, props, {
+}), _object_spread_props(_object_spread({}, props), {
     key: "bar"
 });
 var props2 = {
     answer: 42
 };
-_object_spread({}, props2, {
+_object_spread_props(_object_spread({}, props2), {
     children: "text"
-}), _object_spread({}, props2, {
+}), _object_spread_props(_object_spread({}, props2), {
     key: "bar"
 });

--- a/crates/swc/tests/tsc-references/objectLiteralNormalization_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectLiteralNormalization_es2015.1.normal.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 // @strict: true
 // @declaration: true
 // Object literals in unions are normalized upon widening
@@ -59,7 +60,7 @@ a2 = {
 a2 = {
     a: 1
 }; // Error
-let b2 = _object_spread({}, b1, {
+let b2 = _object_spread_props(_object_spread({}, b1), {
     z: 55
 });
 let b3 = _object_spread({}, b2);

--- a/crates/swc/tests/tsc-references/objectLiteralNormalization_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectLiteralNormalization_es2015.2.minified.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 let a1 = {
     a: 0
 };
@@ -27,7 +28,7 @@ a2.a, a2.b, a2 = {
 }, a2 = {
     a: 1
 };
-let b2 = _object_spread({}, b1, {
+let b2 = _object_spread_props(_object_spread({}, b1), {
     z: 55
 });
 _object_spread({}, b2);

--- a/crates/swc/tests/tsc-references/objectLiteralNormalization_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectLiteralNormalization_es5.1.normal.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 // @strict: true
 // @declaration: true
 // Object literals in unions are normalized upon widening
@@ -59,7 +60,7 @@ a2 = {
 a2 = {
     a: 1
 }; // Error
-var b2 = _object_spread({}, b1, {
+var b2 = _object_spread_props(_object_spread({}, b1), {
     z: 55
 });
 var b3 = _object_spread({}, b2);

--- a/crates/swc/tests/tsc-references/objectLiteralNormalization_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectLiteralNormalization_es5.2.minified.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 var a1 = {
     a: 0
 };
@@ -27,7 +28,7 @@ a2.a, a2.b, a2 = {
 }, a2 = {
     a: 1
 };
-var b2 = _object_spread({}, b1, {
+var b2 = _object_spread_props(_object_spread({}, b1), {
     z: 55
 });
 _object_spread({}, b2);

--- a/crates/swc/tests/tsc-references/objectRestForOf_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectRestForOf_es2015.1.normal.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 import _object_without_properties from "@swc/helpers/lib/_object_without_properties.js";
 // @target: es2015
 let array;
@@ -23,7 +24,7 @@ for (var _ref1 of array){
         rrestOff
     ];
 }
-for (const norest of array.map((a)=>_object_spread({}, a, {
+for (const norest of array.map((a)=>_object_spread_props(_object_spread({}, a), {
         x: 'a string'
     }))){
     [

--- a/crates/swc/tests/tsc-references/objectRestForOf_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectRestForOf_es2015.2.minified.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 import _object_without_properties from "@swc/helpers/lib/_object_without_properties.js";
 let array;
 for (let _ref of array){
@@ -11,6 +12,6 @@ let xx;
 for (var _ref1 of array)_object_without_properties(__ref = _ref1, [
     "x"
 ]), { x: xx  } = __ref;
-for (let norest of array.map((a)=>_object_spread({}, a, {
+for (let norest of array.map((a)=>_object_spread_props(_object_spread({}, a), {
         x: 'a string'
     })))norest.x, norest.y;

--- a/crates/swc/tests/tsc-references/objectRestForOf_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectRestForOf_es5.1.normal.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 import _object_without_properties from "@swc/helpers/lib/_object_without_properties.js";
 // @target: es2015
 var array;
@@ -61,7 +62,7 @@ try {
 var _iteratorNormalCompletion2 = true, _didIteratorError2 = false, _iteratorError2 = undefined;
 try {
     for(var _iterator2 = array.map(function(a) {
-        return _object_spread({}, a, {
+        return _object_spread_props(_object_spread({}, a), {
             x: "a string"
         });
     })[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true){

--- a/crates/swc/tests/tsc-references/objectRestForOf_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectRestForOf_es5.2.minified.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 import _object_without_properties from "@swc/helpers/lib/_object_without_properties.js";
 var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
@@ -34,7 +35,7 @@ try {
 var _iteratorNormalCompletion2 = !0, _didIteratorError2 = !1, _iteratorError2 = void 0;
 try {
     for(var _step2, _iterator2 = array.map(function(a) {
-        return _object_spread({}, a, {
+        return _object_spread_props(_object_spread({}, a), {
             x: "a string"
         });
     })[Symbol.iterator](); !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = !0){

--- a/crates/swc/tests/tsc-references/objectSpreadComputedProperty_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectSpreadComputedProperty_es2015.1.normal.js
@@ -1,20 +1,21 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 // fixes #12200
 function f() {
     let n = 12;
     let m = 13;
     let a = null;
-    const o1 = _object_spread({}, {}, {
+    const o1 = _object_spread_props(_object_spread({}, {}), {
         [n]: n
     });
-    const o2 = _object_spread({}, {}, {
+    const o2 = _object_spread_props(_object_spread({}, {}), {
         [a]: n
     });
-    const o3 = _object_spread({
+    const o3 = _object_spread_props(_object_spread(_object_spread_props(_object_spread({
         [a]: n
-    }, {}, {
+    }, {}), {
         [n]: n
-    }, {}, {
+    }), {}), {
         [m]: m
     });
 }

--- a/crates/swc/tests/tsc-references/objectSpreadComputedProperty_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectSpreadComputedProperty_es2015.2.minified.js
@@ -1,1 +1,2 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";

--- a/crates/swc/tests/tsc-references/objectSpreadComputedProperty_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectSpreadComputedProperty_es5.1.normal.js
@@ -1,11 +1,12 @@
 import _define_property from "@swc/helpers/lib/_define_property.js";
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 // fixes #12200
 function f() {
     var n = 12;
     var m = 13;
     var a = null;
-    var o1 = _object_spread({}, {}, _define_property({}, n, n));
-    var o2 = _object_spread({}, {}, _define_property({}, a, n));
-    var o3 = _object_spread(_define_property({}, a, n), {}, _define_property({}, n, n), {}, _define_property({}, m, m));
+    var o1 = _object_spread_props(_object_spread({}, {}), _define_property({}, n, n));
+    var o2 = _object_spread_props(_object_spread({}, {}), _define_property({}, a, n));
+    var o3 = _object_spread_props(_object_spread(_object_spread_props(_object_spread(_define_property({}, a, n), {}), _define_property({}, n, n)), {}), _define_property({}, m, m));
 }

--- a/crates/swc/tests/tsc-references/objectSpreadComputedProperty_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectSpreadComputedProperty_es5.2.minified.js
@@ -1,2 +1,3 @@
 import _define_property from "@swc/helpers/lib/_define_property.js";
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";

--- a/crates/swc/tests/tsc-references/objectSpreadIndexSignature_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectSpreadIndexSignature_es2015.1.normal.js
@@ -1,5 +1,6 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-let i = _object_spread({}, indexed1, {
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+let i = _object_spread_props(_object_spread({}, indexed1), {
     b: 11
 });
 // only indexed has indexer, so i[101]: any

--- a/crates/swc/tests/tsc-references/objectSpreadIndexSignature_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectSpreadIndexSignature_es2015.2.minified.js
@@ -1,5 +1,6 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-_object_spread({}, indexed1, {
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+_object_spread_props(_object_spread({}, indexed1), {
     b: 11
 })[101], _object_spread({}, indexed1, indexed2)[1001], indexed3 = _object_spread({}, b ? indexed3 : void 0);
 var writable = _object_spread({}, roindex);

--- a/crates/swc/tests/tsc-references/objectSpreadIndexSignature_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectSpreadIndexSignature_es5.1.normal.js
@@ -1,5 +1,6 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-var i = _object_spread({}, indexed1, {
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+var i = _object_spread_props(_object_spread({}, indexed1), {
     b: 11
 });
 // only indexed has indexer, so i[101]: any

--- a/crates/swc/tests/tsc-references/objectSpreadIndexSignature_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectSpreadIndexSignature_es5.2.minified.js
@@ -1,5 +1,6 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-_object_spread({}, indexed1, {
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+_object_spread_props(_object_spread({}, indexed1), {
     b: 11
 })[101], _object_spread({}, indexed1, indexed2)[1001], indexed3 = _object_spread({}, b ? indexed3 : void 0);
 var writable = _object_spread({}, roindex);

--- a/crates/swc/tests/tsc-references/objectSpreadNegative_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectSpreadNegative_es2015.1.normal.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 // @target: es5
 // @strictNullChecks: true
 let o = {
@@ -26,11 +27,11 @@ let b = {
 };
 spread = b; // error, missing 's'
 // literal repeats are not allowed, but spread repeats are fine
-let duplicated = _object_spread({
+let duplicated = _object_spread_props(_object_spread(_object_spread_props(_object_spread({
     b: 'bad'
-}, o, {
+}, o), {
     b: 'bad'
-}, o2, {
+}), o2), {
     b: 'bad'
 });
 let duplicatedSpread = _object_spread({}, o, o);
@@ -49,27 +50,27 @@ let o4 = {
 let combinedBefore = _object_spread({
     b: 'ok'
 }, o3, o4);
-let combinedMid = _object_spread({}, o3, {
+let combinedMid = _object_spread(_object_spread_props(_object_spread({}, o3), {
     b: 'ok'
-}, o4);
-let combinedNested = _object_spread({}, _object_spread({
+}), o4);
+let combinedNested = _object_spread(_object_spread_props(_object_spread({}, _object_spread({
     a: 4
 }, {
     b: false,
     c: 'overriden'
-}), {
+})), {
     d: 'actually new'
-}, {
+}), {
     a: 5,
     d: 'maybe new'
 });
 let changeTypeBefore = _object_spread({
     a: 'wrong type?'
 }, o3);
-let computedMiddle = _object_spread({}, o3, {
+let computedMiddle = _object_spread(_object_spread_props(_object_spread({}, o3), {
     ['in the middle']: 13,
     b: 'maybe?'
-}, o4);
+}), o4);
 // primitives are not allowed, except for falsy ones
 let spreadNum = _object_spread({}, 12);
 let spreadSum = _object_spread({}, 1 + 1);

--- a/crates/swc/tests/tsc-references/objectSpreadNegative_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectSpreadNegative_es2015.2.minified.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 let o = {
     a: 1,
     b: 'no'
@@ -7,11 +8,11 @@ o2.x, _object_spread({}, optionalString, optionalNumber), _object_spread({}, {
     b: !0
 }, {
     s: "foo"
-}), _object_spread({
+}), _object_spread_props(_object_spread(_object_spread_props(_object_spread({
     b: 'bad'
-}, o, {
+}, o), {
     b: 'bad'
-}, o2, {
+}), o2), {
     b: 'bad'
 }), _object_spread({}, o, o), _object_spread({
     b: 'ignored'
@@ -25,24 +26,24 @@ let o3 = {
 };
 _object_spread({
     b: 'ok'
-}, o3, o4), _object_spread({}, o3, {
+}, o3, o4), _object_spread(_object_spread_props(_object_spread({}, o3), {
     b: 'ok'
-}, o4), _object_spread({}, _object_spread({
+}), o4), _object_spread(_object_spread_props(_object_spread({}, _object_spread({
     a: 4
 }, {
     b: !1,
     c: 'overriden'
-}), {
+})), {
     d: 'actually new'
-}, {
+}), {
     a: 5,
     d: 'maybe new'
 }), _object_spread({
     a: 'wrong type?'
-}, o3), _object_spread({}, o3, {
+}, o3), _object_spread(_object_spread_props(_object_spread({}, o3), {
     'in the middle': 13,
     b: 'maybe?'
-}, o4), _object_spread({}, 12), _object_spread({}, 2), _object_spread({}, 0).toFixed(), _object_spread({}, !0).valueOf();
+}), o4), _object_spread({}, 12), _object_spread({}, 2), _object_spread({}, 0).toFixed(), _object_spread({}, !0).valueOf();
 let spreadStr = _object_spread({}, 'foo');
 spreadStr.length, spreadStr.charAt(1), _object_spread({}, function() {})(), _object_spread({}, {
     set b (bad){}

--- a/crates/swc/tests/tsc-references/objectSpreadNegative_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectSpreadNegative_es5.1.normal.js
@@ -1,6 +1,7 @@
 import _class_call_check from "@swc/helpers/lib/_class_call_check.js";
 import _define_property from "@swc/helpers/lib/_define_property.js";
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 // @target: es5
 // @strictNullChecks: true
 var o = {
@@ -32,11 +33,11 @@ var b = {
 };
 spread = b; // error, missing 's'
 // literal repeats are not allowed, but spread repeats are fine
-var duplicated = _object_spread({
+var duplicated = _object_spread_props(_object_spread(_object_spread_props(_object_spread({
     b: "bad"
-}, o, {
+}, o), {
     b: "bad"
-}, o2, {
+}), o2), {
     b: "bad"
 });
 var duplicatedSpread = _object_spread({}, o, o);
@@ -55,17 +56,17 @@ var o4 = {
 var combinedBefore = _object_spread({
     b: "ok"
 }, o3, o4);
-var combinedMid = _object_spread({}, o3, {
+var combinedMid = _object_spread(_object_spread_props(_object_spread({}, o3), {
     b: "ok"
-}, o4);
-var combinedNested = _object_spread({}, _object_spread({
+}), o4);
+var combinedNested = _object_spread(_object_spread_props(_object_spread({}, _object_spread({
     a: 4
 }, {
     b: false,
     c: "overriden"
-}), {
+})), {
     d: "actually new"
-}, {
+}), {
     a: 5,
     d: "maybe new"
 });
@@ -73,7 +74,7 @@ var changeTypeBefore = _object_spread({
     a: "wrong type?"
 }, o3);
 var _obj;
-var computedMiddle = _object_spread({}, o3, (_obj = {}, _define_property(_obj, "in the middle", 13), _define_property(_obj, "b", "maybe?"), _obj), o4);
+var computedMiddle = _object_spread(_object_spread_props(_object_spread({}, o3), (_obj = {}, _define_property(_obj, "in the middle", 13), _define_property(_obj, "b", "maybe?"), _obj)), o4);
 // primitives are not allowed, except for falsy ones
 var spreadNum = _object_spread({}, 12);
 var spreadSum = _object_spread({}, 1 + 1);

--- a/crates/swc/tests/tsc-references/objectSpreadNegative_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectSpreadNegative_es5.2.minified.js
@@ -1,6 +1,7 @@
 import _class_call_check from "@swc/helpers/lib/_class_call_check.js";
 import _define_property from "@swc/helpers/lib/_define_property.js";
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 var _obj, o = {
     a: 1,
     b: "no"
@@ -15,11 +16,11 @@ o2.x, _object_spread({}, optionalString, optionalNumber), _object_spread({}, {
     b: !0
 }, {
     s: "foo"
-}), _object_spread({
+}), _object_spread_props(_object_spread(_object_spread_props(_object_spread({
     b: "bad"
-}, o, {
+}, o), {
     b: "bad"
-}, o2, {
+}), o2), {
     b: "bad"
 }), _object_spread({}, o, o), _object_spread({
     b: "ignored"
@@ -33,21 +34,21 @@ var o3 = {
 };
 _object_spread({
     b: "ok"
-}, o3, o4), _object_spread({}, o3, {
+}, o3, o4), _object_spread(_object_spread_props(_object_spread({}, o3), {
     b: "ok"
-}, o4), _object_spread({}, _object_spread({
+}), o4), _object_spread(_object_spread_props(_object_spread({}, _object_spread({
     a: 4
 }, {
     b: !1,
     c: "overriden"
-}), {
+})), {
     d: "actually new"
-}, {
+}), {
     a: 5,
     d: "maybe new"
 }), _object_spread({
     a: "wrong type?"
-}, o3), _object_spread({}, o3, (_define_property(_obj = {}, "in the middle", 13), _define_property(_obj, "b", "maybe?"), _obj), o4), _object_spread({}, 12), _object_spread({}, 2), _object_spread({}, 0).toFixed(), _object_spread({}, !0).valueOf();
+}, o3), _object_spread(_object_spread_props(_object_spread({}, o3), (_define_property(_obj = {}, "in the middle", 13), _define_property(_obj, "b", "maybe?"), _obj)), o4), _object_spread({}, 12), _object_spread({}, 2), _object_spread({}, 0).toFixed(), _object_spread({}, !0).valueOf();
 var spreadStr = _object_spread({}, "foo");
 spreadStr.length, spreadStr.charAt(1), _object_spread({}, function() {})(), _object_spread({}, {
     set b (bad){}

--- a/crates/swc/tests/tsc-references/objectSpreadStrictNull_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectSpreadStrictNull_es2015.1.normal.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 // @strictNullChecks: true
 function f(definiteBoolean, definiteString, optionalString, optionalNumber, undefinedString, undefinedNumber) {
     // optional
@@ -16,7 +17,7 @@ const m = {
     yearReleased: 1999
 };
 // should error here because title: undefined is not assignable to string
-const x = _object_spread({}, m, {
+const x = _object_spread_props(_object_spread({}, m), {
     title: undefined
 });
 function g(fields, partialFields, nearlyPartialFields) {

--- a/crates/swc/tests/tsc-references/objectSpreadStrictNull_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectSpreadStrictNull_es2015.2.minified.js
@@ -1,7 +1,8 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-_object_spread({}, {
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+_object_spread_props(_object_spread({}, {
     title: "The Matrix",
     yearReleased: 1999
-}, {
+}), {
     title: void 0
 });

--- a/crates/swc/tests/tsc-references/objectSpreadStrictNull_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectSpreadStrictNull_es5.1.normal.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 // @strictNullChecks: true
 function f(definiteBoolean, definiteString, optionalString, optionalNumber, undefinedString, undefinedNumber) {
     // optional
@@ -16,7 +17,7 @@ var m = {
     yearReleased: 1999
 };
 // should error here because title: undefined is not assignable to string
-var x = _object_spread({}, m, {
+var x = _object_spread_props(_object_spread({}, m), {
     title: undefined
 });
 function g(fields, partialFields, nearlyPartialFields) {

--- a/crates/swc/tests/tsc-references/objectSpreadStrictNull_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectSpreadStrictNull_es5.2.minified.js
@@ -1,7 +1,8 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-_object_spread({}, {
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+_object_spread_props(_object_spread({}, {
     title: "The Matrix",
     yearReleased: 1999
-}, {
+}), {
     title: void 0
 });

--- a/crates/swc/tests/tsc-references/objectSpread_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectSpread_es2015.1.normal.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 // @strictNullChecks: true
 // @target: es5
 let o = {
@@ -13,33 +14,33 @@ let swap = {
     a: 'yes',
     b: -1
 };
-let addAfter = _object_spread({}, o, {
+let addAfter = _object_spread_props(_object_spread({}, o), {
     c: false
 });
 let addBefore = _object_spread({
     c: false
 }, o);
-let override = _object_spread({}, o, {
+let override = _object_spread_props(_object_spread({}, o), {
     b: 'override'
 });
-let nested = _object_spread({}, _object_spread({
+let nested = _object_spread_props(_object_spread({}, _object_spread({
     a: 3
 }, {
     b: false,
     c: 'overriden'
-}), {
+})), {
     c: 'whatever'
 });
 let combined = _object_spread({}, o, o2);
-let combinedAfter = _object_spread({}, o, o2, {
+let combinedAfter = _object_spread_props(_object_spread({}, o, o2), {
     b: 'ok'
 });
-let combinedNestedChangeType = _object_spread({}, _object_spread({
+let combinedNestedChangeType = _object_spread_props(_object_spread({}, _object_spread({
     a: 1
 }, {
     b: false,
     c: 'overriden'
-}), {
+})), {
     c: -1
 });
 let propertyNested = {
@@ -52,7 +53,7 @@ let op = {
         return 6;
     }
 };
-let getter = _object_spread({}, op, {
+let getter = _object_spread_props(_object_spread({}, op), {
     c: 7
 });
 getter.a = 12;
@@ -116,14 +117,14 @@ class C {
 let c = new C();
 let spreadC = _object_spread({}, c);
 // own methods are enumerable
-let cplus = _object_spread({}, c, {
+let cplus = _object_spread_props(_object_spread({}, c), {
     plus () {
         return this.p + 1;
     }
 });
 cplus.plus();
 // new field's type conflicting with existing field is OK
-let changeTypeAfter = _object_spread({}, o, {
+let changeTypeAfter = _object_spread_props(_object_spread({}, o), {
     a: 'wrong type?'
 });
 let changeTypeBoth = _object_spread({}, o, swap);
@@ -133,26 +134,26 @@ function container(definiteBoolean, definiteString, optionalString, optionalNumb
     let optionalUnionDuplicates = _object_spread({}, definiteBoolean, definiteString, optionalString, optionalNumber);
     let allOptional = _object_spread({}, optionalString, optionalNumber);
     // computed property
-    let computedFirst = _object_spread({
+    let computedFirst = _object_spread_props(_object_spread({
         ['before everything']: 12
-    }, o, {
+    }, o), {
         b: 'yes'
     });
-    let computedAfter = _object_spread({}, o, {
+    let computedAfter = _object_spread_props(_object_spread({}, o), {
         b: 'yeah',
         ['at the end']: 14
     });
 }
 // shortcut syntax
 let a = 12;
-let shortCutted = _object_spread({}, o, {
+let shortCutted = _object_spread_props(_object_spread({}, o), {
     a
 });
 // non primitive
 let spreadNonPrimitive = _object_spread({}, {});
 // generic spreads
 function f(t, u) {
-    return _object_spread({}, t, u, {
+    return _object_spread_props(_object_spread({}, t, u), {
         id: 'id'
     });
 }
@@ -190,27 +191,27 @@ function genericSpread(t, u, v, w, obj) {
         a: 5,
         b: 'hi'
     }, t);
-    let x06 = _object_spread({}, t, {
+    let x06 = _object_spread_props(_object_spread({}, t), {
         a: 5,
         b: 'hi'
     });
-    let x07 = _object_spread({
+    let x07 = _object_spread(_object_spread_props(_object_spread({
         a: 5,
         b: 'hi'
-    }, t, {
+    }, t), {
         c: true
-    }, obj);
-    let x09 = _object_spread({
+    }), obj);
+    let x09 = _object_spread(_object_spread_props(_object_spread({
         a: 5
-    }, t, {
+    }, t), {
         b: 'hi',
         c: true
-    }, obj);
-    let x10 = _object_spread({
+    }), obj);
+    let x10 = _object_spread(_object_spread_props(_object_spread({
         a: 5
-    }, t, {
+    }, t), {
         b: 'hi'
-    }, u, obj);
+    }), u, obj);
     let x11 = _object_spread({}, v);
     let x12 = _object_spread({}, v, obj);
     let x13 = _object_spread({}, w);

--- a/crates/swc/tests/tsc-references/objectSpread_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectSpread_es2015.2.minified.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 let o = {
     a: 1,
     b: 'no'
@@ -6,33 +7,33 @@ let o = {
     b: 'yes',
     c: !0
 };
-_object_spread({}, o, {
+_object_spread_props(_object_spread({}, o), {
     c: !1
 }), _object_spread({
     c: !1
-}, o), _object_spread({}, o, {
+}, o), _object_spread_props(_object_spread({}, o), {
     b: 'override'
-}), _object_spread({}, _object_spread({
+}), _object_spread_props(_object_spread({}, _object_spread({
     a: 3
 }, {
     b: !1,
     c: 'overriden'
-}), {
+})), {
     c: 'whatever'
-}), _object_spread({}, o, o2), _object_spread({}, o, o2, {
+}), _object_spread({}, o, o2), _object_spread_props(_object_spread({}, o, o2), {
     b: 'ok'
-}), _object_spread({}, _object_spread({
+}), _object_spread_props(_object_spread({}, _object_spread({
     a: 1
 }, {
     b: !1,
     c: 'overriden'
-}), {
+})), {
     c: -1
-}), _object_spread({}, o), _object_spread({}, {
+}), _object_spread({}, o), _object_spread_props(_object_spread({}, {
     get a () {
         return 6;
     }
-}, {
+}), {
     c: 7
 }).a = 12, _object_spread({}, function() {}), _object_spread({}, void 0);
 let c = new class {
@@ -42,20 +43,20 @@ let c = new class {
     }
 }();
 function f(t, u) {
-    return _object_spread({}, t, u, {
+    return _object_spread_props(_object_spread({}, t, u), {
         id: 'id'
     });
 }
-_object_spread({}, c), _object_spread({}, c, {
+_object_spread({}, c), _object_spread_props(_object_spread({}, c), {
     plus () {
         return this.p + 1;
     }
-}).plus(), _object_spread({}, o, {
+}).plus(), _object_spread_props(_object_spread({}, o), {
     a: 'wrong type?'
 }), _object_spread({}, o, {
     a: 'yes',
     b: -1
-}), _object_spread({}, o, {
+}), _object_spread_props(_object_spread({}, o), {
     a: 12
 }), _object_spread({}, {}), f({
     a: 1,

--- a/crates/swc/tests/tsc-references/objectSpread_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/objectSpread_es5.1.normal.js
@@ -1,6 +1,7 @@
 import _class_call_check from "@swc/helpers/lib/_class_call_check.js";
 import _define_property from "@swc/helpers/lib/_define_property.js";
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 // @strictNullChecks: true
 // @target: es5
 var o = {
@@ -15,33 +16,33 @@ var swap = {
     a: "yes",
     b: -1
 };
-var addAfter = _object_spread({}, o, {
+var addAfter = _object_spread_props(_object_spread({}, o), {
     c: false
 });
 var addBefore = _object_spread({
     c: false
 }, o);
-var override = _object_spread({}, o, {
+var override = _object_spread_props(_object_spread({}, o), {
     b: "override"
 });
-var nested = _object_spread({}, _object_spread({
+var nested = _object_spread_props(_object_spread({}, _object_spread({
     a: 3
 }, {
     b: false,
     c: "overriden"
-}), {
+})), {
     c: "whatever"
 });
 var combined = _object_spread({}, o, o2);
-var combinedAfter = _object_spread({}, o, o2, {
+var combinedAfter = _object_spread_props(_object_spread({}, o, o2), {
     b: "ok"
 });
-var combinedNestedChangeType = _object_spread({}, _object_spread({
+var combinedNestedChangeType = _object_spread_props(_object_spread({}, _object_spread({
     a: 1
 }, {
     b: false,
     c: "overriden"
-}), {
+})), {
     c: -1
 });
 var propertyNested = {
@@ -54,7 +55,7 @@ var op = {
         return 6;
     }
 };
-var getter = _object_spread({}, op, {
+var getter = _object_spread_props(_object_spread({}, op), {
     c: 7
 });
 getter.a = 12;
@@ -122,14 +123,14 @@ var C = /*#__PURE__*/ function() {
 var c = new C();
 var spreadC = _object_spread({}, c);
 // own methods are enumerable
-var cplus = _object_spread({}, c, {
+var cplus = _object_spread_props(_object_spread({}, c), {
     plus: function plus() {
         return this.p + 1;
     }
 });
 cplus.plus();
 // new field's type conflicting with existing field is OK
-var changeTypeAfter = _object_spread({}, o, {
+var changeTypeAfter = _object_spread_props(_object_spread({}, o), {
     a: "wrong type?"
 });
 var changeTypeBoth = _object_spread({}, o, swap);
@@ -139,23 +140,23 @@ function container(definiteBoolean, definiteString, optionalString, optionalNumb
     var optionalUnionDuplicates = _object_spread({}, definiteBoolean, definiteString, optionalString, optionalNumber);
     var allOptional = _object_spread({}, optionalString, optionalNumber);
     // computed property
-    var computedFirst = _object_spread(_define_property({}, "before everything", 12), o, {
+    var computedFirst = _object_spread_props(_object_spread(_define_property({}, "before everything", 12), o), {
         b: "yes"
     });
-    var computedAfter = _object_spread({}, o, _define_property({
+    var computedAfter = _object_spread_props(_object_spread({}, o), _define_property({
         b: "yeah"
     }, "at the end", 14));
 }
 // shortcut syntax
 var a = 12;
-var shortCutted = _object_spread({}, o, {
+var shortCutted = _object_spread_props(_object_spread({}, o), {
     a: a
 });
 // non primitive
 var spreadNonPrimitive = _object_spread({}, {});
 // generic spreads
 function f(t, u) {
-    return _object_spread({}, t, u, {
+    return _object_spread_props(_object_spread({}, t, u), {
         id: "id"
     });
 }
@@ -193,27 +194,27 @@ function genericSpread(t, u, v, w, obj) {
         a: 5,
         b: "hi"
     }, t);
-    var x06 = _object_spread({}, t, {
+    var x06 = _object_spread_props(_object_spread({}, t), {
         a: 5,
         b: "hi"
     });
-    var x07 = _object_spread({
+    var x07 = _object_spread(_object_spread_props(_object_spread({
         a: 5,
         b: "hi"
-    }, t, {
+    }, t), {
         c: true
-    }, obj);
-    var x09 = _object_spread({
+    }), obj);
+    var x09 = _object_spread(_object_spread_props(_object_spread({
         a: 5
-    }, t, {
+    }, t), {
         b: "hi",
         c: true
-    }, obj);
-    var x10 = _object_spread({
+    }), obj);
+    var x10 = _object_spread(_object_spread_props(_object_spread({
         a: 5
-    }, t, {
+    }, t), {
         b: "hi"
-    }, u, obj);
+    }), u, obj);
     var x11 = _object_spread({}, v);
     var x12 = _object_spread({}, v, obj);
     var x13 = _object_spread({}, w);

--- a/crates/swc/tests/tsc-references/objectSpread_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectSpread_es5.2.minified.js
@@ -1,6 +1,7 @@
 import _class_call_check from "@swc/helpers/lib/_class_call_check.js";
 import _define_property from "@swc/helpers/lib/_define_property.js";
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 var anything, o = {
     a: 1,
     b: "no"
@@ -8,33 +9,33 @@ var anything, o = {
     b: "yes",
     c: !0
 };
-_object_spread({}, o, {
+_object_spread_props(_object_spread({}, o), {
     c: !1
 }), _object_spread({
     c: !1
-}, o), _object_spread({}, o, {
+}, o), _object_spread_props(_object_spread({}, o), {
     b: "override"
-}), _object_spread({}, _object_spread({
+}), _object_spread_props(_object_spread({}, _object_spread({
     a: 3
 }, {
     b: !1,
     c: "overriden"
-}), {
+})), {
     c: "whatever"
-}), _object_spread({}, o, o2), _object_spread({}, o, o2, {
+}), _object_spread({}, o, o2), _object_spread_props(_object_spread({}, o, o2), {
     b: "ok"
-}), _object_spread({}, _object_spread({
+}), _object_spread_props(_object_spread({}, _object_spread({
     a: 1
 }, {
     b: !1,
     c: "overriden"
-}), {
+})), {
     c: -1
-}), _object_spread({}, o), _object_spread({}, {
+}), _object_spread({}, o), _object_spread_props(_object_spread({}, {
     get a () {
         return 6;
     }
-}, {
+}), {
     c: 7
 }).a = 12, _object_spread({}, function() {}), _object_spread({}, anything);
 var C = function() {
@@ -45,20 +46,20 @@ var C = function() {
     return C.prototype.m = function() {}, C;
 }(), c = new C();
 function f(t, u) {
-    return _object_spread({}, t, u, {
+    return _object_spread_props(_object_spread({}, t, u), {
         id: "id"
     });
 }
-_object_spread({}, c), _object_spread({}, c, {
+_object_spread({}, c), _object_spread_props(_object_spread({}, c), {
     plus: function() {
         return this.p + 1;
     }
-}).plus(), _object_spread({}, o, {
+}).plus(), _object_spread_props(_object_spread({}, o), {
     a: "wrong type?"
 }), _object_spread({}, o, {
     a: "yes",
     b: -1
-}), _object_spread({}, o, {
+}), _object_spread_props(_object_spread({}, o), {
     a: 12
 }), _object_spread({}, {}), f({
     a: 1,

--- a/crates/swc/tests/tsc-references/spreadNonPrimitive_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/spreadNonPrimitive_es2015.1.normal.js
@@ -1,6 +1,7 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-const x = _object_spread({
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+const x = _object_spread_props(_object_spread({
     a: 1
-}, o, {
+}, o), {
     b: 2
 });

--- a/crates/swc/tests/tsc-references/spreadNonPrimitive_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/spreadNonPrimitive_es2015.2.minified.js
@@ -1,6 +1,7 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-_object_spread({
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+_object_spread_props(_object_spread({
     a: 1
-}, o, {
+}, o), {
     b: 2
 });

--- a/crates/swc/tests/tsc-references/spreadNonPrimitive_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/spreadNonPrimitive_es5.1.normal.js
@@ -1,6 +1,7 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-var x = _object_spread({
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+var x = _object_spread_props(_object_spread({
     a: 1
-}, o, {
+}, o), {
     b: 2
 });

--- a/crates/swc/tests/tsc-references/spreadNonPrimitive_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/spreadNonPrimitive_es5.2.minified.js
@@ -1,6 +1,7 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-_object_spread({
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+_object_spread_props(_object_spread({
     a: 1
-}, o, {
+}, o), {
     b: 2
 });

--- a/crates/swc/tests/tsc-references/spreadOverwritesPropertyStrict_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/spreadOverwritesPropertyStrict_es2015.1.normal.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 var unused1 = _object_spread({
     b: 1
 }, ab) // error
@@ -9,11 +10,11 @@ var unused3 = _object_spread({
     b: 1
 }, abq) // ok, abq might have b: undefined
 ;
-var unused4 = _object_spread({}, ab, {
+var unused4 = _object_spread_props(_object_spread({}, ab), {
     b: 1
 }) // ok, we don't care that b in ab is overwritten
 ;
-var unused5 = _object_spread({}, abq, {
+var unused5 = _object_spread_props(_object_spread({}, abq), {
     b: 1
 }) // ok
 ;
@@ -48,13 +49,13 @@ function j() {
     ;
 }
 function k(t) {
-    return _object_spread({
+    return _object_spread(_object_spread_props(_object_spread({
         command: "hi"
     }, {
         spoiler: true
-    }, {
+    }), {
         spoiler2: true
-    }, t) // error
+    }), t) // error
     ;
 }
 function l(anyrequired) {

--- a/crates/swc/tests/tsc-references/spreadOverwritesPropertyStrict_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/spreadOverwritesPropertyStrict_es2015.2.minified.js
@@ -1,10 +1,11 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 _object_spread({
     b: 1
 }, ab), _object_spread({}, ab, ab), _object_spread({
     b: 1
-}, abq), _object_spread({}, ab, {
+}, abq), _object_spread_props(_object_spread({}, ab), {
     b: 1
-}), _object_spread({}, abq, {
+}), _object_spread_props(_object_spread({}, abq), {
     b: 1
 });

--- a/crates/swc/tests/tsc-references/spreadOverwritesPropertyStrict_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/spreadOverwritesPropertyStrict_es5.1.normal.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 var unused1 = _object_spread({
     b: 1
 }, ab) // error
@@ -9,11 +10,11 @@ var unused3 = _object_spread({
     b: 1
 }, abq) // ok, abq might have b: undefined
 ;
-var unused4 = _object_spread({}, ab, {
+var unused4 = _object_spread_props(_object_spread({}, ab), {
     b: 1
 }) // ok, we don't care that b in ab is overwritten
 ;
-var unused5 = _object_spread({}, abq, {
+var unused5 = _object_spread_props(_object_spread({}, abq), {
     b: 1
 }) // ok
 ;
@@ -48,13 +49,13 @@ function j() {
     ;
 }
 function k(t) {
-    return _object_spread({
+    return _object_spread(_object_spread_props(_object_spread({
         command: "hi"
     }, {
         spoiler: true
-    }, {
+    }), {
         spoiler2: true
-    }, t) // error
+    }), t) // error
     ;
 }
 function l(anyrequired) {

--- a/crates/swc/tests/tsc-references/spreadOverwritesPropertyStrict_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/spreadOverwritesPropertyStrict_es5.2.minified.js
@@ -1,10 +1,11 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 _object_spread({
     b: 1
 }, ab), _object_spread({}, ab, ab), _object_spread({
     b: 1
-}, abq), _object_spread({}, ab, {
+}, abq), _object_spread_props(_object_spread({}, ab), {
     b: 1
-}), _object_spread({}, abq, {
+}), _object_spread_props(_object_spread({}, abq), {
     b: 1
 });

--- a/crates/swc/tests/tsc-references/spreadUnion_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/spreadUnion_es2015.1.normal.js
@@ -1,9 +1,10 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 var union;
 var o3;
 var o3 = _object_spread({}, union);
 var o4;
-var o4 = _object_spread({}, union, {
+var o4 = _object_spread_props(_object_spread({}, union), {
     a: false
 });
 var o5;

--- a/crates/swc/tests/tsc-references/spreadUnion_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/spreadUnion_es2015.2.minified.js
@@ -1,5 +1,6 @@
 var union;
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-_object_spread({}, union), _object_spread({}, union, {
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+_object_spread({}, union), _object_spread_props(_object_spread({}, union), {
     a: !1
 }), _object_spread({}, union, union);

--- a/crates/swc/tests/tsc-references/spreadUnion_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/spreadUnion_es5.1.normal.js
@@ -1,9 +1,10 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 var union;
 var o3;
 var o3 = _object_spread({}, union);
 var o4;
-var o4 = _object_spread({}, union, {
+var o4 = _object_spread_props(_object_spread({}, union), {
     a: false
 });
 var o5;

--- a/crates/swc/tests/tsc-references/spreadUnion_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/spreadUnion_es5.2.minified.js
@@ -1,5 +1,6 @@
 var union;
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
-_object_spread({}, union), _object_spread({}, union, {
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
+_object_spread({}, union), _object_spread_props(_object_spread({}, union), {
     a: !1
 }), _object_spread({}, union, union);

--- a/crates/swc/tests/vercel/full/react-autowhatever/1/output/index.js
+++ b/crates/swc/tests/vercel/full/react-autowhatever/1/output/index.js
@@ -2,10 +2,10 @@
 Object.defineProperty(exports, "__esModule", {
     value: !0
 }), exports.default = void 0;
-var f = require("@swc/helpers/lib/_class_call_check.js").default, g = require("@swc/helpers/lib/_inherits.js").default, c = require("@swc/helpers/lib/_interop_require_default.js").default, d = require("@swc/helpers/lib/_interop_require_wildcard.js").default, h = require("@swc/helpers/lib/_object_spread.js").default, i = require("@swc/helpers/lib/_create_super.js").default, j = require("react/jsx-runtime"), e = d(require("react")), a = c(require("prop-types")), b = function(c) {
+var f = require("@swc/helpers/lib/_class_call_check.js").default, g = require("@swc/helpers/lib/_inherits.js").default, c = require("@swc/helpers/lib/_interop_require_default.js").default, d = require("@swc/helpers/lib/_interop_require_wildcard.js").default, h = require("@swc/helpers/lib/_object_spread.js").default, i = require("@swc/helpers/lib/_object_spread_props.js").default, j = require("@swc/helpers/lib/_create_super.js").default, k = require("react/jsx-runtime"), e = d(require("react")), a = c(require("prop-types")), b = function(c) {
     "use strict";
     g(b, c);
-    var d = i(b);
+    var d = j(b);
     function b() {
         var a;
         return f(this, b), a = d.apply(this, arguments), a.storeHighlightedItemReference = function(b) {
@@ -16,25 +16,25 @@ var f = require("@swc/helpers/lib/_class_call_check.js").default, g = require("@
     return a.shouldComponentUpdate = function(a) {
         return !0;
     }, a.render = function() {
-        var i = this, a = this.props, d = a.items, e = a.itemProps, k = a.renderItem, l = a.renderItemData, b = a.sectionIndex, m = a.highlightedItemIndex, n = a.getItemId, f = a.theme, c = a.keyPrefix, g = null === b ? c : "".concat(c, "section-").concat(b, "-"), o = "function" == typeof e;
-        return j.jsx("ul", h({
+        var j = this, a = this.props, d = a.items, e = a.itemProps, l = a.renderItem, m = a.renderItemData, b = a.sectionIndex, n = a.highlightedItemIndex, o = a.getItemId, f = a.theme, c = a.keyPrefix, g = null === b ? c : "".concat(c, "section-").concat(b, "-"), p = "function" == typeof e;
+        return k.jsx("ul", i(h({
             role: "listbox"
-        }, f("".concat(g, "items-list"), "itemsList"), {
-            children: d.map(function(p, a) {
-                var c = a === m, q = "".concat(g, "item-").concat(a), r = o ? e({
+        }, f("".concat(g, "items-list"), "itemsList")), {
+            children: d.map(function(q, a) {
+                var c = a === n, r = "".concat(g, "item-").concat(a), s = p ? e({
                     sectionIndex: b,
                     itemIndex: a
                 }) : e, d = h({
-                    id: n(b, a),
+                    id: o(b, a),
                     "aria-selected": c
-                }, f(q, "item", 0 === a && "itemFirst", c && "itemHighlighted"), r);
-                return c && (d.ref = i.storeHighlightedItemReference), j.jsx(Item, h({}, d, {
+                }, f(r, "item", 0 === a && "itemFirst", c && "itemHighlighted"), s);
+                return c && (d.ref = j.storeHighlightedItemReference), k.jsx(Item, i(h({}, d), {
                     sectionIndex: b,
                     isHighlighted: c,
                     itemIndex: a,
-                    item: p,
-                    renderItem: k,
-                    renderItemData: l
+                    item: q,
+                    renderItem: l,
+                    renderItemData: m
                 }));
             })
         }));

--- a/crates/swc/tests/vercel/full/react-autowhatever/2/output/index.js
+++ b/crates/swc/tests/vercel/full/react-autowhatever/2/output/index.js
@@ -2,13 +2,13 @@
 Object.defineProperty(exports, "__esModule", {
     value: !0
 }), exports.default = void 0;
-var d = require("@swc/helpers/lib/_class_call_check.js").default, e = require("@swc/helpers/lib/_inherits.js").default, b = require("@swc/helpers/lib/_interop_require_wildcard.js").default, f = require("@swc/helpers/lib/_object_spread.js").default, g = require("@swc/helpers/lib/_create_super.js").default, h = require("react/jsx-runtime"), c = b(require("react")), a = function(c) {
+var d = require("@swc/helpers/lib/_class_call_check.js").default, e = require("@swc/helpers/lib/_inherits.js").default, b = require("@swc/helpers/lib/_interop_require_wildcard.js").default, f = require("@swc/helpers/lib/_object_spread.js").default, g = require("@swc/helpers/lib/_object_spread_props.js").default, h = require("@swc/helpers/lib/_create_super.js").default, i = require("react/jsx-runtime"), c = b(require("react")), a = function(c) {
     "use strict";
     e(a, c);
-    var i = g(a);
+    var j = h(a);
     function a() {
         var b;
-        return d(this, a), b = i.apply(this, arguments), b.storeHighlightedItemReference = function(a) {
+        return d(this, a), b = j.apply(this, arguments), b.storeHighlightedItemReference = function(a) {
             b.props.onHighlightedItemChange(null === a ? null : a.item);
         }, b;
     }
@@ -18,25 +18,25 @@ var d = require("@swc/helpers/lib/_class_call_check.js").default, e = require("@
             "itemProps"
         ]);
     }, b.render = function() {
-        var j = this, a = this.props, d = a.items, e = a.itemProps, k = a.renderItem, l = a.renderItemData, b = a.sectionIndex, m = a.highlightedItemIndex, n = a.getItemId, g = a.theme, c = a.keyPrefix, i = null === b ? c : "".concat(c, "section-").concat(b, "-"), o = "function" == typeof e;
-        return h.jsx("ul", f({
+        var k = this, a = this.props, d = a.items, e = a.itemProps, l = a.renderItem, m = a.renderItemData, b = a.sectionIndex, n = a.highlightedItemIndex, o = a.getItemId, h = a.theme, c = a.keyPrefix, j = null === b ? c : "".concat(c, "section-").concat(b, "-"), p = "function" == typeof e;
+        return i.jsx("ul", g(f({
             role: "listbox"
-        }, g("".concat(i, "items-list"), "itemsList"), {
-            children: d.map(function(p, a) {
-                var c = a === m, q = "".concat(i, "item-").concat(a), r = o ? e({
+        }, h("".concat(j, "items-list"), "itemsList")), {
+            children: d.map(function(q, a) {
+                var c = a === n, r = "".concat(j, "item-").concat(a), s = p ? e({
                     sectionIndex: b,
                     itemIndex: a
                 }) : e, d = f({
-                    id: n(b, a),
+                    id: o(b, a),
                     "aria-selected": c
-                }, g(q, "item", 0 === a && "itemFirst", c && "itemHighlighted"), r);
-                return c && (d.ref = j.storeHighlightedItemReference), h.jsx(Item, f({}, d, {
+                }, h(r, "item", 0 === a && "itemFirst", c && "itemHighlighted"), s);
+                return c && (d.ref = k.storeHighlightedItemReference), i.jsx(Item, g(f({}, d), {
                     sectionIndex: b,
                     isHighlighted: c,
                     itemIndex: a,
-                    item: p,
-                    renderItem: k,
-                    renderItemData: l
+                    item: q,
+                    renderItem: l,
+                    renderItemData: m
                 }));
             })
         }));

--- a/crates/swc/tests/vercel/full/react-instantsearch/2/output/index.js
+++ b/crates/swc/tests/vercel/full/react-instantsearch/2/output/index.js
@@ -1,120 +1,121 @@
 import a from "@swc/helpers/lib/_define_property.js";
 import b from "@swc/helpers/lib/_object_spread.js";
-import c from "@swc/helpers/lib/_object_without_properties.js";
-import d from "@swc/helpers/lib/_to_consumable_array.js";
-import e from "algoliasearch-helper";
-import f from "./createWidgetsManager";
-import { HIGHLIGHT_TAGS as g } from "./highlight";
-import { hasMultipleIndices as h } from "./indexUtils";
-import { version as i } from "react";
-import j from "./version";
-function k(a) {
-    "function" == typeof a.addAlgoliaAgent && (a.addAlgoliaAgent("react (".concat(i, ")")), a.addAlgoliaAgent("react-instantsearch (".concat(j, ")")));
+import c from "@swc/helpers/lib/_object_spread_props.js";
+import d from "@swc/helpers/lib/_object_without_properties.js";
+import e from "@swc/helpers/lib/_to_consumable_array.js";
+import f from "algoliasearch-helper";
+import g from "./createWidgetsManager";
+import { HIGHLIGHT_TAGS as h } from "./highlight";
+import { hasMultipleIndices as i } from "./indexUtils";
+import { version as j } from "react";
+import k from "./version";
+function l(a) {
+    "function" == typeof a.addAlgoliaAgent && (a.addAlgoliaAgent("react (".concat(j, ")")), a.addAlgoliaAgent("react-instantsearch (".concat(k, ")")));
 }
-var l = function(a) {
-    return h({
+var m = function(a) {
+    return i({
         ais: a.props.contextValue,
         multiIndexContext: a.props.indexContextValue
     });
-}, m = function(a, b) {
+}, n = function(a, b) {
     return a.props.indexContextValue.targetedIndex === b;
-}, n = function(a) {
+}, o = function(a) {
     return Boolean(a.props.indexId);
-}, o = function(a, b) {
+}, p = function(a, b) {
     return a.props.indexId === b;
-}, p = function(c, d) {
-    var a = n(c), b = n(d);
+}, q = function(c, d) {
+    var a = o(c), b = o(d);
     return a && !b ? -1 : !a && b ? 1 : 0;
 };
-export default function q(h) {
-    var s = h.indexName, t = h.initialState, j = h.searchClient, q = h.resultsState, C = h.stalledSearchDelay, D = function(a) {
-        return A.getWidgets().filter(function(a) {
+export default function r(i) {
+    var t = i.indexName, u = i.initialState, k = i.searchClient, r = i.resultsState, D = i.stalledSearchDelay, E = function(a) {
+        return B.getWidgets().filter(function(a) {
             return Boolean(a.getMetadata);
         }).map(function(b) {
             return b.getMetadata(a);
         });
-    }, v = function() {
-        var c = A.getWidgets().filter(function(a) {
+    }, w = function() {
+        var d = B.getWidgets().filter(function(a) {
             return Boolean(a.getSearchParameters);
         }).filter(function(a) {
-            return !l(a) && !n(a);
+            return !m(a) && !o(a);
         }).reduce(function(a, b) {
             return b.getSearchParameters(a);
-        }, K), d = A.getWidgets().filter(function(a) {
+        }, L), e = B.getWidgets().filter(function(a) {
             return Boolean(a.getSearchParameters);
         }).filter(function(a) {
-            var b = l(a) && m(a, s), c = n(a) && o(a, s);
+            var b = m(a) && n(a, t), c = o(a) && p(a, t);
             return b || c;
-        }).sort(p).reduce(function(a, b) {
+        }).sort(q).reduce(function(a, b) {
             return b.getSearchParameters(a);
-        }, c), e = A.getWidgets().filter(function(a) {
+        }, d), f = B.getWidgets().filter(function(a) {
             return Boolean(a.getSearchParameters);
         }).filter(function(a) {
-            var b = l(a) && !m(a, s), c = n(a) && !o(a, s);
+            var b = m(a) && !n(a, t), c = o(a) && !p(a, t);
             return b || c;
-        }).sort(p).reduce(function(d, c) {
-            var e = l(c) ? c.props.indexContextValue.targetedIndex : c.props.indexId, f = d[e] || [];
-            return b({}, d, a({}, e, f.concat(c)));
-        }, {}), f = Object.keys(e).map(function(a) {
+        }).sort(q).reduce(function(e, d) {
+            var f = m(d) ? d.props.indexContextValue.targetedIndex : d.props.indexId, g = e[f] || [];
+            return c(b({}, e), a({}, f, g.concat(d)));
+        }, {}), g = Object.keys(f).map(function(a) {
             return {
-                parameters: e[a].reduce(function(a, b) {
+                parameters: f[a].reduce(function(a, b) {
                     return b.getSearchParameters(a);
-                }, c),
+                }, d),
                 indexId: a
             };
         });
         return {
-            mainParameters: d,
-            derivedParameters: f
+            mainParameters: e,
+            derivedParameters: g
         };
-    }, E = function() {
-        if (!I) {
-            var a = v(u.state), b = a.mainParameters, c = a.derivedParameters;
-            u.derivedHelpers.slice().forEach(function(a) {
+    }, F = function() {
+        if (!J) {
+            var a = w(v.state), b = a.mainParameters, c = a.derivedParameters;
+            v.derivedHelpers.slice().forEach(function(a) {
                 a.detach();
             }), c.forEach(function(a) {
-                var b = a.indexId, d = a.parameters, c = u.derive(function() {
+                var b = a.indexId, d = a.parameters, c = v.derive(function() {
                     return d;
                 });
-                c.on("result", w({
+                c.on("result", x({
                     indexId: b
-                })).on("error", x);
-            }), u.setState(b), u.search();
+                })).on("error", y);
+            }), v.setState(b), v.search();
         }
-    }, w = function(d) {
-        var e = d.indexId;
-        return function(g) {
-            var h = B.getState(), i = !u.derivedHelpers.length, d = h.results ? h.results : {};
-            d = !i && d.getFacetByName ? {} : d, d = i ? g.results : b({}, d, a({}, e, g.results));
-            var f = B.getState(), j = f.isSearchStalled;
-            u.hasPendingRequests() || (clearTimeout(J), J = null, j = !1), f.resultsFacetValues;
-            var k = c(f, [
+    }, x = function(e) {
+        var f = e.indexId;
+        return function(h) {
+            var i = C.getState(), j = !v.derivedHelpers.length, e = i.results ? i.results : {};
+            e = !j && e.getFacetByName ? {} : e, e = j ? h.results : c(b({}, e), a({}, f, h.results));
+            var g = C.getState(), k = g.isSearchStalled;
+            v.hasPendingRequests() || (clearTimeout(K), K = null, k = !1), g.resultsFacetValues;
+            var l = d(g, [
                 "resultsFacetValues"
             ]);
-            B.setState(b({}, k, {
-                results: d,
-                isSearchStalled: j,
+            C.setState(c(b({}, l), {
+                results: e,
+                isSearchStalled: k,
                 searching: !1,
                 error: null
             }));
         };
-    }, x = function(e) {
-        var f = e.error, a = B.getState(), d = a.isSearchStalled;
-        u.hasPendingRequests() || (clearTimeout(J), d = !1), a.resultsFacetValues;
-        var g = c(a, [
+    }, y = function(f) {
+        var g = f.error, a = C.getState(), e = a.isSearchStalled;
+        v.hasPendingRequests() || (clearTimeout(K), e = !1), a.resultsFacetValues;
+        var h = d(a, [
             "resultsFacetValues"
         ]);
-        B.setState(b({}, g, {
-            isSearchStalled: d,
-            error: f,
+        C.setState(c(b({}, h), {
+            isSearchStalled: e,
+            error: g,
             searching: !1
         }));
-    }, F = function(c, d) {
-        if (c.transporter) {
-            c.transporter.responsesCache.set({
+    }, G = function(d, e) {
+        if (d.transporter) {
+            d.transporter.responsesCache.set({
                 method: "search",
                 args: [
-                    d.reduce(function(a, b) {
+                    e.reduce(function(a, b) {
                         return a.concat(b.rawResults.map(function(a) {
                             return {
                                 indexName: a.index,
@@ -124,14 +125,14 @@ export default function q(h) {
                     }, []), 
                 ]
             }, {
-                results: d.reduce(function(a, b) {
+                results: e.reduce(function(a, b) {
                     return a.concat(b.rawResults);
                 }, [])
             });
             return;
         }
-        var e = "/1/indexes/*/queries_body_".concat(JSON.stringify({
-            requests: d.reduce(function(a, b) {
+        var f = "/1/indexes/*/queries_body_".concat(JSON.stringify({
+            requests: e.reduce(function(a, b) {
                 return a.concat(b.rawResults.map(function(a) {
                     return {
                         indexName: a.index,
@@ -140,17 +141,17 @@ export default function q(h) {
                 }));
             }, [])
         }));
-        c.cache = b({}, c.cache, a({}, e, JSON.stringify({
-            results: d.reduce(function(a, b) {
+        d.cache = c(b({}, d.cache), a({}, f, JSON.stringify({
+            results: e.reduce(function(a, b) {
                 return a.concat(b.rawResults);
             }, [])
         })));
-    }, G = function(c, d) {
-        if (c.transporter) {
-            c.transporter.responsesCache.set({
+    }, H = function(d, e) {
+        if (d.transporter) {
+            d.transporter.responsesCache.set({
                 method: "search",
                 args: [
-                    d.rawResults.map(function(a) {
+                    e.rawResults.map(function(a) {
                         return {
                             indexName: a.index,
                             params: a.params
@@ -158,129 +159,129 @@ export default function q(h) {
                     }), 
                 ]
             }, {
-                results: d.rawResults
+                results: e.rawResults
             });
             return;
         }
-        var e = "/1/indexes/*/queries_body_".concat(JSON.stringify({
-            requests: d.rawResults.map(function(a) {
+        var f = "/1/indexes/*/queries_body_".concat(JSON.stringify({
+            requests: e.rawResults.map(function(a) {
                 return {
                     indexName: a.index,
                     params: a.params
                 };
             })
         }));
-        c.cache = b({}, c.cache, a({}, e, JSON.stringify({
-            results: d.rawResults
+        d.cache = c(b({}, d.cache), a({}, f, JSON.stringify({
+            results: e.rawResults
         })));
-    }, u = e(j, s, b({}, g));
-    k(j), u.on("search", function() {
-        !J && (J = setTimeout(function() {
-            var a = B.getState(), d = (a.resultsFacetValues, c(a, [
+    }, v = f(k, t, b({}, h));
+    l(k), v.on("search", function() {
+        !K && (K = setTimeout(function() {
+            var a = C.getState(), e = (a.resultsFacetValues, d(a, [
                 "resultsFacetValues"
             ]));
-            B.setState(b({}, d, {
+            C.setState(c(b({}, e), {
                 isSearchStalled: !0
             }));
-        }, C));
-    }).on("result", w({
-        indexId: s
-    })).on("error", x);
-    var i, H, y, z, I = !1, J = null, K = u.state, A = f(function() {
-        var a = D(B.getState().widgets);
-        B.setState(b({}, B.getState(), {
+        }, D));
+    }).on("result", x({
+        indexId: t
+    })).on("error", y);
+    var j, I, z, A, J = !1, K = null, L = v.state, B = g(function() {
+        var a = E(C.getState().widgets);
+        C.setState(c(b({}, C.getState()), {
             metadata: a,
             searching: !0
-        })), E();
+        })), F();
     });
-    !function(a, c) {
-        if (c && (a.transporter && !a._cacheHydrated || a._useCache && "function" == typeof a.addAlgoliaAgent)) {
+    !function(a, d) {
+        if (d && (a.transporter && !a._cacheHydrated || a._useCache && "function" == typeof a.addAlgoliaAgent)) {
             if (a.transporter && !a._cacheHydrated) {
                 a._cacheHydrated = !0;
-                var e = a.search;
-                a.search = function(h) {
-                    for(var f = arguments.length, g = new Array(f > 1 ? f - 1 : 0), c = 1; c < f; c++)g[c - 1] = arguments[c];
-                    var i = h.map(function(a) {
-                        var c, d;
-                        return b({}, a, {
-                            params: (c = a.params, d = function(c) {
+                var f = a.search;
+                a.search = function(i) {
+                    for(var g = arguments.length, h = new Array(g > 1 ? g - 1 : 0), d = 1; d < g; d++)h[d - 1] = arguments[d];
+                    var j = i.map(function(a) {
+                        var d, e;
+                        return c(b({}, a), {
+                            params: (d = a.params, e = function(c) {
                                 for(var b = arguments.length, d = new Array(b > 1 ? b - 1 : 0), a = 1; a < b; a++)d[a - 1] = arguments[a];
                                 var e = 0;
                                 return c.replace(/%s/g, function() {
                                     return encodeURIComponent(d[e++]);
                                 });
-                            }, Object.keys(c).map(function(a) {
+                            }, Object.keys(d).map(function(a) {
                                 var b;
-                                return d("%s=%s", a, (b = c[a], "[object Object]" === Object.prototype.toString.call(b) || "[object Array]" === Object.prototype.toString.call(b)) ? JSON.stringify(c[a]) : c[a]);
+                                return e("%s=%s", a, (b = d[a], "[object Object]" === Object.prototype.toString.call(b) || "[object Array]" === Object.prototype.toString.call(b)) ? JSON.stringify(d[a]) : d[a]);
                             }).join("&"))
                         });
                     });
                     return a.transporter.responsesCache.get({
                         method: "search",
                         args: [
-                            i
-                        ].concat(d(g))
+                            j
+                        ].concat(e(h))
                     }, function() {
-                        return e.apply(void 0, [
-                            h
-                        ].concat(d(g)));
+                        return f.apply(void 0, [
+                            i
+                        ].concat(e(h)));
                     });
                 };
             }
-            if (Array.isArray(c.results)) {
-                F(a, c.results);
+            if (Array.isArray(d.results)) {
+                G(a, d.results);
                 return;
             }
-            G(a, c);
+            H(a, d);
         }
-    }(j, q);
-    var B = (y = {
-        widgets: void 0 === t ? {} : t,
-        metadata: r(q),
-        results: (i = q) ? Array.isArray(i.results) ? i.results.reduce(function(d, c) {
-            return b({}, d, a({}, c._internalIndexId, new e.SearchResults(new e.SearchParameters(c.state), c.rawResults)));
-        }, {}) : new e.SearchResults(new e.SearchParameters(i.state), i.rawResults) : null,
+    }(k, r);
+    var C = (z = {
+        widgets: void 0 === u ? {} : u,
+        metadata: s(r),
+        results: (j = r) ? Array.isArray(j.results) ? j.results.reduce(function(e, d) {
+            return c(b({}, e), a({}, d._internalIndexId, new f.SearchResults(new f.SearchParameters(d.state), d.rawResults)));
+        }, {}) : new f.SearchResults(new f.SearchParameters(j.state), j.rawResults) : null,
         error: null,
         searching: !1,
         isSearchStalled: !0,
         searchingForFacetValues: !1
-    }, z = [], {
+    }, A = [], {
         getState: function() {
-            return y;
+            return z;
         },
         setState: function(a) {
-            y = a, z.forEach(function(a) {
+            z = a, A.forEach(function(a) {
                 return a();
             });
         },
         subscribe: function(a) {
-            return z.push(a), function() {
-                z.splice(z.indexOf(a), 1);
+            return A.push(a), function() {
+                A.splice(A.indexOf(a), 1);
             };
         }
     });
     return {
-        store: B,
-        widgetsManager: A,
+        store: C,
+        widgetsManager: B,
         getWidgetsIds: function() {
-            return B.getState().metadata.reduce(function(a, b) {
+            return C.getState().metadata.reduce(function(a, b) {
                 return void 0 !== b.id ? a.concat(b.id) : a;
             }, []);
         },
-        getSearchParameters: v,
-        onSearchForFacetValues: function(c) {
-            var e = c.facetName, f = c.query, d = c.maxFacetHits;
-            B.setState(b({}, B.getState(), {
+        getSearchParameters: w,
+        onSearchForFacetValues: function(d) {
+            var f = d.facetName, g = d.query, e = d.maxFacetHits;
+            C.setState(c(b({}, C.getState()), {
                 searchingForFacetValues: !0
-            })), u.searchForFacetValues(e, f, Math.max(1, Math.min(void 0 === d ? 10 : d, 100))).then(function(d) {
-                var c;
-                B.setState(b({}, B.getState(), {
+            })), v.searchForFacetValues(f, g, Math.max(1, Math.min(void 0 === e ? 10 : e, 100))).then(function(e) {
+                var d;
+                C.setState(c(b({}, C.getState()), {
                     error: null,
                     searchingForFacetValues: !1,
-                    resultsFacetValues: b({}, B.getState().resultsFacetValues, (a(c = {}, e, d.facetHits), a(c, "query", f), c))
+                    resultsFacetValues: c(b({}, C.getState().resultsFacetValues), (a(d = {}, f, e.facetHits), a(d, "query", g), d))
                 }));
             }, function(a) {
-                B.setState(b({}, B.getState(), {
+                C.setState(c(b({}, C.getState()), {
                     searchingForFacetValues: !1,
                     error: a
                 }));
@@ -291,48 +292,48 @@ export default function q(h) {
             });
         },
         onExternalStateUpdate: function(a) {
-            var c = D(a);
-            B.setState(b({}, B.getState(), {
+            var d = E(a);
+            C.setState(c(b({}, C.getState()), {
                 widgets: a,
-                metadata: c,
+                metadata: d,
                 searching: !0
-            })), E();
+            })), F();
         },
         transitionState: function(a) {
-            var b = B.getState().widgets;
-            return A.getWidgets().filter(function(a) {
+            var b = C.getState().widgets;
+            return B.getWidgets().filter(function(a) {
                 return Boolean(a.transitionState);
             }).reduce(function(a, c) {
                 return c.transitionState(b, a);
             }, a);
         },
         updateClient: function(a) {
-            k(a), u.setClient(a), E();
+            l(a), v.setClient(a), F();
         },
         updateIndex: function(a) {
-            K = K.setIndex(a);
+            L = L.setIndex(a);
         },
         clearCache: function() {
-            u.clearCache(), E();
+            v.clearCache(), F();
         },
         skipSearch: function() {
-            I = !0;
+            J = !0;
         }
     };
 };
-function r(a) {
+function s(a) {
     return a ? a.metadata.map(function(a) {
-        return b({
+        return c(b({
             value: function() {
                 return {};
             }
-        }, a, {
+        }, a), {
             items: a.items && a.items.map(function(a) {
-                return b({
+                return c(b({
                     value: function() {
                         return {};
                     }
-                }, a, {
+                }, a), {
                     items: a.items && a.items.map(function(a) {
                         return b({
                             value: function() {

--- a/crates/swc/tests/vercel/loader-only/next-33291/1-automatic/output/index.js
+++ b/crates/swc/tests/vercel/loader-only/next-33291/1-automatic/output/index.js
@@ -1,4 +1,5 @@
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 import _object_without_properties from "@swc/helpers/lib/_object_without_properties.js";
 import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
 import { createElement as _createElement } from "react";
@@ -42,9 +43,9 @@ export default function Home() {
                         var href = _param.href, linkProps = _object_without_properties(_param, [
                             "href"
                         ]);
-                        return _createElement("link", _object_spread({
+                        return _createElement("link", _object_spread_props(_object_spread({
                             href: href
-                        }, linkProps, {
+                        }, linkProps), {
                             rel: "icon",
                             key: href,
                             __source: {

--- a/crates/swc/tests/vercel/loader-only/react-autowhatever/1/output/index.js
+++ b/crates/swc/tests/vercel/loader-only/react-autowhatever/1/output/index.js
@@ -1,6 +1,7 @@
 import _class_call_check from "@swc/helpers/lib/_class_call_check.js";
 import _inherits from "@swc/helpers/lib/_inherits.js";
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 import _create_super from "@swc/helpers/lib/_create_super.js";
 import { jsx as _jsx } from "react/jsx-runtime";
 import React, { Component } from "react";
@@ -31,9 +32,9 @@ var ItemsList = /*#__PURE__*/ function(Component1) {
         var _props = this.props, items = _props.items, itemProps = _props.itemProps, renderItem = _props.renderItem, renderItemData = _props.renderItemData, sectionIndex = _props.sectionIndex, highlightedItemIndex = _props.highlightedItemIndex, getItemId = _props.getItemId, theme = _props.theme, keyPrefix = _props.keyPrefix;
         var sectionPrefix = sectionIndex === null ? keyPrefix : "".concat(keyPrefix, "section-").concat(sectionIndex, "-");
         var isItemPropsFunction = typeof itemProps === "function";
-        return /*#__PURE__*/ _jsx("ul", _object_spread({
+        return /*#__PURE__*/ _jsx("ul", _object_spread_props(_object_spread({
             role: "listbox"
-        }, theme("".concat(sectionPrefix, "items-list"), "itemsList"), {
+        }, theme("".concat(sectionPrefix, "items-list"), "itemsList")), {
             children: items.map(function(item, itemIndex) {
                 var isFirst = itemIndex === 0;
                 var isHighlighted = itemIndex === highlightedItemIndex;
@@ -50,7 +51,7 @@ var ItemsList = /*#__PURE__*/ function(Component1) {
                     allItemProps.ref = _this.storeHighlightedItemReference;
                 }
                 // `key` is provided by theme()
-                /* eslint-disable react/jsx-key */ return /*#__PURE__*/ _jsx(Item, _object_spread({}, allItemProps, {
+                /* eslint-disable react/jsx-key */ return /*#__PURE__*/ _jsx(Item, _object_spread_props(_object_spread({}, allItemProps), {
                     sectionIndex: sectionIndex,
                     isHighlighted: isHighlighted,
                     itemIndex: itemIndex,

--- a/crates/swc/tests/vercel/loader-only/react-instantsearch/1/output/index.js
+++ b/crates/swc/tests/vercel/loader-only/react-instantsearch/1/output/index.js
@@ -1,5 +1,6 @@
 import _define_property from "@swc/helpers/lib/_define_property.js";
 import _object_spread from "@swc/helpers/lib/_object_spread.js";
+import _object_spread_props from "@swc/helpers/lib/_object_spread_props.js";
 import _object_without_properties from "@swc/helpers/lib/_object_without_properties.js";
 import _to_consumable_array from "@swc/helpers/lib/_to_consumable_array.js";
 import algoliasearchHelper from "algoliasearch-helper";
@@ -142,7 +143,7 @@ function serializeQueryParameters(parameters) {
         .sort(sortIndexWidgetsFirst).reduce(function(indices, widget) {
             var indexId = isMultiIndexContext(widget) ? widget.props.indexContextValue.targetedIndex : widget.props.indexId;
             var widgets = indices[indexId] || [];
-            return _object_spread({}, indices, _define_property({}, indexId, widgets.concat(widget)));
+            return _object_spread_props(_object_spread({}, indices), _define_property({}, indexId, widgets.concat(widget)));
         }, {});
         var derivedParameters = Object.keys(derivedIndices).map(function(indexId) {
             return {
@@ -205,7 +206,7 @@ function serializeQueryParameters(parameters) {
             // unused results.
             results = !isDerivedHelpersEmpty && results.getFacetByName ? {} : results;
             if (!isDerivedHelpersEmpty) {
-                results = _object_spread({}, results, _define_property({}, indexId, event.results));
+                results = _object_spread_props(_object_spread({}, results), _define_property({}, indexId, event.results));
             } else {
                 results = event.results;
             }
@@ -219,7 +220,7 @@ function serializeQueryParameters(parameters) {
             var resultsFacetValues = currentState.resultsFacetValues, partialState = _object_without_properties(currentState, [
                 "resultsFacetValues"
             ]);
-            store.setState(_object_spread({}, partialState, {
+            store.setState(_object_spread_props(_object_spread({}, partialState), {
                 results: results,
                 isSearchStalled: nextIsSearchStalled,
                 searching: false,
@@ -238,7 +239,7 @@ function serializeQueryParameters(parameters) {
         var resultsFacetValues = currentState.resultsFacetValues, partialState = _object_without_properties(currentState, [
             "resultsFacetValues"
         ]);
-        store.setState(_object_spread({}, partialState, {
+        store.setState(_object_spread_props(_object_spread({}, partialState), {
             isSearchStalled: nextIsSearchStalled,
             error: error,
             searching: false
@@ -251,7 +252,7 @@ function serializeQueryParameters(parameters) {
                 var _ref = store.getState(), resultsFacetValues = _ref.resultsFacetValues, partialState = _object_without_properties(_ref, [
                     "resultsFacetValues"
                 ]);
-                store.setState(_object_spread({}, partialState, {
+                store.setState(_object_spread_props(_object_spread({}, partialState), {
                     isSearchStalled: true
                 }));
             }, stalledSearchDelay), stalledSearchTimer = _tmp, _tmp;
@@ -282,7 +283,7 @@ function serializeQueryParameters(parameters) {
                     methodArgs[_key - 1] = arguments[_key];
                 }
                 var requestsWithSerializedParams = requests.map(function(request) {
-                    return _object_spread({}, request, {
+                    return _object_spread_props(_object_spread({}, request), {
                         params: serializeQueryParameters(request.params)
                     });
                 });
@@ -343,7 +344,7 @@ function serializeQueryParameters(parameters) {
                 }));
             }, [])
         }));
-        client.cache = _object_spread({}, client.cache, _define_property({}, key, JSON.stringify({
+        client.cache = _object_spread_props(_object_spread({}, client.cache), _define_property({}, key, JSON.stringify({
             results: results.reduce(function(acc, result) {
                 return acc.concat(result.rawResults);
             }, [])
@@ -382,7 +383,7 @@ function serializeQueryParameters(parameters) {
                 };
             })
         }));
-        client.cache = _object_spread({}, client.cache, _define_property({}, key, JSON.stringify({
+        client.cache = _object_spread_props(_object_spread({}, client.cache), _define_property({}, key, JSON.stringify({
             results: results.rawResults
         })));
     };
@@ -392,7 +393,7 @@ function serializeQueryParameters(parameters) {
         }
         if (Array.isArray(results.results)) {
             return results.results.reduce(function(acc, result) {
-                return _object_spread({}, acc, _define_property({}, result._internalIndexId, new algoliasearchHelper.SearchResults(new algoliasearchHelper.SearchParameters(result.state), result.rawResults)));
+                return _object_spread_props(_object_spread({}, acc), _define_property({}, result._internalIndexId, new algoliasearchHelper.SearchResults(new algoliasearchHelper.SearchParameters(result.state), result.rawResults)));
             }, {});
         }
         return new algoliasearchHelper.SearchResults(new algoliasearchHelper.SearchParameters(results.state), results.rawResults);
@@ -400,7 +401,7 @@ function serializeQueryParameters(parameters) {
     var onWidgetsUpdate = // Called whenever a widget has been rendered with new props.
     function onWidgetsUpdate() {
         var metadata = getMetadata(store.getState().widgets);
-        store.setState(_object_spread({}, store.getState(), {
+        store.setState(_object_spread_props(_object_spread({}, store.getState()), {
             metadata: metadata,
             searching: true
         }));
@@ -418,7 +419,7 @@ function serializeQueryParameters(parameters) {
     };
     var onExternalStateUpdate = function onExternalStateUpdate(nextSearchState) {
         var metadata = getMetadata(nextSearchState);
-        store.setState(_object_spread({}, store.getState(), {
+        store.setState(_object_spread_props(_object_spread({}, store.getState()), {
             widgets: nextSearchState,
             metadata: metadata,
             searching: true
@@ -430,18 +431,18 @@ function serializeQueryParameters(parameters) {
         // The values 1, 100 are the min / max values that the engine accepts.
         // see: https://www.algolia.com/doc/api-reference/api-parameters/maxFacetHits
         var maxFacetHitsWithinRange = Math.max(1, Math.min(maxFacetHits, 100));
-        store.setState(_object_spread({}, store.getState(), {
+        store.setState(_object_spread_props(_object_spread({}, store.getState()), {
             searchingForFacetValues: true
         }));
         helper.searchForFacetValues(facetName, query, maxFacetHitsWithinRange).then(function(content) {
             var _obj;
-            store.setState(_object_spread({}, store.getState(), {
+            store.setState(_object_spread_props(_object_spread({}, store.getState()), {
                 error: null,
                 searchingForFacetValues: false,
-                resultsFacetValues: _object_spread({}, store.getState().resultsFacetValues, (_obj = {}, _define_property(_obj, facetName, content.facetHits), _define_property(_obj, "query", query), _obj))
+                resultsFacetValues: _object_spread_props(_object_spread({}, store.getState().resultsFacetValues), (_obj = {}, _define_property(_obj, facetName, content.facetHits), _define_property(_obj, "query", query), _obj))
             }));
         }, function(error) {
-            store.setState(_object_spread({}, store.getState(), {
+            store.setState(_object_spread_props(_object_spread({}, store.getState()), {
                 searchingForFacetValues: false,
                 error: error
             }));
@@ -503,17 +504,17 @@ function hydrateMetadata(resultsState) {
     }
     // add a value noop, which gets replaced once the widgets are mounted
     return resultsState.metadata.map(function(datum) {
-        return _object_spread({
+        return _object_spread_props(_object_spread({
             value: function() {
                 return {};
             }
-        }, datum, {
+        }, datum), {
             items: datum.items && datum.items.map(function(item) {
-                return _object_spread({
+                return _object_spread_props(_object_spread({
                     value: function() {
                         return {};
                     }
-                }, item, {
+                }, item), {
                     items: item.items && item.items.map(function(nestedItem) {
                         return _object_spread({
                             value: function() {

--- a/crates/swc_ecma_preset_env/src/lib.rs
+++ b/crates/swc_ecma_preset_env/src/lib.rs
@@ -162,7 +162,8 @@ where
         ObjectRestSpread,
         es2018::object_rest_spread(es2018::object_rest_spread::Config {
             no_symbol: loose || assumptions.object_rest_no_symbols,
-            set_property: loose || assumptions.set_spread_properties
+            set_property: loose || assumptions.set_spread_properties,
+            pure_getters: loose || assumptions.pure_getters
         })
     );
 

--- a/crates/swc_ecma_transforms_base/src/helpers/_object_spread_props.js
+++ b/crates/swc_ecma_transforms_base/src/helpers/_object_spread_props.js
@@ -1,0 +1,30 @@
+function ownKeys(object, enumerableOnly) {
+  var keys = Object.keys(object);
+  if (Object.getOwnPropertySymbols) {
+    var symbols = Object.getOwnPropertySymbols(object);
+    if (enumerableOnly) {
+      symbols = symbols.filter(function (sym) {
+        return Object.getOwnPropertyDescriptor(object, sym).enumerable;
+      });
+    }
+    keys.push.apply(keys, symbols);
+  }
+  return keys;
+}
+
+function _objectSpreadProps(target, source) {
+  source = source != null ? source : {}
+  if (Object.getOwnPropertyDescriptors) {
+    Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
+  } else {
+    ownKeys(Object(source)).forEach(function (key) {
+      Object.defineProperty(
+        target,
+        key,
+        Object.getOwnPropertyDescriptor(source, key)
+      );
+    });
+  }
+
+  return target;
+}

--- a/crates/swc_ecma_transforms_base/src/helpers/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/helpers/mod.rs
@@ -283,6 +283,7 @@ define_helpers!(Helpers {
     non_iterable_rest: (),
     non_iterable_spread: (),
     object_spread: (define_property),
+    object_spread_props: (),
     object_without_properties: (object_without_properties_loose),
     object_without_properties_loose: (),
     possible_constructor_return: (type_of, assert_this_initialized),

--- a/crates/swc_ecma_transforms_compat/tests/es2018_object_rest_spread.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2018_object_rest_spread.rs
@@ -1155,12 +1155,12 @@ test!(
 ({ ...{ get foo () { return 'foo' } } });
 "#,
     r#"
-_objectSpread({
-  x
-}, y, {
-  a
-}, b, {
-  c
+_objectSpreadProps(_objectSpread(_objectSpreadProps(_objectSpread({
+    x
+}, y), {
+    a
+}), b), {
+    c
 });
 
 _objectSpread({}, Object.prototype);
@@ -1173,7 +1173,6 @@ _objectSpread({}, {
   get foo() {
     return 'foo';
   }
-
 });
 "#
 );
@@ -2751,7 +2750,8 @@ test!(
     syntax(),
     |_| tr(Config {
         no_symbol: true,
-        set_property: true
+        set_property: true,
+        pure_getters: true
     }),
     no_symbol_rest_assignment_expression,
     r#"({ a, b, ...c } = obj);"#,
@@ -2768,7 +2768,8 @@ test!(
     syntax(),
     |_| tr(Config {
         no_symbol: true,
-        set_property: true
+        set_property: true,
+        pure_getters: true
     }),
     no_symbol_computed,
     r#"let { [a]: b, ...c } = obj;"#,
@@ -2785,7 +2786,8 @@ test_exec!(
     syntax(),
     |_| tr(Config {
         no_symbol: true,
-        set_property: true
+        set_property: true,
+        pure_getters: true
     }),
     set_property_ignore_symbol_exec,
     r#"
@@ -2803,7 +2805,8 @@ test!(
     syntax(),
     |_| tr(Config {
         no_symbol: true,
-        set_property: true
+        set_property: true,
+        pure_getters: true
     }),
     no_symbol_rest_nested,
     r#"let { a, nested: { b, c, ...d }, e } = obj;"#,
@@ -2824,7 +2827,8 @@ test!(
     syntax(),
     |_| tr(Config {
         no_symbol: true,
-        set_property: true
+        set_property: true,
+        pure_getters: true
     }),
     no_symbol_var_declaration,
     r#"var { a, b, ...c } = obj;"#,
@@ -2841,7 +2845,8 @@ test!(
     syntax(),
     |_| tr(Config {
         no_symbol: true,
-        set_property: true
+        set_property: true,
+        pure_getters: true
     }),
     set_property_assignment,
     r#"
@@ -2871,7 +2876,8 @@ test!(
     syntax(),
     |_| tr(Config {
         no_symbol: true,
-        set_property: true
+        set_property: true,
+        pure_getters: true
     }),
     set_property_expression,
     r#"
@@ -2923,7 +2929,8 @@ test_exec!(
     syntax(),
     |_| tr(Config {
         no_symbol: true,
-        set_property: true
+        set_property: true,
+        pure_getters: true
     }),
     set_property_expression_exec,
     r#"
@@ -2943,7 +2950,8 @@ test_exec!(
     syntax(),
     |_| tr(Config {
         no_symbol: true,
-        set_property: true
+        set_property: true,
+        pure_getters: true
     }),
     set_property_no_get_own_property_exec,
     r#"
@@ -2962,7 +2970,8 @@ test_exec!(
     syntax(),
     |_| tr(Config {
         no_symbol: true,
-        set_property: true
+        set_property: true,
+        pure_getters: true
     }),
     set_property_no_object_assign_exec,
     r#"
@@ -3016,7 +3025,8 @@ test!(
     syntax(),
     |_| tr(Config {
         no_symbol: true,
-        set_property: true
+        set_property: true,
+        pure_getters: true
     }),
     statements_for_of_dstr_obj_rest_to_property,
     r#"
@@ -3052,7 +3062,8 @@ test_exec!(
     syntax(),
     |_| tr(Config {
         no_symbol: true,
-        set_property: true
+        set_property: true,
+        pure_getters: true
     }),
     statements_for_of_dstr_obj_rest_to_property_exec,
     r#"
@@ -3068,5 +3079,25 @@ test_exec!(
     }
 
     expect(counter).toEqual(1);
+"#
+);
+
+test_exec!(
+    syntax(),
+    |_| tr(Default::default()),
+    issue_4631,
+    r#"
+let counter = 0
+const b = {}
+const a = {
+	...b,
+	get c() {
+		counter ++
+	}
+}
+
+expect(counter).toEqual(0);
+a.c;a.c;
+expect(counter).toEqual(2);
 "#
 );

--- a/packages/swc-helpers/src/_object_spread_props.js
+++ b/packages/swc-helpers/src/_object_spread_props.js
@@ -1,0 +1,30 @@
+function ownKeys(object, enumerableOnly) {
+  var keys = Object.keys(object);
+  if (Object.getOwnPropertySymbols) {
+    var symbols = Object.getOwnPropertySymbols(object);
+    if (enumerableOnly) {
+      symbols = symbols.filter(function (sym) {
+        return Object.getOwnPropertyDescriptor(object, sym).enumerable;
+      });
+    }
+    keys.push.apply(keys, symbols);
+  }
+  return keys;
+}
+
+export default function _objectSpreadProps(target, source) {
+  source = source != null ? source : {}
+  if (Object.getOwnPropertyDescriptors) {
+    Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
+  } else {
+    ownKeys(Object(source)).forEach(function (key) {
+      Object.defineProperty(
+        target,
+        key,
+        Object.getOwnPropertyDescriptor(source, key)
+      );
+    });
+  }
+
+  return target;
+}

--- a/packages/swc-helpers/src/index.js
+++ b/packages/swc-helpers/src/index.js
@@ -56,6 +56,7 @@ export { default as newArrowCheck } from './_new_arrow_check';
 export { default as nonIterableRest } from './_non_iterable_rest';
 export { default as nonIterableSpread } from './_non_iterable_spread';
 export { default as objectSpread } from './_object_spread';
+export { default as objectSpreadProps } from './_object_spread_props';
 export { default as objectWithoutProperties } from './_object_without_properties';
 export { default as objectWithoutPropertiesLoose } from './_object_without_properties_loose';
 export { default as possibleConstructorReturn } from './_possible_constructor_return';


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

So, for following code
```js
({...a, b , ...c, c})
```

At first, I tried to copy babel's behavior, which would be
```js
_objectSpread(
  _objectSpread(
    _objectSpread({}, a),
    {},
    {
      b
    },
    c
  ),
  {},
  {
    c
  }
);
``` 

which seems a bit redundant, but it's necessary in babel's case: babel's helper `_objectSpread2`(swc copied `_objectSpread`) would only apply `getOwnPropertyDescriptors` for even targets, so it need an extra empty object for every non spread props, which doesn't seem to be optimal.

So I checkout esbuild and it would do
```js
var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b));

// project/index.ts
__spreadProps(__spreadValues(__spreadValues(__spreadProps(__spreadValues({}, a), { b }), c), d), { c });
```
which is more concise, but doesn't support loose.

So I took the third way, which introduces a new helper `objectSpreadProps` which is alike to `__spreadProps` and let `_objectSpread` remain the same.

This would result in an extra helper, but could reduce generated size and improve performance. I don't if it's the right thing to do.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
closes #4631