### PR TITLE
feat(dbg-swc): Improve minifier comparator

### DIFF
--- a/crates/dbg-swc/src/minify/ensure_size.rs
+++ b/crates/dbg-swc/src/minify/ensure_size.rs
@@ -66,18 +66,16 @@ impl EnsureSize {
             }
         }
 
+        let swc_total = results.iter().map(|f| f.swc.mangled_size).sum::<usize>();
+        let terser_total = results
+            .iter()
+            .flat_map(|f| f.terser.map(|v| v.mangled_size))
+            .sum::<usize>();
+
         println!("Total");
-        println!(
-            "  swc: {} bytes",
-            results.iter().map(|f| f.swc.mangled_size).sum::<usize>()
-        );
-        println!(
-            "  terser: {} bytes",
-            results
-                .iter()
-                .flat_map(|f| f.terser.map(|v| v.mangled_size))
-                .sum::<usize>()
-        );
+        println!("  swc: {} bytes", swc_total);
+
+        println!("  terser: {} bytes", terser_total);
 
         Ok(())
     }

--- a/crates/dbg-swc/src/minify/ensure_size.rs
+++ b/crates/dbg-swc/src/minify/ensure_size.rs
@@ -74,8 +74,25 @@ impl EnsureSize {
 
         println!("Total");
         println!("  swc: {} bytes", swc_total);
-
         println!("  terser: {} bytes", terser_total);
+        println!("Ratio: {}", swc_total as f64 / terser_total as f64);
+
+        let swc_smaller_file_count = results
+            .iter()
+            .filter(|f| {
+                if let Some(terser) = &f.terser {
+                    f.swc.mangled_size <= terser.mangled_size
+                } else {
+                    false
+                }
+            })
+            .count();
+        println!(
+            "swc produced smaller or equal output for {} files out of {} files, {:.2}%",
+            swc_smaller_file_count,
+            all_files.len(),
+            100.0 * swc_smaller_file_count as f64 / results.len() as f64
+        );
 
         Ok(())
     }

--- a/crates/dbg-swc/src/minify/ensure_size.rs
+++ b/crates/dbg-swc/src/minify/ensure_size.rs
@@ -45,10 +45,13 @@ impl EnsureSize {
         })?;
 
         for f in &results {
-            println!();
-            println!("{}", f.fm.name);
-
             if let Some(terser) = &f.terser {
+                if f.swc.mangled_size > terser.mangled_size
+                    || f.swc.no_mangle_size > terser.no_mangle_size
+                {
+                    println!();
+                    println!("{}", f.fm.name);
+                }
                 if f.swc.mangled_size > terser.mangled_size {
                     println!("  Mangled");
                     println!("    swc: {} bytes", f.swc.mangled_size);

--- a/crates/dbg-swc/src/minify/ensure_size.rs
+++ b/crates/dbg-swc/src/minify/ensure_size.rs
@@ -75,7 +75,7 @@ impl EnsureSize {
         println!("Total");
         println!("  swc: {} bytes", swc_total);
         println!("  terser: {} bytes", terser_total);
-        println!("Ratio: {}", swc_total as f64 / terser_total as f64);
+        println!("  Size ratio: {}", swc_total as f64 / terser_total as f64);
 
         let swc_smaller_file_count = results
             .iter()

--- a/crates/swc_ecma_minifier/tests/golden.txt
+++ b/crates/swc_ecma_minifier/tests/golden.txt
@@ -382,6 +382,7 @@ drop_unused/assign_binding/input.js
 drop_unused/assign_chain/input.js
 drop_unused/cascade_drop_assign/input.js
 drop_unused/const_assign/input.js
+drop_unused/defun_lambda_same_name/input.js
 drop_unused/double_assign_3/input.js
 drop_unused/drop_fnames/input.js
 drop_unused/drop_toplevel_all/input.js
@@ -395,6 +396,7 @@ drop_unused/issue_1715_2/input.js
 drop_unused/issue_2136_1/input.js
 drop_unused/issue_2226_1/input.js
 drop_unused/issue_2418_5/input.js
+drop_unused/issue_2660_1/input.js
 drop_unused/issue_2768/input.js
 drop_unused/issue_2995/input.js
 drop_unused/issue_3146_1/input.js
@@ -555,6 +557,7 @@ functions/issue_1841_2/input.js
 functions/issue_2097/input.js
 functions/issue_2101/input.js
 functions/issue_2531_2/input.js
+functions/issue_2630_3/input.js
 functions/issue_2647_1/input.js
 functions/issue_2647_2/input.js
 functions/issue_2647_3/input.js
@@ -568,6 +571,7 @@ functions/issue_485_crashing_1530/input.js
 functions/no_webkit/input.js
 functions/non_ascii_function_identifier_name/input.js
 functions/recursive_inline_1/input.js
+functions/recursive_inline_2/input.js
 functions/webkit/input.js
 global_defs/conditional_chains/input.js
 global_defs/expanded/input.js
@@ -816,6 +820,7 @@ issue_2652/unary_postfix/input.js
 issue_267/issue_267/input.js
 issue_269/issue_269_dangers/input.js
 issue_269/issue_269_in_scope/input.js
+issue_2719/warn/input.js
 issue_281/drop_fargs/input.js
 issue_281/inner_var_for_in_1/input.js
 issue_281/issue_1254_negate_iife_nested/input.js
@@ -1112,6 +1117,7 @@ reduce_vars/defun_assign/input.js
 reduce_vars/defun_call/input.js
 reduce_vars/defun_catch_4/input.js
 reduce_vars/defun_catch_5/input.js
+reduce_vars/defun_inline_2/input.js
 reduce_vars/defun_inline_3/input.js
 reduce_vars/defun_single_use_loop/input.js
 reduce_vars/defun_var_3/input.js

--- a/crates/swc_ecma_minifier/tests/postponed.txt
+++ b/crates/swc_ecma_minifier/tests/postponed.txt
@@ -126,7 +126,6 @@ destructuring/mangle_destructuring_decl_collapse_vars/input.js
 destructuring/unused_destructuring_arrow_param/input.js
 destructuring/unused_destructuring_getter_side_effect_2/input.js
 drop_unused/chained_3/input.js
-drop_unused/defun_lambda_same_name/input.js
 drop_unused/delete_assign_1/input.js
 drop_unused/delete_assign_2/input.js
 drop_unused/double_assign_1/input.js
@@ -168,7 +167,6 @@ drop_unused/issue_2418_3/input.js
 drop_unused/issue_2418_4/input.js
 drop_unused/issue_2516_1/input.js
 drop_unused/issue_2516_2/input.js
-drop_unused/issue_2660_1/input.js
 drop_unused/issue_2660_2/input.js
 drop_unused/issue_2665/input.js
 drop_unused/issue_2846/input.js
@@ -245,7 +243,6 @@ functions/issue_2620_3/input.js
 functions/issue_2620_4/input.js
 functions/issue_2630_1/input.js
 functions/issue_2630_2/input.js
-functions/issue_2630_3/input.js
 functions/issue_2630_4/input.js
 functions/issue_2630_5/input.js
 functions/issue_2657/input.js
@@ -264,7 +261,6 @@ functions/issue_3166/input.js
 functions/issue_t131a/input.js
 functions/issue_t131b/input.js
 functions/loop_init_arg/input.js
-functions/recursive_inline_2/input.js
 functions/unsafe_apply_1/input.js
 functions/unsafe_apply_2/input.js
 functions/unsafe_apply_expansion_1/input.js
@@ -401,7 +397,6 @@ issue_22/return_with_no_value_in_if_body/input.js
 issue_269/issue_269_1/input.js
 issue_269/regexp/input.js
 issue_269/strings_concat/input.js
-issue_2719/warn/input.js
 issue_281/collapse_vars_constants/input.js
 issue_281/issue_1758/input.js
 issue_2871/comparison_with_undefined/input.js
@@ -563,7 +558,6 @@ reduce_vars/defun_catch_2/input.js
 reduce_vars/defun_catch_3/input.js
 reduce_vars/defun_catch_6/input.js
 reduce_vars/defun_inline_1/input.js
-reduce_vars/defun_inline_2/input.js
 reduce_vars/defun_label/input.js
 reduce_vars/defun_redefine/input.js
 reduce_vars/defun_reference/input.js


### PR DESCRIPTION
**Description:**

```
Total
  swc: 32898142 bytes
  terser: 32956139 bytes
  Size ratio: 0.998240176132283
swc produced smaller or equal output for 897 files out of 999 files, 89.79%
```



**Related issue (if exists):**
