### PR TITLE
fix(swc/core): bump versions, separate css

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,7 +2898,7 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.222.2"
+version = "0.222.3"
 dependencies = [
  "ahash",
  "ansi_term",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "binding_macros",
  "once_cell",
@@ -3092,8 +3092,13 @@ dependencies = [
  "swc_bundler",
  "swc_cached",
  "swc_common",
- "swc_css",
+ "swc_css_ast",
+ "swc_css_codegen",
+ "swc_css_minifier",
+ "swc_css_parser",
  "swc_css_prefixer",
+ "swc_css_utils",
+ "swc_css_visit",
  "swc_ecma_ast",
  "swc_ecma_codegen",
  "swc_ecma_loader",
@@ -3585,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.128.2"
+version = "0.128.3"
 dependencies = [
  "ahash",
  "arrayvec",

--- a/crates/binding_macros/Cargo.toml
+++ b/crates/binding_macros/Cargo.toml
@@ -32,7 +32,7 @@ binding_wasm = [
 # Common deps for the SWC imports
 swc                 = { optional = true, version = "0.222.0", path = "../swc" }
 swc_common          = { optional = true, version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast        = { optional = true, version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast        = { optional = true, version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_transforms = { optional = true, version = "0.189.0", path = "../swc_ecma_transforms" }
 
 # Optional deps for the wasm binding macro

--- a/crates/dbg-swc/Cargo.toml
+++ b/crates/dbg-swc/Cargo.toml
@@ -21,7 +21,7 @@ swc_atoms = { version = "0.4.5", path = "../swc_atoms" }
 swc_common = { version = "0.27.13", features = [
   "concurrent",
 ], path = "../swc_common" }
-swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "0.123.0", path = "../swc_ecma_codegen" }
 swc_ecma_minifier = { version = "0.150.0", path = "../swc_ecma_minifier", features = [
   "concurrent",

--- a/crates/jsdoc/Cargo.toml
+++ b/crates/jsdoc/Cargo.toml
@@ -20,6 +20,6 @@ swc_common = { version = "0.27.13", path = "../swc_common" }
 [dev-dependencies]
 anyhow          = "1"
 dashmap         = "5.1.0"
-swc_ecma_ast    = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast    = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_parser = { version = "0.118.0", path = "../swc_ecma_parser" }
 testing         = { version = "0.29.4", path = "../testing" }

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -9,7 +9,7 @@ include       = ["Cargo.toml", "src/**/*.rs"]
 license       = "Apache-2.0"
 name          = "swc"
 repository    = "https://github.com/swc-project/swc.git"
-version       = "0.222.2"
+version       = "0.222.3"
 
 [lib]
 bench = false
@@ -62,7 +62,7 @@ swc_common = { version = "0.27.13", path = "../swc_common", features = [
   "parking_lot",
 ] }
 swc_config = { version = "0.1.1", path = "../swc_config" }
-swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "0.123.0", path = "../swc_ecma_codegen" }
 swc_ecma_ext_transforms = { version = "0.86.0", path = "../swc_ecma_ext_transforms" }
 swc_ecma_lints = { version = "0.60.0", path = "../swc_ecma_lints" }
@@ -83,7 +83,7 @@ swc_ecma_transforms = { version = "0.189.0", path = "../swc_ecma_transforms", fe
   "typescript",
 ] }
 swc_ecma_transforms_base = { version = "0.105.0", path = "../swc_ecma_transforms_base" }
-swc_ecma_transforms_compat = { version = "0.128.0", path = "../swc_ecma_transforms_compat" }
+swc_ecma_transforms_compat = { version = "0.128.3", path = "../swc_ecma_transforms_compat" }
 swc_ecma_transforms_optimization = { version = "0.158.0", path = "../swc_ecma_transforms_optimization" }
 swc_ecma_utils = { version = "0.100.2", path = "../swc_ecma_utils" }
 swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit" }

--- a/crates/swc_bundler/Cargo.toml
+++ b/crates/swc_bundler/Cargo.toml
@@ -39,7 +39,7 @@ relative-path                    = "1.2"
 retain_mut                       = "0.1.2"
 swc_atoms                        = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                       = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast                     = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast                     = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_codegen                 = { version = "0.123.0", path = "../swc_ecma_codegen" }
 swc_ecma_loader                  = { version = "0.39.4", path = "../swc_ecma_loader" }
 swc_ecma_parser                  = { version = "0.118.0", path = "../swc_ecma_parser" }

--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -6,7 +6,7 @@ edition       = "2021"
 license       = "Apache-2.0"
 name          = "swc_core"
 repository    = "https://github.com/swc-project/swc.git"
-version       = "0.17.0"
+version       = "0.17.1"
   [package.metadata.docs.rs]
   features = [
     "common_perf",
@@ -132,7 +132,12 @@ codegen = ["swc_ecma_codegen"]
 minifier = ["swc_ecma_minifier"]
 
 # Enable swc_css
-css          = ["__css"]
+css_ast      = ["__css", "swc_css_ast"]
+css_codegen  = ["__css", "swc_css_codegen"]
+css_minifier = ["__css", "swc_css_minifier"]
+css_parser   = ["__css", "swc_css_parser"]
+css_utils    = ["__css", "swc_css_utils"]
+css_visit    = ["__css", "swc_css_visit"]
 css_prefixer = ["__css", "swc_css_prefixer"]
 
 # Enable trace macro support.
@@ -246,7 +251,7 @@ __binding_macros    = ["common", "__base", "__transforms", "ast", "binding_macro
 __bundler           = ["swc_bundler"]
 __cached            = ["swc_cached"]
 __common            = ["swc_common"]
-__css               = ["swc_css"]
+__css               = []
 __loader            = ["swc_ecma_loader"]
 __parser            = ["swc_ecma_parser"]
 __testing_transform = ["swc_ecma_transforms_testing"]
@@ -261,12 +266,17 @@ wasmer-wasi = { optional = true, version = "2.3.0", default-features = false }
 
 # swc_* dependencies
 binding_macros              = { optional = true, version = "0.10.0", path = "../binding_macros" }
-swc                         = { optional = true, version = "0.222.0", path = "../swc" }
+swc                         = { optional = true, version = "0.222.3", path = "../swc" }
 swc_atoms                   = { optional = true, version = "0.4.8", path = "../swc_atoms" }
 swc_bundler                 = { optional = true, version = "0.183.0", path = "../swc_bundler" }
 swc_cached                  = { optional = true, version = "0.3.5", path = "../swc_cached" }
 swc_common                  = { optional = true, version = "0.27.12", path = "../swc_common" }
-swc_css                     = { optional = true, version = "0.123.0", path = "../swc_css" }
+swc_css_ast                 = { optional = true, version = "0.110.0", path = "../swc_css_ast"}
+swc_css_codegen             = { optional = true, version = "0.120.0", path = "../swc_css_codegen"}
+swc_css_minifier            = { optional = true, version = "0.85.0", path = "../swc_css_minifier"}
+swc_css_parser              = { optional = true, version = "0.119.0", path = "../swc_css_parser"}
+swc_css_utils               = { optional = true, version = "0.107.0", path = "../swc_css_utils/"}
+swc_css_visit               = { optional = true, version = "0.109.0", path = "../swc_css_visit"}
 swc_css_prefixer            = { optional = true, version = "0.121.0", path = "../swc_css_prefixer" }
 swc_ecma_ast                = { optional = true, version = "0.90.10", path = "../swc_ecma_ast" }
 swc_ecma_codegen            = { optional = true, version = "0.123.0", path = "../swc_ecma_codegen" }

--- a/crates/swc_core/src/lib.rs
+++ b/crates/swc_core/src/lib.rs
@@ -141,13 +141,47 @@ pub mod minifier {
 #[cfg(feature = "__css")]
 #[cfg_attr(docsrs, doc(cfg(feature = "__css")))]
 pub mod css {
-    pub use swc_css::*;
-}
+    #[cfg(feature = "css_ast")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "css_ast")))]
+    pub mod ast {
+        pub use swc_css_ast::*;
+    }
 
-#[cfg(feature = "css_prefixer")]
-#[cfg_attr(docsrs, doc(cfg(feature = "css_prefixer")))]
-pub mod css_prefixer {
-    pub use swc_css_prefixer::*;
+    #[cfg(feature = "css_codegen")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "css_codegen")))]
+    pub mod codegen {
+        pub use swc_css_codegen::*;
+    }
+
+    #[cfg(feature = "css_minifier")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "css_minifier")))]
+    pub mod minifier {
+        pub use swc_css_minifier::*;
+    }
+
+    #[cfg(feature = "css_parser")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "css_parser")))]
+    pub mod parser {
+        pub use swc_css_parser::*;
+    }
+
+    #[cfg(feature = "css_utils")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "css_utils")))]
+    pub mod utils {
+        pub use swc_css_utils::*;
+    }
+
+    #[cfg(feature = "css_visit")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "css_visit")))]
+    pub mod visit {
+        pub use swc_css_visit::*;
+    }
+
+    #[cfg(feature = "css_prefixer")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "css_prefixer")))]
+    pub mod prefixer {
+        pub use swc_css_prefixer::*;
+    }
 }
 
 #[cfg(feature = "__cached")]

--- a/crates/swc_ecma_codegen/Cargo.toml
+++ b/crates/swc_ecma_codegen/Cargo.toml
@@ -21,7 +21,7 @@ serde                   = "1.0.127"
 sourcemap               = "6"
 swc_atoms               = { version = "0.4.5", path = "../swc_atoms" }
 swc_common              = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast            = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast            = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_codegen_macros = { version = "0.7.1", path = "../swc_ecma_codegen_macros" }
 tracing                 = "0.1.32"
 

--- a/crates/swc_ecma_dep_graph/Cargo.toml
+++ b/crates/swc_ecma_dep_graph/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 [dependencies]
 swc_atoms      = { version = "0.4.5", path = "../swc_atoms" }
 swc_common     = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast   = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast   = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit" }
 
 [dev-dependencies]

--- a/crates/swc_ecma_ext_transforms/Cargo.toml
+++ b/crates/swc_ecma_ext_transforms/Cargo.toml
@@ -14,6 +14,6 @@ bench = false
 phf            = { version = "0.10", features = ["macros"] }
 swc_atoms      = { version = "0.4.5", path = "../swc_atoms" }
 swc_common     = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast   = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast   = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_utils = { version = "0.100.2", path = "../swc_ecma_utils" }
 swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit" }

--- a/crates/swc_ecma_lints/Cargo.toml
+++ b/crates/swc_ecma_lints/Cargo.toml
@@ -25,7 +25,7 @@ swc_common = { version = "0.27.13", path = "../swc_common", features = [
   "concurrent",
 ] }
 swc_config = { version = "0.1.0", path = "../swc_config" }
-swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_utils = { version = "0.100.2", path = "../swc_ecma_utils" }
 swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit" }
 

--- a/crates/swc_ecma_minifier/Cargo.toml
+++ b/crates/swc_ecma_minifier/Cargo.toml
@@ -46,7 +46,7 @@ swc_atoms                        = { version = "0.4.5", path = "../swc_atoms" }
 swc_cached                       = { version = "0.3.5", path = "../swc_cached" }
 swc_common                       = { version = "0.27.13", path = "../swc_common" }
 swc_config                       = { version = "0.1.0", path = "../swc_config" }
-swc_ecma_ast                     = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast                     = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_codegen                 = { version = "0.123.0", path = "../swc_ecma_codegen" }
 swc_ecma_parser                  = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_transforms_base         = { version = "0.105.0", path = "../swc_ecma_transforms_base" }

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -32,7 +32,7 @@ serde          = { version = "1", features = ["derive"] }
 smallvec       = "1.8.0"
 swc_atoms      = { version = "0.4.5", path = "../swc_atoms" }
 swc_common     = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast   = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast   = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit", optional = true }
 tracing        = "0.1.32"
 typed-arena    = "2.0.1"

--- a/crates/swc_ecma_preset_env/Cargo.toml
+++ b/crates/swc_ecma_preset_env/Cargo.toml
@@ -25,7 +25,7 @@ st-map = "0.1.2"
 string_enum = { version = "0.3.1", path = "../string_enum" }
 swc_atoms = { version = "0.4.5", path = "../swc_atoms" }
 swc_common = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_transforms = { version = "0.189.0", path = "../swc_ecma_transforms", features = [
   "compat",
   "proposal",

--- a/crates/swc_ecma_quote/Cargo.toml
+++ b/crates/swc_ecma_quote/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 [dependencies]
 swc_atoms             = { version = "0.4.5", path = "../swc_atoms" }
 swc_common            = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast          = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast          = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_quote_macros = { version = "0.29.0", path = "../swc_ecma_quote_macros" }
 swc_ecma_utils        = { version = "0.100.2", path = "../swc_ecma_utils" }
 

--- a/crates/swc_ecma_quote_macros/Cargo.toml
+++ b/crates/swc_ecma_quote_macros/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro2       = "1"
 quote             = "1"
 swc_atoms         = { version = "0.4.5", path = "../swc_atoms" }
 swc_common        = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast      = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast      = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_parser   = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_macros_common = { version = "0.3.3", path = "../swc_macros_common" }
 syn               = "1"

--- a/crates/swc_ecma_testing/Cargo.toml
+++ b/crates/swc_ecma_testing/Cargo.toml
@@ -17,6 +17,6 @@ hex              = "0.4"
 sha-1            = "0.10"
 swc_atoms        = { version = "0.4.5", path = "../swc_atoms" }
 swc_common       = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast     = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast     = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "0.123.0", path = "../swc_ecma_codegen" }
 testing          = { version = "0.29.4", path = "../testing" }

--- a/crates/swc_ecma_transforms/Cargo.toml
+++ b/crates/swc_ecma_transforms/Cargo.toml
@@ -33,9 +33,9 @@ typescript = ["swc_ecma_transforms_typescript"]
 [dependencies]
 swc_atoms                        = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                       = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast                     = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast                     = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_transforms_base         = { version = "0.105.0", path = "../swc_ecma_transforms_base" }
-swc_ecma_transforms_compat       = { version = "0.128.0", path = "../swc_ecma_transforms_compat", optional = true }
+swc_ecma_transforms_compat       = { version = "0.128.3", path = "../swc_ecma_transforms_compat", optional = true }
 swc_ecma_transforms_module       = { version = "0.145.0", path = "../swc_ecma_transforms_module", optional = true }
 swc_ecma_transforms_optimization = { version = "0.158.0", path = "../swc_ecma_transforms_optimization", optional = true }
 swc_ecma_transforms_proposal     = { version = "0.136.0", path = "../swc_ecma_transforms_proposal", optional = true }

--- a/crates/swc_ecma_transforms_base/Cargo.toml
+++ b/crates/swc_ecma_transforms_base/Cargo.toml
@@ -28,7 +28,7 @@ serde             = { version = "1", features = ["derive"] }
 smallvec          = "1.8.0"
 swc_atoms         = { version = "0.4.5", path = "../swc_atoms" }
 swc_common        = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast      = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast      = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_parser   = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_utils    = { version = "0.100.2", path = "../swc_ecma_utils" }
 swc_ecma_visit    = { version = "0.76.6", path = "../swc_ecma_visit" }

--- a/crates/swc_ecma_transforms_classes/Cargo.toml
+++ b/crates/swc_ecma_transforms_classes/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 [dependencies]
 swc_atoms                = { version = "0.4.5", path = "../swc_atoms" }
 swc_common               = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast             = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast             = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_transforms_base = { version = "0.105.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_utils           = { version = "0.100.2", path = "../swc_ecma_utils" }
 swc_ecma_visit           = { version = "0.76.6", path = "../swc_ecma_visit" }

--- a/crates/swc_ecma_transforms_compat/Cargo.toml
+++ b/crates/swc_ecma_transforms_compat/Cargo.toml
@@ -7,7 +7,7 @@ include       = ["Cargo.toml", "src/**/*.rs"]
 license       = "Apache-2.0"
 name          = "swc_ecma_transforms_compat"
 repository    = "https://github.com/swc-project/swc.git"
-version       = "0.128.2"
+version       = "0.128.3"
 
 [lib]
 bench = false
@@ -32,7 +32,7 @@ smallvec                    = "1.8.0"
 swc_atoms                   = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                  = { version = "0.27.13", path = "../swc_common" }
 swc_config                  = { version = "0.1.0", path = "../swc_config" }
-swc_ecma_ast                = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast                = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_transforms_base    = { version = "0.105.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_classes = { version = "0.94.0", path = "../swc_ecma_transforms_classes" }
 swc_ecma_transforms_macros  = { version = "0.5.0", path = "../swc_ecma_transforms_macros" }

--- a/crates/swc_ecma_transforms_module/Cargo.toml
+++ b/crates/swc_ecma_transforms_module/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.118", features = ["derive"] }
 swc_atoms = { version = "0.4.5", path = "../swc_atoms" }
 swc_cached = { version = "0.3.5", path = "../swc_cached" }
 swc_common = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_loader = { version = "0.39.4", path = "../swc_ecma_loader", features = [
   "node",
 ] }
@@ -43,6 +43,6 @@ swc_ecma_loader = { version = "0.39.4", path = "../swc_ecma_loader", features = 
   "node",
   "tsc",
 ] }
-swc_ecma_transforms_compat = { version = "0.128.0", path = "../swc_ecma_transforms_compat" }
+swc_ecma_transforms_compat = { version = "0.128.3", path = "../swc_ecma_transforms_compat" }
 swc_ecma_transforms_testing = { version = "0.107.0", path = "../swc_ecma_transforms_testing" }
 testing = { version = "0.29.4", path = "../testing/" }

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -27,7 +27,7 @@ rustc-hash                 = "1.1.0"
 serde_json                 = "1.0.61"
 swc_atoms                  = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                 = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast               = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast               = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_parser            = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_transforms_base   = { version = "0.105.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_macros = { version = "0.5.0", path = "../swc_ecma_transforms_macros" }
@@ -36,7 +36,7 @@ swc_ecma_visit             = { version = "0.76.6", path = "../swc_ecma_visit" }
 tracing                    = "0.1.32"
 
 [dev-dependencies]
-swc_ecma_transforms_compat     = { version = "0.128.0", path = "../swc_ecma_transforms_compat" }
+swc_ecma_transforms_compat     = { version = "0.128.3", path = "../swc_ecma_transforms_compat" }
 swc_ecma_transforms_module     = { version = "0.145.0", path = "../swc_ecma_transforms_module" }
 swc_ecma_transforms_proposal   = { version = "0.136.0", path = "../swc_ecma_transforms_proposal" }
 swc_ecma_transforms_react      = { version = "0.147.0", path = "../swc_ecma_transforms_react" }

--- a/crates/swc_ecma_transforms_proposal/Cargo.toml
+++ b/crates/swc_ecma_transforms_proposal/Cargo.toml
@@ -22,7 +22,7 @@ serde                       = { version = "1.0.118", features = ["derive"] }
 smallvec                    = "1.8.0"
 swc_atoms                   = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                  = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast                = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast                = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_loader             = { version = "0.39.4", path = "../swc_ecma_loader", optional = true }
 swc_ecma_transforms_base    = { version = "0.105.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_classes = { version = "0.94.0", path = "../swc_ecma_transforms_classes" }
@@ -33,6 +33,6 @@ swc_ecma_visit              = { version = "0.76.6", path = "../swc_ecma_visit" }
 [dev-dependencies]
 serde_json                  = "1.0.66"
 swc_ecma_parser             = { version = "0.118.0", path = "../swc_ecma_parser" }
-swc_ecma_transforms_compat  = { version = "0.128.0", path = "../swc_ecma_transforms_compat" }
+swc_ecma_transforms_compat  = { version = "0.128.3", path = "../swc_ecma_transforms_compat" }
 swc_ecma_transforms_testing = { version = "0.107.0", path = "../swc_ecma_transforms_testing" }
 testing                     = { version = "0.29.4", path = "../testing" }

--- a/crates/swc_ecma_transforms_react/Cargo.toml
+++ b/crates/swc_ecma_transforms_react/Cargo.toml
@@ -29,7 +29,7 @@ string_enum                = { version = "0.3.1", path = "../string_enum" }
 swc_atoms                  = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                 = { version = "0.27.13", path = "../swc_common" }
 swc_config                 = { version = "0.1.0", path = "../swc_config" }
-swc_ecma_ast               = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast               = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_parser            = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_transforms_base   = { version = "0.105.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_macros = { version = "0.5.0", path = "../swc_ecma_transforms_macros" }

--- a/crates/swc_ecma_transforms_testing/Cargo.toml
+++ b/crates/swc_ecma_transforms_testing/Cargo.toml
@@ -19,7 +19,7 @@ serde                    = "1"
 serde_json               = "1"
 sha-1                    = "0.10"
 swc_common               = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast             = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast             = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_codegen         = { version = "0.123.0", path = "../swc_ecma_codegen" }
 swc_ecma_parser          = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_testing         = { version = "0.16.0", path = "../swc_ecma_testing" }

--- a/crates/swc_ecma_transforms_typescript/Cargo.toml
+++ b/crates/swc_ecma_transforms_typescript/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 serde                     = { version = "1.0.118", features = ["derive"] }
 swc_atoms                 = { version = "0.4.5", path = "../swc_atoms" }
 swc_common                = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast              = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast              = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_transforms_base  = { version = "0.105.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_react = { version = "0.147.0", path = "../swc_ecma_transforms_react" }
 swc_ecma_utils            = { version = "0.100.2", path = "../swc_ecma_utils" }
@@ -26,7 +26,7 @@ swc_ecma_visit            = { version = "0.76.6", path = "../swc_ecma_visit" }
 criterion                    = "0.3"
 swc_ecma_codegen             = { version = "0.123.0", path = "../swc_ecma_codegen" }
 swc_ecma_parser              = { version = "0.118.0", path = "../swc_ecma_parser" }
-swc_ecma_transforms_compat   = { version = "0.128.0", path = "../swc_ecma_transforms_compat" }
+swc_ecma_transforms_compat   = { version = "0.128.3", path = "../swc_ecma_transforms_compat" }
 swc_ecma_transforms_proposal = { version = "0.136.0", path = "../swc_ecma_transforms_proposal" }
 swc_ecma_transforms_testing  = { version = "0.107.0", path = "../swc_ecma_transforms_testing" }
 testing                      = { version = "0.29.4", path = "../testing" }

--- a/crates/swc_ecma_utils/Cargo.toml
+++ b/crates/swc_ecma_utils/Cargo.toml
@@ -25,7 +25,7 @@ once_cell      = "1.10.0"
 rayon          = { version = "1.5.1", optional = true }
 swc_atoms      = { version = "0.4.5", path = "../swc_atoms" }
 swc_common     = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast   = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast   = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit" }
 tracing        = "0.1.32"
 unicode-id     = "0.3"

--- a/crates/swc_ecma_visit/Cargo.toml
+++ b/crates/swc_ecma_visit/Cargo.toml
@@ -25,6 +25,6 @@ num-bigint   = { version = "0.4", features = ["serde"] }
 serde        = { version = "1", optional = true }
 swc_atoms    = { version = "0.4.5", path = "../swc_atoms" }
 swc_common   = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_visit    = { version = "0.5.2", path = "../swc_visit" }
 tracing      = "0.1.32"

--- a/crates/swc_ecmascript/Cargo.toml
+++ b/crates/swc_ecmascript/Cargo.toml
@@ -39,7 +39,7 @@ react        = ["swc_ecma_transforms/react"]
 typescript   = ["typescript-parser", "swc_ecma_transforms/typescript"]
 
 [dependencies]
-swc_ecma_ast        = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast        = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_codegen    = { version = "0.123.0", path = "../swc_ecma_codegen", optional = true }
 swc_ecma_dep_graph  = { version = "0.90.0", path = "../swc_ecma_dep_graph", optional = true }
 swc_ecma_minifier   = { version = "0.150.0", path = "../swc_ecma_minifier", optional = true }

--- a/crates/swc_estree_compat/Cargo.toml
+++ b/crates/swc_estree_compat/Cargo.toml
@@ -28,7 +28,7 @@ swc_common = { version = "0.27.13", path = "../swc_common", features = [
   "sourcemap",
   "tty-emitter",
 ] }
-swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_parser = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_utils = { version = "0.100.2", path = "../swc_ecma_utils" }
 swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit" }
@@ -39,7 +39,7 @@ swc_node_comments = { version = "0.14.4", path = "../swc_node_comments/" }
 criterion           = "0.3"
 pretty_assertions   = "1.1"
 swc                 = { version = "0.222.0", path = "../swc" }
-swc_ecma_ast        = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast        = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_parser     = { version = "0.118.0", path = "../swc_ecma_parser" }
 swc_ecma_transforms = { version = "0.189.0", path = "../swc_ecma_transforms/" }
 testing             = { version = "0.29.4", path = "../testing" }

--- a/crates/swc_html_minifier/Cargo.toml
+++ b/crates/swc_html_minifier/Cargo.toml
@@ -26,7 +26,7 @@ swc_css_ast              = { version = "0.110.0", path = "../swc_css_ast" }
 swc_css_codegen          = { version = "0.120.0", path = "../swc_css_codegen" }
 swc_css_minifier         = { version = "0.85.0", path = "../swc_css_minifier" }
 swc_css_parser           = { version = "0.119.0", path = "../swc_css_parser" }
-swc_ecma_ast             = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast             = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_codegen         = { version = "0.123.0", path = "../swc_ecma_codegen" }
 swc_ecma_minifier        = { version = "0.150.0", path = "../swc_ecma_minifier" }
 swc_ecma_parser          = { version = "0.118.0", path = "../swc_ecma_parser" }

--- a/crates/swc_node_bundler/Cargo.toml
+++ b/crates/swc_node_bundler/Cargo.toml
@@ -34,7 +34,7 @@ swc_bundler = { version = "0.183.0", path = "../swc_bundler", features = [
 swc_common = { version = "0.27.13", path = "../swc_common", features = [
   "concurrent",
 ] }
-swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "0.123.0", path = "../swc_ecma_codegen" }
 swc_ecma_loader = { version = "0.39.4", path = "../swc_ecma_loader" }
 swc_ecma_parser = { version = "0.118.0", path = "../swc_ecma_parser" }

--- a/crates/swc_plugin_proxy/Cargo.toml
+++ b/crates/swc_plugin_proxy/Cargo.toml
@@ -23,6 +23,6 @@ rkyv = "=0.7.37"
 swc_common = { version = "0.27.13", path = "../swc_common", features = [
   "plugin-base",
 ] }
-swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast" }
+swc_ecma_ast = { version = "0.90.15", path = "../swc_ecma_ast" }
 swc_trace_macro = { version = "0.1.2", path = "../swc_trace_macro" }
 tracing = "0.1.32"

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -32,7 +32,7 @@ swc_common = { version = "0.27.13", path = "../swc_common", features = [
   "plugin-rt",
   "concurrent",
 ] }
-swc_ecma_ast = { version = "0.90.12", path = "../swc_ecma_ast", features = [
+swc_ecma_ast = { version = "0.90.15", path = "../swc_ecma_ast", features = [
   "rkyv-impl",
 ] }
 swc_plugin_proxy = { version = "0.18.13", path = "../swc_plugin_proxy", features = [


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

With latest `swc_core` there's some errors like

```
error[E0277]: the trait bound `Box<swc_ecma_ast::Expr>: From<swc_ecma_ast::Function>` is not satisfied
    --> /Users/ojkwon/.cargo/registry/src/github.com-1ecc6299db9ec823/swc_ecma_transforms_compat-0.128.2/src/es2015/generator.rs:1282:34
     |
1282 | ...                   .into(),
     |                        ^^^^ the trait `From<swc_ecma_ast::Function>` is not implemented for `Box<swc_ecma_ast::Expr>`
     |
     = help: the following other types implement trait `From<T>`:
               <Box<(dyn StdError + 'a)> as From<E>>
               <Box<(dyn StdError + 'static)> as From<&str>>
```

Guess it requires another missing version bump.

Also PR splits swc_core importing whole `swc_css` to importing individual.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
