### PR TITLE
fix(es/parser): Handle `async` in `for...of`

### DIFF
--- a/crates/swc/tests/tsc-references/parserForOfStatement23_es2015.1.normal.js
+++ b/crates/swc/tests/tsc-references/parserForOfStatement23_es2015.1.normal.js
@@ -1,11 +1,34 @@
-//!
-//!  x Expected '=>', got 'x'
-//!   ,----
-//! 5 | for await (async of x) {}
-//!   :                     ^
-//!   `----
-//!
-//!
-//!Caused by:
-//!    0: failed to process input file
-//!    1: Syntax Error
+// @target: esnext
+import _async_iterator from "@swc/helpers/src/_async_iterator.mjs";
+import _async_to_generator from "@swc/helpers/src/_async_to_generator.mjs";
+function foo(x) {
+    return _foo.apply(this, arguments);
+}
+function _foo() {
+    _foo = _async_to_generator(function*(x) {
+        var async;
+        {
+            var _iteratorAbruptCompletion = false, _didIteratorError = false, _iteratorError;
+            try {
+                for(var _iterator = _async_iterator(x), _step; _iteratorAbruptCompletion = !(_step = yield _iterator.next()).done; _iteratorAbruptCompletion = false){
+                    let _value = _step.value;
+                    async = _value;
+                }
+            } catch (err) {
+                _didIteratorError = true;
+                _iteratorError = err;
+            } finally{
+                try {
+                    if (_iteratorAbruptCompletion && _iterator.return != null) {
+                        yield _iterator.return();
+                    }
+                } finally{
+                    if (_didIteratorError) {
+                        throw _iteratorError;
+                    }
+                }
+            }
+        }
+    });
+    return _foo.apply(this, arguments);
+}

--- a/crates/swc/tests/tsc-references/parserForOfStatement23_es2015.2.minified.js
+++ b/crates/swc/tests/tsc-references/parserForOfStatement23_es2015.2.minified.js
@@ -1,11 +1,2 @@
-//!
-//!  x Expected '=>', got 'x'
-//!   ,----
-//! 5 | for await (async of x) {}
-//!   :                     ^
-//!   `----
-//!
-//!
-//!Caused by:
-//!    0: failed to process input file
-//!    1: Syntax Error
+import _async_iterator from "@swc/helpers/src/_async_iterator.mjs";
+import _async_to_generator from "@swc/helpers/src/_async_to_generator.mjs";

--- a/crates/swc/tests/tsc-references/parserForOfStatement23_es5.1.normal.js
+++ b/crates/swc/tests/tsc-references/parserForOfStatement23_es5.1.normal.js
@@ -1,11 +1,99 @@
-//!
-//!  x Expected '=>', got 'x'
-//!   ,----
-//! 5 | for await (async of x) {}
-//!   :                     ^
-//!   `----
-//!
-//!
-//!Caused by:
-//!    0: failed to process input file
-//!    1: Syntax Error
+// @target: esnext
+import _async_iterator from "@swc/helpers/src/_async_iterator.mjs";
+import _async_to_generator from "@swc/helpers/src/_async_to_generator.mjs";
+import _ts_generator from "@swc/helpers/src/_ts_generator.mjs";
+function foo(x) {
+    return _foo.apply(this, arguments);
+}
+function _foo() {
+    _foo = _async_to_generator(function(x) {
+        var async, _iteratorAbruptCompletion, _didIteratorError, _iteratorError, _iterator, _step, _value, err;
+        return _ts_generator(this, function(_state) {
+            switch(_state.label){
+                case 0:
+                    _iteratorAbruptCompletion = false, _didIteratorError = false;
+                    _state.label = 1;
+                case 1:
+                    _state.trys.push([
+                        1,
+                        6,
+                        7,
+                        12
+                    ]);
+                    _iterator = _async_iterator(x);
+                    _state.label = 2;
+                case 2:
+                    return [
+                        4,
+                        _iterator.next()
+                    ];
+                case 3:
+                    if (!(_iteratorAbruptCompletion = !(_step = _state.sent()).done)) return [
+                        3,
+                        5
+                    ];
+                    _value = _step.value;
+                    async = _value;
+                    _state.label = 4;
+                case 4:
+                    _iteratorAbruptCompletion = false;
+                    return [
+                        3,
+                        2
+                    ];
+                case 5:
+                    return [
+                        3,
+                        12
+                    ];
+                case 6:
+                    err = _state.sent();
+                    _didIteratorError = true;
+                    _iteratorError = err;
+                    return [
+                        3,
+                        12
+                    ];
+                case 7:
+                    _state.trys.push([
+                        7,
+                        ,
+                        10,
+                        11
+                    ]);
+                    if (!(_iteratorAbruptCompletion && _iterator.return != null)) return [
+                        3,
+                        9
+                    ];
+                    return [
+                        4,
+                        _iterator.return()
+                    ];
+                case 8:
+                    _state.sent();
+                    _state.label = 9;
+                case 9:
+                    return [
+                        3,
+                        11
+                    ];
+                case 10:
+                    if (_didIteratorError) {
+                        throw _iteratorError;
+                    }
+                    return [
+                        7
+                    ];
+                case 11:
+                    return [
+                        7
+                    ];
+                case 12:
+                    return [
+                        2
+                    ];
+            }
+        });
+    });
+    return _foo.apply(this, arguments);
+}

--- a/crates/swc/tests/tsc-references/parserForOfStatement23_es5.2.minified.js
+++ b/crates/swc/tests/tsc-references/parserForOfStatement23_es5.2.minified.js
@@ -1,11 +1,3 @@
-//!
-//!  x Expected '=>', got 'x'
-//!   ,----
-//! 5 | for await (async of x) {}
-//!   :                     ^
-//!   `----
-//!
-//!
-//!Caused by:
-//!    0: failed to process input file
-//!    1: Syntax Error
+import _async_iterator from "@swc/helpers/src/_async_iterator.mjs";
+import _async_to_generator from "@swc/helpers/src/_async_to_generator.mjs";
+import _ts_generator from "@swc/helpers/src/_ts_generator.mjs";

--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -224,6 +224,7 @@ pub enum SyntaxError {
     TS1100,
     TS1102,
     TS1105,
+    TS1106,
     TS1107,
     TS1109,
     TS1110,
@@ -586,6 +587,9 @@ impl SyntaxError {
             SyntaxError::TS1105 => "A 'break' statement can only be used within an enclosing \
                                     iteration or switch statement"
                 .into(),
+            SyntaxError::TS1106 => {
+                "The left-hand side of a `for...of` statement may not be `async`".into()
+            }
             SyntaxError::TS1107 => "Jump target cannot cross function boundary".into(),
             SyntaxError::TS1109 => "Expression expected".into(),
             SyntaxError::TS1114 => "Duplicate label".into(),

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -341,6 +341,9 @@ pub struct Context {
     module: bool,
     can_be_module: bool,
     strict: bool,
+
+    expr_ctx: ExpressionContext,
+
     include_in_expr: bool,
     /// If true, await expression is parsed, and "await" is treated as a
     /// keyword.
@@ -387,6 +390,14 @@ pub struct Context {
     ignore_else_clause: bool,
 
     disallow_conditional_types: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ExpressionContext {
+    // TODO:
+    // - include_in
+    for_loop_init: bool,
+    for_await_loop_init: bool,
 }
 
 #[cfg(test)]

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -390,6 +390,7 @@ impl<I: Tokens> Parser<I> {
                 && !self.input.had_line_break_before_cur()
                 && is!(self, BindingIdent)
             {
+                // see https://github.com/tc39/ecma262/issues/2034
                 // ```js
                 // for(async of
                 // for(async of x);

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -1187,7 +1187,7 @@ impl<'a, I: Tokens> Parser<I> {
             self.include_in_expr(false).parse_expr_or_pat()?
         };
 
-        // ```spec
+        // ```spec https://tc39.es/ecma262/#prod-ForInOfStatement
         // for ( [lookahead ∉ { let, async of }] LeftHandSideExpression[?Yield, ?Await] of AssignmentExpression[+In, ?Yield, ?Await] ) Statement[?Yield, ?Await, ?Return]
         // [+Await] for await ( [lookahead ≠ let] LeftHandSideExpression[?Yield, ?Await] of AssignmentExpression[+In, ?Yield, ?Await] ) Statement[?Yield, ?Await, ?Return]
         // ```

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -2073,8 +2073,14 @@ export default function waitUntil(callback, options = {}) {
     }
 
     #[test]
-    fn for_async_of_eqgt() {
-        let src = "for (async of => {};;);";
+    fn for_of_head_lhs_async_dot() {
+        let src = "for (async.x of [1]) ;";
+        test_parser(src, Syntax::Es(Default::default()), |p| p.parse_module());
+    }
+
+    #[test]
+    fn for_head_init_async_of() {
+        let src = "for (async of => {}; i < 10; ++i) { ++counter; }";
         test_parser(src, Syntax::Es(Default::default()), |p| p.parse_module());
     }
 

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -1187,6 +1187,10 @@ impl<'a, I: Tokens> Parser<I> {
             self.include_in_expr(false).parse_expr_or_pat()?
         };
 
+        // ```spec
+        // for ( [lookahead ∉ { let, async of }] LeftHandSideExpression[?Yield, ?Await] of AssignmentExpression[+In, ?Yield, ?Await] ) Statement[?Yield, ?Await, ?Return]
+        // [+Await] for await ( [lookahead ≠ let] LeftHandSideExpression[?Yield, ?Await] of AssignmentExpression[+In, ?Yield, ?Await] ) Statement[?Yield, ?Await, ?Return]
+        // ```
         if starts_with_async_of && !is_for_await {
             self.emit_err(self.input.prev_span(), SyntaxError::TS1106);
         }

--- a/crates/swc_ecma_parser/tests/errors/ts1106/input.js
+++ b/crates/swc_ecma_parser/tests/errors/ts1106/input.js
@@ -1,0 +1,2 @@
+let async;
+for (async of [1]) ;

--- a/crates/swc_ecma_parser/tests/errors/ts1106/input.js.stderr
+++ b/crates/swc_ecma_parser/tests/errors/ts1106/input.js.stderr
@@ -1,0 +1,6 @@
+
+  x The left-hand side of a `for...of` statement may not be `async`
+   ,-[$DIR/tests/errors/ts1106/input.js:2:1]
+ 2 | for (async of [1]) ;
+   :      ^^^^^
+   `----


### PR DESCRIPTION
Invalid:

```JavaScript
for (async of []) {}
```

Valid

```JavaScript
 for await (async of []) {}
```