### PR TITLE
chore: Drop support for node v10 and v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "tsc"
     ],
     "engines": {
-        "node": ">=10"
+        "node": ">=14"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
**Description:**

**BREAKING CHANGE:**
- dropping support for node v10
- dropping support for node v12

**Related issue (if exists):**
- closes #5348