### PR TITLE
fix(es/modules/amd): Support `export * as foo from 'foo'`

### DIFF
--- a/crates/swc/tests/fixture/4896/input/.swcrc
+++ b/crates/swc/tests/fixture/4896/input/.swcrc
@@ -1,0 +1,14 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": false
+        },
+        "target": "es2021",
+        "loose": false
+    },
+    "module": {
+        "type": "amd",
+        "noInterop": true
+    }
+}

--- a/crates/swc/tests/fixture/4896/input/index.ts
+++ b/crates/swc/tests/fixture/4896/input/index.ts
@@ -1,0 +1,1 @@
+export * as icons from "vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedIcons";

--- a/crates/swc/tests/fixture/4896/output/index.ts
+++ b/crates/swc/tests/fixture/4896/output/index.ts
@@ -1,0 +1,12 @@
+define([
+    "require",
+    "exports",
+    "vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedIcons"
+], function(require, _exports, _gettingStartedIcons) {
+    "use strict";
+    Object.defineProperty(_exports, "__esModule", {
+        value: true
+    });
+    _exports.icons = void 0;
+    _exports.icons = _gettingStartedIcons;
+});

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -366,7 +366,7 @@ impl Fold for Amd {
 
                             stmts.reserve(export.specifiers.len());
 
-                            for s in export.specifiers.iter() {
+                            for s in export.specifiers {
                                 match s {
                                     ExportSpecifier::Named(ExportNamedSpecifier {
                                         orig,
@@ -439,9 +439,9 @@ impl Fold for Amd {
                                                 AssignExpr {
                                                     span: DUMMY_SP,
                                                     left: PatOrExpr::Expr(Box::new(
-                                                        exports_ident.clone().make_member(
-                                                            exported.unwrap_or(orig).clone(),
-                                                        ),
+                                                        exports_ident
+                                                            .clone()
+                                                            .make_member(exported.unwrap_or(orig)),
                                                     )),
                                                     op: op!("="),
                                                     right: value,


### PR DESCRIPTION
**Description:**


**Related issue (if exists):**

 - Closes https://github.com/swc-project/swc/issues/4896