### PR TITLE
feat(css/parser): make `keyword` optional

### DIFF
--- a/crates/swc_css_ast/src/at_rule.rs
+++ b/crates/swc_css_ast/src/at_rule.rs
@@ -183,13 +183,21 @@ pub struct MediaQueryList {
 }
 
 #[ast_node("MediaQuery")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, Hash)]
 pub struct MediaQuery {
     pub span: Span,
     pub modifier: Option<Ident>,
     pub media_type: Option<Ident>,
     pub keyword: Option<Ident>,
     pub condition: Option<MediaConditionType>,
+}
+
+impl EqIgnoreSpan for MediaQuery {
+    fn eq_ignore_span(&self, other: &Self) -> bool {
+        self.modifier.eq_ignore_span(&other.modifier)
+            && self.media_type.eq_ignore_span(&other.media_type)
+            && self.condition.eq_ignore_span(&other.condition)
+    }
 }
 
 #[ast_node]
@@ -246,27 +254,45 @@ pub enum MediaConditionWithoutOrType {
 }
 
 #[ast_node("MediaNot")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, Hash)]
 pub struct MediaNot {
     pub span: Span,
-    pub keyword: Ident,
+    pub keyword: Option<Ident>,
     pub condition: MediaInParens,
+}
+
+impl EqIgnoreSpan for MediaNot {
+    fn eq_ignore_span(&self, other: &Self) -> bool {
+        self.condition.eq_ignore_span(&other.condition)
+    }
 }
 
 #[ast_node("MediaAnd")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, Hash)]
 pub struct MediaAnd {
     pub span: Span,
-    pub keyword: Ident,
+    pub keyword: Option<Ident>,
     pub condition: MediaInParens,
 }
 
+impl EqIgnoreSpan for MediaAnd {
+    fn eq_ignore_span(&self, other: &Self) -> bool {
+        self.condition.eq_ignore_span(&other.condition)
+    }
+}
+
 #[ast_node("MediaOr")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, Hash)]
 pub struct MediaOr {
     pub span: Span,
-    pub keyword: Ident,
+    pub keyword: Option<Ident>,
     pub condition: MediaInParens,
+}
+
+impl EqIgnoreSpan for MediaOr {
+    fn eq_ignore_span(&self, other: &Self) -> bool {
+        self.condition.eq_ignore_span(&other.condition)
+    }
 }
 
 #[ast_node]
@@ -410,27 +436,45 @@ pub enum SupportsConditionType {
 }
 
 #[ast_node("SupportsNot")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, Hash)]
 pub struct SupportsNot {
     pub span: Span,
-    pub keyword: Ident,
+    pub keyword: Option<Ident>,
     pub condition: SupportsInParens,
+}
+
+impl EqIgnoreSpan for SupportsNot {
+    fn eq_ignore_span(&self, other: &Self) -> bool {
+        self.condition.eq_ignore_span(&other.condition)
+    }
 }
 
 #[ast_node("SupportsAnd")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, Hash)]
 pub struct SupportsAnd {
     pub span: Span,
-    pub keyword: Ident,
+    pub keyword: Option<Ident>,
     pub condition: SupportsInParens,
 }
 
+impl EqIgnoreSpan for SupportsAnd {
+    fn eq_ignore_span(&self, other: &Self) -> bool {
+        self.condition.eq_ignore_span(&other.condition)
+    }
+}
+
 #[ast_node("SupportsOr")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, Hash)]
 pub struct SupportsOr {
     pub span: Span,
-    pub keyword: Ident,
+    pub keyword: Option<Ident>,
     pub condition: SupportsInParens,
+}
+
+impl EqIgnoreSpan for SupportsOr {
+    fn eq_ignore_span(&self, other: &Self) -> bool {
+        self.condition.eq_ignore_span(&other.condition)
+    }
 }
 
 #[ast_node]

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -450,9 +450,6 @@ where
 
     #[emitter]
     fn emit_media_not(&mut self, n: &MediaNot) -> Result {
-        emit!(self, n.keyword);
-        formatting_space!(self);
-
         if n.keyword.is_some() {
             emit!(self, n.keyword);
         } else {
@@ -465,9 +462,6 @@ where
 
     #[emitter]
     fn emit_media_and(&mut self, n: &MediaAnd) -> Result {
-        emit!(self, n.keyword);
-        formatting_space!(self);
-
         if n.keyword.is_some() {
             emit!(self, n.keyword);
         } else {
@@ -480,9 +474,6 @@ where
 
     #[emitter]
     fn emit_media_or(&mut self, n: &MediaOr) -> Result {
-        emit!(self, n.keyword);
-        formatting_space!(self);
-
         if n.keyword.is_some() {
             emit!(self, n.keyword);
         } else {

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -381,7 +381,13 @@ where
 
             if n.condition.is_some() {
                 space!(self);
-                emit!(self, n.keyword);
+
+                if n.keyword.is_some() {
+                    emit!(self, n.keyword);
+                } else {
+                    write_raw!(self, "and");
+                }
+
                 space!(self);
             }
         }
@@ -445,6 +451,14 @@ where
     #[emitter]
     fn emit_media_not(&mut self, n: &MediaNot) -> Result {
         emit!(self, n.keyword);
+        formatting_space!(self);
+
+        if n.keyword.is_some() {
+            emit!(self, n.keyword);
+        } else {
+            write_raw!(self, "not");
+        }
+
         space!(self);
         emit!(self, n.condition);
     }
@@ -452,6 +466,14 @@ where
     #[emitter]
     fn emit_media_and(&mut self, n: &MediaAnd) -> Result {
         emit!(self, n.keyword);
+        formatting_space!(self);
+
+        if n.keyword.is_some() {
+            emit!(self, n.keyword);
+        } else {
+            write_raw!(self, "and");
+        }
+
         space!(self);
         emit!(self, n.condition);
     }
@@ -459,6 +481,14 @@ where
     #[emitter]
     fn emit_media_or(&mut self, n: &MediaOr) -> Result {
         emit!(self, n.keyword);
+        formatting_space!(self);
+
+        if n.keyword.is_some() {
+            emit!(self, n.keyword);
+        } else {
+            write_raw!(self, "or");
+        }
+
         space!(self);
         emit!(self, n.condition);
     }
@@ -572,21 +602,36 @@ where
 
     #[emitter]
     fn emit_supports_not(&mut self, n: &SupportsNot) -> Result {
-        emit!(self, n.keyword);
+        if n.keyword.is_some() {
+            emit!(self, n.keyword);
+        } else {
+            write_raw!(self, "not");
+        }
+
         space!(self);
         emit!(self, n.condition);
     }
 
     #[emitter]
     fn emit_supports_and(&mut self, n: &SupportsAnd) -> Result {
-        emit!(self, n.keyword);
+        if n.keyword.is_some() {
+            emit!(self, n.keyword);
+        } else {
+            write_raw!(self, "and");
+        }
+
         space!(self);
         emit!(self, n.condition);
     }
 
     #[emitter]
     fn emit_support_or(&mut self, n: &SupportsOr) -> Result {
-        emit!(self, n.keyword);
+        if n.keyword.is_some() {
+            emit!(self, n.keyword);
+        } else {
+            write_raw!(self, "or");
+        }
+
         space!(self);
         emit!(self, n.condition);
     }

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -931,7 +931,7 @@ where
         let span = self.input.cur_span()?;
         let keyword = match cur!(self) {
             Token::Ident { value, .. } if value.as_ref().eq_ignore_ascii_case("not") => {
-                self.parse()?
+                Some(self.parse()?)
             }
             _ => {
                 return Err(Error::new(
@@ -961,7 +961,7 @@ where
         let span = self.input.cur_span()?;
         let keyword = match cur!(self) {
             Token::Ident { value, .. } if value.as_ref().eq_ignore_ascii_case("and") => {
-                self.parse()?
+                Some(self.parse()?)
             }
             _ => {
                 return Err(Error::new(
@@ -991,7 +991,7 @@ where
         let span = self.input.cur_span()?;
         let keyword = match cur!(self) {
             Token::Ident { value, .. } if value.as_ref().eq_ignore_ascii_case("or") => {
-                self.parse()?
+                Some(self.parse()?)
             }
             _ => {
                 return Err(Error::new(
@@ -1390,7 +1390,7 @@ where
         let span = self.input.cur_span()?;
         let keyword = match cur!(self) {
             Token::Ident { value, .. } if value.as_ref().eq_ignore_ascii_case("not") => {
-                self.parse()?
+                Some(self.parse()?)
             }
             _ => {
                 return Err(Error::new(
@@ -1420,7 +1420,7 @@ where
         let span = self.input.cur_span()?;
         let keyword = match cur!(self) {
             Token::Ident { value, .. } if value.as_ref().eq_ignore_ascii_case("and") => {
-                self.parse()?
+                Some(self.parse()?)
             }
             _ => {
                 return Err(Error::new(
@@ -1450,7 +1450,7 @@ where
         let span = self.input.cur_span()?;
         let keyword = match cur!(self) {
             Token::Ident { value, .. } if value.as_ref().eq_ignore_ascii_case("or") => {
-                self.parse()?
+                Some(self.parse()?)
             }
             _ => {
                 return Err(Error::new(

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -3,7 +3,6 @@ use std::mem::take;
 
 use once_cell::sync::Lazy;
 use preset_env_base::{query::targets_to_versions, version::Version, BrowserData, Versions};
-use swc_atoms::js_word;
 use swc_common::{
     collections::{AHashMap, AHashSet},
     EqIgnoreSpan, DUMMY_SP,
@@ -712,11 +711,7 @@ impl VisitMut for Prefixer {
                 for n in take(&mut self.added_declarations) {
                     let supports_condition_type = SupportsConditionType::Or(SupportsOr {
                         span: DUMMY_SP,
-                        keyword: Ident {
-                            span: DUMMY_SP,
-                            value: js_word!("or"),
-                            raw: None,
-                        },
+                        keyword: None,
                         condition: SupportsInParens::Feature(SupportsFeature::Declaration(n)),
                     });
 
@@ -755,11 +750,7 @@ impl VisitMut for Prefixer {
                     for n in take(&mut self.added_declarations) {
                         let supports_condition_type = SupportsConditionType::Or(SupportsOr {
                             span: DUMMY_SP,
-                            keyword: Ident {
-                                span: DUMMY_SP,
-                                value: js_word!("or"),
-                                raw: None,
-                            },
+                            keyword: None,
                             condition: SupportsInParens::Feature(SupportsFeature::Declaration(n)),
                         });
 

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -670,19 +670,19 @@ define!({
 
     pub struct MediaNot {
         pub span: Span,
-        pub keyword: Ident,
+        pub keyword: Option<Ident>,
         pub condition: MediaInParens,
     }
 
     pub struct MediaAnd {
         pub span: Span,
-        pub keyword: Ident,
+        pub keyword: Option<Ident>,
         pub condition: MediaInParens,
     }
 
     pub struct MediaOr {
         pub span: Span,
-        pub keyword: Ident,
+        pub keyword: Option<Ident>,
         pub condition: MediaInParens,
     }
 
@@ -771,19 +771,19 @@ define!({
 
     pub struct SupportsNot {
         pub span: Span,
-        pub keyword: Ident,
+        pub keyword: Option<Ident>,
         pub condition: SupportsInParens,
     }
 
     pub struct SupportsAnd {
         pub span: Span,
-        pub keyword: Ident,
+        pub keyword: Option<Ident>,
         pub condition: SupportsInParens,
     }
 
     pub struct SupportsOr {
         pub span: Span,
-        pub keyword: Ident,
+        pub keyword: Option<Ident>,
         pub condition: SupportsInParens,
     }
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

`keyword` is like `raw` required only for linter, but we don't need to spend time on it in transformations

**BREAKING CHANGE:**

Yes

**Related issue (if exists):**

No