### PR TITLE
fix(swc/cli): emit sourcemap with file inputs

### DIFF
--- a/crates/swc_cli/src/commands/compile.rs
+++ b/crates/swc_cli/src/commands/compile.rs
@@ -54,7 +54,7 @@ pub struct CompileOptions {
 
     /// Define the file for the source map.
     #[clap(long)]
-    source_maps_target: Option<String>,
+    source_map_target: Option<String>,
 
     /// Set sources[0] on returned source map
     #[clap(long)]
@@ -340,7 +340,7 @@ impl CompileOptions {
                         let fm = compiler
                             .cm
                             .load_file(file_path)
-                            .context("failed to load file");
+                            .context(format!("Failed to open file {}", file_path.display()));
                         fm.map(|fm| InputContext {
                             options,
                             fm,
@@ -389,10 +389,39 @@ impl CompileOptions {
                     .expect("Parent should be available"),
             )?;
             let mut buf = File::create(single_out_file)?;
+            let mut buf_srcmap = None;
 
-            result?
-                .iter()
-                .try_for_each(|r| buf.write(r.code.as_bytes()).and(Ok(())))?;
+            // write all transformed files to single output buf
+            result?.iter().try_for_each(|r| {
+                if let Some(src_map) = r.map.as_ref() {
+                    if buf_srcmap.is_none() {
+                        // we'll init buf lazily as we don't read ./.swcrc directly to determine if
+                        // sourcemap would be generated or not
+                        let srcmap_buf_name =
+                            if let Some(source_map_target) = &self.source_map_target {
+                                File::create(source_map_target)?
+                            } else {
+                                File::create(single_out_file.with_extension(format!(
+                                    "{}map",
+                                    if let Some(ext) = single_out_file.extension() {
+                                        format!("{}.", ext.to_string_lossy())
+                                    } else {
+                                        "".to_string()
+                                    }
+                                )))?
+                            };
+                        buf_srcmap = Some(srcmap_buf_name);
+                    }
+
+                    buf_srcmap
+                        .as_ref()
+                        .expect("Srcmap buffer should be available")
+                        .write(src_map.as_bytes())
+                        .and(Ok(()))?;
+                }
+
+                buf.write(r.code.as_bytes()).and(Ok(()))
+            })?;
 
             buf.flush()
                 .context("Failed to write output into single file")


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- close #5171

Attempt to close #5171, emits sourcemap if inputs are file instead of dir.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
