### PR TITLE
feat(es/minifier): Exclude `JSON` from alias list

### DIFF
--- a/crates/swc_ecma_minifier/src/alias/mod.rs
+++ b/crates/swc_ecma_minifier/src/alias/mod.rs
@@ -63,7 +63,8 @@ impl InfectionCollector<'_> {
 
         if self.unresolved_ctxt == Some(e.1) {
             match e.0 {
-                js_word!("String")
+                js_word!("JSON")
+                | js_word!("String")
                 | js_word!("Object")
                 | js_word!("Number")
                 | js_word!("BigInt")


### PR DESCRIPTION
**Description:**

I found that `JSON` is treated as an alias and it prevents proper minification

**Related issue (if exists):**
