### PR TITLE
feat(swc/plugin_runner): allow to read metadata lazily

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -24,6 +24,7 @@ use swc_common::{
     collections::{AHashMap, AHashSet},
     comments::SingleThreadedComments,
     errors::Handler,
+    plugin::metadata::TransformPluginMetadataContext,
     FileName, Mark, SourceMap, SyntaxContext,
 };
 use swc_config::{
@@ -62,7 +63,6 @@ use swc_ecma_transforms::{
 use swc_ecma_transforms_compat::es2015::regenerator;
 use swc_ecma_transforms_optimization::{inline_globals2, GlobalExprMap};
 use swc_ecma_visit::{Fold, VisitMutWith};
-use swc_plugin_runner::TransformPluginMetadataContext;
 
 use crate::{
     builder::PassBuilder,

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -62,6 +62,7 @@ use swc_ecma_transforms::{
 use swc_ecma_transforms_compat::es2015::regenerator;
 use swc_ecma_transforms_optimization::{inline_globals2, GlobalExprMap};
 use swc_ecma_visit::{Fold, VisitMutWith};
+use swc_plugin_runner::TransformPluginMetadataContext;
 
 use crate::{
     builder::PassBuilder,
@@ -526,9 +527,14 @@ impl Options {
             };
 
             let plugin_context = PluginContext {
-                filename: transform_filename,
+                filename: transform_filename.clone(),
                 env_name: self.env_name.to_owned(),
             };
+
+            let transform_metadata_context = Arc::new(TransformPluginMetadataContext::new(
+                transform_filename,
+                self.env_name.to_owned(),
+            ));
 
             if experimental.plugins.is_some() {
                 swc_plugin_runner::cache::init_plugin_module_cache_once(&experimental.cache_root);
@@ -537,10 +543,11 @@ impl Options {
             let comments = comments.cloned();
             let source_map = cm.clone();
             crate::plugin::plugins(
+                experimental.plugins,
+                transform_metadata_context,
                 Some(plugin_resolver),
                 comments,
                 source_map,
-                experimental,
                 plugin_context,
                 unresolved_mark,
             )

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -65,10 +65,8 @@ use swc_ecma_transforms_optimization::{inline_globals2, GlobalExprMap};
 use swc_ecma_visit::{Fold, VisitMutWith};
 
 use crate::{
-    builder::PassBuilder,
-    dropped_comments_preserver::dropped_comments_preserver,
-    plugin::{PluginConfig, PluginContext},
-    SwcImportResolver,
+    builder::PassBuilder, dropped_comments_preserver::dropped_comments_preserver,
+    plugin::PluginConfig, SwcImportResolver,
 };
 
 #[cfg(test)]
@@ -526,11 +524,6 @@ impl Options {
                 _ => None,
             };
 
-            let plugin_context = PluginContext {
-                filename: transform_filename.clone(),
-                env_name: self.env_name.to_owned(),
-            };
-
             let transform_metadata_context = Arc::new(TransformPluginMetadataContext::new(
                 transform_filename,
                 self.env_name.to_owned(),
@@ -549,7 +542,6 @@ impl Options {
                 Some(plugin_resolver),
                 comments,
                 source_map,
-                plugin_context,
                 unresolved_mark,
             )
         };
@@ -564,11 +556,6 @@ impl Options {
                 FileName::Real(path) => path.as_os_str().to_str().map(String::from),
                 FileName::Custom(filename) => Some(filename.to_owned()),
                 _ => None,
-            };
-
-            let plugin_context = PluginContext {
-                filename: transform_filename.clone(),
-                env_name: self.env_name.to_owned(),
             };
 
             let transform_metadata_context = Arc::new(TransformPluginMetadataContext::new(
@@ -586,7 +573,6 @@ impl Options {
                 None,
                 comments,
                 source_map,
-                plugin_context,
                 unresolved_mark,
             )
         };

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -566,18 +566,24 @@ impl Options {
             };
 
             let plugin_context = PluginContext {
-                filename: transform_filename,
+                filename: transform_filename.clone(),
                 env_name: self.env_name.to_owned(),
             };
+
+            let transform_metadata_context = Arc::new(TransformPluginMetadataContext::new(
+                transform_filename,
+                self.env_name.to_owned(),
+            ));
 
             swc_plugin_runner::cache::init_plugin_module_cache_once();
             let comments = comments.cloned();
             let source_map = cm.clone();
             crate::plugin::plugins(
+                experimental.plugins,
+                transform_metadata_context,
                 None,
                 comments,
                 source_map,
-                experimental,
                 plugin_context,
                 unresolved_mark,
             )

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -534,6 +534,7 @@ impl Options {
             let transform_metadata_context = Arc::new(TransformPluginMetadataContext::new(
                 transform_filename,
                 self.env_name.to_owned(),
+                None,
             ));
 
             if experimental.plugins.is_some() {
@@ -573,6 +574,7 @@ impl Options {
             let transform_metadata_context = Arc::new(TransformPluginMetadataContext::new(
                 transform_filename,
                 self.env_name.to_owned(),
+                None,
             ));
 
             swc_plugin_runner::cache::init_plugin_module_cache_once();

--- a/crates/swc/src/plugin.rs
+++ b/crates/swc/src/plugin.rs
@@ -10,6 +10,7 @@ use swc_ecma_loader::resolvers::{lru::CachingResolver, node::NodeModulesResolver
 #[cfg(not(feature = "plugin"))]
 use swc_ecma_transforms::pass::noop;
 use swc_ecma_visit::{noop_fold_type, Fold};
+use swc_plugin_runner::TransformPluginMetadataContext;
 
 /// A tuple represents a plugin.
 /// First element is a resolvable name to the plugin, second is a JSON object
@@ -43,19 +44,21 @@ pub struct PluginContext {
 
 #[cfg(feature = "plugin")]
 pub fn plugins(
+    configured_plugins: Option<Vec<PluginConfig>>,
+    metadata_context: std::sync::Arc<TransformPluginMetadataContext>,
     resolver: Option<CachingResolver<NodeModulesResolver>>,
     comments: Option<swc_common::comments::SingleThreadedComments>,
     source_map: std::sync::Arc<swc_common::SourceMap>,
-    config: crate::config::JscExperimental,
     plugin_context: PluginContext,
     unresolved_mark: swc_common::Mark,
 ) -> impl Fold {
     {
         RustPlugins {
+            plugins: configured_plugins,
+            metadata_context,
             resolver,
             comments,
             source_map,
-            plugins: config.plugins,
             plugin_context,
             unresolved_mark,
         }
@@ -68,9 +71,10 @@ pub fn plugins() -> impl Fold {
 }
 
 struct RustPlugins {
+    plugins: Option<Vec<PluginConfig>>,
+    metadata_context: std::sync::Arc<TransformPluginMetadataContext>,
     resolver: Option<CachingResolver<NodeModulesResolver>>,
     comments: Option<swc_common::comments::SingleThreadedComments>,
-    plugins: Option<Vec<PluginConfig>>,
     source_map: std::sync::Arc<swc_common::SourceMap>,
     plugin_context: PluginContext,
     unresolved_mark: swc_common::Mark,
@@ -122,8 +126,8 @@ impl RustPlugins {
                 // Note: This doesn't mean plugin won't perform any se/deserialization: it
                 // still have to construct from raw bytes internally to perform actual
                 // transform.
-                if let Some(plugins) = &self.plugins {
-                    for p in plugins {
+                if let Some(plugins) = &mut self.plugins {
+                    for p in plugins.drain(..) {
                         let resolved_path = self
                             .resolver
                             .as_ref()
@@ -136,11 +140,21 @@ impl RustPlugins {
                             anyhow::bail!("Failed to resolve plugin path: {:?}", resolved_path);
                         };
 
+                        let serialized_config_json = serde_json::to_string(&p.1.clone())
+                            .context("Failed to serialize plugin config as json")
+                            .and_then(|value| {
+                                PluginSerializedBytes::try_serialize(&VersionedSerializable::new(
+                                    value,
+                                ))
+                            })?;
+
                         let mut transform_plugin_executor =
                             swc_plugin_runner::create_plugin_transform_executor(
                                 &path,
                                 &swc_plugin_runner::cache::PLUGIN_MODULE_CACHE,
                                 &self.source_map,
+                                &self.metadata_context,
+                                Some(p.1),
                             )?;
 
                         if !transform_plugin_executor.is_transform_schema_compatible()? {
@@ -153,14 +167,6 @@ impl RustPlugins {
                             plugin_module = p.0.as_str()
                         );
                         let context_span_guard = span.enter();
-
-                        let serialized_config_json = serde_json::to_string(&p.1)
-                            .context("Failed to serialize plugin config as json")
-                            .and_then(|value| {
-                                PluginSerializedBytes::try_serialize(&VersionedSerializable::new(
-                                    value,
-                                ))
-                            })?;
 
                         let serialized_context_json = serde_json::to_string(&self.plugin_context)
                             .context("Failed to serialize plugin context as json")

--- a/crates/swc/src/plugin.rs
+++ b/crates/swc/src/plugin.rs
@@ -10,7 +10,6 @@ use swc_ecma_loader::resolvers::{lru::CachingResolver, node::NodeModulesResolver
 #[cfg(not(feature = "plugin"))]
 use swc_ecma_transforms::pass::noop;
 use swc_ecma_visit::{noop_fold_type, Fold};
-use swc_plugin_runner::TransformPluginMetadataContext;
 
 /// A tuple represents a plugin.
 /// First element is a resolvable name to the plugin, second is a JSON object
@@ -45,7 +44,7 @@ pub struct PluginContext {
 #[cfg(feature = "plugin")]
 pub fn plugins(
     configured_plugins: Option<Vec<PluginConfig>>,
-    metadata_context: std::sync::Arc<TransformPluginMetadataContext>,
+    metadata_context: std::sync::Arc<swc_common::plugin::metadata::TransformPluginMetadataContext>,
     resolver: Option<CachingResolver<NodeModulesResolver>>,
     comments: Option<swc_common::comments::SingleThreadedComments>,
     source_map: std::sync::Arc<swc_common::SourceMap>,
@@ -72,7 +71,7 @@ pub fn plugins() -> impl Fold {
 
 struct RustPlugins {
     plugins: Option<Vec<PluginConfig>>,
-    metadata_context: std::sync::Arc<TransformPluginMetadataContext>,
+    metadata_context: std::sync::Arc<swc_common::plugin::metadata::TransformPluginMetadataContext>,
     resolver: Option<CachingResolver<NodeModulesResolver>>,
     comments: Option<swc_common::comments::SingleThreadedComments>,
     source_map: std::sync::Arc<swc_common::SourceMap>,
@@ -101,7 +100,7 @@ impl RustPlugins {
         use anyhow::Context;
         use swc_common::{
             collections::AHashMap,
-            plugin::{PluginSerializedBytes, VersionedSerializable},
+            plugin::serialized::{PluginSerializedBytes, VersionedSerializable},
             FileName,
         };
         use swc_ecma_loader::resolve::Resolve;
@@ -226,7 +225,7 @@ impl RustPlugins {
         use anyhow::Context;
         use swc_common::{
             collections::AHashMap,
-            plugin::{PluginSerializedBytes, VersionedSerializable},
+            plugin::serialized::{PluginSerializedBytes, VersionedSerializable},
             FileName,
         };
         use swc_ecma_loader::resolve::Resolve;

--- a/crates/swc/src/plugin.rs
+++ b/crates/swc/src/plugin.rs
@@ -21,26 +21,6 @@ use swc_ecma_visit::{noop_fold_type, Fold};
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct PluginConfig(String, serde_json::Value);
 
-/// Struct represents arbitrary `context` or `state` to be passed to plugin's
-/// entrypoint.
-/// While internally this is strongly typed, it is not exposed as public
-/// interface to plugin's entrypoint but instead will be passed as JSON string.
-/// First, not all of plugins will need to deserialize this - plugin may opt in
-/// to access when it's needed. Secondly, we do not have way to avoid breaking
-/// changes when adding a new property. We may change this to typed
-/// deserialization in the future if we have add-only schema support with
-/// serialization / deserialization.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct PluginContext {
-    /// The path of the file being processed. This includes all of the path as
-    /// much as possible.
-    pub filename: Option<String>,
-    /// The current environment resolved as process.env.SWC_ENV ||
-    /// process.env.NODE_ENV || "development"
-    pub env_name: String,
-}
-
 #[cfg(feature = "plugin")]
 pub fn plugins(
     configured_plugins: Option<Vec<PluginConfig>>,
@@ -48,7 +28,6 @@ pub fn plugins(
     resolver: Option<CachingResolver<NodeModulesResolver>>,
     comments: Option<swc_common::comments::SingleThreadedComments>,
     source_map: std::sync::Arc<swc_common::SourceMap>,
-    plugin_context: PluginContext,
     unresolved_mark: swc_common::Mark,
 ) -> impl Fold {
     {
@@ -58,7 +37,6 @@ pub fn plugins(
             resolver,
             comments,
             source_map,
-            plugin_context,
             unresolved_mark,
         }
     }
@@ -75,7 +53,6 @@ struct RustPlugins {
     resolver: Option<CachingResolver<NodeModulesResolver>>,
     comments: Option<swc_common::comments::SingleThreadedComments>,
     source_map: std::sync::Arc<swc_common::SourceMap>,
-    plugin_context: PluginContext,
     unresolved_mark: swc_common::Mark,
 }
 
@@ -87,7 +64,7 @@ impl RustPlugins {
         self.apply_inner(n).with_context(|| {
             format!(
                 "failed to invoke plugin on '{:?}'",
-                self.plugin_context.filename
+                self.metadata_context.filename
             )
         })
     }
@@ -99,7 +76,6 @@ impl RustPlugins {
 
         use anyhow::Context;
         use swc_common::{
-            collections::AHashMap,
             plugin::serialized::{PluginSerializedBytes, VersionedSerializable},
             FileName,
         };
@@ -139,14 +115,6 @@ impl RustPlugins {
                             anyhow::bail!("Failed to resolve plugin path: {:?}", resolved_path);
                         };
 
-                        let serialized_config_json = serde_json::to_string(&p.1.clone())
-                            .context("Failed to serialize plugin config as json")
-                            .and_then(|value| {
-                                PluginSerializedBytes::try_serialize(&VersionedSerializable::new(
-                                    value,
-                                ))
-                            })?;
-
                         let mut transform_plugin_executor =
                             swc_plugin_runner::create_plugin_transform_executor(
                                 &path,
@@ -162,41 +130,14 @@ impl RustPlugins {
 
                         let span = tracing::span!(
                             tracing::Level::INFO,
-                            "serialize_context",
-                            plugin_module = p.0.as_str()
-                        );
-                        let context_span_guard = span.enter();
-
-                        let serialized_context_json = serde_json::to_string(&self.plugin_context)
-                            .context("Failed to serialize plugin context as json")
-                            .and_then(|value| {
-                                PluginSerializedBytes::try_serialize(&VersionedSerializable::new(
-                                    value,
-                                ))
-                            })?;
-                        drop(context_span_guard);
-
-                        let span = tracing::span!(
-                            tracing::Level::INFO,
                             "execute_plugin_runner",
                             plugin_module = p.0.as_str()
                         )
                         .entered();
 
-                        // Forward host side experimental metadata into plugin.
-                        // This is currently not being used, reserved to enable proper serialization
-                        // transform.
-                        let experimental_metadata: AHashMap<String, String> = AHashMap::default();
-                        let experimental_metadata_reserved = PluginSerializedBytes::try_serialize(
-                            &VersionedSerializable::new(experimental_metadata),
-                        )?;
-
                         serialized_program = transform_plugin_executor
                             .transform(
                                 &serialized_program,
-                                &serialized_config_json,
-                                &serialized_context_json,
-                                &experimental_metadata_reserved,
                                 self.unresolved_mark,
                                 should_enable_comments_proxy,
                             )
@@ -242,22 +183,6 @@ impl RustPlugins {
 
                 if let Some(plugins) = &mut self.plugins {
                     for p in plugins.drain(..) {
-                        let serialized_config_json = serde_json::to_string(&p.1)
-                            .context("Failed to serialize plugin config as json")
-                            .and_then(|value| {
-                                PluginSerializedBytes::try_serialize(&VersionedSerializable::new(
-                                    value,
-                                ))
-                            })?;
-
-                        let serialized_context_json = serde_json::to_string(&self.plugin_context)
-                            .context("Failed to serialize plugin context as json")
-                            .and_then(|value| {
-                                PluginSerializedBytes::try_serialize(&VersionedSerializable::new(
-                                    value,
-                                ))
-                            })?;
-
                         let mut transform_plugin_executor =
                             swc_plugin_runner::create_plugin_transform_executor(
                                 &PathBuf::from(&p.0),
@@ -267,20 +192,9 @@ impl RustPlugins {
                                 Some(p.1),
                             )?;
 
-                        // Forward host side experimental metadata into plugin.
-                        // This is currently not being used, reserved to enable proper serialization
-                        // transform.
-                        let experimental_metadata: AHashMap<String, String> = AHashMap::default();
-                        let experimental_metadata_reserved = PluginSerializedBytes::try_serialize(
-                            &VersionedSerializable::new(experimental_metadata),
-                        )?;
-
                         serialized_program = transform_plugin_executor
                             .transform(
                                 &serialized_program,
-                                &serialized_config_json,
-                                &serialized_context_json,
-                                &experimental_metadata_reserved,
                                 self.unresolved_mark,
                                 should_enable_comments_proxy,
                             )

--- a/crates/swc/src/plugin.rs
+++ b/crates/swc/src/plugin.rs
@@ -241,8 +241,8 @@ impl RustPlugins {
                 let program = VersionedSerializable::new(n);
                 let mut serialized_program = PluginSerializedBytes::try_serialize(&program)?;
 
-                if let Some(plugins) = &self.plugins {
-                    for p in plugins {
+                if let Some(plugins) = &mut self.plugins {
+                    for p in plugins.drain(..) {
                         let serialized_config_json = serde_json::to_string(&p.1)
                             .context("Failed to serialize plugin config as json")
                             .and_then(|value| {
@@ -264,6 +264,8 @@ impl RustPlugins {
                                 &PathBuf::from(&p.0),
                                 &swc_plugin_runner::cache::PLUGIN_MODULE_CACHE,
                                 &self.source_map,
+                                &self.metadata_context,
+                                Some(p.1),
                             )?;
 
                         // Forward host side experimental metadata into plugin.

--- a/crates/swc_common/src/lib.rs
+++ b/crates/swc_common/src/lib.rs
@@ -70,8 +70,6 @@ pub mod input;
 pub mod iter;
 pub mod macros;
 pub mod pass;
-#[cfg(feature = "plugin-base")]
-#[cfg_attr(docsrs, doc(cfg(feature = "plugin-base")))]
 pub mod plugin;
 mod pos;
 mod rustc_data_structures;

--- a/crates/swc_common/src/plugin/metadata.rs
+++ b/crates/swc_common/src/plugin/metadata.rs
@@ -1,4 +1,4 @@
-use swc_common::collections::AHashMap;
+use crate::collections::AHashMap;
 
 /// Host side metadata context plugin may need to access.
 /// This is a global context - any plugin will have same values.

--- a/crates/swc_common/src/plugin/metadata.rs
+++ b/crates/swc_common/src/plugin/metadata.rs
@@ -11,11 +11,15 @@ pub struct TransformPluginMetadataContext {
 }
 
 impl TransformPluginMetadataContext {
-    pub fn new(filename: Option<String>, env: String) -> Self {
+    pub fn new(
+        filename: Option<String>,
+        env: String,
+        experimental: Option<AHashMap<String, String>>,
+    ) -> Self {
         TransformPluginMetadataContext {
             filename,
             env,
-            experimental: AHashMap::default(),
+            experimental: experimental.unwrap_or_default(),
         }
     }
 }

--- a/crates/swc_common/src/plugin/metadata.rs
+++ b/crates/swc_common/src/plugin/metadata.rs
@@ -2,12 +2,51 @@ use std::env;
 
 use crate::collections::AHashMap;
 
+/// Indexable key to the metadata context for a transform plugin, avoiding
+/// serialization & allocation to the host by using incremental number.
+/// TransformPluginMetadataContext does not implement Index trait, instead
+/// host does manual matching to corresponding value.
 #[derive(Copy, Clone)]
 pub enum TransformPluginMetadataContextKind {
+    // This value always should increase, even if some keys are removed in the
+    // future.
     Filename = 1,
     Env = 2,
     Cwd = 3,
 }
+
+impl From<u32> for TransformPluginMetadataContextKind {
+    fn from(key: u32) -> TransformPluginMetadataContextKind {
+        match key {
+            1 => TransformPluginMetadataContextKind::Filename,
+            2 => TransformPluginMetadataContextKind::Env,
+            3 => TransformPluginMetadataContextKind::Cwd,
+            _ => panic!("Invalid TransformPluginMetadataContextKind key"),
+        }
+    }
+}
+
+/*
+impl TransformPluginMetadataContextKind {
+    pub fn from(key: u32) -> TransformPluginMetadataContextKind {
+        match key {
+            1 => TransformPluginMetadataContextKind::Filename,
+            2 => TransformPluginMetadataContextKind::Env,
+            3 => TransformPluginMetadataContextKind::Cwd,
+            _ => panic!("Invalid TransformPluginMetadataContextKind key"),
+        }
+    }
+}
+
+impl Into<u32> for TransformPluginMetadataContextKind {
+    fn into(self) -> u32 {
+        match self {
+            TransformPluginMetadataContextKind::Filename => 1,
+            TransformPluginMetadataContextKind::Env => 2,
+            TransformPluginMetadataContextKind::Cwd => 3,
+        }
+    }
+}*/
 
 /// Host side metadata context plugin may need to access.
 /// This is a global context - any plugin in single transform will have same
@@ -32,6 +71,14 @@ impl TransformPluginMetadataContext {
                 .map(|cwd| cwd.as_path().to_string_lossy().to_string())
                 .ok(),
             experimental: experimental.unwrap_or_default(),
+        }
+    }
+
+    pub fn get(&self, key: &TransformPluginMetadataContextKind) -> Option<String> {
+        match key {
+            TransformPluginMetadataContextKind::Filename => self.filename.clone(),
+            TransformPluginMetadataContextKind::Env => Some(self.env.clone()),
+            TransformPluginMetadataContextKind::Cwd => self.cwd.clone(),
         }
     }
 }

--- a/crates/swc_common/src/plugin/metadata.rs
+++ b/crates/swc_common/src/plugin/metadata.rs
@@ -52,8 +52,13 @@ impl Into<u32> for TransformPluginMetadataContextKind {
 /// This is a global context - any plugin in single transform will have same
 /// values.
 pub struct TransformPluginMetadataContext {
+    /// The path of the file being processed. This includes all of the path as
+    /// much as possible.
     pub filename: Option<String>,
+    /// The current environment resolved as process.env.SWC_ENV ||
+    /// process.env.NODE_ENV || "development"
     pub env: String,
+    /// The current working directory.
     pub cwd: Option<String>,
     pub experimental: AHashMap<String, String>,
 }

--- a/crates/swc_common/src/plugin/metadata.rs
+++ b/crates/swc_common/src/plugin/metadata.rs
@@ -1,12 +1,21 @@
+use std::env;
+
 use crate::collections::AHashMap;
 
+#[derive(Copy, Clone)]
+pub enum TransformPluginMetadataContextKind {
+    Filename = 1,
+    Env = 2,
+    Cwd = 3,
+}
+
 /// Host side metadata context plugin may need to access.
-/// This is a global context - any plugin will have same values.
+/// This is a global context - any plugin in single transform will have same
+/// values.
 pub struct TransformPluginMetadataContext {
     pub filename: Option<String>,
     pub env: String,
-    // swcconfig
-    // cwd
+    pub cwd: Option<String>,
     pub experimental: AHashMap<String, String>,
 }
 
@@ -19,6 +28,9 @@ impl TransformPluginMetadataContext {
         TransformPluginMetadataContext {
             filename,
             env,
+            cwd: env::current_dir()
+                .map(|cwd| cwd.as_path().to_string_lossy().to_string())
+                .ok(),
             experimental: experimental.unwrap_or_default(),
         }
     }

--- a/crates/swc_common/src/plugin/mod.rs
+++ b/crates/swc_common/src/plugin/mod.rs
@@ -1,0 +1,4 @@
+pub mod metadata;
+#[cfg(feature = "plugin-base")]
+#[cfg_attr(docsrs, doc(cfg(feature = "plugin-base")))]
+pub mod serialized;

--- a/crates/swc_common/src/syntax_pos/hygiene.rs
+++ b/crates/swc_common/src/syntax_pos/hygiene.rs
@@ -179,8 +179,8 @@ impl Mark {
     pub fn is_descendant_of(mut self, ancestor: Mark) -> bool {
         // This code path executed inside of the guest memory context.
         // In here, preallocate memory for the context.
-        let serialized = crate::plugin::PluginSerializedBytes::try_serialize(
-            &crate::plugin::VersionedSerializable::new(MutableMarkContext(0, 0, 0)),
+        let serialized = crate::plugin::serialized::PluginSerializedBytes::try_serialize(
+            &crate::plugin::serialized::VersionedSerializable::new(MutableMarkContext(0, 0, 0)),
         )
         .expect("Should be serializable");
         let (ptr, len) = serialized.as_ptr();
@@ -193,7 +193,7 @@ impl Mark {
 
         // Deserialize result, assign / return values as needed.
         let context: MutableMarkContext = unsafe {
-            crate::plugin::deserialize_from_ptr(
+            crate::plugin::serialized::deserialize_from_ptr(
                 ptr,
                 len.try_into().expect("Should able to convert ptr length"),
             )
@@ -221,8 +221,8 @@ impl Mark {
     #[allow(unused_mut, unused_assignments)]
     #[cfg(all(feature = "plugin-mode", target_arch = "wasm32"))]
     pub fn least_ancestor(mut a: Mark, mut b: Mark) -> Mark {
-        let serialized = crate::plugin::PluginSerializedBytes::try_serialize(
-            &crate::plugin::VersionedSerializable::new(MutableMarkContext(0, 0, 0)),
+        let serialized = crate::plugin::serialized::PluginSerializedBytes::try_serialize(
+            &crate::plugin::serialized::VersionedSerializable::new(MutableMarkContext(0, 0, 0)),
         )
         .expect("Should be serializable");
         let (ptr, len) = serialized.as_ptr();
@@ -232,7 +232,7 @@ impl Mark {
         }
 
         let context: MutableMarkContext = unsafe {
-            crate::plugin::deserialize_from_ptr(
+            crate::plugin::serialized::deserialize_from_ptr(
                 ptr,
                 len.try_into().expect("Should able to convert ptr length"),
             )
@@ -387,8 +387,9 @@ impl SyntaxContext {
 
     #[cfg(all(feature = "plugin-mode", target_arch = "wasm32"))]
     pub fn remove_mark(&mut self) -> Mark {
-        let context = crate::plugin::VersionedSerializable::new(MutableMarkContext(0, 0, 0));
-        let serialized = crate::plugin::PluginSerializedBytes::try_serialize(&context)
+        let context =
+            crate::plugin::serialized::VersionedSerializable::new(MutableMarkContext(0, 0, 0));
+        let serialized = crate::plugin::serialized::PluginSerializedBytes::try_serialize(&context)
             .expect("Should be serializable");
         let (ptr, len) = serialized.as_ptr();
 
@@ -397,7 +398,7 @@ impl SyntaxContext {
         }
 
         let context: MutableMarkContext = unsafe {
-            crate::plugin::deserialize_from_ptr(
+            crate::plugin::serialized::deserialize_from_ptr(
                 ptr,
                 len.try_into().expect("Should able to convert ptr length"),
             )

--- a/crates/swc_plugin/src/handler.rs
+++ b/crates/swc_plugin/src/handler.rs
@@ -1,5 +1,5 @@
 use swc_common::{
-    plugin::{PluginSerializedBytes, VersionedSerializable},
+    plugin::serialized::{PluginSerializedBytes, VersionedSerializable},
     sync::OnceCell,
 };
 

--- a/crates/swc_plugin/src/lib.rs
+++ b/crates/swc_plugin/src/lib.rs
@@ -29,6 +29,10 @@ pub mod source_map {
     pub use swc_plugin_proxy::PluginSourceMapProxy;
 }
 
+pub mod metadata {
+    pub use swc_plugin_proxy::TransformPluginProgramMetadata;
+}
+
 pub mod utils {
     pub use swc_common::util::take;
     #[cfg(feature = "swc_ecma_quote")]
@@ -66,6 +70,3 @@ pub mod memory {
     pub use crate::allocation::*;
 }
 mod pseudo_scoped_key;
-
-mod transform_plugin_metadata;
-pub use transform_plugin_metadata::TransformPluginProgramMetadata;

--- a/crates/swc_plugin/src/lib.rs
+++ b/crates/swc_plugin/src/lib.rs
@@ -3,7 +3,7 @@
 // Reexports
 pub use swc_common::{
     chain,
-    plugin::{
+    plugin::serialized::{
         deserialize_from_ptr, PluginError, PluginSerializedBytes, VersionedSerializable,
         PLUGIN_TRANSFORM_AST_SCHEMA_VERSION,
     },

--- a/crates/swc_plugin/src/lib.rs
+++ b/crates/swc_plugin/src/lib.rs
@@ -30,6 +30,7 @@ pub mod source_map {
 }
 
 pub mod metadata {
+    pub use swc_common::plugin::metadata::TransformPluginMetadataContextKind;
     pub use swc_plugin_proxy::TransformPluginProgramMetadata;
 }
 

--- a/crates/swc_plugin/src/lib.rs
+++ b/crates/swc_plugin/src/lib.rs
@@ -59,7 +59,6 @@ pub mod environment {
 // We don't set target cfg as it'll block macro expansions
 // in ide (i.e rust-analyzer) or non-wasm target `cargo check`
 pub use swc_plugin_macro::plugin_transform;
-use swc_plugin_proxy::{PluginCommentsProxy, PluginSourceMapProxy};
 #[cfg(target_arch = "wasm32")]
 mod allocation;
 #[cfg(target_arch = "wasm32")]
@@ -68,42 +67,5 @@ pub mod memory {
 }
 mod pseudo_scoped_key;
 
-/// An arbitary metadata for given Program to run transform in plugin.
-/// These are information not directly attached to Program's AST structures
-/// but required for certain transforms.
-#[derive(Debug)]
-pub struct TransformPluginProgramMetadata {
-    /// Proxy to the comments for the Program passed into plugin.
-    /// This is a proxy to the actual data lives in the host. Only when plugin
-    /// attempts to read these it'll ask to the host to get values.
-    pub comments: Option<PluginCommentsProxy>,
-    /// Proxy to the sourceMap for the Program passed into plugin.
-    /// This is a proxy to the actual data lives in the host. Only when plugin
-    /// attempts to read these it'll ask to the host to get values.
-    pub source_map: PluginSourceMapProxy,
-    /// Stringified JSON value for given plugin's configuration.
-    /// This is readonly. Changing value in plugin doesn't affect host's
-    /// behavior.
-    pub plugin_config: String,
-    pub unresolved_mark: crate::syntax_pos::Mark,
-    /// Stringified JSON value for relative context while running transform,
-    /// like filenames.
-    /// This is readonly. Changing value in plugin doesn't affect host's
-    /// behavior.
-    pub transform_context: String,
-    /// Non typed, extensible properties without breaking plugin compability
-    /// between host.
-    ///
-    /// Adding a new property to this metadata will be a breaking changes we
-    /// can't do freely.
-    /// Instead, we use this as a placeholder `@swc/core` may try new metadata.
-    /// Once it's proven to be stable with enough usecases, it'll be
-    /// promoted to actual property to TransformPluginProgramMetadata with
-    /// proper type support.
-    ///
-    /// There is no typed deserialization support for this unfortunately. Plugin
-    /// need to deserialize stringified values manually. In most cases this'll
-    /// be JSON type, but depends on the nature of the metadata it may
-    /// require different way to deserialize.
-    pub experimental: collections::AHashMap<String, String>,
-}
+mod transform_plugin_metadata;
+pub use transform_plugin_metadata::TransformPluginProgramMetadata;

--- a/crates/swc_plugin/src/transform_plugin_metadata.rs
+++ b/crates/swc_plugin/src/transform_plugin_metadata.rs
@@ -1,0 +1,78 @@
+use swc_plugin_proxy::{PluginCommentsProxy, PluginSourceMapProxy};
+
+/// An arbitary metadata for given Program to run transform in plugin.
+/// These are not directly attached to Program's AST structures
+/// but required for certain transforms.
+#[derive(Debug)]
+pub struct TransformPluginProgramMetadata {
+    /// Proxy to the comments for the Program passed into plugin.
+    /// This is a proxy to the actual data lives in the host. Only when plugin
+    /// attempts to read these it'll ask to the host to get values.
+    pub comments: Option<PluginCommentsProxy>,
+    /// Proxy to the sourceMap for the Program passed into plugin.
+    /// This is a proxy to the actual data lives in the host. Only when plugin
+    /// attempts to read these it'll ask to the host to get values.
+    pub source_map: PluginSourceMapProxy,
+    /// Stringified JSON value for given plugin's configuration.
+    /// This is readonly. Changing value in plugin doesn't affect host's
+    /// behavior.
+    pub plugin_config: String,
+    pub unresolved_mark: crate::syntax_pos::Mark,
+    /// Stringified JSON value for relative context while running transform,
+    /// like filenames.
+    /// This is readonly. Changing value in plugin doesn't affect host's
+    /// behavior.
+    pub transform_context: String,
+    /// Non typed, extensible properties without breaking plugin compability
+    /// between host.
+    ///
+    /// Adding a new property to this metadata will be a breaking changes we
+    /// can't do freely.
+    /// Instead, we use this as a placeholder `@swc/core` may try new metadata.
+    /// Once it's proven to be stable with enough usecases, it'll be
+    /// promoted to actual property to TransformPluginProgramMetadata with
+    /// proper type support.
+    ///
+    /// There is no typed deserialization support for this unfortunately. Plugin
+    /// need to deserialize stringified values manually. In most cases this'll
+    /// be JSON type, but depends on the nature of the metadata it may
+    /// require different way to deserialize.
+    pub experimental: swc_common::collections::AHashMap<String, String>,
+}
+
+#[cfg(target_arch = "wasm32")] // Allow testing
+extern "C" {
+    fn __get_raw_experiemtal_transform_context();
+}
+
+impl TransformPluginProgramMetadata {
+    pub fn get_context() {
+        unimplemented!()
+    }
+
+    pub fn get_raw_context() {
+        unimplemented!()
+    }
+
+    /// Returns non typed, extensible metadata properties without breaking
+    /// plugin compability between host.
+    ///
+    /// `@swc/core` internally keeps a placeholder storage for adding new
+    /// metadata without making a breaking changes, plugin can ask to return
+    /// these values.
+    ///
+    /// There is no typed deserialization support for this unfortunately. Plugin
+    /// need to deserialize stringified values manually.
+    ///
+    /// Note these metadata values can be changed anytime. There is no gaurantee
+    /// values will be available across different @swc/core versions.
+    pub fn get_experimental_context(key: &str) -> String {
+        unimplemented!()
+    }
+
+    /// Returns experimental metadata context, but returns whole value as a
+    /// HashMap.
+    pub fn get_raw_experimental_context() -> swc_common::collections::AHashMap<String, String> {
+        unimplemented!()
+    }
+}

--- a/crates/swc_plugin_macro/src/lib.rs
+++ b/crates/swc_plugin_macro/src/lib.rs
@@ -69,9 +69,6 @@ fn handle_func(func: ItemFn) -> TokenStream {
         #[no_mangle]
         pub fn #transform_process_impl_ident(
             ast_ptr: *const u8, ast_ptr_len: i32,
-            config_str_ptr: *const u8, config_str_ptr_len: i32,
-            context_str_ptr: *const u8, context_str_ptr_len: i32,
-            experimental_metadata_ptr: *const u8, experimental_metadata_ptr_len: i32,
             unresolved_mark: u32, should_enable_comments_proxy: i32) -> i32 {
             // Reconstruct `Program` & config string from serialized program
             // Host (SWC) should allocate memory, copy bytes and pass ptr to plugin.
@@ -81,29 +78,6 @@ fn handle_func(func: ItemFn) -> TokenStream {
                 return construct_error_ptr(err);
             }
             let program: Program = program.expect("Should be a program");
-
-            let config = unsafe { swc_plugin::deserialize_from_ptr(config_str_ptr, config_str_ptr_len).map(|v| v.into_inner()) };
-            if config.is_err() {
-                let err = swc_plugin::PluginError::Deserialize(
-                        "Failed to deserialize config string received from host".to_string()
-                    );
-                return construct_error_ptr(err);
-            }
-            let config: String = config.expect("Should be a string");
-
-            let context = unsafe { swc_plugin::deserialize_from_ptr(context_str_ptr, context_str_ptr_len).map(|v| v.into_inner()) };
-            if context.is_err() {
-                let err = swc_plugin::PluginError::Deserialize("Failed to deserialize context string received from host".to_string());
-                return construct_error_ptr(err);
-            }
-            let context: String = context.expect("Should be a string");
-
-            let experimental_metadata = unsafe { swc_plugin::deserialize_from_ptr(experimental_metadata_ptr, experimental_metadata_ptr_len).map(|v| v.into_inner()) };
-            if experimental_metadata.is_err() {
-                let err = swc_plugin::PluginError::Deserialize("Failed to deserialize experimental_metadata received from host".to_string());
-                return construct_error_ptr(err);
-            }
-            let experimental_metadata: swc_plugin::collections::AHashMap<String, String> = experimental_metadata.expect("Should be a hashmap");
 
             // Create a handler wired with plugin's diagnostic emitter, set it for global context.
             let handler = swc_plugin::errors::Handler::with_emitter(
@@ -125,10 +99,7 @@ fn handle_func(func: ItemFn) -> TokenStream {
             let mut metadata = swc_plugin::metadata::TransformPluginProgramMetadata {
                 comments: plugin_comments_proxy,
                 source_map: swc_plugin::source_map::PluginSourceMapProxy,
-                plugin_config: config,
                 unresolved_mark: swc_plugin::syntax_pos::Mark::from_u32(unresolved_mark),
-                transform_context: context,
-                experimental: experimental_metadata,
             };
 
             // Take original plugin fn ident, then call it with interop'ed args

--- a/crates/swc_plugin_macro/src/lib.rs
+++ b/crates/swc_plugin_macro/src/lib.rs
@@ -122,7 +122,7 @@ fn handle_func(func: ItemFn) -> TokenStream {
 
             // Construct metadata to the `Program` for the transform plugin.
             let plugin_comments_proxy = if should_enable_comments_proxy == 1 { Some(swc_plugin::comments::PluginCommentsProxy) } else { None };
-            let mut metadata = swc_plugin::TransformPluginProgramMetadata {
+            let mut metadata = swc_plugin::metadata::TransformPluginProgramMetadata {
                 comments: plugin_comments_proxy,
                 source_map: swc_plugin::source_map::PluginSourceMapProxy,
                 plugin_config: config,

--- a/crates/swc_plugin_proxy/src/comments/plugin_comments_proxy.rs
+++ b/crates/swc_plugin_proxy/src/comments/plugin_comments_proxy.rs
@@ -50,9 +50,10 @@ impl PluginCommentsProxy {
     {
         #[cfg(target_arch = "wasm32")]
         {
-            let value = swc_common::plugin::VersionedSerializable::new(value);
-            let serialized = swc_common::plugin::PluginSerializedBytes::try_serialize(&value)
-                .expect("Should able to serialize value");
+            let value = swc_common::plugin::serialized::VersionedSerializable::new(value);
+            let serialized =
+                swc_common::plugin::serialized::PluginSerializedBytes::try_serialize(&value)
+                    .expect("Should able to serialize value");
             let (serialized_comment_ptr, serialized_comment_ptr_len) = serialized.as_ptr();
             unsafe {
                 // We need to copy PluginCommentProxy's param for add_leading (Comment, or

--- a/crates/swc_plugin_proxy/src/lib.rs
+++ b/crates/swc_plugin_proxy/src/lib.rs
@@ -1,10 +1,13 @@
 mod comments;
 mod memory_interop;
+mod metadata;
 mod source_map;
 #[cfg(feature = "plugin-mode")]
 pub use comments::PluginCommentsProxy;
 #[cfg(feature = "plugin-rt")]
 pub use comments::{HostCommentsStorage, COMMENTS};
 pub use memory_interop::AllocatedBytesPtr;
+#[cfg(feature = "plugin-mode")]
+pub use metadata::TransformPluginProgramMetadata;
 #[cfg(feature = "plugin-mode")]
 pub use source_map::PluginSourceMapProxy;

--- a/crates/swc_plugin_proxy/src/memory_interop/read_returned_result_from_host.rs
+++ b/crates/swc_plugin_proxy/src/memory_interop/read_returned_result_from_host.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(not(target_arch = "wasm32"), allow(unused))]
-use swc_common::plugin::{
+use swc_common::plugin::serialized::{
     deserialize_from_ptr, deserialize_from_ptr_into_fallible, PluginSerializedBytes,
     VersionedSerializable,
 };

--- a/crates/swc_plugin_proxy/src/metadata/mod.rs
+++ b/crates/swc_plugin_proxy/src/metadata/mod.rs
@@ -1,0 +1,4 @@
+mod transform_plugin_metadata;
+
+#[cfg(feature = "plugin-mode")]
+pub use transform_plugin_metadata::TransformPluginProgramMetadata;

--- a/crates/swc_plugin_proxy/src/metadata/transform_plugin_metadata.rs
+++ b/crates/swc_plugin_proxy/src/metadata/transform_plugin_metadata.rs
@@ -24,31 +24,7 @@ pub struct TransformPluginProgramMetadata {
     /// This is a proxy to the actual data lives in the host. Only when plugin
     /// attempts to read these it'll ask to the host to get values.
     pub source_map: PluginSourceMapProxy,
-    /// Stringified JSON value for given plugin's configuration.
-    /// This is readonly. Changing value in plugin doesn't affect host's
-    /// behavior.
-    pub plugin_config: String,
     pub unresolved_mark: Mark,
-    /// Stringified JSON value for relative context while running transform,
-    /// like filenames.
-    /// This is readonly. Changing value in plugin doesn't affect host's
-    /// behavior.
-    pub transform_context: String,
-    /// Non typed, extensible properties without breaking plugin compability
-    /// between host.
-    ///
-    /// Adding a new property to this metadata will be a breaking changes we
-    /// can't do freely.
-    /// Instead, we use this as a placeholder `@swc/core` may try new metadata.
-    /// Once it's proven to be stable with enough usecases, it'll be
-    /// promoted to actual property to TransformPluginProgramMetadata with
-    /// proper type support.
-    ///
-    /// There is no typed deserialization support for this unfortunately. Plugin
-    /// need to deserialize stringified values manually. In most cases this'll
-    /// be JSON type, but depends on the nature of the metadata it may
-    /// require different way to deserialize.
-    pub experimental: swc_common::collections::AHashMap<String, String>,
 }
 
 #[cfg(target_arch = "wasm32")] // Allow testing

--- a/crates/swc_plugin_proxy/src/metadata/transform_plugin_metadata.rs
+++ b/crates/swc_plugin_proxy/src/metadata/transform_plugin_metadata.rs
@@ -1,5 +1,6 @@
+use swc_common::plugin::metadata::TransformPluginMetadataContextKind;
 #[cfg(feature = "plugin-mode")]
-use swc_common::{collections::AHashMap, Mark};
+use swc_common::Mark;
 
 #[cfg(feature = "plugin-mode")]
 #[cfg_attr(not(target_arch = "wasm32"), allow(unused))]
@@ -53,36 +54,53 @@ pub struct TransformPluginProgramMetadata {
 
 #[cfg(target_arch = "wasm32")] // Allow testing
 extern "C" {
+    fn __copy_context_key_to_host_env(bytes_ptr: i32, bytes_ptr_len: i32);
+    fn __get_transform_plugin_config(allocated_ret_ptr: i32) -> i32;
+    fn __get_experimental_transform_context(allocated_ret_ptr: i32) -> i32;
     fn __get_raw_experiemtal_transform_context(allocated_ret_ptr: i32) -> i32;
 }
 
 #[cfg(feature = "plugin-mode")]
 impl TransformPluginProgramMetadata {
-    pub fn get_context(&self) {
+    pub fn get_transform_plugin_config(&self) -> Option<String> {
+        #[cfg(target_arch = "wasm32")]
+        return read_returned_result_from_host(|serialized_ptr| unsafe {
+            __get_transform_plugin_config(serialized_ptr)
+        });
+
+        #[cfg(not(target_arch = "wasm32"))]
+        None
+    }
+
+    pub fn get_context(&self, key: &TransformPluginMetadataContextKind) -> Option<String> {
         unimplemented!()
     }
 
-    pub fn get_raw_context(&self) {
-        unimplemented!()
-    }
-
-    /// Returns non typed, extensible metadata properties without breaking
-    /// plugin compability between host.
+    /// Returns an experimental metadata value if exists. Returned value is
+    /// always a String, but depends on the nature of the metadata it may
+    /// require additional postprocessing.
     ///
     /// Each time this is called, it'll require a call between host-plugin which
     /// involves serialization / deserialization.
     ///
-    /// `@swc/core` internally keeps a placeholder storage for adding new
-    /// metadata without making a breaking changes, plugin can ask to return
-    /// these values.
-    ///
-    /// There is no typed deserialization support for this unfortunately. Plugin
-    /// need to deserialize stringified values manually.
-    ///
     /// Note these metadata values can be changed anytime. There is no gaurantee
     /// values will be available across different @swc/core versions.
-    pub fn get_experimental_context(&self, key: &str) -> String {
-        unimplemented!()
+    #[cfg_attr(not(target_arch = "wasm32"), allow(unused))]
+    pub fn get_experimental_context(&self, key: &str) -> Option<String> {
+        #[cfg(target_arch = "wasm32")]
+        return read_returned_result_from_host(|serialized_ptr| unsafe {
+            let key = swc_common::plugin::serialized::VersionedSerializable::new(key.to_string());
+            let serialized =
+                swc_common::plugin::serialized::PluginSerializedBytes::try_serialize(&key)
+                    .expect("Should be serializable");
+            let (key_ptr, key_ptr_len) = serialized.as_ptr();
+            __copy_context_key_to_host_env(key_ptr as i32, key_ptr_len as i32);
+
+            __get_experimental_transform_context(serialized_ptr)
+        });
+
+        #[cfg(not(target_arch = "wasm32"))]
+        None
     }
 
     /// Returns experimental metadata context, but returns whole value as a
@@ -90,9 +108,13 @@ impl TransformPluginProgramMetadata {
     ///
     /// Each time this is called, it'll require a call between host-plugin which
     /// involves serialization / deserialization.
+    #[allow(unreachable_code)]
     pub fn get_raw_experimental_context(
         &self,
     ) -> swc_common::collections::AHashMap<String, String> {
+        // TODO: There is not clear usecase yet - enable when we have a correct usecase.
+        unimplemented!("Not supported yet");
+
         #[cfg(target_arch = "wasm32")]
         return read_returned_result_from_host(|serialized_ptr| unsafe {
             __get_raw_experiemtal_transform_context(serialized_ptr)
@@ -100,6 +122,6 @@ impl TransformPluginProgramMetadata {
         .expect("Raw experimental metadata should exists, even if it's empty map");
 
         #[cfg(not(target_arch = "wasm32"))]
-        AHashMap::default()
+        swc_common::collections::AHashMap::default()
     }
 }

--- a/crates/swc_plugin_proxy/src/metadata/transform_plugin_metadata.rs
+++ b/crates/swc_plugin_proxy/src/metadata/transform_plugin_metadata.rs
@@ -58,11 +58,11 @@ extern "C" {
 
 #[cfg(feature = "plugin-mode")]
 impl TransformPluginProgramMetadata {
-    pub fn get_context() {
+    pub fn get_context(&self) {
         unimplemented!()
     }
 
-    pub fn get_raw_context() {
+    pub fn get_raw_context(&self) {
         unimplemented!()
     }
 
@@ -81,7 +81,7 @@ impl TransformPluginProgramMetadata {
     ///
     /// Note these metadata values can be changed anytime. There is no gaurantee
     /// values will be available across different @swc/core versions.
-    pub fn get_experimental_context(key: &str) -> String {
+    pub fn get_experimental_context(&self, key: &str) -> String {
         unimplemented!()
     }
 
@@ -90,7 +90,9 @@ impl TransformPluginProgramMetadata {
     ///
     /// Each time this is called, it'll require a call between host-plugin which
     /// involves serialization / deserialization.
-    pub fn get_raw_experimental_context() -> swc_common::collections::AHashMap<String, String> {
+    pub fn get_raw_experimental_context(
+        &self,
+    ) -> swc_common::collections::AHashMap<String, String> {
         #[cfg(target_arch = "wasm32")]
         return read_returned_result_from_host(|serialized_ptr| unsafe {
             __get_raw_experiemtal_transform_context(serialized_ptr)

--- a/crates/swc_plugin_proxy/src/source_map/plugin_source_map_proxy.rs
+++ b/crates/swc_plugin_proxy/src/source_map/plugin_source_map_proxy.rs
@@ -2,7 +2,7 @@
 #![allow(unused_variables)]
 #[cfg(feature = "plugin-mode")]
 use swc_common::{
-    plugin::VersionedSerializable,
+    plugin::serialized::VersionedSerializable,
     source_map::{
         DistinctSources, FileLinesResult, MalformedSourceMapPositions, Pos, SpanSnippetError,
     },
@@ -226,7 +226,7 @@ impl SourceMapper for PluginSourceMapProxy {
                 ctxt: swc_common::SyntaxContext::empty(),
             };
 
-            let serialized = swc_common::plugin::PluginSerializedBytes::try_serialize(
+            let serialized = swc_common::plugin::serialized::PluginSerializedBytes::try_serialize(
                 &VersionedSerializable::new(span),
             )
             .expect("Should be serializable");

--- a/crates/swc_plugin_runner/benches/invoke.rs
+++ b/crates/swc_plugin_runner/benches/invoke.rs
@@ -16,7 +16,7 @@ use swc_common::{
 };
 use swc_ecma_ast::EsVersion;
 use swc_ecma_parser::parse_file_as_program;
-use swc_plugin_runner::cache::PluginModuleCache;
+use swc_plugin_runner::{cache::PluginModuleCache, TransformPluginMetadataContext};
 
 static SOURCE: &str = include_str!("./assets/input.js");
 
@@ -71,6 +71,11 @@ fn bench_transform(b: &mut Bencher, plugin_dir: &Path) {
                 .join("swc_internal_plugin.wasm"),
             &swc_plugin_runner::cache::PLUGIN_MODULE_CACHE,
             &cm,
+            &Arc::new(TransformPluginMetadataContext::new(
+                None,
+                "development".to_string(),
+            )),
+            None,
         )
         .unwrap();
 

--- a/crates/swc_plugin_runner/benches/invoke.rs
+++ b/crates/swc_plugin_runner/benches/invoke.rs
@@ -77,6 +77,7 @@ fn bench_transform(b: &mut Bencher, plugin_dir: &Path) {
             &Arc::new(TransformPluginMetadataContext::new(
                 None,
                 "development".to_string(),
+                None,
             )),
             None,
         )

--- a/crates/swc_plugin_runner/benches/invoke.rs
+++ b/crates/swc_plugin_runner/benches/invoke.rs
@@ -90,20 +90,7 @@ fn bench_transform(b: &mut Bencher, plugin_dir: &Path) {
         .expect("Should be a hashmap");
 
         let res = transform_plugin_executor
-            .transform(
-                &program_ser,
-                &PluginSerializedBytes::try_serialize(&VersionedSerializable::new(String::from(
-                    "{}",
-                )))
-                .unwrap(),
-                &PluginSerializedBytes::try_serialize(&VersionedSerializable::new(String::from(
-                    "{}",
-                )))
-                .unwrap(),
-                &experimental_metadata,
-                Mark::new(),
-                true,
-            )
+            .transform(&program_ser, Mark::new(), true)
             .unwrap();
 
         let _ = black_box(res);

--- a/crates/swc_plugin_runner/benches/invoke.rs
+++ b/crates/swc_plugin_runner/benches/invoke.rs
@@ -11,12 +11,15 @@ use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 use once_cell::sync::Lazy;
 use swc_common::{
     collections::AHashMap,
-    plugin::{PluginSerializedBytes, VersionedSerializable},
+    plugin::{
+        metadata::TransformPluginMetadataContext,
+        serialized::{PluginSerializedBytes, VersionedSerializable},
+    },
     FileName, FilePathMapping, Mark, SourceMap,
 };
 use swc_ecma_ast::EsVersion;
 use swc_ecma_parser::parse_file_as_program;
-use swc_plugin_runner::{cache::PluginModuleCache, TransformPluginMetadataContext};
+use swc_plugin_runner::cache::PluginModuleCache;
 
 static SOURCE: &str = include_str!("./assets/input.js");
 

--- a/crates/swc_plugin_runner/src/imported_fn/comments.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/comments.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use swc_common::{
     comments::{Comments, SingleThreadedComments},
-    plugin::{PluginSerializedBytes, VersionedSerializable},
+    plugin::serialized::{PluginSerializedBytes, VersionedSerializable},
     BytePos,
 };
 use swc_plugin_proxy::COMMENTS;

--- a/crates/swc_plugin_runner/src/imported_fn/handler.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/handler.rs
@@ -1,6 +1,6 @@
 use swc_common::{
     errors::{Diagnostic, HANDLER},
-    plugin::PluginSerializedBytes,
+    plugin::serialized::PluginSerializedBytes,
 };
 
 use crate::{host_environment::BaseHostEnvironment, memory_interop::copy_bytes_into_host};

--- a/crates/swc_plugin_runner/src/imported_fn/hygiene.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/hygiene.rs
@@ -1,6 +1,6 @@
 use swc_common::{
     hygiene::MutableMarkContext,
-    plugin::{PluginSerializedBytes, VersionedSerializable},
+    plugin::serialized::{PluginSerializedBytes, VersionedSerializable},
     Mark, SyntaxContext,
 };
 

--- a/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use wasmer::{LazyInit, Memory};
+
+#[derive(wasmer::WasmerEnv, Clone)]
+pub struct MetadataContextHostEnvironment {
+    #[wasmer(export)]
+    pub memory: wasmer::LazyInit<Memory>,
+    //pub transform_result: Arc<Mutex<Vec<u8>>>,
+}
+
+impl MetadataContextHostEnvironment {
+    pub fn new() -> Self {
+        MetadataContextHostEnvironment {
+            memory: LazyInit::default(),
+        }
+    }
+    /*
+    pub fn new(transform_result: &Arc<Mutex<Vec<u8>>>) -> TransformResultHostEnvironment {
+        TransformResultHostEnvironment {
+            memory: LazyInit::default(),
+            transform_result: transform_result.clone(),
+        }
+    } */
+}
+
+pub fn get_raw_experiemtal_transform_context(env: &MetadataContextHostEnvironment) -> u32 {
+    0
+}

--- a/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
@@ -1,30 +1,63 @@
 use std::sync::Arc;
 
-use wasmer::{LazyInit, Memory};
+use parking_lot::Mutex;
+use swc_common::plugin::{PluginSerializedBytes, VersionedSerializable};
+use wasmer::{LazyInit, Memory, NativeFunc};
 
-use crate::TransformPluginMetadataContext;
+use crate::{memory_interop::allocate_return_values_into_guest, TransformPluginMetadataContext};
 
 #[derive(wasmer::WasmerEnv, Clone)]
 pub struct MetadataContextHostEnvironment {
     #[wasmer(export)]
     pub memory: wasmer::LazyInit<Memory>,
+    /// Attached imported fn `__alloc` to the hostenvironment to allow any other
+    /// imported fn can allocate guest's memory space from host runtime.
+    #[wasmer(export(name = "__alloc"))]
+    pub alloc_guest_memory: LazyInit<NativeFunc<u32, i32>>,
     pub metadata_context: Arc<TransformPluginMetadataContext>,
     pub plugin_config: Option<serde_json::Value>,
+    /// A buffer to non-determined size of return value from the host.
+    pub mutable_metadata_context_buffer: Arc<Mutex<Vec<u8>>>,
 }
 
 impl MetadataContextHostEnvironment {
     pub fn new(
         metadata_context: Arc<TransformPluginMetadataContext>,
         plugin_config: Option<serde_json::Value>,
+        mutable_metadata_context_buffer: &Arc<Mutex<Vec<u8>>>,
     ) -> Self {
         MetadataContextHostEnvironment {
             memory: LazyInit::default(),
+            alloc_guest_memory: LazyInit::default(),
             metadata_context,
             plugin_config,
+            mutable_metadata_context_buffer: mutable_metadata_context_buffer.clone(),
         }
     }
 }
 
-pub fn get_raw_experiemtal_transform_context(env: &MetadataContextHostEnvironment) -> u32 {
-    0
+pub fn get_raw_experiemtal_transform_context(
+    env: &MetadataContextHostEnvironment,
+    allocated_ret_ptr: i32,
+) -> i32 {
+    if let Some(memory) = env.memory_ref() {
+        let experimental_context =
+            VersionedSerializable::new(env.metadata_context.experimental.clone());
+        let serialized_experimental_context_bytes =
+            PluginSerializedBytes::try_serialize(&experimental_context)
+                .expect("Should be serializable");
+        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
+            allocate_return_values_into_guest(
+                memory,
+                alloc_guest_memory,
+                allocated_ret_ptr,
+                &serialized_experimental_context_bytes,
+            );
+            1
+        } else {
+            0
+        }
+    } else {
+        0
+    }
 }

--- a/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use swc_common::plugin::{
-    metadata::TransformPluginMetadataContext,
+    metadata::{TransformPluginMetadataContext, TransformPluginMetadataContextKind},
     serialized::{PluginSerializedBytes, VersionedSerializable},
 };
 use wasmer::{LazyInit, Memory, NativeFunc};
@@ -77,6 +77,36 @@ pub fn get_transform_plugin_config(
 
                     return 1;
                 }
+            }
+        }
+    }
+    0
+}
+
+pub fn get_transform_context(
+    env: &MetadataContextHostEnvironment,
+    key: u32,
+    allocated_ret_ptr: i32,
+) -> i32 {
+    if let Some(memory) = env.memory_ref() {
+        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
+            let value = env
+                .metadata_context
+                .get(&TransformPluginMetadataContextKind::from(key));
+
+            if let Some(value) = value {
+                let value = VersionedSerializable::new(value);
+                let serialized =
+                    PluginSerializedBytes::try_serialize(&value).expect("Should be serializable");
+
+                allocate_return_values_into_guest(
+                    memory,
+                    alloc_guest_memory,
+                    allocated_ret_ptr,
+                    &serialized,
+                );
+
+                return 1;
             }
         }
     }

--- a/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
@@ -1,10 +1,13 @@
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use swc_common::plugin::{PluginSerializedBytes, VersionedSerializable};
+use swc_common::plugin::{
+    metadata::TransformPluginMetadataContext,
+    serialized::{PluginSerializedBytes, VersionedSerializable},
+};
 use wasmer::{LazyInit, Memory, NativeFunc};
 
-use crate::{memory_interop::allocate_return_values_into_guest, TransformPluginMetadataContext};
+use crate::memory_interop::allocate_return_values_into_guest;
 
 #[derive(wasmer::WasmerEnv, Clone)]
 pub struct MetadataContextHostEnvironment {

--- a/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use parking_lot::Mutex;
 use swc_common::plugin::{
     metadata::TransformPluginMetadataContext,
     serialized::{PluginSerializedBytes, VersionedSerializable},
@@ -19,22 +18,18 @@ pub struct MetadataContextHostEnvironment {
     pub alloc_guest_memory: LazyInit<NativeFunc<u32, i32>>,
     pub metadata_context: Arc<TransformPluginMetadataContext>,
     pub plugin_config: Option<serde_json::Value>,
-    /// A buffer to non-determined size of return value from the host.
-    pub mutable_metadata_context_buffer: Arc<Mutex<Vec<u8>>>,
 }
 
 impl MetadataContextHostEnvironment {
     pub fn new(
         metadata_context: Arc<TransformPluginMetadataContext>,
         plugin_config: Option<serde_json::Value>,
-        mutable_metadata_context_buffer: &Arc<Mutex<Vec<u8>>>,
     ) -> Self {
         MetadataContextHostEnvironment {
             memory: LazyInit::default(),
             alloc_guest_memory: LazyInit::default(),
             metadata_context,
             plugin_config,
-            mutable_metadata_context_buffer: mutable_metadata_context_buffer.clone(),
         }
     }
 }

--- a/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
@@ -1,28 +1,28 @@
 use std::sync::Arc;
 
-use parking_lot::Mutex;
 use wasmer::{LazyInit, Memory};
+
+use crate::TransformPluginMetadataContext;
 
 #[derive(wasmer::WasmerEnv, Clone)]
 pub struct MetadataContextHostEnvironment {
     #[wasmer(export)]
     pub memory: wasmer::LazyInit<Memory>,
-    //pub transform_result: Arc<Mutex<Vec<u8>>>,
+    pub metadata_context: Arc<TransformPluginMetadataContext>,
+    pub plugin_config: Option<serde_json::Value>,
 }
 
 impl MetadataContextHostEnvironment {
-    pub fn new() -> Self {
+    pub fn new(
+        metadata_context: Arc<TransformPluginMetadataContext>,
+        plugin_config: Option<serde_json::Value>,
+    ) -> Self {
         MetadataContextHostEnvironment {
             memory: LazyInit::default(),
+            metadata_context,
+            plugin_config,
         }
     }
-    /*
-    pub fn new(transform_result: &Arc<Mutex<Vec<u8>>>) -> TransformResultHostEnvironment {
-        TransformResultHostEnvironment {
-            memory: LazyInit::default(),
-            transform_result: transform_result.clone(),
-        }
-    } */
 }
 
 pub fn get_raw_experiemtal_transform_context(env: &MetadataContextHostEnvironment) -> u32 {

--- a/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
+use parking_lot::Mutex;
 use swc_common::plugin::{
     metadata::TransformPluginMetadataContext,
     serialized::{PluginSerializedBytes, VersionedSerializable},
 };
 use wasmer::{LazyInit, Memory, NativeFunc};
 
-use crate::memory_interop::allocate_return_values_into_guest;
+use crate::memory_interop::{allocate_return_values_into_guest, copy_bytes_into_host};
 
 #[derive(wasmer::WasmerEnv, Clone)]
 pub struct MetadataContextHostEnvironment {
@@ -17,21 +18,106 @@ pub struct MetadataContextHostEnvironment {
     #[wasmer(export(name = "__alloc"))]
     pub alloc_guest_memory: LazyInit<NativeFunc<u32, i32>>,
     pub metadata_context: Arc<TransformPluginMetadataContext>,
-    pub plugin_config: Option<serde_json::Value>,
+    pub transform_plugin_config: Option<serde_json::Value>,
+    /// A buffer to string key to the context plugin need to pass to the host.
+    pub mutable_context_key_buffer: Arc<Mutex<Vec<u8>>>,
 }
 
 impl MetadataContextHostEnvironment {
     pub fn new(
-        metadata_context: Arc<TransformPluginMetadataContext>,
-        plugin_config: Option<serde_json::Value>,
+        metadata_context: &Arc<TransformPluginMetadataContext>,
+        plugin_config: &Option<serde_json::Value>,
+        mutable_context_key_buffer: &Arc<Mutex<Vec<u8>>>,
     ) -> Self {
         MetadataContextHostEnvironment {
             memory: LazyInit::default(),
             alloc_guest_memory: LazyInit::default(),
-            metadata_context,
-            plugin_config,
+            metadata_context: metadata_context.clone(),
+            transform_plugin_config: plugin_config.clone(),
+            mutable_context_key_buffer: mutable_context_key_buffer.clone(),
         }
     }
+}
+
+/// Copy given serialized byte into host's comment buffer, subsequent proxy call
+/// in the host can read it.
+pub fn copy_context_key_to_host_env(
+    env: &MetadataContextHostEnvironment,
+    bytes_ptr: i32,
+    bytes_ptr_len: i32,
+) {
+    if let Some(memory) = env.memory_ref() {
+        (*env.mutable_context_key_buffer.lock()) =
+            copy_bytes_into_host(memory, bytes_ptr, bytes_ptr_len);
+    }
+}
+
+pub fn get_transform_plugin_config(
+    env: &MetadataContextHostEnvironment,
+    allocated_ret_ptr: i32,
+) -> i32 {
+    if let Some(memory) = env.memory_ref() {
+        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
+            let config_value = &env.transform_plugin_config;
+            if let Some(config_value) = config_value {
+                // Lazy as possible as we can - only deserialize json value if transform plugin
+                // actually needs it.
+                let config = serde_json::to_string(config_value).ok();
+                if let Some(config) = config {
+                    let value = VersionedSerializable::new(config);
+                    let serialized = PluginSerializedBytes::try_serialize(&value)
+                        .expect("Should be serializable");
+
+                    allocate_return_values_into_guest(
+                        memory,
+                        alloc_guest_memory,
+                        allocated_ret_ptr,
+                        &serialized,
+                    );
+
+                    return 1;
+                }
+            }
+        }
+    }
+    0
+}
+
+pub fn get_experimental_transform_context(
+    env: &MetadataContextHostEnvironment,
+    allocated_ret_ptr: i32,
+) -> i32 {
+    if let Some(memory) = env.memory_ref() {
+        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
+            let context_key_buffer = &*env.mutable_context_key_buffer.lock();
+            let key: VersionedSerializable<String> =
+                PluginSerializedBytes::from_slice(&context_key_buffer[..])
+                    .deserialize()
+                    .expect("Should able to deserialize");
+
+            let value = env
+                .metadata_context
+                .experimental
+                .get(key.inner())
+                .map(|v| v.to_string());
+
+            if let Some(value) = value {
+                let value = VersionedSerializable::new(value);
+                let serialized =
+                    PluginSerializedBytes::try_serialize(&value).expect("Should be serializable");
+
+                allocate_return_values_into_guest(
+                    memory,
+                    alloc_guest_memory,
+                    allocated_ret_ptr,
+                    &serialized,
+                );
+
+                return 1;
+            }
+        }
+    }
+    0
 }
 
 pub fn get_raw_experiemtal_transform_context(

--- a/crates/swc_plugin_runner/src/imported_fn/mod.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/mod.rs
@@ -96,9 +96,14 @@ pub(crate) fn build_import_object(
     let wasmer_store = module.store();
 
     // metadata
+    let metadata_context_buffer = Arc::new(Mutex::new(vec![]));
     let get_raw_experiemtal_transform_context_fn_decl = Function::new_native_with_env(
         wasmer_store,
-        MetadataContextHostEnvironment::new(metadata_context, plugin_config),
+        MetadataContextHostEnvironment::new(
+            metadata_context,
+            plugin_config,
+            &metadata_context_buffer,
+        ),
         get_raw_experiemtal_transform_context,
     );
 

--- a/crates/swc_plugin_runner/src/imported_fn/mod.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/mod.rs
@@ -95,14 +95,9 @@ pub(crate) fn build_import_object(
     let wasmer_store = module.store();
 
     // metadata
-    let metadata_context_buffer = Arc::new(Mutex::new(vec![]));
     let get_raw_experiemtal_transform_context_fn_decl = Function::new_native_with_env(
         wasmer_store,
-        MetadataContextHostEnvironment::new(
-            metadata_context,
-            plugin_config,
-            &metadata_context_buffer,
-        ),
+        MetadataContextHostEnvironment::new(metadata_context, plugin_config),
         get_raw_experiemtal_transform_context,
     );
 

--- a/crates/swc_plugin_runner/src/imported_fn/mod.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/mod.rs
@@ -61,6 +61,7 @@ use crate::{
         set_transform_result::{set_transform_result, TransformResultHostEnvironment},
         span::span_dummy_with_cmt_proxy,
     },
+    TransformPluginMetadataContext,
 };
 
 mod comments;
@@ -89,13 +90,15 @@ pub(crate) fn build_import_object(
     module: &Module,
     transform_result: &Arc<Mutex<Vec<u8>>>,
     source_map: Arc<SourceMap>,
+    metadata_context: Arc<TransformPluginMetadataContext>,
+    plugin_config: Option<serde_json::Value>,
 ) -> ImportObject {
     let wasmer_store = module.store();
 
     // metadata
     let get_raw_experiemtal_transform_context_fn_decl = Function::new_native_with_env(
         wasmer_store,
-        MetadataContextHostEnvironment::new(),
+        MetadataContextHostEnvironment::new(metadata_context, plugin_config),
         get_raw_experiemtal_transform_context,
     );
 

--- a/crates/swc_plugin_runner/src/imported_fn/mod.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/mod.rs
@@ -76,7 +76,7 @@ use hygiene::*;
 
 use self::{
     metadata_context::{
-        copy_context_key_to_host_env, get_experimental_transform_context,
+        copy_context_key_to_host_env, get_experimental_transform_context, get_transform_context,
         get_transform_plugin_config, MetadataContextHostEnvironment,
     },
     source_map::{
@@ -108,6 +108,11 @@ pub(crate) fn build_import_object(
         wasmer_store,
         MetadataContextHostEnvironment::new(&metadata_context, &plugin_config, &context_key_buffer),
         get_transform_plugin_config,
+    );
+    let get_transform_context_fn_decl = Function::new_native_with_env(
+        wasmer_store,
+        MetadataContextHostEnvironment::new(&metadata_context, &plugin_config, &context_key_buffer),
+        get_transform_context,
     );
     let get_experimental_transform_context_fn_decl = Function::new_native_with_env(
         wasmer_store,
@@ -291,6 +296,7 @@ pub(crate) fn build_import_object(
             // metadata
             "__copy_context_key_to_host_env" => copy_context_key_to_host_env_fn_decl,
             "__get_transform_plugin_config" => get_transform_plugin_config_fn_decl,
+            "__get_transform_context" => get_transform_context_fn_decl,
             "__get_experimental_transform_context" => get_experimental_transform_context_fn_decl,
             "__get_raw_experiemtal_transform_context" => get_raw_experiemtal_transform_context_fn_decl,
             // transform

--- a/crates/swc_plugin_runner/src/imported_fn/mod.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/mod.rs
@@ -44,7 +44,7 @@
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use swc_common::SourceMap;
+use swc_common::{plugin::metadata::TransformPluginMetadataContext, SourceMap};
 use wasmer::{imports, Function, ImportObject, Module};
 
 use crate::{
@@ -61,7 +61,6 @@ use crate::{
         set_transform_result::{set_transform_result, TransformResultHostEnvironment},
         span::span_dummy_with_cmt_proxy,
     },
-    TransformPluginMetadataContext,
 };
 
 mod comments;

--- a/crates/swc_plugin_runner/src/imported_fn/source_map.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/source_map.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use swc_common::{
-    plugin::{PluginSerializedBytes, VersionedSerializable},
+    plugin::serialized::{PluginSerializedBytes, VersionedSerializable},
     BytePos, SourceMap, Span, SyntaxContext,
 };
 use wasmer::{LazyInit, Memory, NativeFunc};

--- a/crates/swc_plugin_runner/src/lib.rs
+++ b/crates/swc_plugin_runner/src/lib.rs
@@ -4,6 +4,7 @@ use anyhow::Error;
 use once_cell::sync::Lazy;
 use swc_common::SourceMap;
 use transform_executor::TransformExecutor;
+pub use transform_metadata_context::TransformPluginMetadataContext;
 
 pub mod cache;
 mod host_environment;
@@ -11,6 +12,7 @@ mod imported_fn;
 mod load_plugin;
 mod memory_interop;
 mod transform_executor;
+mod transform_metadata_context;
 
 /**
  * Attempt to create a executor to run plugin binaries.
@@ -24,6 +26,8 @@ pub fn create_plugin_transform_executor(
     path: &Path,
     cache: &Lazy<cache::PluginModuleCache>,
     source_map: &Arc<SourceMap>,
+    metadata_context: &Arc<TransformPluginMetadataContext>,
+    plugin_config: Option<serde_json::Value>,
 ) -> Result<TransformExecutor, Error> {
-    TransformExecutor::new(path, cache, source_map)
+    TransformExecutor::new(path, cache, source_map, metadata_context, plugin_config)
 }

--- a/crates/swc_plugin_runner/src/lib.rs
+++ b/crates/swc_plugin_runner/src/lib.rs
@@ -2,9 +2,8 @@ use std::{path::Path, sync::Arc};
 
 use anyhow::Error;
 use once_cell::sync::Lazy;
-use swc_common::SourceMap;
+use swc_common::{plugin::metadata::TransformPluginMetadataContext, SourceMap};
 use transform_executor::TransformExecutor;
-pub use transform_metadata_context::TransformPluginMetadataContext;
 
 pub mod cache;
 mod host_environment;
@@ -12,7 +11,6 @@ mod imported_fn;
 mod load_plugin;
 mod memory_interop;
 mod transform_executor;
-mod transform_metadata_context;
 
 /**
  * Attempt to create a executor to run plugin binaries.

--- a/crates/swc_plugin_runner/src/load_plugin.rs
+++ b/crates/swc_plugin_runner/src/load_plugin.rs
@@ -2,11 +2,11 @@ use std::{env, sync::Arc};
 
 use anyhow::{Context, Error};
 use parking_lot::Mutex;
-use swc_common::SourceMap;
+use swc_common::{plugin::metadata::TransformPluginMetadataContext, SourceMap};
 use wasmer::{ChainableNamedResolver, Instance};
 use wasmer_wasi::{is_wasi_module, WasiState};
 
-use crate::{imported_fn::build_import_object, TransformPluginMetadataContext};
+use crate::imported_fn::build_import_object;
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn load_plugin(

--- a/crates/swc_plugin_runner/src/memory_interop.rs
+++ b/crates/swc_plugin_runner/src/memory_interop.rs
@@ -1,4 +1,4 @@
-use swc_common::plugin::{PluginSerializedBytes, VersionedSerializable};
+use swc_common::plugin::serialized::{PluginSerializedBytes, VersionedSerializable};
 use swc_plugin_proxy::AllocatedBytesPtr;
 use wasmer::{Array, Memory, NativeFunc, WasmPtr};
 

--- a/crates/swc_plugin_runner/src/transform_executor.rs
+++ b/crates/swc_plugin_runner/src/transform_executor.rs
@@ -3,12 +3,15 @@ use std::sync::Arc;
 use anyhow::{anyhow, Error};
 use parking_lot::Mutex;
 use swc_common::{
-    plugin::{PluginError, PluginSerializedBytes, PLUGIN_TRANSFORM_AST_SCHEMA_VERSION},
+    plugin::{
+        metadata::TransformPluginMetadataContext,
+        serialized::{PluginError, PluginSerializedBytes, PLUGIN_TRANSFORM_AST_SCHEMA_VERSION},
+    },
     SourceMap,
 };
 use wasmer::Instance;
 
-use crate::{memory_interop::write_into_memory_view, TransformPluginMetadataContext};
+use crate::memory_interop::write_into_memory_view;
 
 /// A struct encapsule executing a plugin's transform interop to its teardown
 pub struct TransformExecutor {

--- a/crates/swc_plugin_runner/src/transform_metadata_context.rs
+++ b/crates/swc_plugin_runner/src/transform_metadata_context.rs
@@ -1,0 +1,21 @@
+use swc_common::collections::AHashMap;
+
+/// Host side metadata context plugin may need to access.
+/// This is a global context - any plugin will have same values.
+pub struct TransformPluginMetadataContext {
+    pub filename: Option<String>,
+    pub env: String,
+    // swcconfig
+    // cwd
+    pub experimental: AHashMap<String, String>,
+}
+
+impl TransformPluginMetadataContext {
+    pub fn new(filename: Option<String>, env: String) -> Self {
+        TransformPluginMetadataContext {
+            filename,
+            env,
+            experimental: AHashMap::default(),
+        }
+    }
+}

--- a/crates/swc_plugin_runner/tests/fixture/swc_internal_plugin/Cargo.lock
+++ b/crates/swc_plugin_runner/tests/fixture/swc_internal_plugin/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "ast_node"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "darling",
  "pmutil",
@@ -71,9 +71,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a31f923c2db9513e4298b72df143e6e655a759b3d6a0966df18f81223fff54f"
+checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb17c862a905d912174daa27ae002326fff56dc8b8ada50a0a5f0976cb174f0"
+checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "bitflags",
  "bytecheck",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "either",
  "enum_kind",

--- a/crates/swc_plugin_runner/tests/fixture/swc_internal_plugin/Cargo.lock
+++ b/crates/swc_plugin_runner/tests/fixture/swc_internal_plugin/Cargo.lock
@@ -704,7 +704,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "swc_atoms"
-version = "0.2.13"
+version = "0.3.0"
 dependencies = [
  "bytecheck",
  "once_cell",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "bitflags",
  "bytecheck",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "either",
  "enum_kind",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "indexmap",
  "once_cell",
@@ -793,10 +793,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.73.0"
+version = "0.74.1"
 dependencies = [
  "num-bigint",
- "serde",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -806,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.184.0"
+version = "0.185.0"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
@@ -844,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.85.0"
+version = "0.87.0"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -855,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -864,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "better_scoped_tls",
  "bytecheck",

--- a/crates/swc_plugin_runner/tests/fixture/swc_internal_plugin/src/lib.rs
+++ b/crates/swc_plugin_runner/tests/fixture/swc_internal_plugin/src/lib.rs
@@ -53,8 +53,15 @@ pub fn process(program: Program, metadata: TransformPluginProgramMetadata) -> Pr
             .emit();
     });
 
-    // Arbitaray call for now
-    metadata.experimental.is_empty();
+    let experimental_metadata = metadata.get_raw_experimental_context();
+    let experimental_value = experimental_metadata
+        .get("TestExperimental")
+        .expect("Experimental metadata should exist");
+
+    // Let test fail if metadata is not correctly passed
+    if experimental_value != "ExperimentalValue" {
+        return program;
+    }
 
     program.fold_with(&mut as_folder(ConsoleOutputReplacer))
 }

--- a/crates/swc_plugin_runner/tests/fixture/swc_internal_plugin/src/lib.rs
+++ b/crates/swc_plugin_runner/tests/fixture/swc_internal_plugin/src/lib.rs
@@ -53,14 +53,34 @@ pub fn process(program: Program, metadata: TransformPluginProgramMetadata) -> Pr
             .emit();
     });
 
-    let experimental_metadata = metadata.get_raw_experimental_context();
-    let experimental_value = experimental_metadata
-        .get("TestExperimental")
+    let experimental_value = metadata
+        .get_experimental_context("TestExperimental")
         .expect("Experimental metadata should exist");
 
     // Let test fail if metadata is not correctly passed
-    if experimental_value != "ExperimentalValue" {
-        return program;
+    if &experimental_value != "ExperimentalValue" {
+        panic!("Experimental metadata should be `ExperimentalValue`");
+    }
+
+    let experimental_value = metadata
+        .get_experimental_context("OtherTest")
+        .expect("Experimental metadata 'othertest' should exist");
+
+    if &experimental_value != "OtherVal" {
+        panic!("Experimental metadata 'othertest' should be `OtherVal`");
+    }
+
+    let nonexistent_value = metadata.get_experimental_context("Nonexistent");
+
+    if nonexistent_value.is_some() {
+        panic!("Experimental metadata 'nonexistent' should not exist");
+    }
+
+    let plugin_config = metadata
+        .get_transform_plugin_config()
+        .expect("Plugin config should exist");
+    if plugin_config != "{\"pluginConfig\":\"testValue\"}" {
+        panic!("Plugin config should be testValue");
     }
 
     program.fold_with(&mut as_folder(ConsoleOutputReplacer))

--- a/crates/swc_plugin_runner/tests/fixture/swc_internal_plugin/src/lib.rs
+++ b/crates/swc_plugin_runner/tests/fixture/swc_internal_plugin/src/lib.rs
@@ -1,5 +1,8 @@
 use swc_plugin::{
-    ast::*, errors::HANDLER, metadata::TransformPluginProgramMetadata, plugin_transform,
+    ast::*,
+    errors::HANDLER,
+    metadata::{TransformPluginMetadataContextKind, TransformPluginProgramMetadata},
+    plugin_transform,
     syntax_pos::DUMMY_SP,
 };
 
@@ -52,6 +55,13 @@ pub fn process(program: Program, metadata: TransformPluginProgramMetadata) -> Pr
             .struct_span_err(DUMMY_SP, "Test diagnostics from plugin")
             .emit();
     });
+
+    let env = metadata
+        .get_context(&TransformPluginMetadataContextKind::Env)
+        .expect("Metadata should exists");
+    if env != "development" {
+        panic!("Env should be development");
+    }
 
     let experimental_value = metadata
         .get_experimental_context("TestExperimental")

--- a/crates/swc_plugin_runner/tests/fixture/swc_internal_plugin/src/lib.rs
+++ b/crates/swc_plugin_runner/tests/fixture/swc_internal_plugin/src/lib.rs
@@ -1,5 +1,6 @@
 use swc_plugin::{
-    ast::*, errors::HANDLER, plugin_transform, syntax_pos::DUMMY_SP, TransformPluginProgramMetadata,
+    ast::*, errors::HANDLER, metadata::TransformPluginProgramMetadata, plugin_transform,
+    syntax_pos::DUMMY_SP,
 };
 
 struct ConsoleOutputReplacer;

--- a/crates/swc_plugin_runner/tests/integration.rs
+++ b/crates/swc_plugin_runner/tests/integration.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Error};
+use serde_json::json;
 use swc_common::{
     collections::AHashMap,
     errors::HANDLER,
@@ -105,10 +106,13 @@ fn internal() -> Result<(), Error> {
             "{sourceFileName: 'single_plugin_test'}".to_string(),
         ))
         .expect("Should serializable");
-        let experimental_metadata: AHashMap<String, String> = [(
-            "TestExperimental".to_string(),
-            "ExperimentalValue".to_string(),
-        )]
+        let experimental_metadata: AHashMap<String, String> = [
+            (
+                "TestExperimental".to_string(),
+                "ExperimentalValue".to_string(),
+            ),
+            ("OtherTest".to_string(), "OtherVal".to_string()),
+        ]
         .into_iter()
         .collect();
         let experimental_metadata_serialized = PluginSerializedBytes::try_serialize(
@@ -126,7 +130,7 @@ fn internal() -> Result<(), Error> {
                 "development".to_string(),
                 Some(experimental_metadata),
             )),
-            None,
+            Some(json!({ "pluginConfig": "testValue" })),
         )
         .expect("Should load plugin");
 
@@ -181,10 +185,13 @@ fn internal() -> Result<(), Error> {
             "{sourceFileName: 'single_plugin_handler_test'}".to_string(),
         ))
         .expect("Should serializable");
-        let experimental_metadata: AHashMap<String, String> = [(
-            "TestExperimental".to_string(),
-            "ExperimentalValue".to_string(),
-        )]
+        let experimental_metadata: AHashMap<String, String> = [
+            (
+                "TestExperimental".to_string(),
+                "ExperimentalValue".to_string(),
+            ),
+            ("OtherTest".to_string(), "OtherVal".to_string()),
+        ]
         .into_iter()
         .collect();
         let experimental_metadata_serialized = PluginSerializedBytes::try_serialize(
@@ -205,7 +212,7 @@ fn internal() -> Result<(), Error> {
                         "development".to_string(),
                         Some(experimental_metadata),
                     )),
-                    None,
+                    Some(json!({ "pluginConfig": "testValue" })),
                 )
                 .expect("Should load plugin");
 
@@ -245,10 +252,13 @@ fn internal() -> Result<(), Error> {
                 .expect("Should serializable");
         let cache: Lazy<PluginModuleCache> = Lazy::new(PluginModuleCache::new);
 
-        let experimental_metadata: AHashMap<String, String> = [(
-            "TestExperimental".to_string(),
-            "ExperimentalValue".to_string(),
-        )]
+        let experimental_metadata: AHashMap<String, String> = [
+            (
+                "TestExperimental".to_string(),
+                "ExperimentalValue".to_string(),
+            ),
+            ("OtherTest".to_string(), "OtherVal".to_string()),
+        ]
         .into_iter()
         .collect();
         let experimental_metadata_serialized = PluginSerializedBytes::try_serialize(
@@ -265,7 +275,7 @@ fn internal() -> Result<(), Error> {
                 "development".to_string(),
                 Some(experimental_metadata.clone()),
             )),
-            None,
+            Some(json!({ "pluginConfig": "testValue" })),
         )
         .expect("Should load plugin");
 
@@ -296,7 +306,7 @@ fn internal() -> Result<(), Error> {
                 "development".to_string(),
                 Some(experimental_metadata.clone()),
             )),
-            None,
+            Some(json!({ "pluginConfig": "testValue" })),
         )
         .expect("Should load plugin");
 

--- a/crates/swc_plugin_runner/tests/integration.rs
+++ b/crates/swc_plugin_runner/tests/integration.rs
@@ -105,9 +105,14 @@ fn internal() -> Result<(), Error> {
             "{sourceFileName: 'single_plugin_test'}".to_string(),
         ))
         .expect("Should serializable");
-        let experimental_metadata: AHashMap<String, String> = AHashMap::default();
-        let experimental_metadata = PluginSerializedBytes::try_serialize(
-            &VersionedSerializable::new(experimental_metadata),
+        let experimental_metadata: AHashMap<String, String> = [(
+            "TestExperimental".to_string(),
+            "ExperimentalValue".to_string(),
+        )]
+        .into_iter()
+        .collect();
+        let experimental_metadata_serialized = PluginSerializedBytes::try_serialize(
+            &VersionedSerializable::new(experimental_metadata.clone()),
         )
         .expect("Should be a hashmap");
 
@@ -119,6 +124,7 @@ fn internal() -> Result<(), Error> {
             &Arc::new(TransformPluginMetadataContext::new(
                 None,
                 "development".to_string(),
+                Some(experimental_metadata),
             )),
             None,
         )
@@ -129,7 +135,7 @@ fn internal() -> Result<(), Error> {
                 &program,
                 &config,
                 &context,
-                &experimental_metadata,
+                &experimental_metadata_serialized,
                 Mark::new(),
                 false,
             )
@@ -175,9 +181,14 @@ fn internal() -> Result<(), Error> {
             "{sourceFileName: 'single_plugin_handler_test'}".to_string(),
         ))
         .expect("Should serializable");
-        let experimental_metadata: AHashMap<String, String> = AHashMap::default();
-        let experimental_metadata = PluginSerializedBytes::try_serialize(
-            &VersionedSerializable::new(experimental_metadata),
+        let experimental_metadata: AHashMap<String, String> = [(
+            "TestExperimental".to_string(),
+            "ExperimentalValue".to_string(),
+        )]
+        .into_iter()
+        .collect();
+        let experimental_metadata_serialized = PluginSerializedBytes::try_serialize(
+            &VersionedSerializable::new(experimental_metadata.clone()),
         )
         .expect("Should be a hashmap");
 
@@ -192,6 +203,7 @@ fn internal() -> Result<(), Error> {
                     &Arc::new(TransformPluginMetadataContext::new(
                         None,
                         "development".to_string(),
+                        Some(experimental_metadata),
                     )),
                     None,
                 )
@@ -202,7 +214,7 @@ fn internal() -> Result<(), Error> {
                     &program,
                     &config,
                     &context,
-                    &experimental_metadata,
+                    &experimental_metadata_serialized,
                     Mark::new(),
                     false,
                 )
@@ -233,6 +245,17 @@ fn internal() -> Result<(), Error> {
                 .expect("Should serializable");
         let cache: Lazy<PluginModuleCache> = Lazy::new(PluginModuleCache::new);
 
+        let experimental_metadata: AHashMap<String, String> = [(
+            "TestExperimental".to_string(),
+            "ExperimentalValue".to_string(),
+        )]
+        .into_iter()
+        .collect();
+        let experimental_metadata_serialized = PluginSerializedBytes::try_serialize(
+            &VersionedSerializable::new(experimental_metadata.clone()),
+        )
+        .expect("Should be a hashmap");
+
         let mut plugin_transform_executor = swc_plugin_runner::create_plugin_transform_executor(
             &path,
             &cache,
@@ -240,16 +263,11 @@ fn internal() -> Result<(), Error> {
             &Arc::new(TransformPluginMetadataContext::new(
                 None,
                 "development".to_string(),
+                Some(experimental_metadata.clone()),
             )),
             None,
         )
         .expect("Should load plugin");
-
-        let experimental_metadata: AHashMap<String, String> = AHashMap::default();
-        let experimental_metadata = PluginSerializedBytes::try_serialize(
-            &VersionedSerializable::new(experimental_metadata),
-        )
-        .expect("Should be a hashmap");
 
         serialized_program = plugin_transform_executor
             .transform(
@@ -262,7 +280,7 @@ fn internal() -> Result<(), Error> {
                     "{sourceFileName: 'multiple_plugin_test'}".to_string(),
                 ))
                 .expect("Should serializable"),
-                &experimental_metadata,
+                &experimental_metadata_serialized,
                 Mark::new(),
                 false,
             )
@@ -276,6 +294,7 @@ fn internal() -> Result<(), Error> {
             &Arc::new(TransformPluginMetadataContext::new(
                 None,
                 "development".to_string(),
+                Some(experimental_metadata.clone()),
             )),
             None,
         )
@@ -292,7 +311,7 @@ fn internal() -> Result<(), Error> {
                     "{sourceFileName: 'multiple_plugin_test2'}".to_string(),
                 ))
                 .expect("Should serializable"),
-                &experimental_metadata,
+                &experimental_metadata_serialized,
                 Mark::new(),
                 false,
             )

--- a/crates/swc_plugin_runner/tests/integration.rs
+++ b/crates/swc_plugin_runner/tests/integration.rs
@@ -9,14 +9,17 @@ use anyhow::{anyhow, Error};
 use swc_common::{
     collections::AHashMap,
     errors::HANDLER,
-    plugin::{PluginSerializedBytes, VersionedSerializable},
+    plugin::{
+        metadata::TransformPluginMetadataContext,
+        serialized::{PluginSerializedBytes, VersionedSerializable},
+    },
     sync::Lazy,
     FileName, Mark,
 };
 use swc_ecma_ast::{CallExpr, Callee, EsVersion, Expr, Lit, MemberExpr, Program, Str};
 use swc_ecma_parser::{parse_file_as_program, EsConfig, Syntax};
 use swc_ecma_visit::{Visit, VisitWith};
-use swc_plugin_runner::{cache::PluginModuleCache, TransformPluginMetadataContext};
+use swc_plugin_runner::cache::PluginModuleCache;
 
 /// Returns the path to the built plugin
 fn build_plugin(dir: &Path) -> Result<PathBuf, Error> {

--- a/crates/swc_plugin_runner/tests/integration.rs
+++ b/crates/swc_plugin_runner/tests/integration.rs
@@ -99,13 +99,6 @@ fn internal() -> Result<(), Error> {
 
         let program = PluginSerializedBytes::try_serialize(&VersionedSerializable::new(program))
             .expect("Should serializable");
-        let config =
-            PluginSerializedBytes::try_serialize(&VersionedSerializable::new("{}".to_string()))
-                .expect("Should serializable");
-        let context = PluginSerializedBytes::try_serialize(&VersionedSerializable::new(
-            "{sourceFileName: 'single_plugin_test'}".to_string(),
-        ))
-        .expect("Should serializable");
         let experimental_metadata: AHashMap<String, String> = [
             (
                 "TestExperimental".to_string(),
@@ -115,10 +108,6 @@ fn internal() -> Result<(), Error> {
         ]
         .into_iter()
         .collect();
-        let experimental_metadata_serialized = PluginSerializedBytes::try_serialize(
-            &VersionedSerializable::new(experimental_metadata.clone()),
-        )
-        .expect("Should be a hashmap");
 
         let cache: Lazy<PluginModuleCache> = Lazy::new(PluginModuleCache::new);
         let mut plugin_transform_executor = swc_plugin_runner::create_plugin_transform_executor(
@@ -135,14 +124,7 @@ fn internal() -> Result<(), Error> {
         .expect("Should load plugin");
 
         let program_bytes = plugin_transform_executor
-            .transform(
-                &program,
-                &config,
-                &context,
-                &experimental_metadata_serialized,
-                Mark::new(),
-                false,
-            )
+            .transform(&program, Mark::new(), false)
             .expect("Plugin should apply transform");
 
         let program: Program = program_bytes
@@ -178,13 +160,6 @@ fn internal() -> Result<(), Error> {
 
         let program = PluginSerializedBytes::try_serialize(&VersionedSerializable::new(program))
             .expect("Should serializable");
-        let config =
-            PluginSerializedBytes::try_serialize(&VersionedSerializable::new("{}".to_string()))
-                .expect("Should serializable");
-        let context = PluginSerializedBytes::try_serialize(&VersionedSerializable::new(
-            "{sourceFileName: 'single_plugin_handler_test'}".to_string(),
-        ))
-        .expect("Should serializable");
         let experimental_metadata: AHashMap<String, String> = [
             (
                 "TestExperimental".to_string(),
@@ -194,10 +169,6 @@ fn internal() -> Result<(), Error> {
         ]
         .into_iter()
         .collect();
-        let experimental_metadata_serialized = PluginSerializedBytes::try_serialize(
-            &VersionedSerializable::new(experimental_metadata.clone()),
-        )
-        .expect("Should be a hashmap");
 
         let cache: Lazy<PluginModuleCache> = Lazy::new(PluginModuleCache::new);
 
@@ -217,14 +188,7 @@ fn internal() -> Result<(), Error> {
                 .expect("Should load plugin");
 
             plugin_transform_executor
-                .transform(
-                    &program,
-                    &config,
-                    &context,
-                    &experimental_metadata_serialized,
-                    Mark::new(),
-                    false,
-                )
+                .transform(&program, Mark::new(), false)
                 .expect("Plugin should apply transform")
         });
 
@@ -261,10 +225,6 @@ fn internal() -> Result<(), Error> {
         ]
         .into_iter()
         .collect();
-        let experimental_metadata_serialized = PluginSerializedBytes::try_serialize(
-            &VersionedSerializable::new(experimental_metadata.clone()),
-        )
-        .expect("Should be a hashmap");
 
         let mut plugin_transform_executor = swc_plugin_runner::create_plugin_transform_executor(
             &path,
@@ -280,20 +240,7 @@ fn internal() -> Result<(), Error> {
         .expect("Should load plugin");
 
         serialized_program = plugin_transform_executor
-            .transform(
-                &serialized_program,
-                &PluginSerializedBytes::try_serialize(&VersionedSerializable::new(
-                    "{}".to_string(),
-                ))
-                .expect("Should serializable"),
-                &PluginSerializedBytes::try_serialize(&VersionedSerializable::new(
-                    "{sourceFileName: 'multiple_plugin_test'}".to_string(),
-                ))
-                .expect("Should serializable"),
-                &experimental_metadata_serialized,
-                Mark::new(),
-                false,
-            )
+            .transform(&serialized_program, Mark::new(), false)
             .expect("Plugin should apply transform");
 
         // TODO: we'll need to apply 2 different plugins
@@ -311,20 +258,7 @@ fn internal() -> Result<(), Error> {
         .expect("Should load plugin");
 
         serialized_program = plugin_transform_executor
-            .transform(
-                &serialized_program,
-                &PluginSerializedBytes::try_serialize(&VersionedSerializable::new(
-                    "{}".to_string(),
-                ))
-                .expect("Should serializable"),
-                &PluginSerializedBytes::try_serialize(&VersionedSerializable::new(
-                    "{sourceFileName: 'multiple_plugin_test2'}".to_string(),
-                ))
-                .expect("Should serializable"),
-                &experimental_metadata_serialized,
-                Mark::new(),
-                false,
-            )
+            .transform(&serialized_program, Mark::new(), false)
             .expect("Plugin should apply transform");
 
         let program: Program = serialized_program

--- a/crates/swc_plugin_runner/tests/integration.rs
+++ b/crates/swc_plugin_runner/tests/integration.rs
@@ -2,6 +2,7 @@ use std::{
     env, fs,
     path::{Path, PathBuf},
     process::{Command, Stdio},
+    sync::Arc,
 };
 
 use anyhow::{anyhow, Error};
@@ -15,7 +16,7 @@ use swc_common::{
 use swc_ecma_ast::{CallExpr, Callee, EsVersion, Expr, Lit, MemberExpr, Program, Str};
 use swc_ecma_parser::{parse_file_as_program, EsConfig, Syntax};
 use swc_ecma_visit::{Visit, VisitWith};
-use swc_plugin_runner::cache::PluginModuleCache;
+use swc_plugin_runner::{cache::PluginModuleCache, TransformPluginMetadataContext};
 
 /// Returns the path to the built plugin
 fn build_plugin(dir: &Path) -> Result<PathBuf, Error> {
@@ -108,9 +109,17 @@ fn internal() -> Result<(), Error> {
         .expect("Should be a hashmap");
 
         let cache: Lazy<PluginModuleCache> = Lazy::new(PluginModuleCache::new);
-        let mut plugin_transform_executor =
-            swc_plugin_runner::create_plugin_transform_executor(&path, &cache, &cm)
-                .expect("Should load plugin");
+        let mut plugin_transform_executor = swc_plugin_runner::create_plugin_transform_executor(
+            &path,
+            &cache,
+            &cm,
+            &Arc::new(TransformPluginMetadataContext::new(
+                None,
+                "development".to_string(),
+            )),
+            None,
+        )
+        .expect("Should load plugin");
 
         let program_bytes = plugin_transform_executor
             .transform(
@@ -173,8 +182,17 @@ fn internal() -> Result<(), Error> {
 
         let _res = HANDLER.set(&handler, || {
             let mut plugin_transform_executor =
-                swc_plugin_runner::create_plugin_transform_executor(&path, &cache, &cm)
-                    .expect("Should load plugin");
+                swc_plugin_runner::create_plugin_transform_executor(
+                    &path,
+                    &cache,
+                    &cm,
+                    &Arc::new(TransformPluginMetadataContext::new(
+                        None,
+                        "development".to_string(),
+                    )),
+                    None,
+                )
+                .expect("Should load plugin");
 
             plugin_transform_executor
                 .transform(
@@ -212,9 +230,17 @@ fn internal() -> Result<(), Error> {
                 .expect("Should serializable");
         let cache: Lazy<PluginModuleCache> = Lazy::new(PluginModuleCache::new);
 
-        let mut plugin_transform_executor =
-            swc_plugin_runner::create_plugin_transform_executor(&path, &cache, &cm)
-                .expect("Should load plugin");
+        let mut plugin_transform_executor = swc_plugin_runner::create_plugin_transform_executor(
+            &path,
+            &cache,
+            &cm,
+            &Arc::new(TransformPluginMetadataContext::new(
+                None,
+                "development".to_string(),
+            )),
+            None,
+        )
+        .expect("Should load plugin");
 
         let experimental_metadata: AHashMap<String, String> = AHashMap::default();
         let experimental_metadata = PluginSerializedBytes::try_serialize(
@@ -240,9 +266,17 @@ fn internal() -> Result<(), Error> {
             .expect("Plugin should apply transform");
 
         // TODO: we'll need to apply 2 different plugins
-        let mut plugin_transform_executor =
-            swc_plugin_runner::create_plugin_transform_executor(&path, &cache, &cm)
-                .expect("Should load plugin");
+        let mut plugin_transform_executor = swc_plugin_runner::create_plugin_transform_executor(
+            &path,
+            &cache,
+            &cm,
+            &Arc::new(TransformPluginMetadataContext::new(
+                None,
+                "development".to_string(),
+            )),
+            None,
+        )
+        .expect("Should load plugin");
 
         serialized_program = plugin_transform_executor
             .transform(

--- a/node-swc/e2e/fixtures/plugin_transform_schema_v1/src/lib.rs
+++ b/node-swc/e2e/fixtures/plugin_transform_schema_v1/src/lib.rs
@@ -1,4 +1,6 @@
-use swc_plugin::{ast::*, plugin_transform, syntax_pos::DUMMY_SP, TransformPluginProgramMetadata};
+use swc_plugin::{
+    ast::*, plugin_transform, syntax_pos::DUMMY_SP, TransformPluginProgramMetadata,
+};
 
 struct ConsoleOutputReplacer;
 

--- a/node-swc/e2e/fixtures/plugin_transform_schema_vtest/Cargo.lock
+++ b/node-swc/e2e/fixtures/plugin_transform_schema_vtest/Cargo.lock
@@ -712,7 +712,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "swc_atoms"
-version = "0.2.13"
+version = "0.3.0"
 dependencies = [
  "bytecheck",
  "once_cell",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "bitflags",
  "bytecheck",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "either",
  "enum_kind",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "indexmap",
  "once_cell",
@@ -801,10 +801,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.73.0"
+version = "0.74.1"
 dependencies = [
  "num-bigint",
- "serde",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -814,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.184.0"
+version = "0.185.0"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
@@ -844,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "0.85.0"
+version = "0.87.0"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -855,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -864,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "better_scoped_tls",
  "bytecheck",

--- a/node-swc/e2e/fixtures/plugin_transform_schema_vtest/src/lib.rs
+++ b/node-swc/e2e/fixtures/plugin_transform_schema_vtest/src/lib.rs
@@ -1,4 +1,6 @@
-use swc_plugin::{ast::*, plugin_transform, syntax_pos::DUMMY_SP, TransformPluginProgramMetadata};
+use swc_plugin::{
+    ast::*, metadata::TransformPluginProgramMetadata, plugin_transform, syntax_pos::DUMMY_SP,
+};
 
 struct ConsoleOutputReplacer;
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

- closes https://github.com/swc-project/swc/issues/5281

This PR implements interfaces for `TransformPluginProgramMetadata` to be able to request metadata context lazily. This is a clear breaking change since the old eager, static values are gone. 

Initial interfaces are exposed as below. 

```
fn get_transform_plugin_config() -> Option<String>;
fn get_context(key: &TransformPluginMetadataContextKind) -> Option<String>;
fn get_experimental_context(key: &str) -> Option<String>;
```

`get_transform_plugin_config` returns given transform plugin's config. Since this is being deserialized from `serde_json::Value`, host pass whole stringified JSON as is. Once plugin receives it, deserialization is up to plugin as same as before.

`get_context` replaces `transform_context` values. This accepts known list of the indexer for the values (`TransformPluginMetadataContextKind`) for predefined values. Adding, or removing new values for this context will be a breaking change.

`get_experimental_context` replaces recently introduced experimental metadata. This'll be a placeholder we'll add / remove new metadata values without causing breaking change.

For getting context / expeirmental both, current interface requires to specify specific key for the specific value. We may need to have getting all context at once - but we can add new interface always once we have solid usecase, so decided to not to have those as first step.

All of these functions are lazy, as well as will involve communication between host to the plugin with serialization & deserialization. Plugin should own responsibility to memoize values to avoid redundant costs.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
