### PR TITLE
Some general refactoring in swc_cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,33 +380,42 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.0"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
+checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "once_cell",
  "strsim",
  "termcolor",
  "terminal_size",
- "textwrap 0.14.2",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.1.0"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
+checksum = "c11d40217d16aee8508cc8e5fde8b4ff24639758608e5374e731b53f85749fb9"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -771,7 +780,7 @@ name = "dbg-swc"
 version = "0.21.0"
 dependencies = [
  "anyhow",
- "clap 3.1.0",
+ "clap 3.2.5",
  "rayon",
  "sha1 0.10.1",
  "swc_atoms",
@@ -1896,9 +1905,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "output_vt100"
@@ -3066,7 +3072,7 @@ version = "0.64.0"
 dependencies = [
  "anyhow",
  "atty",
- "clap 3.1.0",
+ "clap 3.2.5",
  "glob",
  "path-absolutize",
  "rayon",
@@ -4311,9 +4317,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
  "smawk",
- "terminal_size",
  "unicode-linebreak",
  "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+dependencies = [
+ "terminal_size",
 ]
 
 [[package]]

--- a/crates/swc_cli/Cargo.toml
+++ b/crates/swc_cli/Cargo.toml
@@ -25,7 +25,7 @@ plugin = [
 [dependencies]
 anyhow = "1.0.53"
 atty = "0.2.14"
-clap = { version = "3.1.0", features = ["derive", "wrap_help"] }
+clap = { version = "3.2.5", features = ["derive", "wrap_help"] }
 glob = "0.3.0"
 rayon = "1"
 relative-path = "1.6.1"

--- a/crates/swc_cli/src/commands/compile.rs
+++ b/crates/swc_cli/src/commands/compile.rs
@@ -425,19 +425,9 @@ impl CompileOptions {
 #[swc_trace]
 impl super::CommandRunner for CompileOptions {
     fn execute(&self) -> anyhow::Result<()> {
-        let guard = if self.experimental_trace {
-            init_trace(&self.trace_out_file)
-        } else {
-            None
-        };
-
+        let guard = init_trace(self.trace_out_file.as_deref());
         let ret = self.execute_inner();
-
-        if let Some(guard) = guard {
-            guard.flush();
-            drop(guard);
-        }
-
+        guard.flush();
         ret
     }
 }

--- a/crates/swc_cli/src/util/clap.rs
+++ b/crates/swc_cli/src/util/clap.rs
@@ -1,0 +1,20 @@
+use std::{collections::HashSet, hash::Hash, str::FromStr};
+
+use anyhow::Context as _;
+
+pub(crate) fn parse_hash_set<T>(
+    s: &str,
+) -> Result<HashSet<T>, Box<dyn std::error::Error + Send + Sync + 'static>>
+where
+    T: FromStr + Eq + Hash,
+    T::Err: std::error::Error + Send + Sync + 'static,
+{
+    let mut set = HashSet::new();
+    for s in s.split(',').map(|s| s.trim()) {
+        let item = s
+            .parse::<T>()
+            .with_context(|| format!("Failed to parse '{}' into a valid type", s))?;
+        set.insert(item);
+    }
+    Ok(set)
+}

--- a/crates/swc_cli/src/util/mod.rs
+++ b/crates/swc_cli/src/util/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod clap;
 pub(crate) mod trace;

--- a/crates/swc_cli/src/util/trace.rs
+++ b/crates/swc_cli/src/util/trace.rs
@@ -4,11 +4,11 @@ use tracing_subscriber::{
 };
 
 /// Register a tracing subscriber generated event trace format output.
-pub(crate) fn init_trace(out_file: &Option<String>) -> Option<FlushGuard> {
+pub(crate) fn init_trace(out_file: Option<&str>) -> FlushGuard {
     let mut layer = ChromeLayerBuilder::new().include_args(true);
 
     if let Some(trace_out_file) = out_file {
-        layer = layer.file(trace_out_file.clone());
+        layer = layer.file(trace_out_file);
     }
 
     let (chrome_layer, guard) = layer.build();
@@ -19,5 +19,5 @@ pub(crate) fn init_trace(out_file: &Option<String>) -> Option<FlushGuard> {
         .try_init()
         .expect("Should able to register trace");
 
-    Some(guard)
+    guard
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Hi all. First time contributor here. 

I saw @kwonoj 's comment in this [issue](https://github.com/swc-project/swc/issues/1589#issuecomment-1054774477) and became interested in the port of `swc_cli` to rust. I had a couple of free hours today and so just went through trying to familiarize myself with the existing code a bit and perform a few changes. 

I mostly focused on the `compile` command.

I noticed a couple of small improvement opportunities if you guys like them:

* Avoid a few unnecessary allocations in places (You can get away with keeping pointers to paths in several places where before you were allocating new `PathBuf`s)
* Using buffered readers and writers when trying to read/write to files (this should be marginally faster)
* Generally adding a little more context to error messages
* Some small nits like changing `&Option<PathBuf>` in function signatures to what I think is the slightly more idiomatic `Option<&Path>`.
* A little cleanup of some control flow here and there

At some point, I'd like to try my hand at adding some new code fill in more of the missing pieces of the cli, but, today, I just started with some general tweaks to what's already there.

Looking forward to seeing if you're interested in any of these changes.

Best,
Brian

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

Previously, the user was only able to provide as command line arguments for `files`:
* One directory, or
* One or more files

I changed this so it is now OK for the user to provide,
* One or more directories, and/or
* One or more files

I'm not sure if you'll want this API change, but it's pretty easy to back out if you want to keep the existing semantics.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

#1589
