### PR TITLE
feat(swc/core): implement engine diagnostics

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -126,6 +126,7 @@ jobs:
       - name: Publish crates
         if: steps.bump.outcome == 'success' && steps.bump.conclusion == 'success'
         run: |
+          npx ts-node src/cargo/update-constants.ts
           cargo mono publish --no-verify
           cargo mono publish --no-verify
           cargo mono publish --no-verify

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
 name = "arbitrary"
@@ -820,7 +820,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
 dependencies = [
- "enum-iterator-derive",
+ "enum-iterator-derive 0.7.0",
+]
+
+[[package]]
+name = "enum-iterator"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+dependencies = [
+ "enum-iterator-derive 1.0.2",
 ]
 
 [[package]]
@@ -828,6 +837,17 @@ name = "enum-iterator-derive"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13f1e69590421890f90448c3cd5f554746a31adc6dc0dac406ec6901db8dc25"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1008,6 +1028,18 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1757,6 +1789,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2088,11 +2129,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2117,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -3047,6 +3088,7 @@ dependencies = [
  "swc_plugin_runner",
  "swc_trace_macro",
  "testing",
+ "vergen",
  "wasmer",
  "wasmer-wasi",
 ]
@@ -4195,13 +4237,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -4307,18 +4349,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4378,6 +4420,17 @@ dependencies = [
  "time-macros",
  "version_check",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]
@@ -4585,6 +4638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4285d92be83dfbc8950a2601178b89ed36f979ebf51bfcf7b272b17001184e6c"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
 name = "unicode-linebreak"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4607,12 +4666,6 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "unreachable"
@@ -4646,6 +4699,21 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffa80ed519f45995741e70664d4abcf147d2a47b8c7ea0a4aa495548ef9474f"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "enum-iterator 1.1.3",
+ "getset",
+ "rustversion",
+ "thiserror",
+ "time 0.3.13",
+]
 
 [[package]]
 name = "version_check"
@@ -4887,7 +4955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
 dependencies = [
  "cfg-if 1.0.0",
- "enum-iterator",
+ "enum-iterator 0.7.0",
  "enumset",
  "leb128",
  "libloading",
@@ -4932,7 +5000,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
 dependencies = [
- "enum-iterator",
+ "enum-iterator 0.7.0",
  "enumset",
  "loupe",
  "rkyv",
@@ -4961,7 +5029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
 dependencies = [
  "backtrace",
- "enum-iterator",
+ "enum-iterator 0.7.0",
  "indexmap",
  "loupe",
  "more-asserts",
@@ -4992,7 +5060,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "corosensei",
- "enum-iterator",
+ "enum-iterator 0.7.0",
  "indexmap",
  "lazy_static",
  "libc",

--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -249,3 +249,6 @@ swc_plugin_runner = { optional = true, version = "0.71.15", path = "../swc_plugi
 
 [dev-dependencies]
 testing = { version = "0.29.4", path = "../testing" }
+
+[build-dependencies]
+vergen = { version = "7.3.2", default-features = false, features = ["cargo"] }

--- a/crates/swc_core/build.rs
+++ b/crates/swc_core/build.rs
@@ -5,6 +5,8 @@ use std::{
     path::Path,
 };
 
+use vergen::{vergen, Config};
+
 // Validate conflict between host / plugin features
 #[cfg(all(
     feature = "plugin_transform",
@@ -37,4 +39,8 @@ fn main() {
         File::create(&dest_path).expect("Failed to create swc_core version constant"),
     );
     write!(f, "{}", pkg_version).expect("Failed to write swc_core version constant");
+
+    // Attempt to collect some build time env values but will skip if there are any
+    // errors.
+    let _ = vergen(Config::default());
 }

--- a/crates/swc_core/src/__diagnostics.rs
+++ b/crates/swc_core/src/__diagnostics.rs
@@ -1,0 +1,7 @@
+// This is auto-generated when publish.
+
+// A fallback semver version set via cargo build script.
+pub(crate) static PKG_SEMVER_FALLBACK: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/core_pkg_version.txt"));
+
+pub(crate) static GIT_SHA: &str = "dev";

--- a/crates/swc_core/src/lib.rs
+++ b/crates/swc_core/src/lib.rs
@@ -125,3 +125,31 @@ pub mod node {
 extern crate swc_node_base;
 
 pub static SWC_CORE_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/core_pkg_version.txt"));
+
+mod __diagnostics;
+pub mod diagnostics {
+    use crate::__diagnostics::{GIT_SHA, PKG_SEMVER_FALLBACK};
+
+    #[derive(Debug)]
+    pub struct CoreEngineDiagnostics {
+        /// Semver package version of swc_core.
+        pub package_semver: String,
+        /// Commit sha of swc_core built against.
+        pub git_sha: String,
+        /// List of features enabled
+        pub cargo_features: String,
+    }
+
+    /// Returns metadata about the swc_core engine that was built against.
+    pub fn get_core_engine_diagnostics() -> CoreEngineDiagnostics {
+        CoreEngineDiagnostics {
+            package_semver: option_env!("VERGEN_BUILD_SEMVER")
+                .unwrap_or_else(|| PKG_SEMVER_FALLBACK)
+                .to_string(),
+            git_sha: GIT_SHA.to_string(),
+            cargo_features: option_env!("VERGEN_CARGO_FEATURES")
+                .unwrap_or_else(|| "Unavailable to query")
+                .to_string(),
+        }
+    }
+}

--- a/scripts/bot/src/cargo/update-constants.ts
+++ b/scripts/bot/src/cargo/update-constants.ts
@@ -1,0 +1,26 @@
+import { exec } from "child_process";
+import { getCommitSha } from "../util/git";
+import * as fs from "fs";
+import { promisify } from "util";
+import * as path from "path";
+
+const writeFile = promisify(fs.writeFile);
+
+(async () => {
+    const sha = await getCommitSha();
+    const filePath = path.resolve(
+        __dirname,
+        "../../../../crates/swc_core/src/__diagnostics.rs"
+    );
+
+    await writeFile(
+        filePath,
+        `pub(crate) static PKG_SEMVER_FALLBACK: &str = include_str!(concat!(env!("OUT_DIR"), "/core_pkg_version.txt"));
+pub(crate) static GIT_SHA: &str = "${sha}";`,
+        "utf-8"
+    );
+
+    // we won't push, it's only to avoid dirty check for the publish
+    exec(`git add ${filePath}`);
+    exec(`git commit -m build(swc/core): bump sha`);
+})();

--- a/scripts/bot/src/util/git.ts
+++ b/scripts/bot/src/util/git.ts
@@ -19,3 +19,13 @@ export async function getTitleOfLatestCommit(): Promise<string> {
 
     return s.split("\n")[0];
 }
+
+export async function getCommitSha(): Promise<string> {
+    const { stdout } = exec("git rev-parse HEAD");
+
+    const msg = await streamToString(stdout!);
+
+    const s = msg.trim();
+
+    return s;
+}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR is second attempt to https://github.com/swc-project/swc/pull/5501 . 

Relying on build script time git info is not something we want - since `build` can occur when binary try to import `swc_core`. What we need is pre-baked in constants when `swc_core` is published. PR still try to use vergen for some optional values, but for the git sha it uses a more direct approach to generate sha when publish script running.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
