### PR TITLE
perf(es/minifier): Cache the list of bindings for DCE

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/mod.rs
@@ -386,18 +386,18 @@ where
         if self.options.unused {
             let _timer = timer!("remove dead code");
 
+            let mut visitor = swc_ecma_transforms_optimization::simplify::dce::dce(
+                swc_ecma_transforms_optimization::simplify::dce::Config {
+                    module_mark: None,
+                    top_level: self.options.top_level(),
+                    top_retain: self.options.top_retain.clone(),
+                },
+                self.marks.unresolved_mark,
+            );
+
             loop {
                 #[cfg(feature = "debug")]
                 let start = n.dump();
-
-                let mut visitor = swc_ecma_transforms_optimization::simplify::dce::dce(
-                    swc_ecma_transforms_optimization::simplify::dce::Config {
-                        module_mark: None,
-                        top_level: self.options.top_level(),
-                        top_retain: self.options.top_retain.clone(),
-                    },
-                    self.marks.unresolved_mark,
-                );
 
                 n.apply(&mut visitor);
 
@@ -417,6 +417,8 @@ where
                 } else {
                     break;
                 }
+
+                visitor.reset();
             }
         }
 


### PR DESCRIPTION
**Description:**

# main
```
Gnuplot not found, using plotters backend
Benchmarking es/minify/libraries/antd
Benchmarking es/minify/libraries/antd: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.6s.
Benchmarking es/minify/libraries/antd: Collecting 10 samples in estimated 8.6131 s (10 iterations)
Benchmarking es/minify/libraries/antd: Analyzing
es/minify/libraries/antd
                        time:   [859.87 ms 863.75 ms 867.53 ms]
                        change: [-15.382% -9.3986% -5.5054%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/d3
Benchmarking es/minify/libraries/d3: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.3s or enable flat sampling.
Benchmarking es/minify/libraries/d3: Collecting 10 samples in estimated 9.2530 s (55 iterations)
Benchmarking es/minify/libraries/d3: Analyzing
es/minify/libraries/d3  time:   [156.17 ms 157.37 ms 160.31 ms]
                        change: [-3.6496% -1.5282% +1.0129%] (p = 0.28 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
Benchmarking es/minify/libraries/echarts
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.6s.
Benchmarking es/minify/libraries/echarts: Collecting 10 samples in estimated 6.5951 s (10 iterations)
Benchmarking es/minify/libraries/echarts: Analyzing
es/minify/libraries/echarts
                        time:   [656.10 ms 659.73 ms 664.68 ms]
                        change: [-2.6179% -2.0175% -1.3017%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/jquery
Benchmarking es/minify/libraries/jquery: Warming up for 3.0000 s
Benchmarking es/minify/libraries/jquery: Collecting 10 samples in estimated 7.2969 s (165 iterations)
Benchmarking es/minify/libraries/jquery: Analyzing
es/minify/libraries/jquery
                        time:   [43.978 ms 44.044 ms 44.111 ms]
                        change: [-2.6659% -2.1343% -1.5676%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/lodash
Benchmarking es/minify/libraries/lodash: Warming up for 3.0000 s
Benchmarking es/minify/libraries/lodash: Collecting 10 samples in estimated 6.2759 s (110 iterations)
Benchmarking es/minify/libraries/lodash: Analyzing
es/minify/libraries/lodash
                        time:   [56.374 ms 56.482 ms 56.611 ms]
                        change: [-2.5320% -1.9686% -1.3363%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/moment
Benchmarking es/minify/libraries/moment: Warming up for 3.0000 s
Benchmarking es/minify/libraries/moment: Collecting 10 samples in estimated 5.8154 s (220 iterations)
Benchmarking es/minify/libraries/moment: Analyzing
es/minify/libraries/moment
                        time:   [25.956 ms 25.989 ms 26.038 ms]
                        change: [-3.9522% -3.2344% -2.5488%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/react
Benchmarking es/minify/libraries/react: Warming up for 3.0000 s
Benchmarking es/minify/libraries/react: Collecting 10 samples in estimated 5.0170 s (440 iterations)
Benchmarking es/minify/libraries/react: Analyzing
es/minify/libraries/react
                        time:   [11.243 ms 11.266 ms 11.298 ms]
                        change: [-1.5611% -1.0931% -0.5776%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/terser
Benchmarking es/minify/libraries/terser: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.2s or enable flat sampling.
Benchmarking es/minify/libraries/terser: Collecting 10 samples in estimated 7.2326 s (55 iterations)
Benchmarking es/minify/libraries/terser: Analyzing
es/minify/libraries/terser
                        time:   [130.39 ms 131.01 ms 131.52 ms]
                        change: [-1.5334% -0.8431% -0.0668%] (p = 0.05 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/three
Benchmarking es/minify/libraries/three: Warming up for 3.0000 s
Benchmarking es/minify/libraries/three: Collecting 10 samples in estimated 6.3420 s (30 iterations)
Benchmarking es/minify/libraries/three: Analyzing
es/minify/libraries/three
                        time:   [209.66 ms 210.91 ms 212.52 ms]
                        change: [-2.4993% -1.8130% -0.9814%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/typescript
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 18.5s.
Benchmarking es/minify/libraries/typescript: Collecting 10 samples in estimated 18.457 s (10 iterations)
Benchmarking es/minify/libraries/typescript: Analyzing
es/minify/libraries/typescript
                        time:   [1.8374 s 1.8418 s 1.8464 s]
                        change: [-14.743% -14.431% -14.126%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/victory
Benchmarking es/minify/libraries/victory: Warming up for 3.0000 s
Benchmarking es/minify/libraries/victory: Collecting 10 samples in estimated 6.7208 s (20 iterations)
Benchmarking es/minify/libraries/victory: Analyzing
es/minify/libraries/victory
                        time:   [334.39 ms 336.38 ms 338.35 ms]
                        change: [-4.9164% -3.9091% -3.0092%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/vue
Benchmarking es/minify/libraries/vue: Warming up for 3.0000 s
Benchmarking es/minify/libraries/vue: Collecting 10 samples in estimated 7.3465 s (110 iterations)
Benchmarking es/minify/libraries/vue: Analyzing
es/minify/libraries/vue time:   [66.174 ms 66.349 ms 66.465 ms]
                        change: [-2.8703% -2.1909% -1.5366%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
```


## new

```
Gnuplot not found, using plotters backend
Benchmarking es/minify/libraries/antd
Benchmarking es/minify/libraries/antd: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.2s.
Benchmarking es/minify/libraries/antd: Collecting 10 samples in estimated 8.1609 s (10 iterations)
Benchmarking es/minify/libraries/antd: Analyzing
es/minify/libraries/antd
                        time:   [809.02 ms 813.88 ms 819.43 ms]
                        change: [-1.0284% +0.1267% +1.1750%] (p = 0.85 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/d3
Benchmarking es/minify/libraries/d3: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.8s or enable flat sampling.
Benchmarking es/minify/libraries/d3: Collecting 10 samples in estimated 8.8364 s (55 iterations)
Benchmarking es/minify/libraries/d3: Analyzing
es/minify/libraries/d3  time:   [154.95 ms 155.98 ms 157.48 ms]
                        change: [-0.9454% +0.1147% +1.3733%] (p = 0.85 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
Benchmarking es/minify/libraries/echarts
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.6s.
Benchmarking es/minify/libraries/echarts: Collecting 10 samples in estimated 6.6213 s (10 iterations)
Benchmarking es/minify/libraries/echarts: Analyzing
es/minify/libraries/echarts
                        time:   [643.70 ms 646.85 ms 650.85 ms]
                        change: [-2.2663% -1.6752% -0.9699%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/jquery
Benchmarking es/minify/libraries/jquery: Warming up for 3.0000 s
Benchmarking es/minify/libraries/jquery: Collecting 10 samples in estimated 7.2309 s (165 iterations)
Benchmarking es/minify/libraries/jquery: Analyzing
es/minify/libraries/jquery
                        time:   [43.458 ms 43.969 ms 44.600 ms]
                        change: [-13.721% -7.7203% -2.1616%] (p = 0.02 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/lodash
Benchmarking es/minify/libraries/lodash: Warming up for 3.0000 s
Benchmarking es/minify/libraries/lodash: Collecting 10 samples in estimated 6.3487 s (110 iterations)
Benchmarking es/minify/libraries/lodash: Analyzing
es/minify/libraries/lodash
                        time:   [56.985 ms 57.363 ms 57.706 ms]
                        change: [-4.0773% -1.9953% -0.0469%] (p = 0.09 > 0.05)
                        No change in performance detected.
Found 4 outliers among 10 measurements (40.00%)
  2 (20.00%) low mild
  2 (20.00%) high severe
Benchmarking es/minify/libraries/moment
Benchmarking es/minify/libraries/moment: Warming up for 3.0000 s
Benchmarking es/minify/libraries/moment: Collecting 10 samples in estimated 5.8747 s (220 iterations)
Benchmarking es/minify/libraries/moment: Analyzing
es/minify/libraries/moment
                        time:   [25.847 ms 26.118 ms 26.326 ms]
                        change: [-1.5027% -0.6066% +0.2685%] (p = 0.21 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/react
Benchmarking es/minify/libraries/react: Warming up for 3.0000 s
Benchmarking es/minify/libraries/react: Collecting 10 samples in estimated 5.1880 s (440 iterations)
Benchmarking es/minify/libraries/react: Analyzing
es/minify/libraries/react
                        time:   [11.433 ms 11.581 ms 11.801 ms]
                        change: [+0.7725% +2.6202% +4.4649%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/terser
Benchmarking es/minify/libraries/terser: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.3s or enable flat sampling.
Benchmarking es/minify/libraries/terser: Collecting 10 samples in estimated 7.3009 s (55 iterations)
Benchmarking es/minify/libraries/terser: Analyzing
es/minify/libraries/terser
                        time:   [131.52 ms 132.04 ms 132.79 ms]
                        change: [-0.7189% +0.5363% +2.2739%] (p = 0.62 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/three
Benchmarking es/minify/libraries/three: Warming up for 3.0000 s
Benchmarking es/minify/libraries/three: Collecting 10 samples in estimated 6.3111 s (30 iterations)
Benchmarking es/minify/libraries/three: Analyzing
es/minify/libraries/three
                        time:   [210.03 ms 211.24 ms 212.43 ms]
                        change: [+0.5147% +1.0946% +1.6654%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/typescript
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 18.4s.
Benchmarking es/minify/libraries/typescript: Collecting 10 samples in estimated 18.414 s (10 iterations)
Benchmarking es/minify/libraries/typescript: Analyzing
es/minify/libraries/typescript
                        time:   [1.8202 s 1.8253 s 1.8308 s]
                        change: [-0.0897% +0.2783% +0.6713%] (p = 0.18 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/victory
Benchmarking es/minify/libraries/victory: Warming up for 3.0000 s
Benchmarking es/minify/libraries/victory: Collecting 10 samples in estimated 7.1051 s (20 iterations)
Benchmarking es/minify/libraries/victory: Analyzing
es/minify/libraries/victory
                        time:   [349.01 ms 352.21 ms 354.95 ms]
                        change: [-0.6742% +0.2647% +1.1304%] (p = 0.60 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/vue
Benchmarking es/minify/libraries/vue: Warming up for 3.0000 s
Benchmarking es/minify/libraries/vue: Collecting 10 samples in estimated 7.3124 s (110 iterations)
Benchmarking es/minify/libraries/vue: Analyzing
es/minify/libraries/vue time:   [65.253 ms 65.507 ms 65.651 ms]
                        change: [-1.6910% -1.1232% -0.5801%] (p = 0.00 < 0.05)
                        Change within noise threshold.``

```

**Related issue (if exists):**
