### PR TITLE
perf(es/minifier): Make name mangler parallel

### DIFF
--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
@@ -31,8 +31,13 @@ impl Analyzer {
             .map(|v| v.0)
             .collect::<FxHashSet<_>>();
         preserved_symbols.extend(unresolved.iter().cloned());
-        self.scope
-            .rename(&mut map, &Default::default(), preserved, &preserved_symbols);
+        self.scope.rename(
+            &mut map,
+            &Default::default(),
+            &Default::default(),
+            preserved,
+            &preserved_symbols,
+        );
 
         map
     }

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
@@ -31,12 +31,16 @@ impl Analyzer {
             .map(|v| v.0)
             .collect::<FxHashSet<_>>();
         preserved_symbols.extend(unresolved.iter().cloned());
+
+        let cost = self.scope.rename_cost();
+
         self.scope.rename(
             &mut map,
             &Default::default(),
             &Default::default(),
             preserved,
             &preserved_symbols,
+            cost > 256,
         );
 
         map

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/mod.rs
@@ -40,7 +40,7 @@ impl Analyzer {
             &Default::default(),
             preserved,
             &preserved_symbols,
-            cost > 256,
+            cost > 1024,
         );
 
         map

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
@@ -108,6 +108,12 @@ impl Scope {
             })
             .collect::<Vec<_>>();
 
+        if cfg!(debug_assertions) {
+            for (k, _) in iter.clone().into_iter().flatten() {
+                assert!(to.contains_key(&k), "Duplicate entry?");
+            }
+        }
+
         to.extend(iter.into_iter().flatten());
     }
 

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+#[allow(unused)]
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::{js_word, JsWord};
@@ -88,9 +89,12 @@ impl Scope {
             preserved_symbols,
         );
 
-        let iter = self
-            .children
-            .par_iter_mut()
+        #[cfg(not(target_arch = "wasm32"))]
+        let iter = self.children.par_iter_mut();
+        #[cfg(target_arch = "wasm32")]
+        let iter = self.children.iter_mut();
+
+        let iter = iter
             .map(|child| {
                 let mut new_map = HashMap::default();
                 child.rename(

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
@@ -6,7 +6,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::{js_word, JsWord};
 use swc_common::{collections::AHashMap, util::take::Take};
 use swc_ecma_ast::Id;
-use tracing::{debug, error};
+use tracing::debug;
 
 use crate::util::base54;
 
@@ -108,15 +108,9 @@ impl Scope {
             })
             .collect::<Vec<_>>();
 
-        if cfg!(debug_assertions) {
-            for (k, v) in iter.clone().into_iter().flatten() {
-                if to.contains_key(&k) {
-                    error!("Duplicate entry?: {}{:?} => {}", k.0, k.1, v);
-                }
-            }
+        for (k, v) in iter.into_iter().flatten() {
+            to.entry(k).or_insert(v);
         }
-
-        to.extend(iter.into_iter().flatten());
     }
 
     #[inline(never)]

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
@@ -110,7 +110,7 @@ impl Scope {
 
         if cfg!(debug_assertions) {
             for (k, _) in iter.clone().into_iter().flatten() {
-                assert!(to.contains_key(&k), "Duplicate entry?");
+                assert!(!to.contains_key(&k), "Duplicate entry?");
             }
         }
 

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/analyzer/scope.rs
@@ -6,7 +6,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::{js_word, JsWord};
 use swc_common::{collections::AHashMap, util::take::Take};
 use swc_ecma_ast::Id;
-use tracing::debug;
+use tracing::{debug, error};
 
 use crate::util::base54;
 
@@ -109,8 +109,10 @@ impl Scope {
             .collect::<Vec<_>>();
 
         if cfg!(debug_assertions) {
-            for (k, _) in iter.clone().into_iter().flatten() {
-                assert!(!to.contains_key(&k), "Duplicate entry?");
+            for (k, v) in iter.clone().into_iter().flatten() {
+                if to.contains_key(&k) {
+                    error!("Duplicate entry?: {}{:?} => {}", k.0, k.1, v);
+                }
             }
         }
 

--- a/crates/swc_ecma_preset_env/data/core-js-compat/data.json
+++ b/crates/swc_ecma_preset_env/data/core-js-compat/data.json
@@ -457,6 +457,7 @@
     "deno": "1.0",
     "edge": "14",
     "electron": "1.4",
+    "firefox": "102",
     "ios": "10.0",
     "node": "7.0",
     "opera": "40",
@@ -745,7 +746,6 @@
     "node": "0.11.9",
     "opera": "19",
     "opera_mobile": "19",
-    "rhino": "1.7.14",
     "safari": "7.1",
     "samsung": "2.0"
   },
@@ -1934,6 +1934,7 @@
     "node": "10.4",
     "opera": "54",
     "opera_mobile": "48",
+    "rhino": "1.7.14",
     "safari": "11.0",
     "samsung": "9.0"
   },
@@ -1976,6 +1977,7 @@
     "node": "10.4",
     "opera": "54",
     "opera_mobile": "48",
+    "rhino": "1.7.14",
     "safari": "13.0.3",
     "samsung": "9.0"
   },
@@ -2561,7 +2563,6 @@
     "node": "8.3",
     "opera": "46",
     "opera_mobile": "43",
-    "rhino": "1.7.13",
     "safari": "12.1",
     "samsung": "7.0"
   },
@@ -3260,7 +3261,6 @@
     "node": "0.11.0",
     "opera": "16",
     "opera_mobile": "16",
-    "rhino": "1.7.14",
     "safari": "7.1",
     "samsung": "1.5"
   },


### PR DESCRIPTION
### `main`


```
Profiling target/release/deps/full-1c2407c1e9bfa73a with template 'Time Profiler'
Running "xcrun" "xctrace" "record" "--template" "Time Profiler" "--output" "/Users/kdy1/projects/master-swc/target/instruments/full-1c2407c1e9bfa73a_Time-Profiler_2022-05-27_165158-311.trace" "--target-stdin" "/dev/ttys003" "--target-stdout" "/dev/ttys003" "--launch" "--" "/Users/kdy1/projects/master-swc/target/release/deps/full-1c2407c1e9bfa73a" "--bench"
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
Benchmarking es/minify/libraries/antd
Benchmarking es/minify/libraries/antd: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.6s.
Benchmarking es/minify/libraries/antd: Collecting 10 samples in estimated 7.5986 s (10 iterations)
Benchmarking es/minify/libraries/antd: Analyzing
es/minify/libraries/antd
                        time:   [754.46 ms 757.18 ms 759.96 ms]
                        change: [-0.7353% -0.1297% +0.4174%] (p = 0.68 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/d3
Benchmarking es/minify/libraries/d3: Warming up for 3.0000 s
Benchmarking es/minify/libraries/d3: Collecting 10 samples in estimated 6.4226 s (30 iterations)
Benchmarking es/minify/libraries/d3: Analyzing
es/minify/libraries/d3  time:   [212.71 ms 213.48 ms 214.15 ms]
                        change: [+0.1972% +0.6635% +1.1494%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
Benchmarking es/minify/libraries/echarts
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.8s.
Benchmarking es/minify/libraries/echarts: Collecting 10 samples in estimated 8.7848 s (10 iterations)
Benchmarking es/minify/libraries/echarts: Analyzing
es/minify/libraries/echarts
                        time:   [877.00 ms 877.90 ms 878.83 ms]
                        change: [+0.0818% +0.4058% +0.7097%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/jquery
Benchmarking es/minify/libraries/jquery: Warming up for 3.0000 s
Benchmarking es/minify/libraries/jquery: Collecting 10 samples in estimated 5.1556 s (110 iterations)
Benchmarking es/minify/libraries/jquery: Analyzing
es/minify/libraries/jquery
                        time:   [46.731 ms 46.820 ms 46.906 ms]
                        change: [-1.3722% -0.6288% -0.0310%] (p = 0.09 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/lodash
Benchmarking es/minify/libraries/lodash: Warming up for 3.0000 s
Benchmarking es/minify/libraries/lodash: Collecting 10 samples in estimated 7.3949 s (110 iterations)
Benchmarking es/minify/libraries/lodash: Analyzing
es/minify/libraries/lodash
                        time:   [67.046 ms 67.146 ms 67.240 ms]
                        change: [-0.4402% -0.0075% +0.3834%] (p = 0.98 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
Benchmarking es/minify/libraries/moment
Benchmarking es/minify/libraries/moment: Warming up for 3.0000 s
Benchmarking es/minify/libraries/moment: Collecting 10 samples in estimated 6.0084 s (220 iterations)
Benchmarking es/minify/libraries/moment: Analyzing
es/minify/libraries/moment
                        time:   [27.120 ms 27.213 ms 27.292 ms]
                        change: [-1.7026% -0.8067% +0.1103%] (p = 0.12 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/react
Benchmarking es/minify/libraries/react: Warming up for 3.0000 s
Benchmarking es/minify/libraries/react: Collecting 10 samples in estimated 5.0442 s (495 iterations)
Benchmarking es/minify/libraries/react: Analyzing
es/minify/libraries/react
                        time:   [10.043 ms 10.103 ms 10.159 ms]
                        change: [-0.9174% -0.0308% +0.8374%] (p = 0.95 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/terser
Benchmarking es/minify/libraries/terser: Warming up for 3.0000 s
Benchmarking es/minify/libraries/terser: Collecting 10 samples in estimated 6.8859 s (20 iterations)
Benchmarking es/minify/libraries/terser: Analyzing
es/minify/libraries/terser
                        time:   [341.33 ms 342.13 ms 342.97 ms]
                        change: [-0.1963% +0.1845% +0.5836%] (p = 0.39 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/three
Benchmarking es/minify/libraries/three: Warming up for 3.0000 s
Benchmarking es/minify/libraries/three: Collecting 10 samples in estimated 5.0867 s (20 iterations)
Benchmarking es/minify/libraries/three: Analyzing
es/minify/libraries/three
                        time:   [254.18 ms 254.97 ms 255.84 ms]
                        change: [-0.6463% +0.2612% +1.0023%] (p = 0.60 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/typescript
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 17.3s.
Benchmarking es/minify/libraries/typescript: Collecting 10 samples in estimated 17.336 s (10 iterations)
Benchmarking es/minify/libraries/typescript: Analyzing
es/minify/libraries/typescript
                        time:   [1.7253 s 1.7283 s 1.7318 s]
                        change: [-0.0612% +0.1892% +0.4679%] (p = 0.21 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/victory
Benchmarking es/minify/libraries/victory: Warming up for 3.0000 s
Benchmarking es/minify/libraries/victory: Collecting 10 samples in estimated 6.5128 s (20 iterations)
Benchmarking es/minify/libraries/victory: Analyzing
es/minify/libraries/victory
                        time:   [320.20 ms 321.11 ms 321.89 ms]
                        change: [-0.1605% +0.1830% +0.4972%] (p = 0.30 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
Benchmarking es/minify/libraries/vue
Benchmarking es/minify/libraries/vue: Warming up for 3.0000 s
Benchmarking es/minify/libraries/vue: Collecting 10 samples in estimated 7.8137 s (110 iterations)
Benchmarking es/minify/libraries/vue: Analyzing
es/minify/libraries/vue time:   [70.717 ms 70.935 ms 71.185 ms]
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high severe

Trace file target/instruments/full-1c2407c1e9bfa73a_Time-Profiler_2022-05-27_165158-311.trace

```


### new

```
Profiling target/release/deps/full-f0d04e016f0d00dd with template 'Time Profiler'
Running "xcrun" "xctrace" "record" "--template" "Time Profiler" "--output" "/Users/kdy1/projects/s/perf/target/instruments/full-f0d04e016f0d00dd_Time-Profiler_2022-05-27_165515-141.trace" "--target-stdin" "/dev/ttys000" "--target-stdout" "/dev/ttys000" "--launch" "--" "/Users/kdy1/projects/s/perf/target/release/deps/full-f0d04e016f0d00dd" "--bench"
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
Benchmarking es/minify/libraries/antd
Benchmarking es/minify/libraries/antd: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.7s.
Benchmarking es/minify/libraries/antd: Collecting 10 samples in estimated 7.6981 s (10 iterations)
Benchmarking es/minify/libraries/antd: Analyzing
es/minify/libraries/antd
                        time:   [763.56 ms 765.80 ms 768.31 ms]
                        change: [+0.5136% +1.1201% +1.6816%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/d3
Benchmarking es/minify/libraries/d3: Warming up for 3.0000 s
Benchmarking es/minify/libraries/d3: Collecting 10 samples in estimated 6.1701 s (30 iterations)
Benchmarking es/minify/libraries/d3: Analyzing
es/minify/libraries/d3  time:   [196.99 ms 197.81 ms 198.71 ms]
                        change: [-1.3967% -0.6343% +0.1085%] (p = 0.14 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/echarts
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.4s.
Benchmarking es/minify/libraries/echarts: Collecting 10 samples in estimated 8.4156 s (10 iterations)
Benchmarking es/minify/libraries/echarts: Analyzing
es/minify/libraries/echarts
                        time:   [839.17 ms 841.54 ms 843.96 ms]
                        change: [+0.3052% +0.6596% +1.0442%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/jquery
Benchmarking es/minify/libraries/jquery: Warming up for 3.0000 s
Benchmarking es/minify/libraries/jquery: Collecting 10 samples in estimated 5.1851 s (110 iterations)
Benchmarking es/minify/libraries/jquery: Analyzing
es/minify/libraries/jquery
                        time:   [46.612 ms 46.767 ms 46.912 ms]
                        change: [-1.9001% -1.0882% -0.3897%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/lodash
Benchmarking es/minify/libraries/lodash: Warming up for 3.0000 s
Benchmarking es/minify/libraries/lodash: Collecting 10 samples in estimated 7.5030 s (110 iterations)
Benchmarking es/minify/libraries/lodash: Analyzing
es/minify/libraries/lodash
                        time:   [67.738 ms 68.235 ms 68.718 ms]
                        change: [-0.7010% +0.0793% +0.9195%] (p = 0.86 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/moment
Benchmarking es/minify/libraries/moment: Warming up for 3.0000 s
Benchmarking es/minify/libraries/moment: Collecting 10 samples in estimated 6.0765 s (220 iterations)
Benchmarking es/minify/libraries/moment: Analyzing
es/minify/libraries/moment
                        time:   [27.615 ms 27.760 ms 27.914 ms]
                        change: [+0.4842% +2.2794% +5.1690%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/react
Benchmarking es/minify/libraries/react: Warming up for 3.0000 s
Benchmarking es/minify/libraries/react: Collecting 10 samples in estimated 5.1213 s (495 iterations)
Benchmarking es/minify/libraries/react: Analyzing
es/minify/libraries/react
                        time:   [10.197 ms 10.287 ms 10.358 ms]
                        change: [-1.4604% -0.4471% +0.6749%] (p = 0.44 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/terser
Benchmarking es/minify/libraries/terser: Warming up for 3.0000 s
Benchmarking es/minify/libraries/terser: Collecting 10 samples in estimated 6.9044 s (20 iterations)
Benchmarking es/minify/libraries/terser: Analyzing
es/minify/libraries/terser
                        time:   [343.64 ms 344.59 ms 345.56 ms]
                        change: [-0.7083% -0.2487% +0.1889%] (p = 0.31 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/three
Benchmarking es/minify/libraries/three: Warming up for 3.0000 s
Benchmarking es/minify/libraries/three: Collecting 10 samples in estimated 5.1162 s (20 iterations)
Benchmarking es/minify/libraries/three: Analyzing
es/minify/libraries/three
                        time:   [256.00 ms 257.64 ms 260.05 ms]
                        change: [+1.2397% +2.1373% +3.1505%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/typescript
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 17.4s.
Benchmarking es/minify/libraries/typescript: Collecting 10 samples in estimated 17.443 s (10 iterations)
Benchmarking es/minify/libraries/typescript: Analyzing
es/minify/libraries/typescript
                        time:   [1.7216 s 1.7256 s 1.7299 s]
                        change: [-0.4567% -0.0403% +0.3556%] (p = 0.86 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
Benchmarking es/minify/libraries/victory
Benchmarking es/minify/libraries/victory: Warming up for 3.0000 s
Benchmarking es/minify/libraries/victory: Collecting 10 samples in estimated 6.4633 s (20 iterations)
Benchmarking es/minify/libraries/victory: Analyzing
es/minify/libraries/victory
                        time:   [319.80 ms 321.10 ms 322.57 ms]
                        change: [+0.3960% +0.8699% +1.4319%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/vue
Benchmarking es/minify/libraries/vue: Warming up for 3.0000 s
Benchmarking es/minify/libraries/vue: Collecting 10 samples in estimated 7.8218 s (110 iterations)
Benchmarking es/minify/libraries/vue: Analyzing
es/minify/libraries/vue time:   [70.460 ms 70.792 ms 71.055 ms]
                        change: [-0.7436% +0.4281% +1.6724%] (p = 0.52 > 0.05)
                        No change in performance detected.
```


### with 1024 as threshold

`--bench -b main`:

```
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.7s.
Benchmarking es/minify/libraries/antd: Collecting 10 samples in estimated 7.6757 s (10 iterations)
Benchmarking es/minify/libraries/antd: Analyzing
es/minify/libraries/antd
                        time:   [757.96 ms 759.76 ms 761.76 ms]
                        change: [-0.7362% -0.2546% +0.2411%] (p = 0.34 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
Benchmarking es/minify/libraries/d3
Benchmarking es/minify/libraries/d3: Warming up for 3.0000 s
Benchmarking es/minify/libraries/d3: Collecting 10 samples in estimated 6.0340 s (30 iterations)
Benchmarking es/minify/libraries/d3: Analyzing
es/minify/libraries/d3  time:   [197.69 ms 199.48 ms 201.99 ms]
                        change: [-6.4840% -5.4645% -4.1206%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/echarts
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.4s.
Benchmarking es/minify/libraries/echarts: Collecting 10 samples in estimated 8.4288 s (10 iterations)
Benchmarking es/minify/libraries/echarts: Analyzing
es/minify/libraries/echarts
                        time:   [842.47 ms 847.43 ms 853.40 ms]
                        change: [-3.6871% -3.0873% -2.3661%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/jquery
Benchmarking es/minify/libraries/jquery: Warming up for 3.0000 s
Benchmarking es/minify/libraries/jquery: Collecting 10 samples in estimated 5.1830 s (110 iterations)
Benchmarking es/minify/libraries/jquery: Analyzing
es/minify/libraries/jquery
                        time:   [46.529 ms 46.668 ms 46.838 ms]
                        change: [+0.5609% +1.2557% +1.9261%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/lodash
Benchmarking es/minify/libraries/lodash: Warming up for 3.0000 s
Benchmarking es/minify/libraries/lodash: Collecting 10 samples in estimated 7.4758 s (110 iterations)
Benchmarking es/minify/libraries/lodash: Analyzing
es/minify/libraries/lodash
                        time:   [67.370 ms 67.807 ms 68.177 ms]
                        change: [+0.3610% +1.1715% +1.8462%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/moment
Benchmarking es/minify/libraries/moment: Warming up for 3.0000 s
Benchmarking es/minify/libraries/moment: Collecting 10 samples in estimated 6.2193 s (220 iterations)
Benchmarking es/minify/libraries/moment: Analyzing
es/minify/libraries/moment
                        time:   [27.178 ms 27.356 ms 27.609 ms]
                        change: [-0.1521% +1.4081% +3.2215%] (p = 0.14 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/react
Benchmarking es/minify/libraries/react: Warming up for 3.0000 s
Benchmarking es/minify/libraries/react: Collecting 10 samples in estimated 5.0328 s (495 iterations)
Benchmarking es/minify/libraries/react: Analyzing
es/minify/libraries/react
                        time:   [10.067 ms 10.127 ms 10.173 ms]
                        change: [-6.8452% -3.1005% +0.1968%] (p = 0.13 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/terser
Benchmarking es/minify/libraries/terser: Warming up for 3.0000 s
Benchmarking es/minify/libraries/terser: Collecting 10 samples in estimated 6.8115 s (20 iterations)
Benchmarking es/minify/libraries/terser: Analyzing
es/minify/libraries/terser
                        time:   [339.24 ms 340.12 ms 340.91 ms]
                        change: [-1.2896% -0.6486% -0.1070%] (p = 0.05 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/three
Benchmarking es/minify/libraries/three: Warming up for 3.0000 s
Benchmarking es/minify/libraries/three: Collecting 10 samples in estimated 5.1065 s (20 iterations)
Benchmarking es/minify/libraries/three: Analyzing
es/minify/libraries/three
                        time:   [253.88 ms 255.05 ms 256.32 ms]
                        change: [+0.7581% +1.3523% +1.9026%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/typescript
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 17.3s.
Benchmarking es/minify/libraries/typescript: Collecting 10 samples in estimated 17.302 s (10 iterations)
Benchmarking es/minify/libraries/typescript: Analyzing
es/minify/libraries/typescript
                        time:   [1.7235 s 1.7265 s 1.7291 s]
                        change: [-0.2322% +0.0639% +0.3640%] (p = 0.70 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) low mild
Benchmarking es/minify/libraries/victory
Benchmarking es/minify/libraries/victory: Warming up for 3.0000 s
Benchmarking es/minify/libraries/victory: Collecting 10 samples in estimated 6.4226 s (20 iterations)
Benchmarking es/minify/libraries/victory: Analyzing
es/minify/libraries/victory
                        time:   [319.54 ms 320.60 ms 321.68 ms]
                        change: [-0.0374% +0.4675% +0.9566%] (p = 0.10 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/vue
Benchmarking es/minify/libraries/vue: Warming up for 3.0000 s
Benchmarking es/minify/libraries/vue: Collecting 10 samples in estimated 7.7857 s (110 iterations)
Benchmarking es/minify/libraries/vue: Analyzing
es/minify/libraries/vue time:   [70.326 ms 70.703 ms 71.180 ms]
                        change: [+1.2887% +2.6367% +4.9749%] (p = 0.01 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

```