### PR TITLE
fix(es/module): indirect call for lazy require

### DIFF
--- a/crates/swc_ecma_transforms_module/src/module_ref_rewriter.rs
+++ b/crates/swc_ecma_transforms_module/src/module_ref_rewriter.rs
@@ -84,9 +84,7 @@ impl VisitMut for ModuleRefRewriter {
                 let is_indirect_callee = e
                     .as_ident()
                     .and_then(|ident| self.import_map.get(&ident.to_id()))
-                    .map(|(mod_ident, prop)| {
-                        prop.is_some() && !self.lazy_record.contains(&mod_ident.to_id())
-                    })
+                    .map(|(_, prop)| prop.is_some())
                     .unwrap_or_default();
 
                 e.visit_mut_with(self);

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/lazy/computed-prop-name/output.cjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/lazy/computed-prop-name/output.cjs
@@ -19,6 +19,6 @@ function _liby() {
 class F {
     get [_libx().x]() {}
     get y() {
-        _liby().y();
+        (0, _liby().y)();
     }
 }

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/lazy/import-all-from-object-config/output.cjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/lazy/import-all-from-object-config/output.cjs
@@ -17,5 +17,5 @@ function _external() {
     return data;
 }
 function use() {
-    _local().local(_external().external);
+    (0, _local().local)(_external().external);
 }

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/lazy/issue-3081/1/output.cjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/lazy/issue-3081/1/output.cjs
@@ -14,6 +14,6 @@ function log() {
 }
 const other = ()=>{
     const nestedClosure = ()=>{
-        _childProcess().spawn("ls");
+        (0, _childProcess().spawn)("ls");
     };
 };

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/lazy/issue-3081/2/output.cjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/lazy/issue-3081/2/output.cjs
@@ -10,7 +10,7 @@ function _lib() {
     return data;
 }
 function myFn() {
-    _lib().fn();
+    (0, _lib().fn)();
 }
 class MyClass extends _lib().Klass {
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

It is my mistake to skip the indirect call transforms if the  callee is lazy required.
It still needs to be transformed into indirect call to correct `this`.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
