### PR TITLE
fix(es/compat): Destructuring assignments and updates of super prop

### DIFF
--- a/crates/swc/tests/tsc-references/errorSuperPropertyAccess_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/errorSuperPropertyAccess_es5.1.normal.js
@@ -144,22 +144,22 @@ var SomeDerived3 = /*#__PURE__*/ function(SomeBase) {
         return _super.apply(this, arguments);
     }
     SomeDerived3.fn = function fn() {
-        _set(_get_prototype_of(SomeDerived3.prototype), "publicStaticMember", 3, this, true);
-        _set(_get_prototype_of(SomeDerived3.prototype), "privateStaticMember", 3, this, true);
+        _set(_get_prototype_of(SomeDerived3), "publicStaticMember", 3, this, true);
+        _set(_get_prototype_of(SomeDerived3), "privateStaticMember", 3, this, true);
         _get(_get_prototype_of(SomeDerived3), "privateStaticFunc", this).call(this);
     };
     _create_class(SomeDerived3, null, [
         {
             key: "a",
             get: function get() {
-                _set(_get_prototype_of(SomeDerived3.prototype), "publicStaticMember", 3, this, true);
-                _set(_get_prototype_of(SomeDerived3.prototype), "privateStaticMember", 3, this, true);
+                _set(_get_prototype_of(SomeDerived3), "publicStaticMember", 3, this, true);
+                _set(_get_prototype_of(SomeDerived3), "privateStaticMember", 3, this, true);
                 _get(_get_prototype_of(SomeDerived3), "privateStaticFunc", this).call(this);
                 return "";
             },
             set: function set(n) {
-                _set(_get_prototype_of(SomeDerived3.prototype), "publicStaticMember", 3, this, true);
-                _set(_get_prototype_of(SomeDerived3.prototype), "privateStaticMember", 3, this, true);
+                _set(_get_prototype_of(SomeDerived3), "publicStaticMember", 3, this, true);
+                _set(_get_prototype_of(SomeDerived3), "privateStaticMember", 3, this, true);
                 _get(_get_prototype_of(SomeDerived3), "privateStaticFunc", this).call(this);
             }
         }

--- a/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers1_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers1_es2015.1.normal.js
@@ -5,7 +5,7 @@ import _extends from "@swc/helpers/src/_extends.mjs";
 import _get from "@swc/helpers/src/_get.mjs";
 import _get_prototype_of from "@swc/helpers/src/_get_prototype_of.mjs";
 import _set from "@swc/helpers/src/_set.mjs";
-var _ref, _super_a;
+import _update from "@swc/helpers/src/_update.mjs";
 class C extends B {
     constructor(...args){
         super(...args);
@@ -25,32 +25,32 @@ C.z1 = _get(_get_prototype_of(C), "a", C);
 C.z2 = _get(_get_prototype_of(C), "a", C);
 C.z3 = _get(_get_prototype_of(C), "f", C).call(C);
 C.z4 = _get(_get_prototype_of(C), "f", C).call(C);
-C.z5 = _set(_get_prototype_of(C.prototype), "a", 0, C, true);
-C.z6 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, true);
+C.z5 = _set(_get_prototype_of(C), "a", 0, C, true);
+C.z6 = _update(_get_prototype_of(C), "a", C, true)._ += 1;
 C.z7 = (()=>{
-    _set(_get_prototype_of(C.prototype), "a", 0, C, true);
+    _set(_get_prototype_of(C), "a", 0, C, true);
 })();
-C.z8 = [_get(_get_prototype_of(C), "a", C)] = [
+C.z8 = [_update(_get_prototype_of(C), "a", C, true)._] = [
     0
 ];
-C.z9 = [_get(_get_prototype_of(C), "a", C) = 0] = [
+C.z9 = [_update(_get_prototype_of(C), "a", C, true)._ = 0] = [
     0
 ];
-C.z10 = [..._get(_get_prototype_of(C), "a", C)] = [
+C.z10 = [..._update(_get_prototype_of(C), "a", C, true)._] = [
     0
 ];
-C.z11 = { x: _get(_get_prototype_of(C), "a", C)  } = {
+C.z11 = { x: _update(_get_prototype_of(C), "a", C, true)._  } = {
     x: 0
 };
-C.z12 = { x: _get(_get_prototype_of(C), "a", C) = 0  } = {
+C.z12 = { x: _update(_get_prototype_of(C), "a", C, true)._ = 0  } = {
     x: 0
 };
 var _tmp;
 C.z13 = (_tmp = {
     x: 0
-}, _get(_get_prototype_of(C), "a", C) = _extends({}, _tmp), _tmp);
-C.z14 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, true);
-C.z15 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) - 1, C, true);
-C.z16 = _set(_get_prototype_of(C.prototype), _ref = "a", _get(_get_prototype_of(C), _ref, C) + 1, C, true);
-C.z17 = (_set(_get_prototype_of(C.prototype), "a", (_super_a = +_get(_get_prototype_of(C), "a", C)) + 1, C, true), _super_a);
+}, _update(_get_prototype_of(C), "a", C, true)._ = _extends({}, _tmp), _tmp);
+C.z14 = ++_update(_get_prototype_of(C), "a", C, true)._;
+C.z15 = --_update(_get_prototype_of(C), "a", C, true)._;
+C.z16 = ++_update(_get_prototype_of(C), "a", C, true)._;
+C.z17 = _update(_get_prototype_of(C), "a", C, true)._++;
 C.z18 = _get(_get_prototype_of(C), "a", C)``;

--- a/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers1_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers1_es2015.2.minified.js
@@ -1,23 +1,24 @@
-var _ref, _super_a, _tmp;
+var _tmp;
 import _extends from "@swc/helpers/src/_extends.mjs";
 import _get from "@swc/helpers/src/_get.mjs";
 import _get_prototype_of from "@swc/helpers/src/_get_prototype_of.mjs";
 import _set from "@swc/helpers/src/_set.mjs";
+import _update from "@swc/helpers/src/_update.mjs";
 class C extends B {
     constructor(...args){
         super(...args), this.x = 1, this.y = this.x, this.z = super.f();
     }
 }
-C.x = void 0, C.y1 = C.x, C.y2 = C.x(), C.y3 = null == C ? void 0 : C.x(), C.y4 = C.x(), C.y5 = null == C ? void 0 : C.x(), C.z1 = _get(_get_prototype_of(C), "a", C), C.z2 = _get(_get_prototype_of(C), "a", C), C.z3 = _get(_get_prototype_of(C), "f", C).call(C), C.z4 = _get(_get_prototype_of(C), "f", C).call(C), C.z5 = _set(_get_prototype_of(C.prototype), "a", 0, C, !0), C.z6 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, !0), C.z7 = void _set(_get_prototype_of(C.prototype), "a", 0, C, !0), C.z8 = [_get(_get_prototype_of(C), "a", C)] = [
+C.x = void 0, C.y1 = C.x, C.y2 = C.x(), C.y3 = null == C ? void 0 : C.x(), C.y4 = C.x(), C.y5 = null == C ? void 0 : C.x(), C.z1 = _get(_get_prototype_of(C), "a", C), C.z2 = _get(_get_prototype_of(C), "a", C), C.z3 = _get(_get_prototype_of(C), "f", C).call(C), C.z4 = _get(_get_prototype_of(C), "f", C).call(C), C.z5 = _set(_get_prototype_of(C), "a", 0, C, !0), C.z6 = _update(_get_prototype_of(C), "a", C, !0)._ += 1, C.z7 = void _set(_get_prototype_of(C), "a", 0, C, !0), C.z8 = [_update(_get_prototype_of(C), "a", C, !0)._] = [
     0
-], C.z9 = [_get(_get_prototype_of(C), "a", C) = 0] = [
+], C.z9 = [_update(_get_prototype_of(C), "a", C, !0)._ = 0] = [
     0
-], C.z10 = [..._get(_get_prototype_of(C), "a", C)] = [
+], C.z10 = [..._update(_get_prototype_of(C), "a", C, !0)._] = [
     0
-], C.z11 = { x: _get(_get_prototype_of(C), "a", C)  } = {
+], C.z11 = { x: _update(_get_prototype_of(C), "a", C, !0)._  } = {
     x: 0
-}, C.z12 = { x: _get(_get_prototype_of(C), "a", C) = 0  } = {
+}, C.z12 = { x: _update(_get_prototype_of(C), "a", C, !0)._ = 0  } = {
     x: 0
 }, C.z13 = (_tmp = {
     x: 0
-}, _get(_get_prototype_of(C), "a", C) = _extends({}, _tmp), _tmp), C.z14 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, !0), C.z15 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) - 1, C, !0), C.z16 = _set(_get_prototype_of(C.prototype), _ref = "a", _get(_get_prototype_of(C), _ref, C) + 1, C, !0), C.z17 = (_set(_get_prototype_of(C.prototype), "a", (_super_a = +_get(_get_prototype_of(C), "a", C)) + 1, C, !0), _super_a), C.z18 = _get(_get_prototype_of(C), "a", C)``;
+}, _update(_get_prototype_of(C), "a", C, !0)._ = _extends({}, _tmp), _tmp), C.z14 = ++_update(_get_prototype_of(C), "a", C, !0)._, C.z15 = --_update(_get_prototype_of(C), "a", C, !0)._, C.z16 = ++_update(_get_prototype_of(C), "a", C, !0)._, C.z17 = _update(_get_prototype_of(C), "a", C, !0)._++, C.z18 = _get(_get_prototype_of(C), "a", C)``;

--- a/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers1_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers1_es5.1.normal.js
@@ -9,6 +9,7 @@ import _get_prototype_of from "@swc/helpers/src/_get_prototype_of.mjs";
 import _inherits from "@swc/helpers/src/_inherits.mjs";
 import _set from "@swc/helpers/src/_set.mjs";
 import _tagged_template_literal from "@swc/helpers/src/_tagged_template_literal.mjs";
+import _update from "@swc/helpers/src/_update.mjs";
 import _create_super from "@swc/helpers/src/_create_super.mjs";
 function _templateObject() {
     var data = _tagged_template_literal([
@@ -19,7 +20,6 @@ function _templateObject() {
     };
     return data;
 }
-var _ref, _super_a;
 var C = /*#__PURE__*/ function(B1) {
     "use strict";
     _inherits(C, B1);
@@ -46,37 +46,37 @@ C.z1 = _get(_get_prototype_of(C), "a", C);
 C.z2 = _get(_get_prototype_of(C), "a", C);
 C.z3 = _get(_get_prototype_of(C), "f", C).call(C);
 C.z4 = _get(_get_prototype_of(C), "f", C).call(C);
-C.z5 = _set(_get_prototype_of(C.prototype), "a", 0, C, true);
-C.z6 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, true);
+C.z5 = _set(_get_prototype_of(C), "a", 0, C, true);
+C.z6 = _update(_get_prototype_of(C), "a", C, true)._ += 1;
 C.z7 = function() {
-    _set(_get_prototype_of(C.prototype), "a", 0, C, true);
+    _set(_get_prototype_of(C), "a", 0, C, true);
 }();
 var ref;
 C.z8 = (ref = [
     0
-], _get(_get_prototype_of(C), "a", C) = ref[0], ref);
+], _update(_get_prototype_of(C), "a", C, true)._ = ref[0], ref);
 var ref1, ref2;
 C.z9 = (ref1 = [
     0
-], ref2 = ref1[0], _get(_get_prototype_of(C), "a", C) = ref2 === void 0 ? 0 : ref2, ref1);
+], ref2 = ref1[0], _update(_get_prototype_of(C), "a", C, true)._ = ref2 === void 0 ? 0 : ref2, ref1);
 var ref3;
 C.z10 = (ref3 = [
     0
-], _get(_get_prototype_of(C), "a", C) = ref3.slice(0), ref3);
+], _update(_get_prototype_of(C), "a", C, true)._ = ref3.slice(0), ref3);
 var ref4;
 C.z11 = (ref4 = {
     x: 0
-}, _get(_get_prototype_of(C), "a", C) = ref4.x, ref4);
+}, _update(_get_prototype_of(C), "a", C, true)._ = ref4.x, ref4);
 var ref5, ref6;
 C.z12 = (ref5 = {
     x: 0
-}, ref6 = ref5.x, _get(_get_prototype_of(C), "a", C) = ref6 === void 0 ? 0 : ref6, ref5);
+}, ref6 = ref5.x, _update(_get_prototype_of(C), "a", C, true)._ = ref6 === void 0 ? 0 : ref6, ref5);
 var _tmp;
 C.z13 = (_tmp = {
     x: 0
-}, _get(_get_prototype_of(C), "a", C) = _extends({}, _tmp), _tmp);
-C.z14 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, true);
-C.z15 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) - 1, C, true);
-C.z16 = _set(_get_prototype_of(C.prototype), _ref = "a", _get(_get_prototype_of(C), _ref, C) + 1, C, true);
-C.z17 = (_set(_get_prototype_of(C.prototype), "a", (_super_a = +_get(_get_prototype_of(C), "a", C)) + 1, C, true), _super_a);
+}, _update(_get_prototype_of(C), "a", C, true)._ = _extends({}, _tmp), _tmp);
+C.z14 = ++_update(_get_prototype_of(C), "a", C, true)._;
+C.z15 = --_update(_get_prototype_of(C), "a", C, true)._;
+C.z16 = ++_update(_get_prototype_of(C), "a", C, true)._;
+C.z17 = _update(_get_prototype_of(C), "a", C, true)._++;
 C.z18 = _get(_get_prototype_of(C), "a", C)(_templateObject());

--- a/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers1_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers1_es5.2.minified.js
@@ -6,6 +6,7 @@ import _get_prototype_of from "@swc/helpers/src/_get_prototype_of.mjs";
 import _inherits from "@swc/helpers/src/_inherits.mjs";
 import _set from "@swc/helpers/src/_set.mjs";
 import _tagged_template_literal from "@swc/helpers/src/_tagged_template_literal.mjs";
+import _update from "@swc/helpers/src/_update.mjs";
 import _create_super from "@swc/helpers/src/_create_super.mjs";
 function _templateObject() {
     var data = _tagged_template_literal([
@@ -15,7 +16,7 @@ function _templateObject() {
         return data;
     }, data;
 }
-var _ref, _super_a, ref, ref1, ref2, ref3, ref4, ref5, ref6, _tmp, C = function(B1) {
+var ref, ref1, ref2, ref3, ref4, ref5, ref6, _tmp, C = function(B1) {
     "use strict";
     _inherits(C, B1);
     var _super = _create_super(C);
@@ -25,16 +26,16 @@ var _ref, _super_a, ref, ref1, ref2, ref3, ref4, ref5, ref6, _tmp, C = function(
     }
     return C;
 }(B);
-C.x = void 0, C.y1 = C.x, C.y2 = C.x(), C.y3 = null == C ? void 0 : C.x(), C.y4 = C.x(), C.y5 = null == C ? void 0 : C.x(), C.z1 = _get(_get_prototype_of(C), "a", C), C.z2 = _get(_get_prototype_of(C), "a", C), C.z3 = _get(_get_prototype_of(C), "f", C).call(C), C.z4 = _get(_get_prototype_of(C), "f", C).call(C), C.z5 = _set(_get_prototype_of(C.prototype), "a", 0, C, !0), C.z6 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, !0), C.z7 = void _set(_get_prototype_of(C.prototype), "a", 0, C, !0), C.z8 = (ref = [
+C.x = void 0, C.y1 = C.x, C.y2 = C.x(), C.y3 = null == C ? void 0 : C.x(), C.y4 = C.x(), C.y5 = null == C ? void 0 : C.x(), C.z1 = _get(_get_prototype_of(C), "a", C), C.z2 = _get(_get_prototype_of(C), "a", C), C.z3 = _get(_get_prototype_of(C), "f", C).call(C), C.z4 = _get(_get_prototype_of(C), "f", C).call(C), C.z5 = _set(_get_prototype_of(C), "a", 0, C, !0), C.z6 = _update(_get_prototype_of(C), "a", C, !0)._ += 1, C.z7 = void _set(_get_prototype_of(C), "a", 0, C, !0), C.z8 = (ref = [
     0
-], _get(_get_prototype_of(C), "a", C) = ref[0], ref), C.z9 = (ref2 = (ref1 = [
+], _update(_get_prototype_of(C), "a", C, !0)._ = ref[0], ref), C.z9 = (ref2 = (ref1 = [
     0
-])[0], _get(_get_prototype_of(C), "a", C) = void 0 === ref2 ? 0 : ref2, ref1), C.z10 = (ref3 = [
+])[0], _update(_get_prototype_of(C), "a", C, !0)._ = void 0 === ref2 ? 0 : ref2, ref1), C.z10 = (ref3 = [
     0
-], _get(_get_prototype_of(C), "a", C) = ref3.slice(0), ref3), C.z11 = (ref4 = {
+], _update(_get_prototype_of(C), "a", C, !0)._ = ref3.slice(0), ref3), C.z11 = (ref4 = {
     x: 0
-}, _get(_get_prototype_of(C), "a", C) = ref4.x, ref4), C.z12 = (ref6 = (ref5 = {
+}, _update(_get_prototype_of(C), "a", C, !0)._ = ref4.x, ref4), C.z12 = (ref6 = (ref5 = {
     x: 0
-}).x, _get(_get_prototype_of(C), "a", C) = void 0 === ref6 ? 0 : ref6, ref5), C.z13 = (_tmp = {
+}).x, _update(_get_prototype_of(C), "a", C, !0)._ = void 0 === ref6 ? 0 : ref6, ref5), C.z13 = (_tmp = {
     x: 0
-}, _get(_get_prototype_of(C), "a", C) = _extends({}, _tmp), _tmp), C.z14 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, !0), C.z15 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) - 1, C, !0), C.z16 = _set(_get_prototype_of(C.prototype), _ref = "a", _get(_get_prototype_of(C), _ref, C) + 1, C, !0), C.z17 = (_set(_get_prototype_of(C.prototype), "a", (_super_a = +_get(_get_prototype_of(C), "a", C)) + 1, C, !0), _super_a), C.z18 = _get(_get_prototype_of(C), "a", C)(_templateObject());
+}, _update(_get_prototype_of(C), "a", C, !0)._ = _extends({}, _tmp), _tmp), C.z14 = ++_update(_get_prototype_of(C), "a", C, !0)._, C.z15 = --_update(_get_prototype_of(C), "a", C, !0)._, C.z16 = ++_update(_get_prototype_of(C), "a", C, !0)._, C.z17 = _update(_get_prototype_of(C), "a", C, !0)._++, C.z18 = _get(_get_prototype_of(C), "a", C)(_templateObject());

--- a/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers2_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers2_es2015.1.normal.js
@@ -5,7 +5,7 @@ import _extends from "@swc/helpers/src/_extends.mjs";
 import _get from "@swc/helpers/src/_get.mjs";
 import _get_prototype_of from "@swc/helpers/src/_get_prototype_of.mjs";
 import _set from "@swc/helpers/src/_set.mjs";
-var _ref, _super_a;
+import _update from "@swc/helpers/src/_update.mjs";
 class C extends B {
     constructor(...args){
         super(...args);
@@ -25,32 +25,32 @@ C.z1 = _get(_get_prototype_of(C), "a", C);
 C.z2 = _get(_get_prototype_of(C), "a", C);
 C.z3 = _get(_get_prototype_of(C), "f", C).call(C);
 C.z4 = _get(_get_prototype_of(C), "f", C).call(C);
-C.z5 = _set(_get_prototype_of(C.prototype), "a", 0, C, true);
-C.z6 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, true);
+C.z5 = _set(_get_prototype_of(C), "a", 0, C, true);
+C.z6 = _update(_get_prototype_of(C), "a", C, true)._ += 1;
 C.z7 = (()=>{
-    _set(_get_prototype_of(C.prototype), "a", 0, C, true);
+    _set(_get_prototype_of(C), "a", 0, C, true);
 })();
-C.z8 = [_get(_get_prototype_of(C), "a", C)] = [
+C.z8 = [_update(_get_prototype_of(C), "a", C, true)._] = [
     0
 ];
-C.z9 = [_get(_get_prototype_of(C), "a", C) = 0] = [
+C.z9 = [_update(_get_prototype_of(C), "a", C, true)._ = 0] = [
     0
 ];
-C.z10 = [..._get(_get_prototype_of(C), "a", C)] = [
+C.z10 = [..._update(_get_prototype_of(C), "a", C, true)._] = [
     0
 ];
-C.z11 = { x: _get(_get_prototype_of(C), "a", C)  } = {
+C.z11 = { x: _update(_get_prototype_of(C), "a", C, true)._  } = {
     x: 0
 };
-C.z12 = { x: _get(_get_prototype_of(C), "a", C) = 0  } = {
+C.z12 = { x: _update(_get_prototype_of(C), "a", C, true)._ = 0  } = {
     x: 0
 };
 var _tmp;
 C.z13 = (_tmp = {
     x: 0
-}, _get(_get_prototype_of(C), "a", C) = _extends({}, _tmp), _tmp);
-C.z14 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, true);
-C.z15 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) - 1, C, true);
-C.z16 = _set(_get_prototype_of(C.prototype), _ref = "a", _get(_get_prototype_of(C), _ref, C) + 1, C, true);
-C.z17 = (_set(_get_prototype_of(C.prototype), "a", (_super_a = +_get(_get_prototype_of(C), "a", C)) + 1, C, true), _super_a);
+}, _update(_get_prototype_of(C), "a", C, true)._ = _extends({}, _tmp), _tmp);
+C.z14 = ++_update(_get_prototype_of(C), "a", C, true)._;
+C.z15 = --_update(_get_prototype_of(C), "a", C, true)._;
+C.z16 = ++_update(_get_prototype_of(C), "a", C, true)._;
+C.z17 = _update(_get_prototype_of(C), "a", C, true)._++;
 C.z18 = _get(_get_prototype_of(C), "a", C)``;

--- a/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers2_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers2_es2015.2.minified.js
@@ -1,23 +1,24 @@
-var _ref, _super_a, _tmp;
+var _tmp;
 import _extends from "@swc/helpers/src/_extends.mjs";
 import _get from "@swc/helpers/src/_get.mjs";
 import _get_prototype_of from "@swc/helpers/src/_get_prototype_of.mjs";
 import _set from "@swc/helpers/src/_set.mjs";
+import _update from "@swc/helpers/src/_update.mjs";
 class C extends B {
     constructor(...args){
         super(...args), this.x = 1, this.y = this.x, this.z = super.f();
     }
 }
-C.x = void 0, C.y1 = C.x, C.y2 = C.x(), C.y3 = null == C ? void 0 : C.x(), C.y4 = C.x(), C.y5 = null == C ? void 0 : C.x(), C.z1 = _get(_get_prototype_of(C), "a", C), C.z2 = _get(_get_prototype_of(C), "a", C), C.z3 = _get(_get_prototype_of(C), "f", C).call(C), C.z4 = _get(_get_prototype_of(C), "f", C).call(C), C.z5 = _set(_get_prototype_of(C.prototype), "a", 0, C, !0), C.z6 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, !0), C.z7 = void _set(_get_prototype_of(C.prototype), "a", 0, C, !0), C.z8 = [_get(_get_prototype_of(C), "a", C)] = [
+C.x = void 0, C.y1 = C.x, C.y2 = C.x(), C.y3 = null == C ? void 0 : C.x(), C.y4 = C.x(), C.y5 = null == C ? void 0 : C.x(), C.z1 = _get(_get_prototype_of(C), "a", C), C.z2 = _get(_get_prototype_of(C), "a", C), C.z3 = _get(_get_prototype_of(C), "f", C).call(C), C.z4 = _get(_get_prototype_of(C), "f", C).call(C), C.z5 = _set(_get_prototype_of(C), "a", 0, C, !0), C.z6 = _update(_get_prototype_of(C), "a", C, !0)._ += 1, C.z7 = void _set(_get_prototype_of(C), "a", 0, C, !0), C.z8 = [_update(_get_prototype_of(C), "a", C, !0)._] = [
     0
-], C.z9 = [_get(_get_prototype_of(C), "a", C) = 0] = [
+], C.z9 = [_update(_get_prototype_of(C), "a", C, !0)._ = 0] = [
     0
-], C.z10 = [..._get(_get_prototype_of(C), "a", C)] = [
+], C.z10 = [..._update(_get_prototype_of(C), "a", C, !0)._] = [
     0
-], C.z11 = { x: _get(_get_prototype_of(C), "a", C)  } = {
+], C.z11 = { x: _update(_get_prototype_of(C), "a", C, !0)._  } = {
     x: 0
-}, C.z12 = { x: _get(_get_prototype_of(C), "a", C) = 0  } = {
+}, C.z12 = { x: _update(_get_prototype_of(C), "a", C, !0)._ = 0  } = {
     x: 0
 }, C.z13 = (_tmp = {
     x: 0
-}, _get(_get_prototype_of(C), "a", C) = _extends({}, _tmp), _tmp), C.z14 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, !0), C.z15 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) - 1, C, !0), C.z16 = _set(_get_prototype_of(C.prototype), _ref = "a", _get(_get_prototype_of(C), _ref, C) + 1, C, !0), C.z17 = (_set(_get_prototype_of(C.prototype), "a", (_super_a = +_get(_get_prototype_of(C), "a", C)) + 1, C, !0), _super_a), C.z18 = _get(_get_prototype_of(C), "a", C)``;
+}, _update(_get_prototype_of(C), "a", C, !0)._ = _extends({}, _tmp), _tmp), C.z14 = ++_update(_get_prototype_of(C), "a", C, !0)._, C.z15 = --_update(_get_prototype_of(C), "a", C, !0)._, C.z16 = ++_update(_get_prototype_of(C), "a", C, !0)._, C.z17 = _update(_get_prototype_of(C), "a", C, !0)._++, C.z18 = _get(_get_prototype_of(C), "a", C)``;

--- a/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers2_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers2_es5.1.normal.js
@@ -9,6 +9,7 @@ import _get_prototype_of from "@swc/helpers/src/_get_prototype_of.mjs";
 import _inherits from "@swc/helpers/src/_inherits.mjs";
 import _set from "@swc/helpers/src/_set.mjs";
 import _tagged_template_literal from "@swc/helpers/src/_tagged_template_literal.mjs";
+import _update from "@swc/helpers/src/_update.mjs";
 import _create_super from "@swc/helpers/src/_create_super.mjs";
 function _templateObject() {
     var data = _tagged_template_literal([
@@ -19,7 +20,6 @@ function _templateObject() {
     };
     return data;
 }
-var _ref, _super_a;
 var C = /*#__PURE__*/ function(B1) {
     "use strict";
     _inherits(C, B1);
@@ -46,37 +46,37 @@ C.z1 = _get(_get_prototype_of(C), "a", C);
 C.z2 = _get(_get_prototype_of(C), "a", C);
 C.z3 = _get(_get_prototype_of(C), "f", C).call(C);
 C.z4 = _get(_get_prototype_of(C), "f", C).call(C);
-C.z5 = _set(_get_prototype_of(C.prototype), "a", 0, C, true);
-C.z6 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, true);
+C.z5 = _set(_get_prototype_of(C), "a", 0, C, true);
+C.z6 = _update(_get_prototype_of(C), "a", C, true)._ += 1;
 C.z7 = function() {
-    _set(_get_prototype_of(C.prototype), "a", 0, C, true);
+    _set(_get_prototype_of(C), "a", 0, C, true);
 }();
 var ref;
 C.z8 = (ref = [
     0
-], _get(_get_prototype_of(C), "a", C) = ref[0], ref);
+], _update(_get_prototype_of(C), "a", C, true)._ = ref[0], ref);
 var ref1, ref2;
 C.z9 = (ref1 = [
     0
-], ref2 = ref1[0], _get(_get_prototype_of(C), "a", C) = ref2 === void 0 ? 0 : ref2, ref1);
+], ref2 = ref1[0], _update(_get_prototype_of(C), "a", C, true)._ = ref2 === void 0 ? 0 : ref2, ref1);
 var ref3;
 C.z10 = (ref3 = [
     0
-], _get(_get_prototype_of(C), "a", C) = ref3.slice(0), ref3);
+], _update(_get_prototype_of(C), "a", C, true)._ = ref3.slice(0), ref3);
 var ref4;
 C.z11 = (ref4 = {
     x: 0
-}, _get(_get_prototype_of(C), "a", C) = ref4.x, ref4);
+}, _update(_get_prototype_of(C), "a", C, true)._ = ref4.x, ref4);
 var ref5, ref6;
 C.z12 = (ref5 = {
     x: 0
-}, ref6 = ref5.x, _get(_get_prototype_of(C), "a", C) = ref6 === void 0 ? 0 : ref6, ref5);
+}, ref6 = ref5.x, _update(_get_prototype_of(C), "a", C, true)._ = ref6 === void 0 ? 0 : ref6, ref5);
 var _tmp;
 C.z13 = (_tmp = {
     x: 0
-}, _get(_get_prototype_of(C), "a", C) = _extends({}, _tmp), _tmp);
-C.z14 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, true);
-C.z15 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) - 1, C, true);
-C.z16 = _set(_get_prototype_of(C.prototype), _ref = "a", _get(_get_prototype_of(C), _ref, C) + 1, C, true);
-C.z17 = (_set(_get_prototype_of(C.prototype), "a", (_super_a = +_get(_get_prototype_of(C), "a", C)) + 1, C, true), _super_a);
+}, _update(_get_prototype_of(C), "a", C, true)._ = _extends({}, _tmp), _tmp);
+C.z14 = ++_update(_get_prototype_of(C), "a", C, true)._;
+C.z15 = --_update(_get_prototype_of(C), "a", C, true)._;
+C.z16 = ++_update(_get_prototype_of(C), "a", C, true)._;
+C.z17 = _update(_get_prototype_of(C), "a", C, true)._++;
 C.z18 = _get(_get_prototype_of(C), "a", C)(_templateObject());

--- a/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers2_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/thisAndSuperInStaticMembers2_es5.2.minified.js
@@ -6,6 +6,7 @@ import _get_prototype_of from "@swc/helpers/src/_get_prototype_of.mjs";
 import _inherits from "@swc/helpers/src/_inherits.mjs";
 import _set from "@swc/helpers/src/_set.mjs";
 import _tagged_template_literal from "@swc/helpers/src/_tagged_template_literal.mjs";
+import _update from "@swc/helpers/src/_update.mjs";
 import _create_super from "@swc/helpers/src/_create_super.mjs";
 function _templateObject() {
     var data = _tagged_template_literal([
@@ -15,7 +16,7 @@ function _templateObject() {
         return data;
     }, data;
 }
-var _ref, _super_a, ref, ref1, ref2, ref3, ref4, ref5, ref6, _tmp, C = function(B1) {
+var ref, ref1, ref2, ref3, ref4, ref5, ref6, _tmp, C = function(B1) {
     "use strict";
     _inherits(C, B1);
     var _super = _create_super(C);
@@ -25,16 +26,16 @@ var _ref, _super_a, ref, ref1, ref2, ref3, ref4, ref5, ref6, _tmp, C = function(
     }
     return C;
 }(B);
-C.x = void 0, C.y1 = C.x, C.y2 = C.x(), C.y3 = null == C ? void 0 : C.x(), C.y4 = C.x(), C.y5 = null == C ? void 0 : C.x(), C.z1 = _get(_get_prototype_of(C), "a", C), C.z2 = _get(_get_prototype_of(C), "a", C), C.z3 = _get(_get_prototype_of(C), "f", C).call(C), C.z4 = _get(_get_prototype_of(C), "f", C).call(C), C.z5 = _set(_get_prototype_of(C.prototype), "a", 0, C, !0), C.z6 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, !0), C.z7 = void _set(_get_prototype_of(C.prototype), "a", 0, C, !0), C.z8 = (ref = [
+C.x = void 0, C.y1 = C.x, C.y2 = C.x(), C.y3 = null == C ? void 0 : C.x(), C.y4 = C.x(), C.y5 = null == C ? void 0 : C.x(), C.z1 = _get(_get_prototype_of(C), "a", C), C.z2 = _get(_get_prototype_of(C), "a", C), C.z3 = _get(_get_prototype_of(C), "f", C).call(C), C.z4 = _get(_get_prototype_of(C), "f", C).call(C), C.z5 = _set(_get_prototype_of(C), "a", 0, C, !0), C.z6 = _update(_get_prototype_of(C), "a", C, !0)._ += 1, C.z7 = void _set(_get_prototype_of(C), "a", 0, C, !0), C.z8 = (ref = [
     0
-], _get(_get_prototype_of(C), "a", C) = ref[0], ref), C.z9 = (ref2 = (ref1 = [
+], _update(_get_prototype_of(C), "a", C, !0)._ = ref[0], ref), C.z9 = (ref2 = (ref1 = [
     0
-])[0], _get(_get_prototype_of(C), "a", C) = void 0 === ref2 ? 0 : ref2, ref1), C.z10 = (ref3 = [
+])[0], _update(_get_prototype_of(C), "a", C, !0)._ = void 0 === ref2 ? 0 : ref2, ref1), C.z10 = (ref3 = [
     0
-], _get(_get_prototype_of(C), "a", C) = ref3.slice(0), ref3), C.z11 = (ref4 = {
+], _update(_get_prototype_of(C), "a", C, !0)._ = ref3.slice(0), ref3), C.z11 = (ref4 = {
     x: 0
-}, _get(_get_prototype_of(C), "a", C) = ref4.x, ref4), C.z12 = (ref6 = (ref5 = {
+}, _update(_get_prototype_of(C), "a", C, !0)._ = ref4.x, ref4), C.z12 = (ref6 = (ref5 = {
     x: 0
-}).x, _get(_get_prototype_of(C), "a", C) = void 0 === ref6 ? 0 : ref6, ref5), C.z13 = (_tmp = {
+}).x, _update(_get_prototype_of(C), "a", C, !0)._ = void 0 === ref6 ? 0 : ref6, ref5), C.z13 = (_tmp = {
     x: 0
-}, _get(_get_prototype_of(C), "a", C) = _extends({}, _tmp), _tmp), C.z14 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) + 1, C, !0), C.z15 = _set(_get_prototype_of(C.prototype), "a", _get(_get_prototype_of(C), "a", C) - 1, C, !0), C.z16 = _set(_get_prototype_of(C.prototype), _ref = "a", _get(_get_prototype_of(C), _ref, C) + 1, C, !0), C.z17 = (_set(_get_prototype_of(C.prototype), "a", (_super_a = +_get(_get_prototype_of(C), "a", C)) + 1, C, !0), _super_a), C.z18 = _get(_get_prototype_of(C), "a", C)(_templateObject());
+}, _update(_get_prototype_of(C), "a", C, !0)._ = _extends({}, _tmp), _tmp), C.z14 = ++_update(_get_prototype_of(C), "a", C, !0)._, C.z15 = --_update(_get_prototype_of(C), "a", C, !0)._, C.z16 = ++_update(_get_prototype_of(C), "a", C, !0)._, C.z17 = _update(_get_prototype_of(C), "a", C, !0)._++, C.z18 = _get(_get_prototype_of(C), "a", C)(_templateObject());

--- a/crates/swc_ecma_transforms_base/src/helpers/_update.js
+++ b/crates/swc_ecma_transforms_base/src/helpers/_update.js
@@ -1,0 +1,10 @@
+function _update(target, property, receiver, isStrict) {
+    return {
+        get _() {
+            return _get(target, property, receiver);
+        },
+        set _(value) {
+            _set(target, property, value, receiver, isStrict);
+        },
+    };
+}

--- a/crates/swc_ecma_transforms_base/src/helpers/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/helpers/mod.rs
@@ -324,6 +324,7 @@ define_helpers!(Helpers {
     ),
     to_primitive: (type_of),
     to_property_key: (type_of, to_primitive),
+    update: (get, set),
     type_of: (),
     unsupported_iterable_to_array: (array_like_to_array),
     wrap_async_generator: (async_generator),

--- a/crates/swc_ecma_transforms_classes/src/super_field.rs
+++ b/crates/swc_ecma_transforms_classes/src/super_field.rs
@@ -4,7 +4,7 @@ use swc_atoms::js_word;
 use swc_common::{util::take::Take, Mark, Span, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
-use swc_ecma_utils::{alias_ident_for, is_rest_arguments, private_ident, quote_ident, ExprFactory};
+use swc_ecma_utils::{is_rest_arguments, quote_ident, ExprFactory};
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
 use super::get_prototype_of;
@@ -45,6 +45,8 @@ pub struct SuperFieldAccessFolder<'a> {
     pub constant_super: bool,
 
     pub super_class: &'a Option<Ident>,
+
+    pub in_pat: bool,
 }
 
 macro_rules! mark_nested {
@@ -82,36 +84,75 @@ impl<'a> VisitMut for SuperFieldAccessFolder<'a> {
                     ),
                     "_this"
                 ));
-                return;
             }
-            _ => {}
-        }
-
-        // We pretend method folding mode for while folding injected `_defineProperty`
-        // calls.
-        if let Expr::Call(CallExpr {
-            callee: Callee::Expr(expr),
-            ..
-        }) = n
-        {
-            if let Expr::Ident(Ident {
-                sym: js_word!("_defineProperty"),
+            // We pretend method folding mode for while folding injected `_defineProperty`
+            // calls.
+            Expr::Call(CallExpr {
+                callee: Callee::Expr(expr),
                 ..
-            }) = &**expr
+            }) if matches!(
+                &**expr,
+                Expr::Ident(Ident {
+                    sym: js_word!("_defineProperty"),
+                    ..
+                })
+            ) =>
             {
                 let old = self.in_injected_define_property_call;
                 self.in_injected_define_property_call = true;
                 n.visit_mut_children_with(self);
                 self.in_injected_define_property_call = old;
-                return;
+            }
+            Expr::SuperProp(..) => {
+                self.visit_mut_super_member_get(n);
+            }
+            Expr::Update(UpdateExpr { arg, .. }) if !self.constant_super && arg.is_super_prop() => {
+                if let Expr::SuperProp(SuperPropExpr {
+                    obj: Super {
+                        span: super_token, ..
+                    },
+                    prop,
+                    ..
+                }) = &**arg
+                {
+                    *arg = Box::new(self.super_to_update_call(*super_token, prop.clone()));
+                }
+            }
+            Expr::Assign(AssignExpr {
+                ref left,
+                op: op!("="),
+                right,
+                ..
+            }) if !self.constant_super && is_assign_to_super_prop(left) => {
+                right.visit_mut_children_with(self);
+                self.visit_mut_super_member_set(n)
+            }
+            Expr::Assign(AssignExpr { left, right, .. })
+                if !self.constant_super && is_assign_to_super_prop(left) =>
+            {
+                right.visit_mut_children_with(self);
+                self.visit_mut_super_member_update(n);
+            }
+            Expr::Call(CallExpr {
+                callee: Callee::Expr(callee_expr),
+                args,
+                ..
+            }) if !self.constant_super && callee_expr.is_super_prop() => {
+                args.visit_mut_children_with(self);
+
+                self.visit_mut_super_member_call(n);
+            }
+            _ => {
+                n.visit_mut_children_with(self);
             }
         }
+    }
 
-        self.visit_mut_super_member_call(n);
-        self.visit_mut_super_member_set(n);
-        self.visit_mut_super_member_get(n);
-
-        n.visit_mut_children_with(self)
+    fn visit_mut_pat(&mut self, n: &mut Pat) {
+        let in_pat = self.in_pat;
+        self.in_pat = true;
+        n.visit_mut_children_with(self);
+        self.in_pat = in_pat;
     }
 
     fn visit_mut_function(&mut self, n: &mut Function) {
@@ -210,56 +251,25 @@ impl<'a> SuperFieldAccessFolder<'a> {
     /// _set(_getPrototypeOf(Clazz.prototype), "foo", bar, this, true)
     /// ```
     fn visit_mut_super_member_set(&mut self, n: &mut Expr) {
-        match n {
-            Expr::Update(UpdateExpr {
-                arg, op, prefix, ..
-            }) => {
-                if let Expr::SuperProp(SuperPropExpr {
-                    obj: Super { span: super_token },
-                    prop,
-                    ..
-                }) = &mut **arg
-                {
-                    let op = match op {
-                        op!("++") => op!("+="),
-                        op!("--") => op!("-="),
-                    };
-
-                    *n = self.super_to_set_call(
-                        *super_token,
-                        Some(*prefix),
-                        prop.take(),
-                        op,
-                        1.0.into(),
-                    );
-                }
-            }
-
-            Expr::Assign(AssignExpr {
-                span,
-                left,
-                op,
-                right,
-            }) => {
-                if let PatOrExpr::Expr(expr) = left {
+        if let Expr::Assign(AssignExpr {
+            left,
+            op: op @ op!("="),
+            right,
+            ..
+        }) = n
+        {
+            match left {
+                PatOrExpr::Expr(expr) => {
                     if let Expr::SuperProp(SuperPropExpr {
                         obj: Super { span: super_token },
                         prop,
                         ..
                     }) = &mut **expr
                     {
-                        *n = self.super_to_set_call(
-                            *super_token,
-                            None,
-                            prop.take(),
-                            *op,
-                            right.take(),
-                        );
-                        return;
+                        *n = self.super_to_set_call(*super_token, prop.take(), *op, right.take());
                     }
                 }
-
-                if let PatOrExpr::Pat(pat) = left {
+                PatOrExpr::Pat(pat) => {
                     if let Pat::Expr(expr) = &mut **pat {
                         if let Expr::SuperProp(SuperPropExpr {
                             obj:
@@ -272,24 +282,14 @@ impl<'a> SuperFieldAccessFolder<'a> {
                         {
                             *n = self.super_to_set_call(
                                 *super_token,
-                                None,
                                 prop.take(),
                                 *op,
                                 right.take(),
                             );
-                            return;
                         }
                     }
-                };
-                left.visit_mut_children_with(self);
-                *n = Expr::Assign(AssignExpr {
-                    span: *span,
-                    left: left.take(),
-                    op: *op,
-                    right: right.take(),
-                })
+                }
             }
-            _ => {}
         }
     }
 
@@ -308,239 +308,124 @@ impl<'a> SuperFieldAccessFolder<'a> {
             ..
         }) = n
         {
-            *n = self.super_to_get_call(*super_token, (*prop).take())
+            let super_token = *super_token;
+            prop.visit_mut_children_with(self);
+
+            let prop = prop.take();
+            *n = if self.constant_super {
+                self.super_to_constant_call(super_token, prop)
+            } else if self.in_pat {
+                self.super_to_update_call(super_token, prop)
+            } else {
+                self.super_to_get_call(super_token, prop)
+            };
         }
     }
 
-    fn super_to_get_call(&mut self, super_token: Span, prop: SuperProp) -> Expr {
-        if self.constant_super {
-            Expr::Member(MemberExpr {
-                span: super_token,
-                obj: Box::new({
-                    let name = self.super_class.clone().unwrap_or_else(|| {
-                        quote_ident!(if self.is_static { "Function" } else { "Object" })
-                    });
-                    // in static default super class is Function.prototype
-                    if self.is_static && self.super_class.is_some() {
-                        Expr::Ident(name)
-                    } else {
-                        name.make_member(quote_ident!("prototype"))
+    fn visit_mut_super_member_update(&mut self, n: &mut Expr) {
+        if let Expr::Assign(AssignExpr { left, op, .. }) = n {
+            debug_assert_ne!(*op, op!("="));
+
+            match left {
+                PatOrExpr::Expr(expr) => {
+                    if let Expr::SuperProp(SuperPropExpr {
+                        obj: Super { span: super_token },
+                        prop,
+                        ..
+                    }) = *expr.take()
+                    {
+                        *expr = Box::new(self.super_to_update_call(super_token, prop));
                     }
-                }),
-                prop: match prop {
-                    SuperProp::Ident(i) => MemberProp::Ident(i),
-                    SuperProp::Computed(c) => MemberProp::Computed(c),
-                },
-            })
-        } else {
-            let mut proto_arg = get_prototype_of(if self.is_static {
-                // Foo
-                Expr::Ident(self.class_name.clone())
-            } else {
-                // Foo.prototype
-                self.class_name
-                    .clone()
-                    .make_member(quote_ident!("prototype"))
-            });
-
-            if let Some(mark) = self.constructor_this_mark {
-                let this = quote_ident!(DUMMY_SP.apply_mark(mark), "_this");
-
-                proto_arg = Expr::Seq(SeqExpr {
-                    span: DUMMY_SP,
-                    exprs: vec![
-                        Expr::Call(CallExpr {
-                            span: DUMMY_SP,
-                            callee: helper!(assert_this_initialized, "assertThisInitialized"),
-                            args: vec![this.as_arg()],
-                            type_args: Default::default(),
-                        })
-                        .into(),
-                        proto_arg.into(),
-                    ],
-                })
+                }
+                PatOrExpr::Pat(pat) => {
+                    if let Pat::Expr(expr) = &mut **pat {
+                        if let Expr::SuperProp(SuperPropExpr {
+                            obj:
+                                Super {
+                                    span: super_token, ..
+                                },
+                            prop,
+                            ..
+                        }) = *expr.take()
+                        {
+                            *expr = Box::new(self.super_to_update_call(super_token, prop));
+                        }
+                    }
+                }
             }
-
-            let prop_arg = match prop {
-                SuperProp::Ident(Ident {
-                    sym: value, span, ..
-                }) => Expr::Lit(Lit::Str(Str {
-                    span,
-                    raw: None,
-                    value,
-                })),
-                SuperProp::Computed(c) => *c.expr,
-            }
-            .as_arg();
-
-            let this_arg = match self.constructor_this_mark {
-                Some(mark) => quote_ident!(super_token.apply_mark(mark), "_this").as_arg(),
-                None => ThisExpr { span: super_token }.as_arg(),
-            };
-
-            Expr::Call(CallExpr {
-                span: super_token,
-                callee: helper!(get, "get"),
-                args: vec![proto_arg.as_arg(), prop_arg, this_arg],
-                type_args: Default::default(),
-            })
         }
+    }
+
+    fn super_to_constant_call(&mut self, super_token: Span, prop: SuperProp) -> Expr {
+        Expr::Member(MemberExpr {
+            span: super_token,
+            obj: Box::new({
+                let name = self.super_class.clone().unwrap_or_else(|| {
+                    quote_ident!(if self.is_static { "Function" } else { "Object" })
+                });
+                // in static default super class is Function.prototype
+                if self.is_static && self.super_class.is_some() {
+                    Expr::Ident(name)
+                } else {
+                    name.make_member(quote_ident!("prototype"))
+                }
+            }),
+            prop: match prop {
+                SuperProp::Ident(i) => MemberProp::Ident(i),
+                SuperProp::Computed(c) => MemberProp::Computed(c),
+            },
+        })
+    }
+
+    fn super_to_get_call(&mut self, super_token: Span, prop: SuperProp) -> Expr {
+        let proto_arg = self.proto_arg();
+
+        let prop_arg = prop_arg(prop).as_arg();
+
+        let this_arg = self.this_arg(super_token).as_arg();
+
+        Expr::Call(CallExpr {
+            span: super_token,
+            callee: helper!(get, "get"),
+            args: vec![proto_arg.as_arg(), prop_arg, this_arg],
+            type_args: Default::default(),
+        })
     }
 
     fn super_to_set_call(
         &mut self,
         super_token: Span,
-        update_prefix: Option<bool>,
         prop: SuperProp,
         op: AssignOp,
         rhs: Box<Expr>,
     ) -> Expr {
-        let mut ref_ident = Ident::dummy();
-
-        let mut update_ident = Ident::dummy();
-
-        if op != op!("=") {
-            // Memoize
-            if let SuperProp::Computed(c) = &prop {
-                ref_ident = alias_ident_for(&c.expr, "_ref");
-                self.vars.push(VarDeclarator {
-                    span: DUMMY_SP,
-                    name: ref_ident.clone().into(),
-                    init: None,
-                    definite: false,
-                });
-            }
-
-            // return value of suffix ++
-            if let Some(false) = update_prefix {
-                update_ident = match &prop {
-                    SuperProp::Ident(i) => private_ident!(i.span, format!("_{}", i.sym.clone())),
-                    SuperProp::Computed(c) => alias_ident_for(&c.expr, "_ref"),
-                };
-                update_ident.sym = format!("_super{}", update_ident.sym).into();
-                self.vars.push(VarDeclarator {
-                    span: DUMMY_SP,
-                    name: update_ident.clone().into(),
-                    init: None,
-                    definite: false,
-                });
-            }
-        }
+        debug_assert_eq!(op, op!("="));
 
         let this_expr = Box::new(match self.constructor_this_mark {
             Some(mark) => quote_ident!(super_token.apply_mark(mark), "_this").into(),
             None => ThisExpr { span: super_token }.into(),
         });
 
-        let getter_prop = match &prop {
-            SuperProp::Ident(ident) => SuperProp::Ident(ident.clone()),
-
-            SuperProp::Computed(_) => SuperProp::Computed(ComputedPropName {
-                span: ref_ident.span,
-                expr: Box::new(Expr::Ident(ref_ident.clone())),
-            }),
-        };
-
-        let rhs = match op {
-            op!("=") => rhs,
-            _ => {
-                let left = Box::new(self.super_to_get_call(super_token, getter_prop));
-                let left = if let Some(false) = update_prefix {
-                    Box::new(
-                        AssignExpr {
-                            span: DUMMY_SP,
-                            left: PatOrExpr::Pat(update_ident.clone().into()),
-                            op: op!("="),
-                            right: Box::new(Expr::Unary(UnaryExpr {
-                                span: DUMMY_SP,
-                                op: op!(unary, "+"),
-                                arg: left,
-                            })),
-                        }
-                        .into(),
-                    )
-                } else {
-                    left
-                };
-
-                Box::new(Expr::Bin(BinExpr {
-                    span: DUMMY_SP,
-                    left,
-                    op: op.to_update().unwrap(),
-                    right: rhs,
-                }))
-            }
-        };
-
-        let expr = if self.constant_super {
+        if self.constant_super {
             let left = Expr::Member(MemberExpr {
                 span: super_token,
                 obj: this_expr,
                 prop: match prop {
                     SuperProp::Ident(i) => MemberProp::Ident(i),
-                    SuperProp::Computed(c) if op == op!("=") => MemberProp::Computed(c),
-                    SuperProp::Computed(ComputedPropName { span, expr }) => {
-                        MemberProp::Computed(ComputedPropName {
-                            span,
-                            expr: Box::new(Expr::Assign(AssignExpr {
-                                span,
-                                left: PatOrExpr::Pat(ref_ident.into()),
-                                op: op!("="),
-                                right: expr,
-                            })),
-                        })
-                    }
+                    SuperProp::Computed(c) => MemberProp::Computed(c),
                 },
             });
 
             Expr::Assign(AssignExpr {
                 span: super_token,
                 left: PatOrExpr::Expr(left.into()),
-                op: op!("="),
+                op,
                 right: rhs,
             })
         } else {
-            let mut proto_arg = get_prototype_of(
-                self.class_name
-                    .clone()
-                    .make_member(quote_ident!("prototype")),
-            );
+            let proto_arg = self.proto_arg();
 
-            if let Some(mark) = self.constructor_this_mark {
-                let this = quote_ident!(DUMMY_SP.apply_mark(mark), "_this");
-
-                proto_arg = Expr::Seq(SeqExpr {
-                    span: DUMMY_SP,
-                    exprs: vec![
-                        Expr::Call(CallExpr {
-                            span: DUMMY_SP,
-                            callee: helper!(assert_this_initialized, "assertThisInitialized"),
-                            args: vec![this.as_arg()],
-                            type_args: Default::default(),
-                        })
-                        .into(),
-                        proto_arg.into(),
-                    ],
-                })
-            }
-
-            let prop_arg = match prop {
-                SuperProp::Ident(Ident {
-                    sym: value, span, ..
-                }) => Box::new(Expr::Lit(Lit::Str(Str {
-                    span,
-                    raw: None,
-                    value,
-                }))),
-                SuperProp::Computed(c) if op == op!("=") => c.expr,
-                SuperProp::Computed(c) => Box::new(Expr::Assign(AssignExpr {
-                    span: DUMMY_SP,
-                    left: PatOrExpr::Pat(ref_ident.into()),
-                    op: op!("="),
-                    right: c.expr,
-                })),
-            }
-            .as_arg();
+            let prop_arg = prop_arg(prop).as_arg();
 
             Expr::Call(CallExpr {
                 span: super_token,
@@ -555,15 +440,91 @@ impl<'a> SuperFieldAccessFolder<'a> {
                 ],
                 type_args: Default::default(),
             })
-        };
-
-        if let Some(false) = update_prefix {
-            Expr::Seq(SeqExpr {
-                span: DUMMY_SP,
-                exprs: vec![Box::new(expr), Box::new(Expr::Ident(update_ident))],
-            })
-        } else {
-            expr
         }
+    }
+
+    fn super_to_update_call(&mut self, super_token: Span, prop: SuperProp) -> Expr {
+        let proto_arg = self.proto_arg();
+
+        let prop_arg = prop_arg(prop).as_arg();
+
+        let this_arg = self.this_arg(super_token).as_arg();
+
+        let expr = Expr::Call(CallExpr {
+            span: super_token,
+            callee: helper!(update, "update"),
+            args: vec![
+                proto_arg.as_arg(),
+                prop_arg,
+                this_arg,
+                // strict
+                true.as_arg(),
+            ],
+            type_args: Default::default(),
+        });
+
+        expr.make_member(quote_ident!("_"))
+    }
+
+    fn proto_arg(&mut self) -> Expr {
+        let mut proto_arg = get_prototype_of(if self.is_static {
+            // Foo
+            Expr::Ident(self.class_name.clone())
+        } else {
+            // Foo.prototype
+            self.class_name
+                .clone()
+                .make_member(quote_ident!("prototype"))
+        });
+
+        if let Some(mark) = self.constructor_this_mark {
+            let this = quote_ident!(DUMMY_SP.apply_mark(mark), "_this");
+
+            proto_arg = Expr::Seq(SeqExpr {
+                span: DUMMY_SP,
+                exprs: vec![
+                    Expr::Call(CallExpr {
+                        span: DUMMY_SP,
+                        callee: helper!(assert_this_initialized, "assertThisInitialized"),
+                        args: vec![this.as_arg()],
+                        type_args: Default::default(),
+                    })
+                    .into(),
+                    proto_arg.into(),
+                ],
+            })
+        }
+
+        proto_arg
+    }
+
+    fn this_arg(&self, super_token: Span) -> Expr {
+        match self.constructor_this_mark {
+            Some(mark) => quote_ident!(super_token.apply_mark(mark), "_this").into(),
+            None => ThisExpr { span: super_token }.into(),
+        }
+    }
+}
+
+fn is_assign_to_super_prop(left: &PatOrExpr) -> bool {
+    match left {
+        PatOrExpr::Expr(expr) => expr.is_super_prop(),
+        PatOrExpr::Pat(pat) => match &**pat {
+            Pat::Expr(expr) => expr.is_super_prop(),
+            _ => false,
+        },
+    }
+}
+
+fn prop_arg(prop: SuperProp) -> Expr {
+    match prop {
+        SuperProp::Ident(Ident {
+            sym: value, span, ..
+        }) => Expr::Lit(Lit::Str(Str {
+            span,
+            raw: None,
+            value,
+        })),
+        SuperProp::Computed(c) => *c.expr,
     }
 }

--- a/crates/swc_ecma_transforms_classes/src/super_field.rs
+++ b/crates/swc_ecma_transforms_classes/src/super_field.rs
@@ -442,14 +442,7 @@ impl<'a> SuperFieldAccessFolder<'a> {
     }
 
     fn proto_arg(&mut self) -> Expr {
-        if self.constant_super {
-            return self
-                .class_name
-                .clone()
-                .make_member(quote_ident!("prototype"));
-        }
-
-        let mut proto_arg = get_prototype_of(if self.is_static {
+        let expr = if self.is_static {
             // Foo
             Expr::Ident(self.class_name.clone())
         } else {
@@ -457,7 +450,13 @@ impl<'a> SuperFieldAccessFolder<'a> {
             self.class_name
                 .clone()
                 .make_member(quote_ident!("prototype"))
-        });
+        };
+
+        if self.constant_super {
+            return expr;
+        }
+
+        let mut proto_arg = get_prototype_of(expr);
 
         if let Some(mark) = self.constructor_this_mark {
             let this = quote_ident!(DUMMY_SP.apply_mark(mark), "_this");

--- a/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/classes/mod.rs
@@ -832,6 +832,7 @@ where
             this_alias_mark: None,
             constant_super: self.config.constant_super,
             super_class: super_class_ident,
+            in_pat: false,
         };
 
         body.visit_mut_with(&mut folder);
@@ -1014,6 +1015,7 @@ where
                 this_alias_mark: None,
                 constant_super: self.config.constant_super,
                 super_class: super_class_ident,
+                in_pat: false,
             };
             m.function.visit_mut_with(&mut folder);
 

--- a/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2022/class_properties/mod.rs
@@ -648,6 +648,7 @@ impl<C: Comments> ClassProperties<C> {
                             this_alias_mark: None,
                             constant_super: self.c.constant_super,
                             super_class: &super_ident,
+                            in_pat: false,
                         });
                         value.visit_mut_with(&mut ThisInStaticFolder {
                             ident: class_ident.clone(),

--- a/crates/swc_ecma_transforms_compat/tests/es2015_classes.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2015_classes.rs
@@ -6921,7 +6921,7 @@ let Test = /*#__PURE__*/function (Foo) {
   _createClass(Test, null, [{
     key: "test",
     value: function test() {
-      return _get(Test.prototype, "wow", this).call(this); 
+      return _get(Test, "wow", this).call(this);
     }
   }]);
   return Test;
@@ -6964,7 +6964,7 @@ let Test = /*#__PURE__*/function () {
   _createClass(Test, null, [{
     key: "test",
     value: function test() {
-      return _get(Test.prototype, "constructor", this);
+      return _get(Test, "constructor", this);
     }
   }]);
   return Test;

--- a/crates/swc_ecma_transforms_compat/tests/es2015_classes.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2015_classes.rs
@@ -1579,16 +1579,12 @@ function (Base) {
   _createClass(Obj, [{
     key: "update",
     value: function update() {
-      var _prop, _super_prop;
-
-      _set(_getPrototypeOf(Obj.prototype), _prop = proper.prop, (_super_prop = +_get(_getPrototypeOf(Obj.prototype), _prop, this)) + 1, this, true), _super_prop;
+      _update(_getPrototypeOf(Obj.prototype), proper.prop, this, true)._++;
     }
   }, {
     key: "update2",
     value: function update2() {
-      var _i, _super_i
-
-      _set(_getPrototypeOf(Obj.prototype), _i = i, (_super_i = +_get(_getPrototypeOf(Obj.prototype), _i, this)) + 1, this, true), _super_i;
+      _update(_getPrototypeOf(Obj.prototype), i, this, true)._++; 
     }
   }]);
 
@@ -4287,16 +4283,12 @@ function (Base) {
   _createClass(Obj, [{
     key: "assign",
     value: function assign() {
-      var _prop;
-
-      _set(_getPrototypeOf(Obj.prototype), _prop = proper.prop, _get(_getPrototypeOf(Obj.prototype), _prop, this) + 1, this, true);
+      _update(_getPrototypeOf(Obj.prototype), proper.prop, this, true)._ += 1;
     }
   }, {
     key: "assign2",
     value: function assign2() {
-      var _i;
-
-      _set(_getPrototypeOf(Obj.prototype), _i = i, _get(_getPrototypeOf(Obj.prototype), _i, this) + 1, this, true);
+      _update(_getPrototypeOf(Obj.prototype), i, this, true)._ += 1;
     }
   }]);
 
@@ -6444,12 +6436,11 @@ let A = function(B) {
   var _super = _createSuper(A);
   function A() {
       _classCallCheck(this, A);
-      var _super_foo, _baz, _super_baz, _quz;
       var _this;
-      _set((_assertThisInitialized(_this), _getPrototypeOf(A.prototype)), "foo", (_super_foo = +_get((_assertThisInitialized(_this), _getPrototypeOf(A.prototype)), "foo", _this)) + 1, _this, true), _super_foo;
-      _set((_assertThisInitialized(_this), _getPrototypeOf(A.prototype)), "bar", _get((_assertThisInitialized(_this), _getPrototypeOf(A.prototype)), "bar", _this) + 123, _this, true);
-      _set((_assertThisInitialized(_this), _getPrototypeOf(A.prototype)), _baz = baz, (_super_baz = +_get((_assertThisInitialized(_this), _getPrototypeOf(A.prototype)), _baz, _this)) - 1, _this, true), _super_baz;
-      _set((_assertThisInitialized(_this), _getPrototypeOf(A.prototype)), _quz = quz, _get((_assertThisInitialized(_this), _getPrototypeOf(A.prototype)), _quz, _this) - 456, _this, true);
+      _update((_assertThisInitialized(_this), _getPrototypeOf(A.prototype)), "foo", _this, true)._++;
+      _update((_assertThisInitialized(_this), _getPrototypeOf(A.prototype)), "bar", _this, true)._ += 123;
+      _update((_assertThisInitialized(_this), _getPrototypeOf(A.prototype)), baz, _this, true)._--;
+      _update((_assertThisInitialized(_this), _getPrototypeOf(A.prototype)), quz, _this, true)._ -= 456;
       return _possibleConstructorReturn(_this);
   }
   return A;
@@ -6481,8 +6472,7 @@ let A = function(B) {
     {
         key: "foo",
         value: function foo() {
-            var _baz;
-            _set(_getPrototypeOf(A.prototype), _baz = baz, _get(_getPrototypeOf(A.prototype), _baz, this) - 1, this, true);
+            --_update(_getPrototypeOf(A.prototype), baz, this, true)._;
         }
     }
   ]);
@@ -6833,11 +6823,11 @@ function Test() {
   var _this;
   woops.super.test();
   _this = _super.call(this);
-  Foo.prototype.test.call(_assertThisInitialized(_this));
+  _get(Test.prototype, "test", _this).call(_assertThisInitialized(_this));
   _this = _super.call(this, ...arguments);
   _this = _super.call(this, "test", ...arguments);
-  Foo.prototype.test.apply(_assertThisInitialized(_this), arguments);
-  Foo.prototype.test.call(_assertThisInitialized(_this), "test", ...arguments);
+  _get(Test.prototype, "test", _this).apply(_assertThisInitialized(_this), arguments);
+  _get(Test.prototype, "test", _this).call(_assertThisInitialized(_this), "test", ...arguments);
   return _this;
 }
 
@@ -6876,8 +6866,8 @@ let Test = /*#__PURE__*/function (Foo) {
   function Test() {
     _classCallCheck(this, Test);
     var _this = _super.call(this);
-    Foo.prototype.test;
-    Foo.prototype.test.whatever;
+    _get(Test.prototype, "test", _this);
+    _get(Test.prototype, "test", _this).whatever;
     return _this;
   }
 
@@ -6921,9 +6911,9 @@ let Test = /*#__PURE__*/function (Foo) {
     _classCallCheck(this, Test);
     var _this = _super.call(this);
 
-    Foo.prototype.test.whatever();
+    _get(Test.prototype, "test", _this).whatever();
 
-    Foo.prototype.test.call(_assertThisInitialized(_this));
+    _get(Test.prototype, "test", _this).call(_assertThisInitialized(_this));
 
     return _this;
   }
@@ -6931,7 +6921,7 @@ let Test = /*#__PURE__*/function (Foo) {
   _createClass(Test, null, [{
     key: "test",
     value: function test() {
-      return Foo.wow.call(this);
+      return _get(Test.prototype, "wow", this).call(this); 
     }
   }]);
   return Test;
@@ -6967,14 +6957,14 @@ let Test = /*#__PURE__*/function () {
 
   function Test() {
     _classCallCheck(this, Test);
-    Object.prototype.hasOwnProperty.call(this, "test");
-    return Object.prototype.constructor;
+    _get(Test.prototype, "hasOwnProperty", this).call(this, "test");
+    return _get(Test.prototype, "constructor", this);
   }
 
   _createClass(Test, null, [{
     key: "test",
     value: function test() {
-      return Function.prototype.constructor;
+      return _get(Test.prototype, "constructor", this);
     }
   }]);
   return Test;
@@ -7008,14 +6998,13 @@ let A = function(B) {
   _inherits(A, B);
   var _super = _createSuper(A);
   function A() {
-    _classCallCheck(this, A);
-    var _super_foo, _baz, _super_baz, _quz;
-    var _this;
-    _this.foo = (_super_foo = +B.prototype.foo) + 1, _super_foo;
-    _this.bar = B.prototype.bar + 123;
-    _this[_baz = baz] = (_super_baz = +B.prototype[_baz]) - 1, _super_baz;
-    _this[_quz = quz] = B.prototype[_quz] - 456;
-    return _possibleConstructorReturn(_this);
+      _classCallCheck(this, A);
+      var _this;
+      _update(A.prototype, "foo", _this, true)._++;
+      _update(A.prototype, "bar", _this, true)._ += 123;
+      _update(A.prototype, baz, _this, true)._--;
+      _update(A.prototype, quz, _this, true)._ -= 456;
+      return _possibleConstructorReturn(_this);
   }
   return A;
 }(B);

--- a/crates/swc_ecma_transforms_compat/tests/es2022_class_properties.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2022_class_properties.rs
@@ -6023,7 +6023,7 @@ var _B;
 
 class A extends (_B = class B {}) {}
 
-_defineProperty(A, "x", _get(A.prototype, "x", A));
+_defineProperty(A, "x", _get(A, "x", A));
 "#
 );
 
@@ -6051,7 +6051,7 @@ class A extends B {
   }
 }
 
-_defineProperty(A, "foo", _get(A.prototype, "bar", A));
+_defineProperty(A, "foo", _get(A, "bar", A));
 "#
 );
 

--- a/crates/swc_ecma_transforms_compat/tests/es2022_class_properties.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2022_class_properties.rs
@@ -6018,13 +6018,13 @@ class A extends class B {} {
   static x = super.x;
 }
 ",
-    "
+    r#"
 var _B;
 
 class A extends (_B = class B {}) {}
 
-_defineProperty(A, \"x\", _B.x);
-"
+_defineProperty(A, "x", _get(A.prototype, "x", A));
+"#
 );
 
 test!(
@@ -6043,16 +6043,16 @@ class A extends B {
   static foo = super.bar;
 }
 ",
-    "
+    r#"
 class A extends B {
   constructor(...args) {
     super(...args);
-    _defineProperty(this, \"foo\", super.bar);
+    _defineProperty(this, "foo", super.bar);
   }
 }
 
-_defineProperty(A, \"foo\", B.bar)
-"
+_defineProperty(A, "foo", _get(A.prototype, "bar", A));
+"#
 );
 
 test!(

--- a/crates/swc_ecma_transforms_proposal/src/decorators/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/mod.rs
@@ -335,6 +335,7 @@ impl Decorators {
                     // TODO: loose mode
                     constant_super: false,
                     super_class: &None,
+                    in_pat: false,
                 });
 
                 let method = method.fold_with(&mut folder);

--- a/packages/swc-helpers/src/_update.mjs
+++ b/packages/swc-helpers/src/_update.mjs
@@ -1,0 +1,13 @@
+import get from "./_get.mjs";
+import set from "./_set.mjs";
+
+export default function _update(target, property, receiver, isStrict) {
+    return {
+        get _() {
+            return get(target, property, receiver);
+        },
+        set _(value) {
+            set(target, property, value, receiver, isStrict);
+        },
+    };
+}


### PR DESCRIPTION
This PR fix the following code.

```JavaScript 
class B {
    static a = 1;
}

class C extends B {
    static z8 = [super.a] = [0];
    static z14 = ++super.a;
    static z15 = --super.a;
    static z16 = ++super["a"];
}

console.log(B.a, C.a, C.z14, C.z15, C.z16);

```