### PR TITLE
feat(swc/wasm): enable interning strings

### DIFF
--- a/crates/binding_core_wasm/Cargo.toml
+++ b/crates/binding_core_wasm/Cargo.toml
@@ -45,7 +45,10 @@ swc_ecma_lints = { path = "../swc_ecma_lints", features = [
 swc_ecmascript = { path = "../swc_ecmascript" }
 swc_plugin_runner = { path = "../swc_plugin_runner", default-features = false, optional = true }
 tracing = { version = "0.1.35", features = ["release_max_level_off"] }
-wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.82", features = [
+  "serde-serialize",
+  "enable-interning",
+] }
 wasmer = { version = "2.3.0", optional = true, default-features = false }
 wasmer-wasi = { version = "2.3.0", optional = true, default-features = false }
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR enables interning string feature from wasm-bindgen (https://github.com/rustwasm/wasm-bindgen/blob/062aa5f70a1e8a170d0ae90123ebdeb3242ac782/CHANGELOG.md) . This is not well exposed in the docs somehow.

While it _sounds_ like a nice improvement, it is not clear if it'll give a noticeable gain for us. I felt it's worth trying if we haven't done this before.

I tried quick search but I may miss history if we did this & revert. If that's the case, please feel free to close.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
