### PR TITLE
test(swc): test plugins with different schema versions (#5060 Part 6)

### DIFF
--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -37,7 +37,7 @@ pub use self::{
     },
     list::ListFormat,
     lit::{BigInt, Bool, Lit, Null, Number, Regex, Str},
-    module::{Module, ModuleItem, Program, Script},
+    module::{Module, ModuleItem, Program, ReservedUnused, Script},
     module_decl::{
         DefaultDecl, ExportAll, ExportDecl, ExportDefaultDecl, ExportDefaultExpr,
         ExportDefaultSpecifier, ExportNamedSpecifier, ExportNamespaceSpecifier, ExportSpecifier,

--- a/crates/swc_ecma_ast/src/module.rs
+++ b/crates/swc_ecma_ast/src/module.rs
@@ -12,6 +12,27 @@ pub enum Program {
     Module(Module),
     #[tag("Script")]
     Script(Script),
+    /// Reserved type for the testing purpose only. Prod codes does not utilize
+    /// this at all and user should not try to attempt to use this as well.
+    #[tag("ReservedUnused")]
+    ReservedUnused(ReservedUnused),
+}
+
+#[ast_node("ReservedUnused")]
+#[derive(Eq, Hash, EqIgnoreSpan)]
+pub struct ReservedUnused {
+    pub span: Span,
+    pub body: Option<Vec<ModuleItem>>,
+}
+
+#[cfg(feature = "arbitrary")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arbitrary")))]
+impl<'a> arbitrary::Arbitrary<'a> for ReservedUnused {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let span = u.arbitrary()?;
+        let body = u.arbitrary()?;
+        Ok(Self { span, body })
+    }
 }
 
 #[ast_node("Module")]

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -86,6 +86,7 @@ where
         match *node {
             Program::Module(ref m) => emit!(m),
             Program::Script(ref s) => emit!(s),
+            _ => unreachable!(),
         }
     }
 

--- a/crates/swc_ecma_lints/tests/fixture.rs
+++ b/crates/swc_ecma_lints/tests/fixture.rs
@@ -69,6 +69,7 @@ fn pass(input: PathBuf) {
             Program::Script(s) => {
                 rules.lint_script(s);
             }
+            _ => unreachable!(),
         });
 
         if handler.has_errors() {

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -276,6 +276,8 @@ where
 
     method!(fold_program, Program);
 
+    method!(fold_reserved_unused, ReservedUnused);
+
     #[inline(always)]
     fn fold_module(&mut self, mut n: Module) -> Module {
         #[cfg(all(debug_assertions, feature = "debug"))]
@@ -1007,6 +1009,7 @@ define!({
     pub enum Program {
         Module(Module),
         Script(Script),
+        ReservedUnused(ReservedUnused),
     }
     pub struct Module {
         pub span: Span,
@@ -1807,6 +1810,11 @@ define!({
         pub span: Span,
         pub expr: Box<Expr>,
         pub type_args: TsTypeParamInstantiation,
+    }
+
+    pub struct ReservedUnused {
+        pub span: Span,
+        pub body: Option<Vec<ModuleItem>>,
     }
 });
 

--- a/crates/swc_estree_compat/src/babelify/module.rs
+++ b/crates/swc_estree_compat/src/babelify/module.rs
@@ -18,6 +18,7 @@ impl Babelify for Program {
         let program = match self {
             Program::Module(module) => module.babelify(ctx),
             Program::Script(script) => script.babelify(ctx),
+            _ => unreachable!(),
         };
 
         File {

--- a/node-swc/e2e/fixtures/plugin_transform_schema_v1/Cargo.lock
+++ b/node-swc/e2e/fixtures/plugin_transform_schema_v1/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.81.0"
+version = "0.81.1"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/node-swc/e2e/fixtures/plugin_transform_schema_v1/Cargo.lock
+++ b/node-swc/e2e/fixtures/plugin_transform_schema_v1/Cargo.lock
@@ -41,6 +41,8 @@ checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 [[package]]
 name = "ast_node"
 version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87549fcb780f81054407f313a1693d102396c223f5c49ccc5d90b46a6cbef34a"
 dependencies = [
  "darling",
  "pmutil",
@@ -59,6 +61,8 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "better_scoped_tls"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73e8ecdec39e98aa3b19e8cd0b8ed8f77ccb86a6b0b2dc7cd86d105438a2123"
 dependencies = [
  "scoped-tls",
 ]
@@ -149,6 +153,8 @@ checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 [[package]]
 name = "enum_kind"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b940da354ae81ef0926c5eaa428207b8f4f091d3956c891dfbd124162bed99"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -175,6 +181,8 @@ dependencies = [
 [[package]]
 name = "from_variant"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0951635027ca477be98f8774abd6f0345233439d63f307e47101acb40c7cc63d"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -696,6 +704,8 @@ dependencies = [
 [[package]]
 name = "string_enum"
 version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f584cc881e9e5f1fd6bf827b0444aa94c30d8fe6378cf241071b5f5700b2871f"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -713,6 +723,8 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 [[package]]
 name = "swc_atoms"
 version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d99c0ac33707dd1162a3665d6ca1a28b2f6594e9c37c4703e417fc5e1ce532e"
 dependencies = [
  "bytecheck",
  "once_cell",
@@ -726,6 +738,8 @@ dependencies = [
 [[package]]
 name = "swc_common"
 version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8079454dffb593d1377a0a28f9133903fa9d5592b4d6cc523c3bd246eee552c6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -753,7 +767,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.85.1"
+version = "0.86.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec6e61a59dcf6495822d3241f173a9304125a29aa8f0071ca6b79cccf509ccb6"
 dependencies = [
  "bitflags",
  "bytecheck",
@@ -770,7 +786,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.112.2"
+version = "0.113.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b743803ca5de3213b0df02777ba0f8b36db6b13910170601e11e179de3e7df0c"
 dependencies = [
  "either",
  "enum_kind",
@@ -787,7 +805,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.94.0"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24db1ef1ca5b15d774e9c5e36f258f5504fbb3be1d7a20764b044f2e90c3c8f"
 dependencies = [
  "indexmap",
  "once_cell",
@@ -801,7 +821,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.71.1"
+version = "0.72.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e227dc3034adf4837fd0cd9f99a406634b80f8f0c0560cf3ca6440affcad37ae"
 dependencies = [
  "num-bigint",
  "serde",
@@ -814,7 +836,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.181.1"
+version = "0.183.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6e1c126c2d4bb3cbda1c8c01c840d048b99e1f9dc3a4d1ce892aa9670c841a"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
@@ -825,6 +849,8 @@ dependencies = [
 [[package]]
 name = "swc_eq_ignore_macros"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c8f200a2eaed938e7c1a685faaa66e6d42fa9e17da5f62572d3cbc335898f5e"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -835,6 +861,8 @@ dependencies = [
 [[package]]
 name = "swc_macros_common"
 version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4be988307882648d9bc7c71a6a73322b7520ef0211e920489a98f8391d8caa2"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -844,7 +872,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.81.1"
+version = "0.83.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467923f1ba75b2b951beded9e178594be3c9b5bfb9deca23f445384997fce6a2"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -856,6 +886,8 @@ dependencies = [
 [[package]]
 name = "swc_plugin_macro"
 version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7888f999cdf25ace0c1efeb614f29c2a2490153a82bf41c90e292522000388dc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -864,7 +896,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.13.0"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705f4ac5ac67b4153cdebd0732a707b82f2ba44568b0162e44278ff5f086acd6"
 dependencies = [
  "better_scoped_tls",
  "bytecheck",
@@ -876,6 +910,8 @@ dependencies = [
 [[package]]
 name = "swc_visit"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a9c3d8bc1c6145416d92a745940553650ca8cd3878f176fe1d8b8e890db852"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -883,7 +919,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.1"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fda2daf67d99e8bc63d61b12818994863f65b7bcf52d4faab338154c7058546"
 dependencies = [
  "Inflector",
  "pmutil",

--- a/node-swc/e2e/fixtures/plugin_transform_schema_v1/Cargo.toml
+++ b/node-swc/e2e/fixtures/plugin_transform_schema_v1/Cargo.toml
@@ -11,4 +11,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 serde = "1"
-swc_plugin = { path = "../../../../crates/swc_plugin", default-features = false, features = ["plugin_transform_schema_v1"] }
+# Intentionally referencing published version, known to not contain new AST struct changes.
+# Be careful to change this dependency version. Unless there isn't explicit reason to do so,
+# do not change.
+swc_plugin = { version = "0.83.0", default-features = false, features = [
+  "plugin_transform_schema_v1",
+] }

--- a/node-swc/e2e/fixtures/plugin_transform_schema_v1/src/lib.rs
+++ b/node-swc/e2e/fixtures/plugin_transform_schema_v1/src/lib.rs
@@ -22,5 +22,12 @@ impl VisitMut for ConsoleOutputReplacer {
 
 #[plugin_transform]
 pub fn process(program: Program, _metadata: TransformPluginProgramMetadata) -> Program {
+    // Ensure this plugin uses v1 AST struct schema, by compile-time validating
+    // it doesn't have new enum for the testing purpose.
+    match &program {
+        Program::Script(_script) => {}
+        Program::Module(_module) => {}
+    }
+
     program.fold_with(&mut as_folder(ConsoleOutputReplacer))
 }

--- a/node-swc/e2e/fixtures/plugin_transform_schema_vtest/Cargo.lock
+++ b/node-swc/e2e/fixtures/plugin_transform_schema_vtest/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.81.0"
+version = "0.81.1"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/node-swc/e2e/fixtures/plugin_transform_schema_vtest/Cargo.lock
+++ b/node-swc/e2e/fixtures/plugin_transform_schema_vtest/Cargo.lock
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "bitflags",
  "bytecheck",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.112.2"
+version = "0.113.0"
 dependencies = [
  "either",
  "enum_kind",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "indexmap",
  "once_cell",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.71.1"
+version = "0.72.0"
 dependencies = [
  "num-bigint",
  "serde",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.181.1"
+version = "0.183.0"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.81.1"
+version = "0.83.0"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "better_scoped_tls",
  "bytecheck",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "Inflector",
  "pmutil",

--- a/node-swc/e2e/fixtures/plugin_transform_schema_vtest/src/lib.rs
+++ b/node-swc/e2e/fixtures/plugin_transform_schema_vtest/src/lib.rs
@@ -22,5 +22,15 @@ impl VisitMut for ConsoleOutputReplacer {
 
 #[plugin_transform]
 pub fn process(program: Program, _metadata: TransformPluginProgramMetadata) -> Program {
+    // Ensure this plugin uses vtest AST struct schema, by compile-time validating
+    // it does have new enum for the testing purpose.
+    match &program {
+        Program::Script(..) => {}
+        Program::Module(..) => {}
+        Program::ReservedUnused(_reserved_unused) => {
+            println!("{:#?}", _reserved_unused);
+            panic!("ReservedUnused is not supported");
+        }
+    }
     program.fold_with(&mut as_folder(ConsoleOutputReplacer))
 }

--- a/node-swc/e2e/plugins/plugins.schema.test.js
+++ b/node-swc/e2e/plugins/plugins.schema.test.js
@@ -66,36 +66,39 @@ describe("Plugins", () => {
     describe("Transform AST schema versions", () => {
         const versionMatrix = [
             {
+                host: "plugin_transform_schema_v1",
+                plugin: ["plugin_transform_schema_v1"],
+            },
+            {
                 host: "plugin_transform_schema_vtest",
                 plugin: [
                     "plugin_transform_schema_v1",
                     "plugin_transform_schema_vtest",
                 ],
             },
-            /* TODO
-            ["v1", "vtest"],
-            ["vtest", "v1"],
-            ["vtest", "vtest"],
-            */
         ];
 
         describe.each(versionMatrix)(
             "Host schema version '$host'",
             ({ host, plugin: pluginVersions }) => {
-                // Arbitrary large number to ensure test doesn't timeout due to native binaries build time.
+                // For v1 struct, we use published, prebuilt bindings as-is.
+                // Note this relies on devDependencies in package.json to pick up last known version -
+                // Do not update its version unless explicitly required.
+                const shouldUsePrebuiltHost = host.includes(
+                    "plugin_transform_schema_v1"
+                );
+
+                // Put arbitrary large number for timeout to ensure test doesn't timeout due to native binaries build time.
                 beforeAll(async () => {
-                    await buildHost(host);
+                    if (!shouldUsePrebuiltHost) {
+                        await buildHost(host);
+                    }
                     await Promise.all(
                         pluginVersions.map((p) => buildPlugin(p))
                     );
                 }, 10000000);
 
                 const transform = (code, feature) => {
-                    const { transformSync } = require(path.resolve(
-                        getPkgRoot(),
-                        `swc_host_${host}.node`
-                    ));
-
                     const options = {
                         jsc: {
                             experimental: {
@@ -104,11 +107,22 @@ describe("Plugins", () => {
                         },
                     };
 
-                    return transformSync(
-                        code,
-                        false,
-                        Buffer.from(JSON.stringify(options))
-                    );
+                    if (shouldUsePrebuiltHost) {
+                        const { transformSync } = require("@swc/core");
+
+                        return transformSync(code, options);
+                    } else {
+                        const { transformSync } = require(path.resolve(
+                            getPkgRoot(),
+                            `swc_host_${host}.node`
+                        ));
+
+                        return transformSync(
+                            code,
+                            false,
+                            Buffer.from(JSON.stringify(options))
+                        );
+                    }
                 };
 
                 it.each(pluginVersions)(
@@ -118,6 +132,9 @@ describe("Plugins", () => {
                             `console.log('boo')`,
                             pluginVersion
                         );
+
+                        // Consider test passes if plugin transform is successful.
+                        expect(result.code.includes(pluginVersion)).toBe(true);
                     }
                 );
             }

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
         "@babel/preset-typescript": "^7.13.0",
         "@babel/types": "^7.14.0",
         "@napi-rs/cli": "^2.10.0",
+        "@swc/core": "^1.2.218",
         "@swc/helpers": "^0.4.2",
         "@taplo/cli": "^0.3.2",
         "@types/jest": "^28.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1716,65 +1716,149 @@
   resolved "https://registry.yarnpkg.com/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.146.tgz#027c9b0c57377ce6cf4c7806ba07acf156e70d3a"
   integrity sha512-vRlxDksEDdprqfj9VACYUGyCJr/tYLetNjhjel46qmKoXU5uAib1WLWWgMB1Ur+oh8eCSTN8cnOblOziqfC1Rw==
 
+"@swc/core-android-arm-eabi@1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.218.tgz#017792272e70a0511d7df3397a31d73c6ef37b40"
+  integrity sha512-Q/uLCh262t3xxNzhCz+ZW9t+g2nWd0gZZO4jMYFWJs7ilKVNsBfRtfnNGGACHzkVuWLNDIWtAS2PSNodl7VUHQ==
+
 "@swc/core-android-arm64@1.2.146":
   version "1.2.146"
   resolved "https://registry.yarnpkg.com/@swc/core-android-arm64/-/core-android-arm64-1.2.146.tgz#e906088244bab3672ef4c40bd0631d2a09ab51fd"
   integrity sha512-YoJygRvjZ6IXvWstYZHGThEj1aWshzoMohX0i6WH5NIZhkzeF0UhRu/IZoS9VcQsd0WtDEMQe0G0wcrd/FToNg==
+
+"@swc/core-android-arm64@1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core-android-arm64/-/core-android-arm64-1.2.218.tgz#ee1b6cd7281d9bd0f26d5d24843addf09365c137"
+  integrity sha512-dy+8lUHUcyrkfPcl7azEQ4M44duRo1Uibz1E5/tltXCGoR6tu2ZN2VkqEKgA2a9XR3UD8/x4lv2r5evwJWy+uQ==
 
 "@swc/core-darwin-arm64@1.2.146":
   version "1.2.146"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.146.tgz#e47a8f5c1b18278c1005007121553a3d01d15622"
   integrity sha512-ftAyhczQHSUQo1Mox/VyZ3YL9KtG0LgOFUUUuLD3Pb9zKQB20Jc/Dfnh/bFktemVG8XiH0rOyR9yEI2EANHuEA==
 
+"@swc/core-darwin-arm64@1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.218.tgz#d73f6eedf0aac4ad117e67227d65d65c57657858"
+  integrity sha512-aTpFjWio8G0oukN76VtXCBPtFzH0PXIQ+1dFjGGkzrBcU5suztCCbhPBGhKRoWp3NJBwfPDwwWzmG+ddXrVAKg==
+
 "@swc/core-darwin-x64@1.2.146":
   version "1.2.146"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.2.146.tgz#5e9a2d9fe1049ec8cdaec265b73781eb08579365"
   integrity sha512-mYRN/WTS7TfYt3jqJYghcrpAW7zkpjdeEx9Rot8rmUEmk97luh9Bcwqafzjb9ndoG1mAiaTQcqvs/QqT2efS5Q==
+
+"@swc/core-darwin-x64@1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.2.218.tgz#a872c618727ceac8780539b5fa8aa45ae600d362"
+  integrity sha512-H3w/gNzROE6gVPZCAg5qvvPihzlg88Yi7HWb/mowfpNqH9/iJ8XMdwqJyovnfUeUXsuJQBFv6uXv/ri7qhGMHA==
 
 "@swc/core-freebsd-x64@1.2.146":
   version "1.2.146"
   resolved "https://registry.yarnpkg.com/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.146.tgz#6bda670ae5abb05abecb51d832950b3c159289d1"
   integrity sha512-eYU5g7p/dY98+hvg3VJtwiX+btRWnq+WO4y4M+X1nguqghvuTv6jtVLeHDNr8FEhc+FMSJPYKO321ZVa0xCKXw==
 
+"@swc/core-freebsd-x64@1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.218.tgz#6abc75e409739cad2ed9d57c1c741e8e5759794c"
+  integrity sha512-kkch07yCSlpUrSMp0FZPWtMHJjh3lfHiwp7JYNf6CUl5xXlgT19NeomPYq31dbTzPV2VnE7TVVlAawIjuuOH4g==
+
 "@swc/core-linux-arm-gnueabihf@1.2.146":
   version "1.2.146"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.146.tgz#f37f6876cfd42bb58037f7c3b2dd13b58f1cf40d"
   integrity sha512-ahKwlP9b41HUlwY+0eRJjgG4yJZN+uT16iBB2X7VedipmRO0aOOaP8xLReDjn4Z13DL14iAPC6Jnxiaw5rl8LQ==
+
+"@swc/core-linux-arm-gnueabihf@1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.218.tgz#a1a1bb172632082766770e47426df606c828d28c"
+  integrity sha512-vwEgvtD9f/+0HFxYD5q4sd8SG6zd0cxm17cwRGZ6jWh/d4Ninjht3CpDGE1ffh9nJ+X3Mb/7rjU/kTgWFz5qfg==
 
 "@swc/core-linux-arm64-gnu@1.2.146":
   version "1.2.146"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.146.tgz#9daed25cbcc3fcfbf792fadc26b0d13a1bd8a130"
   integrity sha512-S/0EJI8BWBQtsyIuYwVg+Gq03NlGl/xWOJgwLJss5+DawvxK8YZFteczw7M/bN/E5D2TqZRyybLM6baQozgDAg==
 
+"@swc/core-linux-arm64-gnu@1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.218.tgz#4d3325cd35016dd5ec389084bd5c304348002b15"
+  integrity sha512-g5PQI6COUHV7x7tyaZQn6jXWtOLXXNIEQK1HS5/e+6kqqsM2NsndE9bjLhoH1EQuXiN2eUjAR/ZDOFAg102aRw==
+
 "@swc/core-linux-arm64-musl@1.2.146":
   version "1.2.146"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.146.tgz#af5bdc23160fbb9db49ea1f05580000baabde063"
   integrity sha512-tOHcanuqgniMwUWMwjA+zr/hZyVn931l8DiIi3Mthyplp/PDY68PVAUJ8miJd4C5XDPcYfPOe5kRyXsFrdZzhw==
+
+"@swc/core-linux-arm64-musl@1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.218.tgz#8abab2fe12bb6a7687ff3bbd6030fcc728ed007d"
+  integrity sha512-IETYHB6H01NmVmlw+Ng8nkjdFBv1exGQRR74GAnHis1bVx1Uq14hREIF6XT3I1Aj26nRwlGkIYQuEKnFO5/j3Q==
 
 "@swc/core-linux-x64-gnu@1.2.146":
   version "1.2.146"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.146.tgz#aeef122f0b313fb95438e209f22697ddb3da5c7d"
   integrity sha512-w9jHnFe1XLYfQYWkaJwKgmtb/HKsgyFy0sCQpVjgDq/+ds8PPyACthDINpiEMsAOFN+IfE59HDn4A2gN3qyVgg==
 
+"@swc/core-linux-x64-gnu@1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.218.tgz#39227c15018d9b5253e7679bc8bbe3fd7ed109cd"
+  integrity sha512-PK39Zg4/YZbfchQRw77iVfB7Qat7QaK58sQt8enH39CUMXlJ+GSfC0Fqw2mtZ12sFGwmsGrK9yBy3ZVoOws5Ng==
+
 "@swc/core-linux-x64-musl@1.2.146":
   version "1.2.146"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.146.tgz#d146fd167e9d84a08637a9e1d535b04f2204bd99"
   integrity sha512-iwKiHvV8p48/82+eJRCy/WcnAZBOFr2ZJ5VLtRuV+sz0mkWjoimnLZ8SEshoru9PVoKF7hfG7AMqKaVOUjSJFg==
+
+"@swc/core-linux-x64-musl@1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.218.tgz#d661bfc6a9f0c35979c0e608777355222092e534"
+  integrity sha512-SNjrzORJYiKTSmFbaBkKZAf5B/PszwoZoFZOcd86AG192zsvQBSvKjQzMjT5rDZxB+sOnhRE7wH/bvqxZishQQ==
 
 "@swc/core-win32-arm64-msvc@1.2.146":
   version "1.2.146"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.146.tgz#23b52c4fdcf1395861eb915924285b7857c3db68"
   integrity sha512-n21riIEGTPim19Y0mrBIDVZfOrYdfd2W8QEgbiG/f+kcOlWckvyh9ZKexd6D8QpHe73C4lOX1RrmH3DgnPGhqA==
 
+"@swc/core-win32-arm64-msvc@1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.218.tgz#ea94260b36010d67f529d2f73c99e7d338a98711"
+  integrity sha512-lVXFWkYl+w8+deq9mgGsfvSY5Gr1RRjFgqZ+0wMZgyaonfx7jNn3TILUwc7egumEwxK0anNriVZCyKfcO3ZIjA==
+
 "@swc/core-win32-ia32-msvc@1.2.146":
   version "1.2.146"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.146.tgz#3e56db016661cf877b8ae39056fadbb14ec17eef"
   integrity sha512-5b99VzxvTqTQCZDmpKrGevUc9SK0QBiGZG4Oeh5CnSJyx8SZU0A3R7rbMoSR5/raP9OA/0ZvlXefUDXIsKNadA==
 
+"@swc/core-win32-ia32-msvc@1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.218.tgz#b5b5fbbe17680e0e1626d974ac2ace2866da7639"
+  integrity sha512-jgP+NZsHUh9Cp8PcXznnkpJTW3hPDLUgsXI0NKfE+8+Xvc6hALHxl6K46IyPYU67FfFlegYcBSNkOgpc85gk0A==
+
 "@swc/core-win32-x64-msvc@1.2.146":
   version "1.2.146"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.146.tgz#e9010b06fbfebdc745d2dd324b752ddd4f685bc9"
   integrity sha512-P45vAh0hR9dISIceSv6MkypjT0WduLWB4U8LPoCneeAw7mA1U7liS0Uu1PeiafxQVMWg8SNyIJFDcSg/haLJgg==
+
+"@swc/core-win32-x64-msvc@1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.218.tgz#9f6ba50cac6e3322d844cc24418c7b0ab08f7e0e"
+  integrity sha512-XYLjX00KV4ft324Q3QDkw61xHkoN7EKkVvIpb0wXaf6wVshwU+BCDyPw2CSg4PQecNP8QGgMRQf9QM7xNtEM7A==
+
+"@swc/core@^1.2.218":
+  version "1.2.218"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.2.218.tgz#3bc7532621f491bf920d103a4a0433ac7df9d390"
+  integrity sha512-wzXTeBUi3YAHr305lCo1tlxRj5Zpk7hu6rmulngH06NgrH7fS6bj8IaR7K2QPZ4ZZ4U+TGS2tOKbXBmqeMRUtg==
+  optionalDependencies:
+    "@swc/core-android-arm-eabi" "1.2.218"
+    "@swc/core-android-arm64" "1.2.218"
+    "@swc/core-darwin-arm64" "1.2.218"
+    "@swc/core-darwin-x64" "1.2.218"
+    "@swc/core-freebsd-x64" "1.2.218"
+    "@swc/core-linux-arm-gnueabihf" "1.2.218"
+    "@swc/core-linux-arm64-gnu" "1.2.218"
+    "@swc/core-linux-arm64-musl" "1.2.218"
+    "@swc/core-linux-x64-gnu" "1.2.218"
+    "@swc/core-linux-x64-musl" "1.2.218"
+    "@swc/core-win32-arm64-msvc" "1.2.218"
+    "@swc/core-win32-ia32-msvc" "1.2.218"
+    "@swc/core-win32-x64-msvc" "1.2.218"
 
 "@swc/helpers@^0.4.2":
   version "0.4.2"


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Continuation of https://github.com/swc-project/swc/pull/5243, where actually establishes versioned schema compatiblity verification. Good new is, it works well. Not good, or somewhat annoying thing is current ergonomics is not elegant for the core devs. (Plugin authors or users are fine!)

First, let's start with compatibility table. `1` and `2` indicate **AST VERSION**, not actual major pkg versions of each.

|   |  plugin@1  | plugin@2  |
|---|---|---|
| @swc/core@1  |  ⭕  | ❌   | 
| @swc/core@2  | ⭕   | ⭕  | 

This is our desired behavior. Say we add a new AST property and it increases AST version to 2, we expect new `@swc/core` can seamleassly use plugin@1, 2 both without asking to rebuild. In case of old version of `@swc/core@`, it won't be able to read newly updated plugin.

The thing I originally tried to do was `@swc/core` itself can be selectively compiled based on the versions, so `rkyv` can choose specific type to be serialized / deserialized. But actually, rkyv was able to fluently serialize / deserialze backward-compatible types. To test those, PR updates tests with adding a dummy property to top-level AST (`Program`) to ensure compile time compatibility as well as runtime compatibility for desired 3 working cases. 

Problem is core's development ergonomics - since AST update is detached to AST version, this is the way we need when we add new property in the AST struct

1. Properly add new property into some of AST struct
2. Update / create new `plugin_transform_schema_v${new}` feature
3. Change default to `v${current}` to `v${new}`

Lastly, when we release a new breaking changes we can safely remove old `v*` flags except latest current one. (We'll ever increment only for the version, so we'll not reset current).

It's not great, but not too bad as well in my opinion. However, would love to hear thoughts. Once this is approved, I'll try to write down some instruction documentation for the compatibility table with workflows.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
