### PR TITLE
fix(es/minifier): Don't drop `typeof`

### DIFF
--- a/crates/swc/tests/fixture/issues-4xxx/4855/input/1/.swcrc
+++ b/crates/swc/tests/fixture/issues-4xxx/4855/input/1/.swcrc
@@ -1,0 +1,18 @@
+{
+    "jsc": {
+        "externalHelpers": true,
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": false
+        },
+        "target": "es2022",
+        "loose": false,
+        "minify": {
+            "compress": true,
+            "mangle": true
+        }
+    },
+    "module": {
+        "type": "es6"
+    }
+}

--- a/crates/swc/tests/fixture/issues-4xxx/4855/input/1/input.js
+++ b/crates/swc/tests/fixture/issues-4xxx/4855/input/1/input.js
@@ -1,0 +1,2 @@
+if (typeof process === "undefined") {
+}

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -535,7 +535,7 @@ impl Pure<'_> {
         if self.options.side_effects {
             match e {
                 Expr::Unary(UnaryExpr {
-                    op: op!("void") | op!("typeof") | op!(unary, "+") | op!(unary, "-"),
+                    op: op!("void") | op!(unary, "+") | op!(unary, "-"),
                     arg,
                     ..
                 }) => {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -1516,12 +1516,9 @@ fn ignore_result(e: Expr, drop_str_lit: bool, ctx: &ExprCtx) -> Option<Expr> {
                 Some(Expr::Unary(UnaryExpr { span, op, arg }))
             }
 
-            op!("void")
-            | op!("typeof")
-            | op!(unary, "+")
-            | op!(unary, "-")
-            | op!("!")
-            | op!("~") => ignore_result(*arg, true, ctx),
+            op!("void") | op!(unary, "+") | op!(unary, "-") | op!("!") | op!("~") => {
+                ignore_result(*arg, true, ctx)
+            }
             _ => Some(Expr::Unary(UnaryExpr { span, op, arg })),
         },
 


### PR DESCRIPTION
**Description:**


**Related issue (if exists):**

 - Closes https://github.com/swc-project/swc/issues/4855