### PR TITLE
fix(html/parser): span

### DIFF
--- a/crates/swc_html_parser/src/lexer/mod.rs
+++ b/crates/swc_html_parser/src/lexer/mod.rs
@@ -240,6 +240,10 @@ where
         self.input.cur_pos()
     }
 
+    fn last_pos(&mut self) -> swc_common::BytePos {
+        self.input.last_pos()
+    }
+
     fn take_errors(&mut self) -> Vec<Error> {
         take(&mut self.errors)
     }

--- a/crates/swc_html_parser/src/parser/mod.rs
+++ b/crates/swc_html_parser/src/parser/mod.rs
@@ -8182,7 +8182,7 @@ where
                         }
 
                         let first_pos = text.span.lo();
-                        let last_pos = self.input.last_pos()?;
+                        let last_pos = token_and_info.span.hi();
                         let index = children.len() - 1;
 
                         children[index] = Node::new(Data::Text(Text {

--- a/crates/swc_html_parser/src/parser/mod.rs
+++ b/crates/swc_html_parser/src/parser/mod.rs
@@ -7262,10 +7262,13 @@ where
             self.insert_at_position(appropriate_place, last_node.clone());
 
             // 15.
-            let last_pos = self.input.last_pos()?;
             let new_element = self.create_element_for_token(
                 formatting_element.2.token.clone(),
-                Span::new(formatting_element.2.span.lo(), last_pos, Default::default()),
+                Span::new(
+                    formatting_element.2.span.lo(),
+                    token_and_info.span.hi(),
+                    Default::default(),
+                ),
                 Some(Namespace::HTML),
                 None,
             );
@@ -8238,9 +8241,8 @@ where
         // is the same as that of the element in which the adjusted insertion location
         // finds itself, and insert the newly created node at the adjusted insertion
         // location.
-        let last_pos = self.input.last_pos()?;
         let text = Node::new(Data::Text(Text {
-            span: Span::new(token_and_info.span.lo(), last_pos, Default::default()),
+            span: token_and_info.span,
             value: match &token_and_info.token {
                 Token::Character { value, .. } => value.to_string().into(),
                 _ => {

--- a/crates/swc_html_parser/src/parser/mod.rs
+++ b/crates/swc_html_parser/src/parser/mod.rs
@@ -158,7 +158,7 @@ where
         let last = self.input.last_pos()?;
 
         Ok(Document {
-            span: Span::new(start.lo, last, Default::default()),
+            span: Span::new(start.lo(), last, Default::default()),
             mode: self.document_mode,
             children,
         })
@@ -346,7 +346,7 @@ where
         let last = self.input.last_pos()?;
 
         Ok(DocumentFragment {
-            span: Span::new(start.lo, last, Default::default()),
+            span: Span::new(start.lo(), last, Default::default()),
             children,
         })
     }
@@ -385,15 +385,15 @@ where
 
                         // Elements and text after `</html>` are moving into `<body>`
                         let end_html = match node.end_tag_span.take() {
-                            Some(end_tag_span) => end_tag_span.hi,
-                            _ => element.span.hi,
+                            Some(end_tag_span) => end_tag_span.hi(),
+                            _ => element.span.hi(),
                         };
                         let end_children = match new_children.last() {
-                            Some(Child::DocumentType(DocumentType { span, .. })) => span.hi,
-                            Some(Child::Element(Element { span, .. })) => span.hi,
-                            Some(Child::Comment(Comment { span, .. })) => span.hi,
-                            Some(Child::Text(Text { span, .. })) => span.hi,
-                            _ => element.span.hi,
+                            Some(Child::DocumentType(DocumentType { span, .. })) => span.hi(),
+                            Some(Child::Element(Element { span, .. })) => span.hi(),
+                            Some(Child::Comment(Comment { span, .. })) => span.hi(),
+                            Some(Child::Text(Text { span, .. })) => span.hi(),
+                            _ => element.span.hi(),
                         };
                         let end = if end_html >= end_children {
                             end_html
@@ -402,7 +402,7 @@ where
                         };
 
                         Child::Element(Element {
-                            span: Span::new(element.span.lo, end, Default::default()),
+                            span: Span::new(element.span.lo(), end, Default::default()),
                             children: new_children,
                             content: None,
                             attributes,
@@ -419,15 +419,15 @@ where
 
                         // Elements and text after `</body>` are moving into `<body>`
                         let end_body = match node.end_tag_span.take() {
-                            Some(end_tag_span) => end_tag_span.hi,
-                            _ => element.span.hi,
+                            Some(end_tag_span) => end_tag_span.hi(),
+                            _ => element.span.hi(),
                         };
                         let end_children = match new_children.last() {
-                            Some(Child::DocumentType(DocumentType { span, .. })) => span.hi,
-                            Some(Child::Element(Element { span, .. })) => span.hi,
-                            Some(Child::Comment(Comment { span, .. })) => span.hi,
-                            Some(Child::Text(Text { span, .. })) => span.hi,
-                            _ => element.span.hi,
+                            Some(Child::DocumentType(DocumentType { span, .. })) => span.hi(),
+                            Some(Child::Element(Element { span, .. })) => span.hi(),
+                            Some(Child::Comment(Comment { span, .. })) => span.hi(),
+                            Some(Child::Text(Text { span, .. })) => span.hi(),
+                            _ => element.span.hi(),
                         };
                         let end = if end_body >= end_children {
                             end_body
@@ -436,7 +436,7 @@ where
                         };
 
                         Child::Element(Element {
-                            span: Span::new(element.span.lo, end, Default::default()),
+                            span: Span::new(element.span.lo(), end, Default::default()),
                             children: new_children,
                             content: None,
                             attributes,
@@ -445,16 +445,16 @@ where
                     }
                     "template" if element.namespace == Namespace::HTML => {
                         let end = match node.end_tag_span.take() {
-                            Some(end_tag_span) => end_tag_span.hi,
+                            Some(end_tag_span) => end_tag_span.hi(),
                             _ => match new_children.last() {
-                                Some(Child::DocumentType(DocumentType { span, .. })) => span.hi,
-                                Some(Child::Element(Element { span, .. })) => span.hi,
-                                Some(Child::Comment(Comment { span, .. })) => span.hi,
-                                Some(Child::Text(Text { span, .. })) => span.hi,
-                                _ => element.span.hi,
+                                Some(Child::DocumentType(DocumentType { span, .. })) => span.hi(),
+                                Some(Child::Element(Element { span, .. })) => span.hi(),
+                                Some(Child::Comment(Comment { span, .. })) => span.hi(),
+                                Some(Child::Text(Text { span, .. })) => span.hi(),
+                                _ => element.span.hi(),
                             },
                         };
-                        let span = Span::new(element.span.lo, end, Default::default());
+                        let span = Span::new(element.span.lo(), end, Default::default());
 
                         Child::Element(Element {
                             span,
@@ -469,18 +469,18 @@ where
                     }
                     _ => {
                         let end = match node.end_tag_span.take() {
-                            Some(end_tag_span) => end_tag_span.hi,
+                            Some(end_tag_span) => end_tag_span.hi(),
                             _ => match new_children.last() {
-                                Some(Child::DocumentType(DocumentType { span, .. })) => span.hi,
-                                Some(Child::Element(Element { span, .. })) => span.hi,
-                                Some(Child::Comment(Comment { span, .. })) => span.hi,
-                                Some(Child::Text(Text { span, .. })) => span.hi,
-                                _ => element.span.hi,
+                                Some(Child::DocumentType(DocumentType { span, .. })) => span.hi(),
+                                Some(Child::Element(Element { span, .. })) => span.hi(),
+                                Some(Child::Comment(Comment { span, .. })) => span.hi(),
+                                Some(Child::Text(Text { span, .. })) => span.hi(),
+                                _ => element.span.hi(),
                             },
                         };
 
                         Child::Element(Element {
-                            span: Span::new(element.span.lo, end, Default::default()),
+                            span: Span::new(element.span.lo(), end, Default::default()),
                             children: new_children,
                             content: None,
                             attributes,
@@ -511,7 +511,7 @@ where
                     let token = bump!(self);
 
                     TokenAndInfo {
-                        span: span!(self, span.lo),
+                        span: span!(self, span.lo()),
                         acknowledged: false,
                         token,
                     }
@@ -1309,7 +1309,7 @@ where
                         }
 
                         let document_type = Node::new(Data::DocumentType(DocumentType {
-                            span: span!(self, token_and_info.span.lo),
+                            span: span!(self, token_and_info.span.lo()),
                             name: name.clone(),
                             public_id: public_id.clone(),
                             system_id: system_id.clone(),
@@ -1450,7 +1450,7 @@ where
                         ..
                     } if tag_name == "html" => {
                         let element = Node::new(Data::Element(Element {
-                            span: span!(self, token_and_info.span.lo),
+                            span: span!(self, token_and_info.span.lo()),
                             namespace: Namespace::HTML,
                             tag_name: tag_name.into(),
                             attributes: attributes
@@ -1773,12 +1773,11 @@ where
                     //
                     // 10. Switch the insertion mode to "text".
                     Token::StartTag { tag_name, .. } if tag_name == "script" => {
-                        let last_pos = self.input.last_pos()?;
                         let adjusted_insertion_location =
                             self.get_appropriate_place_for_inserting_node(None)?;
                         let node = self.create_element_for_token(
                             token_and_info.token.clone(),
-                            Span::new(token_and_info.span.lo, last_pos, Default::default()),
+                            token_and_info.span,
                             Some(Namespace::HTML),
                             None,
                         );
@@ -7218,8 +7217,8 @@ where
                 let new_element = self.create_element_for_token(
                     token_and_info.token.clone(),
                     Span::new(
-                        token_and_info.span.lo,
-                        token_and_info.span.hi,
+                        token_and_info.span.lo(),
+                        token_and_info.span.hi(),
                         Default::default(),
                     ),
                     Some(Namespace::HTML),
@@ -7266,7 +7265,7 @@ where
             let last_pos = self.input.last_pos()?;
             let new_element = self.create_element_for_token(
                 formatting_element.2.token.clone(),
-                Span::new(formatting_element.2.span.lo, last_pos, Default::default()),
+                Span::new(formatting_element.2.span.lo(), last_pos, Default::default()),
                 Some(Namespace::HTML),
                 None,
             );
@@ -8082,9 +8081,8 @@ where
         // Create a Comment node whose data attribute is set to data and whose
         // node document is the same as that of the node in which the adjusted
         // insertion location finds itself.
-        let last_pos = self.input.last_pos()?;
         let comment = Node::new(Data::Comment(Comment {
-            span: Span::new(token_and_info.span.lo, last_pos, Default::default()),
+            span: token_and_info.span,
             data: match &token_and_info.token {
                 Token::Comment { data } => data.into(),
                 _ => {
@@ -8183,7 +8181,7 @@ where
                             }
                         }
 
-                        let first_pos = text.span.lo;
+                        let first_pos = text.span.lo();
                         let last_pos = self.input.last_pos()?;
                         let index = children.len() - 1;
 
@@ -8216,8 +8214,8 @@ where
                                     }
                                 }
 
-                                let first_pos = text.span.lo;
-                                let last_pos = self.input.last_pos()?;
+                                let first_pos = text.span.lo();
+                                let last_pos = token_and_info.span.hi();
 
                                 children[i - 1] = Node::new(Data::Text(Text {
                                     span: swc_common::Span::new(
@@ -8242,7 +8240,7 @@ where
         // location.
         let last_pos = self.input.last_pos()?;
         let text = Node::new(Data::Text(Text {
-            span: Span::new(token_and_info.span.lo, last_pos, Default::default()),
+            span: Span::new(token_and_info.span.lo(), last_pos, Default::default()),
             value: match &token_and_info.token {
                 Token::Character { value, .. } => value.to_string().into(),
                 _ => {
@@ -8276,7 +8274,7 @@ where
         let last_pos = self.input.last_pos()?;
         let node = self.create_element_for_token(
             token_and_info.token.clone(),
-            Span::new(token_and_info.span.lo, last_pos, Default::default()),
+            Span::new(token_and_info.span.lo(), last_pos, Default::default()),
             Some(namespace),
             adjust_attributes,
         );

--- a/crates/swc_html_parser/tests/fixture/element/caption/output.json
+++ b/crates/swc_html_parser/tests/fixture/element/caption/output.json
@@ -182,7 +182,7 @@
                   "type": "Element",
                   "span": {
                     "start": 0,
-                    "end": 356,
+                    "end": 348,
                     "ctxt": 0
                   },
                   "tagName": "tbody",
@@ -472,7 +472,7 @@
                       "type": "Text",
                       "span": {
                         "start": 347,
-                        "end": 356,
+                        "end": 348,
                         "ctxt": 0
                       },
                       "value": "\n"

--- a/crates/swc_html_parser/tests/fixture/element/caption/output.json
+++ b/crates/swc_html_parser/tests/fixture/element/caption/output.json
@@ -141,7 +141,7 @@
                   "type": "Text",
                   "span": {
                     "start": 91,
-                    "end": 105,
+                    "end": 96,
                     "ctxt": 0
                   },
                   "value": "\n    "
@@ -173,7 +173,7 @@
                   "type": "Text",
                   "span": {
                     "start": 130,
-                    "end": 139,
+                    "end": 135,
                     "ctxt": 0
                   },
                   "value": "\n    "
@@ -204,7 +204,7 @@
                           "type": "Text",
                           "span": {
                             "start": 139,
-                            "end": 152,
+                            "end": 148,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -236,7 +236,7 @@
                           "type": "Text",
                           "span": {
                             "start": 162,
-                            "end": 175,
+                            "end": 171,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -268,7 +268,7 @@
                           "type": "Text",
                           "span": {
                             "start": 185,
-                            "end": 195,
+                            "end": 190,
                             "ctxt": 0
                           },
                           "value": "\n    "
@@ -280,7 +280,7 @@
                       "type": "Text",
                       "span": {
                         "start": 195,
-                        "end": 204,
+                        "end": 200,
                         "ctxt": 0
                       },
                       "value": "\n    "
@@ -300,7 +300,7 @@
                           "type": "Text",
                           "span": {
                             "start": 204,
-                            "end": 217,
+                            "end": 213,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -332,7 +332,7 @@
                           "type": "Text",
                           "span": {
                             "start": 227,
-                            "end": 240,
+                            "end": 236,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -364,7 +364,7 @@
                           "type": "Text",
                           "span": {
                             "start": 261,
-                            "end": 271,
+                            "end": 266,
                             "ctxt": 0
                           },
                           "value": "\n    "
@@ -376,7 +376,7 @@
                       "type": "Text",
                       "span": {
                         "start": 271,
-                        "end": 280,
+                        "end": 276,
                         "ctxt": 0
                       },
                       "value": "\n    "
@@ -396,7 +396,7 @@
                           "type": "Text",
                           "span": {
                             "start": 280,
-                            "end": 293,
+                            "end": 289,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -428,7 +428,7 @@
                           "type": "Text",
                           "span": {
                             "start": 303,
-                            "end": 316,
+                            "end": 312,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -460,7 +460,7 @@
                           "type": "Text",
                           "span": {
                             "start": 337,
-                            "end": 347,
+                            "end": 342,
                             "ctxt": 0
                           },
                           "value": "\n    "

--- a/crates/swc_html_parser/tests/fixture/element/caption/span.rust-debug
+++ b/crates/swc_html_parser/tests/fixture/element/caption/span.rust-debug
@@ -648,14 +648,16 @@
 
   x Child
     ,-[$DIR/tests/fixture/element/caption/input.html:20:5]
- 20 | ,-> </tr>
- 21 | `-> </table>
+ 20 | </tr>
+    :      ^
+ 21 | </table>
     `----
 
   x Text
     ,-[$DIR/tests/fixture/element/caption/input.html:20:5]
- 20 | ,-> </tr>
- 21 | `-> </table>
+ 20 | </tr>
+    :      ^
+ 21 | </table>
     `----
 
   x Child

--- a/crates/swc_html_parser/tests/fixture/element/colgroup/output.json
+++ b/crates/swc_html_parser/tests/fixture/element/colgroup/output.json
@@ -141,7 +141,7 @@
                   "type": "Text",
                   "span": {
                     "start": 91,
-                    "end": 105,
+                    "end": 96,
                     "ctxt": 0
                   },
                   "value": "\n    "
@@ -173,7 +173,7 @@
                   "type": "Text",
                   "span": {
                     "start": 139,
-                    "end": 154,
+                    "end": 144,
                     "ctxt": 0
                   },
                   "value": "\n    "
@@ -285,7 +285,7 @@
                   "type": "Text",
                   "span": {
                     "start": 227,
-                    "end": 236,
+                    "end": 232,
                     "ctxt": 0
                   },
                   "value": "\n    "
@@ -316,7 +316,7 @@
                           "type": "Text",
                           "span": {
                             "start": 236,
-                            "end": 249,
+                            "end": 245,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -348,7 +348,7 @@
                           "type": "Text",
                           "span": {
                             "start": 256,
-                            "end": 281,
+                            "end": 265,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -393,7 +393,7 @@
                           "type": "Text",
                           "span": {
                             "start": 292,
-                            "end": 317,
+                            "end": 301,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -438,7 +438,7 @@
                           "type": "Text",
                           "span": {
                             "start": 327,
-                            "end": 352,
+                            "end": 336,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -483,7 +483,7 @@
                           "type": "Text",
                           "span": {
                             "start": 366,
-                            "end": 391,
+                            "end": 375,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -528,7 +528,7 @@
                           "type": "Text",
                           "span": {
                             "start": 405,
-                            "end": 415,
+                            "end": 410,
                             "ctxt": 0
                           },
                           "value": "\n    "

--- a/crates/swc_html_parser/tests/fixture/element/colgroup/output.json
+++ b/crates/swc_html_parser/tests/fixture/element/colgroup/output.json
@@ -294,7 +294,7 @@
                   "type": "Element",
                   "span": {
                     "start": 0,
-                    "end": 424,
+                    "end": 416,
                     "ctxt": 0
                   },
                   "tagName": "tbody",
@@ -540,7 +540,7 @@
                       "type": "Text",
                       "span": {
                         "start": 415,
-                        "end": 424,
+                        "end": 416,
                         "ctxt": 0
                       },
                       "value": "\n"

--- a/crates/swc_html_parser/tests/fixture/element/colgroup/span.rust-debug
+++ b/crates/swc_html_parser/tests/fixture/element/colgroup/span.rust-debug
@@ -618,14 +618,16 @@
 
   x Child
     ,-[$DIR/tests/fixture/element/colgroup/input.html:16:5]
- 16 | ,-> </tr>
- 17 | `-> </table>
+ 16 | </tr>
+    :      ^
+ 17 | </table>
     `----
 
   x Text
     ,-[$DIR/tests/fixture/element/colgroup/input.html:16:5]
- 16 | ,-> </tr>
- 17 | `-> </table>
+ 16 | </tr>
+    :      ^
+ 17 | </table>
     `----
 
   x Child

--- a/crates/swc_html_parser/tests/fixture/element/table/output.json
+++ b/crates/swc_html_parser/tests/fixture/element/table/output.json
@@ -270,7 +270,7 @@
                   "type": "Text",
                   "span": {
                     "start": 321,
-                    "end": 334,
+                    "end": 330,
                     "ctxt": 0
                   },
                   "value": "\n        "
@@ -279,7 +279,7 @@
                   "type": "Element",
                   "span": {
                     "start": 0,
-                    "end": 1223,
+                    "end": 1215,
                     "ctxt": 0
                   },
                   "tagName": "tbody",
@@ -301,7 +301,7 @@
                           "type": "Text",
                           "span": {
                             "start": 334,
-                            "end": 351,
+                            "end": 347,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -333,7 +333,7 @@
                           "type": "Text",
                           "span": {
                             "start": 362,
-                            "end": 379,
+                            "end": 375,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -365,7 +365,7 @@
                           "type": "Text",
                           "span": {
                             "start": 390,
-                            "end": 407,
+                            "end": 403,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -397,7 +397,7 @@
                           "type": "Text",
                           "span": {
                             "start": 416,
-                            "end": 433,
+                            "end": 429,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -429,7 +429,7 @@
                           "type": "Text",
                           "span": {
                             "start": 442,
-                            "end": 459,
+                            "end": 455,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -461,7 +461,7 @@
                           "type": "Text",
                           "span": {
                             "start": 468,
-                            "end": 482,
+                            "end": 477,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -473,7 +473,7 @@
                       "type": "Text",
                       "span": {
                         "start": 482,
-                        "end": 495,
+                        "end": 491,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -493,7 +493,7 @@
                           "type": "Text",
                           "span": {
                             "start": 495,
-                            "end": 512,
+                            "end": 508,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -525,7 +525,7 @@
                           "type": "Text",
                           "span": {
                             "start": 522,
-                            "end": 539,
+                            "end": 535,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -557,7 +557,7 @@
                           "type": "Text",
                           "span": {
                             "start": 556,
-                            "end": 573,
+                            "end": 569,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -589,7 +589,7 @@
                           "type": "Text",
                           "span": {
                             "start": 584,
-                            "end": 601,
+                            "end": 597,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -621,7 +621,7 @@
                           "type": "Text",
                           "span": {
                             "start": 615,
-                            "end": 632,
+                            "end": 628,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -653,7 +653,7 @@
                           "type": "Text",
                           "span": {
                             "start": 651,
-                            "end": 665,
+                            "end": 660,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -665,7 +665,7 @@
                       "type": "Text",
                       "span": {
                         "start": 665,
-                        "end": 678,
+                        "end": 674,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -685,7 +685,7 @@
                           "type": "Text",
                           "span": {
                             "start": 678,
-                            "end": 695,
+                            "end": 691,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -717,7 +717,7 @@
                           "type": "Text",
                           "span": {
                             "start": 703,
-                            "end": 720,
+                            "end": 716,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -749,7 +749,7 @@
                           "type": "Text",
                           "span": {
                             "start": 727,
-                            "end": 744,
+                            "end": 740,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -781,7 +781,7 @@
                           "type": "Text",
                           "span": {
                             "start": 750,
-                            "end": 767,
+                            "end": 763,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -813,7 +813,7 @@
                           "type": "Text",
                           "span": {
                             "start": 774,
-                            "end": 791,
+                            "end": 787,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -845,7 +845,7 @@
                           "type": "Text",
                           "span": {
                             "start": 797,
-                            "end": 811,
+                            "end": 806,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -857,7 +857,7 @@
                       "type": "Text",
                       "span": {
                         "start": 811,
-                        "end": 824,
+                        "end": 820,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -877,7 +877,7 @@
                           "type": "Text",
                           "span": {
                             "start": 824,
-                            "end": 841,
+                            "end": 837,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -909,7 +909,7 @@
                           "type": "Text",
                           "span": {
                             "start": 851,
-                            "end": 868,
+                            "end": 864,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -941,7 +941,7 @@
                           "type": "Text",
                           "span": {
                             "start": 886,
-                            "end": 903,
+                            "end": 899,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -973,7 +973,7 @@
                           "type": "Text",
                           "span": {
                             "start": 910,
-                            "end": 927,
+                            "end": 923,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1005,7 +1005,7 @@
                           "type": "Text",
                           "span": {
                             "start": 934,
-                            "end": 951,
+                            "end": 947,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1037,7 +1037,7 @@
                           "type": "Text",
                           "span": {
                             "start": 969,
-                            "end": 983,
+                            "end": 978,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -1049,7 +1049,7 @@
                       "type": "Text",
                       "span": {
                         "start": 983,
-                        "end": 996,
+                        "end": 992,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -1069,7 +1069,7 @@
                           "type": "Text",
                           "span": {
                             "start": 996,
-                            "end": 1013,
+                            "end": 1009,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1101,7 +1101,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1031,
-                            "end": 1048,
+                            "end": 1044,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1133,7 +1133,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1078,
-                            "end": 1095,
+                            "end": 1091,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1165,7 +1165,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1115,
-                            "end": 1132,
+                            "end": 1128,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1197,7 +1197,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1149,
-                            "end": 1166,
+                            "end": 1162,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1229,7 +1229,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1196,
-                            "end": 1210,
+                            "end": 1205,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -1241,7 +1241,7 @@
                       "type": "Text",
                       "span": {
                         "start": 1210,
-                        "end": 1223,
+                        "end": 1215,
                         "ctxt": 0
                       },
                       "value": "\n    "
@@ -1276,7 +1276,7 @@
                   "type": "Text",
                   "span": {
                     "start": 1236,
-                    "end": 1252,
+                    "end": 1245,
                     "ctxt": 0
                   },
                   "value": "\n        "
@@ -1296,7 +1296,7 @@
                       "type": "Text",
                       "span": {
                         "start": 1252,
-                        "end": 1265,
+                        "end": 1261,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -1316,7 +1316,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1265,
-                            "end": 1282,
+                            "end": 1278,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1348,7 +1348,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1297,
-                            "end": 1314,
+                            "end": 1310,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1380,7 +1380,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1323,
-                            "end": 1337,
+                            "end": 1332,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -1392,7 +1392,7 @@
                       "type": "Text",
                       "span": {
                         "start": 1337,
-                        "end": 1354,
+                        "end": 1346,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -1404,7 +1404,7 @@
                   "type": "Text",
                   "span": {
                     "start": 1354,
-                    "end": 1370,
+                    "end": 1363,
                     "ctxt": 0
                   },
                   "value": "\n        "
@@ -1424,7 +1424,7 @@
                       "type": "Text",
                       "span": {
                         "start": 1370,
-                        "end": 1383,
+                        "end": 1379,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -1444,7 +1444,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1383,
-                            "end": 1412,
+                            "end": 1396,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1489,7 +1489,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1433,
-                            "end": 1447,
+                            "end": 1442,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -1501,7 +1501,7 @@
                       "type": "Text",
                       "span": {
                         "start": 1447,
-                        "end": 1460,
+                        "end": 1456,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -1521,7 +1521,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1460,
-                            "end": 1477,
+                            "end": 1473,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1553,7 +1553,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1489,
-                            "end": 1506,
+                            "end": 1502,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1585,7 +1585,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1524,
-                            "end": 1538,
+                            "end": 1533,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -1597,7 +1597,7 @@
                       "type": "Text",
                       "span": {
                         "start": 1538,
-                        "end": 1551,
+                        "end": 1547,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -1617,7 +1617,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1551,
-                            "end": 1568,
+                            "end": 1564,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1649,7 +1649,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1580,
-                            "end": 1597,
+                            "end": 1593,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1681,7 +1681,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1618,
-                            "end": 1632,
+                            "end": 1627,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -1693,7 +1693,7 @@
                       "type": "Text",
                       "span": {
                         "start": 1632,
-                        "end": 1645,
+                        "end": 1641,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -1713,7 +1713,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1645,
-                            "end": 1662,
+                            "end": 1658,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1745,7 +1745,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1674,
-                            "end": 1691,
+                            "end": 1687,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1777,7 +1777,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1707,
-                            "end": 1721,
+                            "end": 1716,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -1789,7 +1789,7 @@
                       "type": "Text",
                       "span": {
                         "start": 1721,
-                        "end": 1738,
+                        "end": 1730,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -1801,7 +1801,7 @@
                   "type": "Text",
                   "span": {
                     "start": 1738,
-                    "end": 1754,
+                    "end": 1747,
                     "ctxt": 0
                   },
                   "value": "\n        "
@@ -1821,7 +1821,7 @@
                       "type": "Text",
                       "span": {
                         "start": 1754,
-                        "end": 1767,
+                        "end": 1763,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -1841,7 +1841,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1767,
-                            "end": 1796,
+                            "end": 1780,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1886,7 +1886,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1819,
-                            "end": 1833,
+                            "end": 1828,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -1898,7 +1898,7 @@
                       "type": "Text",
                       "span": {
                         "start": 1833,
-                        "end": 1846,
+                        "end": 1842,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -1918,7 +1918,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1846,
-                            "end": 1863,
+                            "end": 1859,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1950,7 +1950,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1875,
-                            "end": 1892,
+                            "end": 1888,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -1982,7 +1982,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1908,
-                            "end": 1922,
+                            "end": 1917,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -1994,7 +1994,7 @@
                       "type": "Text",
                       "span": {
                         "start": 1922,
-                        "end": 1939,
+                        "end": 1931,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -2006,7 +2006,7 @@
                   "type": "Text",
                   "span": {
                     "start": 1939,
-                    "end": 1955,
+                    "end": 1948,
                     "ctxt": 0
                   },
                   "value": "\n        "
@@ -2026,7 +2026,7 @@
                       "type": "Text",
                       "span": {
                         "start": 1955,
-                        "end": 1968,
+                        "end": 1964,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -2046,7 +2046,7 @@
                           "type": "Text",
                           "span": {
                             "start": 1968,
-                            "end": 1997,
+                            "end": 1981,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -2091,7 +2091,7 @@
                           "type": "Text",
                           "span": {
                             "start": 2014,
-                            "end": 2028,
+                            "end": 2023,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -2103,7 +2103,7 @@
                       "type": "Text",
                       "span": {
                         "start": 2028,
-                        "end": 2041,
+                        "end": 2037,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -2123,7 +2123,7 @@
                           "type": "Text",
                           "span": {
                             "start": 2041,
-                            "end": 2058,
+                            "end": 2054,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -2155,7 +2155,7 @@
                           "type": "Text",
                           "span": {
                             "start": 2070,
-                            "end": 2087,
+                            "end": 2083,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -2187,7 +2187,7 @@
                           "type": "Text",
                           "span": {
                             "start": 2109,
-                            "end": 2123,
+                            "end": 2118,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -2199,7 +2199,7 @@
                       "type": "Text",
                       "span": {
                         "start": 2123,
-                        "end": 2136,
+                        "end": 2132,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -2219,7 +2219,7 @@
                           "type": "Text",
                           "span": {
                             "start": 2136,
-                            "end": 2153,
+                            "end": 2149,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -2251,7 +2251,7 @@
                           "type": "Text",
                           "span": {
                             "start": 2165,
-                            "end": 2182,
+                            "end": 2178,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -2283,7 +2283,7 @@
                           "type": "Text",
                           "span": {
                             "start": 2201,
-                            "end": 2215,
+                            "end": 2210,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -2295,7 +2295,7 @@
                       "type": "Text",
                       "span": {
                         "start": 2215,
-                        "end": 2232,
+                        "end": 2224,
                         "ctxt": 0
                       },
                       "value": "\n        "
@@ -2307,7 +2307,7 @@
                   "type": "Text",
                   "span": {
                     "start": 2232,
-                    "end": 2245,
+                    "end": 2237,
                     "ctxt": 0
                   },
                   "value": "\n    "

--- a/crates/swc_html_parser/tests/fixture/text/entity/output.json
+++ b/crates/swc_html_parser/tests/fixture/text/entity/output.json
@@ -1005,7 +1005,7 @@
                   "type": "Text",
                   "span": {
                     "start": 1082,
-                    "end": 1104,
+                    "end": 1103,
                     "ctxt": 0
                   },
                   "value": "A space character: &&"

--- a/crates/swc_html_parser/tests/fixture/text/entity/span.rust-debug
+++ b/crates/swc_html_parser/tests/fixture/text/entity/span.rust-debug
@@ -1480,13 +1480,13 @@
   x Child
     ,-[$DIR/tests/fixture/text/entity/input.html:40:1]
  40 | <div>A space character: &&</div>
-    :      ^^^^^^^^^^^^^^^^^^^^^^
+    :      ^^^^^^^^^^^^^^^^^^^^^
     `----
 
   x Text
     ,-[$DIR/tests/fixture/text/entity/input.html:40:1]
  40 | <div>A space character: &&</div>
-    :      ^^^^^^^^^^^^^^^^^^^^^^
+    :      ^^^^^^^^^^^^^^^^^^^^^
     `----
 
   x Child

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/adoption01_dat/10/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/adoption01_dat/10/output.json
@@ -69,7 +69,7 @@
               "type": "Element",
               "span": {
                 "start": 8,
-                "end": 31,
+                "end": 23,
                 "ctxt": 0
               },
               "tagName": "a",
@@ -80,7 +80,7 @@
                   "type": "Text",
                   "span": {
                     "start": 22,
-                    "end": 31,
+                    "end": 23,
                     "ctxt": 0
                   },
                   "value": "3"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/adoption01_dat/11/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/adoption01_dat/11/output.json
@@ -46,7 +46,7 @@
               "type": "Text",
               "span": {
                 "start": 8,
-                "end": 28,
+                "end": 20,
                 "ctxt": 0
               },
               "value": "AC"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/domjs-unsafe_dat/0/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/domjs-unsafe_dat/0/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 22,
+    "end": 25,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/domjs-unsafe_dat/1/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/domjs-unsafe_dat/1/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 22,
+    "end": 25,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/domjs-unsafe_dat/2/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/domjs-unsafe_dat/2/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 22,
+    "end": 25,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/domjs-unsafe_dat/36/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/domjs-unsafe_dat/36/output.json
@@ -46,7 +46,7 @@
               "type": "Text",
               "span": {
                 "start": 19,
-                "end": 33,
+                "end": 22,
                 "ctxt": 0
               },
               "value": "foo"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/domjs-unsafe_dat/9/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/domjs-unsafe_dat/9/output.json
@@ -57,7 +57,7 @@
                   "type": "Text",
                   "span": {
                     "start": 21,
-                    "end": 32,
+                    "end": 31,
                     "ctxt": 0
                   },
                   "value": "<!-- foo-<"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/entities01_dat/9/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/entities01_dat/9/output.json
@@ -46,7 +46,7 @@
               "type": "Text",
               "span": {
                 "start": 1,
-                "end": 6,
+                "end": 5,
                 "ctxt": 0
               },
               "value": "FOO&"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/pending-spec-changes-plain-text-unsafe_dat/0/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/pending-spec-changes-plain-text-unsafe_dat/0/output.json
@@ -46,7 +46,7 @@
               "type": "Text",
               "span": {
                 "start": 15,
-                "end": 27,
+                "end": 26,
                 "ctxt": 0
               },
               "value": "fillertext"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/plain-text-unsafe_dat/10/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/plain-text-unsafe_dat/10/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 28,
+    "end": 31,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/template_dat/12/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/template_dat/12/output.json
@@ -57,7 +57,7 @@
                   "type": "Text",
                   "span": {
                     "start": 8,
-                    "end": 21,
+                    "end": 11,
                     "ctxt": 0
                   },
                   "value": "   "

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests15_dat/10/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests15_dat/10/output.json
@@ -57,7 +57,7 @@
               "type": "Text",
               "span": {
                 "start": 23,
-                "end": 31,
+                "end": 24,
                 "ctxt": 0
               },
               "value": "X"
@@ -100,7 +100,7 @@
                   "type": "Text",
                   "span": {
                     "start": 46,
-                    "end": 55,
+                    "end": 47,
                     "ctxt": 0
                   },
                   "value": " "

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests15_dat/11/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests15_dat/11/output.json
@@ -102,7 +102,7 @@
                       "type": "Text",
                       "span": {
                         "start": 38,
-                        "end": 43,
+                        "end": 39,
                         "ctxt": 0
                       },
                       "value": " "
@@ -156,7 +156,7 @@
                               "type": "Text",
                               "span": {
                                 "start": 55,
-                                "end": 61,
+                                "end": 56,
                                 "ctxt": 0
                               },
                               "value": " "

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests15_dat/6/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests15_dat/6/output.json
@@ -57,7 +57,7 @@
               "type": "Text",
               "span": {
                 "start": 23,
-                "end": 31,
+                "end": 25,
                 "ctxt": 0
               },
               "value": " X"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests15_dat/7/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests15_dat/7/output.json
@@ -57,7 +57,7 @@
               "type": "Text",
               "span": {
                 "start": 23,
-                "end": 33,
+                "end": 25,
                 "ctxt": 0
               },
               "value": " x"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests15_dat/8/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests15_dat/8/output.json
@@ -57,7 +57,7 @@
               "type": "Text",
               "span": {
                 "start": 23,
-                "end": 34,
+                "end": 26,
                 "ctxt": 0
               },
               "value": " x "

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests15_dat/9/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests15_dat/9/output.json
@@ -57,7 +57,7 @@
               "type": "Text",
               "span": {
                 "start": 27,
-                "end": 37,
+                "end": 29,
                 "ctxt": 0
               },
               "value": " x"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/10/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/10/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 24,
+    "end": 33,
     "ctxt": 0
   },
   "mode": "no-quirks",
@@ -22,7 +22,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 24,
+        "end": 33,
         "ctxt": 0
       },
       "tagName": "html",
@@ -60,7 +60,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 24,
+            "end": 33,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/109/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/109/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 9,
+    "end": 18,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 9,
+        "end": 18,
         "ctxt": 0
       },
       "tagName": "html",
@@ -49,7 +49,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 9,
+            "end": 18,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/116/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/116/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 9,
+    "end": 18,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 9,
+        "end": 18,
         "ctxt": 0
       },
       "tagName": "html",
@@ -49,7 +49,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 9,
+            "end": 18,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/121/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/121/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 22,
+    "end": 13,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 22,
+        "end": 13,
         "ctxt": 0
       },
       "tagName": "html",
@@ -59,7 +59,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 22,
+            "end": 13,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/121/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/121/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 13,
+    "end": 22,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 13,
+        "end": 22,
         "ctxt": 0
       },
       "tagName": "html",
@@ -59,7 +59,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 13,
+            "end": 22,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/127/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/127/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 13,
+    "end": 22,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 13,
+        "end": 22,
         "ctxt": 0
       },
       "tagName": "html",
@@ -59,7 +59,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 13,
+            "end": 22,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/144/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/144/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 30,
+    "end": 39,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 30,
+        "end": 39,
         "ctxt": 0
       },
       "tagName": "html",
@@ -59,7 +59,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 30,
+            "end": 39,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/145/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/145/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 30,
+    "end": 39,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 30,
+        "end": 39,
         "ctxt": 0
       },
       "tagName": "html",
@@ -59,7 +59,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 30,
+            "end": 39,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/151/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/151/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 33,
+    "end": 24,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 33,
+        "end": 24,
         "ctxt": 0
       },
       "tagName": "html",
@@ -59,7 +59,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 33,
+            "end": 24,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/151/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/151/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 24,
+    "end": 33,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 24,
+        "end": 33,
         "ctxt": 0
       },
       "tagName": "html",
@@ -59,7 +59,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 24,
+            "end": 33,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/155/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/155/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 24,
+    "end": 33,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 24,
+        "end": 33,
         "ctxt": 0
       },
       "tagName": "html",
@@ -59,7 +59,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 24,
+            "end": 33,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/156/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/156/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 24,
+    "end": 33,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 24,
+        "end": 33,
         "ctxt": 0
       },
       "tagName": "html",
@@ -59,7 +59,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 24,
+            "end": 33,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/17/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/17/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 24,
+    "end": 33,
     "ctxt": 0
   },
   "mode": "no-quirks",
@@ -22,7 +22,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 24,
+        "end": 33,
         "ctxt": 0
       },
       "tagName": "html",
@@ -60,7 +60,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 24,
+            "end": 33,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/28/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/28/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 28,
+    "end": 37,
     "ctxt": 0
   },
   "mode": "no-quirks",
@@ -22,7 +22,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 28,
+        "end": 37,
         "ctxt": 0
       },
       "tagName": "html",
@@ -70,7 +70,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 28,
+            "end": 37,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/45/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/45/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 45,
+    "end": 54,
     "ctxt": 0
   },
   "mode": "no-quirks",
@@ -22,7 +22,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 45,
+        "end": 54,
         "ctxt": 0
       },
       "tagName": "html",
@@ -70,7 +70,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 45,
+            "end": 54,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/46/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/46/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 45,
+    "end": 54,
     "ctxt": 0
   },
   "mode": "no-quirks",
@@ -22,7 +22,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 45,
+        "end": 54,
         "ctxt": 0
       },
       "tagName": "html",
@@ -70,7 +70,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 45,
+            "end": 54,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/58/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/58/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 39,
+    "end": 48,
     "ctxt": 0
   },
   "mode": "no-quirks",
@@ -22,7 +22,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 39,
+        "end": 48,
         "ctxt": 0
       },
       "tagName": "html",
@@ -70,7 +70,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 39,
+            "end": 48,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/59/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests16_dat/59/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 39,
+    "end": 48,
     "ctxt": 0
   },
   "mode": "no-quirks",
@@ -22,7 +22,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 39,
+        "end": 48,
         "ctxt": 0
       },
       "tagName": "html",
@@ -70,7 +70,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 39,
+            "end": 48,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests19_dat/24/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests19_dat/24/output.json
@@ -57,7 +57,7 @@
               "type": "Text",
               "span": {
                 "start": 23,
-                "end": 36,
+                "end": 26,
                 "ctxt": 0
               },
               "value": "abc"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests19_dat/25/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests19_dat/25/output.json
@@ -68,7 +68,7 @@
                   "type": "Text",
                   "span": {
                     "start": 23,
-                    "end": 35,
+                    "end": 25,
                     "ctxt": 0
                   },
                   "value": "  "

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests19_dat/26/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests19_dat/26/output.json
@@ -57,7 +57,7 @@
               "type": "Text",
               "span": {
                 "start": 23,
-                "end": 36,
+                "end": 26,
                 "ctxt": 0
               },
               "value": " b "

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests19_dat/90/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests19_dat/90/output.json
@@ -77,7 +77,7 @@
                   "type": "Text",
                   "span": {
                     "start": 20,
-                    "end": 32,
+                    "end": 29,
                     "ctxt": 0
                   },
                   "value": "bc"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests19_dat/95/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests19_dat/95/output.json
@@ -114,7 +114,7 @@
                   "type": "Text",
                   "span": {
                     "start": 37,
-                    "end": 41,
+                    "end": 38,
                     "ctxt": 0
                   },
                   "value": "c"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/32/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/32/output.json
@@ -77,7 +77,7 @@
                       "type": "Text",
                       "span": {
                         "start": 20,
-                        "end": 42,
+                        "end": 39,
                         "ctxt": 0
                       },
                       "value": "helloexcite!"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/36/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/36/output.json
@@ -22,7 +22,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 3,
+            "end": 2,
             "ctxt": 0
           },
           "tagName": "head",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/61/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/61/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 0,
-    "end": 9,
+    "end": 1,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 9,
+        "end": 1,
         "ctxt": 0
       },
       "tagName": "html",
@@ -22,7 +22,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 9,
+            "end": 1,
             "ctxt": 0
           },
           "tagName": "head",
@@ -35,7 +35,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 9,
+            "end": 1,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/61/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/61/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 0,
-    "end": 1,
+    "end": 9,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 1,
+        "end": 9,
         "ctxt": 0
       },
       "tagName": "html",
@@ -22,7 +22,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 1,
+            "end": 9,
             "ctxt": 0
           },
           "tagName": "head",
@@ -35,7 +35,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 1,
+            "end": 9,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/77/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/77/output.json
@@ -115,7 +115,7 @@
                   "type": "Element",
                   "span": {
                     "start": 26,
-                    "end": 69,
+                    "end": 61,
                     "ctxt": 0
                   },
                   "tagName": "a",
@@ -139,7 +139,7 @@
                       "type": "Text",
                       "span": {
                         "start": 60,
-                        "end": 69,
+                        "end": 61,
                         "ctxt": 0
                       },
                       "value": "x"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/78/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/78/output.json
@@ -70,7 +70,7 @@
                   "type": "Text",
                   "span": {
                     "start": 16,
-                    "end": 69,
+                    "end": 61,
                     "ctxt": 0
                   },
                   "value": "abax"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/79/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests1_dat/79/output.json
@@ -82,7 +82,7 @@
               "type": "Element",
               "span": {
                 "start": 8,
-                "end": 69,
+                "end": 61,
                 "ctxt": 0
               },
               "tagName": "a",
@@ -106,7 +106,7 @@
                   "type": "Text",
                   "span": {
                     "start": 60,
-                    "end": 69,
+                    "end": 61,
                     "ctxt": 0
                   },
                   "value": "x"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/0/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/0/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 18,
+    "end": 21,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/1/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/1/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 19,
+    "end": 22,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/12/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/12/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 36,
+    "end": 37,
     "ctxt": 0
   },
   "mode": "no-quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/13/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/13/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 37,
+    "end": 38,
     "ctxt": 0
   },
   "mode": "no-quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/14/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/14/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 38,
+    "end": 39,
     "ctxt": 0
   },
   "mode": "no-quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/16/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/16/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 20,
+    "end": 23,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/17/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/17/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 22,
+    "end": 25,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/24/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/24/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 25,
+    "end": 28,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/3/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/3/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 18,
+    "end": 21,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/3/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/3/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 21,
+    "end": 18,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/5/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/5/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 18,
+    "end": 15,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/5/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/5/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 6,
+    "end": 18,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/6/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/6/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 15,
+    "end": 18,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/6/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/6/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 6,
+    "end": 15,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/7/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/7/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 19,
+    "end": 22,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/8/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests21_dat/8/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 19,
+    "end": 22,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests2_dat/16/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests2_dat/16/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 0,
-    "end": 4,
+    "end": 9,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 4,
+        "end": 9,
         "ctxt": 0
       },
       "tagName": "html",
@@ -22,7 +22,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 4,
+            "end": 9,
             "ctxt": 0
           },
           "tagName": "head",
@@ -35,7 +35,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 4,
+            "end": 9,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests2_dat/16/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests2_dat/16/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 0,
-    "end": 1,
+    "end": 4,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 1,
+        "end": 4,
         "ctxt": 0
       },
       "tagName": "html",
@@ -22,7 +22,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 1,
+            "end": 4,
             "ctxt": 0
           },
           "tagName": "head",
@@ -35,7 +35,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 1,
+            "end": 4,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/16/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/16/output.json
@@ -57,7 +57,7 @@
               "type": "Text",
               "span": {
                 "start": 23,
-                "end": 43,
+                "end": 24,
                 "ctxt": 0
               },
               "value": "X"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/17/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/17/output.json
@@ -68,7 +68,7 @@
                   "type": "Text",
                   "span": {
                     "start": 23,
-                    "end": 44,
+                    "end": 25,
                     "ctxt": 0
                   },
                   "value": "  "

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/18/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/18/output.json
@@ -68,7 +68,7 @@
                   "type": "Text",
                   "span": {
                     "start": 23,
-                    "end": 46,
+                    "end": 25,
                     "ctxt": 0
                   },
                   "value": "  "

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/27/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/27/output.json
@@ -59,7 +59,7 @@
               "type": "Element",
               "span": {
                 "start": 8,
-                "end": 43,
+                "end": 35,
                 "ctxt": 0
               },
               "tagName": "b",
@@ -70,7 +70,7 @@
                   "type": "Text",
                   "span": {
                     "start": 32,
-                    "end": 43,
+                    "end": 35,
                     "ctxt": 0
                   },
                   "value": "bbb"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/28/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/28/output.json
@@ -46,7 +46,7 @@
               "type": "Text",
               "span": {
                 "start": 1,
-                "end": 30,
+                "end": 22,
                 "ctxt": 0
               },
               "value": "A B B"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/29/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/29/output.json
@@ -46,7 +46,7 @@
               "type": "Text",
               "span": {
                 "start": 1,
-                "end": 35,
+                "end": 27,
                 "ctxt": 0
               },
               "value": "A BC"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/29/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/29/output.json
@@ -66,7 +66,7 @@
                   "type": "Element",
                   "span": {
                     "start": 0,
-                    "end": 26,
+                    "end": 21,
                     "ctxt": 0
                   },
                   "tagName": "tbody",
@@ -90,7 +90,7 @@
                       "type": "Text",
                       "span": {
                         "start": 20,
-                        "end": 26,
+                        "end": 21,
                         "ctxt": 0
                       },
                       "value": " "

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/5/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/5/output.json
@@ -57,7 +57,7 @@
               "type": "Text",
               "span": {
                 "start": 23,
-                "end": 28,
+                "end": 24,
                 "ctxt": 0
               },
               "value": "X"
@@ -134,7 +134,7 @@
                                   "type": "Text",
                                   "span": {
                                     "start": 39,
-                                    "end": 46,
+                                    "end": 40,
                                     "ctxt": 0
                                   },
                                   "value": " "

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/8/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/8/output.json
@@ -91,7 +91,7 @@
                   "type": "Text",
                   "span": {
                     "start": 45,
-                    "end": 54,
+                    "end": 46,
                     "ctxt": 0
                   },
                   "value": " "

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/9/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tests7_dat/9/output.json
@@ -68,7 +68,7 @@
                   "type": "Element",
                   "span": {
                     "start": 23,
-                    "end": 63,
+                    "end": 55,
                     "ctxt": 0
                   },
                   "tagName": "tbody",
@@ -102,7 +102,7 @@
                       "type": "Text",
                       "span": {
                         "start": 54,
-                        "end": 63,
+                        "end": 55,
                         "ctxt": 0
                       },
                       "value": " "

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tricky01_dat/5/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tricky01_dat/5/output.json
@@ -139,7 +139,7 @@
                   "type": "Text",
                   "span": {
                     "start": 33,
-                    "end": 39,
+                    "end": 34,
                     "ctxt": 0
                   },
                   "value": " "
@@ -148,7 +148,7 @@
                   "type": "Element",
                   "span": {
                     "start": 0,
-                    "end": 69,
+                    "end": 61,
                     "ctxt": 0
                   },
                   "tagName": "tbody",
@@ -193,7 +193,7 @@
                           "type": "Text",
                           "span": {
                             "start": 54,
-                            "end": 60,
+                            "end": 55,
                             "ctxt": 0
                           },
                           "value": " "
@@ -205,7 +205,7 @@
                       "type": "Text",
                       "span": {
                         "start": 60,
-                        "end": 69,
+                        "end": 61,
                         "ctxt": 0
                       },
                       "value": " "

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/tricky01_dat/7/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/tricky01_dat/7/output.json
@@ -96,7 +96,7 @@
               "type": "Element",
               "span": {
                 "start": 1,
-                "end": 55,
+                "end": 49,
                 "ctxt": 0
               },
               "tagName": "table",
@@ -107,7 +107,7 @@
                   "type": "Text",
                   "span": {
                     "start": 8,
-                    "end": 13,
+                    "end": 9,
                     "ctxt": 0
                   },
                   "value": "\n"
@@ -116,7 +116,7 @@
                   "type": "Element",
                   "span": {
                     "start": 0,
-                    "end": 55,
+                    "end": 49,
                     "ctxt": 0
                   },
                   "tagName": "tbody",
@@ -138,7 +138,7 @@
                           "type": "Text",
                           "span": {
                             "start": 13,
-                            "end": 22,
+                            "end": 14,
                             "ctxt": 0
                           },
                           "value": "\n"
@@ -163,7 +163,7 @@
                       "type": "Element",
                       "span": {
                         "start": 44,
-                        "end": 55,
+                        "end": 49,
                         "ctxt": 0
                       },
                       "tagName": "tr",
@@ -174,7 +174,7 @@
                           "type": "Text",
                           "span": {
                             "start": 48,
-                            "end": 55,
+                            "end": 49,
                             "ctxt": 0
                           },
                           "value": "\n"

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/webkit01_dat/3/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/webkit01_dat/3/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 0,
-    "end": 1,
+    "end": 4,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 1,
+        "end": 4,
         "ctxt": 0
       },
       "tagName": "html",
@@ -22,7 +22,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 1,
+            "end": 4,
             "ctxt": 0
           },
           "tagName": "head",
@@ -35,7 +35,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 1,
+            "end": 4,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/html5lib-tests-fixture/webkit02_dat/4/output.json
+++ b/crates/swc_html_parser/tests/html5lib-tests-fixture/webkit02_dat/4/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 13,
+    "end": 68,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/recovery/attribute/bogus-2/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/attribute/bogus-2/output.stderr
@@ -12,3 +12,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/attribute/bogus-2/input.html:1:1]
+ 1 | <h a=&not=>
+   :            ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/attribute/bogus/output.json
+++ b/crates/swc_html_parser/tests/recovery/attribute/bogus/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 0,
-    "end": 1,
+    "end": 24,
     "ctxt": 0
   },
   "mode": "quirks",
@@ -11,7 +11,7 @@
       "type": "Element",
       "span": {
         "start": 0,
-        "end": 1,
+        "end": 24,
         "ctxt": 0
       },
       "tagName": "html",
@@ -22,7 +22,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 1,
+            "end": 24,
             "ctxt": 0
           },
           "tagName": "head",
@@ -35,7 +35,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 1,
+            "end": 24,
             "ctxt": 0
           },
           "tagName": "body",

--- a/crates/swc_html_parser/tests/recovery/attribute/bogus/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/attribute/bogus/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen without seeing a doctype first, expected "<!DOCTYPE html>"
+   ,-[$DIR/tests/recovery/attribute/bogus/input.html:1:1]
+ 1 | <div test="test'></div>
+   :                        ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/attribute/missing-value/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/attribute/missing-value/output.stderr
@@ -30,3 +30,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/attribute/missing-value/input.html:4:1]
+ 4 | <z ====>
+   :         ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/comment/bogus-1/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/comment/bogus-1/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen without seeing a doctype first, expected "<!DOCTYPE html>"
+   ,-[$DIR/tests/recovery/comment/bogus-1/input.html:1:1]
+ 1 | <!-- test
+   :          ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/comment/bogus-2/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/comment/bogus-2/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen without seeing a doctype first, expected "<!DOCTYPE html>"
+   ,-[$DIR/tests/recovery/comment/bogus-2/input.html:1:1]
+ 1 | <!-- test>
+   :           ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/comment/bogus/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/comment/bogus/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen without seeing a doctype first, expected "<!DOCTYPE html>"
+   ,-[$DIR/tests/recovery/comment/bogus/input.html:1:1]
+ 1 | <!–– Failing New York Times Comment -->
+   :                                            ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/comment/cdata-2/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/comment/cdata-2/output.stderr
@@ -12,3 +12,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/comment/cdata-2/input.html:1:1]
+ 1 | <div><![CDATA[foo]]>
+   :                     ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/a-4/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/a-4/output.stderr
@@ -54,3 +54,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/a-4/input.html:1:1]
+ 1 | <table><a>1<p>2</a>3</p>
+   :                         ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/applet-2/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/applet-2/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/applet-2/input.html:1:17]
+ 1 |  
+   : ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/applet/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/applet/output.stderr
@@ -12,3 +12,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/applet/input.html:1:18]
+ 1 |  
+   : ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/b-3/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/b-3/output.stderr
@@ -12,3 +12,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/b-3/input.html:1:1]
+ 1 | <b><a><b><p></a>
+   :                 ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/body-3/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/body-3/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/body-3/input.html:1:1]
+ 1 | <!DOCTYPE html>X</body><div>
+   :                             ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/colgroup/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/colgroup/output.json
@@ -141,7 +141,7 @@
                   "type": "Text",
                   "span": {
                     "start": 91,
-                    "end": 105,
+                    "end": 96,
                     "ctxt": 0
                   },
                   "value": "\n    "
@@ -173,7 +173,7 @@
                   "type": "Text",
                   "span": {
                     "start": 139,
-                    "end": 154,
+                    "end": 144,
                     "ctxt": 0
                   },
                   "value": "\n    "
@@ -205,7 +205,7 @@
                   "type": "Text",
                   "span": {
                     "start": 169,
-                    "end": 183,
+                    "end": 178,
                     "ctxt": 0
                   },
                   "value": "\n        "

--- a/crates/swc_html_parser/tests/recovery/element/colgroup/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/colgroup/output.json
@@ -344,7 +344,7 @@
                   "type": "Text",
                   "span": {
                     "start": 274,
-                    "end": 283,
+                    "end": 275,
                     "ctxt": 0
                   },
                   "value": "\n"

--- a/crates/swc_html_parser/tests/recovery/element/colgroup/span.rust-debug
+++ b/crates/swc_html_parser/tests/recovery/element/colgroup/span.rust-debug
@@ -419,14 +419,16 @@
 
   x Child
     ,-[$DIR/tests/recovery/element/colgroup/input.html:14:5]
- 14 | ,-> </colgroup>
- 15 | `-> </table>
+ 14 | </colgroup>
+    :            ^
+ 15 | </table>
     `----
 
   x Text
     ,-[$DIR/tests/recovery/element/colgroup/input.html:14:5]
- 14 | ,-> </colgroup>
- 15 | `-> </table>
+ 14 | </colgroup>
+    :            ^
+ 15 | </table>
     `----
 
   x Child

--- a/crates/swc_html_parser/tests/recovery/element/font/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/font/output.stderr
@@ -12,3 +12,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/font/input.html:1:1]
+ 1 | <p><font size=4><font color=red><font color=red><p>X
+   :                                                     ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/foreign-context/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/foreign-context/output.json
@@ -22,7 +22,7 @@
       "type": "Element",
       "span": {
         "start": 17,
-        "end": 2677,
+        "end": 2672,
         "ctxt": 0
       },
       "tagName": "html",
@@ -239,7 +239,7 @@
           "type": "Element",
           "span": {
             "start": 303,
-            "end": 2677,
+            "end": 2672,
             "ctxt": 0
           },
           "tagName": "body",
@@ -259,7 +259,7 @@
               "type": "Element",
               "span": {
                 "start": 310,
-                "end": 2677,
+                "end": 2672,
                 "ctxt": 0
               },
               "tagName": "div",
@@ -305,7 +305,7 @@
                   "type": "Element",
                   "span": {
                     "start": 336,
-                    "end": 2677,
+                    "end": 2672,
                     "ctxt": 0
                   },
                   "tagName": "div",
@@ -351,7 +351,7 @@
                       "type": "Element",
                       "span": {
                         "start": 363,
-                        "end": 2677,
+                        "end": 2672,
                         "ctxt": 0
                       },
                       "tagName": "div",
@@ -375,7 +375,7 @@
                           "type": "Element",
                           "span": {
                             "start": 373,
-                            "end": 2677,
+                            "end": 2672,
                             "ctxt": 0
                           },
                           "tagName": "b",
@@ -395,7 +395,7 @@
                               "type": "Element",
                               "span": {
                                 "start": 388,
-                                "end": 2677,
+                                "end": 2672,
                                 "ctxt": 0
                               },
                               "tagName": "div",
@@ -419,7 +419,7 @@
                                   "type": "Element",
                                   "span": {
                                     "start": 398,
-                                    "end": 2677,
+                                    "end": 2672,
                                     "ctxt": 0
                                   },
                                   "tagName": "big",
@@ -439,7 +439,7 @@
                                       "type": "Element",
                                       "span": {
                                         "start": 415,
-                                        "end": 2677,
+                                        "end": 2672,
                                         "ctxt": 0
                                       },
                                       "tagName": "div",
@@ -463,7 +463,7 @@
                                           "type": "Element",
                                           "span": {
                                             "start": 425,
-                                            "end": 2677,
+                                            "end": 2672,
                                             "ctxt": 0
                                           },
                                           "tagName": "blockquote",
@@ -483,7 +483,7 @@
                                               "type": "Element",
                                               "span": {
                                                 "start": 449,
-                                                "end": 2677,
+                                                "end": 2672,
                                                 "ctxt": 0
                                               },
                                               "tagName": "div",
@@ -529,7 +529,7 @@
                                                   "type": "Element",
                                                   "span": {
                                                     "start": 475,
-                                                    "end": 2677,
+                                                    "end": 2672,
                                                     "ctxt": 0
                                                   },
                                                   "tagName": "div",
@@ -553,7 +553,7 @@
                                                       "type": "Element",
                                                       "span": {
                                                         "start": 485,
-                                                        "end": 2677,
+                                                        "end": 2672,
                                                         "ctxt": 0
                                                       },
                                                       "tagName": "center",
@@ -573,7 +573,7 @@
                                                           "type": "Element",
                                                           "span": {
                                                             "start": 505,
-                                                            "end": 2677,
+                                                            "end": 2672,
                                                             "ctxt": 0
                                                           },
                                                           "tagName": "div",
@@ -597,7 +597,7 @@
                                                               "type": "Element",
                                                               "span": {
                                                                 "start": 515,
-                                                                "end": 2677,
+                                                                "end": 2672,
                                                                 "ctxt": 0
                                                               },
                                                               "tagName": "code",
@@ -617,7 +617,7 @@
                                                                   "type": "Element",
                                                                   "span": {
                                                                     "start": 533,
-                                                                    "end": 2677,
+                                                                    "end": 2672,
                                                                     "ctxt": 0
                                                                   },
                                                                   "tagName": "div",
@@ -641,7 +641,7 @@
                                                                       "type": "Element",
                                                                       "span": {
                                                                         "start": 543,
-                                                                        "end": 2677,
+                                                                        "end": 2672,
                                                                         "ctxt": 0
                                                                       },
                                                                       "tagName": "dd",
@@ -661,7 +661,7 @@
                                                                           "type": "Element",
                                                                           "span": {
                                                                             "start": 559,
-                                                                            "end": 2677,
+                                                                            "end": 2672,
                                                                             "ctxt": 0
                                                                           },
                                                                           "tagName": "div",
@@ -685,7 +685,7 @@
                                                                               "type": "Element",
                                                                               "span": {
                                                                                 "start": 569,
-                                                                                "end": 2677,
+                                                                                "end": 2672,
                                                                                 "ctxt": 0
                                                                               },
                                                                               "tagName": "div",
@@ -705,7 +705,7 @@
                                                                                   "type": "Element",
                                                                                   "span": {
                                                                                     "start": 586,
-                                                                                    "end": 2677,
+                                                                                    "end": 2672,
                                                                                     "ctxt": 0
                                                                                   },
                                                                                   "tagName": "div",
@@ -729,7 +729,7 @@
                                                                                       "type": "Element",
                                                                                       "span": {
                                                                                         "start": 596,
-                                                                                        "end": 2677,
+                                                                                        "end": 2672,
                                                                                         "ctxt": 0
                                                                                       },
                                                                                       "tagName": "dl",
@@ -749,7 +749,7 @@
                                                                                           "type": "Element",
                                                                                           "span": {
                                                                                             "start": 612,
-                                                                                            "end": 2677,
+                                                                                            "end": 2672,
                                                                                             "ctxt": 0
                                                                                           },
                                                                                           "tagName": "div",
@@ -773,7 +773,7 @@
                                                                                               "type": "Element",
                                                                                               "span": {
                                                                                                 "start": 622,
-                                                                                                "end": 2677,
+                                                                                                "end": 2672,
                                                                                                 "ctxt": 0
                                                                                               },
                                                                                               "tagName": "dt",
@@ -793,7 +793,7 @@
                                                                                                   "type": "Element",
                                                                                                   "span": {
                                                                                                     "start": 638,
-                                                                                                    "end": 2677,
+                                                                                                    "end": 2672,
                                                                                                     "ctxt": 0
                                                                                                   },
                                                                                                   "tagName": "div",
@@ -817,7 +817,7 @@
                                                                                                       "type": "Element",
                                                                                                       "span": {
                                                                                                         "start": 648,
-                                                                                                        "end": 2677,
+                                                                                                        "end": 2672,
                                                                                                         "ctxt": 0
                                                                                                       },
                                                                                                       "tagName": "em",
@@ -837,7 +837,7 @@
                                                                                                           "type": "Element",
                                                                                                           "span": {
                                                                                                             "start": 664,
-                                                                                                            "end": 2677,
+                                                                                                            "end": 2672,
                                                                                                             "ctxt": 0
                                                                                                           },
                                                                                                           "tagName": "div",
@@ -883,7 +883,7 @@
                                                                                                               "type": "Element",
                                                                                                               "span": {
                                                                                                                 "start": 693,
-                                                                                                                "end": 2677,
+                                                                                                                "end": 2672,
                                                                                                                 "ctxt": 0
                                                                                                               },
                                                                                                               "tagName": "div",
@@ -907,7 +907,7 @@
                                                                                                                   "type": "Element",
                                                                                                                   "span": {
                                                                                                                     "start": 703,
-                                                                                                                    "end": 2677,
+                                                                                                                    "end": 2672,
                                                                                                                     "ctxt": 0
                                                                                                                   },
                                                                                                                   "tagName": "h1",
@@ -927,7 +927,7 @@
                                                                                                                       "type": "Element",
                                                                                                                       "span": {
                                                                                                                         "start": 719,
-                                                                                                                        "end": 2677,
+                                                                                                                        "end": 2672,
                                                                                                                         "ctxt": 0
                                                                                                                       },
                                                                                                                       "tagName": "div",
@@ -951,7 +951,7 @@
                                                                                                                           "type": "Element",
                                                                                                                           "span": {
                                                                                                                             "start": 729,
-                                                                                                                            "end": 2677,
+                                                                                                                            "end": 2672,
                                                                                                                             "ctxt": 0
                                                                                                                           },
                                                                                                                           "tagName": "h2",
@@ -971,7 +971,7 @@
                                                                                                                               "type": "Element",
                                                                                                                               "span": {
                                                                                                                                 "start": 745,
-                                                                                                                                "end": 2677,
+                                                                                                                                "end": 2672,
                                                                                                                                 "ctxt": 0
                                                                                                                               },
                                                                                                                               "tagName": "div",
@@ -995,7 +995,7 @@
                                                                                                                                   "type": "Element",
                                                                                                                                   "span": {
                                                                                                                                     "start": 755,
-                                                                                                                                    "end": 2677,
+                                                                                                                                    "end": 2672,
                                                                                                                                     "ctxt": 0
                                                                                                                                   },
                                                                                                                                   "tagName": "h3",
@@ -1015,7 +1015,7 @@
                                                                                                                                       "type": "Element",
                                                                                                                                       "span": {
                                                                                                                                         "start": 771,
-                                                                                                                                        "end": 2677,
+                                                                                                                                        "end": 2672,
                                                                                                                                         "ctxt": 0
                                                                                                                                       },
                                                                                                                                       "tagName": "div",
@@ -1039,7 +1039,7 @@
                                                                                                                                           "type": "Element",
                                                                                                                                           "span": {
                                                                                                                                             "start": 781,
-                                                                                                                                            "end": 2677,
+                                                                                                                                            "end": 2672,
                                                                                                                                             "ctxt": 0
                                                                                                                                           },
                                                                                                                                           "tagName": "h4",
@@ -1059,7 +1059,7 @@
                                                                                                                                               "type": "Element",
                                                                                                                                               "span": {
                                                                                                                                                 "start": 797,
-                                                                                                                                                "end": 2677,
+                                                                                                                                                "end": 2672,
                                                                                                                                                 "ctxt": 0
                                                                                                                                               },
                                                                                                                                               "tagName": "div",
@@ -1083,7 +1083,7 @@
                                                                                                                                                   "type": "Element",
                                                                                                                                                   "span": {
                                                                                                                                                     "start": 807,
-                                                                                                                                                    "end": 2677,
+                                                                                                                                                    "end": 2672,
                                                                                                                                                     "ctxt": 0
                                                                                                                                                   },
                                                                                                                                                   "tagName": "h5",
@@ -1103,7 +1103,7 @@
                                                                                                                                                       "type": "Element",
                                                                                                                                                       "span": {
                                                                                                                                                         "start": 823,
-                                                                                                                                                        "end": 2677,
+                                                                                                                                                        "end": 2672,
                                                                                                                                                         "ctxt": 0
                                                                                                                                                       },
                                                                                                                                                       "tagName": "div",
@@ -1127,7 +1127,7 @@
                                                                                                                                                           "type": "Element",
                                                                                                                                                           "span": {
                                                                                                                                                             "start": 833,
-                                                                                                                                                            "end": 2677,
+                                                                                                                                                            "end": 2672,
                                                                                                                                                             "ctxt": 0
                                                                                                                                                           },
                                                                                                                                                           "tagName": "h6",
@@ -1147,7 +1147,7 @@
                                                                                                                                                               "type": "Element",
                                                                                                                                                               "span": {
                                                                                                                                                                 "start": 849,
-                                                                                                                                                                "end": 2677,
+                                                                                                                                                                "end": 2672,
                                                                                                                                                                 "ctxt": 0
                                                                                                                                                               },
                                                                                                                                                               "tagName": "div",
@@ -1193,7 +1193,7 @@
                                                                                                                                                                   "type": "Element",
                                                                                                                                                                   "span": {
                                                                                                                                                                     "start": 875,
-                                                                                                                                                                    "end": 2677,
+                                                                                                                                                                    "end": 2672,
                                                                                                                                                                     "ctxt": 0
                                                                                                                                                                   },
                                                                                                                                                                   "tagName": "div",
@@ -1217,7 +1217,7 @@
                                                                                                                                                                       "type": "Element",
                                                                                                                                                                       "span": {
                                                                                                                                                                         "start": 885,
-                                                                                                                                                                        "end": 2677,
+                                                                                                                                                                        "end": 2672,
                                                                                                                                                                         "ctxt": 0
                                                                                                                                                                       },
                                                                                                                                                                       "tagName": "i",
@@ -1237,7 +1237,7 @@
                                                                                                                                                                           "type": "Element",
                                                                                                                                                                           "span": {
                                                                                                                                                                             "start": 900,
-                                                                                                                                                                            "end": 2677,
+                                                                                                                                                                            "end": 2672,
                                                                                                                                                                             "ctxt": 0
                                                                                                                                                                           },
                                                                                                                                                                           "tagName": "div",
@@ -1283,7 +1283,7 @@
                                                                                                                                                                               "type": "Element",
                                                                                                                                                                               "span": {
                                                                                                                                                                                 "start": 927,
-                                                                                                                                                                                "end": 2677,
+                                                                                                                                                                                "end": 2672,
                                                                                                                                                                                 "ctxt": 0
                                                                                                                                                                               },
                                                                                                                                                                               "tagName": "div",
@@ -1307,7 +1307,7 @@
                                                                                                                                                                                   "type": "Element",
                                                                                                                                                                                   "span": {
                                                                                                                                                                                     "start": 937,
-                                                                                                                                                                                    "end": 2677,
+                                                                                                                                                                                    "end": 2672,
                                                                                                                                                                                     "ctxt": 0
                                                                                                                                                                                   },
                                                                                                                                                                                   "tagName": "li",
@@ -1327,7 +1327,7 @@
                                                                                                                                                                                       "type": "Element",
                                                                                                                                                                                       "span": {
                                                                                                                                                                                         "start": 953,
-                                                                                                                                                                                        "end": 2677,
+                                                                                                                                                                                        "end": 2672,
                                                                                                                                                                                         "ctxt": 0
                                                                                                                                                                                       },
                                                                                                                                                                                       "tagName": "div",
@@ -1351,7 +1351,7 @@
                                                                                                                                                                                           "type": "Element",
                                                                                                                                                                                           "span": {
                                                                                                                                                                                             "start": 963,
-                                                                                                                                                                                            "end": 2677,
+                                                                                                                                                                                            "end": 2672,
                                                                                                                                                                                             "ctxt": 0
                                                                                                                                                                                           },
                                                                                                                                                                                           "tagName": "listing",
@@ -1371,7 +1371,7 @@
                                                                                                                                                                                               "type": "Element",
                                                                                                                                                                                               "span": {
                                                                                                                                                                                                 "start": 984,
-                                                                                                                                                                                                "end": 2677,
+                                                                                                                                                                                                "end": 2672,
                                                                                                                                                                                                 "ctxt": 0
                                                                                                                                                                                               },
                                                                                                                                                                                               "tagName": "div",
@@ -1395,7 +1395,7 @@
                                                                                                                                                                                                   "type": "Element",
                                                                                                                                                                                                   "span": {
                                                                                                                                                                                                     "start": 994,
-                                                                                                                                                                                                    "end": 2677,
+                                                                                                                                                                                                    "end": 2672,
                                                                                                                                                                                                     "ctxt": 0
                                                                                                                                                                                                   },
                                                                                                                                                                                                   "tagName": "menu",
@@ -1415,7 +1415,7 @@
                                                                                                                                                                                                       "type": "Element",
                                                                                                                                                                                                       "span": {
                                                                                                                                                                                                         "start": 1012,
-                                                                                                                                                                                                        "end": 2677,
+                                                                                                                                                                                                        "end": 2672,
                                                                                                                                                                                                         "ctxt": 0
                                                                                                                                                                                                       },
                                                                                                                                                                                                       "tagName": "div",
@@ -1461,7 +1461,7 @@
                                                                                                                                                                                                           "type": "Element",
                                                                                                                                                                                                           "span": {
                                                                                                                                                                                                             "start": 1040,
-                                                                                                                                                                                                            "end": 2677,
+                                                                                                                                                                                                            "end": 2672,
                                                                                                                                                                                                             "ctxt": 0
                                                                                                                                                                                                           },
                                                                                                                                                                                                           "tagName": "div",
@@ -1485,7 +1485,7 @@
                                                                                                                                                                                                               "type": "Element",
                                                                                                                                                                                                               "span": {
                                                                                                                                                                                                                 "start": 1050,
-                                                                                                                                                                                                                "end": 2677,
+                                                                                                                                                                                                                "end": 2672,
                                                                                                                                                                                                                 "ctxt": 0
                                                                                                                                                                                                               },
                                                                                                                                                                                                               "tagName": "nobr",
@@ -1505,7 +1505,7 @@
                                                                                                                                                                                                                   "type": "Element",
                                                                                                                                                                                                                   "span": {
                                                                                                                                                                                                                     "start": 1068,
-                                                                                                                                                                                                                    "end": 2677,
+                                                                                                                                                                                                                    "end": 2672,
                                                                                                                                                                                                                     "ctxt": 0
                                                                                                                                                                                                                   },
                                                                                                                                                                                                                   "tagName": "div",
@@ -1529,7 +1529,7 @@
                                                                                                                                                                                                                       "type": "Element",
                                                                                                                                                                                                                       "span": {
                                                                                                                                                                                                                         "start": 1078,
-                                                                                                                                                                                                                        "end": 2677,
+                                                                                                                                                                                                                        "end": 2672,
                                                                                                                                                                                                                         "ctxt": 0
                                                                                                                                                                                                                       },
                                                                                                                                                                                                                       "tagName": "ol",
@@ -1549,7 +1549,7 @@
                                                                                                                                                                                                                           "type": "Element",
                                                                                                                                                                                                                           "span": {
                                                                                                                                                                                                                             "start": 1094,
-                                                                                                                                                                                                                            "end": 2677,
+                                                                                                                                                                                                                            "end": 2672,
                                                                                                                                                                                                                             "ctxt": 0
                                                                                                                                                                                                                           },
                                                                                                                                                                                                                           "tagName": "div",
@@ -1596,7 +1596,7 @@
                                                                                                                                                                                                                               "type": "Element",
                                                                                                                                                                                                                               "span": {
                                                                                                                                                                                                                                 "start": 1119,
-                                                                                                                                                                                                                                "end": 2677,
+                                                                                                                                                                                                                                "end": 2672,
                                                                                                                                                                                                                                 "ctxt": 0
                                                                                                                                                                                                                               },
                                                                                                                                                                                                                               "tagName": "div",
@@ -1620,7 +1620,7 @@
                                                                                                                                                                                                                                   "type": "Element",
                                                                                                                                                                                                                                   "span": {
                                                                                                                                                                                                                                     "start": 1129,
-                                                                                                                                                                                                                                    "end": 2677,
+                                                                                                                                                                                                                                    "end": 2672,
                                                                                                                                                                                                                                     "ctxt": 0
                                                                                                                                                                                                                                   },
                                                                                                                                                                                                                                   "tagName": "pre",
@@ -1640,7 +1640,7 @@
                                                                                                                                                                                                                                       "type": "Element",
                                                                                                                                                                                                                                       "span": {
                                                                                                                                                                                                                                         "start": 1146,
-                                                                                                                                                                                                                                        "end": 2677,
+                                                                                                                                                                                                                                        "end": 2672,
                                                                                                                                                                                                                                         "ctxt": 0
                                                                                                                                                                                                                                       },
                                                                                                                                                                                                                                       "tagName": "div",
@@ -1664,7 +1664,7 @@
                                                                                                                                                                                                                                           "type": "Element",
                                                                                                                                                                                                                                           "span": {
                                                                                                                                                                                                                                             "start": 1156,
-                                                                                                                                                                                                                                            "end": 2677,
+                                                                                                                                                                                                                                            "end": 2672,
                                                                                                                                                                                                                                             "ctxt": 0
                                                                                                                                                                                                                                           },
                                                                                                                                                                                                                                           "tagName": "ruby",
@@ -1684,7 +1684,7 @@
                                                                                                                                                                                                                                               "type": "Element",
                                                                                                                                                                                                                                               "span": {
                                                                                                                                                                                                                                                 "start": 1174,
-                                                                                                                                                                                                                                                "end": 2677,
+                                                                                                                                                                                                                                                "end": 2672,
                                                                                                                                                                                                                                                 "ctxt": 0
                                                                                                                                                                                                                                               },
                                                                                                                                                                                                                                               "tagName": "div",
@@ -1708,7 +1708,7 @@
                                                                                                                                                                                                                                                   "type": "Element",
                                                                                                                                                                                                                                                   "span": {
                                                                                                                                                                                                                                                     "start": 1184,
-                                                                                                                                                                                                                                                    "end": 2677,
+                                                                                                                                                                                                                                                    "end": 2672,
                                                                                                                                                                                                                                                     "ctxt": 0
                                                                                                                                                                                                                                                   },
                                                                                                                                                                                                                                                   "tagName": "s",
@@ -1728,7 +1728,7 @@
                                                                                                                                                                                                                                                       "type": "Element",
                                                                                                                                                                                                                                                       "span": {
                                                                                                                                                                                                                                                         "start": 1199,
-                                                                                                                                                                                                                                                        "end": 2677,
+                                                                                                                                                                                                                                                        "end": 2672,
                                                                                                                                                                                                                                                         "ctxt": 0
                                                                                                                                                                                                                                                       },
                                                                                                                                                                                                                                                       "tagName": "div",
@@ -1752,7 +1752,7 @@
                                                                                                                                                                                                                                                           "type": "Element",
                                                                                                                                                                                                                                                           "span": {
                                                                                                                                                                                                                                                             "start": 1209,
-                                                                                                                                                                                                                                                            "end": 2677,
+                                                                                                                                                                                                                                                            "end": 2672,
                                                                                                                                                                                                                                                             "ctxt": 0
                                                                                                                                                                                                                                                           },
                                                                                                                                                                                                                                                           "tagName": "small",
@@ -1772,7 +1772,7 @@
                                                                                                                                                                                                                                                               "type": "Element",
                                                                                                                                                                                                                                                               "span": {
                                                                                                                                                                                                                                                                 "start": 1228,
-                                                                                                                                                                                                                                                                "end": 2677,
+                                                                                                                                                                                                                                                                "end": 2672,
                                                                                                                                                                                                                                                                 "ctxt": 0
                                                                                                                                                                                                                                                               },
                                                                                                                                                                                                                                                               "tagName": "div",
@@ -1796,7 +1796,7 @@
                                                                                                                                                                                                                                                                   "type": "Element",
                                                                                                                                                                                                                                                                   "span": {
                                                                                                                                                                                                                                                                     "start": 1238,
-                                                                                                                                                                                                                                                                    "end": 2677,
+                                                                                                                                                                                                                                                                    "end": 2672,
                                                                                                                                                                                                                                                                     "ctxt": 0
                                                                                                                                                                                                                                                                   },
                                                                                                                                                                                                                                                                   "tagName": "span",
@@ -1816,7 +1816,7 @@
                                                                                                                                                                                                                                                                       "type": "Element",
                                                                                                                                                                                                                                                                       "span": {
                                                                                                                                                                                                                                                                         "start": 1256,
-                                                                                                                                                                                                                                                                        "end": 2677,
+                                                                                                                                                                                                                                                                        "end": 2672,
                                                                                                                                                                                                                                                                         "ctxt": 0
                                                                                                                                                                                                                                                                       },
                                                                                                                                                                                                                                                                       "tagName": "div",
@@ -1840,7 +1840,7 @@
                                                                                                                                                                                                                                                                           "type": "Element",
                                                                                                                                                                                                                                                                           "span": {
                                                                                                                                                                                                                                                                             "start": 1266,
-                                                                                                                                                                                                                                                                            "end": 2677,
+                                                                                                                                                                                                                                                                            "end": 2672,
                                                                                                                                                                                                                                                                             "ctxt": 0
                                                                                                                                                                                                                                                                           },
                                                                                                                                                                                                                                                                           "tagName": "strong",
@@ -1860,7 +1860,7 @@
                                                                                                                                                                                                                                                                               "type": "Element",
                                                                                                                                                                                                                                                                               "span": {
                                                                                                                                                                                                                                                                                 "start": 1286,
-                                                                                                                                                                                                                                                                                "end": 2677,
+                                                                                                                                                                                                                                                                                "end": 2672,
                                                                                                                                                                                                                                                                                 "ctxt": 0
                                                                                                                                                                                                                                                                               },
                                                                                                                                                                                                                                                                               "tagName": "div",
@@ -1884,7 +1884,7 @@
                                                                                                                                                                                                                                                                                   "type": "Element",
                                                                                                                                                                                                                                                                                   "span": {
                                                                                                                                                                                                                                                                                     "start": 1296,
-                                                                                                                                                                                                                                                                                    "end": 2677,
+                                                                                                                                                                                                                                                                                    "end": 2672,
                                                                                                                                                                                                                                                                                     "ctxt": 0
                                                                                                                                                                                                                                                                                   },
                                                                                                                                                                                                                                                                                   "tagName": "strike",
@@ -1904,7 +1904,7 @@
                                                                                                                                                                                                                                                                                       "type": "Element",
                                                                                                                                                                                                                                                                                       "span": {
                                                                                                                                                                                                                                                                                         "start": 1316,
-                                                                                                                                                                                                                                                                                        "end": 2677,
+                                                                                                                                                                                                                                                                                        "end": 2672,
                                                                                                                                                                                                                                                                                         "ctxt": 0
                                                                                                                                                                                                                                                                                       },
                                                                                                                                                                                                                                                                                       "tagName": "div",
@@ -1928,7 +1928,7 @@
                                                                                                                                                                                                                                                                                           "type": "Element",
                                                                                                                                                                                                                                                                                           "span": {
                                                                                                                                                                                                                                                                                             "start": 1326,
-                                                                                                                                                                                                                                                                                            "end": 2677,
+                                                                                                                                                                                                                                                                                            "end": 2672,
                                                                                                                                                                                                                                                                                             "ctxt": 0
                                                                                                                                                                                                                                                                                           },
                                                                                                                                                                                                                                                                                           "tagName": "sub",
@@ -1948,7 +1948,7 @@
                                                                                                                                                                                                                                                                                               "type": "Element",
                                                                                                                                                                                                                                                                                               "span": {
                                                                                                                                                                                                                                                                                                 "start": 1343,
-                                                                                                                                                                                                                                                                                                "end": 2677,
+                                                                                                                                                                                                                                                                                                "end": 2672,
                                                                                                                                                                                                                                                                                                 "ctxt": 0
                                                                                                                                                                                                                                                                                               },
                                                                                                                                                                                                                                                                                               "tagName": "div",
@@ -1972,7 +1972,7 @@
                                                                                                                                                                                                                                                                                                   "type": "Element",
                                                                                                                                                                                                                                                                                                   "span": {
                                                                                                                                                                                                                                                                                                     "start": 1353,
-                                                                                                                                                                                                                                                                                                    "end": 2677,
+                                                                                                                                                                                                                                                                                                    "end": 2672,
                                                                                                                                                                                                                                                                                                     "ctxt": 0
                                                                                                                                                                                                                                                                                                   },
                                                                                                                                                                                                                                                                                                   "tagName": "sup",
@@ -1992,7 +1992,7 @@
                                                                                                                                                                                                                                                                                                       "type": "Element",
                                                                                                                                                                                                                                                                                                       "span": {
                                                                                                                                                                                                                                                                                                         "start": 1370,
-                                                                                                                                                                                                                                                                                                        "end": 2677,
+                                                                                                                                                                                                                                                                                                        "end": 2672,
                                                                                                                                                                                                                                                                                                         "ctxt": 0
                                                                                                                                                                                                                                                                                                       },
                                                                                                                                                                                                                                                                                                       "tagName": "div",
@@ -4186,7 +4186,7 @@
                                                                                                                                                                                                                                                                                                           "type": "Element",
                                                                                                                                                                                                                                                                                                           "span": {
                                                                                                                                                                                                                                                                                                             "start": 1380,
-                                                                                                                                                                                                                                                                                                            "end": 1404,
+                                                                                                                                                                                                                                                                                                            "end": 1399,
                                                                                                                                                                                                                                                                                                             "ctxt": 0
                                                                                                                                                                                                                                                                                                           },
                                                                                                                                                                                                                                                                                                           "tagName": "table",
@@ -4197,7 +4197,7 @@
                                                                                                                                                                                                                                                                                                               "type": "Text",
                                                                                                                                                                                                                                                                                                               "span": {
                                                                                                                                                                                                                                                                                                                 "start": 1398,
-                                                                                                                                                                                                                                                                                                                "end": 1404,
+                                                                                                                                                                                                                                                                                                                "end": 1399,
                                                                                                                                                                                                                                                                                                                 "ctxt": 0
                                                                                                                                                                                                                                                                                                               },
                                                                                                                                                                                                                                                                                                               "value": "\n"
@@ -4577,7 +4577,7 @@
                                                                                                                                                                                                                                                                                                           "type": "Element",
                                                                                                                                                                                                                                                                                                           "span": {
                                                                                                                                                                                                                                                                                                             "start": 2652,
-                                                                                                                                                                                                                                                                                                            "end": 2677,
+                                                                                                                                                                                                                                                                                                            "end": 2672,
                                                                                                                                                                                                                                                                                                             "ctxt": 0
                                                                                                                                                                                                                                                                                                           },
                                                                                                                                                                                                                                                                                                           "tagName": "table",
@@ -4588,7 +4588,7 @@
                                                                                                                                                                                                                                                                                                               "type": "Text",
                                                                                                                                                                                                                                                                                                               "span": {
                                                                                                                                                                                                                                                                                                                 "start": 2671,
-                                                                                                                                                                                                                                                                                                                "end": 2677,
+                                                                                                                                                                                                                                                                                                                "end": 2672,
                                                                                                                                                                                                                                                                                                                 "ctxt": 0
                                                                                                                                                                                                                                                                                                               },
                                                                                                                                                                                                                                                                                                               "value": "\n"

--- a/crates/swc_html_parser/tests/recovery/element/foreign-context/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/foreign-context/output.stderr
@@ -3348,3 +3348,7 @@
      `----
 
   x End of file seen and there were open elements
+     ,-[$DIR/tests/recovery/element/foreign-context/input.html:100:1]
+ 100 | </html>
+     :        ^
+     `----

--- a/crates/swc_html_parser/tests/recovery/element/foreign-context/span.rust-debug
+++ b/crates/swc_html_parser/tests/recovery/element/foreign-context/span.rust-debug
@@ -209,8 +209,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -307,8 +307,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Attribute
@@ -591,8 +591,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -681,8 +681,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -784,8 +784,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -873,8 +873,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -999,8 +999,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -1087,8 +1087,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -1212,8 +1212,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -1299,8 +1299,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -1398,8 +1398,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -1485,8 +1485,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -1585,8 +1585,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -1671,8 +1671,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -1769,8 +1769,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -1855,8 +1855,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -1954,8 +1954,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -2039,8 +2039,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -2136,8 +2136,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -2221,8 +2221,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -2319,8 +2319,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -2403,8 +2403,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -2524,8 +2524,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -2607,8 +2607,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -2702,8 +2702,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -2785,8 +2785,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -2881,8 +2881,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -2963,8 +2963,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -3057,8 +3057,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -3139,8 +3139,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -3234,8 +3234,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -3315,8 +3315,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -3408,8 +3408,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -3489,8 +3489,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -3583,8 +3583,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -3663,8 +3663,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -3755,8 +3755,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -3835,8 +3835,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -3928,8 +3928,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -4007,8 +4007,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -4098,8 +4098,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -4177,8 +4177,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -4269,8 +4269,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -4347,8 +4347,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -4437,8 +4437,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -4515,8 +4515,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -4606,8 +4606,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -4683,8 +4683,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -4772,8 +4772,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -4849,8 +4849,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -4939,8 +4939,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -5015,8 +5015,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -5128,8 +5128,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -5203,8 +5203,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -5290,8 +5290,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -5365,8 +5365,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -5453,8 +5453,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -5527,8 +5527,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -5613,8 +5613,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -5687,8 +5687,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -5774,8 +5774,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -5847,8 +5847,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -5932,8 +5932,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -6005,8 +6005,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -6091,8 +6091,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -6163,8 +6163,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -6247,8 +6247,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -6319,8 +6319,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -6404,8 +6404,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -6475,8 +6475,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -6558,8 +6558,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -6629,8 +6629,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -6713,8 +6713,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -6783,8 +6783,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -6865,8 +6865,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -6935,8 +6935,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -7018,8 +7018,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -7087,8 +7087,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -7193,8 +7193,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -7261,8 +7261,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -7341,8 +7341,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -7409,8 +7409,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -7490,8 +7490,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -7557,8 +7557,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -7661,8 +7661,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -7727,8 +7727,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -7805,8 +7805,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -7871,8 +7871,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -7950,8 +7950,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -8015,8 +8015,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -8092,8 +8092,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -8157,8 +8157,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -8235,8 +8235,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -8299,8 +8299,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -8375,8 +8375,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -8439,8 +8439,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -8516,8 +8516,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -8579,8 +8579,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -8679,8 +8679,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -8741,8 +8741,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -8815,8 +8815,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -8877,8 +8877,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -8952,8 +8952,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -9013,8 +9013,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -9086,8 +9086,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -9147,8 +9147,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -9221,8 +9221,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -9281,8 +9281,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -9380,8 +9380,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -9439,8 +9439,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -9510,8 +9510,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -9569,8 +9569,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -9641,8 +9641,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -9699,8 +9699,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -9769,8 +9769,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -9827,8 +9827,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -9898,8 +9898,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -9955,8 +9955,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -10024,8 +10024,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -10081,8 +10081,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -10151,8 +10151,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -10207,8 +10207,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -10275,8 +10275,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -10331,8 +10331,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -10400,8 +10400,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -10455,8 +10455,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -10522,8 +10522,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -10577,8 +10577,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -10645,8 +10645,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -10699,8 +10699,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -10765,8 +10765,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -10819,8 +10819,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -10886,8 +10886,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -10939,8 +10939,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -11004,8 +11004,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -11057,8 +11057,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -11123,8 +11123,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -11175,8 +11175,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -11239,8 +11239,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -11291,8 +11291,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -11356,8 +11356,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -11407,8 +11407,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -11470,8 +11470,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -11521,8 +11521,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -11585,8 +11585,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Element
@@ -11635,8 +11635,8 @@
  91 | |   <div><math><strike></math</div>
  92 | |   <div><math><sub></math</div>
  93 | |   <div><math><sup></math</div>
- 94 | |   <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | `-> <div><math><table></math</div>
+ 95 |     <div><math><tt></math</div>
     `----
 
   x Child
@@ -17065,26 +17065,30 @@
 
   x Child
     ,-[$DIR/tests/recovery/element/foreign-context/input.html:50:1]
- 50 | ,-> <div><svg><table></svg</div>
- 51 | `-> <div><svg><tt></svg</div>
+ 50 | <div><svg><table></svg</div>
+    :           ^^^^^^^^^^^^^^^^^^^
+ 51 | <div><svg><tt></svg</div>
     `----
 
   x Element
     ,-[$DIR/tests/recovery/element/foreign-context/input.html:50:1]
- 50 | ,-> <div><svg><table></svg</div>
- 51 | `-> <div><svg><tt></svg</div>
+ 50 | <div><svg><table></svg</div>
+    :           ^^^^^^^^^^^^^^^^^^^
+ 51 | <div><svg><tt></svg</div>
     `----
 
   x Child
     ,-[$DIR/tests/recovery/element/foreign-context/input.html:50:1]
- 50 | ,-> <div><svg><table></svg</div>
- 51 | `-> <div><svg><tt></svg</div>
+ 50 | <div><svg><table></svg</div>
+    :                             ^
+ 51 | <div><svg><tt></svg</div>
     `----
 
   x Text
     ,-[$DIR/tests/recovery/element/foreign-context/input.html:50:1]
- 50 | ,-> <div><svg><table></svg</div>
- 51 | `-> <div><svg><tt></svg</div>
+ 50 | <div><svg><table></svg</div>
+    :                             ^
+ 51 | <div><svg><tt></svg</div>
     `----
 
   x Child
@@ -18127,24 +18131,28 @@
 
   x Child
     ,-[$DIR/tests/recovery/element/foreign-context/input.html:94:1]
- 94 | ,-> <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | <div><math><table></math</div>
+    :            ^^^^^^^^^^^^^^^^^^^^
+ 95 | <div><math><tt></math</div>
     `----
 
   x Element
     ,-[$DIR/tests/recovery/element/foreign-context/input.html:94:1]
- 94 | ,-> <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | <div><math><table></math</div>
+    :            ^^^^^^^^^^^^^^^^^^^^
+ 95 | <div><math><tt></math</div>
     `----
 
   x Child
     ,-[$DIR/tests/recovery/element/foreign-context/input.html:94:1]
- 94 | ,-> <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | <div><math><table></math</div>
+    :                               ^
+ 95 | <div><math><tt></math</div>
     `----
 
   x Text
     ,-[$DIR/tests/recovery/element/foreign-context/input.html:94:1]
- 94 | ,-> <div><math><table></math</div>
- 95 | `-> <div><math><tt></math</div>
+ 94 | <div><math><table></math</div>
+    :                               ^
+ 95 | <div><math><tt></math</div>
     `----

--- a/crates/swc_html_parser/tests/recovery/element/hgroup/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/hgroup/output.stderr
@@ -1,2 +1,6 @@
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/hgroup/input.html:1:1]
+ 1 | <!doctype html><p>foo<hgroup>bar<p>baz
+   :                                       ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/isindex/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/isindex/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/isindex/input.html:1:1]
+ 1 | <isindex>
+   :          ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/main-1/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/main-1/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/main-1/input.html:1:1]
+ 1 | <!DOCTYPE html>xxx<svg><x><g><a><main><b>
+   :                                          ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/main/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/main/output.stderr
@@ -1,2 +1,6 @@
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/main/input.html:1:1]
+ 1 | <!doctype html><p>foo<main>bar<p>baz
+   :                                     ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/nobr-1/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/nobr-1/output.stderr
@@ -12,3 +12,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/nobr-1/input.html:1:1]
+ 1 | <!doctype html><nobr><nobr><nobr>
+   :                                  ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/nobr/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/nobr/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/nobr/input.html:1:1]
+ 1 | <nobr>X
+   :        ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/p-1/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/p-1/output.stderr
@@ -12,3 +12,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/p-1/input.html:1:1]
+ 1 | <div><p>a</x> b
+   :                ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/p-2/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/p-2/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/p-2/input.html:1:12]
+ 1 |  
+   : ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/plaintext/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/plaintext/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+    ,-[$DIR/tests/recovery/element/plaintext/input.html:33:1]
+ 33 | </html>
+    :        ^
+    `----

--- a/crates/swc_html_parser/tests/recovery/element/rb-1/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/rb-1/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/rb-1/input.html:1:1]
+ 1 | <!doctype html><div><p><rt>
+   :                            ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/rb/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/rb/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/rb/input.html:1:1]
+ 1 | <!doctype html><ruby><div><p><rb>
+   :                                  ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/rt-1/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/rt-1/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/rt-1/input.html:1:1]
+ 1 | <!doctype html><div><p><rt>
+   :                            ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/rt/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/rt/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/rt/input.html:1:1]
+ 1 | <!doctype html><ruby><div><p><rt>
+   :                                  ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/s/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/s/output.stderr
@@ -36,3 +36,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/s/input.html:1:1]
+ 1 | <div><table><svg><foreignObject><select><table><s>
+   :                                                   ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/search-1/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/search-1/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/search-1/input.html:1:1]
+ 1 | <!DOCTYPE html>xxx<svg><x><g><a><search><b>
+   :                                            ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/svg-1/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/svg-1/output.json
@@ -2,7 +2,7 @@
   "type": "Document",
   "span": {
     "start": 1,
-    "end": 22,
+    "end": 25,
     "ctxt": 0
   },
   "mode": "quirks",

--- a/crates/swc_html_parser/tests/recovery/element/svg-1/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/svg-1/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/svg-1/input.html:2:1]
+ 2 | bar]]>
+   :       ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/svg-3/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/svg-3/output.stderr
@@ -18,3 +18,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/svg-3/input.html:1:1]
+ 1 | <svg></p><foo>
+   :               ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/svg/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/svg/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/svg/input.html:1:1]
+ 1 | <!DOCTYPE html>xxx<svg><x><g><a><main><b>
+   :                                          ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/table-1/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/table-1/output.stderr
@@ -18,3 +18,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/table-1/input.html:1:1]
+ 1 | <table><td></tbody>A
+   :                     ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/table-2/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/table-2/output.json
@@ -130,7 +130,7 @@
               "type": "Element",
               "span": {
                 "start": 84,
-                "end": 103,
+                "end": 96,
                 "ctxt": 0
               },
               "tagName": "table",
@@ -141,7 +141,7 @@
                   "type": "Text",
                   "span": {
                     "start": 91,
-                    "end": 103,
+                    "end": 96,
                     "ctxt": 0
                   },
                   "value": "\n    "
@@ -196,7 +196,7 @@
                   "type": "Text",
                   "span": {
                     "start": 121,
-                    "end": 130,
+                    "end": 126,
                     "ctxt": 0
                   },
                   "value": "\n    "
@@ -205,7 +205,7 @@
                   "type": "Element",
                   "span": {
                     "start": 0,
-                    "end": 147,
+                    "end": 139,
                     "ctxt": 0
                   },
                   "tagName": "tbody",
@@ -216,7 +216,7 @@
                       "type": "Element",
                       "span": {
                         "start": 126,
-                        "end": 147,
+                        "end": 139,
                         "ctxt": 0
                       },
                       "tagName": "tr",
@@ -227,7 +227,7 @@
                           "type": "Text",
                           "span": {
                             "start": 130,
-                            "end": 147,
+                            "end": 139,
                             "ctxt": 0
                           },
                           "value": "\n        "

--- a/crates/swc_html_parser/tests/recovery/element/table-2/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/table-2/output.json
@@ -164,7 +164,7 @@
                   "type": "Text",
                   "span": {
                     "start": 103,
-                    "end": 112,
+                    "end": 104,
                     "ctxt": 0
                   },
                   "value": "\n"

--- a/crates/swc_html_parser/tests/recovery/element/table-2/span.rust-debug
+++ b/crates/swc_html_parser/tests/recovery/element/table-2/span.rust-debug
@@ -245,14 +245,16 @@
 
   x Child
    ,-[$DIR/tests/recovery/element/table-2/input.html:8:5]
- 8 | ,-> <table>
- 9 | `-> </table>
+ 8 | <table>
+   :        ^
+ 9 | </table>
    `----
 
   x Text
    ,-[$DIR/tests/recovery/element/table-2/input.html:8:5]
- 8 | ,-> <table>
- 9 | `-> </table>
+ 8 | <table>
+   :        ^
+ 9 | </table>
    `----
 
   x Child

--- a/crates/swc_html_parser/tests/recovery/element/table-3/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/table-3/output.json
@@ -141,7 +141,7 @@
                   "type": "Text",
                   "span": {
                     "start": 91,
-                    "end": 105,
+                    "end": 96,
                     "ctxt": 0
                   },
                   "value": "\n    "

--- a/crates/swc_html_parser/tests/recovery/element/table-5/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/table-5/output.json
@@ -57,7 +57,7 @@
               "type": "Text",
               "span": {
                 "start": 23,
-                "end": 34,
+                "end": 26,
                 "ctxt": 0
               },
               "value": " x "

--- a/crates/swc_html_parser/tests/recovery/element/table-5/span.rust-debug
+++ b/crates/swc_html_parser/tests/recovery/element/table-5/span.rust-debug
@@ -28,13 +28,13 @@
   x Child
    ,-[$DIR/tests/recovery/element/table-5/input.html:1:1]
  1 | <!doctype html><table> x </table>
-   :                       ^^^^^^^^^^^
+   :                       ^^^
    `----
 
   x Text
    ,-[$DIR/tests/recovery/element/table-5/input.html:1:1]
  1 | <!doctype html><table> x </table>
-   :                       ^^^^^^^^^^^
+   :                       ^^^
    `----
 
   x Child

--- a/crates/swc_html_parser/tests/recovery/element/table-6/dom.rust-debug
+++ b/crates/swc_html_parser/tests/recovery/element/table-6/dom.rust-debug
@@ -1,0 +1,7 @@
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+|         <tr>
+|           <td>

--- a/crates/swc_html_parser/tests/recovery/element/table-6/input.html
+++ b/crates/swc_html_parser/tests/recovery/element/table-6/input.html
@@ -1,0 +1,1 @@
+<table><td><div

--- a/crates/swc_html_parser/tests/recovery/element/table-6/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/table-6/output.json
@@ -1,0 +1,107 @@
+{
+  "type": "Document",
+  "span": {
+    "start": 1,
+    "end": 16,
+    "ctxt": 0
+  },
+  "mode": "quirks",
+  "children": [
+    {
+      "type": "Element",
+      "span": {
+        "start": 0,
+        "end": 12,
+        "ctxt": 0
+      },
+      "tagName": "html",
+      "namespace": "http://www.w3.org/1999/xhtml",
+      "attributes": [],
+      "children": [
+        {
+          "type": "Element",
+          "span": {
+            "start": 0,
+            "end": 8,
+            "ctxt": 0
+          },
+          "tagName": "head",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "attributes": [],
+          "children": [],
+          "content": null
+        },
+        {
+          "type": "Element",
+          "span": {
+            "start": 0,
+            "end": 12,
+            "ctxt": 0
+          },
+          "tagName": "body",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "attributes": [],
+          "children": [
+            {
+              "type": "Element",
+              "span": {
+                "start": 1,
+                "end": 12,
+                "ctxt": 0
+              },
+              "tagName": "table",
+              "namespace": "http://www.w3.org/1999/xhtml",
+              "attributes": [],
+              "children": [
+                {
+                  "type": "Element",
+                  "span": {
+                    "start": 0,
+                    "end": 12,
+                    "ctxt": 0
+                  },
+                  "tagName": "tbody",
+                  "namespace": "http://www.w3.org/1999/xhtml",
+                  "attributes": [],
+                  "children": [
+                    {
+                      "type": "Element",
+                      "span": {
+                        "start": 0,
+                        "end": 12,
+                        "ctxt": 0
+                      },
+                      "tagName": "tr",
+                      "namespace": "http://www.w3.org/1999/xhtml",
+                      "attributes": [],
+                      "children": [
+                        {
+                          "type": "Element",
+                          "span": {
+                            "start": 8,
+                            "end": 12,
+                            "ctxt": 0
+                          },
+                          "tagName": "td",
+                          "namespace": "http://www.w3.org/1999/xhtml",
+                          "attributes": [],
+                          "children": [],
+                          "content": null
+                        }
+                      ],
+                      "content": null
+                    }
+                  ],
+                  "content": null
+                }
+              ],
+              "content": null
+            }
+          ],
+          "content": null
+        }
+      ],
+      "content": null
+    }
+  ]
+}

--- a/crates/swc_html_parser/tests/recovery/element/table-6/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/table-6/output.stderr
@@ -1,0 +1,24 @@
+
+  x Start tag seen without seeing a doctype firs, expected "<!DOCTYPE html>"
+   ,-[$DIR/tests/recovery/element/table-6/input.html:1:1]
+ 1 | <table><td><div
+   : ^^^^^^^
+   `----
+
+  x Start tag "td" seen in "table" body
+   ,-[$DIR/tests/recovery/element/table-6/input.html:1:1]
+ 1 | <table><td><div
+   :        ^^^^
+   `----
+
+  x Eof in tag
+   ,-[$DIR/tests/recovery/element/table-6/input.html:1:1]
+ 1 | <table><td><div
+   :                ^
+   `----
+
+  x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/table-6/input.html:1:1]
+ 1 | <table><td><div
+   :                ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/table-6/span.rust-debug
+++ b/crates/swc_html_parser/tests/recovery/element/table-6/span.rust-debug
@@ -1,0 +1,38 @@
+
+  x Document
+   ,-[$DIR/tests/recovery/element/table-6/input.html:1:1]
+ 1 | <table><td><div
+   : ^^^^^^^^^^^^^^^
+   `----
+
+  x Child
+
+  x Element
+
+  x Child
+
+  x Element
+
+  x Child
+   ,-[$DIR/tests/recovery/element/table-6/input.html:1:1]
+ 1 | <table><td><div
+   : ^^^^^^^^^^^
+   `----
+
+  x Element
+   ,-[$DIR/tests/recovery/element/table-6/input.html:1:1]
+ 1 | <table><td><div
+   : ^^^^^^^^^^^
+   `----
+
+  x Child
+   ,-[$DIR/tests/recovery/element/table-6/input.html:1:1]
+ 1 | <table><td><div
+   :        ^^^^
+   `----
+
+  x Element
+   ,-[$DIR/tests/recovery/element/table-6/input.html:1:1]
+ 1 | <table><td><div
+   :        ^^^^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/table/broken-3/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/table/broken-3/output.json
@@ -130,7 +130,7 @@
               "type": "Element",
               "span": {
                 "start": 85,
-                "end": 104,
+                "end": 97,
                 "ctxt": 0
               },
               "tagName": "table",
@@ -141,7 +141,7 @@
                   "type": "Text",
                   "span": {
                     "start": 92,
-                    "end": 104,
+                    "end": 97,
                     "ctxt": 0
                   },
                   "value": "\n    "
@@ -164,7 +164,7 @@
                   "type": "Text",
                   "span": {
                     "start": 104,
-                    "end": 117,
+                    "end": 113,
                     "ctxt": 0
                   },
                   "value": "\n        "
@@ -173,7 +173,7 @@
                   "type": "Element",
                   "span": {
                     "start": 0,
-                    "end": 201,
+                    "end": 193,
                     "ctxt": 0
                   },
                   "tagName": "tbody",
@@ -195,7 +195,7 @@
                           "type": "Text",
                           "span": {
                             "start": 117,
-                            "end": 134,
+                            "end": 130,
                             "ctxt": 0
                           },
                           "value": "\n            "
@@ -227,7 +227,7 @@
                           "type": "Text",
                           "span": {
                             "start": 174,
-                            "end": 188,
+                            "end": 183,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -239,7 +239,7 @@
                       "type": "Text",
                       "span": {
                         "start": 188,
-                        "end": 201,
+                        "end": 193,
                         "ctxt": 0
                       },
                       "value": "\n    "

--- a/crates/swc_html_parser/tests/recovery/element/table/broken-6/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/table/broken-6/output.json
@@ -141,7 +141,7 @@
                   "type": "Text",
                   "span": {
                     "start": 91,
-                    "end": 100,
+                    "end": 96,
                     "ctxt": 0
                   },
                   "value": "\n    "
@@ -172,7 +172,7 @@
                           "type": "Text",
                           "span": {
                             "start": 100,
-                            "end": 113,
+                            "end": 109,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -212,7 +212,7 @@
                                   "type": "Text",
                                   "span": {
                                     "start": 133,
-                                    "end": 166,
+                                    "end": 158,
                                     "ctxt": 0
                                   },
                                   "value": "\n        \n    \n"

--- a/crates/swc_html_parser/tests/recovery/element/table/broken-6/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/table/broken-6/output.stderr
@@ -24,3 +24,7 @@
     `----
 
   x End of file seen and there were open elements
+    ,-[$DIR/tests/recovery/element/table/broken-6/input.html:15:1]
+ 15 | </html>
+    :        ^
+    `----

--- a/crates/swc_html_parser/tests/recovery/element/table/broken-6/span.rust-debug
+++ b/crates/swc_html_parser/tests/recovery/element/table/broken-6/span.rust-debug
@@ -324,16 +324,16 @@
     ,-[$DIR/tests/recovery/element/table/broken-6/input.html:10:13]
  10 | ,-> <table>
  11 | |           </td>
- 12 | |       </tr>
- 13 | `-> </table>
+ 12 | `->     </tr>
+ 13 |     </table>
     `----
 
   x Text
     ,-[$DIR/tests/recovery/element/table/broken-6/input.html:10:13]
  10 | ,-> <table>
  11 | |           </td>
- 12 | |       </tr>
- 13 | `-> </table>
+ 12 | `->     </tr>
+ 13 |     </table>
     `----
 
   x Child

--- a/crates/swc_html_parser/tests/recovery/element/table/broken-7/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/table/broken-7/output.json
@@ -142,7 +142,7 @@
                                   "type": "Text",
                                   "span": {
                                     "start": 46,
-                                    "end": 81,
+                                    "end": 73,
                                     "ctxt": 0
                                   },
                                   "value": "\nA BC"

--- a/crates/swc_html_parser/tests/recovery/element/table/broken-7/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/table/broken-7/output.json
@@ -162,7 +162,7 @@
                                       "type": "Element",
                                       "span": {
                                         "start": 0,
-                                        "end": 72,
+                                        "end": 67,
                                         "ctxt": 0
                                       },
                                       "tagName": "tbody",
@@ -186,7 +186,7 @@
                                           "type": "Text",
                                           "span": {
                                             "start": 66,
-                                            "end": 72,
+                                            "end": 67,
                                             "ctxt": 0
                                           },
                                           "value": " "

--- a/crates/swc_html_parser/tests/recovery/element/table/broken-7/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/table/broken-7/output.stderr
@@ -42,3 +42,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/table/broken-7/input.html:2:1]
+ 2 | A<table><tr> B</tr> </em>C</table>
+   :                                   ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/table/broken-7/span.rust-debug
+++ b/crates/swc_html_parser/tests/recovery/element/table/broken-7/span.rust-debug
@@ -140,11 +140,11 @@
   x Child
    ,-[$DIR/tests/recovery/element/table/broken-7/input.html:2:1]
  2 | A<table><tr> B</tr> </em>C</table>
-   :                    ^^^^^^
+   :                    ^
    `----
 
   x Text
    ,-[$DIR/tests/recovery/element/table/broken-7/input.html:2:1]
  2 | A<table><tr> B</tr> </em>C</table>
-   :                    ^^^^^^
+   :                    ^
    `----

--- a/crates/swc_html_parser/tests/recovery/element/table/broken-8/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/element/table/broken-8/output.stderr
@@ -30,3 +30,7 @@
    `----
 
   x End of file seen and there were open elements
+   ,-[$DIR/tests/recovery/element/table/broken-8/input.html:1:1]
+ 1 | <body><table><tr><td><svg><td><foreignObject><span></td>Foo
+   :                                                            ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/element/table/table-characters-2/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/table/table-characters-2/output.json
@@ -121,7 +121,7 @@
               "type": "Text",
               "span": {
                 "start": 83,
-                "end": 117,
+                "end": 109,
                 "ctxt": 0
               },
               "value": "\n    A B C"

--- a/crates/swc_html_parser/tests/recovery/element/table/table-characters-3/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/table/table-characters-3/output.json
@@ -121,7 +121,7 @@
               "type": "Text",
               "span": {
                 "start": 83,
-                "end": 122,
+                "end": 114,
                 "ctxt": 0
               },
               "value": "\n    A BC"

--- a/crates/swc_html_parser/tests/recovery/element/table/table-characters-3/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/table/table-characters-3/output.json
@@ -141,7 +141,7 @@
                   "type": "Element",
                   "span": {
                     "start": 0,
-                    "end": 113,
+                    "end": 108,
                     "ctxt": 0
                   },
                   "tagName": "tbody",
@@ -165,7 +165,7 @@
                       "type": "Text",
                       "span": {
                         "start": 107,
-                        "end": 113,
+                        "end": 108,
                         "ctxt": 0
                       },
                       "value": " "

--- a/crates/swc_html_parser/tests/recovery/element/table/table-characters-3/span.rust-debug
+++ b/crates/swc_html_parser/tests/recovery/element/table/table-characters-3/span.rust-debug
@@ -191,13 +191,13 @@
   x Child
    ,-[$DIR/tests/recovery/element/table/table-characters-3/input.html:7:5]
  7 | A<table><tr> B</tr> </em>C</table>
-   :                    ^^^^^^
+   :                    ^
    `----
 
   x Text
    ,-[$DIR/tests/recovery/element/table/table-characters-3/input.html:7:5]
  7 | A<table><tr> B</tr> </em>C</table>
-   :                    ^^^^^^
+   :                    ^
    `----
 
   x Child

--- a/crates/swc_html_parser/tests/recovery/element/table/table-characters/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/table/table-characters/output.json
@@ -121,7 +121,7 @@
               "type": "Text",
               "span": {
                 "start": 83,
-                "end": 116,
+                "end": 108,
                 "ctxt": 0
               },
               "value": "\n    ABCD"

--- a/crates/swc_html_parser/tests/recovery/element/td/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/td/output.json
@@ -315,7 +315,7 @@
                   "type": "Text",
                   "span": {
                     "start": 317,
-                    "end": 326,
+                    "end": 322,
                     "ctxt": 0
                   },
                   "value": "\n    "
@@ -346,7 +346,7 @@
                           "type": "Text",
                           "span": {
                             "start": 326,
-                            "end": 339,
+                            "end": 335,
                             "ctxt": 0
                           },
                           "value": "\n        "
@@ -392,7 +392,7 @@
                           "type": "Text",
                           "span": {
                             "start": 356,
-                            "end": 436,
+                            "end": 432,
                             "ctxt": 0
                           },
                           "value": "\n            \n            "

--- a/crates/swc_html_parser/tests/recovery/element/td/output.json
+++ b/crates/swc_html_parser/tests/recovery/element/td/output.json
@@ -324,7 +324,7 @@
                   "type": "Element",
                   "span": {
                     "start": 0,
-                    "end": 455,
+                    "end": 447,
                     "ctxt": 0
                   },
                   "tagName": "tbody",
@@ -427,7 +427,7 @@
                       "type": "Text",
                       "span": {
                         "start": 446,
-                        "end": 455,
+                        "end": 447,
                         "ctxt": 0
                       },
                       "value": "\n"

--- a/crates/swc_html_parser/tests/recovery/element/td/span.rust-debug
+++ b/crates/swc_html_parser/tests/recovery/element/td/span.rust-debug
@@ -537,14 +537,16 @@
 
   x Child
     ,-[$DIR/tests/recovery/element/td/input.html:19:5]
- 19 | ,-> </tr>
- 20 | `-> </table>
+ 19 | </tr>
+    :      ^
+ 20 | </table>
     `----
 
   x Text
     ,-[$DIR/tests/recovery/element/td/input.html:19:5]
- 19 | ,-> </tr>
- 20 | `-> </table>
+ 19 | </tr>
+    :      ^
+ 20 | </table>
     `----
 
   x Child

--- a/crates/swc_html_parser/tests/recovery/text/ambiguous-ampersand/output.json
+++ b/crates/swc_html_parser/tests/recovery/text/ambiguous-ampersand/output.json
@@ -104,7 +104,7 @@
                       "type": "Text",
                       "span": {
                         "start": 87,
-                        "end": 153,
+                        "end": 152,
                         "ctxt": 0
                       },
                       "value": "Text: ?a=b&c=d&a0b=c©=1¬i=n¬=in¬in=∉¬&;& &"

--- a/crates/swc_html_parser/tests/recovery/text/ambiguous-ampersand/span.rust-debug
+++ b/crates/swc_html_parser/tests/recovery/text/ambiguous-ampersand/span.rust-debug
@@ -70,13 +70,13 @@
   x Child
    ,-[$DIR/tests/recovery/text/ambiguous-ampersand/input.html:1:1]
  1 | <div><a href='?a=b&c=d&a0b=c&copy=1&noti=n&not=in&notin=&notin;&not;&;& &'>Link</a><p>Text: ?a=b&c=d&a0b=c&copy=1&noti=n&not=in&notin=&notin;&not;&;& &</p></div>
-   :                                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   :                                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
   x Text
    ,-[$DIR/tests/recovery/text/ambiguous-ampersand/input.html:1:1]
  1 | <div><a href='?a=b&c=d&a0b=c&copy=1&noti=n&not=in&notin=&notin;&not;&;& &'>Link</a><p>Text: ?a=b&c=d&a0b=c&copy=1&noti=n&not=in&notin=&notin;&not;&;& &</p></div>
-   :                                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   :                                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
   x Child

--- a/crates/swc_html_parser/tests/recovery/text/cr-as-numeric-entity/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/text/cr-as-numeric-entity/output.stderr
@@ -6,3 +6,7 @@
    `----
 
   x End of file seen without seeing a doctype first, expected "<!DOCTYPE html>"
+   ,-[$DIR/tests/recovery/text/cr-as-numeric-entity/input.html:1:1]
+ 1 | &#013;
+   :       ^
+   `----

--- a/crates/swc_html_parser/tests/recovery/text/empty-entities/output.json
+++ b/crates/swc_html_parser/tests/recovery/text/empty-entities/output.json
@@ -22,7 +22,7 @@
           "type": "Element",
           "span": {
             "start": 0,
-            "end": 4,
+            "end": 3,
             "ctxt": 0
           },
           "tagName": "head",

--- a/crates/swc_html_parser/tests/recovery/text/empty-entities/output.stderr
+++ b/crates/swc_html_parser/tests/recovery/text/empty-entities/output.stderr
@@ -8,7 +8,7 @@
   x Non-space characters found without seeing a doctype first, expected "<!DOCTYPE html>"
    ,-[$DIR/tests/recovery/text/empty-entities/input.html:1:1]
  1 | &# &#;
-   : ^^^
+   : ^^
    `----
 
   x Absence of digits in numeric character reference


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Fix:
- Text spans
- `Eof*` errors positions
- improve perf and avoid writting `last_pos` for each token (I think we can do it for CSS parser too)
- Refactor code to using `.lo()` and `.hi()`

**BREAKING CHANGE:**

Yes, new methods for `Input`

**Related issue (if exists):**

No