### PR TITLE
Synchronize implementation of ECMA minimizers

### DIFF
--- a/crates/swc_ecma_minifier/benches/full.rs
+++ b/crates/swc_ecma_minifier/benches/full.rs
@@ -6,7 +6,7 @@ use std::fs::read_to_string;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use swc_common::{sync::Lrc, FileName, Mark, SourceMap};
-use swc_ecma_codegen::text_writer::JsWriter;
+use swc_ecma_codegen::text_writer::{omit_trailing_semi, JsWriter};
 use swc_ecma_minifier::{
     optimize,
     option::{CompressOptions, ExtraOptions, MangleOptions, MinifyOptions},
@@ -118,7 +118,7 @@ fn print<N: swc_ecma_codegen::Node>(cm: Lrc<SourceMap>, nodes: &[N], minify: boo
             },
             cm: cm.clone(),
             comments: None,
-            wr: Box::new(JsWriter::new(cm, "\n", &mut buf, None)),
+            wr: Box::new(omit_trailing_semi(JsWriter::new(cm, "\n", &mut buf, None))),
         };
 
         for n in nodes {

--- a/crates/swc_ecma_minifier/examples/compress.rs
+++ b/crates/swc_ecma_minifier/examples/compress.rs
@@ -9,7 +9,7 @@ extern crate swc_node_base;
 use std::{env::args, fs, path::Path};
 
 use swc_common::{sync::Lrc, Mark, SourceMap};
-use swc_ecma_codegen::text_writer::JsWriter;
+use swc_ecma_codegen::text_writer::{omit_trailing_semi, JsWriter};
 use swc_ecma_minifier::{
     optimize,
     option::{ExtraOptions, MinifyOptions},
@@ -81,7 +81,7 @@ fn print<N: swc_ecma_codegen::Node>(cm: Lrc<SourceMap>, nodes: &[N], minify: boo
             },
             cm: cm.clone(),
             comments: None,
-            wr: Box::new(JsWriter::new(cm, "\n", &mut buf, None)),
+            wr: Box::new(omit_trailing_semi(JsWriter::new(cm, "\n", &mut buf, None))),
         };
 
         for n in nodes {

--- a/crates/swc_ecma_minifier/examples/minifier.rs
+++ b/crates/swc_ecma_minifier/examples/minifier.rs
@@ -5,7 +5,7 @@ extern crate swc_node_base;
 use std::{env::args, fs, path::Path};
 
 use swc_common::{sync::Lrc, Mark, SourceMap};
-use swc_ecma_codegen::text_writer::JsWriter;
+use swc_ecma_codegen::text_writer::{omit_trailing_semi, JsWriter};
 use swc_ecma_minifier::{
     optimize,
     option::{ExtraOptions, MangleOptions, MinifyOptions},
@@ -80,7 +80,7 @@ fn print<N: swc_ecma_codegen::Node>(cm: Lrc<SourceMap>, nodes: &[N], minify: boo
             },
             cm: cm.clone(),
             comments: None,
-            wr: Box::new(JsWriter::new(cm, "\n", &mut buf, None)),
+            wr: Box::new(omit_trailing_semi(JsWriter::new(cm, "\n", &mut buf, None))),
         };
 
         for n in nodes {

--- a/crates/swc_ecma_minifier/examples/minify-all.rs
+++ b/crates/swc_ecma_minifier/examples/minify-all.rs
@@ -7,7 +7,7 @@ use std::{env, fs, path::PathBuf, time::Instant};
 use anyhow::Result;
 use rayon::prelude::*;
 use swc_common::{sync::Lrc, Mark, SourceMap, GLOBALS};
-use swc_ecma_codegen::text_writer::JsWriter;
+use swc_ecma_codegen::text_writer::{omit_trailing_semi, JsWriter};
 use swc_ecma_minifier::{
     optimize,
     option::{ExtraOptions, MangleOptions, MinifyOptions},
@@ -121,7 +121,7 @@ fn print<N: swc_ecma_codegen::Node>(cm: Lrc<SourceMap>, nodes: &[N], minify: boo
             },
             cm: cm.clone(),
             comments: None,
-            wr: Box::new(JsWriter::new(cm, "\n", &mut buf, None)),
+            wr: Box::new(omit_trailing_semi(JsWriter::new(cm, "\n", &mut buf, None))),
         };
 
         for n in nodes {

--- a/crates/swc_ecma_minifier/src/cli/bin.rs
+++ b/crates/swc_ecma_minifier/src/cli/bin.rs
@@ -1,7 +1,7 @@
 use std::{env::args, io, path::Path};
 use swc_common::{input::SourceFileInput, sync::Lrc, FilePathMapping, Mark, SourceMap};
 use swc_ecma_ast::Module;
-use swc_ecma_codegen::text_writer::JsWriter;
+use swc_ecma_codegen::text_writer::{omit_trailing_semi, JsWriter};
 use swc_ecma_minifier::{
     optimize,
     option::{ExtraOptions, MinifyOptions},
@@ -33,7 +33,9 @@ fn print_js(cm: Lrc<SourceMap>, module: &Module) {
         cfg: swc_ecma_codegen::Config { minify: true },
         cm: cm.clone(),
         comments: None,
-        wr: Box::new(JsWriter::new(cm.clone(), "\n", &stdout, None)),
+        wr: Box::new(omit_trailing_semi(
+            JsWriter::new(cm.clone(), "\n", &stdout, None),
+        )),
     };
     emitter.emit_module(module).unwrap();
 


### PR DESCRIPTION
**Description:**

This makes sure that all transforms are applied to all instances of ECMA minimization.
I also added `omit_trailing_semi`, I hope this is correct.

**Related issue (if exists):**
Fixes #5454.