### PR TITLE
feature(cli): don't block forever waiting on stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,7 +1046,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1600,6 +1600,18 @@ dependencies = [
  "miow",
  "ntapi",
  "winapi",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -3065,9 +3077,9 @@ name = "swc_cli"
 version = "0.64.0"
 dependencies = [
  "anyhow",
- "atty",
  "clap 3.1.0",
  "glob",
+ "mio 0.8.4",
  "path-absolutize",
  "rayon",
  "relative-path",
@@ -3077,6 +3089,7 @@ dependencies = [
  "swc_common",
  "swc_plugin_runner",
  "swc_trace_macro",
+ "thiserror",
  "tracing",
  "tracing-chrome",
  "tracing-futures",
@@ -3084,6 +3097,7 @@ dependencies = [
  "walkdir",
  "wasmer",
  "wasmer-wasi",
+ "windows",
 ]
 
 [[package]]
@@ -4318,18 +4332,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4457,7 +4471,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.7.14",
  "num_cpus",
  "pin-project-lite",
  "winapi",
@@ -4717,6 +4731,12 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -5151,6 +5171,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
+dependencies = [
+ "windows_aarch64_msvc 0.37.0",
+ "windows_i686_gnu 0.37.0",
+ "windows_i686_msvc 0.37.0",
+ "windows_x86_64_gnu 0.37.0",
+ "windows_x86_64_msvc 0.37.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5177,6 +5210,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5187,6 +5233,18 @@ name = "windows_aarch64_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5201,6 +5259,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5211,6 +5281,18 @@ name = "windows_i686_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5225,6 +5307,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5235,6 +5329,18 @@ name = "windows_x86_64_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "winreg"

--- a/crates/swc_cli/Cargo.toml
+++ b/crates/swc_cli/Cargo.toml
@@ -24,7 +24,6 @@ plugin = [
 
 [dependencies]
 anyhow = "1.0.53"
-atty = "0.2.14"
 clap = { version = "3.1.0", features = ["derive", "wrap_help"] }
 glob = "0.3.0"
 rayon = "1"
@@ -35,6 +34,7 @@ swc = { version = "0.190.0", path = "../swc" }
 swc_common = { version = "0.18.0", path = "../swc_common" }
 swc_plugin_runner = { version = "0.56.0", path = "../swc_plugin_runner", default-features = false, optional = true }
 swc_trace_macro = { version = "0.1.0", path = "../swc_trace_macro" }
+thiserror = "1.0.31"
 tracing = "0.1.32"
 tracing-chrome = "0.5.0"
 tracing-futures = "0.2.5"
@@ -46,3 +46,15 @@ wasmer-wasi = { version = "2.3.0", optional = true }
 [dependencies.path-absolutize]
 features = ["once_cell_cache"]
 version = "3.0.11"
+
+[target.'cfg(unix)'.dependencies]
+mio = { version = "0.8.4", features = ["os-ext"] }
+
+[target.'cfg(windows)'.dependencies.windows]
+features = [
+  "Win32_Foundation",
+  "Win32_Storage_FileSystem",
+  "Win32_System_Console",
+  "Win32_System_Threading",
+]
+version = "0.37.0"

--- a/crates/swc_cli/src/util/io.rs
+++ b/crates/swc_cli/src/util/io.rs
@@ -1,0 +1,122 @@
+use std::{io, time::Duration};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ReadFromStdinWithTimeoutError {
+    #[error("IO error while reading from stdin: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("Timeout of {0:?} exceeded while reading from stdin")]
+    Timeout(Duration),
+
+    #[cfg(windows)]
+    #[error("Invalid timeout. Timeout may not exceed u32::MAX milliseconds")]
+    TimeoutInvalid,
+}
+
+impl ReadFromStdinWithTimeoutError {
+    #[cfg(windows)]
+    fn other<S>(s: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self::Io(io::Error::new(io::ErrorKind::Other, s.into()))
+    }
+}
+
+pub(crate) fn read_from_stdin_with_timeout<W>(
+    writer: &mut W,
+    poll_duration: Duration,
+    timeout: Duration,
+) -> Result<u64, ReadFromStdinWithTimeoutError>
+where
+    W: io::Write,
+{
+    wait_for_stdin_with_timeout(poll_duration, timeout)?;
+    let mut stdin = io::stdin().lock();
+    let nbytes = io::copy(&mut stdin, writer)?;
+    Ok(nbytes)
+}
+
+#[cfg(unix)]
+fn wait_for_stdin_with_timeout(
+    poll_duration: Duration,
+    timeout: Duration,
+) -> Result<(), ReadFromStdinWithTimeoutError> {
+    use std::time::Instant;
+
+    use mio::{unix::SourceFd, Events, Interest, Poll, Token};
+
+    const EVENTS_BUFFER_CAPACITY: usize = 32;
+    const STDIN: i32 = 0;
+    const TOKEN: Token = Token(0);
+
+    let now = Instant::now();
+
+    let mut poll = Poll::new()?;
+    let mut events = Events::with_capacity(EVENTS_BUFFER_CAPACITY);
+    let mut source_fd = SourceFd(&STDIN);
+    poll.registry()
+        .register(&mut source_fd, TOKEN, Interest::READABLE)?;
+
+    loop {
+        if now.elapsed() > timeout {
+            return Err(ReadFromStdinWithTimeoutError::Timeout(timeout));
+        }
+        poll.poll(&mut events, Some(poll_duration))?;
+        if events.iter().count() > 0 {
+            return Ok(());
+        }
+    }
+}
+
+#[cfg(windows)]
+fn wait_for_stdin_with_timeout(
+    _poll_duration: Duration,
+    timeout: Duration,
+) -> Result<(), ReadFromStdinWithTimeoutError> {
+    use windows::Win32::{
+        Foundation::{WAIT_FAILED, WAIT_TIMEOUT},
+        Storage::FileSystem::FlushFileBuffers,
+        System::{
+            Console::{GetStdHandle, STD_INPUT_HANDLE},
+            Threading::{WaitForSingleObject, WAIT_OBJECT_0},
+        },
+    };
+
+    let timeout_ms = u32::try_from(timeout.as_millis())
+        .map_err(|_| ReadFromStdinWithTimeoutError::TimeoutInvalid)?;
+
+    unsafe {
+        let handle = GetStdHandle(STD_INPUT_HANDLE).map_err(|e| {
+            ReadFromStdinWithTimeoutError::other(format!(
+                "Failed to get HANDLE to stdin. Error: {}",
+                e
+            ))
+        })?;
+
+        let _ = FlushFileBuffers(handle);
+
+        let ret = WaitForSingleObject(handle, timeout_ms);
+        if ret == WAIT_OBJECT_0 {
+            Ok(())
+        } else if ret == WAIT_TIMEOUT.0 {
+            Err(ReadFromStdinWithTimeoutError::Timeout(timeout))
+        } else if ret == WAIT_FAILED.0 {
+            Err(ReadFromStdinWithTimeoutError::other(
+                "Failed to wait on stdin",
+            ))
+        } else {
+            Err(ReadFromStdinWithTimeoutError::other(
+                "Failed to wait on stdin",
+            ))
+        }
+    }
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn wait_for_stdin_with_timeout(
+    _poll_duration: Duration,
+    _timeout: Duration,
+) -> Result<(), ReadFromStdinWithTimeoutError> {
+    Ok(())
+}

--- a/crates/swc_cli/src/util/mod.rs
+++ b/crates/swc_cli/src/util/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod io;
 pub(crate) mod trace;


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

I use the swc cli via bazel. I noticed today that bazel is unable to supply input to the compile subcommand via `stdin` because it does not pass this check in the current code:

```
if atty::is(atty::Stream::Stdin) {
    return None;
}
```

It seems you probably do not want this check to remain in the long-run, as, as far as I understand it, it means that processes not invoked via a TTY will not be able to supply input for compilation via `stdin`, which seems like an unwanted limitation.

It got me thinking about how supplying input via stdin probably should work for the compile subcommand. I'm not at all sure that I got it right, but I wanted to try an alternative; so here it is.

In this PR I propose the following:

* If files are supplied as arguments, `stdin` is ignored. The user has indicated he/she wants to compile the files listed explicitly as arguments.
* If no files are supplied as arguments, the user is indicating that he/she wants input to be read from `stdin`. 
* However, because you don't want reading from `stdin` to block forever in the case where users accidentally call `swc compile` with no file arguments and without passing information over `stdin`, you probably want reading from `stdin` to timeout after a reasonable period of time and report an error.

It turns out that reading from stdin with a timeout is actually an interesting problem, but this PR accomplishes it using a mini event loop from `mio` on unix and the standard Windows API on windows.

An alternative design would be to use an asynchronous runtime such as `tokio` to add timeouts, but that would involve many other changes to the current structure. Since you don't currently have an architecture that uses an async runtime, I opted to implement "reading from stdin with a timeout" without using one, but depending on what you think I also could see benefits in re-architecting the program to use `tokio`.

Note: I have another "cleanup" PR outstanding (#5003). This does not base itself off of that, but rather off of the current code. If #5003 lands (even partially), I'll rebase these changes on top of that.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

This changes the API for reading input for compilation as described above.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
