### PR TITLE
[PoC] V2 API changes using cargo feature flag

### DIFF
--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -38,6 +38,9 @@ plugin_transform_schema_vtest = [
   "swc_plugin_runner/plugin_transform_schema_vtest",
 ]
 
+swc_v1 = []
+swc_v2 = []
+
 [dependencies]
 ahash = "0.7.4"
 anyhow = "1"

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -1,19 +1,19 @@
 
 
 [package]
-authors       = ["강동윤 <kdy1997.dev@gmail.com>"]
-description   = "Speedy web compiler"
+authors = ["강동윤 <kdy1997.dev@gmail.com>"]
+description = "Speedy web compiler"
 documentation = "https://rustdoc.swc.rs/swc/"
-edition       = "2021"
-include       = ["Cargo.toml", "src/**/*.rs"]
-license       = "Apache-2.0"
-name          = "swc"
-repository    = "https://github.com/swc-project/swc.git"
-version       = "0.214.9"
+edition = "2021"
+include = ["Cargo.toml", "src/**/*.rs"]
+license = "Apache-2.0"
+name = "swc"
+repository = "https://github.com/swc-project/swc.git"
+version = "0.214.9"
 
 [lib]
 bench = false
-name  = "swc"
+name = "swc"
 
 [features]
 # TODO: This may need reorganization with swc_core - swc_core allows to optionally enable
@@ -38,7 +38,6 @@ plugin_transform_schema_vtest = [
   "swc_plugin_runner/plugin_transform_schema_vtest",
 ]
 
-swc_v1 = []
 swc_v2 = []
 
 [dependencies]
@@ -47,7 +46,7 @@ anyhow = "1"
 base64 = "0.13.0"
 dashmap = "5.1.0"
 either = "1"
-indexmap = { version = "1", features = ["serde"] }
+indexmap = {version = "1", features = ["serde"]}
 json_comments = "0.2.0"
 lru = "0.7.1"
 once_cell = "1.10.0"
@@ -55,71 +54,71 @@ parking_lot = "0.12.0"
 pathdiff = "0.2.0"
 regex = "1"
 rustc-hash = "1.1.0"
-serde = { version = "1", features = ["derive"] }
+serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 sourcemap = "6"
-swc_atoms = { version = "0.4.5", path = "../swc_atoms" }
-swc_cached = { version = "0.3.5", path = "../swc_cached" }
-swc_common = { version = "0.27.7", path = "../swc_common", features = [
+swc_atoms = {version = "0.4.5", path = "../swc_atoms"}
+swc_cached = {version = "0.3.5", path = "../swc_cached"}
+swc_common = {version = "0.27.7", path = "../swc_common", features = [
   "sourcemap",
   "parking_lot",
-] }
-swc_config = { version = "0.1.1", path = "../swc_config" }
-swc_ecma_ast = { version = "0.90.10", path = "../swc_ecma_ast" }
-swc_ecma_codegen = { version = "0.121.5", path = "../swc_ecma_codegen" }
-swc_ecma_ext_transforms = { version = "0.85.5", path = "../swc_ecma_ext_transforms" }
-swc_ecma_lints = { version = "0.58.5", path = "../swc_ecma_lints" }
-swc_ecma_loader = { version = "0.39.4", path = "../swc_ecma_loader", features = [
+]}
+swc_config = {version = "0.1.1", path = "../swc_config"}
+swc_ecma_ast = {version = "0.90.10", path = "../swc_ecma_ast"}
+swc_ecma_codegen = {version = "0.121.5", path = "../swc_ecma_codegen"}
+swc_ecma_ext_transforms = {version = "0.85.5", path = "../swc_ecma_ext_transforms"}
+swc_ecma_lints = {version = "0.58.5", path = "../swc_ecma_lints"}
+swc_ecma_loader = {version = "0.39.4", path = "../swc_ecma_loader", features = [
   "cache",
   "node",
   "tsc",
-] }
-swc_ecma_minifier = { version = "0.144.7", path = "../swc_ecma_minifier" }
-swc_ecma_parser = { version = "0.117.5", path = "../swc_ecma_parser" }
-swc_ecma_preset_env = { version = "0.158.4", path = "../swc_ecma_preset_env" }
-swc_ecma_transforms = { version = "0.183.4", path = "../swc_ecma_transforms", features = [
+]}
+swc_ecma_minifier = {version = "0.144.7", path = "../swc_ecma_minifier"}
+swc_ecma_parser = {version = "0.117.5", path = "../swc_ecma_parser"}
+swc_ecma_preset_env = {version = "0.158.4", path = "../swc_ecma_preset_env"}
+swc_ecma_transforms = {version = "0.183.4", path = "../swc_ecma_transforms", features = [
   "compat",
   "module",
   "optimization",
   "proposal",
   "react",
   "typescript",
-] }
-swc_ecma_transforms_base = { version = "0.103.8", path = "../swc_ecma_transforms_base" }
-swc_ecma_transforms_compat = { version = "0.122.6", path = "../swc_ecma_transforms_compat" }
-swc_ecma_transforms_optimization = { version = "0.152.4", path = "../swc_ecma_transforms_optimization" }
-swc_ecma_utils = { version = "0.99.5", path = "../swc_ecma_utils" }
-swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit" }
-swc_error_reporters = { version = "0.11.4", path = "../swc_error_reporters" }
-swc_node_comments = { version = "0.14.4", path = "../swc_node_comments" }
-swc_plugin_proxy = { version = "0.18.13", path = "../swc_plugin_proxy", optional = true }
-swc_plugin_runner = { version = "0.71.15", path = "../swc_plugin_runner", optional = true, default-features = false }
-swc_timer = { version = "0.15.4", path = "../swc_timer" }
-swc_visit = { version = "0.5.2", path = "../swc_visit" }
+]}
+swc_ecma_transforms_base = {version = "0.103.8", path = "../swc_ecma_transforms_base"}
+swc_ecma_transforms_compat = {version = "0.122.6", path = "../swc_ecma_transforms_compat"}
+swc_ecma_transforms_optimization = {version = "0.152.4", path = "../swc_ecma_transforms_optimization"}
+swc_ecma_utils = {version = "0.99.5", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.76.6", path = "../swc_ecma_visit"}
+swc_error_reporters = {version = "0.11.4", path = "../swc_error_reporters"}
+swc_node_comments = {version = "0.14.4", path = "../swc_node_comments"}
+swc_plugin_proxy = {version = "0.18.13", path = "../swc_plugin_proxy", optional = true}
+swc_plugin_runner = {version = "0.71.15", path = "../swc_plugin_runner", optional = true, default-features = false}
+swc_timer = {version = "0.15.4", path = "../swc_timer"}
+swc_visit = {version = "0.5.2", path = "../swc_visit"}
 tracing = "0.1.32"
 
-  [dependencies.napi-derive]
-  default-features = false
-  features         = ["type-def"]
-  optional         = true
-  version          = "2.0.0"
+[dependencies.napi-derive]
+default-features = false
+features = ["type-def"]
+optional = true
+version = "2.0.0"
 
-  [dependencies.napi]
-  default-features = false
-  features         = ["napi3"]
-  optional         = true
-  version          = "2.0.0"
+[dependencies.napi]
+default-features = false
+features = ["napi3"]
+optional = true
+version = "2.0.0"
 
 [dev-dependencies]
 ansi_term = "0.12"
 criterion = "0.3"
 rayon = "1.5.1"
-swc_ecma_lints = { version = "0.58.5", path = "../swc_ecma_lints", features = [
+swc_ecma_lints = {version = "0.58.5", path = "../swc_ecma_lints", features = [
   "non_critical_lints",
-] }
-swc_ecma_testing = { version = "0.14.5", path = "../swc_ecma_testing" }
-swc_node_base = { version = "0.5.0", path = "../swc_node_base" }
-testing = { version = "0.29.4", path = "../testing" }
+]}
+swc_ecma_testing = {version = "0.14.5", path = "../swc_ecma_testing"}
+swc_node_base = {version = "0.5.0", path = "../swc_node_base"}
+testing = {version = "0.29.4", path = "../testing"}
 walkdir = "2"
 
 [[example]]
@@ -127,12 +126,12 @@ name = "transform"
 
 [[bench]]
 harness = false
-name    = "bugs"
+name = "bugs"
 
 [[bench]]
 harness = false
-name    = "minify"
+name = "minify"
 
 [[bench]]
 harness = false
-name    = "typescript"
+name = "typescript"

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -821,6 +821,7 @@ pub struct Config {
     #[serde(default)]
     pub module: Option<ModuleConfig>,
 
+    #[cfg(not(feature = "swc_v2"))]
     #[serde(default)]
     pub minify: BoolConfig<false>,
 
@@ -1159,6 +1160,7 @@ pub struct JscConfig {
     #[serde(default)]
     pub paths: Paths,
 
+    #[cfg(not(feature = "swc_v2"))]
     #[serde(default)]
     pub minify: Option<JsMinifyOptions>,
 

--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
-authors       = ["강동윤 <kdy1997.dev@gmail.com>", "OJ Kwon <kwon.ohjoong@gmail.com>"]
-description   = "TBD"
+authors = ["강동윤 <kdy1997.dev@gmail.com>", "OJ Kwon <kwon.ohjoong@gmail.com>"]
+description = "TBD"
 documentation = "https://rustdoc.swc.rs/swc_core/"
-edition       = "2021"
-license       = "Apache-2.0"
-name          = "swc_core"
-repository    = "https://github.com/swc-project/swc.git"
-version       = "0.7.20"
-  [package.metadata.docs.rs]
-  features = [
-    "common_perf",
-    "allocator_node",
-    "base",
-    "base_node",
-    "common",
-    "visit",
-    "quote",
-    "utils",
-    "transforms",
-    "bundler",
-    "loader",
-    "ast",
-    "trace_macro",
-    "plugin_transform",
-  ]
-  rustdoc-args = ["--cfg", "docsrs"]
+edition = "2021"
+license = "Apache-2.0"
+name = "swc_core"
+repository = "https://github.com/swc-project/swc.git"
+version = "0.7.20"
+[package.metadata.docs.rs]
+features = [
+  "common_perf",
+  "allocator_node",
+  "base",
+  "base_node",
+  "common",
+  "visit",
+  "quote",
+  "utils",
+  "transforms",
+  "bundler",
+  "loader",
+  "ast",
+  "trace_macro",
+  "plugin_transform",
+]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
 doctest = false
@@ -47,16 +47,15 @@ allocator_node = ["swc_node_base"]
 ## General
 # Enable swc reexports. To avoid confusion between swc_core namespace,
 # it is named as 'base' instead.
-base            = ["__base"]
+base = ["__base"]
 base_concurrent = ["__base", "swc/concurrent"]
 # Enables n-api related features.
 base_node = [
   "__base",
-  "swc/node",
-  # Assume if anyone enables n-api related codes, they may would like to use
-  # some utility functions as well.
+  "swc/node", # Assume if anyone enables n-api related codes, they may would like to use  # some utility functions as well.
   "swc_nodejs_common",
 ]
+base_v2 = ["base", "swc/swc_v2"]
 
 # Enable swc_common reexports.
 #
@@ -78,7 +77,7 @@ visit = ["swc_ecma_visit"]
 quote = [
   # Dependent features
   "__common",
-  "ast",                   # Enable optional package
+  "ast", # Enable optional package
   "swc_ecma_quote_macros",
 ]
 
@@ -89,7 +88,7 @@ utils = ["__utils", "__common"]
 transforms = ["__transforms", "__testing_transform"]
 
 # Enable swc_bundler
-bundler         = ["__bundler"]
+bundler = ["__bundler"]
 bundler_node_v1 = ["__bundler", "swc_node_bundler/swc_v1"]
 bundler_node_v2 = ["__bundler", "swc_node_bundler/swc_v2"]
 
@@ -109,7 +108,7 @@ ast = ["swc_ecma_ast", "swc_atoms"]
 trace_macro = ["swc_trace_macro"]
 
 binding_macro_native = ["__binding_macros", "binding_macros/binding_native"]
-binding_macro_wasm   = ["__binding_macros", "binding_macros/binding_wasm"]
+binding_macro_wasm = ["__binding_macros", "binding_macros/binding_wasm"]
 
 ## Plugins
 # Top level features should be enabled to write plugins for the custom transform.
@@ -146,7 +145,7 @@ plugin_transform_host_native = [
 # swc_core.
 __plugin_transform_host_schema_v1 = [
   # Dependent features
-  "__plugin_transform_schema_v1",                 # Enable optional features
+  "__plugin_transform_schema_v1", # Enable optional features
   "swc/plugin_transform_schema_v1",
   "swc_plugin_runner/plugin_transform_schema_v1",
 ]
@@ -155,7 +154,7 @@ __plugin_transform_schema_v1 = ["swc_common/plugin_transform_schema_v1"]
 # Do not use: testing purpose only
 __plugin_transform_host_schema_vtest = [
   # Dependent features
-  "__plugin_transform_schema_vtest",                 # Enable optional features
+  "__plugin_transform_schema_vtest", # Enable optional features
   "swc/plugin_transform_schema_vtest",
   "swc_plugin_runner/plugin_transform_schema_vtest",
 ]
@@ -167,7 +166,7 @@ __plugin_transform = [
   # Dependent features
   "visit",
   "__common",
-  "ast",                          # Enable optional packages
+  "ast", # Enable optional packages
   "swc_ecma_ast/rkyv-impl",
   "swc_atoms/rkyv-impl",
   "swc_common/plugin-mode",
@@ -180,11 +179,10 @@ __plugin_transform = [
 # Internal flags for any transform plugin host feature
 __plugin_transform_host = [
   # Dependent features
-  "__common",               # Enable optional packages
+  "__common", # Enable optional packages
   "swc_ecma_ast/rkyv-impl",
   "swc_atoms/rkyv-impl",
-  "swc_common/plugin-rt",
-  # TODO: we may simply flag around downlevel plugin feature
+  "swc_common/plugin-rt", # TODO: we may simply flag around downlevel plugin feature
   "swc_plugin_proxy/plugin-rt",
   "swc/plugin",
 ]
@@ -209,43 +207,43 @@ __plugin_transform_schema_test = [
 ]
 
 ## Common
-__base              = ["swc"]
-__binding_macros    = ["common", "__base", "__transforms", "ast", "binding_macros"]
-__bundler           = ["swc_bundler"]
-__common            = ["swc_common"]
+__base = ["swc"]
+__binding_macros = ["common", "__base", "__transforms", "ast", "binding_macros"]
+__bundler = ["swc_bundler"]
+__common = ["swc_common"]
 __testing_transform = ["swc_ecma_transforms_testing"]
-__transforms        = ["swc_ecma_transforms"]
-__utils             = ["swc_ecma_utils"]
+__transforms = ["swc_ecma_transforms"]
+__utils = ["swc_ecma_utils"]
 
 [dependencies]
 # 3rd party dependencies
-once_cell   = { optional = true, version = "1.13.0" }
-wasmer      = { optional = true, version = "2.3.0", default-features = false }
-wasmer-wasi = { optional = true, version = "2.3.0", default-features = false }
+once_cell = {optional = true, version = "1.13.0"}
+wasmer = {optional = true, version = "2.3.0", default-features = false}
+wasmer-wasi = {optional = true, version = "2.3.0", default-features = false}
 
 # swc_* dependencies
-binding_macros              = { optional = true, version = "0.2.4", path = "../binding_macros" }
-swc                         = { optional = true, version = "0.214.9", path = "../swc" }
-swc_atoms                   = { optional = true, version = "0.4.8", path = "../swc_atoms" }
-swc_bundler                 = { optional = true, version = "0.177.4", path = "../swc_bundler" }
-swc_common                  = { optional = true, version = "0.27.11", path = "../swc_common" }
-swc_ecma_ast                = { optional = true, version = "0.90.10", path = "../swc_ecma_ast" }
-swc_ecma_loader             = { optional = true, version = "0.39.4", path = "../swc_ecma_loader" }
-swc_ecma_parser             = { optional = true, version = "0.117.5", path = "../swc_ecma_parser" }
-swc_ecma_quote_macros       = { optional = true, version = "0.28.5", path = "../swc_ecma_quote_macros" }
-swc_ecma_transforms         = { optional = true, version = "0.183.4", path = "../swc_ecma_transforms" }
-swc_ecma_transforms_testing = { optional = true, version = "0.105.5", path = "../swc_ecma_transforms_testing" }
-swc_ecma_utils              = { optional = true, version = "0.99.5", path = "../swc_ecma_utils" }
-swc_ecma_visit              = { optional = true, version = "0.76.6", path = "../swc_ecma_visit" }
-swc_node_base               = { optional = true, version = "0.5.5", path = "../swc_node_base" }
-swc_node_bundler            = { optional = true, version = "0.0.3", path = "../swc_node_bundler" }
-swc_nodejs_common           = { optional = true, version = "0.0.1", path = "../swc_nodejs_common" }
-swc_plugin                  = { optional = true, version = "0.89.1", path = "../swc_plugin" }
-swc_plugin_macro            = { optional = true, version = "0.9.7", path = "../swc_plugin_macro" }
-swc_plugin_proxy            = { optional = true, version = "0.18.13", path = "../swc_plugin_proxy" }
-swc_trace_macro             = { optional = true, version = "0.1.2", path = "../swc_trace_macro" }
+binding_macros = {optional = true, version = "0.2.4", path = "../binding_macros"}
+swc = {optional = true, version = "0.214.9", path = "../swc"}
+swc_atoms = {optional = true, version = "0.4.8", path = "../swc_atoms"}
+swc_bundler = {optional = true, version = "0.177.4", path = "../swc_bundler"}
+swc_common = {optional = true, version = "0.27.11", path = "../swc_common"}
+swc_ecma_ast = {optional = true, version = "0.90.10", path = "../swc_ecma_ast"}
+swc_ecma_loader = {optional = true, version = "0.39.4", path = "../swc_ecma_loader"}
+swc_ecma_parser = {optional = true, version = "0.117.5", path = "../swc_ecma_parser"}
+swc_ecma_quote_macros = {optional = true, version = "0.28.5", path = "../swc_ecma_quote_macros"}
+swc_ecma_transforms = {optional = true, version = "0.183.4", path = "../swc_ecma_transforms"}
+swc_ecma_transforms_testing = {optional = true, version = "0.105.5", path = "../swc_ecma_transforms_testing"}
+swc_ecma_utils = {optional = true, version = "0.99.5", path = "../swc_ecma_utils"}
+swc_ecma_visit = {optional = true, version = "0.76.6", path = "../swc_ecma_visit"}
+swc_node_base = {optional = true, version = "0.5.5", path = "../swc_node_base"}
+swc_node_bundler = {optional = true, version = "0.0.3", path = "../swc_node_bundler"}
+swc_nodejs_common = {optional = true, version = "0.0.1", path = "../swc_nodejs_common"}
+swc_plugin = {optional = true, version = "0.89.1", path = "../swc_plugin"}
+swc_plugin_macro = {optional = true, version = "0.9.7", path = "../swc_plugin_macro"}
+swc_plugin_proxy = {optional = true, version = "0.18.13", path = "../swc_plugin_proxy"}
+swc_trace_macro = {optional = true, version = "0.1.2", path = "../swc_trace_macro"}
 # TODO: eventually swc_plugin_runner needs to remove default features
-swc_plugin_runner = { optional = true, version = "0.71.15", path = "../swc_plugin_runner", default-features = false }
+swc_plugin_runner = {optional = true, version = "0.71.15", path = "../swc_plugin_runner", default-features = false}
 
 [dev-dependencies]
-testing = { version = "0.29.4", path = "../testing" }
+testing = {version = "0.29.4", path = "../testing"}


### PR DESCRIPTION
**Description:**

We can use multi-branch but I think it will really hurt rust-side users.
With multi-branch approach, we have to prevent some patches from being published to crates.io, but I think it's not acceptable for some rust-side users.

So I'm suggesting another approach. We can use a (potentially private) feature flag named `swc_v2` in js-surfacing crates like `swc` or `swc_node_bundler` to 'hide' some changes to node api.

This is clearly not additive, and that's why I think it should be a private feature.
As users are not expected to depend on `swc_v2`, enabling it from outside of SWC **may** break the whole dependency tree, but it's fine.

For PoC, I fixed #5527 only for v2.

I want to hear more about opinions about this approach


## Some constraints

 - rust users should not depends on `swc_v2`. This is not considered as a public api.

 - All code should be accessible witthout `swc_v2`. 
 
But altering behavior is fine.
Let's say, we want to `fix` #5535 in v2 and change the order of plugins to after `resolver` but before `decorator` or `typescript::strip`. In this case we can use `#[cfg(feature = "swc_v2")]` and `#[cfg(not(feature = "swc_v2")]` respectively.



**Related issue (if exists):**
