### PR TITLE
perf(css/parser): Skip whitespaces from lexer

### DIFF
--- a/crates/swc_css_parser/scripts/instrument/bench-parser.sh
+++ b/crates/swc_css_parser/scripts/instrument/bench-parser.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eu
+
+export RUST_LOG=off
+export MIMALLOC_SHOW_STATS=1
+
+cargo profile instruments --release -t time --features tracing/release_max_level_info --features swc_common/concurrent --bench parser -- --bench --color

--- a/crates/swc_css_parser/scripts/instrument/bench-parser.sh
+++ b/crates/swc_css_parser/scripts/instrument/bench-parser.sh
@@ -4,4 +4,4 @@ set -eu
 export RUST_LOG=off
 export MIMALLOC_SHOW_STATS=1
 
-cargo profile instruments --release -t time --features tracing/release_max_level_info --features swc_common/concurrent --bench parser -- --bench --color
+cargo profile instruments --release -t time --features swc_common/concurrent --bench parser -- --bench --color

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -157,6 +157,18 @@ where
     fn take_errors(&mut self) -> Vec<Error> {
         take(&mut self.errors)
     }
+
+    fn skip_ws(&mut self) {
+        loop {
+            match self.cur.as_ref().map(|v| &v.token) {
+                Some(tok!(" ")) => {
+                    self.bump_inner()?;
+                }
+
+                Some(..) | None => return Ok(()),
+            }
+        }
+    }
 }
 
 impl<I> Lexer<I>

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -159,15 +159,15 @@ where
     }
 
     fn skip_ws(&mut self) {
-        loop {
-            match self.cur.as_ref().map(|v| &v.token) {
-                Some(tok!(" ")) => {
-                    self.bump_inner()?;
-                }
-
-                Some(..) | None => return Ok(()),
+        if let Some(c) = self.cur {
+            if is_whitespace(c) {
+                self.cur.take();
             }
         }
+
+        self.input.uncons_while(is_whitespace);
+
+        self.cur_pos = self.input.cur_pos();
     }
 }
 

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -158,7 +158,7 @@ where
         take(&mut self.errors)
     }
 
-    fn skip_ws(&mut self) {
+    fn skip_ws(&mut self) -> BytePos {
         if let Some(c) = self.cur {
             if is_whitespace(c) {
                 self.cur.take();
@@ -168,6 +168,8 @@ where
 
             self.cur_pos = self.input.cur_pos();
         }
+
+        self.cur_pos
     }
 }
 

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -163,11 +163,11 @@ where
             if is_whitespace(c) {
                 self.cur.take();
             }
+
+            self.input.uncons_while(is_whitespace);
+
+            self.cur_pos = self.input.cur_pos();
         }
-
-        self.input.uncons_while(is_whitespace);
-
-        self.cur_pos = self.input.cur_pos();
     }
 }
 

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -162,14 +162,14 @@ where
         if let Some(c) = self.cur {
             if is_whitespace(c) {
                 self.cur.take();
+
+                self.input.uncons_while(is_whitespace);
+
+                return self.input.last_pos();
             }
-
-            self.input.uncons_while(is_whitespace);
-
-            self.cur_pos = self.input.cur_pos();
         }
 
-        self.cur_pos
+        self.last_pos.unwrap_or(self.cur_pos)
     }
 }
 

--- a/crates/swc_css_parser/src/parser/input.rs
+++ b/crates/swc_css_parser/src/parser/input.rs
@@ -220,13 +220,15 @@ impl<'a> ParserInput for TokensInput<'a> {
         vec![]
     }
 
-    fn skip_ws(&mut self) {
+    fn skip_ws(&mut self) -> BytePos {
         while let Ok(TokenAndSpan {
             token: tok!(" "), ..
         }) = self.cur()
         {
             self.idx += 1;
         }
+
+        self.tokens.tokens[self.idx - 1].span.hi
     }
 }
 

--- a/crates/swc_css_parser/src/parser/input.rs
+++ b/crates/swc_css_parser/src/parser/input.rs
@@ -126,16 +126,21 @@ where
 
     #[inline(always)]
     pub(super) fn skip_ws(&mut self) -> PResult<()> {
+        if let Some(cur) = &self.cur {
+            self.last_pos = cur.span.hi;
+        }
+
         if let Some(TokenAndSpan {
             token: tok!(" "), ..
         }) = &self.cur
         {
             self.cur = None;
+
+            self.input.skip_ws();
+
+            self.bump_inner()?;
         }
 
-        self.input.skip_ws();
-
-        self.bump_inner()?;
         Ok(())
     }
 
@@ -209,13 +214,11 @@ impl<'a> ParserInput for TokensInput<'a> {
     }
 
     fn skip_ws(&mut self) {
-        loop {
-            if let Ok(TokenAndSpan {
-                token: tok!(" "), ..
-            }) = self.cur()
-            {
-                self.idx += 1;
-            }
+        while let Ok(TokenAndSpan {
+            token: tok!(" "), ..
+        }) = self.cur()
+        {
+            self.idx += 1;
         }
     }
 }

--- a/crates/swc_css_parser/src/parser/input.rs
+++ b/crates/swc_css_parser/src/parser/input.rs
@@ -126,6 +126,13 @@ where
 
     #[inline(always)]
     pub(super) fn skip_ws(&mut self) -> PResult<()> {
+        if let Some(TokenAndSpan {
+            token: tok!(" "), ..
+        }) = &self.cur
+        {
+            self.cur = None;
+        }
+
         self.input.skip_ws();
         Ok(())
     }

--- a/crates/swc_css_parser/src/parser/input.rs
+++ b/crates/swc_css_parser/src/parser/input.rs
@@ -16,6 +16,8 @@ pub trait ParserInput: Iterator<Item = TokenAndSpan> {
     fn reset(&mut self, state: &Self::State);
 
     fn take_errors(&mut self) -> Vec<Error>;
+
+    fn skip_ws(&mut self);
 }
 
 #[derive(Debug)]
@@ -122,16 +124,10 @@ where
         take(&mut self.input.take_errors())
     }
 
+    #[inline(always)]
     pub(super) fn skip_ws(&mut self) -> PResult<()> {
-        loop {
-            match self.cur.as_ref().map(|v| &v.token) {
-                Some(tok!(" ")) => {
-                    self.bump_inner()?;
-                }
-
-                Some(..) | None => return Ok(()),
-            }
-        }
+        self.input.skip_ws();
+        Ok(())
     }
 
     pub(super) fn state(&mut self) -> WrappedState<I::State> {
@@ -201,6 +197,18 @@ impl<'a> ParserInput for TokensInput<'a> {
 
     fn take_errors(&mut self) -> Vec<Error> {
         vec![]
+    }
+
+    fn skip_ws(&mut self) {
+        loop {
+            match self.cur.as_ref().map(|v| &v.token) {
+                Some(tok!(" ")) => {
+                    self.bump_inner()?;
+                }
+
+                Some(..) | None => return Ok(()),
+            }
+        }
     }
 }
 

--- a/crates/swc_css_parser/src/parser/input.rs
+++ b/crates/swc_css_parser/src/parser/input.rs
@@ -134,6 +134,8 @@ where
         }
 
         self.input.skip_ws();
+
+        self.bump_inner()?;
         Ok(())
     }
 

--- a/crates/swc_css_parser/src/parser/input.rs
+++ b/crates/swc_css_parser/src/parser/input.rs
@@ -129,7 +129,8 @@ where
     pub(super) fn skip_ws(&mut self) -> PResult<()> {
         if let Some(TokenAndSpan {
             token: tok!(" "), ..
-        }) = &self.cur
+        })
+        | None = &self.cur
         {
             self.cur = None;
 

--- a/crates/swc_css_parser/src/parser/input.rs
+++ b/crates/swc_css_parser/src/parser/input.rs
@@ -207,15 +207,13 @@ impl<'a> ParserInput for TokensInput<'a> {
     }
 
     fn skip_ws(&mut self) {
-        loop {
-            match self.cur.as_ref().map(|v| &v.token) {
-                Some(tok!(" ")) => {
-                    self.bump_inner()?;
-                }
-
-                Some(..) | None => return Ok(()),
+        self.take_while(|cur| {
+            if let tok!(" ") = &cur.token {
+                true
+            } else {
+                false
             }
-        }
+        });
     }
 }
 

--- a/crates/swc_css_parser/src/parser/input.rs
+++ b/crates/swc_css_parser/src/parser/input.rs
@@ -207,13 +207,14 @@ impl<'a> ParserInput for TokensInput<'a> {
     }
 
     fn skip_ws(&mut self) {
-        self.take_while(|cur| {
-            if let tok!(" ") = &cur.token {
-                true
-            } else {
-                false
+        loop {
+            if let Ok(TokenAndSpan {
+                token: tok!(" "), ..
+            }) = self.cur()
+            {
+                self.idx += 1;
             }
-        });
+        }
     }
 }
 


### PR DESCRIPTION
**Description:**

Lexer can handle this much more efficiently.

