### PR TITLE
chore(visit): expose swc_ecma_visit::Folder member

### DIFF
--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -187,7 +187,7 @@ where
 
 /// Wrap a [VisitMut] as a [Fold]
 #[derive(Debug, Clone, Copy)]
-pub struct Folder<V: VisitMut>(V);
+pub struct Folder<V: VisitMut>(pub V);
 
 impl<V> Repeated for Folder<V>
 where


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Change swc_ecma_visit::Folder member to public in order to let user access visitor's context after visitors running.


For example. I just what to detect some JSXElements is exist with custom visitor.
``` rust
pub fn my_visitor() -> Folder<MyVisitor> {
    as_folder(MyVisitor {
        has_text_jsx: false,
    })
}

#[derive(Debug, Clone, Copy)]
pub struct MyVisitor {
    pub has_text_jsx: bool,
}

impl VisitMut for MyVisitor { ...
```
``` rust
...
let c = swc::Compiler::new(cm.clone());
let progam = c
    .parse_js(
        fm,
        &handler,
        EsVersion::Es2022,
        Syntax::Typescript(TsConfig {
            tsx: true,
            ..Default::default()
        }),
        IsModule::Unknown,
        Some(&SingleThreadedComments::default()),
    )
    .unwrap();
let mut visitor = my_visitor();
progam.fold_with(&mut visitor);

println!("{:#?}", visitor);
// println!("{:#?}", visitor.0.has_text_jsx); // needed
```
I what to get its member, but now it is private.


If there are other ways to get visitor's context, it is also OK. Or is this on purpose?

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->
none

**Related issue (if exists):**

none
