### PR TITLE
fix(es/preset-env): upgrade preset_env_base

### DIFF
--- a/crates/swc_ecma_preset_env/Cargo.toml
+++ b/crates/swc_ecma_preset_env/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1"
 dashmap = "5.1.0"
 indexmap = "1.6.2"
 once_cell = "1.10.0"
-preset_env_base = { version = "0.2.0", path = "../preset_env_base" }
+preset_env_base = { version = "0.2.4", path = "../preset_env_base" }
 semver = { version = "1.0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/28441561/185203706-d46ea2ac-c785-401d-b8e0-5742b3dd4e76.png">


<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This commit manages to specify the latest preset_env_base explicitly, to not use the older preset_env_base which did not include “bun“ and something new.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
Related: #5293
Fixed: #5490
