### PR TITLE
feat(swc/common): add versioned wrapper struct (#5060: Part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,6 +2994,7 @@ dependencies = [
 name = "swc_atoms"
 version = "0.2.12"
 dependencies = [
+ "bytecheck",
  "once_cell",
  "rkyv",
  "rustc-hash",
@@ -3285,6 +3286,7 @@ version = "0.79.0"
 dependencies = [
  "arbitrary",
  "bitflags",
+ "bytecheck",
  "is-macro",
  "num-bigint",
  "rkyv",
@@ -4120,6 +4122,7 @@ name = "swc_plugin_proxy"
 version = "0.4.1"
 dependencies = [
  "better_scoped_tls",
+ "bytecheck",
  "rkyv",
  "swc_common",
  "swc_ecma_ast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,6 +3096,7 @@ dependencies = [
  "ast_node",
  "atty",
  "better_scoped_tls",
+ "bytecheck",
  "cfg-if 1.0.0",
  "criterion",
  "debug_unreachable",

--- a/crates/ast_node/src/lib.rs
+++ b/crates/ast_node/src/lib.rs
@@ -215,6 +215,10 @@ pub fn ast_node(
                 )]
                 #[cfg_attr(
                     feature = "rkyv",
+                    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
+                )]
+                #[cfg_attr(
+                    feature = "rkyv",
                     archive(bound(
                         serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace"
                     ))
@@ -268,6 +272,10 @@ pub fn ast_node(
                     #[cfg_attr(
                         feature = "rkyv",
                         archive(bound(serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace"))
+                    )]
+                    #[cfg_attr(
+                        feature = "rkyv",
+                        archive_attr(repr(C), derive(bytecheck::CheckBytes))
                     )]
                     serde_tag
                     #[serde(rename_all = "camelCase")]

--- a/crates/swc_atoms/Cargo.toml
+++ b/crates/swc_atoms/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.2.12"
 bench = false
 
 [dependencies]
+bytecheck = { version = "0.6.8", optional = true }
 once_cell = "1"
 rkyv = { version = "0.7.39", optional = true }
 rustc-hash = "1.1.0"

--- a/crates/swc_atoms/src/lib.rs
+++ b/crates/swc_atoms/src/lib.rs
@@ -36,6 +36,7 @@ include!(concat!(env!("OUT_DIR"), "/js_word.rs"));
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 pub struct Atom(Arc<str>);
 
 impl Atom {

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -24,7 +24,7 @@ perf = ["parking_lot"]
 plugin-base = ["anyhow", "rkyv-impl", "diagnostic-serde"]
 plugin-mode = ["plugin-base"]
 plugin-rt = ["plugin-base"]
-rkyv-impl = ["rkyv"]
+rkyv-impl = ["rkyv", "bytecheck"]
 tty-emitter = ["atty", "termcolor"]
 
 [dependencies]
@@ -34,7 +34,7 @@ arbitrary = { version = "1", optional = true, features = ["derive"] }
 ast_node = { version = "0.7.5", path = "../ast_node" }
 atty = { version = "0.2", optional = true }
 better_scoped_tls = { version = "0.1.0", path = "../better_scoped_tls" }
-bytecheck = "0.6.8"
+bytecheck = { version = "0.6.8", optional = true }
 cfg-if = "1.0.0"
 debug_unreachable = "0.1.1"
 either = "1.5"

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -29,27 +29,28 @@ tty-emitter = ["atty", "termcolor"]
 
 [dependencies]
 ahash = "0.7.4"
-anyhow = {version = "1.0.45", optional = true}
-arbitrary = {version = "1", optional = true, features = ["derive"]}
-ast_node = {version = "0.7.5", path = "../ast_node"}
-atty = {version = "0.2", optional = true}
-better_scoped_tls = {version = "0.1.0", path = "../better_scoped_tls"}
+anyhow = { version = "1.0.45", optional = true }
+arbitrary = { version = "1", optional = true, features = ["derive"] }
+ast_node = { version = "0.7.5", path = "../ast_node" }
+atty = { version = "0.2", optional = true }
+better_scoped_tls = { version = "0.1.0", path = "../better_scoped_tls" }
+bytecheck = "0.6.8"
 cfg-if = "1.0.0"
 debug_unreachable = "0.1.1"
 either = "1.5"
-from_variant = {version = "0.1.3", path = "../from_variant"}
+from_variant = { version = "0.1.3", path = "../from_variant" }
 num-bigint = "0.4"
 once_cell = "1.10.0"
-parking_lot = {version = "0.12.0", optional = true}
+parking_lot = { version = "0.12.0", optional = true }
 rkyv = { version = "0.7.39", optional = true }
 rustc-hash = "1.1.0"
-serde = {version = "1.0.119", features = ["derive"]}
+serde = { version = "1.0.119", features = ["derive"] }
 siphasher = "0.3.9"
-sourcemap = {version = "6", optional = true}
+sourcemap = { version = "6", optional = true }
 string_cache = "0.8.4"
-swc_eq_ignore_macros = {version = "0.1", path = "../swc_eq_ignore_macros"}
-swc_visit = {version = "0.3.0", path = "../swc_visit"}
-termcolor = {version = "1.0", optional = true}
+swc_eq_ignore_macros = { version = "0.1", path = "../swc_eq_ignore_macros" }
+swc_visit = { version = "0.3.0", path = "../swc_visit" }
+termcolor = { version = "1.0", optional = true }
 tracing = "0.1.32"
 unicode-width = "0.1.4"
 url = "2.2.2"

--- a/crates/swc_common/src/comments.rs
+++ b/crates/swc_common/src/comments.rs
@@ -541,6 +541,7 @@ impl SingleThreadedComments {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 pub struct Comment {
     pub kind: CommentKind,
     pub span: Span,
@@ -557,6 +558,10 @@ impl Spanned for Comment {
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
 )]
 pub enum CommentKind {
     Line,

--- a/crates/swc_common/src/errors/diagnostic.rs
+++ b/crates/swc_common/src/errors/diagnostic.rs
@@ -23,6 +23,10 @@ use crate::syntax_pos::{MultiSpan, Span};
     feature = "plugin-base",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "plugin-base",
+    archive_attr(repr(C), derive(bytecheck::CheckBytes))
+)]
 pub struct Diagnostic {
     pub level: Level,
     pub message: Vec<(String, Style)>,
@@ -41,6 +45,10 @@ pub struct Diagnostic {
     feature = "plugin-base",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "plugin-base",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
+)]
 pub enum DiagnosticId {
     Error(String),
     Lint(String),
@@ -55,6 +63,10 @@ pub enum DiagnosticId {
 #[cfg_attr(
     feature = "plugin-base",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "plugin-base",
+    archive_attr(repr(C), derive(bytecheck::CheckBytes))
 )]
 pub struct SubDiagnostic {
     pub level: Level,

--- a/crates/swc_common/src/errors/mod.rs
+++ b/crates/swc_common/src/errors/mod.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// TODO: https://github.com/rkyv/bytecheck/issues/20
+#![allow(ambiguous_associated_items)]
+
 use std::{
     borrow::Cow,
     cell::RefCell,
@@ -50,6 +53,10 @@ mod styled_buffer;
     feature = "plugin-base",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "plugin-base",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
+)]
 pub enum Applicability {
     MachineApplicable,
     HasPlaceholders,
@@ -65,6 +72,10 @@ pub enum Applicability {
 #[cfg_attr(
     feature = "plugin-base",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "plugin-base",
+    archive_attr(repr(C), derive(bytecheck::CheckBytes))
 )]
 pub struct CodeSuggestion {
     /// Each substitute can have multiple variants due to multiple
@@ -117,6 +128,10 @@ pub struct CodeSuggestion {
     feature = "plugin-base",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "plugin-base",
+    archive_attr(repr(C), derive(bytecheck::CheckBytes))
+)]
 pub struct Substitution {
     pub parts: Vec<SubstitutionPart>,
 }
@@ -129,6 +144,10 @@ pub struct Substitution {
 #[cfg_attr(
     feature = "plugin-base",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "plugin-base",
+    archive_attr(repr(C), derive(bytecheck::CheckBytes))
 )]
 pub struct SubstitutionPart {
     pub span: Span,
@@ -876,6 +895,10 @@ impl Handler {
 #[cfg_attr(
     feature = "plugin-base",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "plugin-base",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
 )]
 pub enum Level {
     Bug,

--- a/crates/swc_common/src/errors/snippet.rs
+++ b/crates/swc_common/src/errors/snippet.rs
@@ -184,6 +184,10 @@ pub struct StyledString {
     feature = "plugin-base",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "plugin-base",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
+)]
 pub enum Style {
     MainHeaderMsg,
     HeaderMsg,

--- a/crates/swc_common/src/plugin.rs
+++ b/crates/swc_common/src/plugin.rs
@@ -18,6 +18,10 @@ use crate::{syntax_pos::Mark, SyntaxContext};
     feature = "plugin-base",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "plugin-base",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
+)]
 /// Enum for possible errors while running transform via plugin.
 /// This error indicates internal operation failure either in plugin_runner
 /// or plugin_macro. Plugin's transform fn itself does not allow to return

--- a/crates/swc_common/src/plugin.rs
+++ b/crates/swc_common/src/plugin.rs
@@ -7,6 +7,8 @@
 use std::any::type_name;
 
 use anyhow::Error;
+use bytecheck::CheckBytes;
+use rkyv::{with::AsBox, Archive, Deserialize, Serialize};
 
 use crate::{syntax_pos::Mark, SyntaxContext};
 
@@ -157,3 +159,15 @@ impl Serialized {
         }
     }
 }
+
+/// A wrapper type for the structures to be passed into plugins
+/// serializes the contained value out-of-line so that newer
+/// versions can be viewed as the older version.
+///
+/// First field indicate version of struct type (schema). Any consumers like
+/// swc_plugin_macro can use this to validate compatiblility before attempt to
+/// serialize.
+#[derive(Archive, Deserialize, Serialize)]
+#[repr(transparent)]
+#[archive_attr(repr(transparent), derive(CheckBytes))]
+pub struct VersionedSerializable<T>(#[with(AsBox)] pub (u32, T));

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -33,6 +33,7 @@ pub mod hygiene;
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 pub struct Span {
     #[serde(rename = "start")]
     #[cfg_attr(feature = "rkyv", omit_bounds)]
@@ -105,6 +106,10 @@ better_scoped_tls::scoped_tls!(
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
 )]
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
 pub enum FileName {
@@ -298,6 +303,10 @@ impl FileName {
 #[cfg_attr(
     feature = "plugin-base",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "plugin-base",
+    archive_attr(repr(C), derive(bytecheck::CheckBytes))
 )]
 pub struct MultiSpan {
     primary_spans: Vec<Span>,
@@ -710,6 +719,7 @@ pub const NO_EXPANSION: SyntaxContext = SyntaxContext::empty();
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct MultiByteChar {
     /// The absolute offset of the character in the SourceMap
@@ -722,6 +732,10 @@ pub struct MultiByteChar {
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
 )]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum NonNarrowChar {
@@ -790,6 +804,7 @@ impl Sub<BytePos> for NonNarrowChar {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 #[derive(Clone)]
 pub struct SourceFile {
     /// The name of the file that the source came from. Source that doesn't
@@ -990,6 +1005,7 @@ pub trait Pos {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 pub struct BytePos(#[cfg_attr(feature = "rkyv", omit_bounds)] pub u32);
 
 impl BytePos {
@@ -1015,6 +1031,7 @@ impl BytePos {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 pub struct CharPos(pub usize);
 
@@ -1110,6 +1127,7 @@ impl Sub for CharPos {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 #[derive(Debug, Clone)]
 pub struct Loc {
     /// Information about the original source
@@ -1144,6 +1162,7 @@ pub struct SourceFileAndLine {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 #[derive(Debug)]
 pub struct SourceFileAndBytePos {
     pub sf: Lrc<SourceFile>,
@@ -1155,6 +1174,7 @@ pub struct SourceFileAndBytePos {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 pub struct LineInfo {
     /// Index of line, starting from 0.
     pub line_index: usize,
@@ -1177,6 +1197,7 @@ pub struct LineCol {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 pub struct FileLines {
     pub file: Lrc<SourceFile>,
     pub lines: Vec<LineInfo>,
@@ -1193,6 +1214,10 @@ pub type FileLinesResult = Result<FileLines, SpanLinesError>;
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
 )]
 pub enum SpanLinesError {
     IllFormedSpan(Span),
@@ -1213,6 +1238,7 @@ pub enum SpanSnippetError {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 pub struct DistinctSources {
     pub begin: (FileName, BytePos),
     pub end: (FileName, BytePos),

--- a/crates/swc_common/src/syntax_pos/hygiene.rs
+++ b/crates/swc_common/src/syntax_pos/hygiene.rs
@@ -34,6 +34,7 @@ use crate::collections::AHashMap;
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 pub struct SyntaxContext(#[cfg_attr(feature = "rkyv", omit_bounds)] u32);
 
 #[cfg(feature = "arbitrary")]
@@ -70,6 +71,7 @@ struct MarkData {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 pub struct MutableMarkContext(pub u32, pub u32, pub u32);
 
 // List of proxy calls injected by the host in the plugin's runtime context.

--- a/crates/swc_common/tests/attr_interop.rs
+++ b/crates/swc_common/tests/attr_interop.rs
@@ -22,6 +22,7 @@ pub struct Tuple(#[span] HasSpan, usize, usize);
     feature = "rkyv",
     archive(bound(serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace"))
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 pub struct HasSpan {
     #[cfg_attr(feature = "rkyv", omit_bounds)]
     pub span: Span,

--- a/crates/swc_ecma_ast/Cargo.toml
+++ b/crates/swc_ecma_ast/Cargo.toml
@@ -18,11 +18,12 @@ bench = false
 [features]
 default = []
 fuzzing = ["arbitrary", "swc_common/arbitrary"]
-rkyv-impl = ["rkyv", "swc_common/rkyv-impl"]
+rkyv-impl = ["rkyv", "bytecheck", "swc_common/rkyv-impl"]
 
 [dependencies]
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 bitflags = "1"
+bytecheck = { version = "0.6.8", optional = true }
 is-macro = "0.2.0"
 num-bigint = { version = "0.4", features = ["serde"] }
 rkyv = { version = "0.7.39", optional = true }

--- a/crates/swc_ecma_ast/src/class.rs
+++ b/crates/swc_ecma_ast/src/class.rs
@@ -248,6 +248,10 @@ pub struct Decorator {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
+)]
 pub enum MethodKind {
     #[serde(rename = "method")]
     Method,

--- a/crates/swc_ecma_ast/src/decl.rs
+++ b/crates/swc_ecma_ast/src/decl.rs
@@ -110,6 +110,10 @@ impl Take for VarDecl {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
+)]
 pub enum VarDeclKind {
     /// `var`
     Var,

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -713,6 +713,10 @@ pub struct MetaPropExpr {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
+)]
 pub enum MetaPropKind {
     /// `new.target`
     NewTarget,
@@ -896,6 +900,7 @@ impl Take for Import {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 #[cfg_attr(
     feature = "rkyv",
     archive(bound(serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace"))

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -21,6 +21,7 @@ use crate::typescript::TsTypeAnn;
     feature = "rkyv",
     archive(bound(serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace"))
 )]
+#[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(bytecheck::CheckBytes)))]
 pub struct BindingIdent {
     #[span]
     #[serde(flatten)]

--- a/crates/swc_ecma_ast/src/operators.rs
+++ b/crates/swc_ecma_ast/src/operators.rs
@@ -7,6 +7,10 @@ use swc_common::EqIgnoreSpan;
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
+)]
 pub enum BinaryOp {
     /// `==`
     EqEq,
@@ -112,6 +116,10 @@ impl BinaryOp {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
+)]
 pub enum AssignOp {
     /// `=`
     Assign,
@@ -181,6 +189,10 @@ impl AssignOp {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
+)]
 pub enum UpdateOp {
     /// `++`
     PlusPlus,
@@ -193,6 +205,10 @@ pub enum UpdateOp {
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
 )]
 pub enum UnaryOp {
     /// `-`

--- a/crates/swc_ecma_ast/src/typescript.rs
+++ b/crates/swc_ecma_ast/src/typescript.rs
@@ -392,6 +392,10 @@ pub struct TsKeywordType {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
+)]
 pub enum TsKeywordTypeKind {
     #[serde(rename = "any")]
     TsAnyKeyword,
@@ -673,6 +677,10 @@ pub struct TsTypeOperator {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
+)]
 pub enum TsTypeOperatorOp {
     /// `keyof`
     KeyOf,
@@ -698,6 +706,10 @@ pub struct TsIndexedAccessType {
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
 )]
 pub enum TruePlusMinus {
     True,
@@ -1058,6 +1070,10 @@ pub struct TsNonNullExpr {
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(
+    feature = "rkyv",
+    archive_attr(repr(u32), derive(bytecheck::CheckBytes))
 )]
 pub enum Accessibility {
     #[serde(rename = "public")]

--- a/crates/swc_plugin_proxy/Cargo.toml
+++ b/crates/swc_plugin_proxy/Cargo.toml
@@ -18,6 +18,7 @@ plugin-mode = []
 
 [dependencies]
 better_scoped_tls = { version = "0.1.0", path = "../better_scoped_tls" }
+bytecheck = "0.6.8"
 rkyv = "0.7.39"
 swc_common = { version = "0.18.0", path = "../swc_common", features = [
   "plugin-base",

--- a/crates/swc_plugin_proxy/src/memory_interop/read_returned_result_from_host.rs
+++ b/crates/swc_plugin_proxy/src/memory_interop/read_returned_result_from_host.rs
@@ -3,6 +3,7 @@ use swc_common::plugin::Serialized;
 
 /// A struct to exchange allocated data between memory spaces.
 #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive_attr(repr(C), derive(bytecheck::CheckBytes))]
 pub struct AllocatedBytesPtr(pub i32, pub i32);
 
 /// Performs an interop while calling host fn to get non-determined size return


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Related to #5060.

PR introduces a new struct `versioned`, which is a transparent type can be used to carry over different versioned struct. Also PR wraps ast with `bytecheck` to validate serialized byte with each versions.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
