### PR TITLE
refactor(swc/transforms): remove unstable syntax

### DIFF
--- a/crates/swc_ecma_transforms_compat/src/es2017/async_to_generator.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2017/async_to_generator.rs
@@ -353,8 +353,10 @@ impl<C: Comments> Actual<C> {
 
                 wrapper.function = make_fn_ref(fn_expr);
                 *expr = wrapper.into();
-                if !in_iife && let Some(c) = &mut self.comments {
-                    c.add_pure_comment(expr.span().lo)
+                if !in_iife {
+                    if let Some(c) = &mut self.comments {
+                        c.add_pure_comment(expr.span().lo)
+                    }
                 }
             }
 
@@ -374,8 +376,10 @@ impl<C: Comments> Actual<C> {
                 wrapper.function = make_fn_ref(fn_expr);
 
                 *expr = wrapper.into();
-                if !in_iife && let Some(c) = &mut self.comments {
-                    c.add_pure_comment(expr.span().lo)
+                if !in_iife {
+                    if let Some(c) = &mut self.comments {
+                        c.add_pure_comment(expr.span().lo)
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
- closes https://github.com/swc-project/swc/issues/5469

Personally I'm fine if we can use unstable syntax encapsulated in swc's codebase, but this leaks into user level for the ppl wants to write plugins or custom binary.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
