### PR TITLE
fix(es/lint): allow duplicate function in non top level in module

### DIFF
--- a/crates/swc_ecma_lints/tests/pass/issue-4907/1/input.js
+++ b/crates/swc_ecma_lints/tests/pass/issue-4907/1/input.js
@@ -1,0 +1,9 @@
+export function promisify(original) {
+    if (kCustomPromisifiedSymbol && original[kCustomPromisifiedSymbol]) {
+      var fn = original[kCustomPromisifiedSymbol];
+      return fn;
+    }
+
+    function fn() {
+    }
+  }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

So, [per spec](https://tc39.es/ecma262/#sec-static-semantics-lexicallydeclarednames)

> At the top level of a [Module](https://tc39.es/ecma262/#prod-Module), function declarations are treated like lexical declarations rather than like var declarations.

and it's only an error at the top level of module

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
closes #4907 