### PR TITLE
feat(html/parser): improve API

### DIFF
--- a/crates/swc_html_codegen/src/lib.rs
+++ b/crates/swc_html_codegen/src/lib.rs
@@ -21,11 +21,11 @@ mod list;
 pub mod writer;
 
 #[derive(Debug, Clone, Default)]
-pub struct CodegenConfig {
+pub struct CodegenConfig<'a> {
     pub minify: bool,
     pub scripting_enabled: bool,
     /// Should be used only for `DocumentFragment` code generation
-    pub context_element: Option<Element>,
+    pub context_element: Option<&'a Element>,
     /// By default `true` when `minify` enabled, otherwise `false`
     pub tag_omission: Option<bool>,
     /// By default `false` when `minify` enabled, otherwise `true`
@@ -39,12 +39,12 @@ enum TagOmissionParent<'a> {
 }
 
 #[derive(Debug)]
-pub struct CodeGenerator<W>
+pub struct CodeGenerator<'a, W>
 where
     W: HtmlWriter,
 {
     wr: W,
-    config: CodegenConfig,
+    config: CodegenConfig<'a>,
     ctx: Ctx,
     // For legacy `<plaintext>`
     is_plaintext: bool,
@@ -52,11 +52,11 @@ where
     self_closing_void_elements: bool,
 }
 
-impl<W> CodeGenerator<W>
+impl<'a, W> CodeGenerator<'a, W>
 where
     W: HtmlWriter,
 {
-    pub fn new(wr: W, config: CodegenConfig) -> Self {
+    pub fn new(wr: W, config: CodegenConfig<'a>) -> Self {
         let tag_omission = config.tag_omission.unwrap_or(config.minify);
         let self_closing_void_elements = config.tag_omission.unwrap_or(!config.minify);
 

--- a/crates/swc_html_codegen/tests/fixture.rs
+++ b/crates/swc_html_codegen/tests/fixture.rs
@@ -127,7 +127,9 @@ fn print_document_fragment(
         let mut errors = vec![];
         let mut document_fragment = parse_file_as_document_fragment(
             &fm,
-            context_element.clone(),
+            &context_element,
+            DocumentMode::NoQuirks,
+            None,
             parser_config,
             &mut errors,
         )
@@ -152,7 +154,9 @@ fn print_document_fragment(
         let mut errors = vec![];
         let mut document_fragment_parsed_again = parse_file_as_document_fragment(
             &fm_output,
-            context_element.clone(),
+            &context_element,
+            DocumentMode::NoQuirks,
+            None,
             parser_config,
             &mut errors,
         )
@@ -259,7 +263,7 @@ fn verify_document_fragment(
         _ => CodegenConfig::default(),
     };
 
-    codegen_config.context_element = Some(context_element.clone());
+    codegen_config.context_element = Some(&context_element);
 
     testing::run_test2(false, |cm, handler| {
         let fm = cm.load_file(input).unwrap();
@@ -267,7 +271,9 @@ fn verify_document_fragment(
 
         let mut document_fragment = parse_file_as_document_fragment(
             &fm,
-            context_element.clone(),
+            &context_element,
+            DocumentMode::NoQuirks,
+            None,
             parser_config,
             &mut errors,
         )
@@ -291,7 +297,9 @@ fn verify_document_fragment(
         let mut parsed_errors = vec![];
         let mut document_fragment_parsed_again = parse_file_as_document_fragment(
             &new_fm,
-            context_element.clone(),
+            &context_element,
+            DocumentMode::NoQuirks,
+            None,
             parser_config,
             &mut parsed_errors,
         )

--- a/crates/swc_html_codegen_macros/src/lib.rs
+++ b/crates/swc_html_codegen_macros/src/lib.rs
@@ -59,7 +59,7 @@ fn (&mut self, node: Node) -> Result;
                 },
                 {
                     {
-                        impl<W> crate::Emit<NodeType> for crate::CodeGenerator<W>
+                        impl<W> crate::Emit<NodeType> for crate::CodeGenerator<'_, W>
                         where
                             W: crate::writer::HtmlWriter,
                         {

--- a/crates/swc_html_minifier/src/lib.rs
+++ b/crates/swc_html_minifier/src/lib.rs
@@ -1035,7 +1035,9 @@ impl Minifier {
         };
         let mut document_fragment = match swc_html_parser::parse_file_as_document_fragment(
             &fm,
-            context_element.clone(),
+            &context_element,
+            DocumentMode::NoQuirks,
+            None,
             Default::default(),
             &mut errors,
         ) {
@@ -1077,7 +1079,7 @@ impl Minifier {
             swc_html_codegen::CodegenConfig {
                 minify: true,
                 scripting_enabled: false,
-                context_element: Some(context_element),
+                context_element: Some(&context_element),
                 tag_omission: None,
                 self_closing_void_elements: None,
             },
@@ -1519,10 +1521,10 @@ pub fn minify_document(document: &mut Document, options: &MinifyOptions) {
 
 pub fn minify_document_fragment(
     document: &mut DocumentFragment,
-    context_element: Element,
+    context_element: &Element,
     options: &MinifyOptions,
 ) {
-    let mut minifier = create_minifier(Some(&context_element), options);
+    let mut minifier = create_minifier(Some(context_element), options);
 
     document.visit_mut_with(&mut minifier);
 }

--- a/crates/swc_html_minifier/tests/fixture.rs
+++ b/crates/swc_html_minifier/tests/fixture.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use swc_html_ast::{Document, DocumentFragment, Element, Namespace};
+use swc_html_ast::{Document, DocumentFragment, DocumentMode, Element, Namespace};
 use swc_html_codegen::{
     writer::basic::{BasicHtmlWriter, BasicHtmlWriterConfig},
     CodeGenerator, CodegenConfig, Emit,
@@ -140,7 +140,9 @@ fn test_minify_document_fragment(input: PathBuf) {
         let mut errors = vec![];
         let result: Result<DocumentFragment, _> = parse_file_as_document_fragment(
             &fm,
-            context_element.clone(),
+            &context_element,
+            DocumentMode::NoQuirks,
+            None,
             Default::default(),
             &mut errors,
         );
@@ -160,7 +162,7 @@ fn test_minify_document_fragment(input: PathBuf) {
         };
 
         // Apply transforms
-        minify_document_fragment(&mut document_fragment, context_element, &config);
+        minify_document_fragment(&mut document_fragment, &context_element, &config);
 
         let mut html_str = String::new();
         {

--- a/crates/swc_html_parser/benches/compare.rs
+++ b/crates/swc_html_parser/benches/compare.rs
@@ -2,7 +2,7 @@ extern crate swc_node_base;
 
 use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 use swc_common::{input::StringInput, FileName, Span, SyntaxContext, DUMMY_SP};
-use swc_html_ast::{Document, DocumentFragment, Element, Namespace};
+use swc_html_ast::{Document, DocumentFragment, DocumentMode, Element, Namespace};
 use swc_html_parser::{lexer::Lexer, parser::Parser};
 use swc_html_visit::{Fold, FoldWith, VisitMut, VisitMutWith};
 
@@ -40,15 +40,19 @@ where
         let lexer = Lexer::new(StringInput::from(&*fm));
         let mut parser = Parser::new(lexer, Default::default());
         let document_fragment: DocumentFragment = parser
-            .parse_document_fragment(Element {
-                span: Default::default(),
-                tag_name: "template".into(),
-                namespace: Namespace::HTML,
-                attributes: vec![],
-                is_self_closing: false,
-                children: vec![],
-                content: None,
-            })
+            .parse_document_fragment(
+                Element {
+                    span: Default::default(),
+                    tag_name: "template".into(),
+                    namespace: Namespace::HTML,
+                    attributes: vec![],
+                    is_self_closing: false,
+                    children: vec![],
+                    content: None,
+                },
+                DocumentMode::NoQuirks,
+                None,
+            )
             .unwrap();
 
         b.iter(|| {

--- a/crates/swc_html_parser/benches/parser.rs
+++ b/crates/swc_html_parser/benches/parser.rs
@@ -2,7 +2,7 @@ extern crate swc_node_base;
 
 use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 use swc_common::{input::StringInput, FileName};
-use swc_html_ast::{Element, Namespace};
+use swc_html_ast::{DocumentMode, Element, Namespace};
 use swc_html_parser::{lexer::Lexer, parser::Parser};
 
 fn bench_document(b: &mut Bencher, src: &'static str) {
@@ -31,15 +31,19 @@ fn bench_document_fragment(b: &mut Bencher, src: &'static str) {
                 let lexer = Lexer::new(StringInput::from(&*fm));
                 let mut parser = Parser::new(lexer, Default::default());
 
-                parser.parse_document_fragment(Element {
-                    span: Default::default(),
-                    tag_name: "template".into(),
-                    namespace: Namespace::HTML,
-                    attributes: vec![],
-                    is_self_closing: false,
-                    children: vec![],
-                    content: None,
-                })
+                parser.parse_document_fragment(
+                    Element {
+                        span: Default::default(),
+                        tag_name: "template".into(),
+                        namespace: Namespace::HTML,
+                        attributes: vec![],
+                        is_self_closing: false,
+                        children: vec![],
+                        content: None,
+                    },
+                    DocumentMode::NoQuirks,
+                    None,
+                )
             });
         });
 

--- a/crates/swc_html_parser/src/lib.rs
+++ b/crates/swc_html_parser/src/lib.rs
@@ -44,15 +44,16 @@ pub fn parse_file_as_document(
 /// `errors`.
 pub fn parse_file_as_document_fragment(
     fm: &SourceFile,
-    context_element: Element,
+    context_element: &Element,
     mode: DocumentMode,
-    form_element: Option<Element>,
+    form_element: Option<&Element>,
     config: ParserConfig,
     errors: &mut Vec<Error>,
 ) -> PResult<DocumentFragment> {
     let lexer = Lexer::new(StringInput::from(fm));
     let mut parser = Parser::new(lexer, config);
-    let result = parser.parse_document_fragment(context_element, mode, form_element);
+    let result =
+        parser.parse_document_fragment(context_element.clone(), mode, form_element.cloned());
 
     errors.extend(parser.take_errors());
 

--- a/crates/swc_html_parser/src/lib.rs
+++ b/crates/swc_html_parser/src/lib.rs
@@ -46,12 +46,13 @@ pub fn parse_file_as_document_fragment(
     fm: &SourceFile,
     context_element: Element,
     mode: DocumentMode,
+    form_element: Option<Element>,
     config: ParserConfig,
     errors: &mut Vec<Error>,
 ) -> PResult<DocumentFragment> {
     let lexer = Lexer::new(StringInput::from(fm));
     let mut parser = Parser::new(lexer, config);
-    let result = parser.parse_document_fragment(context_element, mode);
+    let result = parser.parse_document_fragment(context_element, mode, form_element);
 
     errors.extend(parser.take_errors());
 

--- a/crates/swc_html_parser/src/lib.rs
+++ b/crates/swc_html_parser/src/lib.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::wrong_self_convention)]
 
 use swc_common::{input::StringInput, SourceFile};
-use swc_html_ast::{Document, DocumentFragment, Element};
+use swc_html_ast::{Document, DocumentFragment, DocumentMode, Element};
 
 use crate::{
     error::Error,
@@ -45,12 +45,13 @@ pub fn parse_file_as_document(
 pub fn parse_file_as_document_fragment(
     fm: &SourceFile,
     context_element: Element,
+    mode: DocumentMode,
     config: ParserConfig,
     errors: &mut Vec<Error>,
 ) -> PResult<DocumentFragment> {
     let lexer = Lexer::new(StringInput::from(fm));
     let mut parser = Parser::new(lexer, config);
-    let result = parser.parse_document_fragment(context_element);
+    let result = parser.parse_document_fragment(context_element, mode);
 
     errors.extend(parser.take_errors());
 

--- a/crates/swc_html_parser/src/parser/mod.rs
+++ b/crates/swc_html_parser/src/parser/mod.rs
@@ -260,7 +260,6 @@ where
     // just inserted into the input stream.
     //
     // 14. Return the child nodes of root, in tree order.
-    // TODO extract code for building tree from parser in TreeBuilder module
     pub fn parse_document_fragment(
         &mut self,
         context_element: Element,
@@ -372,7 +371,7 @@ where
     fn create_document(&self, mode: Option<DocumentMode>) -> RcNode {
         Node::new(
             Data::Document {
-                mode: RefCell::new(mode.unwrap_or_else(|| DocumentMode::NoQuirks)),
+                mode: RefCell::new(mode.unwrap_or(DocumentMode::NoQuirks)),
             },
             DUMMY_SP,
         )

--- a/crates/swc_html_parser/src/parser/mod.rs
+++ b/crates/swc_html_parser/src/parser/mod.rs
@@ -265,6 +265,7 @@ where
         &mut self,
         context_element: Element,
         mode: DocumentMode,
+        form_element: Option<Element>,
     ) -> PResult<DocumentFragment> {
         // 1.
         // 2.
@@ -331,9 +332,18 @@ where
         self.reset_insertion_mode();
 
         // 11.
-        // TODO how we can get parent here?
         if is_html_element!(context_node, "form") {
             self.form_element_pointer = Some(context_node);
+        } else if let Some(form_element) = form_element {
+            self.form_element_pointer = Some(Node::new(
+                Data::Element {
+                    namespace: form_element.namespace,
+                    tag_name: form_element.tag_name,
+                    attributes: RefCell::new(form_element.attributes),
+                    is_self_closing: form_element.is_self_closing,
+                },
+                DUMMY_SP,
+            ));
         }
 
         // 12.

--- a/crates/swc_html_parser/src/parser/mod.rs
+++ b/crates/swc_html_parser/src/parser/mod.rs
@@ -138,7 +138,7 @@ where
     pub fn parse_document(&mut self) -> PResult<Document> {
         let start = self.input.cur_span()?;
 
-        self.document = Some(self.create_document());
+        self.document = Some(self.create_document(None));
 
         self.run()?;
 
@@ -264,12 +264,11 @@ where
     pub fn parse_document_fragment(
         &mut self,
         context_element: Element,
+        mode: DocumentMode,
     ) -> PResult<DocumentFragment> {
         // 1.
-        self.document = Some(self.create_document());
-
         // 2.
-        // TODO add ability to set document mode
+        self.document = Some(self.create_document(Some(mode)));
 
         // 3.
         // Parser already created
@@ -360,10 +359,10 @@ where
         })
     }
 
-    fn create_document(&self) -> RcNode {
+    fn create_document(&self, mode: Option<DocumentMode>) -> RcNode {
         Node::new(
             Data::Document {
-                mode: RefCell::new(DocumentMode::NoQuirks),
+                mode: RefCell::new(mode.unwrap_or_else(|| DocumentMode::NoQuirks)),
             },
             DUMMY_SP,
         )

--- a/crates/swc_html_parser/tests/fixture.rs
+++ b/crates/swc_html_parser/tests/fixture.rs
@@ -1201,7 +1201,7 @@ fn html5lib_test_tree_construction(input: PathBuf) {
             };
 
             DocumentOrDocumentFragment::DocumentFragment(
-                parser.parse_document_fragment(context_element),
+                parser.parse_document_fragment(context_element, DocumentMode::NoQuirks),
             )
         } else {
             DocumentOrDocumentFragment::Document(parser.parse_document())

--- a/crates/swc_html_parser/tests/fixture.rs
+++ b/crates/swc_html_parser/tests/fixture.rs
@@ -1200,9 +1200,11 @@ fn html5lib_test_tree_construction(input: PathBuf) {
                 content: None,
             };
 
-            DocumentOrDocumentFragment::DocumentFragment(
-                parser.parse_document_fragment(context_element, DocumentMode::NoQuirks),
-            )
+            DocumentOrDocumentFragment::DocumentFragment(parser.parse_document_fragment(
+                context_element,
+                DocumentMode::NoQuirks,
+                None,
+            ))
         } else {
             DocumentOrDocumentFragment::Document(parser.parse_document())
         };


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

- Allow to setup document and form element for document fragments
- Context element passed by reference, so no need to clone

I tried to extract tree builder as in TODO, but found less perf and more memory usage, because we need duplicate some things, so I think for perf reasons better to keep parser and tree builder together

**BREAKING CHANGE:**

Yes

**Related issue (if exists):**

No