### PR TITLE
docs: fix the meaning

### DIFF
--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -208,13 +208,13 @@ impl Syntax {
         )
     }
 
-    /// Should we pare typescript?
+    /// Should we parse typescript?
     #[cfg(not(feature = "typescript"))]
     pub const fn typescript(self) -> bool {
         false
     }
 
-    /// Should we pare typescript?
+    /// Should we parse typescript?
     #[cfg(feature = "typescript")]
     pub const fn typescript(self) -> bool {
         matches!(self, Syntax::Typescript(..))


### PR DESCRIPTION
Description:
The place to use is to turn on the parse ts switch, which seems to be a typo
```rust
if syntax.typescript() {
    transform.legacy_decorator = true.into();
}
```

BREAKING CHANGE:

No

Related issue (if exists):

No