### PR TITLE
perf(es/utils): Make `collect_decl` parallel

### DIFF
--- a/crates/swc_ecma_minifier/scripts/instrument/bench.sh
+++ b/crates/swc_ecma_minifier/scripts/instrument/bench.sh
@@ -8,4 +8,4 @@
 
 
 export RUST_LOG=off
-cargo profile instruments -t time --bench full --features concurrent --release -- $@
+cargo profile instruments -t time --bench full --features concurrent --features swc_common/perf --release -- $@

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -2614,30 +2614,6 @@ where
             n.visit_with(v);
         })
     }
-
-    fn visit_prop_or_spreads(&mut self, n: &[PropOrSpread]) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
-            n.visit_with(v);
-        })
-    }
-
-    fn visit_expr_or_spreads(&mut self, n: &[ExprOrSpread]) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
-            n.visit_with(v);
-        })
-    }
-
-    fn visit_opt_vec_expr_or_spreads(&mut self, n: &[Option<ExprOrSpread>]) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
-            n.visit_with(v);
-        })
-    }
-
-    fn visit_exprs(&mut self, n: &[Box<Expr>]) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
-            n.visit_with(v);
-        })
-    }
 }
 
 /// Collects binding identifiers.

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -2603,6 +2603,18 @@ where
         self.is_pat_decl = old;
     }
 
+    fn visit_stmts(&mut self, n: &[Stmt]) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_with(v);
+        })
+    }
+
+    fn visit_module_items(&mut self, n: &[ModuleItem]) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_with(v);
+        })
+    }
+
     fn visit_prop_or_spreads(&mut self, n: &[PropOrSpread]) {
         self.maybe_par(cpu_count() * 8, n, |v, n| {
             n.visit_with(v);

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -16,6 +16,7 @@ use std::{
     ops::Add,
 };
 
+use parallel::Parallel;
 use swc_atoms::{js_word, JsWord};
 use swc_common::{collections::AHashSet, Mark, Span, Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
@@ -2485,6 +2486,22 @@ where
     only: Option<SyntaxContext>,
     bindings: AHashSet<I>,
     is_pat_decl: bool,
+}
+
+impl<I> Parallel for BindingCollector<I>
+where
+    I: IdentLike + Eq + Hash + Send + Sync,
+{
+    fn create(&self) -> Self {
+        Self {
+            bindings: Default::default(),
+            ..*self
+        }
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.bindings.extend(other.bindings);
+    }
 }
 
 impl<I> BindingCollector<I>

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -16,7 +16,7 @@ use std::{
     ops::Add,
 };
 
-use parallel::Parallel;
+use parallel::{cpu_count, Parallel, ParallelExt};
 use swc_atoms::{js_word, JsWord};
 use swc_common::{collections::AHashSet, Mark, Span, Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
@@ -2601,6 +2601,30 @@ where
         self.is_pat_decl = false;
         node.init.visit_with(self);
         self.is_pat_decl = old;
+    }
+
+    fn visit_prop_or_spreads(&mut self, n: &[PropOrSpread]) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_with(v);
+        })
+    }
+
+    fn visit_expr_or_spreads(&mut self, n: &[ExprOrSpread]) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_with(v);
+        })
+    }
+
+    fn visit_opt_vec_expr_or_spreads(&mut self, n: &[Option<ExprOrSpread>]) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_with(v);
+        })
+    }
+
+    fn visit_exprs(&mut self, n: &[Box<Expr>]) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_with(v);
+        })
     }
 }
 

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -2614,6 +2614,30 @@ where
             n.visit_with(v);
         })
     }
+
+    fn visit_prop_or_spreads(&mut self, n: &[PropOrSpread]) {
+        self.maybe_par(cpu_count() * 64, n, |v, n| {
+            n.visit_with(v);
+        })
+    }
+
+    fn visit_expr_or_spreads(&mut self, n: &[ExprOrSpread]) {
+        self.maybe_par(cpu_count() * 64, n, |v, n| {
+            n.visit_with(v);
+        })
+    }
+
+    fn visit_opt_vec_expr_or_spreads(&mut self, n: &[Option<ExprOrSpread>]) {
+        self.maybe_par(cpu_count() * 64, n, |v, n| {
+            n.visit_with(v);
+        })
+    }
+
+    fn visit_exprs(&mut self, n: &[Box<Expr>]) {
+        self.maybe_par(cpu_count() * 64, n, |v, n| {
+            n.visit_with(v);
+        })
+    }
 }
 
 /// Collects binding identifiers.


### PR DESCRIPTION
**Description:**

I'll add perf diff soon

```
Gnuplot not found, using plotters backend
Benchmarking es/minify/libraries/antd
Benchmarking es/minify/libraries/antd: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.9s.
Benchmarking es/minify/libraries/antd: Collecting 10 samples in estimated 8.9324 s (10 iterations)
Benchmarking es/minify/libraries/antd: Analyzing
es/minify/libraries/antd
                        time:   [890.84 ms 894.21 ms 897.59 ms]
                        change: [-1.8844% -1.4198% -0.9331%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/d3
Benchmarking es/minify/libraries/d3: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.9s or enable flat sampling.
Benchmarking es/minify/libraries/d3: Collecting 10 samples in estimated 8.9433 s (55 iterations)
Benchmarking es/minify/libraries/d3: Analyzing
es/minify/libraries/d3  time:   [156.27 ms 156.71 ms 157.22 ms]
                        change: [-0.8706% -0.3411% +0.1631%] (p = 0.27 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/echarts
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.6s.
Benchmarking es/minify/libraries/echarts: Collecting 10 samples in estimated 6.5511 s (10 iterations)
Benchmarking es/minify/libraries/echarts: Analyzing
es/minify/libraries/echarts
                        time:   [651.04 ms 653.73 ms 655.94 ms]
                        change: [-3.4104% -2.9170% -2.4399%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
Benchmarking es/minify/libraries/jquery
Benchmarking es/minify/libraries/jquery: Warming up for 3.0000 s
Benchmarking es/minify/libraries/jquery: Collecting 10 samples in estimated 7.4071 s (165 iterations)
Benchmarking es/minify/libraries/jquery: Analyzing
es/minify/libraries/jquery
                        time:   [44.429 ms 44.656 ms 44.927 ms]
                        change: [-0.3297% +0.5179% +1.2302%] (p = 0.23 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/lodash
Benchmarking es/minify/libraries/lodash: Warming up for 3.0000 s
Benchmarking es/minify/libraries/lodash: Collecting 10 samples in estimated 6.9838 s (110 iterations)
Benchmarking es/minify/libraries/lodash: Analyzing
es/minify/libraries/lodash
                        time:   [61.391 ms 61.602 ms 61.883 ms]
                        change: [+6.7342% +7.8190% +8.8065%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking es/minify/libraries/moment
Benchmarking es/minify/libraries/moment: Warming up for 3.0000 s
Benchmarking es/minify/libraries/moment: Collecting 10 samples in estimated 5.9614 s (220 iterations)
Benchmarking es/minify/libraries/moment: Analyzing
es/minify/libraries/moment
                        time:   [26.650 ms 26.748 ms 26.864 ms]
                        change: [+1.7576% +2.3586% +3.1864%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/react
Benchmarking es/minify/libraries/react: Warming up for 3.0000 s
Benchmarking es/minify/libraries/react: Collecting 10 samples in estimated 5.1766 s (440 iterations)
Benchmarking es/minify/libraries/react: Analyzing
es/minify/libraries/react
                        time:   [11.556 ms 11.597 ms 11.625 ms]
                        change: [+2.0793% +2.4732% +2.8587%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking es/minify/libraries/terser
Benchmarking es/minify/libraries/terser: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.3s or enable flat sampling.
Benchmarking es/minify/libraries/terser: Collecting 10 samples in estimated 7.2845 s (55 iterations)
Benchmarking es/minify/libraries/terser: Analyzing
es/minify/libraries/terser
                        time:   [131.04 ms 131.32 ms 131.67 ms]
                        change: [-0.9222% +0.3611% +1.6937%] (p = 0.67 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/three
Benchmarking es/minify/libraries/three: Warming up for 3.0000 s
Benchmarking es/minify/libraries/three: Collecting 10 samples in estimated 6.3664 s (30 iterations)
Benchmarking es/minify/libraries/three: Analyzing
es/minify/libraries/three
                        time:   [211.38 ms 212.07 ms 212.67 ms]
                        change: [-0.9580% -0.4840% -0.0228%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
Benchmarking es/minify/libraries/typescript
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 18.5s.
Benchmarking es/minify/libraries/typescript: Collecting 10 samples in estimated 18.495 s (10 iterations)
Benchmarking es/minify/libraries/typescript: Analyzing
es/minify/libraries/typescript
                        time:   [1.8497 s 1.8545 s 1.8598 s]
                        change: [-1.5983% -1.1968% -0.7943%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/victory
Benchmarking es/minify/libraries/victory: Warming up for 3.0000 s
Benchmarking es/minify/libraries/victory: Collecting 10 samples in estimated 7.0687 s (20 iterations)
Benchmarking es/minify/libraries/victory: Analyzing
es/minify/libraries/victory
                        time:   [352.33 ms 354.14 ms 355.91 ms]
                        change: [+1.0839% +1.8867% +2.6761%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking es/minify/libraries/vue
Benchmarking es/minify/libraries/vue: Warming up for 3.0000 s
Benchmarking es/minify/libraries/vue: Collecting 10 samples in estimated 7.4511 s (110 iterations)
Benchmarking es/minify/libraries/vue: Analyzing
es/minify/libraries/vue time:   [67.518 ms 67.641 ms 67.856 ms]
                        change: [-0.4181% +0.5830% +1.4572%] (p = 0.26 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low severe
  1 (10.00%) high severe
```


**Related issue (if exists):**
