### PR TITLE
build(swc/core): fix dependency version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3063,7 +3063,7 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "binding_macros",
  "once_cell",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.90.11"
+version = "0.90.12"
 dependencies = [
  "arbitrary",
  "bitflags",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.100.1"
+version = "0.100.2"
 dependencies = [
  "indexmap",
  "once_cell",

--- a/crates/binding_macros/Cargo.toml
+++ b/crates/binding_macros/Cargo.toml
@@ -32,7 +32,7 @@ binding_wasm = [
 # Common deps for the SWC imports
 swc                 = { optional = true, version = "0.218.0", path = "../swc" }
 swc_common          = { optional = true, version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast        = { optional = true, version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast        = { optional = true, version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_transforms = { optional = true, version = "0.185.0", path = "../swc_ecma_transforms" }
 
 # Optional deps for the wasm binding macro

--- a/crates/dbg-swc/Cargo.toml
+++ b/crates/dbg-swc/Cargo.toml
@@ -20,7 +20,7 @@ swc_atoms = { version = "0.4.5", path = "../swc_atoms" }
 swc_common = { version = "0.27.7", features = [
   "concurrent",
 ], path = "../swc_common" }
-swc_ecma_ast = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "0.122.0", path = "../swc_ecma_codegen" }
 swc_ecma_minifier = { version = "0.146.0", path = "../swc_ecma_minifier", features = [
   "concurrent",

--- a/crates/jsdoc/Cargo.toml
+++ b/crates/jsdoc/Cargo.toml
@@ -20,6 +20,6 @@ swc_common = { version = "0.27.7", path = "../swc_common" }
 [dev-dependencies]
 anyhow          = "1"
 dashmap         = "5.1.0"
-swc_ecma_ast    = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast    = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_parser = { version = "0.118.0", path = "../swc_ecma_parser" }
 testing         = { version = "0.29.4", path = "../testing" }

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -62,7 +62,7 @@ swc_common = { version = "0.27.7", path = "../swc_common", features = [
   "parking_lot",
 ] }
 swc_config = { version = "0.1.1", path = "../swc_config" }
-swc_ecma_ast = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "0.122.0", path = "../swc_ecma_codegen" }
 swc_ecma_ext_transforms = { version = "0.86.0", path = "../swc_ecma_ext_transforms" }
 swc_ecma_lints = { version = "0.59.0", path = "../swc_ecma_lints" }

--- a/crates/swc_bundler/Cargo.toml
+++ b/crates/swc_bundler/Cargo.toml
@@ -39,7 +39,7 @@ relative-path                    = "1.2"
 retain_mut                       = "0.1.2"
 swc_atoms                        = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                       = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast                     = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast                     = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_codegen                 = { version = "0.122.0", path = "../swc_ecma_codegen" }
 swc_ecma_loader                  = { version = "0.39.4", path = "../swc_ecma_loader" }
 swc_ecma_parser                  = { version = "0.118.0", path = "../swc_ecma_parser" }

--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -6,7 +6,7 @@ edition       = "2021"
 license       = "Apache-2.0"
 name          = "swc_core"
 repository    = "https://github.com/swc-project/swc.git"
-version       = "0.11.0"
+version       = "0.11.1"
   [package.metadata.docs.rs]
   features = [
     "common_perf",

--- a/crates/swc_ecma_ast/Cargo.toml
+++ b/crates/swc_ecma_ast/Cargo.toml
@@ -6,7 +6,7 @@ edition       = "2021"
 license       = "Apache-2.0"
 name          = "swc_ecma_ast"
 repository    = "https://github.com/swc-project/swc.git"
-version       = "0.90.11"
+version       = "0.90.12"
 
   [package.metadata.docs.rs]
   all-features = true

--- a/crates/swc_ecma_codegen/Cargo.toml
+++ b/crates/swc_ecma_codegen/Cargo.toml
@@ -21,7 +21,7 @@ serde                   = "1.0.127"
 sourcemap               = "6"
 swc_atoms               = { version = "0.4.5", path = "../swc_atoms" }
 swc_common              = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast            = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast            = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_codegen_macros = { version = "0.7.1", path = "../swc_ecma_codegen_macros" }
 tracing                 = "0.1.32"
 

--- a/crates/swc_ecma_dep_graph/Cargo.toml
+++ b/crates/swc_ecma_dep_graph/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 [dependencies]
 swc_atoms      = { version = "0.4.5", path = "../swc_atoms" }
 swc_common     = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast   = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast   = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit" }
 
 [dev-dependencies]

--- a/crates/swc_ecma_ext_transforms/Cargo.toml
+++ b/crates/swc_ecma_ext_transforms/Cargo.toml
@@ -14,6 +14,6 @@ bench = false
 phf            = { version = "0.10", features = ["macros"] }
 swc_atoms      = { version = "0.4.5", path = "../swc_atoms" }
 swc_common     = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast   = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast   = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_utils = { version = "0.100.0", path = "../swc_ecma_utils" }
 swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit" }

--- a/crates/swc_ecma_lints/Cargo.toml
+++ b/crates/swc_ecma_lints/Cargo.toml
@@ -25,7 +25,7 @@ swc_common = { version = "0.27.7", path = "../swc_common", features = [
   "concurrent",
 ] }
 swc_config = { version = "0.1.0", path = "../swc_config" }
-swc_ecma_ast = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_utils = { version = "0.100.0", path = "../swc_ecma_utils" }
 swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit" }
 

--- a/crates/swc_ecma_minifier/Cargo.toml
+++ b/crates/swc_ecma_minifier/Cargo.toml
@@ -46,7 +46,7 @@ swc_atoms                        = { version = "0.4.5", path = "../swc_atoms" }
 swc_cached                       = { version = "0.3.5", path = "../swc_cached" }
 swc_common                       = { version = "0.27.7", path = "../swc_common" }
 swc_config                       = { version = "0.1.0", path = "../swc_config" }
-swc_ecma_ast                     = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast                     = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_codegen                 = { version = "0.122.0", path = "../swc_ecma_codegen" }
 swc_ecma_parser                  = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_transforms_base         = { version = "0.104.0", path = "../swc_ecma_transforms_base" }

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -32,7 +32,7 @@ serde          = { version = "1", features = ["derive"] }
 smallvec       = "1.8.0"
 swc_atoms      = { version = "0.4.5", path = "../swc_atoms" }
 swc_common     = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast   = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast   = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit", optional = true }
 tracing        = "0.1.32"
 typed-arena    = "2.0.1"

--- a/crates/swc_ecma_preset_env/Cargo.toml
+++ b/crates/swc_ecma_preset_env/Cargo.toml
@@ -25,7 +25,7 @@ st-map = "0.1.2"
 string_enum = { version = "0.3.1", path = "../string_enum" }
 swc_atoms = { version = "0.4.5", path = "../swc_atoms" }
 swc_common = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_transforms = { version = "0.185.0", path = "../swc_ecma_transforms", features = [
   "compat",
   "proposal",

--- a/crates/swc_ecma_quote/Cargo.toml
+++ b/crates/swc_ecma_quote/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 [dependencies]
 swc_atoms             = { version = "0.4.5", path = "../swc_atoms" }
 swc_common            = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast          = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast          = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_quote_macros = { version = "0.29.0", path = "../swc_ecma_quote_macros" }
 swc_ecma_utils        = { version = "0.100.0", path = "../swc_ecma_utils" }
 

--- a/crates/swc_ecma_quote_macros/Cargo.toml
+++ b/crates/swc_ecma_quote_macros/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro2       = "1"
 quote             = "1"
 swc_atoms         = { version = "0.4.5", path = "../swc_atoms" }
 swc_common        = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast      = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast      = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_parser   = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_macros_common = { version = "0.3.3", path = "../swc_macros_common" }
 syn               = "1"

--- a/crates/swc_ecma_testing/Cargo.toml
+++ b/crates/swc_ecma_testing/Cargo.toml
@@ -17,6 +17,6 @@ hex              = "0.4"
 sha-1            = "0.10"
 swc_atoms        = { version = "0.4.5", path = "../swc_atoms" }
 swc_common       = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast     = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast     = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "0.122.0", path = "../swc_ecma_codegen" }
 testing          = { version = "0.29.4", path = "../testing" }

--- a/crates/swc_ecma_transforms/Cargo.toml
+++ b/crates/swc_ecma_transforms/Cargo.toml
@@ -33,7 +33,7 @@ typescript = ["swc_ecma_transforms_typescript"]
 [dependencies]
 swc_atoms                        = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                       = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast                     = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast                     = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_transforms_base         = { version = "0.104.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_compat       = { version = "0.124.0", path = "../swc_ecma_transforms_compat", optional = true }
 swc_ecma_transforms_module       = { version = "0.141.0", path = "../swc_ecma_transforms_module", optional = true }

--- a/crates/swc_ecma_transforms_base/Cargo.toml
+++ b/crates/swc_ecma_transforms_base/Cargo.toml
@@ -28,7 +28,7 @@ serde             = { version = "1", features = ["derive"] }
 smallvec          = "1.8.0"
 swc_atoms         = { version = "0.4.5", path = "../swc_atoms" }
 swc_common        = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast      = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast      = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_parser   = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_utils    = { version = "0.100.0", path = "../swc_ecma_utils" }
 swc_ecma_visit    = { version = "0.76.6", path = "../swc_ecma_visit" }

--- a/crates/swc_ecma_transforms_classes/Cargo.toml
+++ b/crates/swc_ecma_transforms_classes/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 [dependencies]
 swc_atoms                = { version = "0.4.5", path = "../swc_atoms" }
 swc_common               = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast             = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast             = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_transforms_base = { version = "0.104.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_utils           = { version = "0.100.0", path = "../swc_ecma_utils" }
 swc_ecma_visit           = { version = "0.76.6", path = "../swc_ecma_visit" }

--- a/crates/swc_ecma_transforms_compat/Cargo.toml
+++ b/crates/swc_ecma_transforms_compat/Cargo.toml
@@ -32,7 +32,7 @@ smallvec                    = "1.8.0"
 swc_atoms                   = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                  = { version = "0.27.7", path = "../swc_common" }
 swc_config                  = { version = "0.1.0", path = "../swc_config" }
-swc_ecma_ast                = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast                = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_transforms_base    = { version = "0.104.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_classes = { version = "0.93.0", path = "../swc_ecma_transforms_classes" }
 swc_ecma_transforms_macros  = { version = "0.5.0", path = "../swc_ecma_transforms_macros" }

--- a/crates/swc_ecma_transforms_module/Cargo.toml
+++ b/crates/swc_ecma_transforms_module/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.118", features = ["derive"] }
 swc_atoms = { version = "0.4.5", path = "../swc_atoms" }
 swc_cached = { version = "0.3.5", path = "../swc_cached" }
 swc_common = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_loader = { version = "0.39.4", path = "../swc_ecma_loader", features = [
   "node",
 ] }

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -27,7 +27,7 @@ rustc-hash                 = "1.1.0"
 serde_json                 = "1.0.61"
 swc_atoms                  = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                 = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast               = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast               = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_parser            = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_transforms_base   = { version = "0.104.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_macros = { version = "0.5.0", path = "../swc_ecma_transforms_macros" }

--- a/crates/swc_ecma_transforms_proposal/Cargo.toml
+++ b/crates/swc_ecma_transforms_proposal/Cargo.toml
@@ -22,7 +22,7 @@ serde                       = { version = "1.0.118", features = ["derive"] }
 smallvec                    = "1.8.0"
 swc_atoms                   = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                  = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast                = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast                = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_loader             = { version = "0.39.4", path = "../swc_ecma_loader", optional = true }
 swc_ecma_transforms_base    = { version = "0.104.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_classes = { version = "0.93.0", path = "../swc_ecma_transforms_classes" }

--- a/crates/swc_ecma_transforms_react/Cargo.toml
+++ b/crates/swc_ecma_transforms_react/Cargo.toml
@@ -29,7 +29,7 @@ string_enum                = { version = "0.3.1", path = "../string_enum" }
 swc_atoms                  = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                 = { version = "0.27.7", path = "../swc_common" }
 swc_config                 = { version = "0.1.0", path = "../swc_config" }
-swc_ecma_ast               = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast               = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_parser            = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_transforms_base   = { version = "0.104.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_macros = { version = "0.5.0", path = "../swc_ecma_transforms_macros" }

--- a/crates/swc_ecma_transforms_testing/Cargo.toml
+++ b/crates/swc_ecma_transforms_testing/Cargo.toml
@@ -19,7 +19,7 @@ serde                    = "1"
 serde_json               = "1"
 sha-1                    = "0.10"
 swc_common               = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast             = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast             = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_codegen         = { version = "0.122.0", path = "../swc_ecma_codegen" }
 swc_ecma_parser          = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_testing         = { version = "0.15.0", path = "../swc_ecma_testing" }

--- a/crates/swc_ecma_transforms_typescript/Cargo.toml
+++ b/crates/swc_ecma_transforms_typescript/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 serde                     = { version = "1.0.118", features = ["derive"] }
 swc_atoms                 = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast              = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast              = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_transforms_base  = { version = "0.104.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_react = { version = "0.143.0", path = "../swc_ecma_transforms_react" }
 swc_ecma_utils            = { version = "0.100.0", path = "../swc_ecma_utils" }

--- a/crates/swc_ecma_utils/Cargo.toml
+++ b/crates/swc_ecma_utils/Cargo.toml
@@ -6,7 +6,7 @@ edition       = "2021"
 license       = "Apache-2.0"
 name          = "swc_ecma_utils"
 repository    = "https://github.com/swc-project/swc.git"
-version       = "0.100.1"
+version       = "0.100.2"
 
   [package.metadata.docs.rs]
   all-features = true
@@ -25,7 +25,7 @@ once_cell      = "1.10.0"
 rayon          = { version = "1.5.1", optional = true }
 swc_atoms      = { version = "0.4.5", path = "../swc_atoms" }
 swc_common     = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast   = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast   = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit" }
 tracing        = "0.1.32"
 unicode-id     = "0.3"

--- a/crates/swc_ecma_visit/Cargo.toml
+++ b/crates/swc_ecma_visit/Cargo.toml
@@ -25,6 +25,6 @@ num-bigint   = { version = "0.4", features = ["serde"] }
 serde        = { version = "1", optional = true }
 swc_atoms    = { version = "0.4.5", path = "../swc_atoms" }
 swc_common   = { version = "0.27.7", path = "../swc_common" }
-swc_ecma_ast = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_visit    = { version = "0.5.2", path = "../swc_visit" }
 tracing      = "0.1.32"

--- a/crates/swc_ecmascript/Cargo.toml
+++ b/crates/swc_ecmascript/Cargo.toml
@@ -39,7 +39,7 @@ react        = ["swc_ecma_transforms/react"]
 typescript   = ["typescript-parser", "swc_ecma_transforms/typescript"]
 
 [dependencies]
-swc_ecma_ast        = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast        = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_codegen    = { version = "0.122.0", path = "../swc_ecma_codegen", optional = true }
 swc_ecma_dep_graph  = { version = "0.90.0", path = "../swc_ecma_dep_graph", optional = true }
 swc_ecma_minifier   = { version = "0.146.0", path = "../swc_ecma_minifier", optional = true }

--- a/crates/swc_estree_compat/Cargo.toml
+++ b/crates/swc_estree_compat/Cargo.toml
@@ -28,7 +28,7 @@ swc_common = { version = "0.27.7", path = "../swc_common", features = [
   "sourcemap",
   "tty-emitter",
 ] }
-swc_ecma_ast = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_parser = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_utils = { version = "0.100.0", path = "../swc_ecma_utils" }
 swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit" }
@@ -39,7 +39,7 @@ swc_node_comments = { version = "0.14.4", path = "../swc_node_comments/" }
 criterion           = "0.3"
 pretty_assertions   = "1.1"
 swc                 = { version = "0.218.0", path = "../swc" }
-swc_ecma_ast        = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast        = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_parser     = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_transforms = { version = "0.185.0", path = "../swc_ecma_transforms/" }
 testing             = { version = "0.29.4", path = "../testing" }

--- a/crates/swc_html_minifier/Cargo.toml
+++ b/crates/swc_html_minifier/Cargo.toml
@@ -26,7 +26,7 @@ swc_css_ast              = { version = "0.108.0", path = "../swc_css_ast" }
 swc_css_codegen          = { version = "0.118.0", path = "../swc_css_codegen" }
 swc_css_minifier         = { version = "0.83.0", path = "../swc_css_minifier" }
 swc_css_parser           = { version = "0.117.0", path = "../swc_css_parser" }
-swc_ecma_ast             = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast             = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_codegen         = { version = "0.122.0", path = "../swc_ecma_codegen" }
 swc_ecma_minifier        = { version = "0.146.0", path = "../swc_ecma_minifier" }
 swc_ecma_parser          = { version = "0.118.0", path = "../swc_ecma_parser" }

--- a/crates/swc_node_bundler/Cargo.toml
+++ b/crates/swc_node_bundler/Cargo.toml
@@ -34,7 +34,7 @@ swc_bundler = { version = "0.179.0", path = "../swc_bundler", features = [
 swc_common = { version = "0.27.7", path = "../swc_common", features = [
   "concurrent",
 ] }
-swc_ecma_ast = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "0.122.0", path = "../swc_ecma_codegen" }
 swc_ecma_loader = { version = "0.39.4", path = "../swc_ecma_loader" }
 swc_ecma_parser = { version = "0.118.0", path = "../swc_ecma_parser" }

--- a/crates/swc_plugin_proxy/Cargo.toml
+++ b/crates/swc_plugin_proxy/Cargo.toml
@@ -23,6 +23,6 @@ rkyv = "=0.7.37"
 swc_common = { version = "0.27.7", path = "../swc_common", features = [
   "plugin-base",
 ] }
-swc_ecma_ast = { version = "0.90.10", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
 swc_trace_macro = { version = "0.1.2", path = "../swc_trace_macro" }
 tracing = "0.1.32"

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -32,7 +32,7 @@ swc_common = { version = "0.27.7", path = "../swc_common", features = [
   "plugin-rt",
   "concurrent",
 ] }
-swc_ecma_ast = { version = "0.90.10", path = "../swc_ecma_ast", features = [
+swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast", features = [
   "rkyv-impl",
 ] }
 swc_plugin_proxy = { version = "0.18.13", path = "../swc_plugin_proxy", features = [


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

latest `ecma_utils` build fails with 

```
 no method named `without_loc` found for struct `swc_ecma_ast::Ident` in the current scope
   --> /Users/ojkwon/.cargo/registry/src/github.com-1ecc6299db9ec823/swc_ecma_utils-0.100.1/src/function/fn_env_hoister.rs:743:22
    |
743 |             name: id.without_loc().into(),
    |                      ^^^^^^^^^^^ method not found in `swc_ecma_ast::Ident`
```

Due to version mismatch after https://github.com/swc-project/swc/pull/5569. PR bumps up version to fix issues.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
