### PR TITLE
fix(es/compat): Optimize for array lit for-of loop

### DIFF
--- a/crates/swc/tests/fixture/issues-1xxx/1918/es5-after-other/output/index.js
+++ b/crates/swc/tests/fixture/issues-1xxx/1918/es5-after-other/output/index.js
@@ -49,7 +49,7 @@ function _asyncToGenerator(fn) {
     };
 }
 _asyncToGenerator(_regeneratorRuntime.default.mark(function _callee() {
-    var counter, resolve, promise, iterable, res, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, v, oldresolve;
+    var counter, resolve, promise, iterable, res, _i, _iter, v, oldresolve;
     return _regeneratorRuntime.default.wrap(function _callee$(_ctx) {
         while(1)switch(_ctx.prev = _ctx.next){
             case 0:
@@ -144,21 +144,19 @@ _asyncToGenerator(_regeneratorRuntime.default.mark(function _callee() {
                         ]
                     ]);
                 }))();
-                _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-                _ctx.prev = 6;
-                _iterator = [
+                _i = 0, _iter = [
                     0,
                     1
-                ][Symbol.iterator]();
-            case 8:
-                if (_iteratorNormalCompletion = (_step = _iterator.next()).done) {
-                    _ctx.next = 18;
+                ];
+            case 6:
+                if (!(_i < _iter.length)) {
+                    _ctx.next = 16;
                     break;
                 }
-                v = _step.value;
-                _ctx.next = 12;
+                v = _iter[_i];
+                _ctx.next = 10;
                 return null;
-            case 12:
+            case 10:
                 oldresolve = resolve;
                 promise = new Promise(function(r) {
                     return resolve = r;
@@ -167,58 +165,20 @@ _asyncToGenerator(_regeneratorRuntime.default.mark(function _callee() {
                     value: v,
                     done: false
                 });
-            case 15:
-                _iteratorNormalCompletion = true;
-                _ctx.next = 8;
+            case 13:
+                _i++;
+                _ctx.next = 6;
                 break;
-            case 18:
-                _ctx.next = 24;
-                break;
-            case 20:
-                _ctx.prev = 20;
-                _ctx.t0 = _ctx["catch"](6);
-                _didIteratorError = true;
-                _iteratorError = _ctx.t0;
-            case 24:
-                _ctx.prev = 24;
-                _ctx.prev = 25;
-                if (!_iteratorNormalCompletion && _iterator.return != null) {
-                    _iterator.return();
-                }
-            case 27:
-                _ctx.prev = 27;
-                if (!_didIteratorError) {
-                    _ctx.next = 30;
-                    break;
-                }
-                throw _iteratorError;
-            case 30:
-                return _ctx.finish(27);
-            case 31:
-                return _ctx.finish(24);
-            case 32:
+            case 16:
                 resolve({
                     value: undefined,
                     done: true
                 });
-                _ctx.next = 35;
+                _ctx.next = 19;
                 return res;
-            case 35:
+            case 19:
             case "end":
                 return _ctx.stop();
         }
-    }, _callee, null, [
-        [
-            6,
-            20,
-            24,
-            32
-        ],
-        [
-            25,
-            ,
-            27,
-            31
-        ]
-    ]);
+    }, _callee);
 }))();

--- a/crates/swc/tests/fixture/issues-1xxx/1918/es5/output/index.js
+++ b/crates/swc/tests/fixture/issues-1xxx/1918/es5/output/index.js
@@ -8,7 +8,7 @@ var _defineProperty = require("@swc/helpers/lib/_define_property.js").default;
 var _interopRequireDefault = require("@swc/helpers/lib/_interop_require_default.js").default;
 var _regeneratorRuntime = /*#__PURE__*/ _interopRequireDefault(require("regenerator-runtime"));
 _asyncToGenerator(_regeneratorRuntime.default.mark(function _callee() {
-    var counter, resolve, promise, iterable, res, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, v, oldresolve;
+    var counter, resolve, promise, iterable, res, _i, _iter, v, oldresolve;
     return _regeneratorRuntime.default.wrap(function _callee$(_ctx) {
         while(1)switch(_ctx.prev = _ctx.next){
             case 0:
@@ -103,21 +103,19 @@ _asyncToGenerator(_regeneratorRuntime.default.mark(function _callee() {
                         ]
                     ]);
                 }))();
-                _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-                _ctx.prev = 6;
-                _iterator = [
+                _i = 0, _iter = [
                     0,
                     1
-                ][Symbol.iterator]();
-            case 8:
-                if (_iteratorNormalCompletion = (_step = _iterator.next()).done) {
-                    _ctx.next = 18;
+                ];
+            case 6:
+                if (!(_i < _iter.length)) {
+                    _ctx.next = 16;
                     break;
                 }
-                v = _step.value;
-                _ctx.next = 12;
+                v = _iter[_i];
+                _ctx.next = 10;
                 return null;
-            case 12:
+            case 10:
                 oldresolve = resolve;
                 promise = new Promise(function(r) {
                     return resolve = r;
@@ -126,58 +124,20 @@ _asyncToGenerator(_regeneratorRuntime.default.mark(function _callee() {
                     value: v,
                     done: false
                 });
-            case 15:
-                _iteratorNormalCompletion = true;
-                _ctx.next = 8;
+            case 13:
+                _i++;
+                _ctx.next = 6;
                 break;
-            case 18:
-                _ctx.next = 24;
-                break;
-            case 20:
-                _ctx.prev = 20;
-                _ctx.t0 = _ctx["catch"](6);
-                _didIteratorError = true;
-                _iteratorError = _ctx.t0;
-            case 24:
-                _ctx.prev = 24;
-                _ctx.prev = 25;
-                if (!_iteratorNormalCompletion && _iterator.return != null) {
-                    _iterator.return();
-                }
-            case 27:
-                _ctx.prev = 27;
-                if (!_didIteratorError) {
-                    _ctx.next = 30;
-                    break;
-                }
-                throw _iteratorError;
-            case 30:
-                return _ctx.finish(27);
-            case 31:
-                return _ctx.finish(24);
-            case 32:
+            case 16:
                 resolve({
                     value: undefined,
                     done: true
                 });
-                _ctx.next = 35;
+                _ctx.next = 19;
                 return res;
-            case 35:
+            case 19:
             case "end":
                 return _ctx.stop();
         }
-    }, _callee, null, [
-        [
-            6,
-            20,
-            24,
-            32
-        ],
-        [
-            25,
-            ,
-            27,
-            31
-        ]
-    ]);
+    }, _callee);
 }))();

--- a/crates/swc/tests/tsc-references/ES3For-ofTypeCheck2_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES3For-ofTypeCheck2_es5.1.normal.js
@@ -1,22 +1,6 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@target: ES3
-    for(var _iterator = [
-        true
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@target: ES3
+for(var _i = 0, _iter = [
+    true
+]; _i < _iter.length; _i++){
+    var v = _iter[_i];
 }

--- a/crates/swc/tests/tsc-references/ES3For-ofTypeCheck2_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES3For-ofTypeCheck2_es5.2.minified.js
@@ -1,14 +1,3 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        !0
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    !0
+]; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/ES5For-of10_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of10_es5.1.normal.js
@@ -3,42 +3,10 @@ function foo() {
         x: 0
     };
 }
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        foo().x = _step.value;
-        var _iteratorNormalCompletion1 = true, _didIteratorError1 = false, _iteratorError1 = undefined;
-        try {
-            for(var _iterator1 = [][Symbol.iterator](), _step1; !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = true){
-                foo().x = _step1.value;
-                var p = foo().x;
-            }
-        } catch (err) {
-            _didIteratorError1 = true;
-            _iteratorError1 = err;
-        } finally{
-            try {
-                if (!_iteratorNormalCompletion1 && _iterator1.return != null) {
-                    _iterator1.return();
-                }
-            } finally{
-                if (_didIteratorError1) {
-                    throw _iteratorError1;
-                }
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    foo().x = _iter[_i];
+    for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++){
+        foo().x = _iter1[_i1];
+        var p = foo().x;
     }
 }

--- a/crates/swc/tests/tsc-references/ES5For-of10_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of10_es5.2.minified.js
@@ -3,29 +3,7 @@ function foo() {
         x: 0
     };
 }
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        foo().x = _step.value;
-        var _iteratorNormalCompletion1 = !0, _didIteratorError1 = !1, _iteratorError1 = void 0;
-        try {
-            for(var _step1, _iterator1 = [][Symbol.iterator](); !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = !0)foo().x = _step1.value, foo().x;
-        } catch (err) {
-            _didIteratorError1 = !0, _iteratorError1 = err;
-        } finally{
-            try {
-                _iteratorNormalCompletion1 || null == _iterator1.return || _iterator1.return();
-            } finally{
-                if (_didIteratorError1) throw _iteratorError1;
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    foo().x = _iter[_i];
+    for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++)foo().x = _iter1[_i1], foo().x;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of11_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of11_es5.1.normal.js
@@ -1,20 +1,4 @@
 var v;
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        v = _step.value;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    v = _iter[_i];
 }

--- a/crates/swc/tests/tsc-references/ES5For-of11_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of11_es5.2.minified.js
@@ -1,12 +1,1 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = []; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/ES5For-of13_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of13_es5.1.normal.js
@@ -1,25 +1,9 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@sourcemap: true
-    for(var _iterator = [
-        "a",
-        "b",
-        "c"
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        var x = v;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@sourcemap: true
+for(var _i = 0, _iter = [
+    "a",
+    "b",
+    "c"
+]; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    var x = v;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of13_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of13_es5.2.minified.js
@@ -1,16 +1,5 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        "a",
-        "b",
-        "c"
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    "a",
+    "b",
+    "c"
+]; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/ES5For-of14_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of14_es5.1.normal.js
@@ -1,20 +1,4 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        var x = v;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    var x = v;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of14_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of14_es5.2.minified.js
@@ -1,12 +1,1 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = []; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/ES5For-of15_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of15_es5.1.normal.js
@@ -1,40 +1,8 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        v;
-        var _iteratorNormalCompletion1 = true, _didIteratorError1 = false, _iteratorError1 = undefined;
-        try {
-            for(var _iterator1 = [][Symbol.iterator](), _step1; !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = true){
-                var v1 = _step1.value;
-                var x = v1;
-            }
-        } catch (err) {
-            _didIteratorError1 = true;
-            _iteratorError1 = err;
-        } finally{
-            try {
-                if (!_iteratorNormalCompletion1 && _iterator1.return != null) {
-                    _iterator1.return();
-                }
-            } finally{
-                if (_didIteratorError1) {
-                    throw _iteratorError1;
-                }
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    v;
+    for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++){
+        var v1 = _iter1[_i1];
+        var x = v1;
     }
 }

--- a/crates/swc/tests/tsc-references/ES5For-of15_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of15_es5.2.minified.js
@@ -1,26 +1,4 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        _step.value;
-        var _iteratorNormalCompletion1 = !0, _didIteratorError1 = !1, _iteratorError1 = void 0;
-        try {
-            for(var _step1, _iterator1 = [][Symbol.iterator](); !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = !0)_step1.value;
-        } catch (err) {
-            _didIteratorError1 = !0, _iteratorError1 = err;
-        } finally{
-            try {
-                _iteratorNormalCompletion1 || null == _iterator1.return || _iterator1.return();
-            } finally{
-                if (_didIteratorError1) throw _iteratorError1;
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    _iter[_i];
+    for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++)_iter1[_i1];
 }

--- a/crates/swc/tests/tsc-references/ES5For-of16_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of16_es5.1.normal.js
@@ -1,41 +1,9 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        v;
-        var _iteratorNormalCompletion1 = true, _didIteratorError1 = false, _iteratorError1 = undefined;
-        try {
-            for(var _iterator1 = [][Symbol.iterator](), _step1; !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = true){
-                var v1 = _step1.value;
-                var x = v1;
-                v1++;
-            }
-        } catch (err) {
-            _didIteratorError1 = true;
-            _iteratorError1 = err;
-        } finally{
-            try {
-                if (!_iteratorNormalCompletion1 && _iterator1.return != null) {
-                    _iterator1.return();
-                }
-            } finally{
-                if (_didIteratorError1) {
-                    throw _iteratorError1;
-                }
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    v;
+    for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++){
+        var v1 = _iter1[_i1];
+        var x = v1;
+        v1++;
     }
 }

--- a/crates/swc/tests/tsc-references/ES5For-of16_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of16_es5.2.minified.js
@@ -1,26 +1,4 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        _step.value;
-        var _iteratorNormalCompletion1 = !0, _didIteratorError1 = !1, _iteratorError1 = void 0;
-        try {
-            for(var _step1, _iterator1 = [][Symbol.iterator](); !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = !0)_step1.value;
-        } catch (err) {
-            _didIteratorError1 = !0, _iteratorError1 = err;
-        } finally{
-            try {
-                _iteratorNormalCompletion1 || null == _iterator1.return || _iterator1.return();
-            } finally{
-                if (_didIteratorError1) throw _iteratorError1;
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    _iter[_i];
+    for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++)_iter1[_i1];
 }

--- a/crates/swc/tests/tsc-references/ES5For-of17_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of17_es5.1.normal.js
@@ -1,43 +1,11 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var _$v = _step.value;
-        _$v;
-        var _iteratorNormalCompletion1 = true, _didIteratorError1 = false, _iteratorError1 = undefined;
-        try {
-            for(var _iterator1 = [
-                _$v1
-            ][Symbol.iterator](), _step1; !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = true){
-                var _$v1 = _step1.value;
-                var x = _$v1;
-                _$v1++;
-            }
-        } catch (err) {
-            _didIteratorError1 = true;
-            _iteratorError1 = err;
-        } finally{
-            try {
-                if (!_iteratorNormalCompletion1 && _iterator1.return != null) {
-                    _iterator1.return();
-                }
-            } finally{
-                if (_didIteratorError1) {
-                    throw _iteratorError1;
-                }
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var _$v = _iter[_i];
+    _$v;
+    for(var _i1 = 0, _iter1 = [
+        _$v1
+    ]; _i1 < _iter1.length; _i1++){
+        var _$v1 = _iter1[_i1];
+        var x = _$v1;
+        _$v1++;
     }
 }

--- a/crates/swc/tests/tsc-references/ES5For-of17_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of17_es5.2.minified.js
@@ -1,31 +1,9 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        _step.value;
-        var _iteratorNormalCompletion1 = !0, _didIteratorError1 = !1, _iteratorError1 = void 0;
-        try {
-            for(var _step1, _iterator1 = [
-                _$v
-            ][Symbol.iterator](); !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = !0){
-                var _$v = _step1.value;
-                _$v++;
-            }
-        } catch (err) {
-            _didIteratorError1 = !0, _iteratorError1 = err;
-        } finally{
-            try {
-                _iteratorNormalCompletion1 || null == _iterator1.return || _iterator1.return();
-            } finally{
-                if (_didIteratorError1) throw _iteratorError1;
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    _iter[_i];
+    for(var _i1 = 0, _iter1 = [
+        _$v
+    ]; _i1 < _iter1.length; _i1++){
+        var _$v = _iter1[_i1];
+        _$v++;
     }
 }

--- a/crates/swc/tests/tsc-references/ES5For-of18_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of18_es5.1.normal.js
@@ -1,40 +1,8 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        v;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    v;
 }
-var _iteratorNormalCompletion1 = true, _didIteratorError1 = false, _iteratorError1 = undefined;
-try {
-    for(var _iterator1 = [][Symbol.iterator](), _step1; !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = true){
-        var v1 = _step1.value;
-        v1;
-    }
-} catch (err) {
-    _didIteratorError1 = true;
-    _iteratorError1 = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion1 && _iterator1.return != null) {
-            _iterator1.return();
-        }
-    } finally{
-        if (_didIteratorError1) {
-            throw _iteratorError1;
-        }
-    }
+for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++){
+    var v1 = _iter1[_i1];
+    v1;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of18_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of18_es5.2.minified.js
@@ -1,24 +1,2 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
-var _iteratorNormalCompletion1 = !0, _didIteratorError1 = !1, _iteratorError1 = void 0;
-try {
-    for(var _step1, _iterator1 = [][Symbol.iterator](); !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = !0)_step1.value;
-} catch (err) {
-    _didIteratorError1 = !0, _iteratorError1 = err;
-} finally{
-    try {
-        _iteratorNormalCompletion1 || null == _iterator1.return || _iterator1.return();
-    } finally{
-        if (_didIteratorError1) throw _iteratorError1;
-    }
-}
+for(var _i = 0, _iter = []; _i < _iter.length; _i++)_iter[_i];
+for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++)_iter1[_i1];

--- a/crates/swc/tests/tsc-references/ES5For-of19_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of19_es5.1.normal.js
@@ -1,42 +1,10 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        var foo = function foo() {
-            var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-            try {
-                for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-                    var v = _step.value;
-                    v;
-                }
-            } catch (err) {
-                _didIteratorError = true;
-                _iteratorError = err;
-            } finally{
-                try {
-                    if (!_iteratorNormalCompletion && _iterator.return != null) {
-                        _iterator.return();
-                    }
-                } finally{
-                    if (_didIteratorError) {
-                        throw _iteratorError;
-                    }
-                }
-            }
-        };
-        v;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    var foo = function foo() {
+        for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+            var v = _iter[_i];
+            v;
         }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+    };
+    v;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of19_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of19_es5.2.minified.js
@@ -1,12 +1,1 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = []; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/ES5For-of1_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of1_es5.1.normal.js
@@ -1,25 +1,9 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@sourcemap: true
-    for(var _iterator = [
-        "a",
-        "b",
-        "c"
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        console.log(v);
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@sourcemap: true
+for(var _i = 0, _iter = [
+    "a",
+    "b",
+    "c"
+]; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    console.log(v);
 }

--- a/crates/swc/tests/tsc-references/ES5For-of1_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of1_es5.2.minified.js
@@ -1,19 +1,8 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        "a",
-        "b",
-        "c"
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        var v = _step.value;
-        console.log(v);
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = [
+    "a",
+    "b",
+    "c"
+]; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    console.log(v);
 }

--- a/crates/swc/tests/tsc-references/ES5For-of21_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of21_es5.1.normal.js
@@ -1,38 +1,6 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        var _iteratorNormalCompletion1 = true, _didIteratorError1 = false, _iteratorError1 = undefined;
-        try {
-            for(var _iterator1 = [][Symbol.iterator](), _step1; !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = true){
-                var _i = _step1.value;
-            }
-        } catch (err) {
-            _didIteratorError1 = true;
-            _iteratorError1 = err;
-        } finally{
-            try {
-                if (!_iteratorNormalCompletion1 && _iterator1.return != null) {
-                    _iterator1.return();
-                }
-            } finally{
-                if (_didIteratorError1) {
-                    throw _iteratorError1;
-                }
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++){
+        var _i2 = _iter1[_i1];
     }
 }

--- a/crates/swc/tests/tsc-references/ES5For-of21_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of21_es5.2.minified.js
@@ -1,26 +1,4 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        _step.value;
-        var _iteratorNormalCompletion1 = !0, _didIteratorError1 = !1, _iteratorError1 = void 0;
-        try {
-            for(var _step1, _iterator1 = [][Symbol.iterator](); !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = !0)_step1.value;
-        } catch (err) {
-            _didIteratorError1 = !0, _iteratorError1 = err;
-        } finally{
-            try {
-                _iteratorNormalCompletion1 || null == _iterator1.return || _iterator1.return();
-            } finally{
-                if (_didIteratorError1) throw _iteratorError1;
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    _iter[_i];
+    for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++)_iter1[_i1];
 }

--- a/crates/swc/tests/tsc-references/ES5For-of22_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of22_es5.1.normal.js
@@ -1,25 +1,9 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [
-        1,
-        2,
-        3
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var x = _step.value;
-        var _a = 0;
-        console.log(x);
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = [
+    1,
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var x = _iter[_i];
+    var _a = 0;
+    console.log(x);
 }

--- a/crates/swc/tests/tsc-references/ES5For-of22_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of22_es5.2.minified.js
@@ -1,19 +1,8 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        1,
-        2,
-        3
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        var x = _step.value;
-        console.log(x);
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = [
+    1,
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var x = _iter[_i];
+    console.log(x);
 }

--- a/crates/swc/tests/tsc-references/ES5For-of23_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of23_es5.1.normal.js
@@ -1,25 +1,9 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [
-        1,
-        2,
-        3
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var x = _step.value;
-        var _a = 0;
-        console.log(x);
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = [
+    1,
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var x = _iter[_i];
+    var _a = 0;
+    console.log(x);
 }

--- a/crates/swc/tests/tsc-references/ES5For-of23_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of23_es5.2.minified.js
@@ -1,19 +1,8 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        1,
-        2,
-        3
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        var x = _step.value;
-        console.log(x);
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = [
+    1,
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var x = _iter[_i];
+    console.log(x);
 }

--- a/crates/swc/tests/tsc-references/ES5For-of26_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of26_es5.1.normal.js
@@ -1,26 +1,10 @@
 import _sliced_to_array from "@swc/helpers/src/_sliced_to_array.mjs";
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@sourcemap: true
-    for(var _iterator = [
-        2,
-        3
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var _value = _sliced_to_array(_step.value, 2), tmp = _value[0], a = tmp === void 0 ? 0 : tmp, tmp1 = _value[1], b = tmp1 === void 0 ? 1 : tmp1;
-        a;
-        b;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@sourcemap: true
+for(var _i = 0, _iter = [
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var __i = _sliced_to_array(_iter[_i], 2), tmp = __i[0], a = tmp === void 0 ? 0 : tmp, tmp1 = __i[1], b = tmp1 === void 0 ? 1 : tmp1;
+    a;
+    b;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of26_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of26_es5.2.minified.js
@@ -1,19 +1,8 @@
 import _sliced_to_array from "@swc/helpers/src/_sliced_to_array.mjs";
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        2,
-        3
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        var _value = _sliced_to_array(_step.value, 2);
-        _value[0], _value[1];
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = [
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var __i = _sliced_to_array(_iter[_i], 2);
+    __i[0], __i[1];
 }

--- a/crates/swc/tests/tsc-references/ES5For-of27_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of27_es5.1.normal.js
@@ -1,24 +1,8 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [
-        2,
-        3
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var _value = _step.value, tmp = _value.x, a = tmp === void 0 ? 0 : tmp, tmp1 = _value.y, b = tmp1 === void 0 ? 1 : tmp1;
-        a;
-        b;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = [
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var __i = _iter[_i], tmp = __i.x, a = tmp === void 0 ? 0 : tmp, tmp1 = __i.y, b = tmp1 === void 0 ? 1 : tmp1;
+    a;
+    b;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of27_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of27_es5.2.minified.js
@@ -1,18 +1,7 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        2,
-        3
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        var _value = _step.value;
-        _value.x, _value.y;
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = [
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var __i = _iter[_i];
+    __i.x, __i.y;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of28_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of28_es5.1.normal.js
@@ -1,25 +1,9 @@
 import _sliced_to_array from "@swc/helpers/src/_sliced_to_array.mjs";
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [
-        2,
-        3
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var _value = _sliced_to_array(_step.value, 2), tmp = _value[0], a = tmp === void 0 ? 0 : tmp, tmp1 = _value[1], b = tmp1 === void 0 ? 1 : tmp1;
-        a;
-        b;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = [
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var __i = _sliced_to_array(_iter[_i], 2), tmp = __i[0], a = tmp === void 0 ? 0 : tmp, tmp1 = __i[1], b = tmp1 === void 0 ? 1 : tmp1;
+    a;
+    b;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of28_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of28_es5.2.minified.js
@@ -1,19 +1,8 @@
 import _sliced_to_array from "@swc/helpers/src/_sliced_to_array.mjs";
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        2,
-        3
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        var _value = _sliced_to_array(_step.value, 2);
-        _value[0], _value[1];
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = [
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var __i = _sliced_to_array(_iter[_i], 2);
+    __i[0], __i[1];
 }

--- a/crates/swc/tests/tsc-references/ES5For-of29_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of29_es5.1.normal.js
@@ -1,24 +1,8 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [
-        2,
-        3
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var _value = _step.value, tmp = _value.x, a = tmp === void 0 ? 0 : tmp, tmp1 = _value.y, b = tmp1 === void 0 ? 1 : tmp1;
-        a;
-        b;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = [
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var __i = _iter[_i], tmp = __i.x, a = tmp === void 0 ? 0 : tmp, tmp1 = __i.y, b = tmp1 === void 0 ? 1 : tmp1;
+    a;
+    b;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of29_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of29_es5.2.minified.js
@@ -1,18 +1,7 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        2,
-        3
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        var _value = _step.value;
-        _value.x, _value.y;
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = [
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var __i = _iter[_i];
+    __i.x, __i.y;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of2_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of2_es5.1.normal.js
@@ -1,20 +1,4 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        var x = v;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    var x = v;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of2_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of2_es5.2.minified.js
@@ -1,12 +1,1 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = []; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/ES5For-of31_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of31_es5.1.normal.js
@@ -1,23 +1,7 @@
 var a, b;
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var ref, ref1, ref2;
-        ref = _step.value, ref1 = ref.a, b = ref1 === void 0 ? 1 : ref1, ref2 = ref.b, a = ref2 === void 0 ? "" : ref2, ref;
-        a;
-        b;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var ref, ref1, ref2;
+    ref = _iter[_i], ref1 = ref.a, b = ref1 === void 0 ? 1 : ref1, ref2 = ref.b, a = ref2 === void 0 ? "" : ref2, ref;
+    a;
+    b;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of31_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of31_es5.2.minified.js
@@ -1,12 +1,1 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var ref, _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)(ref = _step.value).a, ref.b;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var ref, _i = 0, _iter = []; _i < _iter.length; _i++)(ref = _iter[_i]).a, ref.b;

--- a/crates/swc/tests/tsc-references/ES5For-of33_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of33_es5.1.normal.js
@@ -1,26 +1,10 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@sourcemap: true
-    //@downlevelIteration: true
-    for(var _iterator = [
-        "a",
-        "b",
-        "c"
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        console.log(v);
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@sourcemap: true
+//@downlevelIteration: true
+for(var _i = 0, _iter = [
+    "a",
+    "b",
+    "c"
+]; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    console.log(v);
 }

--- a/crates/swc/tests/tsc-references/ES5For-of33_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of33_es5.2.minified.js
@@ -1,19 +1,8 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        "a",
-        "b",
-        "c"
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        var v = _step.value;
-        console.log(v);
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = [
+    "a",
+    "b",
+    "c"
+]; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    console.log(v);
 }

--- a/crates/swc/tests/tsc-references/ES5For-of34_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of34_es5.1.normal.js
@@ -5,27 +5,11 @@ function foo() {
         x: 0
     };
 }
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [
-        "a",
-        "b",
-        "c"
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        foo().x = _step.value;
-        var p = foo().x;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = [
+    "a",
+    "b",
+    "c"
+]; _i < _iter.length; _i++){
+    foo().x = _iter[_i];
+    var p = foo().x;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of34_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of34_es5.2.minified.js
@@ -3,19 +3,8 @@ function foo() {
         x: 0
     };
 }
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        "a",
-        "b",
-        "c"
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)foo().x = _step.value, foo().x;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    "a",
+    "b",
+    "c"
+]; _i < _iter.length; _i++)foo().x = _iter[_i], foo().x;

--- a/crates/swc/tests/tsc-references/ES5For-of35_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of35_es5.1.normal.js
@@ -1,26 +1,10 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@sourcemap: true
-    //@downlevelIteration: true
-    for(var _iterator = [
-        2,
-        3
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var _value = _step.value, tmp = _value.x, a = tmp === void 0 ? 0 : tmp, tmp1 = _value.y, b = tmp1 === void 0 ? 1 : tmp1;
-        a;
-        b;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@sourcemap: true
+//@downlevelIteration: true
+for(var _i = 0, _iter = [
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var __i = _iter[_i], tmp = __i.x, a = tmp === void 0 ? 0 : tmp, tmp1 = __i.y, b = tmp1 === void 0 ? 1 : tmp1;
+    a;
+    b;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of35_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of35_es5.2.minified.js
@@ -1,18 +1,7 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        2,
-        3
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        var _value = _step.value;
-        _value.x, _value.y;
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = [
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var __i = _iter[_i];
+    __i.x, __i.y;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of36_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of36_es5.1.normal.js
@@ -1,27 +1,11 @@
 import _sliced_to_array from "@swc/helpers/src/_sliced_to_array.mjs";
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@sourcemap: true
-    //@downlevelIteration: true
-    for(var _iterator = [
-        2,
-        3
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var _value = _sliced_to_array(_step.value, 2), tmp = _value[0], a = tmp === void 0 ? 0 : tmp, tmp1 = _value[1], b = tmp1 === void 0 ? 1 : tmp1;
-        a;
-        b;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@sourcemap: true
+//@downlevelIteration: true
+for(var _i = 0, _iter = [
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var __i = _sliced_to_array(_iter[_i], 2), tmp = __i[0], a = tmp === void 0 ? 0 : tmp, tmp1 = __i[1], b = tmp1 === void 0 ? 1 : tmp1;
+    a;
+    b;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of36_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of36_es5.2.minified.js
@@ -1,19 +1,8 @@
 import _sliced_to_array from "@swc/helpers/src/_sliced_to_array.mjs";
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        2,
-        3
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        var _value = _sliced_to_array(_step.value, 2);
-        _value[0], _value[1];
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = [
+    2,
+    3
+]; _i < _iter.length; _i++){
+    var __i = _sliced_to_array(_iter[_i], 2);
+    __i[0], __i[1];
 }

--- a/crates/swc/tests/tsc-references/ES5For-of37_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of37_es5.1.normal.js
@@ -1,59 +1,27 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    // @downlevelIteration: true
-    // https://github.com/microsoft/TypeScript/issues/30083
-    for(var _iterator = [
-        0,
-        1,
-        2,
-        3,
-        4
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var i = _step.value;
-        try {
-            var _iteratorNormalCompletion1 = true, _didIteratorError1 = false, _iteratorError1 = undefined;
-            try {
-                // Ensure catch binding for the following loop is reset per iteration:
-                for(var _iterator1 = [
-                    1,
-                    2,
-                    3
-                ][Symbol.iterator](), _step1; !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = true){
-                    var j = _step1.value;
-                    if (i === 2) {
-                        throw new Error("ERR");
-                    }
-                }
-            } catch (err) {
-                _didIteratorError1 = true;
-                _iteratorError1 = err;
-            } finally{
-                try {
-                    if (!_iteratorNormalCompletion1 && _iterator1.return != null) {
-                        _iterator1.return();
-                    }
-                } finally{
-                    if (_didIteratorError1) {
-                        throw _iteratorError1;
-                    }
-                }
-            }
-            console.log(i);
-        } catch (err1) {
-            console.log("E %s %s", i, err1);
-        }
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
+// @downlevelIteration: true
+// https://github.com/microsoft/TypeScript/issues/30083
+for(var _i = 0, _iter = [
+    0,
+    1,
+    2,
+    3,
+    4
+]; _i < _iter.length; _i++){
+    var i = _iter[_i];
     try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+        // Ensure catch binding for the following loop is reset per iteration:
+        for(var _i1 = 0, _iter1 = [
+            1,
+            2,
+            3
+        ]; _i1 < _iter1.length; _i1++){
+            var j = _iter1[_i1];
+            if (i === 2) {
+                throw new Error("ERR");
+            }
         }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
+        console.log(i);
+    } catch (err) {
+        console.log("E %s %s", i, err);
     }
 }

--- a/crates/swc/tests/tsc-references/ES5For-of37_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of37_es5.2.minified.js
@@ -1,41 +1,19 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        0,
-        1,
-        2,
-        3,
-        4
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        var i = _step.value;
-        try {
-            var _iteratorNormalCompletion1 = !0, _didIteratorError1 = !1, _iteratorError1 = void 0;
-            try {
-                for(var _step1, _iterator1 = [
-                    1,
-                    2,
-                    3
-                ][Symbol.iterator](); !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = !0)if (_step1.value, 2 === i) throw Error("ERR");
-            } catch (err) {
-                _didIteratorError1 = !0, _iteratorError1 = err;
-            } finally{
-                try {
-                    _iteratorNormalCompletion1 || null == _iterator1.return || _iterator1.return();
-                } finally{
-                    if (_didIteratorError1) throw _iteratorError1;
-                }
-            }
-            console.log(i);
-        } catch (err1) {
-            console.log("E %s %s", i, err1);
-        }
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
+for(var _i = 0, _iter = [
+    0,
+    1,
+    2,
+    3,
+    4
+]; _i < _iter.length; _i++){
+    var i = _iter[_i];
     try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
+        for(var _i1 = 0, _iter1 = [
+            1,
+            2,
+            3
+        ]; _i1 < _iter1.length; _i1++)if (_iter1[_i1], 2 === i) throw Error("ERR");
+        console.log(i);
+    } catch (err) {
+        console.log("E %s %s", i, err);
     }
 }

--- a/crates/swc/tests/tsc-references/ES5For-of3_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of3_es5.1.normal.js
@@ -1,25 +1,9 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@sourcemap: true
-    for(var _iterator = [
-        "a",
-        "b",
-        "c"
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        var x = v;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@sourcemap: true
+for(var _i = 0, _iter = [
+    "a",
+    "b",
+    "c"
+]; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    var x = v;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of3_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of3_es5.2.minified.js
@@ -1,16 +1,5 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        "a",
-        "b",
-        "c"
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    "a",
+    "b",
+    "c"
+]; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/ES5For-of4_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of4_es5.1.normal.js
@@ -1,21 +1,5 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        var x = v;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    var x = v;
 }
 var y = v;

--- a/crates/swc/tests/tsc-references/ES5For-of4_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of4_es5.2.minified.js
@@ -1,12 +1,1 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = []; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/ES5For-of5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of5_es5.1.normal.js
@@ -1,20 +1,4 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var _a = _step.value;
-        var x = _a;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var _a = _iter[_i];
+    var x = _a;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of5_es5.2.minified.js
@@ -1,12 +1,1 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = []; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/ES5For-of6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of6_es5.1.normal.js
@@ -1,42 +1,10 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var w = _step.value;
-        var _iteratorNormalCompletion1 = true, _didIteratorError1 = false, _iteratorError1 = undefined;
-        try {
-            for(var _iterator1 = [][Symbol.iterator](), _step1; !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = true){
-                var v = _step1.value;
-                var x = [
-                    w,
-                    v
-                ];
-            }
-        } catch (err) {
-            _didIteratorError1 = true;
-            _iteratorError1 = err;
-        } finally{
-            try {
-                if (!_iteratorNormalCompletion1 && _iterator1.return != null) {
-                    _iterator1.return();
-                }
-            } finally{
-                if (_didIteratorError1) {
-                    throw _iteratorError1;
-                }
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var w = _iter[_i];
+    for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++){
+        var v = _iter1[_i1];
+        var x = [
+            w,
+            v
+        ];
     }
 }

--- a/crates/swc/tests/tsc-references/ES5For-of6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of6_es5.2.minified.js
@@ -1,26 +1,4 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        _step.value;
-        var _iteratorNormalCompletion1 = !0, _didIteratorError1 = !1, _iteratorError1 = void 0;
-        try {
-            for(var _step1, _iterator1 = [][Symbol.iterator](); !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = !0)_step1.value;
-        } catch (err) {
-            _didIteratorError1 = !0, _iteratorError1 = err;
-        } finally{
-            try {
-                _iteratorNormalCompletion1 || null == _iterator1.return || _iterator1.return();
-            } finally{
-                if (_didIteratorError1) throw _iteratorError1;
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    _iter[_i];
+    for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++)_iter1[_i1];
 }

--- a/crates/swc/tests/tsc-references/ES5For-of7_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of7_es5.1.normal.js
@@ -1,43 +1,11 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var w = _step.value;
-        var x = w;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var w = _iter[_i];
+    var x = w;
 }
-var _iteratorNormalCompletion1 = true, _didIteratorError1 = false, _iteratorError1 = undefined;
-try {
-    for(var _iterator1 = [][Symbol.iterator](), _step1; !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = true){
-        var v = _step1.value;
-        var x = [
-            w,
-            v
-        ];
-    }
-} catch (err) {
-    _didIteratorError1 = true;
-    _iteratorError1 = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion1 && _iterator1.return != null) {
-            _iterator1.return();
-        }
-    } finally{
-        if (_didIteratorError1) {
-            throw _iteratorError1;
-        }
-    }
+for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++){
+    var v = _iter1[_i1];
+    var x = [
+        w,
+        v
+    ];
 }

--- a/crates/swc/tests/tsc-references/ES5For-of7_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of7_es5.2.minified.js
@@ -1,24 +1,2 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
-var _iteratorNormalCompletion1 = !0, _didIteratorError1 = !1, _iteratorError1 = void 0;
-try {
-    for(var _step1, _iterator1 = [][Symbol.iterator](); !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = !0)_step1.value;
-} catch (err) {
-    _didIteratorError1 = !0, _iteratorError1 = err;
-} finally{
-    try {
-        _iteratorNormalCompletion1 || null == _iterator1.return || _iterator1.return();
-    } finally{
-        if (_didIteratorError1) throw _iteratorError1;
-    }
-}
+for(var _i = 0, _iter = []; _i < _iter.length; _i++)_iter[_i];
+for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++)_iter1[_i1];

--- a/crates/swc/tests/tsc-references/ES5For-of8_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of8_es5.1.normal.js
@@ -4,27 +4,11 @@ function foo() {
         x: 0
     };
 }
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [
-        "a",
-        "b",
-        "c"
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        foo().x = _step.value;
-        var p = foo().x;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = [
+    "a",
+    "b",
+    "c"
+]; _i < _iter.length; _i++){
+    foo().x = _iter[_i];
+    var p = foo().x;
 }

--- a/crates/swc/tests/tsc-references/ES5For-of8_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of8_es5.2.minified.js
@@ -3,19 +3,8 @@ function foo() {
         x: 0
     };
 }
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        "a",
-        "b",
-        "c"
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)foo().x = _step.value, foo().x;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    "a",
+    "b",
+    "c"
+]; _i < _iter.length; _i++)foo().x = _iter[_i], foo().x;

--- a/crates/swc/tests/tsc-references/ES5For-of9_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-of9_es5.1.normal.js
@@ -3,42 +3,10 @@ function foo() {
         x: 0
     };
 }
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        foo().x = _step.value;
-        var _iteratorNormalCompletion1 = true, _didIteratorError1 = false, _iteratorError1 = undefined;
-        try {
-            for(var _iterator1 = [][Symbol.iterator](), _step1; !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = true){
-                foo().x = _step1.value;
-                var p = foo().x;
-            }
-        } catch (err) {
-            _didIteratorError1 = true;
-            _iteratorError1 = err;
-        } finally{
-            try {
-                if (!_iteratorNormalCompletion1 && _iterator1.return != null) {
-                    _iterator1.return();
-                }
-            } finally{
-                if (_didIteratorError1) {
-                    throw _iteratorError1;
-                }
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    foo().x = _iter[_i];
+    for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++){
+        foo().x = _iter1[_i1];
+        var p = foo().x;
     }
 }

--- a/crates/swc/tests/tsc-references/ES5For-of9_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-of9_es5.2.minified.js
@@ -3,29 +3,7 @@ function foo() {
         x: 0
     };
 }
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        foo().x = _step.value;
-        var _iteratorNormalCompletion1 = !0, _didIteratorError1 = !1, _iteratorError1 = void 0;
-        try {
-            for(var _step1, _iterator1 = [][Symbol.iterator](); !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = !0)foo().x = _step1.value, foo().x;
-        } catch (err) {
-            _didIteratorError1 = !0, _iteratorError1 = err;
-        } finally{
-            try {
-                _iteratorNormalCompletion1 || null == _iterator1.return || _iterator1.return();
-            } finally{
-                if (_didIteratorError1) throw _iteratorError1;
-            }
-        }
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    foo().x = _iter[_i];
+    for(var _i1 = 0, _iter1 = []; _i1 < _iter1.length; _i1++)foo().x = _iter1[_i1], foo().x;
 }

--- a/crates/swc/tests/tsc-references/ES5For-ofTypeCheck2_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/ES5For-ofTypeCheck2_es5.1.normal.js
@@ -1,22 +1,6 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@target: ES5
-    for(var _iterator = [
-        true
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@target: ES5
+for(var _i = 0, _iter = [
+    true
+]; _i < _iter.length; _i++){
+    var v = _iter[_i];
 }

--- a/crates/swc/tests/tsc-references/ES5For-ofTypeCheck2_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/ES5For-ofTypeCheck2_es5.2.minified.js
@@ -1,14 +1,3 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        !0
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    !0
+]; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/for-of10_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of10_es5.1.normal.js
@@ -1,23 +1,7 @@
 //@target: ES6
 var v;
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [
-        0
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        v = _step.value;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = [
+    0
+]; _i < _iter.length; _i++){
+    v = _iter[_i];
 }

--- a/crates/swc/tests/tsc-references/for-of10_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of10_es5.2.minified.js
@@ -1,14 +1,3 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        0
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    0
+]; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/for-of11_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of11_es5.1.normal.js
@@ -1,24 +1,8 @@
 //@target: ES6
 var v;
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [
-        0,
-        ""
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        v = _step.value;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = [
+    0,
+    ""
+]; _i < _iter.length; _i++){
+    v = _iter[_i];
 }

--- a/crates/swc/tests/tsc-references/for-of11_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of11_es5.2.minified.js
@@ -1,15 +1,4 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        0,
-        ""
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    0,
+    ""
+]; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/for-of1_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of1_es5.1.normal.js
@@ -1,21 +1,5 @@
 //@target: ES6
 var v;
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        v = _step.value;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    v = _iter[_i];
 }

--- a/crates/swc/tests/tsc-references/for-of1_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of1_es5.2.minified.js
@@ -1,12 +1,1 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = []; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/for-of4_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of4_es5.1.normal.js
@@ -1,23 +1,7 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@target: ES6
-    for(var _iterator = [
-        0
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        v;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@target: ES6
+for(var _i = 0, _iter = [
+    0
+]; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    v;
 }

--- a/crates/swc/tests/tsc-references/for-of4_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of4_es5.2.minified.js
@@ -1,14 +1,3 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        0
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    0
+]; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/for-of52_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of52_es5.1.normal.js
@@ -1,23 +1,7 @@
 import _sliced_to_array from "@swc/helpers/src/_sliced_to_array.mjs";
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@target: ES6
-    for(var _iterator = [
-        []
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var _value = _sliced_to_array(_step.value, 2), v = _value[0], v = _value[1];
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@target: ES6
+for(var _i = 0, _iter = [
+    []
+]; _i < _iter.length; _i++){
+    var __i = _sliced_to_array(_iter[_i], 2), v = __i[0], v = __i[1];
 }

--- a/crates/swc/tests/tsc-references/for-of52_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of52_es5.2.minified.js
@@ -1,18 +1,7 @@
 import _sliced_to_array from "@swc/helpers/src/_sliced_to_array.mjs";
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        []
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0){
-        var _value = _sliced_to_array(_step.value, 2);
-        _value[0], _value[1];
-    }
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
+for(var _i = 0, _iter = [
+    []
+]; _i < _iter.length; _i++){
+    var __i = _sliced_to_array(_iter[_i], 2);
+    __i[0], __i[1];
 }

--- a/crates/swc/tests/tsc-references/for-of53_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of53_es5.1.normal.js
@@ -1,21 +1,5 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@target: ES6
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        var v1;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@target: ES6
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    var v1;
 }

--- a/crates/swc/tests/tsc-references/for-of53_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of53_es5.2.minified.js
@@ -1,12 +1,1 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = []; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/for-of54_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of54_es5.1.normal.js
@@ -1,21 +1,5 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@target: ES6
-    for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        var v1 = 0;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@target: ES6
+for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    var v1 = 0;
 }

--- a/crates/swc/tests/tsc-references/for-of54_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of54_es5.2.minified.js
@@ -1,12 +1,1 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = []; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/for-of5_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of5_es5.1.normal.js
@@ -1,23 +1,7 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@target: ES6
-    for(var _iterator = [
-        0
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-        v;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@target: ES6
+for(var _i = 0, _iter = [
+    0
+]; _i < _iter.length; _i++){
+    var v = _iter[_i];
+    v;
 }

--- a/crates/swc/tests/tsc-references/for-of5_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of5_es5.2.minified.js
@@ -1,14 +1,3 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        0
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    0
+]; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/for-of6_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of6_es5.1.normal.js
@@ -1,23 +1,7 @@
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    //@target: ES6
-    for(var _iterator = [
-        0
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        v = _step.value;
-        var _$v = void 0;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+//@target: ES6
+for(var _i = 0, _iter = [
+    0
+]; _i < _iter.length; _i++){
+    v = _iter[_i];
+    var _$v = void 0;
 }

--- a/crates/swc/tests/tsc-references/for-of6_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of6_es5.2.minified.js
@@ -1,14 +1,3 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        0
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)v = _step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    0
+]; _i < _iter.length; _i++)v = _iter[_i];

--- a/crates/swc/tests/tsc-references/for-of7_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of7_es5.1.normal.js
@@ -1,23 +1,7 @@
 //@target: ES6
 v;
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [
-        0
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var _$v = _step.value;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = [
+    0
+]; _i < _iter.length; _i++){
+    var _$v = _iter[_i];
 }

--- a/crates/swc/tests/tsc-references/for-of7_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of7_es5.2.minified.js
@@ -1,15 +1,4 @@
 v;
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        0
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    0
+]; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/for-of8_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of8_es5.1.normal.js
@@ -1,23 +1,7 @@
 //@target: ES6
 v;
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [
-        0
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        var v = _step.value;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = [
+    0
+]; _i < _iter.length; _i++){
+    var v = _iter[_i];
 }

--- a/crates/swc/tests/tsc-references/for-of8_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of8_es5.2.minified.js
@@ -1,14 +1,3 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        0
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    0
+]; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/for-of9_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/for-of9_es5.1.normal.js
@@ -1,10 +1,13 @@
 //@target: ES6
 var v;
+for(var _i = 0, _iter = [
+    "hello"
+]; _i < _iter.length; _i++){
+    v = _iter[_i];
+}
 var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
 try {
-    for(var _iterator = [
-        "hello"
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
+    for(var _iterator = "hello"[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
         v = _step.value;
     }
 } catch (err) {
@@ -18,25 +21,6 @@ try {
     } finally{
         if (_didIteratorError) {
             throw _iteratorError;
-        }
-    }
-}
-var _iteratorNormalCompletion1 = true, _didIteratorError1 = false, _iteratorError1 = undefined;
-try {
-    for(var _iterator1 = "hello"[Symbol.iterator](), _step1; !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = true){
-        v = _step1.value;
-    }
-} catch (err) {
-    _didIteratorError1 = true;
-    _iteratorError1 = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion1 && _iterator1.return != null) {
-            _iterator1.return();
-        }
-    } finally{
-        if (_didIteratorError1) {
-            throw _iteratorError1;
         }
     }
 }

--- a/crates/swc/tests/tsc-references/for-of9_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/for-of9_es5.2.minified.js
@@ -1,8 +1,9 @@
+for(var _i = 0, _iter = [
+    "hello"
+]; _i < _iter.length; _i++)_iter[_i];
 var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
 try {
-    for(var _step, _iterator = [
-        "hello"
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
+    for(var _step, _iterator = "hello"[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
 } catch (err) {
     _didIteratorError = !0, _iteratorError = err;
 } finally{
@@ -10,17 +11,5 @@ try {
         _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
     } finally{
         if (_didIteratorError) throw _iteratorError;
-    }
-}
-var _iteratorNormalCompletion1 = !0, _didIteratorError1 = !1, _iteratorError1 = void 0;
-try {
-    for(var _step1, _iterator1 = "hello"[Symbol.iterator](); !(_iteratorNormalCompletion1 = (_step1 = _iterator1.next()).done); _iteratorNormalCompletion1 = !0)_step1.value;
-} catch (err) {
-    _didIteratorError1 = !0, _iteratorError1 = err;
-} finally{
-    try {
-        _iteratorNormalCompletion1 || null == _iterator1.return || _iterator1.return();
-    } finally{
-        if (_didIteratorError1) throw _iteratorError1;
     }
 }

--- a/crates/swc/tests/tsc-references/parserForOfStatement24_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/parserForOfStatement24_es5.1.normal.js
@@ -1,25 +1,9 @@
 // @target: esnext
 var async;
-var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-try {
-    for(var _iterator = [
-        1,
-        2
-    ][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-        async = _step.value;
-        ;
-    }
-} catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-} finally{
-    try {
-        if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
-        }
-    } finally{
-        if (_didIteratorError) {
-            throw _iteratorError;
-        }
-    }
+for(var _i = 0, _iter = [
+    1,
+    2
+]; _i < _iter.length; _i++){
+    async = _iter[_i];
+    ;
 }

--- a/crates/swc/tests/tsc-references/parserForOfStatement24_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/parserForOfStatement24_es5.2.minified.js
@@ -1,15 +1,4 @@
-var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-try {
-    for(var _step, _iterator = [
-        1,
-        2
-    ][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-} catch (err) {
-    _didIteratorError = !0, _iteratorError = err;
-} finally{
-    try {
-        _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-    } finally{
-        if (_didIteratorError) throw _iteratorError;
-    }
-}
+for(var _i = 0, _iter = [
+    1,
+    2
+]; _i < _iter.length; _i++)_iter[_i];

--- a/crates/swc/tests/tsc-references/typeofThis_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/typeofThis_es5.1.normal.js
@@ -149,24 +149,8 @@ var Tests12 = /*#__PURE__*/ function() {
         for(var dummy in []){}
     };
     _proto.test4 = function test4() {
-        var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-        try {
-            for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-                var dummy = _step.value;
-            }
-        } catch (err) {
-            _didIteratorError = true;
-            _iteratorError = err;
-        } finally{
-            try {
-                if (!_iteratorNormalCompletion && _iterator.return != null) {
-                    _iterator.return();
-                }
-            } finally{
-                if (_didIteratorError) {
-                    throw _iteratorError;
-                }
-            }
+        for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+            var dummy = _iter[_i];
         }
     };
     return Tests12;

--- a/crates/swc/tests/tsc-references/typeofThis_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/typeofThis_es5.2.minified.js
@@ -70,17 +70,6 @@ var Test9 = function() {
     }, _proto.test3 = function() {
         for(var dummy in []);
     }, _proto.test4 = function() {
-        var _iteratorNormalCompletion = !0, _didIteratorError = !1, _iteratorError = void 0;
-        try {
-            for(var _step, _iterator = [][Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0)_step.value;
-        } catch (err) {
-            _didIteratorError = !0, _iteratorError = err;
-        } finally{
-            try {
-                _iteratorNormalCompletion || null == _iterator.return || _iterator.return();
-            } finally{
-                if (_didIteratorError) throw _iteratorError;
-            }
-        }
+        for(var _i = 0, _iter = []; _i < _iter.length; _i++)_iter[_i];
     }, Tests12;
 }();

--- a/crates/swc/tests/vercel/loader-only/issue-3347/1/output/index.js
+++ b/crates/swc/tests/vercel/loader-only/issue-3347/1/output/index.js
@@ -1,23 +1,7 @@
 var myFunction = function() {
     var _loop = function(j) {
-        var _iteratorNormalCompletion = true, _didIteratorError = false, _iteratorError = undefined;
-        try {
-            for(var _iterator = [][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true){
-                var _ = _step.value;
-            }
-        } catch (err) {
-            _didIteratorError = true;
-            _iteratorError = err;
-        } finally{
-            try {
-                if (!_iteratorNormalCompletion && _iterator.return != null) {
-                    _iterator.return();
-                }
-            } finally{
-                if (_didIteratorError) {
-                    throw _iteratorError;
-                }
-            }
+        for(var _i = 0, _iter = []; _i < _iter.length; _i++){
+            var _ = _iter[_i];
         }
         if (j === 1) {
             console.log("before set timeout, j is:", j);

--- a/crates/swc_ecma_transforms_compat/src/es2015/for_of.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/for_of.rs
@@ -84,7 +84,7 @@ impl ForOf {
             ..
         }: ForOfStmt,
     ) -> Stmt {
-        if self.c.assume_array {
+        if right.is_array() || self.c.assume_array {
             // Convert to normal for loop if rhs is array
             //
             // babel's output:


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
> Convert to normal for loop if rhs is array lit

Note: Babel will trace the lhs which is hard for swc. Babel will optimise the result of the following codes.
```JavaScript 
let x = [1, 2, 3];
let y = x;
for (const item of x) {
}
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
- fix #5140 