### PR TITLE
perf(es/minifier): Optimize precompress optimizer

### DIFF
--- a/crates/swc_ecma_minifier/src/pass/precompress.rs
+++ b/crates/swc_ecma_minifier/src/pass/precompress.rs
@@ -77,17 +77,14 @@ impl PrecompressOptimizer<'_> {
             return;
         }
 
-        maybe_par!(
-            stmts.iter_mut().for_each(|stmt| {
-                stmt.visit_mut_with(&mut PrecompressOptimizer {
-                    options: self.options,
-                    module_info: self.module_info,
-                    marks: self.marks,
-                    ctx: self.ctx,
-                })
-            }),
-            *crate::HEAVY_TASK_PARALLELS
-        );
+        stmts.iter_mut().for_each(|stmt| {
+            stmt.visit_mut_with(&mut PrecompressOptimizer {
+                options: self.options,
+                module_info: self.module_info,
+                marks: self.marks,
+                ctx: self.ctx,
+            })
+        })
     }
 }
 

--- a/crates/swc_ecma_minifier/src/pass/precompress.rs
+++ b/crates/swc_ecma_minifier/src/pass/precompress.rs
@@ -35,7 +35,7 @@ pub(crate) struct PrecompressOptimizer<'a> {
 
     marks: Marks,
 
-    data: Option<ProgramData>,
+    data: Option<&'a ProgramData>,
     ctx: Ctx,
 }
 
@@ -70,7 +70,7 @@ impl PrecompressOptimizer<'_> {
                     options: self.options,
                     module_info: self.module_info,
                     marks: self.marks,
-                    data,
+                    data: data.as_ref(),
                     ctx: self.ctx,
                 });
                 return;

--- a/crates/swc_ecma_minifier/src/pass/precompress.rs
+++ b/crates/swc_ecma_minifier/src/pass/precompress.rs
@@ -88,15 +88,18 @@ impl PrecompressOptimizer<'_> {
                 return;
             }
 
-            stmts.iter_mut().for_each(|stmt| {
-                stmt.visit_mut_with(&mut PrecompressOptimizer {
-                    options: self.options,
-                    module_info: self.module_info,
-                    marks: self.marks,
-                    data: None,
-                    ctx: self.ctx,
-                })
-            });
+            maybe_par!(
+                stmts.iter_mut().for_each(|stmt| {
+                    stmt.visit_mut_with(&mut PrecompressOptimizer {
+                        options: self.options,
+                        module_info: self.module_info,
+                        marks: self.marks,
+                        data: None,
+                        ctx: self.ctx,
+                    })
+                }),
+                *crate::LIGHT_TASK_PARALLELS
+            );
         }
     }
 }

--- a/crates/swc_ecma_minifier/src/pass/precompress.rs
+++ b/crates/swc_ecma_minifier/src/pass/precompress.rs
@@ -1,6 +1,7 @@
 use swc_atoms::js_word;
 use swc_common::util::take::Take;
 use swc_ecma_ast::*;
+use swc_ecma_transforms_base::perf::Parallel;
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith, VisitWith};
 
 use crate::{
@@ -37,6 +38,14 @@ pub(crate) struct PrecompressOptimizer<'a> {
 
     data: Option<&'a ProgramData>,
     ctx: Ctx,
+}
+
+impl Parallel for PrecompressOptimizer<'_> {
+    fn create(&self) -> Self {
+        Self { ..*self }
+    }
+
+    fn merge(&mut self, _: Self) {}
 }
 
 #[derive(Debug, Default, Clone, Copy)]


### PR DESCRIPTION
**Description:**


We don't use analyzed information.

```
Gnuplot not found, using plotters backend
Benchmarking es/minify/libraries/antd
Benchmarking es/minify/libraries/antd: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.5s.
Benchmarking es/minify/libraries/antd: Collecting 10 samples in estimated 9.4594 s (10 iterations)
Benchmarking es/minify/libraries/antd: Analyzing
es/minify/libraries/antd
                        time:   [945.03 ms 959.04 ms 976.73 ms]
                        change: [-6.7750% -5.3805% -3.9554%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
Benchmarking es/minify/libraries/d3
Benchmarking es/minify/libraries/d3: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.8s or enable flat sampling.
Benchmarking es/minify/libraries/d3: Collecting 10 samples in estimated 9.8131 s (55 iterations)
Benchmarking es/minify/libraries/d3: Analyzing
es/minify/libraries/d3  time:   [164.23 ms 164.68 ms 164.99 ms]
                        change: [-6.6207% -5.7992% -4.9443%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/echarts
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.0s.
Benchmarking es/minify/libraries/echarts: Collecting 10 samples in estimated 7.0275 s (10 iterations)
Benchmarking es/minify/libraries/echarts: Analyzing
es/minify/libraries/echarts
                        time:   [702.33 ms 704.55 ms 707.25 ms]
                        change: [-5.5451% -5.0956% -4.6317%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/jquery
Benchmarking es/minify/libraries/jquery: Warming up for 3.0000 s
Benchmarking es/minify/libraries/jquery: Collecting 10 samples in estimated 5.0503 s (110 iterations)
Benchmarking es/minify/libraries/jquery: Analyzing
es/minify/libraries/jquery
                        time:   [45.294 ms 45.496 ms 45.650 ms]
                        change: [-5.5284% -5.1105% -4.6856%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/lodash
Benchmarking es/minify/libraries/lodash: Warming up for 3.0000 s
Benchmarking es/minify/libraries/lodash: Collecting 10 samples in estimated 6.6399 s (110 iterations)
Benchmarking es/minify/libraries/lodash: Analyzing
es/minify/libraries/lodash
                        time:   [58.391 ms 58.495 ms 58.693 ms]
                        change: [-6.4343% -5.9351% -5.4022%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/moment
Benchmarking es/minify/libraries/moment: Warming up for 3.0000 s
Benchmarking es/minify/libraries/moment: Collecting 10 samples in estimated 5.9152 s (220 iterations)
Benchmarking es/minify/libraries/moment: Analyzing
es/minify/libraries/moment
                        time:   [26.737 ms 26.784 ms 26.831 ms]
                        change: [-4.5421% -4.1302% -3.7351%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/react
Benchmarking es/minify/libraries/react: Warming up for 3.0000 s
Benchmarking es/minify/libraries/react: Collecting 10 samples in estimated 5.5529 s (495 iterations)
Benchmarking es/minify/libraries/react: Analyzing
es/minify/libraries/react
                        time:   [11.133 ms 11.174 ms 11.199 ms]
                        change: [-4.8817% -4.4445% -3.9689%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/terser
Benchmarking es/minify/libraries/terser: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.4s or enable flat sampling.
Benchmarking es/minify/libraries/terser: Collecting 10 samples in estimated 7.4083 s (55 iterations)
Benchmarking es/minify/libraries/terser: Analyzing
es/minify/libraries/terser
                        time:   [133.48 ms 134.14 ms 134.61 ms]
                        change: [-6.4549% -5.7183% -5.0636%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/three
Benchmarking es/minify/libraries/three: Warming up for 3.0000 s
Benchmarking es/minify/libraries/three: Collecting 10 samples in estimated 6.7351 s (30 iterations)
Benchmarking es/minify/libraries/three: Analyzing
es/minify/libraries/three
                        time:   [224.49 ms 227.71 ms 231.74 ms]
                        change: [-5.1215% -3.7650% -2.1591%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/typescript
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 20.8s.
Benchmarking es/minify/libraries/typescript: Collecting 10 samples in estimated 20.829 s (10 iterations)
Benchmarking es/minify/libraries/typescript: Analyzing
es/minify/libraries/typescript
                        time:   [2.0569 s 2.0618 s 2.0672 s]
                        change: [-4.0257% -3.7274% -3.4348%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/victory
Benchmarking es/minify/libraries/victory: Warming up for 3.0000 s
Benchmarking es/minify/libraries/victory: Collecting 10 samples in estimated 6.8836 s (20 iterations)
Benchmarking es/minify/libraries/victory: Analyzing
es/minify/libraries/victory
                        time:   [341.79 ms 343.06 ms 344.53 ms]
                        change: [-4.6464% -4.1530% -3.6139%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/vue
Benchmarking es/minify/libraries/vue: Warming up for 3.0000 s
Benchmarking es/minify/libraries/vue: Collecting 10 samples in estimated 7.5975 s (110 iterations)
Benchmarking es/minify/libraries/vue: Analyzing
es/minify/libraries/vue time:   [68.536 ms 68.729 ms 69.000 ms]
                        change: [-5.3909% -4.9216% -4.4301%] (p = 0.00 < 0.05)
                        Performance has improved.
```

**Related issue (if exists):**
