### PR TITLE
perf(html/parser): improve lexer perf

### DIFF
--- a/crates/swc_html_parser/src/lexer/mod.rs
+++ b/crates/swc_html_parser/src/lexer/mod.rs
@@ -390,10 +390,16 @@ where
                 if let Some(attribute) = attributes.last_mut() {
                     if let Some(mut temporary_buffer) = self.temporary_buffer.take() {
                         for c in temporary_buffer.drain(..) {
-                            attribute.name.push(c);
+                            if let Some(old_value) = &mut attribute.value {
+                                old_value.push(c);
+                            } else {
+                                attribute.value = Some(c.to_string());
+                            }
 
-                            if let Some(raw_name) = &mut attribute.raw_name {
-                                raw_name.push(c);
+                            if let Some(raw_value) = &mut attribute.raw_value {
+                                raw_value.push(c);
+                            } else {
+                                attribute.raw_value = Some(c.to_string());
                             }
                         }
                     }
@@ -606,10 +612,14 @@ where
                 if let Some(value) = value {
                     if let Some(old_value) = &mut attribute.value {
                         old_value.push(value.0);
+                    } else {
+                        attribute.value = Some(value.0.to_string());
                     }
 
                     if let Some(raw_value) = &mut attribute.raw_value {
                         raw_value.push(value.1);
+                    } else {
+                        attribute.raw_value = Some(value.1.to_string());
                     }
                 }
             }
@@ -619,11 +629,13 @@ where
     fn append_raw_to_attribute_value(&mut self, before: bool, c: char) {
         if let Some(Tag { attributes, .. }) = &mut self.current_tag_token {
             if let Some(attribute) = attributes.last_mut() {
-                attribute.value = Some("".into());
-
-                let mut raw_new_value = String::new();
+                let mut raw_new_value = String::with_capacity(2);
 
                 if before {
+                    if attribute.value.is_none() {
+                        attribute.value = Some(String::new());
+                    }
+
                     raw_new_value.push(c);
                 }
 
@@ -635,7 +647,7 @@ where
                     raw_new_value.push(c);
                 }
 
-                attribute.raw_value = Some(raw_new_value.into());
+                attribute.raw_value = Some(raw_new_value);
             }
         }
     }

--- a/crates/swc_html_parser/src/lexer/mod.rs
+++ b/crates/swc_html_parser/src/lexer/mod.rs
@@ -454,19 +454,23 @@ where
         if let Some(ref mut token) = self.cur_token {
             match token {
                 Token::StartTag { attributes, .. } | Token::EndTag { attributes, .. } => {
-                    let initial = if let Some(c) = c {
-                        c.to_string()
+                    if let Some(c) = c {
+                        attributes.push(AttributeToken {
+                            span: Default::default(),
+                            name: c.to_string().into(),
+                            raw_name: Some(c.to_string().into()),
+                            value: None,
+                            raw_value: None,
+                        });
                     } else {
-                        "".to_string()
+                        attributes.push(AttributeToken {
+                            span: Default::default(),
+                            name: "".into(),
+                            raw_name: Some("".into()),
+                            value: None,
+                            raw_value: None,
+                        });
                     };
-
-                    attributes.push(AttributeToken {
-                        span: Default::default(),
-                        name: initial.clone().into(),
-                        raw_name: Some(initial.into()),
-                        value: None,
-                        raw_value: None,
-                    });
 
                     self.attribute_start_position = Some(self.cur_pos);
                 }

--- a/crates/swc_html_parser/src/lexer/mod.rs
+++ b/crates/swc_html_parser/src/lexer/mod.rs
@@ -450,6 +450,21 @@ where
         }
     }
 
+    fn append_to_doctype_token(&mut self, system_id: (char, char)) {
+        if let Some(Token::Doctype {
+            system_id: Some(old_system_id),
+            ..
+        }) = &mut self.cur_token
+        {
+            let mut new_system_id = String::new();
+
+            new_system_id.push_str(old_system_id);
+            new_system_id.push(system_id.0);
+
+            *old_system_id = new_system_id.into();
+        }
+    }
+
     fn start_new_attribute(&mut self, c: Option<char>) {
         if let Some(ref mut token) = self.cur_token {
             match token {
@@ -3986,21 +4001,9 @@ where
                     // This is an unexpected-null-character parse error. Append a U+FFFD
                     // REPLACEMENT CHARACTER character to the current DOCTYPE token's system
                     // identifier.
-                    Some('\x00') => {
+                    Some(c @ '\x00') => {
                         self.emit_error(ErrorKind::UnexpectedNullCharacter);
-
-                        if let Some(Token::Doctype {
-                            system_id: Some(system_id),
-                            ..
-                        }) = &mut self.cur_token
-                        {
-                            let mut new_system_id = String::new();
-
-                            new_system_id.push_str(system_id);
-                            new_system_id.push(REPLACEMENT_CHARACTER);
-
-                            *system_id = new_system_id.into();
-                        }
+                        self.append_to_doctype_token((REPLACEMENT_CHARACTER, c));
                     }
                     // U+003E GREATER-THAN SIGN (>)
                     // This is an abrupt-doctype-system-identifier parse error. Set the current
@@ -4036,18 +4039,7 @@ where
                     // Append the current input character to the current DOCTYPE token's system
                     // identifier.
                     Some(c) => {
-                        if let Some(Token::Doctype {
-                            system_id: Some(system_id),
-                            ..
-                        }) = &mut self.cur_token
-                        {
-                            let mut new_system_id = String::new();
-
-                            new_system_id.push_str(system_id);
-                            new_system_id.push(c);
-
-                            *system_id = new_system_id.into();
-                        }
+                        self.append_to_doctype_token((c, c));
                     }
                 }
             }
@@ -4064,21 +4056,9 @@ where
                     // This is an unexpected-null-character parse error. Append a U+FFFD
                     // REPLACEMENT CHARACTER character to the current DOCTYPE token's system
                     // identifier.
-                    Some('\x00') => {
+                    Some(c @ '\x00') => {
                         self.emit_error(ErrorKind::UnexpectedNullCharacter);
-
-                        if let Some(Token::Doctype {
-                            system_id: Some(system_id),
-                            ..
-                        }) = &mut self.cur_token
-                        {
-                            let mut new_system_id = String::new();
-
-                            new_system_id.push_str(system_id);
-                            new_system_id.push(REPLACEMENT_CHARACTER);
-
-                            *system_id = new_system_id.into();
-                        }
+                        self.append_to_doctype_token((REPLACEMENT_CHARACTER, c));
                     }
                     // U+003E GREATER-THAN SIGN (>)
                     // This is an abrupt-doctype-system-identifier parse error. Set the current
@@ -4114,18 +4094,7 @@ where
                     // Append the current input character to the current DOCTYPE token's system
                     // identifier.
                     Some(c) => {
-                        if let Some(Token::Doctype {
-                            system_id: Some(system_id),
-                            ..
-                        }) = &mut self.cur_token
-                        {
-                            let mut new_system_id = String::new();
-
-                            new_system_id.push_str(system_id);
-                            new_system_id.push(c);
-
-                            *system_id = new_system_id.into();
-                        }
+                        self.append_to_doctype_token((c, c));
                     }
                 }
             }

--- a/crates/swc_html_parser/src/lexer/mod.rs
+++ b/crates/swc_html_parser/src/lexer/mod.rs
@@ -465,6 +465,12 @@ where
         }
     }
 
+    fn set_force_quirks(&mut self) {
+        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
+            *force_quirks = true;
+        }
+    }
+
     fn start_new_attribute(&mut self, c: Option<char>) {
         if let Some(ref mut token) = self.cur_token {
             match token {
@@ -3138,11 +3144,7 @@ where
                     // end-of-file token.
                     None => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.emit_cur_token();
                         self.emit_token(Token::Eof);
 
@@ -3197,11 +3199,7 @@ where
                     // end-of-file token.
                     None => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.emit_cur_token();
                         self.emit_token(Token::Eof);
 
@@ -3263,13 +3261,7 @@ where
                                 self.emit_error(
                                     ErrorKind::InvalidCharacterSequenceAfterDoctypeName,
                                 );
-
-                                if let Some(Token::Doctype { force_quirks, .. }) =
-                                    &mut self.cur_token
-                                {
-                                    *force_quirks = true;
-                                }
-
+                                self.set_force_quirks();
                                 self.reconsume_in_state(State::BogusDoctype);
                             }
                         }
@@ -3335,11 +3327,7 @@ where
                     // the current DOCTYPE token.
                     Some('>') => {
                         self.emit_error(ErrorKind::MissingDoctypePublicIdentifier);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.state = State::Data;
                         self.emit_cur_token();
                     }
@@ -3349,11 +3337,7 @@ where
                     // end-of-file token.
                     None => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.emit_cur_token();
                         self.emit_token(Token::Eof);
 
@@ -3365,11 +3349,7 @@ where
                     // bogus DOCTYPE state.
                     _ => {
                         self.emit_error(ErrorKind::MissingQuoteBeforeDoctypePublicIdentifier);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.reconsume_in_state(State::BogusDoctype);
                     }
                 }
@@ -3426,13 +3406,8 @@ where
                     // the current DOCTYPE token.
                     Some('>') => {
                         self.emit_error(ErrorKind::MissingDoctypePublicIdentifier);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.state = State::Data;
-
                         self.emit_cur_token();
                     }
                     // EOF
@@ -3441,11 +3416,7 @@ where
                     // end-of-file token.
                     None => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.emit_cur_token();
                         self.emit_token(Token::Eof);
 
@@ -3457,11 +3428,7 @@ where
                     // bogus DOCTYPE state.
                     _ => {
                         self.emit_error(ErrorKind::MissingQuoteBeforeDoctypePublicIdentifier);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.reconsume_in_state(State::BogusDoctype);
                     }
                 }
@@ -3501,11 +3468,7 @@ where
                     // the current DOCTYPE token.
                     Some('>') => {
                         self.emit_error(ErrorKind::AbruptDoctypePublicIdentifier);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.state = State::Data;
                         self.emit_cur_token();
                     }
@@ -3515,11 +3478,7 @@ where
                     // end-of-file token.
                     None => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.emit_cur_token();
                         self.emit_token(Token::Eof);
 
@@ -3579,11 +3538,7 @@ where
                     // the current DOCTYPE token.
                     Some('>') => {
                         self.emit_error(ErrorKind::AbruptDoctypePublicIdentifier);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.state = State::Data;
                         self.emit_cur_token();
                     }
@@ -3593,11 +3548,7 @@ where
                     // end-of-file token.
                     None => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.emit_cur_token();
                         self.emit_token(Token::Eof);
 
@@ -3691,11 +3642,7 @@ where
                     // end-of-file token.
                     None => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.emit_cur_token();
                         self.emit_token(Token::Eof);
 
@@ -3707,11 +3654,7 @@ where
                     // bogus DOCTYPE state.
                     _ => {
                         self.emit_error(ErrorKind::MissingQuoteBeforeDoctypeSystemIdentifier);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.reconsume_in_state(State::BogusDoctype);
                     }
                 }
@@ -3774,11 +3717,7 @@ where
                     // end-of-file token.
                     None => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.emit_cur_token();
                         self.emit_token(Token::Eof);
 
@@ -3790,11 +3729,7 @@ where
                     // bogus DOCTYPE state
                     _ => {
                         self.emit_error(ErrorKind::MissingQuoteBeforeDoctypeSystemIdentifier);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.reconsume_in_state(State::BogusDoctype);
                     }
                 }
@@ -3858,11 +3793,7 @@ where
                     // the current DOCTYPE token.
                     Some('>') => {
                         self.emit_error(ErrorKind::MissingDoctypeSystemIdentifier);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.state = State::Data;
                         self.emit_cur_token();
                     }
@@ -3872,11 +3803,7 @@ where
                     // end-of-file token.
                     None => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.emit_cur_token();
                         self.emit_token(Token::Eof);
 
@@ -3888,11 +3815,7 @@ where
                     // bogus DOCTYPE state.
                     _ => {
                         self.emit_error(ErrorKind::MissingQuoteBeforeDoctypeSystemIdentifier);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.reconsume_in_state(State::BogusDoctype);
                     }
                 }
@@ -3949,11 +3872,7 @@ where
                     // the current DOCTYPE token.
                     Some('>') => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.state = State::Data;
                         self.emit_cur_token();
                     }
@@ -3963,11 +3882,7 @@ where
                     // end-of-file token.
                     None => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.emit_cur_token();
                         self.emit_token(Token::Eof);
 
@@ -3979,11 +3894,7 @@ where
                     // bogus DOCTYPE state.
                     _ => {
                         self.emit_error(ErrorKind::MissingQuoteBeforeDoctypeSystemIdentifier);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.reconsume_in_state(State::BogusDoctype);
                     }
                 }
@@ -4011,11 +3922,7 @@ where
                     // the current DOCTYPE token.
                     Some('>') => {
                         self.emit_error(ErrorKind::AbruptDoctypeSystemIdentifier);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.state = State::Data;
                         self.emit_cur_token();
                     }
@@ -4025,11 +3932,7 @@ where
                     // end-of-file token.
                     None => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.emit_cur_token();
                         self.emit_token(Token::Eof);
 
@@ -4066,11 +3969,7 @@ where
                     // the current DOCTYPE token.
                     Some('>') => {
                         self.emit_error(ErrorKind::AbruptDoctypeSystemIdentifier);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.state = State::Data;
                         self.emit_cur_token();
                     }
@@ -4080,11 +3979,7 @@ where
                     // end-of-file token.
                     None => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.emit_cur_token();
                         self.emit_token(Token::Eof);
 
@@ -4122,11 +4017,7 @@ where
                     // end-of-file token.
                     None => {
                         self.emit_error(ErrorKind::EofInDoctype);
-
-                        if let Some(Token::Doctype { force_quirks, .. }) = &mut self.cur_token {
-                            *force_quirks = true;
-                        }
-
+                        self.set_force_quirks();
                         self.emit_cur_token();
                         self.emit_token(Token::Eof);
 

--- a/crates/swc_html_parser/tests/fixture.rs
+++ b/crates/swc_html_parser/tests/fixture.rs
@@ -584,12 +584,6 @@ fn html5lib_test_tokenizer(input: PathBuf) {
                     .expect("failed to get lastStartTag in test");
 
                 lexer.set_last_start_tag_name(&last_start_tag);
-                lexer.set_last_start_tag_token(Token::StartTag {
-                    tag_name: last_start_tag.into(),
-                    raw_tag_name: None,
-                    self_closing: false,
-                    attributes: vec![],
-                });
             }
 
             let mut actual_tokens = vec![];

--- a/crates/swc_html_parser/tests/fixture.rs
+++ b/crates/swc_html_parser/tests/fixture.rs
@@ -1,9 +1,10 @@
+#![deny(warnings)]
 #![allow(clippy::if_same_then_else)]
 #![allow(clippy::needless_update)]
 #![allow(clippy::redundant_clone)]
 #![allow(clippy::while_let_on_iterator)]
 
-use std::{fs, mem::take, path::PathBuf, time::Instant};
+use std::{fs, mem::take, path::PathBuf};
 
 use serde_json::Value;
 use swc_atoms::JsWord;
@@ -26,19 +27,7 @@ fn document_test(input: PathBuf, config: ParserConfig) {
     testing::run_test2(false, |cm, handler| {
         let json_path = input.parent().unwrap().join("output.json");
         let fm = cm.load_file(&input).unwrap();
-
-        let start = Instant::now();
-
         let lexer = Lexer::new(SourceFileInput::from(&*fm));
-
-        for t in lexer {}
-
-        let elapsed = start.elapsed();
-
-        println!("Debug: {:?}", elapsed);
-
-        unreachable!();
-
         let mut parser = Parser::new(lexer, config);
         let document: PResult<Document> = parser.parse_document();
         let errors = parser.take_errors();
@@ -422,7 +411,7 @@ impl VisitMut for DomVisualizer<'_> {
     }
 }
 
-#[testing::fixture("tests/fixture/pages/**/*.html")]
+#[testing::fixture("tests/fixture/**/*.html")]
 fn pass(input: PathBuf) {
     document_test(
         input,
@@ -595,6 +584,12 @@ fn html5lib_test_tokenizer(input: PathBuf) {
                     .expect("failed to get lastStartTag in test");
 
                 lexer.set_last_start_tag_name(&last_start_tag);
+                lexer.set_last_start_tag_token(Token::StartTag {
+                    tag_name: last_start_tag.into(),
+                    raw_tag_name: None,
+                    self_closing: false,
+                    attributes: vec![],
+                });
             }
 
             let mut actual_tokens = vec![];

--- a/crates/swc_html_parser/tests/fixture.rs
+++ b/crates/swc_html_parser/tests/fixture.rs
@@ -1,10 +1,9 @@
-#![deny(warnings)]
 #![allow(clippy::if_same_then_else)]
 #![allow(clippy::needless_update)]
 #![allow(clippy::redundant_clone)]
 #![allow(clippy::while_let_on_iterator)]
 
-use std::{fs, mem::take, path::PathBuf};
+use std::{fs, mem::take, path::PathBuf, time::Instant};
 
 use serde_json::Value;
 use swc_atoms::JsWord;
@@ -27,7 +26,19 @@ fn document_test(input: PathBuf, config: ParserConfig) {
     testing::run_test2(false, |cm, handler| {
         let json_path = input.parent().unwrap().join("output.json");
         let fm = cm.load_file(&input).unwrap();
+
+        let start = Instant::now();
+
         let lexer = Lexer::new(SourceFileInput::from(&*fm));
+
+        for t in lexer {}
+
+        let elapsed = start.elapsed();
+
+        println!("Debug: {:?}", elapsed);
+
+        unreachable!();
+
         let mut parser = Parser::new(lexer, config);
         let document: PResult<Document> = parser.parse_document();
         let errors = parser.take_errors();
@@ -411,7 +422,7 @@ impl VisitMut for DomVisualizer<'_> {
     }
 }
 
-#[testing::fixture("tests/fixture/**/*.html")]
+#[testing::fixture("tests/fixture/pages/**/*.html")]
 fn pass(input: PathBuf) {
     document_test(
         input,


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Improve perf of lexer + simplify code, there are still more places, but I will improve it after merge it.

Parsing stackoverflow from benches:

Before:
```
html/lexer/stackoverflow_com_17_05_2022
                        time:   [71.986 ms 72.358 ms 72.837 ms]
                        change: [-2.5210% -1.8364% -1.0132%] (p = 0.00 < 0.05)
                        Performance has improved.
```

After:
```
html/lexer/stackoverflow_com_17_05_2022
                        time:   [11.193 ms 11.224 ms 11.260 ms]
                        change: [-84.599% -84.488% -84.390%] (p = 0.00 < 0.05)
```

**BREAKING CHANGE:**

No

**Related issue (if exists):**

No