### PR TITLE
perf(es/minifier): Skip useless analysis if not required

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/mod.rs
@@ -223,7 +223,7 @@ where
             thread::current().name()
         );
 
-        {
+        if self.options.hoist_vars || self.options.hoist_fns {
             let data = analyze(&*n, self.module_info, Some(self.marks));
 
             let mut v = decl_hoister(


### PR DESCRIPTION
**Description:**

We don't need to run full analyzer if both of options are false

**Related issue (if exists):**
