### PR TITLE
Failing CI, only for discussions for versioned schema features

### DIFF
--- a/crates/dbg-swc/Cargo.toml
+++ b/crates/dbg-swc/Cargo.toml
@@ -11,6 +11,22 @@ version = "0.37.0"
 bench = false
 name = "dbg-swc"
 
+[features]
+plugin_transform_schema_v1 = [
+  "swc_common/plugin_transform_schema_v1",
+  "swc_ecma_ast/plugin_transform_schema_v1",
+  "swc_ecma_codegen/plugin_transform_schema_v1",
+  "swc_ecma_visit/plugin_transform_schema_v1",
+  "swc_ecma_minifier/plugin_transform_schema_v1",
+]
+plugin_transform_schema_vtest = [
+  "swc_common/plugin_transform_schema_vtest",
+  "swc_ecma_ast/plugin_transform_schema_vtest",
+  "swc_ecma_codegen/plugin_transform_schema_vtest",
+  "swc_ecma_visit/plugin_transform_schema_vtest",
+  "swc_ecma_minifier/plugin_transform_schema_vtest",
+]
+
 [dependencies]
 anyhow = "1.0.57"
 clap = { version = "3", features = ["derive"] }

--- a/crates/swc_ecma_ast/Cargo.toml
+++ b/crates/swc_ecma_ast/Cargo.toml
@@ -18,25 +18,22 @@ bench = false
 [features]
 default = []
 fuzzing = ["arbitrary", "swc_common/arbitrary"]
-rkyv-impl = [
-  "rkyv",
-  "bytecheck",
-  "swc_atoms/rkyv-impl",
-  "swc_common/rkyv-impl",
-]
+rkyv-impl = ["rkyv", "bytecheck", "swc_atoms/rkyv-impl", "swc_common/rkyv-impl"]
+plugin_transform_schema_v1 = []
+plugin_transform_schema_vtest = []
 
 [dependencies]
-arbitrary = {version = "1", optional = true, features = ["derive"]}
+arbitrary = { version = "1", optional = true, features = ["derive"] }
 bitflags = "1"
-bytecheck = {version = "0.6.8", optional = true}
+bytecheck = { version = "0.6.8", optional = true }
 is-macro = "0.2.0"
-num-bigint = {version = "0.4", features = ["serde"]}
-rkyv = {version = "0.7.39", optional = true}
+num-bigint = { version = "0.4", features = ["serde"] }
+rkyv = { version = "0.7.39", optional = true }
 scoped-tls = "1.0.0"
-serde = {version = "1.0.133", features = ["derive"]}
-string_enum = {version = "0.3.1", path = "../string_enum"}
-swc_atoms = {version = "0.2", path = "../swc_atoms"}
-swc_common = {version = "0.24.0", path = "../swc_common"}
+serde = { version = "1.0.133", features = ["derive"] }
+string_enum = { version = "0.3.1", path = "../string_enum" }
+swc_atoms = { version = "0.2", path = "../swc_atoms" }
+swc_common = { version = "0.24.0", path = "../swc_common" }
 unicode-id = "0.3"
 
 [dev-dependencies]

--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -14,6 +14,8 @@
 use serde::{Deserialize, Serialize};
 use swc_common::{ast_node, EqIgnoreSpan, Span};
 
+#[cfg(feature = "plugin_transform_schema_vtest")]
+pub use self::module::TestDummy;
 pub use self::{
     class::{
         Class, ClassMember, ClassMethod, ClassProp, Constructor, Decorator, MethodKind,
@@ -37,7 +39,7 @@ pub use self::{
     },
     list::ListFormat,
     lit::{BigInt, Bool, Lit, Null, Number, Regex, Str},
-    module::{Module, ModuleItem, Program, Script, TestDummy},
+    module::{Module, ModuleItem, Program, Script},
     module_decl::{
         DefaultDecl, ExportAll, ExportDecl, ExportDefaultDecl, ExportDefaultExpr,
         ExportDefaultSpecifier, ExportNamedSpecifier, ExportNamespaceSpecifier, ExportSpecifier,

--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -37,7 +37,7 @@ pub use self::{
     },
     list::ListFormat,
     lit::{BigInt, Bool, Lit, Null, Number, Regex, Str},
-    module::{Module, ModuleItem, Program, Script},
+    module::{Module, ModuleItem, Program, Script, TestDummy},
     module_decl::{
         DefaultDecl, ExportAll, ExportDecl, ExportDefaultDecl, ExportDefaultExpr,
         ExportDefaultSpecifier, ExportNamedSpecifier, ExportNamespaceSpecifier, ExportSpecifier,

--- a/crates/swc_ecma_ast/src/module.rs
+++ b/crates/swc_ecma_ast/src/module.rs
@@ -12,6 +12,25 @@ pub enum Program {
     Module(Module),
     #[tag("Script")]
     Script(Script),
+    #[tag("TestDummy")]
+    TestDummy(TestDummy),
+}
+
+#[ast_node("TestDummy")]
+#[derive(Eq, Hash, EqIgnoreSpan)]
+pub struct TestDummy {
+    pub span: Span,
+    pub body: Option<Vec<ModuleItem>>,
+}
+
+#[cfg(feature = "arbitrary")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arbitrary")))]
+impl<'a> arbitrary::Arbitrary<'a> for TestDummy {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let span = u.arbitrary()?;
+        let body = u.arbitrary()?;
+        Ok(Self { span, body })
+    }
 }
 
 #[ast_node("Module")]

--- a/crates/swc_ecma_ast/src/module.rs
+++ b/crates/swc_ecma_ast/src/module.rs
@@ -12,10 +12,12 @@ pub enum Program {
     Module(Module),
     #[tag("Script")]
     Script(Script),
+    #[cfg(feature = "plugin_transform_schema_vtest")]
     #[tag("TestDummy")]
     TestDummy(TestDummy),
 }
 
+#[cfg(feature = "plugin_transform_schema_vtest")]
 #[ast_node("TestDummy")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 pub struct TestDummy {
@@ -23,7 +25,7 @@ pub struct TestDummy {
     pub body: Option<Vec<ModuleItem>>,
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(all(feature = "arbitrary", feature = "plugin_transform_schema_vtest"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "arbitrary")))]
 impl<'a> arbitrary::Arbitrary<'a> for TestDummy {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {

--- a/crates/swc_ecma_codegen/Cargo.toml
+++ b/crates/swc_ecma_codegen/Cargo.toml
@@ -12,6 +12,16 @@ version = "0.116.3"
 [lib]
 bench = false
 
+[features]
+plugin_transform_schema_v1 = [
+  "swc_common/plugin_transform_schema_v1",
+  "swc_ecma_ast/plugin_transform_schema_v1"
+]
+plugin_transform_schema_vtest = [
+  "swc_common/plugin_transform_schema_vtest",
+  "swc_ecma_ast/plugin_transform_schema_vtest"
+]
+
 [dependencies]
 memchr = "2.4.1"
 num-bigint = { version = "0.4", features = ["serde"] }

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -86,6 +86,7 @@ where
         match *node {
             Program::Module(ref m) => emit!(m),
             Program::Script(ref s) => emit!(s),
+            _ => unreachable!(),
         }
     }
 

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -86,6 +86,7 @@ where
         match *node {
             Program::Module(ref m) => emit!(m),
             Program::Script(ref s) => emit!(s),
+            #[cfg(feature = "plugin_transform_schema_vtest")]
             _ => unreachable!(),
         }
     }

--- a/crates/swc_ecma_lints/tests/fixture.rs
+++ b/crates/swc_ecma_lints/tests/fixture.rs
@@ -69,6 +69,7 @@ fn pass(input: PathBuf) {
             Program::Script(s) => {
                 rules.lint_script(s);
             }
+            _ => unreachable!(),
         });
 
         if handler.has_errors() {

--- a/crates/swc_ecma_minifier/Cargo.toml
+++ b/crates/swc_ecma_minifier/Cargo.toml
@@ -19,6 +19,22 @@ bench = false
 [features]
 debug = ["backtrace", "swc_ecma_transforms_optimization/debug"]
 trace-ast = []
+plugin_transform_schema_v1 = [
+  "swc_common/plugin_transform_schema_v1",
+  "swc_ecma_ast/plugin_transform_schema_v1",
+  "swc_ecma_codegen/plugin_transform_schema_v1",
+  "swc_ecma_visit/plugin_transform_schema_v1",
+  "swc_ecma_transforms_base/plugin_transform_schema_v1",
+  "swc_ecma_transforms_optimization/plugin_transform_schema_v1"
+]
+plugin_transform_schema_vtest = [
+  "swc_common/plugin_transform_schema_vtest",
+  "swc_ecma_ast/plugin_transform_schema_vtest",
+  "swc_ecma_codegen/plugin_transform_schema_vtest",
+  "swc_ecma_visit/plugin_transform_schema_vtest",
+  "swc_ecma_transforms_base/plugin_transform_schema_vtest",
+  "swc_ecma_transforms_optimization/plugin_transform_schema_vtest"
+]
 
 [dependencies]
 ahash = "0.7.6"

--- a/crates/swc_ecma_transforms_base/Cargo.toml
+++ b/crates/swc_ecma_transforms_base/Cargo.toml
@@ -15,6 +15,18 @@ bench = false
 [features]
 concurrent = ["concurrent-renamer", "rayon", "swc_ecma_utils/concurrent"]
 concurrent-renamer = ["rayon"]
+plugin_transform_schema_v1 = [
+  "swc_common/plugin_transform_schema_v1",
+  "swc_ecma_ast/plugin_transform_schema_v1",
+  "swc_ecma_visit/plugin_transform_schema_v1",
+  "swc_ecma_utils/plugin_transform_schema_v1"
+]
+plugin_transform_schema_vtest = [
+  "swc_common/plugin_transform_schema_vtest",
+  "swc_ecma_ast/plugin_transform_schema_vtest",
+  "swc_ecma_visit/plugin_transform_schema_vtest",
+  "swc_ecma_utils/plugin_transform_schema_vtest"
+]
 
 [dependencies]
 better_scoped_tls = { version = "0.1.0", path = "../better_scoped_tls" }

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -16,6 +16,20 @@ bench = false
 [features]
 concurrent = ["rayon"]
 debug = []
+plugin_transform_schema_v1 = [
+  "swc_common/plugin_transform_schema_v1",
+  "swc_ecma_ast/plugin_transform_schema_v1",
+  "swc_ecma_utils/plugin_transform_schema_v1",
+  "swc_ecma_visit/plugin_transform_schema_v1",
+  "swc_ecma_transforms_base/plugin_transform_schema_v1",
+]
+plugin_transform_schema_vtest = [
+  "swc_common/plugin_transform_schema_vtest",
+  "swc_ecma_ast/plugin_transform_schema_vtest",
+  "swc_ecma_utils/plugin_transform_schema_vtest",
+  "swc_ecma_visit/plugin_transform_schema_vtest",
+  "swc_ecma_transforms_base/plugin_transform_schema_vtest",
+]
 
 [dependencies]
 ahash = "0.7.4"

--- a/crates/swc_ecma_utils/Cargo.toml
+++ b/crates/swc_ecma_utils/Cargo.toml
@@ -18,6 +18,16 @@ bench = false
 [features]
 # Process in parallel.
 concurrent = ["swc_common/concurrent", "rayon"]
+plugin_transform_schema_v1 = [
+  "swc_common/plugin_transform_schema_v1",
+  "swc_ecma_ast/plugin_transform_schema_v1",
+  "swc_ecma_visit/plugin_transform_schema_v1",
+]
+plugin_transform_schema_vtest = [
+  "swc_common/plugin_transform_schema_vtest",
+  "swc_ecma_ast/plugin_transform_schema_vtest",
+  "swc_ecma_visit/plugin_transform_schema_vtest",
+]
 
 [dependencies]
 indexmap = "1"

--- a/crates/swc_ecma_visit/Cargo.toml
+++ b/crates/swc_ecma_visit/Cargo.toml
@@ -19,6 +19,14 @@ bench = false
 debug = []
 default = ["serde"]
 path = []
+plugin_transform_schema_v1 = [
+  "swc_common/plugin_transform_schema_v1",
+  "swc_ecma_ast/plugin_transform_schema_v1"
+]
+plugin_transform_schema_vtest = [
+  "swc_common/plugin_transform_schema_vtest",
+  "swc_ecma_ast/plugin_transform_schema_vtest"
+]
 
 [dependencies]
 num-bigint = {version = "0.4", features = ["serde"]}

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -276,6 +276,7 @@ where
 
     method!(fold_program, Program);
 
+    #[cfg(feature = "plugin_transform_schema_vtest")]
     method!(fold_test_dummy, TestDummy);
 
     #[inline(always)]
@@ -1009,6 +1010,7 @@ define!({
     pub enum Program {
         Module(Module),
         Script(Script),
+        #[cfg(feature = "plugin_transform_schema_vtest")]
         TestDummy(TestDummy),
     }
     pub struct Module {
@@ -1812,6 +1814,7 @@ define!({
         pub type_args: TsTypeParamInstantiation,
     }
 
+    #[cfg(feature = "plugin_transform_schema_vtest")]
     pub struct TestDummy {
         pub span: Span,
         pub body: Option<Vec<ModuleItem>>,

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -276,6 +276,8 @@ where
 
     method!(fold_program, Program);
 
+    method!(fold_test_dummy, TestDummy);
+
     #[inline(always)]
     fn fold_module(&mut self, mut n: Module) -> Module {
         #[cfg(all(debug_assertions, feature = "debug"))]
@@ -1007,6 +1009,7 @@ define!({
     pub enum Program {
         Module(Module),
         Script(Script),
+        TestDummy(TestDummy),
     }
     pub struct Module {
         pub span: Span,
@@ -1807,6 +1810,11 @@ define!({
         pub span: Span,
         pub expr: Box<Expr>,
         pub type_args: TsTypeParamInstantiation,
+    }
+
+    pub struct TestDummy {
+        pub span: Span,
+        pub body: Option<Vec<ModuleItem>>,
     }
 });
 

--- a/crates/swc_estree_compat/src/babelify/module.rs
+++ b/crates/swc_estree_compat/src/babelify/module.rs
@@ -18,6 +18,7 @@ impl Babelify for Program {
         let program = match self {
             Program::Module(module) => module.babelify(ctx),
             Program::Script(script) => script.babelify(ctx),
+            _ => unreachable!(),
         };
 
         File {

--- a/node-swc/e2e/fixtures/plugin_transform_schema_v1/Cargo.lock
+++ b/node-swc/e2e/fixtures/plugin_transform_schema_v1/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.81.0"
+version = "0.81.1"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/node-swc/e2e/fixtures/plugin_transform_schema_vtest/Cargo.lock
+++ b/node-swc/e2e/fixtures/plugin_transform_schema_vtest/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.81.0"
+version = "0.81.1"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Do not merge, but since CI fails it can't be checked in anyway.

This is a discussion point how we'll enable actual practices around new AST property with compile time flags (which can be serialize / deserialized with rkyv). So far I feel somewhat stuck, and also feel I'm trying to poking wrong bush so would like to get some fresh perspective instead.

The workflow I tried to establish so far is this:

1. When a new property is being added, create a new feature flag (`plugin_transform_schema_vtest` in this case)
2. Add new property under new flag (`Program::TestDummy` enum and `TestDummy` in this case)
3. Set flag accordingly for the specifica package / crate from top-level to downstream to pick up specific AST
4. It works per each version

Theoritically this is straightforward process I expect to make it work somewhat easily, but I found this is lot more trouble than I thought for several reasons

1. There isn't a `single` package consolidate all of the AST changes - some macro, some struct itself (ecma_ast), and there are few others need to be updated.
2. There are unacceptably large references to those packages requires to introduce flags
3. Those are transitive deps, requires 2 to increase exponentially.

2 / 3 makes me think I'm doing something definitely wrong. In real world, we should have less than handful of features need to be updated manually. This could be done by current approach I may do something wrong, or there should be a different approach instead of I'm doing now. Open to suggestions & would like to discuss way forward.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
