### PR TITLE
feat(es/parser): adding 'd' regex flag (ES2022)

### DIFF
--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -334,7 +334,7 @@ impl<I: Tokens> Parser<I> {
                             AHashMap::<char, usize>::default(),
                             |mut map, flag| {
                                 let key = match flag {
-                                    'g' | 'i' | 'm' | 's' | 'u' | 'y' => flag,
+                                    'g' | 'i' | 'm' | 's' | 'u' | 'y' | 'd' => flag,
                                     _ => '\u{0000}', // special marker for unknown flags
                                 };
                                 map.entry(key).and_modify(|count| *count += 1).or_insert(1);

--- a/crates/swc_ecma_preset_env/src/lib.rs
+++ b/crates/swc_ecma_preset_env/src/lib.rs
@@ -99,7 +99,8 @@ where
             Optional::new(
                 regexp(regexp::Config {
                     dot_all_regex: enable_dot_all_regex,
-
+                    // TODO: add Feature:HasIndicesRegex
+                    has_indices: false,
                     // TODO: add Feature::LookbehindAssertion
                     lookbehind_assertion: false,
                     named_capturing_groups_regex: enable_named_capturing_groups_regex,

--- a/crates/swc_ecma_transforms_compat/src/es2015/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/mod.rs
@@ -61,6 +61,7 @@ where
     chain!(
         regexp(regexp::Config {
             dot_all_regex: false,
+            has_indices: false,
             lookbehind_assertion: false,
             named_capturing_groups_regex: false,
             sticky_regex: true,

--- a/crates/swc_ecma_transforms_compat/src/es2018/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2018/mod.rs
@@ -12,6 +12,7 @@ pub fn es2018(c: Config) -> impl Fold {
     chain!(
         regexp(regexp::Config {
             dot_all_regex: true,
+            has_indices: false,
             lookbehind_assertion: true,
             named_capturing_groups_regex: true,
             sticky_regex: false,

--- a/crates/swc_ecma_transforms_compat/src/es2022/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/mod.rs
@@ -5,6 +5,7 @@ pub use self::{
     class_properties::class_properties, private_in_object::private_in_object,
     static_blocks::static_blocks,
 };
+use crate::regexp::{self, regexp};
 
 pub mod class_properties;
 pub mod private_in_object;
@@ -13,6 +14,15 @@ pub mod static_blocks;
 #[tracing::instrument(level = "info", skip_all)]
 pub fn es2022<C: Comments>(cm: Option<C>, config: Config) -> impl Fold {
     chain!(
+        regexp(regexp::Config {
+            dot_all_regex: true,
+            has_indices: true,
+            lookbehind_assertion: true,
+            named_capturing_groups_regex: true,
+            sticky_regex: false,
+            unicode_property_regex: true,
+            unicode_regex: false,
+        }),
         static_blocks(),
         class_properties(cm, config.class_properties),
         private_in_object(),

--- a/crates/swc_ecma_transforms_compat/src/regexp.rs
+++ b/crates/swc_ecma_transforms_compat/src/regexp.rs
@@ -11,6 +11,8 @@ pub fn regexp(config: Config) -> impl Fold + VisitMut {
 pub struct Config {
     /// [s/dotAll flag for regular expressions](https://tc39.github.io/proposal-regexp-dotall-flag/)
     pub dot_all_regex: bool,
+    /// [RegExp.prototype.hasIndices](https://262.ecma-international.org/13.0/#sec-get-regexp.prototype.hasIndices)
+    pub has_indices: bool,
     /// [RegExp Lookbehind Assertions](https://tc39.es/proposal-regexp-lookbehind/)
     pub lookbehind_assertion: bool,
     /// [Named capture groups in regular expressions](https://tc39.es/proposal-regexp-named-groups/)
@@ -37,6 +39,7 @@ impl VisitMut for RegExp {
             if (self.config.dot_all_regex && regex.flags.contains('s'))
                 || (self.config.sticky_regex && regex.flags.contains('y'))
                 || (self.config.unicode_regex && regex.flags.contains('u'))
+                || (self.config.has_indices && regex.flags.contains('d'))
                 || (self.config.named_capturing_groups_regex && regex.exp.contains("(?<"))
                 || (self.config.lookbehind_assertion && regex.exp.contains("(?<=")
                     || regex.exp.contains("(?<!"))


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
ECMAScript2022 version (ES13) released June 2022 includes a new `d` (hasIndices) RegEx flag according to [the spec](https://262.ecma-international.org/13.0/#sec-regexpbuiltinexec). This PR adds such flag.

Currently, we are throwing a `UnknownRegExpFlags` error because `d` is not included in the known flags. Babel allows this and doesn't alter the RegEx flags.

See [play.swc.rs](https://play.swc.rs/?version=1.2.210&code=H4sIAAAAAAAAA9PXSNTW1EjS1tRP0UutSE3WUE8EgqQkdU1rACH6qKMbAAAA&config=H4sIAAAAAAAAA0WMTQrEIAxG75K1286id5hDBCctFv9IUhgR714tlu7C915ehUMsrBUyshCPS0pU%2FMMKZAOKZZcVTNf6tKEXagYUeScdiiyd%2BZSEJjUQXHRbGSWbQmYSeRHG3T9m66GQfucYKmjJdAc%2F0N7G%2FHPynaLySe0Cj9ke9LUAAAA%3D)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
None
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->