### PR TITLE
feat(ecma/parser): add the `allow_return_outside_function` option

### DIFF
--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -246,7 +246,7 @@ impl Syntax {
         }
     }
 
-    pub fn allow_super_outside_method(self) -> bool {
+    pub(crate) fn allow_super_outside_method(self) -> bool {
         match self {
             Syntax::Es(EsConfig {
                 allow_super_outside_method,
@@ -256,7 +256,7 @@ impl Syntax {
         }
     }
 
-    pub fn allow_return_outside_function(self) -> bool {
+    pub(crate) fn allow_return_outside_function(self) -> bool {
         match self {
             Syntax::Es(EsConfig {
                 allow_return_outside_function,

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -256,6 +256,16 @@ impl Syntax {
         }
     }
 
+    pub fn allow_return_outside_function(self) -> bool {
+        match self {
+            Syntax::Es(EsConfig {
+                allow_return_outside_function,
+                ..
+            }) => allow_return_outside_function,
+            Syntax::Typescript(_) => false,
+        }
+    }
+
     pub(crate) fn early_errors(self) -> bool {
         match self {
             Syntax::Typescript(t) => !t.no_early_errors,
@@ -315,6 +325,9 @@ pub struct EsConfig {
 
     #[serde(default, rename = "allowSuperOutsideMethod")]
     pub allow_super_outside_method: bool,
+
+    #[serde(default, rename = "allowReturnOutsideFunction")]
+    pub allow_return_outside_function: bool,
 }
 
 /// Syntactic context.

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -562,7 +562,7 @@ impl<'a, I: Tokens> Parser<I> {
             }))
         });
 
-        if !self.ctx().in_function {
+        if !self.ctx().in_function && !self.input.syntax().allow_return_outside_function() {
             self.emit_err(span!(self, start), SyntaxError::ReturnNotAllowed);
         }
 

--- a/crates/swc_html_minifier/src/lib.rs
+++ b/crates/swc_html_minifier/src/lib.rs
@@ -1079,8 +1079,6 @@ impl Minifier {
             }
         };
 
-        println!("{:?}", errors);
-
         // Avoid compress potential invalid JS
         if !errors.is_empty() {
             return None;

--- a/crates/swc_html_minifier/tests/fixture/attribute/javascript-prefix/input.html
+++ b/crates/swc_html_minifier/tests/fixture/attribute/javascript-prefix/input.html
@@ -15,5 +15,8 @@
          style="width:100%; height:100%; position:absolute; top:0; left:0; z-index:-1;">
         <circle onmouseover="   javascript:alert('test')   " cx="50" cy="50" r="30" style="fill:url(#gradient)" />
     </svg>
+    <div type="text" onmouseover="javascript:myFunction()">test</div>
+    <a href="https://datacadamia.com" onclick="console.log(`Navigation to ${this.href}` + ` cancelled`); return false;">Click me</a>
+    <a href="https://datacadamia.com" onclick="javascript:console.log(`Navigation to ${this.href}` + ` cancelled`); return false;">Click me</a>
 </body>
 </html>

--- a/crates/swc_html_minifier/tests/fixture/attribute/javascript-prefix/output.min.html
+++ b/crates/swc_html_minifier/tests/fixture/attribute/javascript-prefix/output.min.html
@@ -7,3 +7,6 @@
     <svg version=1.1 viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice" style=width:100%;height:100%;position:absolute;top:0;left:0;z-index:-1>
         <circle onmouseover='alert("test")' cx=50 cy=50 r=30 style=fill:url(#gradient) />
     </svg>
+    <div type=text onmouseover=myFunction()>test</div>
+    <a href=https://datacadamia.com onclick="console.log(`Navigation to ${this.href} cancelled`);return false">Click me</a>
+    <a href=https://datacadamia.com onclick="console.log(`Navigation to ${this.href} cancelled`);return false">Click me</a>

--- a/crates/swc_html_minifier/tests/fixture/attribute/onclick/output.min.html
+++ b/crates/swc_html_minifier/tests/fixture/attribute/onclick/output.min.html
@@ -1,2 +1,2 @@
-<!doctype html><html lang=en><meta charset=UTF-8><meta name=viewport content="width=device-width,user-scalable=no,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0"><meta http-equiv=X-UA-Compatible content="ie=edge"><title>Document</title><a href=http://www.google.co.uk/ onclick="return (confirm('Follow' + ' this link?'))">Google</a>
+<!doctype html><html lang=en><meta charset=UTF-8><meta name=viewport content="width=device-width,user-scalable=no,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0"><meta http-equiv=X-UA-Compatible content="ie=edge"><title>Document</title><a href=http://www.google.co.uk/ onclick='return confirm("Follow this link?")'>Google</a>
 <a href=http://www.google.co.uk/ onclick='alert("testtest")'>Google</a>


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Add `allow_return_outside_function` to parse HTML event handler attributes

**BREAKING CHANGE:**

Yes

**Related issue (if exists):**

No