### PR TITLE
feat(html/minifier): option to set html5 doctype

### DIFF
--- a/crates/swc_html_minifier/src/lib.rs
+++ b/crates/swc_html_minifier/src/lib.rs
@@ -279,6 +279,8 @@ struct Minifier {
 
     meta_element_content_type: Option<MetaElementContentType>,
 
+    force_set_html5_doctype: bool,
+
     descendant_of_pre: bool,
     collapse_whitespaces: Option<CollapseWhitespaces>,
 
@@ -596,6 +598,18 @@ impl Minifier {
 }
 
 impl VisitMut for Minifier {
+    fn visit_mut_document_type(&mut self, n: &mut DocumentType) {
+        n.visit_mut_children_with(self);
+
+        if !self.force_set_html5_doctype {
+            return;
+        }
+
+        n.name = Some("html".into());
+        n.system_id = None;
+        n.public_id = None;
+    }
+
     fn visit_mut_element(&mut self, n: &mut Element) {
         self.current_element_namespace = Some(n.namespace);
         self.current_element_tag_name = Some(n.tag_name.clone());
@@ -952,6 +966,8 @@ pub fn minify(document: &mut Document, options: &MinifyOptions) {
         current_element_text_children_type: None,
 
         meta_element_content_type: None,
+
+        force_set_html5_doctype: options.force_set_html5_doctype,
 
         descendant_of_pre: false,
         collapse_whitespaces: options.collapse_whitespaces.clone(),

--- a/crates/swc_html_minifier/src/option.rs
+++ b/crates/swc_html_minifier/src/option.rs
@@ -5,7 +5,7 @@ use swc_cached::regex::CachedRegex;
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct MinifyOptions {
-    #[serde(default = "false_by_default")]
+    #[serde(default)]
     pub force_set_html5_doctype: bool,
     #[serde(default)]
     pub collapse_whitespaces: Option<CollapseWhitespaces>,
@@ -60,6 +60,4 @@ fn default_preserve_comments() -> Option<Vec<CachedRegex>> {
         CachedRegex::new("^\\[if\\s[^\\]+]").unwrap(),
         CachedRegex::new("\\[endif]").unwrap(),
     ])
-const fn false_by_default() -> bool {
-    false
 }

--- a/crates/swc_html_minifier/src/option.rs
+++ b/crates/swc_html_minifier/src/option.rs
@@ -5,6 +5,8 @@ use swc_cached::regex::CachedRegex;
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct MinifyOptions {
+    #[serde(default = "false_by_default")]
+    pub force_set_html5_doctype: bool,
     #[serde(default)]
     pub collapse_whitespaces: Option<CollapseWhitespaces>,
     /// Prevent to remove empty attributes, by default we only remove attributes
@@ -58,4 +60,6 @@ fn default_preserve_comments() -> Option<Vec<CachedRegex>> {
         CachedRegex::new("^\\[if\\s[^\\]+]").unwrap(),
         CachedRegex::new("\\[endif]").unwrap(),
     ])
+const fn false_by_default() -> bool {
+    false
 }

--- a/crates/swc_html_minifier/tests/fixture/doctype/system-force-set-html5-doctype/config.json
+++ b/crates/swc_html_minifier/tests/fixture/doctype/system-force-set-html5-doctype/config.json
@@ -1,0 +1,3 @@
+{
+  "forceSetHtml5Doctype": true
+}

--- a/crates/swc_html_minifier/tests/fixture/doctype/system-force-set-html5-doctype/input.html
+++ b/crates/swc_html_minifier/tests/fixture/doctype/system-force-set-html5-doctype/input.html
@@ -1,0 +1,9 @@
+<!doctype html SYSTEM "about:legacy-compat">
+<html lang="en">
+<head>
+    <title>Document</title>
+</head>
+<body>
+<div>test</div>
+</body>
+</html>

--- a/crates/swc_html_minifier/tests/fixture/doctype/system-force-set-html5-doctype/output.min.html
+++ b/crates/swc_html_minifier/tests/fixture/doctype/system-force-set-html5-doctype/output.min.html
@@ -1,0 +1,3 @@
+<!doctype html><html lang=en><title>Document</title><body>
+<div>test</div>
+

--- a/crates/swc_html_minifier/tests/recovery/doctype/html4-force-html5-doctype/config.json
+++ b/crates/swc_html_minifier/tests/recovery/doctype/html4-force-html5-doctype/config.json
@@ -1,0 +1,3 @@
+{
+  "forceSetHtml5Doctype": true
+}

--- a/crates/swc_html_minifier/tests/recovery/doctype/html4-force-html5-doctype/input.html
+++ b/crates/swc_html_minifier/tests/recovery/doctype/html4-force-html5-doctype/input.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+        "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<body>
+
+<h1>My First Heading</h1>
+
+<p>My first paragraph.</p>
+
+</body>
+</html>

--- a/crates/swc_html_minifier/tests/recovery/doctype/html4-force-html5-doctype/output.min.html
+++ b/crates/swc_html_minifier/tests/recovery/doctype/html4-force-html5-doctype/output.min.html
@@ -1,0 +1,7 @@
+<!doctype html><body>
+
+<h1>My First Heading</h1>
+
+<p>My first paragraph.</p>
+
+


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Add option to force set HTML5 doctype, good for legacy systems, ported from https://terser.org/html-minifier-terser/

**BREAKING CHANGE:**

Yes

**Related issue (if exists):**

No