### PR TITLE
perf(es/minifier): Improve codegen of name mangler

### DIFF
--- a/crates/swc_ecma_codegen/src/text_writer.rs
+++ b/crates/swc_ecma_codegen/src/text_writer.rs
@@ -137,3 +137,97 @@ where
         (**self).commit_pending_semi()
     }
 }
+
+impl<W> WriteJs for &'_ mut W
+where
+    W: ?Sized + WriteJs,
+{
+    #[inline]
+    fn increase_indent(&mut self) -> Result {
+        (**self).increase_indent()
+    }
+
+    #[inline]
+    fn decrease_indent(&mut self) -> Result {
+        (**self).decrease_indent()
+    }
+
+    #[inline]
+    fn write_semi(&mut self, span: Option<Span>) -> Result {
+        (**self).write_semi(span)
+    }
+
+    #[inline]
+    fn write_space(&mut self) -> Result {
+        (**self).write_space()
+    }
+
+    #[inline]
+    fn write_keyword(&mut self, span: Option<Span>, s: &'static str) -> Result {
+        (**self).write_keyword(span, s)
+    }
+
+    #[inline]
+    fn write_operator(&mut self, span: Option<Span>, s: &str) -> Result {
+        (**self).write_operator(span, s)
+    }
+
+    #[inline]
+    fn write_param(&mut self, s: &str) -> Result {
+        (**self).write_param(s)
+    }
+
+    #[inline]
+    fn write_property(&mut self, s: &str) -> Result {
+        (**self).write_property(s)
+    }
+
+    #[inline]
+    fn write_line(&mut self) -> Result {
+        (**self).write_line()
+    }
+
+    #[inline]
+    fn write_lit(&mut self, span: Span, s: &str) -> Result {
+        (**self).write_lit(span, s)
+    }
+
+    #[inline]
+    fn write_comment(&mut self, s: &str) -> Result {
+        (**self).write_comment(s)
+    }
+
+    #[inline]
+    fn write_str_lit(&mut self, span: Span, s: &str) -> Result {
+        (**self).write_str_lit(span, s)
+    }
+
+    #[inline]
+    fn write_str(&mut self, s: &str) -> Result {
+        (**self).write_str(s)
+    }
+
+    #[inline]
+    fn write_symbol(&mut self, span: Span, s: &str) -> Result {
+        (**self).write_symbol(span, s)
+    }
+
+    #[inline]
+    fn write_punct(&mut self, span: Option<Span>, s: &'static str) -> Result {
+        (**self).write_punct(span, s)
+    }
+
+    #[inline]
+    fn care_about_srcmap(&self) -> bool {
+        (**self).care_about_srcmap()
+    }
+
+    #[inline]
+    fn add_srcmap(&mut self, pos: BytePos) -> Result {
+        (**self).add_srcmap(pos)
+    }
+
+    fn commit_pending_semi(&mut self) -> Result {
+        (**self).commit_pending_semi()
+    }
+}

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/mod.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/mod.rs
@@ -80,6 +80,7 @@ impl SourceMapperExt for DummySourceMap {
 }
 
 impl CharFreq {
+    #[inline(always)]
     fn write(&mut self, data: &str) -> io::Result<()> {
         self.scan(data.as_bytes(), 1);
         Ok(())
@@ -87,89 +88,107 @@ impl CharFreq {
 }
 
 impl WriteJs for CharFreq {
+    #[inline(always)]
     fn increase_indent(&mut self) -> io::Result<()> {
         Ok(())
     }
 
+    #[inline(always)]
     fn decrease_indent(&mut self) -> io::Result<()> {
         Ok(())
     }
 
+    #[inline(always)]
     fn write_semi(&mut self, _: Option<Span>) -> io::Result<()> {
         self.write(";")?;
         Ok(())
     }
 
+    #[inline(always)]
     fn write_space(&mut self) -> io::Result<()> {
         self.write(" ")?;
         Ok(())
     }
 
+    #[inline(always)]
     fn write_keyword(&mut self, _: Option<Span>, s: &'static str) -> io::Result<()> {
         self.write(s)?;
         Ok(())
     }
 
+    #[inline(always)]
     fn write_operator(&mut self, _: Option<Span>, s: &str) -> io::Result<()> {
         self.write(s)?;
         Ok(())
     }
 
+    #[inline(always)]
     fn write_param(&mut self, s: &str) -> io::Result<()> {
         self.write(s)?;
         Ok(())
     }
 
+    #[inline(always)]
     fn write_property(&mut self, s: &str) -> io::Result<()> {
         self.write(s)?;
         Ok(())
     }
 
+    #[inline(always)]
     fn write_line(&mut self) -> io::Result<()> {
         Ok(())
     }
 
+    #[inline(always)]
     fn write_lit(&mut self, _: Span, s: &str) -> io::Result<()> {
         self.write(s)?;
 
         Ok(())
     }
 
+    #[inline(always)]
     fn write_comment(&mut self, s: &str) -> io::Result<()> {
         self.write(s)?;
 
         Ok(())
     }
 
+    #[inline(always)]
     fn write_str_lit(&mut self, _: Span, s: &str) -> io::Result<()> {
         self.write(s)?;
 
         Ok(())
     }
 
+    #[inline(always)]
     fn write_str(&mut self, s: &str) -> io::Result<()> {
         self.write(s)?;
         Ok(())
     }
 
+    #[inline(always)]
     fn write_symbol(&mut self, _: Span, s: &str) -> io::Result<()> {
         self.write(s)?;
         Ok(())
     }
 
+    #[inline(always)]
     fn write_punct(&mut self, _: Option<Span>, s: &'static str) -> io::Result<()> {
         self.write(s)?;
         Ok(())
     }
 
+    #[inline(always)]
     fn care_about_srcmap(&self) -> bool {
         false
     }
 
+    #[inline(always)]
     fn add_srcmap(&mut self, _: BytePos) -> io::Result<()> {
         Ok(())
     }
 
+    #[inline(always)]
     fn commit_pending_semi(&mut self) -> io::Result<()> {
         Ok(())
     }


### PR DESCRIPTION
**Description:**

We don't need char-related operations

```
Gnuplot not found, using plotters backend
Benchmarking es/minify/libraries/antd
Benchmarking es/minify/libraries/antd: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.2s.
Benchmarking es/minify/libraries/antd: Collecting 10 samples in estimated 8.1602 s (10 iterations)
Benchmarking es/minify/libraries/antd: Analyzing
es/minify/libraries/antd
                        time:   [805.67 ms 808.53 ms 811.18 ms]
                        change: [-0.9558% -0.4031% +0.1414%] (p = 0.19 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/d3
Benchmarking es/minify/libraries/d3: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.9s or enable flat sampling.
Benchmarking es/minify/libraries/d3: Collecting 10 samples in estimated 8.8516 s (55 iterations)
Benchmarking es/minify/libraries/d3: Analyzing
es/minify/libraries/d3  time:   [154.83 ms 155.33 ms 155.84 ms]
                        change: [-1.3680% -0.3826% +0.5487%] (p = 0.48 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/echarts
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.5s.
Benchmarking es/minify/libraries/echarts: Collecting 10 samples in estimated 6.4528 s (10 iterations)
Benchmarking es/minify/libraries/echarts: Analyzing
es/minify/libraries/echarts
                        time:   [639.89 ms 642.23 ms 644.60 ms]
                        change: [-1.6789% -0.7961% -0.0548%] (p = 0.09 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/jquery
Benchmarking es/minify/libraries/jquery: Warming up for 3.0000 s
Benchmarking es/minify/libraries/jquery: Collecting 10 samples in estimated 7.1762 s (165 iterations)
Benchmarking es/minify/libraries/jquery: Analyzing
es/minify/libraries/jquery
                        time:   [43.106 ms 43.217 ms 43.323 ms]
                        change: [-2.4275% -1.6470% -0.9589%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/lodash
Benchmarking es/minify/libraries/lodash: Warming up for 3.0000 s
Benchmarking es/minify/libraries/lodash: Collecting 10 samples in estimated 6.3142 s (110 iterations)
Benchmarking es/minify/libraries/lodash: Analyzing
es/minify/libraries/lodash
                        time:   [56.189 ms 57.169 ms 57.893 ms]
                        change: [-2.6302% -1.1604% +0.3587%] (p = 0.16 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/moment
Benchmarking es/minify/libraries/moment: Warming up for 3.0000 s
Benchmarking es/minify/libraries/moment: Collecting 10 samples in estimated 5.7577 s (220 iterations)
Benchmarking es/minify/libraries/moment: Analyzing
es/minify/libraries/moment
                        time:   [25.744 ms 25.836 ms 25.917 ms]
                        change: [-2.5468% -1.8024% -1.1290%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/react
Benchmarking es/minify/libraries/react: Warming up for 3.0000 s
Benchmarking es/minify/libraries/react: Collecting 10 samples in estimated 5.0058 s (440 iterations)
Benchmarking es/minify/libraries/react: Analyzing
es/minify/libraries/react
                        time:   [11.197 ms 11.303 ms 11.380 ms]
                        change: [-0.8078% -0.1441% +0.5178%] (p = 0.70 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/terser
Benchmarking es/minify/libraries/terser: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.2s or enable flat sampling.
Benchmarking es/minify/libraries/terser: Collecting 10 samples in estimated 7.2349 s (55 iterations)
Benchmarking es/minify/libraries/terser: Analyzing
es/minify/libraries/terser
                        time:   [131.92 ms 133.79 ms 136.02 ms]
                        change: [-1.0777% +0.4209% +2.0006%] (p = 0.60 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/three
Benchmarking es/minify/libraries/three: Warming up for 3.0000 s
Benchmarking es/minify/libraries/three: Collecting 10 samples in estimated 6.2536 s (30 iterations)
Benchmarking es/minify/libraries/three: Analyzing
es/minify/libraries/three
                        time:   [207.95 ms 208.86 ms 209.83 ms]
                        change: [-1.8775% -1.2140% -0.5778%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/typescript
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 18.2s.
Benchmarking es/minify/libraries/typescript: Collecting 10 samples in estimated 18.187 s (10 iterations)
Benchmarking es/minify/libraries/typescript: Analyzing
es/minify/libraries/typescript
                        time:   [1.8153 s 1.8188 s 1.8228 s]
                        change: [-0.9219% -0.6264% -0.3280%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/victory
Benchmarking es/minify/libraries/victory: Warming up for 3.0000 s
Benchmarking es/minify/libraries/victory: Collecting 10 samples in estimated 7.0466 s (20 iterations)
Benchmarking es/minify/libraries/victory: Analyzing
es/minify/libraries/victory
                        time:   [349.10 ms 350.93 ms 352.95 ms]
                        change: [-0.9129% -0.0581% +0.8581%] (p = 0.90 > 0.05)
                        No change in performance detected.
Benchmarking es/minify/libraries/vue
Benchmarking es/minify/libraries/vue: Warming up for 3.0000 s
Benchmarking es/minify/libraries/vue: Collecting 10 samples in estimated 7.2470 s (110 iterations)
Benchmarking es/minify/libraries/vue: Analyzing
es/minify/libraries/vue time:   [65.286 ms 65.865 ms 66.572 ms]
                        change: [-1.7357% -1.0805% -0.4093%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

```

**Related issue (if exists):**
