### PR TITLE
fix(es/resolver): var xx defined behind the catch(xx) block does not recognize scope correctly

### DIFF
--- a/crates/swc_ecma_transforms_base/tests/resolver/minifier/13/input.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/minifier/13/input.js
@@ -1,0 +1,8 @@
+try {
+    console.log(111);
+} catch (Ic) {
+    throw Ic;
+}
+
+var jc, Ic;
+(Ic = jc).PV = "page_view";

--- a/crates/swc_ecma_transforms_base/tests/resolver/minifier/13/output.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/minifier/13/output.js
@@ -1,0 +1,7 @@
+try {
+    console.log(111);
+} catch (Ic__3) {
+    throw Ic__3;
+}
+var jc__1, Ic__1;
+(Ic__1 = jc__1).PV = "page_view";

--- a/crates/swc_ecma_transforms_base/tests/resolver/minifier/14/input.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/minifier/14/input.js
@@ -1,0 +1,8 @@
+try {
+    console.log(111);
+} catch (Ic) {
+    throw Ic;
+}
+
+export var jc, Ic;
+(Ic = jc).PV = "page_view";

--- a/crates/swc_ecma_transforms_base/tests/resolver/minifier/14/output.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/minifier/14/output.js
@@ -1,0 +1,7 @@
+try {
+    console.log(111);
+} catch (Ic__3) {
+    throw Ic__3;
+}
+export var jc__1, Ic__1;
+(Ic__1 = jc__1).PV = "page_view";


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

the resolver folder does not recognize the following code's scope correctly.

**Input**
```js
try {
    console.log(111);
} catch (Ic) {
    throw Ic;
}

var jc, Ic;
(Ic = jc).PV = "page_view";
```
the `var Ic` appears behind the `catch(Ic)`.

**Expected Output**
```js
try {
    console.log(111);
} catch (Ic__3) {
    throw Ic__3;
}
var jc__1, Ic__1;
(Ic__1 = jc__1).PV = "page_view";
```
the Ic used after `var Ic` should have the same mark as `var Ic`.

**Current Unexpected Output**
```js
try {
    console.log(111);
} catch (Ic__3) {
    throw Ic__3;
}
var jc__1, Ic__1;
(Ic = jc__1).PV = "page_view";
```
Currently `Ic` is treat as `unresolved mark` .

two related test cases added.


**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
