### PR TITLE
perf(es/minifier): Pre-allocate in analyzer

### DIFF
--- a/crates/swc_ecma_minifier/src/analyzer/storage/normal.rs
+++ b/crates/swc_ecma_minifier/src/analyzer/storage/normal.rs
@@ -23,12 +23,16 @@ impl Storage for ProgramData {
     }
 
     fn merge(&mut self, kind: ScopeKind, child: Self) {
+        self.scopes.reserve(child.scopes.len());
+
         for (ctxt, scope) in child.scopes {
             let to = self.scopes.entry(ctxt).or_default();
             self.top.merge(scope.clone(), true);
 
             to.merge(scope, false);
         }
+
+        self.vars.reserve(child.vars.len());
 
         for (id, mut var_info) in child.vars {
             // trace!("merge({:?},{}{:?})", kind, id.0, id.1);


### PR DESCRIPTION
**Description:**

I'll post the performance diff soon

```

Benchmarking es/minify/libraries/antd
Benchmarking es/minify/libraries/antd: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.1s.
Benchmarking es/minify/libraries/antd: Collecting 10 samples in estimated 9.0816 s (10 iterations)
Benchmarking es/minify/libraries/antd: Analyzing
es/minify/libraries/antd
                        time:   [903.22 ms 906.13 ms 909.13 ms]
                        change: [-2.2690% -1.7972% -1.3301%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/d3
Benchmarking es/minify/libraries/d3: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.8s or enable flat sampling.
Benchmarking es/minify/libraries/d3: Collecting 10 samples in estimated 8.8348 s (55 iterations)
Benchmarking es/minify/libraries/d3: Analyzing
es/minify/libraries/d3  time:   [159.83 ms 160.50 ms 161.07 ms]
                        change: [-1.6382% -0.8200% +0.0757%] (p = 0.10 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/echarts
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.8s.
Benchmarking es/minify/libraries/echarts: Collecting 10 samples in estimated 6.7836 s (10 iterations)
Benchmarking es/minify/libraries/echarts: Analyzing
es/minify/libraries/echarts
                        time:   [671.35 ms 673.04 ms 674.91 ms]
                        change: [-1.1519% -0.7174% -0.2991%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/jquery
Benchmarking es/minify/libraries/jquery: Warming up for 3.0000 s
Benchmarking es/minify/libraries/jquery: Collecting 10 samples in estimated 7.4130 s (165 iterations)
Benchmarking es/minify/libraries/jquery: Analyzing
es/minify/libraries/jquery
                        time:   [44.602 ms 44.673 ms 44.762 ms]
                        change: [-1.1543% -0.6512% -0.1741%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/lodash
Benchmarking es/minify/libraries/lodash: Warming up for 3.0000 s
Benchmarking es/minify/libraries/lodash: Collecting 10 samples in estimated 6.3710 s (110 iterations)
Benchmarking es/minify/libraries/lodash: Analyzing
es/minify/libraries/lodash
                        time:   [57.716 ms 57.856 ms 58.040 ms]
                        change: [-0.9685% +0.0044% +0.8727%] (p = 1.00 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/moment
Benchmarking es/minify/libraries/moment: Warming up for 3.0000 s
Benchmarking es/minify/libraries/moment: Collecting 10 samples in estimated 5.8554 s (220 iterations)
Benchmarking es/minify/libraries/moment: Analyzing
es/minify/libraries/moment
                        time:   [26.502 ms 26.634 ms 26.745 ms]
                        change: [-2.6006% -1.2764% -0.1538%] (p = 0.06 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/react
Benchmarking es/minify/libraries/react: Warming up for 3.0000 s
Benchmarking es/minify/libraries/react: Collecting 10 samples in estimated 5.0134 s (440 iterations)
Benchmarking es/minify/libraries/react: Analyzing
es/minify/libraries/react
                        time:   [11.384 ms 11.452 ms 11.543 ms]
                        change: [-2.2452% -0.6114% +0.8497%] (p = 0.49 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
Benchmarking es/minify/libraries/terser
Benchmarking es/minify/libraries/terser: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.2s or enable flat sampling.
Benchmarking es/minify/libraries/terser: Collecting 10 samples in estimated 7.2250 s (55 iterations)
Benchmarking es/minify/libraries/terser: Analyzing
es/minify/libraries/terser
                        time:   [131.06 ms 131.48 ms 131.76 ms]
                        change: [-1.2034% -0.5039% +0.3228%] (p = 0.24 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/three
Benchmarking es/minify/libraries/three: Warming up for 3.0000 s
Benchmarking es/minify/libraries/three: Collecting 10 samples in estimated 6.4320 s (30 iterations)
Benchmarking es/minify/libraries/three: Analyzing
es/minify/libraries/three
                        time:   [213.54 ms 214.35 ms 215.20 ms]
                        change: [-1.1638% -0.4833% +0.1336%] (p = 0.19 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/typescript
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 21.5s.
Benchmarking es/minify/libraries/typescript: Collecting 10 samples in estimated 21.487 s (10 iterations)
Benchmarking es/minify/libraries/typescript: Analyzing
es/minify/libraries/typescript
                        time:   [2.1442 s 2.1490 s 2.1543 s]
                        change: [-0.2987% -0.0424% +0.2186%] (p = 0.77 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/victory
Benchmarking es/minify/libraries/victory: Warming up for 3.0000 s
Benchmarking es/minify/libraries/victory: Collecting 10 samples in estimated 6.9914 s (20 iterations)
Benchmarking es/minify/libraries/victory: Analyzing
es/minify/libraries/victory
                        time:   [347.33 ms 349.75 ms 352.07 ms]
                        change: [-1.3825% -0.5251% +0.3255%] (p = 0.28 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/vue
Benchmarking es/minify/libraries/vue: Warming up for 3.0000 s
Benchmarking es/minify/libraries/vue: Collecting 10 samples in estimated 7.4485 s (110 iterations)
Benchmarking es/minify/libraries/vue: Analyzing
es/minify/libraries/vue time:   [67.121 ms 67.843 ms 68.834 ms]
                        change: [-0.6778% +0.1796% +1.2152%] (p = 0.74 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
```

**Related issue (if exists):**
