### PR TITLE
fix(swc/utils): allow quote_ident works with swc_core

### DIFF
--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -4,6 +4,9 @@
 #[doc(hidden)]
 pub extern crate swc_ecma_ast;
 
+#[doc(hidden)]
+pub extern crate swc_common;
+
 use std::{
     borrow::Cow,
     f64::{INFINITY, NAN},

--- a/crates/swc_ecma_utils/src/macros.rs
+++ b/crates/swc_ecma_utils/src/macros.rs
@@ -2,11 +2,10 @@
 #[macro_export]
 macro_rules! private_ident {
     ($s:expr) => {
-        private_ident!(::swc_common::DUMMY_SP, $s)
+        private_ident!($crate::swc_common::DUMMY_SP, $s)
     };
     ($span:expr, $s:expr) => {{
-        use swc_common::Mark;
-        let mark = Mark::fresh(Mark::root());
+        let mark = $crate::swc_common::Mark::fresh($crate::swc_common::Mark::root());
         let span = $span.apply_mark(mark);
         $crate::swc_ecma_ast::Ident::new($s.into(), span)
     }};
@@ -15,7 +14,7 @@ macro_rules! private_ident {
 #[macro_export]
 macro_rules! quote_ident {
     ($s:expr) => {
-        quote_ident!(::swc_common::DUMMY_SP, $s)
+        quote_ident!($crate::swc_common::DUMMY_SP, $s)
     };
     ($span:expr, $s:expr) => {{
         $crate::swc_ecma_ast::Ident::new($s.into(), $span)
@@ -25,7 +24,7 @@ macro_rules! quote_ident {
 #[macro_export]
 macro_rules! quote_str {
     ($s:expr) => {
-        quote_str!(::swc_common::DUMMY_SP, $s)
+        quote_str!($crate::swc_common::DUMMY_SP, $s)
     };
     ($span:expr, $s:expr) => {{
         $crate::swc_ecma_ast::Str {
@@ -74,7 +73,7 @@ macro_rules! member_expr {
         let prop = MemberProp::Ident($crate::quote_ident!($span, stringify!($first)));
 
         member_expr!(@EXT, $span, Box::new(Expr::Member(MemberExpr{
-            span: ::swc_common::DUMMY_SP,
+            span: $crate::swc_common::DUMMY_SP,
             obj: $obj,
             prop,
         })), $($rest)*)
@@ -85,7 +84,7 @@ macro_rules! member_expr {
         let prop = MemberProp::Ident($crate::quote_ident!($span, stringify!($first)));
 
         Box::new(Expr::Member(MemberExpr{
-            span: ::swc_common::DUMMY_SP,
+            span: $crate::swc_common::DUMMY_SP,
             obj: $obj,
             prop,
         }))


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR allows `quote_ident!` from utils macro works within swc_core, by resolving inner references expansion to its own transitive deps.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
