### PR TITLE
perf(es/minifier): Reduce recursion

### DIFF
--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -1203,16 +1203,6 @@ pub trait ExprExt {
                     }
             }
 
-            Expr::Fn(FnExpr {
-                function:
-                    Function {
-                        params,
-                        body: Some(BlockStmt { stmts, .. }),
-                        ..
-                    },
-                ..
-            }) if params.iter().all(|p| p.pat.is_ident()) && stmts.is_empty() => true,
-
             _ => false,
         }
     }


### PR DESCRIPTION

For 998 files, difference was 8.843936416s vs 9.063045625s

The difference of 0.2 second was consistent