### PR TITLE
refactor(es/utils): Move utilities for parallel processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3587,7 +3587,6 @@ dependencies = [
  "better_scoped_tls",
  "bitflags",
  "criterion",
- "num_cpus",
  "once_cell",
  "phf",
  "rayon",
@@ -3822,6 +3821,7 @@ name = "swc_ecma_utils"
 version = "0.101.0"
 dependencies = [
  "indexmap",
+ "num_cpus",
  "once_cell",
  "rayon",
  "swc_atoms",

--- a/crates/swc_ecma_transforms_base/Cargo.toml
+++ b/crates/swc_ecma_transforms_base/Cargo.toml
@@ -1,52 +1,51 @@
 [package]
-authors       = ["강동윤 <kdy1997.dev@gmail.com>"]
-description   = "rust port of babel and closure compiler."
+authors = ["강동윤 <kdy1997.dev@gmail.com>"]
+description = "rust port of babel and closure compiler."
 documentation = "https://rustdoc.swc.rs/swc_ecma_transforms_base/"
-edition       = "2021"
-include       = ["Cargo.toml", "src/**/*.rs", "src/**/*.js"]
-license       = "Apache-2.0"
-name          = "swc_ecma_transforms_base"
-repository    = "https://github.com/swc-project/swc.git"
-version       = "0.106.1"
+edition = "2021"
+include = ["Cargo.toml", "src/**/*.rs", "src/**/*.js"]
+license = "Apache-2.0"
+name = "swc_ecma_transforms_base"
+repository = "https://github.com/swc-project/swc.git"
+version = "0.106.1"
 
 [lib]
 bench = false
 
 [features]
-concurrent         = ["concurrent-renamer", "rayon", "swc_ecma_utils/concurrent"]
+concurrent = ["concurrent-renamer", "rayon", "swc_ecma_utils/concurrent"]
 concurrent-renamer = ["rayon"]
 
 [dependencies]
-better_scoped_tls = { version = "0.1.0", path = "../better_scoped_tls" }
-bitflags          = "1"
-num_cpus          = "1.13.1"
-once_cell         = "1.10.0"
-phf               = { version = "0.10", features = ["macros"] }
-rayon             = { version = "1", optional = true }
-rustc-hash        = "1.1.0"
-serde             = { version = "1", features = ["derive"] }
-smallvec          = "1.8.0"
-swc_atoms         = { version = "0.4.10", path = "../swc_atoms" }
-swc_common        = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast      = { version = "0.90.15", path = "../swc_ecma_ast" }
-swc_ecma_parser   = { version = "0.118.0", path = "../swc_ecma_parser" }
-swc_ecma_utils    = { version = "0.101.0", path = "../swc_ecma_utils" }
-swc_ecma_visit    = { version = "0.76.6", path = "../swc_ecma_visit" }
-tracing           = "0.1.32"
+better_scoped_tls = {version = "0.1.0", path = "../better_scoped_tls"}
+bitflags = "1"
+once_cell = "1.10.0"
+phf = {version = "0.10", features = ["macros"]}
+rayon = {version = "1", optional = true}
+rustc-hash = "1.1.0"
+serde = {version = "1", features = ["derive"]}
+smallvec = "1.8.0"
+swc_atoms = {version = "0.4.10", path = "../swc_atoms"}
+swc_common = {version = "0.27.13", path = "../swc_common"}
+swc_ecma_ast = {version = "0.90.15", path = "../swc_ecma_ast"}
+swc_ecma_parser = {version = "0.118.0", path = "../swc_ecma_parser"}
+swc_ecma_utils = {version = "0.101.0", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.76.6", path = "../swc_ecma_visit"}
+tracing = "0.1.32"
 
 [dev-dependencies]
-criterion                  = "0.3"
-swc_ecma_codegen           = { version = "0.123.0", path = "../swc_ecma_codegen" }
-swc_ecma_transforms_macros = { version = "0.5.0", path = "../swc_ecma_transforms_macros" }
-swc_node_base              = { version = "0.5.5", path = "../swc_node_base" }
-testing                    = { version = "0.29.4", path = "../testing" }
+criterion = "0.3"
+swc_ecma_codegen = {version = "0.123.0", path = "../swc_ecma_codegen"}
+swc_ecma_transforms_macros = {version = "0.5.0", path = "../swc_ecma_transforms_macros"}
+swc_node_base = {version = "0.5.5", path = "../swc_node_base"}
+testing = {version = "0.29.4", path = "../testing"}
 
 [[bench]]
 harness = false
-name    = "base"
+name = "base"
 [[bench]]
 harness = false
-name    = "deps"
+name = "deps"
 [[bench]]
 harness = false
-name    = "time_complexity"
+name = "time_complexity"

--- a/crates/swc_ecma_transforms_base/src/perf.rs
+++ b/crates/swc_ecma_transforms_base/src/perf.rs
@@ -281,26 +281,6 @@ where
     }
 }
 
-/// This is considered as a private type and it's NOT A PUBLIC API.
-#[cfg(feature = "concurrent")]
-#[allow(clippy::len_without_is_empty)]
-pub trait Items:
-    rayon::iter::IntoParallelIterator<Item = Self::Elem> + IntoIterator<Item = Self::Elem>
-{
-    type Elem: Send + Sync;
-
-    fn len(&self) -> usize;
-}
-
-/// This is considered as a private type and it's NOT A PUBLIC API.
-#[cfg(not(feature = "concurrent"))]
-#[allow(clippy::len_without_is_empty)]
-pub trait Items: IntoIterator<Item = Self::Elem> {
-    type Elem: Send + Sync;
-
-    fn len(&self) -> usize;
-}
-
 pub trait ParallelExt: Parallel {
     /// Invoke `op` in parallel, if `swc_ecma_transforms_base` is compiled with
     /// concurrent feature enabled and `nodes.len()` is bigger than threshold.
@@ -371,49 +351,5 @@ where
         for n in nodes {
             op(self, n);
         }
-    }
-}
-
-impl<T> Items for Vec<T>
-where
-    T: Send + Sync,
-{
-    type Elem = T;
-
-    fn len(&self) -> usize {
-        Vec::len(self)
-    }
-}
-
-impl<'a, T> Items for &'a mut Vec<T>
-where
-    T: Send + Sync,
-{
-    type Elem = &'a mut T;
-
-    fn len(&self) -> usize {
-        Vec::len(self)
-    }
-}
-
-impl<'a, T> Items for &'a mut [T]
-where
-    T: Send + Sync,
-{
-    type Elem = &'a mut T;
-
-    fn len(&self) -> usize {
-        <[T]>::len(self)
-    }
-}
-
-impl<'a, T> Items for &'a [T]
-where
-    T: Send + Sync,
-{
-    type Elem = &'a T;
-
-    fn len(&self) -> usize {
-        <[T]>::len(self)
     }
 }

--- a/crates/swc_ecma_transforms_base/src/perf.rs
+++ b/crates/swc_ecma_transforms_base/src/perf.rs
@@ -2,7 +2,6 @@ use swc_common::util::move_map::MoveMap;
 #[cfg(feature = "concurrent")]
 use swc_common::{errors::HANDLER, GLOBALS};
 use swc_ecma_ast::*;
-use swc_ecma_utils::parallel::Parallel;
 pub use swc_ecma_utils::parallel::*;
 use swc_ecma_visit::{Fold, FoldWith, Visit, VisitMut, VisitMutWith, VisitWith};
 

--- a/crates/swc_ecma_transforms_base/src/perf.rs
+++ b/crates/swc_ecma_transforms_base/src/perf.rs
@@ -3,6 +3,7 @@ use swc_common::util::move_map::MoveMap;
 use swc_common::{errors::HANDLER, GLOBALS};
 use swc_ecma_ast::*;
 use swc_ecma_utils::parallel::Parallel;
+pub use swc_ecma_utils::parallel::*;
 use swc_ecma_visit::{Fold, FoldWith, Visit, VisitMut, VisitMutWith, VisitWith};
 
 #[cfg(feature = "concurrent")]

--- a/crates/swc_ecma_transforms_base/src/perf.rs
+++ b/crates/swc_ecma_transforms_base/src/perf.rs
@@ -1,8 +1,8 @@
-use once_cell::sync::Lazy;
 use swc_common::util::move_map::MoveMap;
 #[cfg(feature = "concurrent")]
 use swc_common::{errors::HANDLER, GLOBALS};
 use swc_ecma_ast::*;
+use swc_ecma_utils::parallel::Parallel;
 use swc_ecma_visit::{Fold, FoldWith, Visit, VisitMut, VisitMutWith, VisitWith};
 
 #[cfg(feature = "concurrent")]
@@ -20,26 +20,6 @@ where
     let mut checker = C::default();
     n.visit_with(&mut checker);
     checker.should_handle()
-}
-
-static CPU_COUNT: Lazy<usize> = Lazy::new(num_cpus::get);
-
-pub fn cpu_count() -> usize {
-    *CPU_COUNT
-}
-
-pub trait Parallel: swc_common::sync::Send + swc_common::sync::Sync {
-    /// Used to create visitor.
-    fn create(&self) -> Self;
-
-    /// This can be called in anytime.
-    fn merge(&mut self, other: Self);
-
-    /// Invoked after visiting all [Stmt]s, possibly in parallel.
-    fn after_stmts(&mut self, _stmts: &mut Vec<Stmt>) {}
-
-    /// Invoked after visiting all [ModuleItem]s, possibly in parallel.
-    fn after_module_items(&mut self, _stmts: &mut Vec<ModuleItem>) {}
 }
 
 pub trait ParExplode: Parallel {
@@ -278,78 +258,5 @@ where
         N: Send + Sync + FoldWith<Self>,
     {
         nodes.move_map(|n| n.fold_with(self))
-    }
-}
-
-pub trait ParallelExt: Parallel {
-    /// Invoke `op` in parallel, if `swc_ecma_transforms_base` is compiled with
-    /// concurrent feature enabled and `nodes.len()` is bigger than threshold.
-    ///
-    ///
-    /// This configures [GLOBALS], while not configuring [HANDLER] nor [HELPERS]
-    fn maybe_par<I, F>(&mut self, threshold: usize, nodes: I, op: F)
-    where
-        I: Items,
-        F: Send + Sync + Fn(&mut Self, I::Elem);
-}
-
-#[cfg(feature = "concurrent")]
-impl<T> ParallelExt for T
-where
-    T: Parallel,
-{
-    fn maybe_par<I, F>(&mut self, threshold: usize, nodes: I, op: F)
-    where
-        I: Items,
-        F: Send + Sync + Fn(&mut Self, I::Elem),
-    {
-        if nodes.len() >= threshold || option_env!("SWC_FORCE_CONCURRENT") == Some("1") {
-            GLOBALS.with(|globals| {
-                use rayon::prelude::*;
-
-                let visitor = nodes
-                    .into_par_iter()
-                    .map(|node| {
-                        GLOBALS.set(globals, || {
-                            let mut visitor = Parallel::create(&*self);
-                            op(&mut visitor, node);
-
-                            visitor
-                        })
-                    })
-                    .reduce(
-                        || Parallel::create(&*self),
-                        |mut a, b| {
-                            Parallel::merge(&mut a, b);
-
-                            a
-                        },
-                    );
-
-                Parallel::merge(self, visitor);
-            });
-
-            return;
-        }
-
-        for n in nodes {
-            op(self, n);
-        }
-    }
-}
-
-#[cfg(not(feature = "concurrent"))]
-impl<T> ParallelExt for T
-where
-    T: Parallel,
-{
-    fn maybe_par<I, F>(&mut self, _threshold: usize, nodes: I, op: F)
-    where
-        I: Items,
-        F: Send + Sync + Fn(&mut Self, I::Elem),
-    {
-        for n in nodes {
-            op(self, n);
-        }
     }
 }

--- a/crates/swc_ecma_utils/Cargo.toml
+++ b/crates/swc_ecma_utils/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-authors       = ["강동윤 <kdy1997.dev@gmail.com>"]
-description   = "Utilities for swc ecmascript ast nodes"
+authors = ["강동윤 <kdy1997.dev@gmail.com>"]
+description = "Utilities for swc ecmascript ast nodes"
 documentation = "https://rustdoc.swc.rs/swc_ecma_utils/"
-edition       = "2021"
-license       = "Apache-2.0"
-name          = "swc_ecma_utils"
-repository    = "https://github.com/swc-project/swc.git"
-version       = "0.101.0"
+edition = "2021"
+license = "Apache-2.0"
+name = "swc_ecma_utils"
+repository = "https://github.com/swc-project/swc.git"
+version = "0.101.0"
 
-  [package.metadata.docs.rs]
-  all-features = true
-  rustdoc-args = ["--cfg", "docsrs"]
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
 bench = false
@@ -20,15 +20,16 @@ bench = false
 concurrent = ["swc_common/concurrent", "rayon"]
 
 [dependencies]
-indexmap       = "1"
-once_cell      = "1.10.0"
-rayon          = { version = "1.5.1", optional = true }
-swc_atoms      = { version = "0.4.10", path = "../swc_atoms" }
-swc_common     = { version = "0.27.13", path = "../swc_common" }
-swc_ecma_ast   = { version = "0.90.15", path = "../swc_ecma_ast" }
-swc_ecma_visit = { version = "0.76.6", path = "../swc_ecma_visit" }
-tracing        = "0.1.32"
-unicode-id     = "0.3"
+indexmap = "1"
+num_cpus = "1.13.1"
+once_cell = "1.10.0"
+rayon = {version = "1.5.1", optional = true}
+swc_atoms = {version = "0.4.10", path = "../swc_atoms"}
+swc_common = {version = "0.27.13", path = "../swc_common"}
+swc_ecma_ast = {version = "0.90.15", path = "../swc_ecma_ast"}
+swc_ecma_visit = {version = "0.76.6", path = "../swc_ecma_visit"}
+tracing = "0.1.32"
+unicode-id = "0.3"
 
 [dev-dependencies]
-swc_ecma_parser = { version = "0.118.0", path = "../swc_ecma_parser" }
+swc_ecma_parser = {version = "0.118.0", path = "../swc_ecma_parser"}

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -46,6 +46,7 @@ pub mod constructor;
 mod factory;
 pub mod function;
 pub mod ident;
+pub mod parallel;
 mod value;
 pub mod var;
 

--- a/crates/swc_ecma_utils/src/parallel.rs
+++ b/crates/swc_ecma_utils/src/parallel.rs
@@ -1,0 +1,65 @@
+//! Module for parallel processing
+
+/// This is considered as a private type and it's NOT A PUBLIC API.
+#[cfg(feature = "concurrent")]
+#[allow(clippy::len_without_is_empty)]
+pub trait Items:
+    rayon::iter::IntoParallelIterator<Item = Self::Elem> + IntoIterator<Item = Self::Elem>
+{
+    type Elem: Send + Sync;
+
+    fn len(&self) -> usize;
+}
+
+/// This is considered as a private type and it's NOT A PUBLIC API.
+#[cfg(not(feature = "concurrent"))]
+#[allow(clippy::len_without_is_empty)]
+pub trait Items: IntoIterator<Item = Self::Elem> {
+    type Elem: Send + Sync;
+
+    fn len(&self) -> usize;
+}
+
+impl<T> Items for Vec<T>
+where
+    T: Send + Sync,
+{
+    type Elem = T;
+
+    fn len(&self) -> usize {
+        Vec::len(self)
+    }
+}
+
+impl<'a, T> Items for &'a mut Vec<T>
+where
+    T: Send + Sync,
+{
+    type Elem = &'a mut T;
+
+    fn len(&self) -> usize {
+        Vec::len(self)
+    }
+}
+
+impl<'a, T> Items for &'a mut [T]
+where
+    T: Send + Sync,
+{
+    type Elem = &'a mut T;
+
+    fn len(&self) -> usize {
+        <[T]>::len(self)
+    }
+}
+
+impl<'a, T> Items for &'a [T]
+where
+    T: Send + Sync,
+{
+    type Elem = &'a T;
+
+    fn len(&self) -> usize {
+        <[T]>::len(self)
+    }
+}

--- a/crates/swc_ecma_utils/src/parallel.rs
+++ b/crates/swc_ecma_utils/src/parallel.rs
@@ -1,5 +1,29 @@
 //! Module for parallel processing
 
+use once_cell::sync::Lazy;
+use swc_common::GLOBALS;
+use swc_ecma_ast::*;
+
+static CPU_COUNT: Lazy<usize> = Lazy::new(num_cpus::get);
+
+pub fn cpu_count() -> usize {
+    *CPU_COUNT
+}
+
+pub trait Parallel: swc_common::sync::Send + swc_common::sync::Sync {
+    /// Used to create visitor.
+    fn create(&self) -> Self;
+
+    /// This can be called in anytime.
+    fn merge(&mut self, other: Self);
+
+    /// Invoked after visiting all [Stmt]s, possibly in parallel.
+    fn after_stmts(&mut self, _stmts: &mut Vec<Stmt>) {}
+
+    /// Invoked after visiting all [ModuleItem]s, possibly in parallel.
+    fn after_module_items(&mut self, _stmts: &mut Vec<ModuleItem>) {}
+}
+
 /// This is considered as a private type and it's NOT A PUBLIC API.
 #[cfg(feature = "concurrent")]
 #[allow(clippy::len_without_is_empty)]
@@ -61,5 +85,78 @@ where
 
     fn len(&self) -> usize {
         <[T]>::len(self)
+    }
+}
+
+pub trait ParallelExt: Parallel {
+    /// Invoke `op` in parallel, if `swc_ecma_transforms_base` is compiled with
+    /// concurrent feature enabled and `nodes.len()` is bigger than threshold.
+    ///
+    ///
+    /// This configures [GLOBALS], while not configuring [HANDLER] nor [HELPERS]
+    fn maybe_par<I, F>(&mut self, threshold: usize, nodes: I, op: F)
+    where
+        I: Items,
+        F: Send + Sync + Fn(&mut Self, I::Elem);
+}
+
+#[cfg(feature = "concurrent")]
+impl<T> ParallelExt for T
+where
+    T: Parallel,
+{
+    fn maybe_par<I, F>(&mut self, threshold: usize, nodes: I, op: F)
+    where
+        I: Items,
+        F: Send + Sync + Fn(&mut Self, I::Elem),
+    {
+        if nodes.len() >= threshold || option_env!("SWC_FORCE_CONCURRENT") == Some("1") {
+            GLOBALS.with(|globals| {
+                use rayon::prelude::*;
+
+                let visitor = nodes
+                    .into_par_iter()
+                    .map(|node| {
+                        GLOBALS.set(globals, || {
+                            let mut visitor = Parallel::create(&*self);
+                            op(&mut visitor, node);
+
+                            visitor
+                        })
+                    })
+                    .reduce(
+                        || Parallel::create(&*self),
+                        |mut a, b| {
+                            Parallel::merge(&mut a, b);
+
+                            a
+                        },
+                    );
+
+                Parallel::merge(self, visitor);
+            });
+
+            return;
+        }
+
+        for n in nodes {
+            op(self, n);
+        }
+    }
+}
+
+#[cfg(not(feature = "concurrent"))]
+impl<T> ParallelExt for T
+where
+    T: Parallel,
+{
+    fn maybe_par<I, F>(&mut self, _threshold: usize, nodes: I, op: F)
+    where
+        I: Items,
+        F: Send + Sync + Fn(&mut Self, I::Elem),
+    {
+        for n in nodes {
+            op(self, n);
+        }
     }
 }


### PR DESCRIPTION
**Description:**

This PR moves some of utilities for parallel processing from `swc_ecma_transforms_base` to `swc_ecma_utils`.

**Related issue (if exists):**
