### PR TITLE
perf(es/minifier): Use faster hash algorithm for DCE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,6 +3690,7 @@ dependencies = [
  "swc_ecma_transforms_typescript",
  "swc_ecma_utils",
  "swc_ecma_visit",
+ "swc_fast_graph",
  "testing",
  "tracing",
 ]

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -38,6 +38,7 @@ swc_ecma_transforms_base   = { version = "0.106.0", path = "../swc_ecma_transfor
 swc_ecma_transforms_macros = { version = "0.5.0", path = "../swc_ecma_transforms_macros" }
 swc_ecma_utils             = { version = "0.101.0", path = "../swc_ecma_utils" }
 swc_ecma_visit             = { version = "0.76.6", path = "../swc_ecma_visit" }
+swc_fast_graph             = { version = "0.15.4", path = "../swc_fast_graph" }
 tracing                    = "0.1.32"
 
 [dev-dependencies]

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, sync::Arc};
 
 use indexmap::IndexSet;
-use petgraph::{algo::tarjan_scc, prelude::DiGraphMap, Direction::Incoming};
+use petgraph::{algo::tarjan_scc, Direction::Incoming};
 use swc_atoms::{js_word, JsWord};
 use swc_common::{
     collections::{AHashMap, AHashSet},
@@ -20,6 +20,7 @@ use swc_ecma_utils::{
 use swc_ecma_visit::{
     as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith, VisitWith,
 };
+use swc_fast_graph::digraph::FastDiGraphMap;
 use tracing::{debug, span, Level};
 
 use crate::debug_assert_valid;
@@ -100,7 +101,7 @@ struct Data {
     used_names: AHashMap<Id, VarInfo>,
 
     /// Variable usage graph
-    graph: DiGraphMap<usize, VarInfo>,
+    graph: FastDiGraphMap<usize, VarInfo>,
     graph_ix: IndexSet<Id, ahash::RandomState>,
 }
 

--- a/crates/swc_fast_graph/src/digraph.rs
+++ b/crates/swc_fast_graph/src/digraph.rs
@@ -19,7 +19,10 @@ use indexmap::{
 };
 use petgraph::{
     graph::{node_index, Graph},
-    visit::{GraphBase, IntoNeighbors, IntoNeighborsDirected, NodeCount, Visitable},
+    visit::{
+        GraphBase, GraphRef, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount,
+        Visitable,
+    },
     Directed, Direction, EdgeType, Incoming, IntoWeightedEdge, Outgoing, Undirected,
 };
 use swc_common::collections::AHashSet;
@@ -892,4 +895,18 @@ where
     fn neighbors_directed(self, n: N, dir: Direction) -> Self::NeighborsDirected {
         self.neighbors_directed(n, dir)
     }
+}
+
+impl<N, E, Ty> GraphRef for FastGraphMap<N, E, Ty>
+where
+    N: Copy + Ord + Hash,
+    Ty: EdgeType,
+{
+}
+
+impl<N, E, Ty> IntoNodeIdentifiers for FastGraphMap<N, E, Ty>
+where
+    N: Copy + Ord + Hash,
+    Ty: EdgeType,
+{
 }

--- a/crates/swc_fast_graph/src/digraph.rs
+++ b/crates/swc_fast_graph/src/digraph.rs
@@ -20,8 +20,7 @@ use indexmap::{
 use petgraph::{
     graph::{node_index, Graph},
     visit::{
-        GraphBase, GraphRef, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount,
-        Visitable,
+        GraphBase, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, Visitable,
     },
     Directed, Direction, EdgeType, Incoming, IntoWeightedEdge, Outgoing, Undirected,
 };
@@ -897,9 +896,18 @@ where
     }
 }
 
-impl<N, E, Ty> IntoNodeIdentifiers for &'_ FastGraphMap<N, E, Ty>
+impl<'a, N, E: 'a, Ty> IntoNodeIdentifiers for &'a FastGraphMap<N, E, Ty>
 where
-    N: Copy + Ord + Hash,
+    N: NodeTrait,
     Ty: EdgeType,
 {
+    type NodeIdentifiers = NodeIdentifiers<'a, N, E, Ty>;
+
+    fn node_identifiers(self) -> Self::NodeIdentifiers {
+        NodeIdentifiers {
+            iter: self.nodes.iter(),
+            ty: self.ty,
+            edge_ty: PhantomData,
+        }
+    }
 }

--- a/crates/swc_fast_graph/src/digraph.rs
+++ b/crates/swc_fast_graph/src/digraph.rs
@@ -897,14 +897,7 @@ where
     }
 }
 
-impl<N, E, Ty> GraphRef for FastGraphMap<N, E, Ty>
-where
-    N: Copy + Ord + Hash,
-    Ty: EdgeType,
-{
-}
-
-impl<N, E, Ty> IntoNodeIdentifiers for FastGraphMap<N, E, Ty>
+impl<N, E, Ty> IntoNodeIdentifiers for &'_ FastGraphMap<N, E, Ty>
 where
     N: Copy + Ord + Hash,
     Ty: EdgeType,

--- a/crates/swc_fast_graph/src/digraph.rs
+++ b/crates/swc_fast_graph/src/digraph.rs
@@ -20,7 +20,8 @@ use indexmap::{
 use petgraph::{
     graph::{node_index, Graph},
     visit::{
-        GraphBase, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, Visitable,
+        GraphBase, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount,
+        NodeIndexable, Visitable,
     },
     Directed, Direction, EdgeType, Incoming, IntoWeightedEdge, Outgoing, Undirected,
 };
@@ -909,5 +910,30 @@ where
             ty: self.ty,
             edge_ty: PhantomData,
         }
+    }
+}
+
+impl<N, E, Ty> NodeIndexable for FastGraphMap<N, E, Ty>
+where
+    N: NodeTrait,
+    Ty: EdgeType,
+{
+    fn node_bound(&self) -> usize {
+        self.node_count()
+    }
+
+    fn to_index(&self, ix: Self::NodeId) -> usize {
+        let (i, _, _) = self.nodes.get_full(&ix).unwrap();
+        i
+    }
+
+    fn from_index(&self, ix: usize) -> Self::NodeId {
+        assert!(
+            ix < self.nodes.len(),
+            "The requested index {} is out-of-bounds.",
+            ix
+        );
+        let (&key, _) = self.nodes.get_index(ix).unwrap();
+        key
     }
 }


### PR DESCRIPTION
**Description:**

```
Gnuplot not found, using plotters backend
Benchmarking es/minify/libraries/antd
Benchmarking es/minify/libraries/antd: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.8s.
Benchmarking es/minify/libraries/antd: Collecting 10 samples in estimated 9.7858 s (10 iterations)
Benchmarking es/minify/libraries/antd: Analyzing
es/minify/libraries/antd
                        time:   [973.97 ms 978.17 ms 982.84 ms]
                        change: [-14.484% -13.774% -13.119%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/d3
Benchmarking es/minify/libraries/d3: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.8s or enable flat sampling.
Benchmarking es/minify/libraries/d3: Collecting 10 samples in estimated 9.7989 s (55 iterations)
Benchmarking es/minify/libraries/d3: Analyzing
es/minify/libraries/d3  time:   [174.23 ms 175.05 ms 176.08 ms]
                        change: [-11.283% -10.465% -9.6405%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/echarts
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.4s.
Benchmarking es/minify/libraries/echarts: Collecting 10 samples in estimated 7.4259 s (10 iterations)
Benchmarking es/minify/libraries/echarts: Analyzing
es/minify/libraries/echarts
                        time:   [732.88 ms 737.46 ms 742.49 ms]
                        change: [-16.454% -15.895% -15.288%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/jquery
Benchmarking es/minify/libraries/jquery: Warming up for 3.0000 s
Benchmarking es/minify/libraries/jquery: Collecting 10 samples in estimated 5.2442 s (110 iterations)
Benchmarking es/minify/libraries/jquery: Analyzing
es/minify/libraries/jquery
                        time:   [47.654 ms 47.760 ms 47.862 ms]
                        change: [-9.5734% -8.7148% -7.9718%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/lodash
Benchmarking es/minify/libraries/lodash: Warming up for 3.0000 s
Benchmarking es/minify/libraries/lodash: Collecting 10 samples in estimated 6.8998 s (110 iterations)
Benchmarking es/minify/libraries/lodash: Analyzing
es/minify/libraries/lodash
                        time:   [62.218 ms 62.358 ms 62.581 ms]
                        change: [-12.808% -11.893% -11.015%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/moment
Benchmarking es/minify/libraries/moment: Warming up for 3.0000 s
Benchmarking es/minify/libraries/moment: Collecting 10 samples in estimated 6.2156 s (220 iterations)
Benchmarking es/minify/libraries/moment: Analyzing
es/minify/libraries/moment
                        time:   [27.879 ms 27.925 ms 28.001 ms]
                        change: [-12.767% -11.830% -10.834%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
Benchmarking es/minify/libraries/react
Benchmarking es/minify/libraries/react: Warming up for 3.0000 s
Benchmarking es/minify/libraries/react: Collecting 10 samples in estimated 5.1460 s (440 iterations)
Benchmarking es/minify/libraries/react: Analyzing
es/minify/libraries/react
                        time:   [11.592 ms 11.638 ms 11.693 ms]
                        change: [-12.449% -11.356% -10.398%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/terser
Benchmarking es/minify/libraries/terser: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.8s or enable flat sampling.
Benchmarking es/minify/libraries/terser: Collecting 10 samples in estimated 7.8352 s (55 iterations)
Benchmarking es/minify/libraries/terser: Analyzing
es/minify/libraries/terser
                        time:   [141.06 ms 141.45 ms 141.92 ms]
                        change: [-11.284% -9.9684% -8.8881%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/three
Benchmarking es/minify/libraries/three: Warming up for 3.0000 s
Benchmarking es/minify/libraries/three: Collecting 10 samples in estimated 7.1344 s (30 iterations)
Benchmarking es/minify/libraries/three: Analyzing
es/minify/libraries/three
                        time:   [236.07 ms 236.62 ms 237.13 ms]
                        change: [-17.076% -15.989% -15.151%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/typescript
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 21.4s.
Benchmarking es/minify/libraries/typescript: Collecting 10 samples in estimated 21.427 s (10 iterations)
Benchmarking es/minify/libraries/typescript: Analyzing
es/minify/libraries/typescript
                        time:   [2.1379 s 2.1416 s 2.1460 s]
                        change: [-12.655% -12.213% -11.821%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
Benchmarking es/minify/libraries/victory
Benchmarking es/minify/libraries/victory: Warming up for 3.0000 s
Benchmarking es/minify/libraries/victory: Collecting 10 samples in estimated 7.3064 s (20 iterations)
Benchmarking es/minify/libraries/victory: Analyzing
es/minify/libraries/victory
                        time:   [356.60 ms 357.92 ms 359.18 ms]
                        change: [-22.616% -19.727% -17.842%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/vue
Benchmarking es/minify/libraries/vue: Warming up for 3.0000 s
Benchmarking es/minify/libraries/vue: Collecting 10 samples in estimated 7.9714 s (110 iterations)
Benchmarking es/minify/libraries/vue: Analyzing
es/minify/libraries/vue time:   [72.312 ms 72.431 ms 72.556 ms]
                        change: [-13.392% -11.778% -10.352%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```

**Related issue (if exists):**
