### PR TITLE
perf(es/minifier): Use efficient logic for entry tracking in DCE

### DIFF
--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -156,6 +156,11 @@ impl Data {
             // We have to exclude cycle from remove list if an outer node refences an item
             // of cycle.
             for &node in &cycle {
+                // It's referenced by an outer node.
+                if self.entries.contains(&node) {
+                    continue 'c;
+                }
+
                 if self.graph.neighbors_directed(node, Incoming).any(|node| {
                     // Node in cycle does not matter
                     !cycle.contains(&node)

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -102,6 +102,9 @@ struct Data {
 
     /// Variable usage graph
     graph: FastDiGraphMap<usize, VarInfo>,
+    /// Entrypoints.
+    entries: Vec<usize>,
+
     graph_ix: IndexSet<Id, ahash::RandomState>,
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, sync::Arc};
 
 use indexmap::IndexSet;
 use petgraph::{algo::tarjan_scc, Direction::Incoming};
+use rustc_hash::FxHashSet;
 use swc_atoms::{js_word, JsWord};
 use swc_common::{
     collections::{AHashMap, AHashSet},
@@ -103,7 +104,7 @@ struct Data {
     /// Variable usage graph
     graph: FastDiGraphMap<usize, VarInfo>,
     /// Entrypoints.
-    entries: Vec<usize>,
+    entries: FxHashSet<usize>,
 
     graph_ix: IndexSet<Id, ahash::RandomState>,
 }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -313,8 +313,8 @@ impl Analyzer<'_> {
 
         if self.scope.is_ast_path_empty() {
             // Add references from top level items into graph
-            self.data
-                .add_dep_edge(Default::default(), id.clone(), assign)
+            let idx = self.data.node(&id);
+            self.data.entries.insert(idx);
         } else {
             let mut scope = Some(&self.scope);
 


### PR DESCRIPTION
**Description:**

We don't need to store it in the graph. Storing it in a fast hash set is enough.

```
Gnuplot not found, using plotters backend
Benchmarking es/minify/libraries/antd
Benchmarking es/minify/libraries/antd: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.7s.
Benchmarking es/minify/libraries/antd: Collecting 10 samples in estimated 8.6817 s (10 iterations)
Benchmarking es/minify/libraries/antd: Analyzing
es/minify/libraries/antd
                        time:   [864.75 ms 868.50 ms 871.61 ms]
                        change: [-3.0474% -2.5227% -2.0182%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
Benchmarking es/minify/libraries/d3
Benchmarking es/minify/libraries/d3: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.9s or enable flat sampling.
Benchmarking es/minify/libraries/d3: Collecting 10 samples in estimated 8.9046 s (55 iterations)
Benchmarking es/minify/libraries/d3: Analyzing
es/minify/libraries/d3  time:   [156.93 ms 157.60 ms 158.81 ms]
                        change: [-0.3360% +0.5260% +1.4169%] (p = 0.30 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/echarts
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.7s.
Benchmarking es/minify/libraries/echarts: Collecting 10 samples in estimated 6.6751 s (10 iterations)
Benchmarking es/minify/libraries/echarts: Analyzing
es/minify/libraries/echarts
                        time:   [662.57 ms 664.90 ms 666.90 ms]
                        change: [+0.6815% +1.2870% +1.8197%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
Benchmarking es/minify/libraries/jquery
Benchmarking es/minify/libraries/jquery: Warming up for 3.0000 s
Benchmarking es/minify/libraries/jquery: Collecting 10 samples in estimated 7.3274 s (165 iterations)
Benchmarking es/minify/libraries/jquery: Analyzing
es/minify/libraries/jquery
                        time:   [44.116 ms 44.260 ms 44.414 ms]
                        change: [-2.0011% -1.3284% -0.7529%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
Benchmarking es/minify/libraries/lodash
Benchmarking es/minify/libraries/lodash: Warming up for 3.0000 s
Benchmarking es/minify/libraries/lodash: Collecting 10 samples in estimated 6.3802 s (110 iterations)
Benchmarking es/minify/libraries/lodash: Analyzing
es/minify/libraries/lodash
                        time:   [56.645 ms 56.756 ms 56.919 ms]
                        change: [-7.0720% -6.1139% -5.1623%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking es/minify/libraries/moment
Benchmarking es/minify/libraries/moment: Warming up for 3.0000 s
Benchmarking es/minify/libraries/moment: Collecting 10 samples in estimated 5.7973 s (220 iterations)
Benchmarking es/minify/libraries/moment: Analyzing
es/minify/libraries/moment
                        time:   [25.966 ms 26.075 ms 26.185 ms]
                        change: [-3.4360% -2.3909% -1.6630%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/react
Benchmarking es/minify/libraries/react: Warming up for 3.0000 s
Benchmarking es/minify/libraries/react: Collecting 10 samples in estimated 5.5953 s (495 iterations)
Benchmarking es/minify/libraries/react: Analyzing
es/minify/libraries/react
                        time:   [11.191 ms 11.224 ms 11.253 ms]
                        change: [-4.7108% -3.3507% -2.4607%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/terser
Benchmarking es/minify/libraries/terser: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.2s or enable flat sampling.
Benchmarking es/minify/libraries/terser: Collecting 10 samples in estimated 7.2155 s (55 iterations)
Benchmarking es/minify/libraries/terser: Analyzing
es/minify/libraries/terser
                        time:   [130.42 ms 130.91 ms 131.42 ms]
                        change: [-3.0181% -1.9351% -0.8502%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/three
Benchmarking es/minify/libraries/three: Warming up for 3.0000 s
Benchmarking es/minify/libraries/three: Collecting 10 samples in estimated 6.3730 s (30 iterations)
Benchmarking es/minify/libraries/three: Analyzing
es/minify/libraries/three
                        time:   [211.59 ms 212.57 ms 213.53 ms]
                        change: [-0.9388% -0.3653% +0.1956%] (p = 0.28 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/typescript
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 18.7s.
Benchmarking es/minify/libraries/typescript: Collecting 10 samples in estimated 18.662 s (10 iterations)
Benchmarking es/minify/libraries/typescript: Analyzing
es/minify/libraries/typescript
                        time:   [1.8482 s 1.8520 s 1.8560 s]
                        change: [-0.5759% -0.2896% -0.0084%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low severe
  1 (10.00%) low mild
  1 (10.00%) high severe
Benchmarking es/minify/libraries/victory
Benchmarking es/minify/libraries/victory: Warming up for 3.0000 s
Benchmarking es/minify/libraries/victory: Collecting 10 samples in estimated 6.8733 s (20 iterations)
Benchmarking es/minify/libraries/victory: Analyzing
es/minify/libraries/victory
                        time:   [338.55 ms 340.65 ms 342.79 ms]
                        change: [-4.7565% -3.8340% -2.9694%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/vue
Benchmarking es/minify/libraries/vue: Warming up for 3.0000 s
Benchmarking es/minify/libraries/vue: Collecting 10 samples in estimated 7.5365 s (110 iterations)
Benchmarking es/minify/libraries/vue: Analyzing
es/minify/libraries/vue time:   [66.739 ms 66.966 ms 67.222 ms]
                        change: [-1.7913% -0.8918% -0.1113%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```

**Related issue (if exists):**
