### PR TITLE
feat(html/minifier): allow to compress additional attributes

### DIFF
--- a/crates/swc_html_minifier/src/option.rs
+++ b/crates/swc_html_minifier/src/option.rs
@@ -49,10 +49,6 @@ pub struct MinifyOptions {
     // i.e. `<div data-html="<html> <body> <p>test.</p>" src="nosrcdoc.html"></div>`
     #[serde(default)]
     pub additional_html_attributes: Option<Vec<CachedRegex>>,
-    #[serde(default = "default_preserve_comments")]
-    pub preserve_comments: Option<Vec<CachedRegex>>,
-    #[serde(default = "true_by_default")]
-    pub minify_conditional_comments: bool,
 }
 
 /// Implement default using serde.

--- a/crates/swc_html_minifier/src/option.rs
+++ b/crates/swc_html_minifier/src/option.rs
@@ -1,6 +1,16 @@
 use serde::{Deserialize, Serialize};
 use swc_cached::regex::CachedRegex;
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+#[serde(deny_unknown_fields)]
+pub enum MinifierType {
+    Js,
+    Json,
+    Css,
+    Html,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
@@ -29,26 +39,18 @@ pub struct MinifyOptions {
     pub collapse_boolean_attributes: bool,
     #[serde(default = "true_by_default")]
     pub minify_js: bool,
-    // Allow to compress custom ECMAScript attributes, i.e. `<div data-click="myFunction(100 * 2,
-    // "value");"></div>`
-    #[serde(default)]
-    pub additional_js_attributes: Option<Vec<CachedRegex>>,
     #[serde(default = "true_by_default")]
     pub minify_json: bool,
-    // Allow to compress custom JSON attributes,
-    // i.e. `<div data-json="{ "foo": "bar }"></div>`
-    #[serde(default)]
-    pub additional_json_attributes: Option<Vec<CachedRegex>>,
     #[serde(default = "true_by_default")]
     pub minify_css: bool,
-    // Allow to compress custom CSS attributes,
-    // i.e. `<div data-style="color: red; background-color: red"></div>`
+    // Allow to compress value of custom attributes,
+    // i.e. `<div data-js="myFunction(100 * 2, 'foo' + 'bar')"></div>`
+    //
+    // The first item is tag_name
+    // The second is attribute name
+    // The third is type of minifier
     #[serde(default)]
-    pub additional_css_attributes: Option<Vec<CachedRegex>>,
-    // Allow to compress custom ECMAScript attributes,
-    // i.e. `<div data-html="<html> <body> <p>test.</p>" src="nosrcdoc.html"></div>`
-    #[serde(default)]
-    pub additional_html_attributes: Option<Vec<CachedRegex>>,
+    pub minify_additional_attributes: Option<Vec<(CachedRegex, MinifierType)>>,
 }
 
 /// Implement default using serde.

--- a/crates/swc_html_minifier/src/option.rs
+++ b/crates/swc_html_minifier/src/option.rs
@@ -29,10 +29,30 @@ pub struct MinifyOptions {
     pub collapse_boolean_attributes: bool,
     #[serde(default = "true_by_default")]
     pub minify_js: bool,
+    // Allow to compress custom ECMAScript attributes, i.e. `<div data-click="myFunction(100 * 2,
+    // "value");"></div>`
+    #[serde(default)]
+    pub additional_js_attributes: Option<Vec<CachedRegex>>,
     #[serde(default = "true_by_default")]
     pub minify_json: bool,
+    // Allow to compress custom JSON attributes,
+    // i.e. `<div data-json="{ "foo": "bar }"></div>`
+    #[serde(default)]
+    pub additional_json_attributes: Option<Vec<CachedRegex>>,
     #[serde(default = "true_by_default")]
     pub minify_css: bool,
+    // Allow to compress custom CSS attributes,
+    // i.e. `<div data-style="color: red; background-color: red"></div>`
+    #[serde(default)]
+    pub additional_css_attributes: Option<Vec<CachedRegex>>,
+    // Allow to compress custom ECMAScript attributes,
+    // i.e. `<div data-html="<html> <body> <p>test.</p>" src="nosrcdoc.html"></div>`
+    #[serde(default)]
+    pub additional_html_attributes: Option<Vec<CachedRegex>>,
+    #[serde(default = "default_preserve_comments")]
+    pub preserve_comments: Option<Vec<CachedRegex>>,
+    #[serde(default = "true_by_default")]
+    pub minify_conditional_comments: bool,
 }
 
 /// Implement default using serde.

--- a/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/config.json
+++ b/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/config.json
@@ -1,6 +1,9 @@
 {
-  "additionalJsAttributes": ["^data-click", "^ng-"],
-  "additionalJsonAttributes": ["^data-json"],
-  "additionalCssAttributes": ["^data-style"],
-  "additionalHtmlAttributes": ["^data-html"]
+  "minifyAdditionalAttributes": [
+    ["^data-click", "js"],
+    ["^ng-", "js"],
+    ["^data-json", "json"],
+    ["^data-style", "css"],
+    ["^data-html", "html"]
+  ]
 }

--- a/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/config.json
+++ b/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/config.json
@@ -1,0 +1,6 @@
+{
+  "additionalJsAttributes": ["^data-click", "^ng-"],
+  "additionalJsonAttributes": ["^data-json"],
+  "additionalCssAttributes": ["^data-style"],
+  "additionalHtmlAttributes": ["^data-html"]
+}

--- a/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/input.html
+++ b/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/input.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+<button type="button" onclick="a(1 + 2)" ng-click="a(1 + 2)" data-click="a(1 + 2)"></button>
+<button type="button" onclick="a(1 + 2)" ng-click="a(1 + 2)" data-click="a(1 + 2)"></button>
+<div data-json="{ 'foo': 'bar' }"></div>
+<div data-style="color: red; background-color: red"></div>
+<iframe srcdoc="<html> <body> <p>test.</p>" src="nosrcdoc.html"></iframe>
+<div data-html="<html> <body> <p>test.</p>" src="nosrcdoc.html"></div>
+</body>
+</html>

--- a/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/input.html
+++ b/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/input.html
@@ -9,7 +9,7 @@
 <body>
 <button type="button" onclick="a(1 + 2)" ng-click="a(1 + 2)" data-click="a(1 + 2)"></button>
 <button type="button" onclick="a(1 + 2)" ng-click="a(1 + 2)" data-click="a(1 + 2)"></button>
-<div data-json="{ 'foo': 'bar' }"></div>
+<div data-json='{ "foo": "bar" }'></div>
 <div data-style="color: red; background-color: red"></div>
 <iframe srcdoc="<html> <body> <p>test.</p>" src="nosrcdoc.html"></iframe>
 <div data-html="<html> <body> <p>test.</p>" src="nosrcdoc.html"></div>

--- a/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/output.min.html
+++ b/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/output.min.html
@@ -1,7 +1,7 @@
 <!doctype html><html lang=en><meta charset=UTF-8><meta name=viewport content="width=device-width,user-scalable=no,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0"><title>Document</title><body>
 <button type=button onclick=a(3) ng-click=a(3) data-click=a(3)></button>
 <button type=button onclick=a(3) ng-click=a(3) data-click=a(3)></button>
-<div data-json="{ 'foo': 'bar' }"></div>
+<div data-json='{"foo":"bar"}'></div>
 <div data-style=color:red;background-color:red></div>
 <iframe srcdoc="<body> <p>test." src=nosrcdoc.html></iframe>
 <div data-html="<body> <p>test." src=nosrcdoc.html></div>

--- a/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/output.min.html
+++ b/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/output.min.html
@@ -1,0 +1,8 @@
+<!doctype html><html lang=en><meta charset=UTF-8><meta name=viewport content="width=device-width,user-scalable=no,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0"><title>Document</title><body>
+<button type=button onclick=a(3) ng-click=a(3) data-click=a(3)></button>
+<button type=button onclick=a(3) ng-click=a(3) data-click=a(3)></button>
+<div data-json="{ 'foo': 'bar' }"></div>
+<div data-style=color:red;background-color:red></div>
+<iframe srcdoc="<body> <p>test." src=nosrcdoc.html></iframe>
+<div data-html="<body> <p>test." src=nosrcdoc.html></div>
+

--- a/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/output.min.html
+++ b/crates/swc_html_minifier/tests/fixture/attribute/custom-attribute/output.min.html
@@ -1,8 +1,6 @@
-<!doctype html><html lang=en><meta charset=UTF-8><meta name=viewport content="width=device-width,user-scalable=no,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0"><title>Document</title><body>
-<button type=button onclick=a(3) ng-click=a(3) data-click=a(3)></button>
+<!doctype html><html lang=en><meta charset=UTF-8><meta name=viewport content="width=device-width,user-scalable=no,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0"><title>Document</title><button type=button onclick=a(3) ng-click=a(3) data-click=a(3)></button>
 <button type=button onclick=a(3) ng-click=a(3) data-click=a(3)></button>
 <div data-json='{"foo":"bar"}'></div>
 <div data-style=color:red;background-color:red></div>
-<iframe srcdoc="<body> <p>test." src=nosrcdoc.html></iframe>
-<div data-html="<body> <p>test." src=nosrcdoc.html></div>
-
+<iframe srcdoc="<p>test." src=nosrcdoc.html></iframe>
+<div data-html="<p>test." src=nosrcdoc.html></div>


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Here:
- minify `srcdoc` for `iframe`
- allow to setup setup custom JS attributes, i.e. `<div data-click="myFunction("test", 10 *   10)">`
- allow to setup setup custom JSON attributes, i.e. `<div data-json='{ "foo": "bar" }'></div>`
- allow to setup setup custom CSS attributes, i.e. `<div data-style="color: red; background-color: red"></div>`
- allow to setup setup custom HTML attributes, i.e. `<div data-html="<html> <body> <p>test.</p>" src="nosrcdoc.html"></div>`

**BREAKING CHANGE:**

Yes

**Related issue (if exists):**

No