### PR TITLE
fix(es/minifier): don't drop params in exported function

### DIFF
--- a/crates/swc/tests/tsc-references/conflictingCommonJSES2015Exports.2.minified.js
+++ b/crates/swc/tests/tsc-references/conflictingCommonJSES2015Exports.2.minified.js
@@ -1,5 +1,5 @@
 //// [bug24934.js]
-export function abc() {
+export function abc(a, b, c) {
     return 5;
 }
 module.exports = {

--- a/crates/swc/tests/tsc-references/jsDeclarationsEnumTag.2.minified.js
+++ b/crates/swc/tests/tsc-references/jsDeclarationsEnumTag.2.minified.js
@@ -20,7 +20,7 @@ export var Fs = {
         return n - 1;
     }
 };
-export function consume() {
+export function consume(t, s, f) {
     Target.START;
 }
 export function ff(s) {

--- a/crates/swc/tests/tsc-references/jsDeclarationsFunctionJSDoc.2.minified.js
+++ b/crates/swc/tests/tsc-references/jsDeclarationsFunctionJSDoc.2.minified.js
@@ -1,6 +1,6 @@
 //// [source.js]
 import _class_call_check from "@swc/helpers/src/_class_call_check.mjs";
-export function foo() {}
+export function foo(a, b) {}
 export var Aleph = function() {
     "use strict";
     function Aleph(a, b) {

--- a/crates/swc/tests/tsc-references/jsDeclarationsFunctions.2.minified.js
+++ b/crates/swc/tests/tsc-references/jsDeclarationsFunctions.2.minified.js
@@ -8,10 +8,10 @@ c.Cls = function _class() {
     "use strict";
     _class_call_check(this, _class);
 };
-export function d() {
+export function d(a, b) {
     return null;
 }
-export function e() {
+export function e(a, b) {
     return null;
 }
 export function f(a) {

--- a/crates/swc/tests/tsc-references/namedTupleMembers.2.minified.js
+++ b/crates/swc/tests/tsc-references/namedTupleMembers.2.minified.js
@@ -3,7 +3,7 @@ import _sliced_to_array from "@swc/helpers/src/_sliced_to_array.mjs";
 import _to_consumable_array from "@swc/helpers/src/_to_consumable_array.mjs";
 a = b, a = c, b = a = d, b = c, b = d, c = a, c = b, c = d, d = a, d = b, d = c;
 export var func = null;
-export function useState() {
+export function useState(initial) {
     return null;
 }
 export function readSegment(param) {

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -1579,7 +1579,7 @@ where
         match n {
             DefaultDecl::Class(_) => {}
             DefaultDecl::Fn(f) => {
-                if !self.options.keep_fargs && self.options.evaluate && self.options.unused {
+                if !self.options.keep_fargs && self.options.unused {
                     self.drop_unused_params(&mut f.function.params);
                 }
             }
@@ -1602,9 +1602,7 @@ where
     #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
     fn visit_mut_export_decl(&mut self, n: &mut ExportDecl) {
         if let Decl::Fn(f) = &mut n.decl {
-            // I don't know why, but terser removes parameters from an exported function if
-            // `unused` is true, regardless of keep_fargs or others.
-            if self.options.unused {
+            if !self.options.keep_fargs && self.options.unused {
                 self.drop_unused_params(&mut f.function.params);
             }
         }
@@ -1816,7 +1814,7 @@ where
             .entry(f.ident.to_id())
             .or_insert_with(|| FnMetadata::from(&f.function));
 
-        if !self.options.keep_fargs && self.options.evaluate && self.options.unused {
+        if !self.options.keep_fargs && self.options.unused {
             self.drop_unused_params(&mut f.function.params);
         }
 

--- a/crates/swc_ecma_minifier/src/option/terser.rs
+++ b/crates/swc_ecma_minifier/src/option/terser.rs
@@ -151,8 +151,8 @@ pub struct TerserCompressorOptions {
     #[serde(default)]
     pub keep_classnames: bool,
 
-    #[serde(default)]
-    pub keep_fargs: Option<bool>,
+    #[serde(default = "true_by_default")]
+    pub keep_fargs: bool,
 
     #[serde(default)]
     pub keep_fnames: bool,
@@ -335,7 +335,7 @@ impl TerserCompressorOptions {
                 .unwrap_or(if self.defaults { 3 } else { 0 }),
             join_vars: self.join_vars.unwrap_or(self.defaults),
             keep_classnames: self.keep_classnames,
-            keep_fargs: self.keep_fargs.unwrap_or(self.defaults),
+            keep_fargs: self.keep_fargs,
             keep_fnames: self.keep_fnames,
             keep_infinity: self.keep_infinity,
             loops: self.loops.unwrap_or(self.defaults),

--- a/crates/swc_ecma_minifier/tests/fixture/issues/4515/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/4515/output.js
@@ -3,4 +3,4 @@ B.c = {
         for(var a = 1; a < 10; a++);
     }
 };
-export function setGetChildNodes() {}
+export function setGetChildNodes(getChildNodesImpl) {}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/react/hooks/3/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/react/hooks/3/output.js
@@ -5,7 +5,7 @@ __webpack_require__.d(__webpack_exports__, {
     }
 });
 var router = __webpack_require__(86677), index_esm = __webpack_require__(45205), use_team = __webpack_require__(502), fetch_api = __webpack_require__(78869), authenticate = __webpack_require__(16966), api_endpoints = __webpack_require__(96236), qs = __webpack_require__(70326), use_project = __webpack_require__(76246);
-export function EnvironmentsSelector() {
+export function EnvironmentsSelector(param) {
     var projectId, token, team, teamId, projectName = (0, router.useRouter)().query.project, projectInfo = (0, use_project.useProject)(projectName).data;
     return (0, use_team.ZP)().teamSlug, (projectId = null == projectInfo ? void 0 : projectInfo.id, token = (0, authenticate.LP)(), teamId = null == (team = (0, use_team.ZP)().team) ? void 0 : team.id, (0, index_esm.ZP)(projectId ? "".concat(api_endpoints.Ms, "/git-branches").concat((0, qs.c)({
         projectId: projectId,


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Terser has since fixed this bug and it's no longer needed.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
