### PR TITLE
feat(es/minifier): Reuse variable names

### DIFF
--- a/crates/swc_ecma_minifier/Cargo.toml
+++ b/crates/swc_ecma_minifier/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-authors       = ["강동윤 <kdy1997.dev@gmail.com>"]
-description   = "EcmaScript code minifier."
+authors = ["강동윤 <kdy1997.dev@gmail.com>"]
+description = "EcmaScript code minifier."
 documentation = "https://rustdoc.swc.rs/swc_ecma_minifier/"
-edition       = "2021"
-include       = ["Cargo.toml", "src/**/*.rs", "src/lists/*.json"]
-license       = "Apache-2.0"
-name          = "swc_ecma_minifier"
-repository    = "https://github.com/swc-project/swc.git"
-version       = "0.152.19"
+edition = "2021"
+include = ["Cargo.toml", "src/**/*.rs", "src/lists/*.json"]
+license = "Apache-2.0"
+name = "swc_ecma_minifier"
+repository = "https://github.com/swc-project/swc.git"
+version = "0.152.19"
 
-  [package.metadata.docs.rs]
-  all-features = true
-  rustdoc-args = ["--cfg", "docsrs"]
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
 bench = false
@@ -20,7 +20,6 @@ bench = false
 # This enables global concurrent mode
 concurrent = [
   "swc_common/concurrent",
-  "swc_ecma_transforms_base/concurrent-renamer",
   "swc_ecma_transforms_optimization/concurrent",
   "rayon",
   "indexmap/rayon",
@@ -29,45 +28,45 @@ debug = ["backtrace", "swc_ecma_transforms_optimization/debug"]
 trace-ast = []
 
 [dependencies]
-ahash                            = "0.7.6"
-arrayvec                         = "0.7.2"
-backtrace                        = { version = "0.3.61", optional = true }
-indexmap                         = "1.7.0"
-num-bigint                       = "0.4.3"
-num_cpus                         = "1.13.1"
-once_cell                        = "1.10.0"
-parking_lot                      = "0.12.0"
-pretty_assertions                = { version = "1.1", optional = true }
-rayon                            = { version = "1.5.1", optional = true }
-regex                            = "1.5.3"
-retain_mut                       = "0.1.2"
-rustc-hash                       = "1.1.0"
-serde                            = { version = "1.0.118", features = ["derive"] }
-serde_json                       = "1.0.61"
-swc_atoms                        = { version = "0.4.10", path = "../swc_atoms" }
-swc_cached                       = { version = "0.3.5", path = "../swc_cached" }
-swc_common                       = { version = "0.27.15", path = "../swc_common" }
-swc_config                       = { version = "0.1.0", path = "../swc_config" }
-swc_ecma_ast                     = { version = "0.90.19", path = "../swc_ecma_ast" }
-swc_ecma_codegen                 = { version = "0.123.4", path = "../swc_ecma_codegen" }
-swc_ecma_parser                  = { version = "0.118.9", path = "../swc_ecma_parser" }
-swc_ecma_transforms_base         = { version = "0.106.7", path = "../swc_ecma_transforms_base" }
-swc_ecma_transforms_optimization = { version = "0.160.12", path = "../swc_ecma_transforms_optimization" }
-swc_ecma_utils                   = { version = "0.101.5", path = "../swc_ecma_utils" }
-swc_ecma_visit                   = { version = "0.76.9", path = "../swc_ecma_visit" }
-swc_timer                        = { version = "0.15.6", path = "../swc_timer" }
-tracing                          = "0.1.32"
+ahash = "0.7.6"
+arrayvec = "0.7.2"
+backtrace = {version = "0.3.61", optional = true}
+indexmap = "1.7.0"
+num-bigint = "0.4.3"
+num_cpus = "1.13.1"
+once_cell = "1.10.0"
+parking_lot = "0.12.0"
+pretty_assertions = {version = "1.1", optional = true}
+rayon = {version = "1.5.1", optional = true}
+regex = "1.5.3"
+retain_mut = "0.1.2"
+rustc-hash = "1.1.0"
+serde = {version = "1.0.118", features = ["derive"]}
+serde_json = "1.0.61"
+swc_atoms = {version = "0.4.10", path = "../swc_atoms"}
+swc_cached = {version = "0.3.5", path = "../swc_cached"}
+swc_common = {version = "0.27.15", path = "../swc_common"}
+swc_config = {version = "0.1.0", path = "../swc_config"}
+swc_ecma_ast = {version = "0.90.19", path = "../swc_ecma_ast"}
+swc_ecma_codegen = {version = "0.123.4", path = "../swc_ecma_codegen"}
+swc_ecma_parser = {version = "0.118.9", path = "../swc_ecma_parser"}
+swc_ecma_transforms_base = {version = "0.106.7", path = "../swc_ecma_transforms_base"}
+swc_ecma_transforms_optimization = {version = "0.160.12", path = "../swc_ecma_transforms_optimization"}
+swc_ecma_utils = {version = "0.101.5", path = "../swc_ecma_utils"}
+swc_ecma_visit = {version = "0.76.9", path = "../swc_ecma_visit"}
+swc_timer = {version = "0.15.6", path = "../swc_timer"}
+tracing = "0.1.32"
 
 [dev-dependencies]
-ansi_term         = "0.12.1"
-anyhow            = "1"
-criterion         = "0.3.5"
+ansi_term = "0.12.1"
+anyhow = "1"
+criterion = "0.3.5"
 pretty_assertions = "1.1"
-swc_ecma_testing  = { version = "0.16.3", path = "../swc_ecma_testing" }
-swc_node_base     = { version = "0.5.0", path = "../swc_node_base" }
-testing           = { version = "0.29.6", path = "../testing" }
-walkdir           = "2"
+swc_ecma_testing = {version = "0.16.3", path = "../swc_ecma_testing"}
+swc_node_base = {version = "0.5.0", path = "../swc_node_base"}
+testing = {version = "0.29.6", path = "../testing"}
+walkdir = "2"
 
 [[bench]]
 harness = false
-name    = "full"
+name = "full"

--- a/crates/swc_ecma_minifier/src/pass/mangle_names/mod.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/mod.rs
@@ -414,7 +414,7 @@ struct ManglingRenamer {
 }
 
 impl Renamer for ManglingRenamer {
-    const PARALLEL: bool = true;
+    const MANGLE: bool = true;
     const RESET_N: bool = false;
 
     fn preserved_ids_for_module(&mut self, _: &Module) -> FxHashSet<Id> {

--- a/crates/swc_ecma_transforms_base/Cargo.toml
+++ b/crates/swc_ecma_transforms_base/Cargo.toml
@@ -13,8 +13,7 @@ version = "0.106.7"
 bench = false
 
 [features]
-concurrent = ["concurrent-renamer", "rayon", "swc_ecma_utils/concurrent"]
-concurrent-renamer = ["rayon"]
+concurrent = ["rayon", "swc_ecma_utils/concurrent"]
 
 [dependencies]
 better_scoped_tls = {version = "0.1.0", path = "../better_scoped_tls"}

--- a/crates/swc_ecma_transforms_base/src/hygiene/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/hygiene/mod.rs
@@ -53,7 +53,7 @@ pub fn hygiene_with_config(config: Config) -> impl 'static + Fold + VisitMut {
 struct HygieneRenamer;
 
 impl Renamer for HygieneRenamer {
-    const PARALLEL: bool = false;
+    const MANGLE: bool = false;
     const RESET_N: bool = true;
 
     fn new_name_for(&self, orig: &Id, n: &mut usize) -> swc_atoms::JsWord {

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -208,7 +208,6 @@ impl Scope {
         true
     }
 
-    #[cfg_attr(not(feature = "concurrent-renamer"), allow(unused))]
     pub(crate) fn rename_parallel<R>(
         &mut self,
         renamer: &R,

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -249,37 +249,6 @@ impl Scope {
             preserved_symbols,
         );
 
-        #[cfg(feature = "concurrent-renamer")]
-        if parallel && false {
-            #[cfg(not(target_arch = "wasm32"))]
-            let iter = self.children.par_iter_mut();
-            #[cfg(target_arch = "wasm32")]
-            let iter = self.children.iter_mut();
-
-            let iter = iter
-                .map(|child| {
-                    use std::collections::HashMap;
-
-                    let mut new_map = HashMap::default();
-                    child.rename_parallel(
-                        renamer,
-                        &mut new_map,
-                        to,
-                        &cloned_reverse,
-                        preserved,
-                        preserved_symbols,
-                        parallel,
-                    );
-                    new_map
-                })
-                .collect::<Vec<_>>();
-
-            for (k, v) in iter.into_iter().flatten() {
-                to.entry(k).or_insert(v);
-            }
-            return;
-        }
-
         for child in &mut self.children {
             child.rename_parallel(
                 renamer,

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -48,7 +48,7 @@ pub(crate) type RenameMap = AHashMap<FastId, JsWord>;
 
 pub(crate) type ReverseMap = FxHashMap<JsWord, Vec<FastId>>;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 struct Count {
     total: u32,
     own: u32,
@@ -62,7 +62,6 @@ pub(super) struct ScopeData {
     ///
     /// If the add-only contraint is violated, it is very likely to be a bug,
     /// because we merge every items in children to current scope.
-    all: FxHashSet<FastId>,
     all: FxHashMap<FastId, Count>,
 
     queue: Vec<Id>,

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -101,14 +101,14 @@ impl Scope {
     /// Copy `children.data.all` to `self.data.all`.
     pub(crate) fn prepare_renaming(&mut self) {
         self.children.iter_mut().for_each(|child| {
-            for (id, count) in self.data.all.iter() {
-                let e = child.data.all.entry(id.clone()).or_default();
+            child.prepare_renaming();
+
+            for (id, count) in child.data.all.iter() {
+                let e = self.data.all.entry(id.clone()).or_default();
 
                 e.total += count.total;
                 e.cur += count.total;
             }
-
-            child.prepare_renaming();
         });
     }
 

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -282,7 +282,7 @@ impl Scope {
     }
 
     fn rename_one_scope_parallel<R>(
-        &self,
+        &mut self,
         renamer: &R,
         to: &mut RenameMap,
         previous: &RenameMap,

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -114,11 +114,9 @@ impl Scope {
 
     fn drop_id(&mut self, id: &FastId, reduce: bool) {
         if let Some(count) = self.data.all.get_mut(id) {
-            if reduce {
-                count.cur -= 1;
-            }
             dbg!(&*count);
-            if reduce || count.cur == count.own {
+            if reduce || count.total == count.own {
+                count.cur -= 1;
                 self.children.iter_mut().for_each(|child| {
                     child.drop_id(id, true);
                 });

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -112,6 +112,12 @@ impl Scope {
         });
     }
 
+    fn drop_id(&mut self, id: &Id) {
+        if id.0 == js_word!("arguments") {
+            return;
+        }
+    }
+
     pub(crate) fn rename_single_thread<R>(
         &mut self,
         renamer: &R,
@@ -318,8 +324,8 @@ impl Scope {
                     let fid = fast_id(id.clone());
                     to.insert(fid.clone(), sym.clone());
                     reverse.entry(sym).or_default().push(fid.clone());
-                    // self.data.decls.remove(&id);
-                    // self.data.usages.remove(&id);
+
+                    self.drop_id(&id);
 
                     break;
                 }

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -117,7 +117,17 @@ impl Scope {
             return;
         }
 
-        if let Some(usage) = self.data.all.get_mut(id) {}
+        if let Some(usage) = self.data.all.get_mut(id) {
+            usage.cur -= 1;
+
+            self.children.iter_mut().for_each(|child| {
+                if let Some(child_usage) = child.data.all.get_mut(id) {
+                    child_usage.cur -= usage.own;
+                }
+
+                child.drop_id(id);
+            });
+        }
     }
 
     pub(crate) fn rename_single_thread<R>(

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -216,7 +216,6 @@ impl Scope {
         reverse: &ReverseMap,
         preserved: &FxHashSet<Id>,
         preserved_symbols: &FxHashSet<JsWord>,
-        parallel: bool,
     ) where
         R: Renamer,
     {
@@ -242,7 +241,6 @@ impl Scope {
                 &cloned_reverse,
                 preserved,
                 preserved_symbols,
-                parallel,
             );
         }
     }
@@ -289,11 +287,6 @@ impl Scope {
                 }
             }
         }
-    }
-
-    pub fn rename_cost(&self) -> usize {
-        let children = &self.children;
-        self.data.queue.len() + children.iter().map(|v| v.rename_cost()).sum::<usize>()
     }
 }
 

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -5,8 +5,6 @@ use std::{
     ops::AddAssign,
 };
 
-#[cfg(feature = "concurrent-renamer")]
-use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::{js_word, JsWord};
 use swc_common::{collections::AHashMap, util::take::Take, SyntaxContext};
@@ -110,18 +108,6 @@ impl Scope {
                 e.cur += count.total;
             }
         });
-    }
-
-    fn drop_id(&mut self, id: &FastId, reduce: bool) {
-        // if let Some(count) = self.data.all.get_mut(id) {
-        //     // dbg!(&*count);
-        //     if reduce || count.total == count.own {
-        //         count.cur -= 1;
-        //         self.children.iter_mut().for_each(|child| {
-        //             // child.drop_id(id, true);
-        //         });
-        //     }
-        // }
     }
 
     pub(crate) fn rename_single_thread<R>(
@@ -299,8 +285,6 @@ impl Scope {
                     let fid = fast_id(id.clone());
                     to.insert(fid.clone(), sym.clone());
                     reverse.entry(sym).or_default().push(fid.clone());
-
-                    self.drop_id(&fid, false);
 
                     break;
                 }

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -113,10 +113,6 @@ impl Scope {
     }
 
     fn drop_id(&mut self, id: &FastId) {
-        if id.0 == js_word!("arguments") {
-            return;
-        }
-
         if let Some(usage) = self.data.all.get_mut(id) {
             usage.cur -= 1;
 

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -208,7 +208,7 @@ impl Scope {
         true
     }
 
-    pub(crate) fn rename_parallel<R>(
+    pub(crate) fn rename_in_mangling_mode<R>(
         &mut self,
         renamer: &R,
         to: &mut RenameMap,
@@ -224,7 +224,7 @@ impl Scope {
 
         let mut cloned_reverse = reverse.clone();
 
-        self.rename_one_scope_parallel(
+        self.rename_one_scope_in_mangling_mode(
             renamer,
             to,
             previous,
@@ -235,7 +235,7 @@ impl Scope {
         );
 
         for child in &mut self.children {
-            child.rename_parallel(
+            child.rename_in_mangling_mode(
                 renamer,
                 to,
                 &Default::default(),
@@ -247,7 +247,7 @@ impl Scope {
         }
     }
 
-    fn rename_one_scope_parallel<R>(
+    fn rename_one_scope_in_mangling_mode<R>(
         &mut self,
         renamer: &R,
         to: &mut RenameMap,

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -227,6 +227,16 @@ impl Scope {
 
         let mut cloned_reverse = reverse.clone();
 
+        self.rename_one_scope_parallel(
+            renamer,
+            to,
+            previous,
+            &mut cloned_reverse,
+            queue,
+            preserved,
+            preserved_symbols,
+        );
+
         #[cfg(feature = "concurrent-renamer")]
         if parallel {
             #[cfg(not(target_arch = "wasm32"))]
@@ -255,16 +265,6 @@ impl Scope {
             for (k, v) in iter.into_iter().flatten() {
                 to.entry(k).or_insert(v);
             }
-
-            self.rename_one_scope_parallel(
-                renamer,
-                to,
-                previous,
-                &mut cloned_reverse,
-                queue,
-                preserved,
-                preserved_symbols,
-            );
             return;
         }
 
@@ -279,16 +279,6 @@ impl Scope {
                 parallel,
             );
         }
-
-        self.rename_one_scope_parallel(
-            renamer,
-            to,
-            previous,
-            &mut cloned_reverse,
-            queue,
-            preserved,
-            preserved_symbols,
-        );
     }
 
     fn rename_one_scope_parallel<R>(

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -227,16 +227,6 @@ impl Scope {
 
         let mut cloned_reverse = reverse.clone();
 
-        self.rename_one_scope_parallel(
-            renamer,
-            to,
-            previous,
-            &mut cloned_reverse,
-            queue,
-            preserved,
-            preserved_symbols,
-        );
-
         #[cfg(feature = "concurrent-renamer")]
         if parallel {
             #[cfg(not(target_arch = "wasm32"))]
@@ -265,6 +255,16 @@ impl Scope {
             for (k, v) in iter.into_iter().flatten() {
                 to.entry(k).or_insert(v);
             }
+
+            self.rename_one_scope_parallel(
+                renamer,
+                to,
+                previous,
+                &mut cloned_reverse,
+                queue,
+                preserved,
+                preserved_symbols,
+            );
             return;
         }
 
@@ -279,6 +279,16 @@ impl Scope {
                 parallel,
             );
         }
+
+        self.rename_one_scope_parallel(
+            renamer,
+            to,
+            previous,
+            &mut cloned_reverse,
+            queue,
+            preserved,
+            preserved_symbols,
+        );
     }
 
     fn rename_one_scope_parallel<R>(

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -112,10 +112,12 @@ impl Scope {
         });
     }
 
-    fn drop_id(&mut self, id: &Id) {
+    fn drop_id(&mut self, id: &FastId) {
         if id.0 == js_word!("arguments") {
             return;
         }
+
+        if let Some(usage) = self.data.all.get_mut(id) {}
     }
 
     pub(crate) fn rename_single_thread<R>(
@@ -325,7 +327,7 @@ impl Scope {
                     to.insert(fid.clone(), sym.clone());
                     reverse.entry(sym).or_default().push(fid.clone());
 
-                    self.drop_id(&id);
+                    self.drop_id(&fid);
 
                     break;
                 }

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -113,11 +113,11 @@ impl Scope {
     }
 
     fn drop_id(&mut self, id: &FastId) {
-        if let Some(usage) = self.data.all.get(id) {
+        if let Some(usage) = self.data.all.get_mut(id) {
+            usage.cur -= 1;
+
             self.children.iter_mut().for_each(|child| {
-                if let Some(child_usage) = child.data.all.get_mut(id) {
-                    child_usage.cur -= usage.own;
-                }
+                // if let Some(child_usage) = child.data.all.get_mut(id) {}
 
                 child.drop_id(id);
             });

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -113,9 +113,7 @@ impl Scope {
     }
 
     fn drop_id(&mut self, id: &FastId) {
-        if let Some(usage) = self.data.all.get_mut(id) {
-            usage.cur -= 1;
-
+        if let Some(usage) = self.data.all.get(id) {
             self.children.iter_mut().for_each(|child| {
                 if let Some(child_usage) = child.data.all.get_mut(id) {
                     child_usage.cur -= usage.own;

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -112,15 +112,17 @@ impl Scope {
         });
     }
 
-    fn drop_id(&mut self, id: &FastId) {
-        if let Some(usage) = self.data.all.get_mut(id) {
-            usage.cur -= 1;
-
-            self.children.iter_mut().for_each(|child| {
-                // if let Some(child_usage) = child.data.all.get_mut(id) {}
-
-                child.drop_id(id);
-            });
+    fn drop_id(&mut self, id: &FastId, reduce: bool) {
+        if let Some(count) = self.data.all.get_mut(id) {
+            if reduce {
+                count.cur -= 1;
+            }
+            dbg!(&*count);
+            if reduce || count.cur == count.own {
+                self.children.iter_mut().for_each(|child| {
+                    child.drop_id(id, true);
+                });
+            }
         }
     }
 
@@ -331,7 +333,7 @@ impl Scope {
                     to.insert(fid.clone(), sym.clone());
                     reverse.entry(sym).or_default().push(fid.clone());
 
-                    self.drop_id(&fid);
+                    self.drop_id(&fid, false);
 
                     break;
                 }

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -103,7 +103,12 @@ impl Scope {
         self.children.iter_mut().for_each(|child| {
             child.prepare_renaming();
 
-            self.data.all.extend(child.data.all.iter().cloned());
+            for (id, count) in child.data.all.iter() {
+                let e = self.data.all.entry(id.clone()).or_default();
+
+                e.total += count.total;
+                e.cur += count.total;
+            }
         });
     }
 
@@ -196,7 +201,7 @@ impl Scope {
                     continue;
                 }
 
-                if self.data.all.contains(left) {
+                if self.data.all.get(left).copied().unwrap_or_default().cur > 0 {
                     return false;
                 }
             }

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -113,15 +113,15 @@ impl Scope {
     }
 
     fn drop_id(&mut self, id: &FastId, reduce: bool) {
-        if let Some(count) = self.data.all.get_mut(id) {
-            dbg!(&*count);
-            if reduce || count.total == count.own {
-                count.cur -= 1;
-                self.children.iter_mut().for_each(|child| {
-                    child.drop_id(id, true);
-                });
-            }
-        }
+        // if let Some(count) = self.data.all.get_mut(id) {
+        //     // dbg!(&*count);
+        //     if reduce || count.total == count.own {
+        //         count.cur -= 1;
+        //         self.children.iter_mut().for_each(|child| {
+        //             // child.drop_id(id, true);
+        //         });
+        //     }
+        // }
     }
 
     pub(crate) fn rename_single_thread<R>(
@@ -250,7 +250,7 @@ impl Scope {
         );
 
         #[cfg(feature = "concurrent-renamer")]
-        if parallel {
+        if parallel && false {
             #[cfg(not(target_arch = "wasm32"))]
             let iter = self.children.par_iter_mut();
             #[cfg(target_arch = "wasm32")]

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -49,12 +49,21 @@ pub(crate) type RenameMap = AHashMap<FastId, JsWord>;
 pub(crate) type ReverseMap = FxHashMap<JsWord, Vec<FastId>>;
 
 #[derive(Debug, Default)]
+struct Count {
+    total: u32,
+    own: u32,
+
+    cur: u32,
+}
+
+#[derive(Debug, Default)]
 pub(super) struct ScopeData {
     /// This is add-only.
     ///
     /// If the add-only contraint is violated, it is very likely to be a bug,
     /// because we merge every items in children to current scope.
     all: FxHashSet<FastId>,
+    all: FxHashMap<FastId, Count>,
 
     queue: Vec<Id>,
 }

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -101,14 +101,14 @@ impl Scope {
     /// Copy `children.data.all` to `self.data.all`.
     pub(crate) fn prepare_renaming(&mut self) {
         self.children.iter_mut().for_each(|child| {
-            child.prepare_renaming();
-
-            for (id, count) in child.data.all.iter() {
-                let e = self.data.all.entry(id.clone()).or_default();
+            for (id, count) in self.data.all.iter() {
+                let e = child.data.all.entry(id.clone()).or_default();
 
                 e.total += count.total;
                 e.cur += count.total;
             }
+
+            child.prepare_renaming();
         });
     }
 

--- a/crates/swc_ecma_transforms_base/src/rename/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/mod.rs
@@ -27,7 +27,7 @@ pub trait Renamer: Send + Sync {
     /// Should reset `n` to 0 for each identifier?
     const RESET_N: bool;
 
-    const PARALLEL: bool;
+    const MANGLE: bool;
 
     fn preserved_ids_for_module(&mut self, _: &Module) -> FxHashSet<Id> {
         Default::default()
@@ -139,7 +139,7 @@ where
                 .extend(self.preserved.iter().map(|v| v.0.clone()));
         }
 
-        if R::PARALLEL {
+        if R::MANGLE {
             let cost = scope.rename_cost();
             scope.rename_parallel(
                 &self.renamer,

--- a/crates/swc_ecma_transforms_base/src/rename/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/mod.rs
@@ -6,10 +6,6 @@ use swc_common::collections::AHashMap;
 use swc_ecma_ast::*;
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith, VisitWith};
 
-#[cfg(feature = "concurrent-renamer")]
-use self::renamer_concurrent::{Send, Sync};
-#[cfg(not(feature = "concurrent-renamer"))]
-use self::renamer_single::{Send, Sync};
 use self::{
     analyzer::{scope::RenameMap, Analyzer},
     collector::{collect_decls, CustomBindingCollector, IdCollector},
@@ -23,7 +19,7 @@ mod collector;
 mod eval;
 mod ops;
 
-pub trait Renamer: Send + Sync {
+pub trait Renamer {
     /// Should reset `n` to 0 for each identifier?
     const RESET_N: bool;
 
@@ -249,20 +245,4 @@ where
 
         s.visit_mut_with(&mut rename_with_config(&map, self.config.clone()));
     }
-}
-
-#[cfg(feature = "concurrent-renamer")]
-mod renamer_concurrent {
-    pub use std::marker::{Send, Sync};
-}
-
-#[cfg(not(feature = "concurrent-renamer"))]
-mod renamer_single {
-    /// Dummy trait because swc_common is in single thread mode.
-    pub trait Send {}
-    /// Dummy trait because swc_common is in single thread mode.
-    pub trait Sync {}
-
-    impl<T> Send for T where T: ?Sized {}
-    impl<T> Sync for T where T: ?Sized {}
 }

--- a/crates/swc_ecma_transforms_base/src/rename/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/mod.rs
@@ -138,7 +138,7 @@ where
 
         if R::MANGLE {
             let cost = scope.rename_cost();
-            scope.rename_parallel(
+            scope.rename_in_mangling_mode(
                 &self.renamer,
                 &mut map,
                 &Default::default(),

--- a/crates/swc_ecma_transforms_base/src/rename/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/mod.rs
@@ -137,7 +137,6 @@ where
         }
 
         if R::MANGLE {
-            let cost = scope.rename_cost();
             scope.rename_in_mangling_mode(
                 &self.renamer,
                 &mut map,
@@ -145,7 +144,6 @@ where
                 &Default::default(),
                 &self.preserved,
                 &unresolved,
-                cost > 1024,
             );
         } else {
             scope.rename_single_thread(

--- a/crates/swc_ecma_transforms_base/src/rename/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/mod.rs
@@ -27,6 +27,7 @@ pub trait Renamer: Send + Sync {
     /// Should reset `n` to 0 for each identifier?
     const RESET_N: bool;
 
+    /// Should be true if the rename expects lots of collisions.
     const MANGLE: bool;
 
     fn preserved_ids_for_module(&mut self, _: &Module) -> FxHashSet<Id> {


### PR DESCRIPTION
**Description:**

Currently, the name mangler works by processing upper scope and processing children scopes in parallel while avoiding symbols used by the parent scope.
But I want to reuse variable names.


The problem is that I can't know if a variable name is safe to reuse without looking at children nodes.