### PR TITLE
feat(swc/common): allow to take inner from versioned (#5060: Part 2) 

### DIFF
--- a/crates/swc_common/src/plugin.rs
+++ b/crates/swc_common/src/plugin.rs
@@ -4,7 +4,7 @@
 //! `swc_common`.
 #![allow(unused)]
 
-use std::any::type_name;
+use std::{any::type_name, mem};
 
 use anyhow::Error;
 use bytecheck::CheckBytes;
@@ -178,7 +178,7 @@ pub struct VersionedSerializable<T>(#[with(AsBox)] (u32, T));
 
 impl<T> VersionedSerializable<T> {
     pub fn new(value: T) -> Self {
-        // TODO: we'll add compile time flag to augment schema version per binary.
+        // TODO: we'll add compile time flag to augment schema version.
         // User should not try to set version by themselves.
         VersionedSerializable((1, value))
     }
@@ -189,5 +189,12 @@ impl<T> VersionedSerializable<T> {
 
     pub fn inner(&self) -> &T {
         &self.0 .1
+    }
+
+    pub fn take(&mut self) -> T
+    where
+        T: Default,
+    {
+        mem::take(&mut self.0 .1)
     }
 }

--- a/crates/swc_common/src/plugin.rs
+++ b/crates/swc_common/src/plugin.rs
@@ -174,4 +174,20 @@ impl Serialized {
 #[derive(Archive, Deserialize, Serialize)]
 #[repr(transparent)]
 #[archive_attr(repr(transparent), derive(CheckBytes))]
-pub struct VersionedSerializable<T>(#[with(AsBox)] pub (u32, T));
+pub struct VersionedSerializable<T>(#[with(AsBox)] (u32, T));
+
+impl<T> VersionedSerializable<T> {
+    pub fn new(value: T) -> Self {
+        // TODO: we'll add compile time flag to augment schema version per binary.
+        // User should not try to set version by themselves.
+        VersionedSerializable((1, value))
+    }
+
+    pub fn version(&self) -> u32 {
+        self.0 .0
+    }
+
+    pub fn inner(&self) -> &T {
+        &self.0 .1
+    }
+}

--- a/crates/swc_ecma_ast/src/module.rs
+++ b/crates/swc_ecma_ast/src/module.rs
@@ -14,6 +14,12 @@ pub enum Program {
     Script(Script),
 }
 
+impl Default for Program {
+    fn default() -> Self {
+        Program::Module(Module::dummy())
+    }
+}
+
 #[ast_node("Module")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 pub struct Module {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I made this PR intentionally short for the verification of idea (which means I'm not certain about this change and I may wrong 😅)

PR implements `take` for the `VersionedSerializable` to move out value after deserializaiton is done from transform. Pseudocodewise, it'll be used like below:

```
let versioned_program = VersionedSerializable::new(program);
let mut serialized = Serialized::serialize(&versioned_program)?;

//... run plugin transform

// deserialize, return actual inner program
return Serialized::deserialize(&serialized)
                    .map(|mut v: VersionedSerializable<Program>| v.take())
```

Main thing I'm unsure is implementing `Default` for the `Program` to use `mem::take` in here. It maybe harmless, but I'm not easily able to say default impl for the program is exactly right. Maybe 1. either default should not be implemented 2. or implement better default ?

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
