### PR TITLE
perf(es/minifier): Merge `MultiReplacer` calls

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -9,10 +9,7 @@ use swc_ecma_utils::{
 };
 use swc_ecma_visit::VisitMutWith;
 
-use super::{
-    util::{MultiReplacer, MultiReplacerMode},
-    Optimizer,
-};
+use super::{util::MultiReplacer, Optimizer};
 #[cfg(feature = "debug")]
 use crate::debug::dump;
 use crate::{
@@ -266,8 +263,8 @@ where
         trace_op!("inline: inline_vars_in_node");
 
         n.visit_mut_with(&mut MultiReplacer {
-            vars,
-            simple_functions: Default::default(),
+            vars: &mut vars,
+            simple_functions: &Default::default(),
             changed: false,
             worked: &mut self.changed,
         });

--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -265,12 +265,12 @@ where
     {
         trace_op!("inline: inline_vars_in_node");
 
-        n.visit_mut_with(&mut MultiReplacer::new(
-            &mut vars,
-            false,
-            MultiReplacerMode::Normal,
-            &mut self.changed,
-        ));
+        n.visit_mut_with(&mut MultiReplacer {
+            vars,
+            simple_functions: Default::default(),
+            changed: false,
+            worked: &mut self.changed,
+        });
     }
 
     /// Fully inlines iife.

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -262,22 +262,14 @@ impl Vars {
         N: for<'aa> VisitMutWith<MultiReplacer<'aa>>,
     {
         let mut changed = false;
-        if !self.simple_functions.is_empty() {
-            n.visit_mut_with(&mut MultiReplacer::new(
-                &mut self.simple_functions,
-                true,
-                MultiReplacerMode::OnlyCallee,
-                &mut changed,
-            ));
-        }
 
-        if !self.vars_for_inlining.is_empty() {
-            n.visit_mut_with(&mut MultiReplacer::new(
-                &mut self.vars_for_inlining,
-                false,
-                MultiReplacerMode::Normal,
-                &mut changed,
-            ));
+        if !self.simple_functions.is_empty() || !self.vars_for_inlining.is_empty() {
+            n.visit_mut_with(&mut MultiReplacer {
+                vars: &mut self.vars_for_inlining,
+                simple_functions: &self.simple_functions,
+                changed: false,
+                worked: &mut changed,
+            });
         }
 
         changed

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -20,7 +20,7 @@ use Value::Known;
 
 use self::{
     unused::PropertyAccessOpts,
-    util::{extract_class_side_effect, MultiReplacer, MultiReplacerMode},
+    util::{extract_class_side_effect, MultiReplacer},
 };
 use super::util::{drop_invalid_stmts, is_fine_for_if_cons};
 #[cfg(feature = "debug")]

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -206,12 +206,12 @@ impl VisitMut for MultiReplacer<'_> {
     }
 
     fn visit_mut_expr(&mut self, e: &mut Expr) {
-        if self.vars.is_empty() {
+        if self.vars.is_empty() && self.simple_functions.is_empty() {
             return;
         }
         e.visit_mut_children_with(self);
 
-        if self.vars.is_empty() {
+        if self.vars.is_empty() && self.simple_functions.is_empty() {
             return;
         }
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -150,8 +150,9 @@ impl VisitMut for Remapper {
 
 pub(crate) struct MultiReplacer<'a> {
     pub vars: &'a mut FxHashMap<Id, Box<Expr>>,
+    pub simple_functions: &'a FxHashMap<Id, Box<Expr>>,
+
     pub changed: bool,
-    pub clone: bool,
     /// `worked` will be changed to `true` if any replacement is done
     pub worked: &'a mut bool,
 }

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -149,11 +149,11 @@ impl VisitMut for Remapper {
 }
 
 pub(crate) struct MultiReplacer<'a> {
-    vars: &'a mut FxHashMap<Id, Box<Expr>>,
-    changed: bool,
-    clone: bool,
-    mode: MultiReplacerMode,
-    worked: &'a mut bool,
+    pub vars: &'a mut FxHashMap<Id, Box<Expr>>,
+    pub changed: bool,
+    pub clone: bool,
+    pub mode: MultiReplacerMode,
+    pub worked: &'a mut bool,
 }
 
 #[repr(u8)]

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -229,7 +229,7 @@ impl VisitMut for MultiReplacer<'_> {
     fn visit_mut_module_items(&mut self, items: &mut Vec<ModuleItem>) {
         loop {
             self.changed = false;
-            if self.vars.is_empty() {
+            if self.vars.is_empty() && self.simple_functions.is_empty() {
                 break;
             }
             items.visit_mut_children_with(self);

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -191,16 +191,14 @@ impl VisitMut for MultiReplacer<'_> {
     fn visit_mut_callee(&mut self, e: &mut Callee) {
         e.visit_mut_children_with(self);
 
-        if matches!(self.mode, MultiReplacerMode::OnlyCallee) {
-            if let Callee::Expr(e) = e {
-                if let Expr::Ident(i) = &**e {
-                    if let Some(new) = self.var(&i.to_id()) {
-                        debug!("multi-replacer: Replaced `{}`", i);
-                        *self.worked = true;
-                        self.changed = true;
+        if let Callee::Expr(e) = e {
+            if let Expr::Ident(i) = &**e {
+                if let Some(new) = self.var(&i.to_id(), MultiReplacerMode::OnlyCallee) {
+                    debug!("multi-replacer: Replaced `{}`", i);
+                    *self.worked = true;
+                    self.changed = true;
 
-                        **e = *new;
-                    }
+                    **e = *new;
                 }
             }
         }
@@ -216,15 +214,13 @@ impl VisitMut for MultiReplacer<'_> {
             return;
         }
 
-        if matches!(self.mode, MultiReplacerMode::Normal) {
-            if let Expr::Ident(i) = e {
-                if let Some(new) = self.var(&i.to_id()) {
-                    debug!("multi-replacer: Replaced `{}`", i);
-                    *self.worked = true;
-                    self.changed = true;
+        if let Expr::Ident(i) = e {
+            if let Some(new) = self.var(&i.to_id(), MultiReplacerMode::Normal) {
+                debug!("multi-replacer: Replaced `{}`", i);
+                *self.worked = true;
+                self.changed = true;
 
-                    *e = *new;
-                }
+                *e = *new;
             }
         }
     }
@@ -251,21 +247,19 @@ impl VisitMut for MultiReplacer<'_> {
     fn visit_mut_prop(&mut self, p: &mut Prop) {
         p.visit_mut_children_with(self);
 
-        if matches!(self.mode, MultiReplacerMode::Normal) {
-            if let Prop::Shorthand(i) = p {
-                if let Some(value) = self.var(&i.to_id()) {
-                    debug!("multi-replacer: Replaced `{}` as shorthand", i);
-                    *self.worked = true;
-                    self.changed = true;
+        if let Prop::Shorthand(i) = p {
+            if let Some(value) = self.var(&i.to_id(), MultiReplacerMode::Normal) {
+                debug!("multi-replacer: Replaced `{}` as shorthand", i);
+                *self.worked = true;
+                self.changed = true;
 
-                    *p = Prop::KeyValue(KeyValueProp {
-                        key: PropName::Ident(Ident::new(
-                            i.sym.clone(),
-                            i.span.with_ctxt(Default::default()),
-                        )),
-                        value,
-                    });
-                }
+                *p = Prop::KeyValue(KeyValueProp {
+                    key: PropName::Ident(Ident::new(
+                        i.sym.clone(),
+                        i.span.with_ctxt(Default::default()),
+                    )),
+                    value,
+                });
             }
         }
     }

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -167,8 +167,8 @@ pub enum MultiReplacerMode {
 
 impl<'a> MultiReplacer<'a> {
     fn var(&mut self, i: &Id, mode: MultiReplacerMode) -> Option<Box<Expr>> {
-        let e = if self.clone {
-            self.vars.get(i).cloned()?
+        let e = if matches!(mode, MultiReplacerMode::OnlyCallee) {
+            self.simple_functions.get(i).cloned()?
         } else {
             self.vars.remove(i)?
         };

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -152,7 +152,7 @@ pub(crate) struct MultiReplacer<'a> {
     pub vars: &'a mut FxHashMap<Id, Box<Expr>>,
     pub changed: bool,
     pub clone: bool,
-    pub mode: MultiReplacerMode,
+    /// `worked` will be changed to `true` if any replacement is done
     pub worked: &'a mut bool,
 }
 
@@ -165,23 +165,7 @@ pub enum MultiReplacerMode {
 }
 
 impl<'a> MultiReplacer<'a> {
-    /// `worked` will be changed to `true` if any replacement is done
-    pub fn new(
-        vars: &'a mut FxHashMap<Id, Box<Expr>>,
-        clone: bool,
-        mode: MultiReplacerMode,
-        worked: &'a mut bool,
-    ) -> Self {
-        MultiReplacer {
-            vars,
-            changed: false,
-            clone,
-            mode,
-            worked,
-        }
-    }
-
-    fn var(&mut self, i: &Id) -> Option<Box<Expr>> {
+    fn var(&mut self, i: &Id, mode: MultiReplacerMode) -> Option<Box<Expr>> {
         let e = if self.clone {
             self.vars.get(i).cloned()?
         } else {


### PR DESCRIPTION
**Description:**

```
Gnuplot not found, using plotters backend
Benchmarking es/minify/libraries/antd
Benchmarking es/minify/libraries/antd: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.8s.
Benchmarking es/minify/libraries/antd: Collecting 10 samples in estimated 7.8214 s (10 iterations)
Benchmarking es/minify/libraries/antd: Analyzing
es/minify/libraries/antd
                        time:   [773.57 ms 776.93 ms 780.70 ms]
                        change: [-4.7613% -3.4320% -2.4893%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/d3
Benchmarking es/minify/libraries/d3: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.7s or enable flat sampling.
Benchmarking es/minify/libraries/d3: Collecting 10 samples in estimated 8.6621 s (55 iterations)
Benchmarking es/minify/libraries/d3: Analyzing
es/minify/libraries/d3  time:   [149.91 ms 150.43 ms 151.03 ms]
                        change: [-3.7706% -2.4403% -0.9355%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/echarts
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.1s.
Benchmarking es/minify/libraries/echarts: Collecting 10 samples in estimated 6.1099 s (10 iterations)
Benchmarking es/minify/libraries/echarts: Analyzing
es/minify/libraries/echarts
                        time:   [606.54 ms 610.35 ms 615.01 ms]
                        change: [-7.1586% -5.1974% -3.6087%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 10 measurements (40.00%)
  2 (20.00%) low mild
  2 (20.00%) high severe
Benchmarking es/minify/libraries/jquery
Benchmarking es/minify/libraries/jquery: Warming up for 3.0000 s
Benchmarking es/minify/libraries/jquery: Collecting 10 samples in estimated 7.0515 s (165 iterations)
Benchmarking es/minify/libraries/jquery: Analyzing
es/minify/libraries/jquery
                        time:   [42.492 ms 42.681 ms 42.867 ms]
                        change: [-1.9771% -1.2653% -0.5811%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/lodash
Benchmarking es/minify/libraries/lodash: Warming up for 3.0000 s
Benchmarking es/minify/libraries/lodash: Collecting 10 samples in estimated 6.2383 s (110 iterations)
Benchmarking es/minify/libraries/lodash: Analyzing
es/minify/libraries/lodash
                        time:   [55.364 ms 55.711 ms 55.963 ms]
                        change: [-1.9754% -1.4232% -0.8464%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/moment
Benchmarking es/minify/libraries/moment: Warming up for 3.0000 s
Benchmarking es/minify/libraries/moment: Collecting 10 samples in estimated 5.6237 s (220 iterations)
Benchmarking es/minify/libraries/moment: Analyzing
es/minify/libraries/moment
                        time:   [25.214 ms 25.330 ms 25.443 ms]
                        change: [-2.0084% -1.3952% -0.7109%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/react
Benchmarking es/minify/libraries/react: Warming up for 3.0000 s
Benchmarking es/minify/libraries/react: Collecting 10 samples in estimated 5.5225 s (495 iterations)
Benchmarking es/minify/libraries/react: Analyzing
es/minify/libraries/react
                        time:   [10.994 ms 11.071 ms 11.145 ms]
                        change: [-2.3686% -1.6502% -0.8911%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/terser
Benchmarking es/minify/libraries/terser: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.2s or enable flat sampling.
Benchmarking es/minify/libraries/terser: Collecting 10 samples in estimated 7.2316 s (55 iterations)
Benchmarking es/minify/libraries/terser: Analyzing
es/minify/libraries/terser
                        time:   [130.17 ms 130.49 ms 130.89 ms]
                        change: [-0.8541% +0.2237% +1.7003%] (p = 0.80 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/three
Benchmarking es/minify/libraries/three: Warming up for 3.0000 s
Benchmarking es/minify/libraries/three: Collecting 10 samples in estimated 6.1436 s (30 iterations)
Benchmarking es/minify/libraries/three: Analyzing
es/minify/libraries/three
                        time:   [201.83 ms 202.15 ms 202.49 ms]
                        change: [-3.1409% -2.8098% -2.4661%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/typescript
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 17.4s.
Benchmarking es/minify/libraries/typescript: Collecting 10 samples in estimated 17.353 s (10 iterations)
Benchmarking es/minify/libraries/typescript: Analyzing
es/minify/libraries/typescript
                        time:   [1.7298 s 1.7352 s 1.7416 s]
                        change: [-4.6216% -4.2576% -3.8500%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low mild
  2 (20.00%) high severe
Benchmarking es/minify/libraries/victory
Benchmarking es/minify/libraries/victory: Warming up for 3.0000 s
Benchmarking es/minify/libraries/victory: Collecting 10 samples in estimated 6.7681 s (20 iterations)
Benchmarking es/minify/libraries/victory: Analyzing
es/minify/libraries/victory
                        time:   [336.93 ms 338.85 ms 341.05 ms]
                        change: [-3.4518% -2.6850% -1.8045%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/vue
Benchmarking es/minify/libraries/vue: Warming up for 3.0000 s
Benchmarking es/minify/libraries/vue: Collecting 10 samples in estimated 7.1725 s (110 iterations)
Benchmarking es/minify/libraries/vue: Analyzing
es/minify/libraries/vue time:   [64.773 ms 64.903 ms 65.114 ms]
                        change: [-8.5106% -5.1215% -2.3009%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low severe
  2 (20.00%) high severe
```

**Related issue (if exists):**
