### PR TITLE
perf(css/parser): Use ascii operations

### DIFF
--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -23,7 +23,7 @@ where
                 unreachable!()
             }
         };
-        let lowercased_name = &*at_keyword_name.0.to_lowercase();
+        let lowercased_name = &*at_keyword_name.0.to_ascii_lowercase();
         let at_rule_name = if at_keyword_name.0.starts_with("--") {
             AtRuleName::DashedIdent(DashedIdent {
                 span: Span::new(
@@ -1072,7 +1072,7 @@ where
 
                 Ok(SupportsFeature::Declaration(declaration))
             }
-            Token::Function { value, .. } if &*value.to_lowercase() == "selector" => {
+            Token::Function { value, .. } if &*value.to_ascii_lowercase() == "selector" => {
                 // TODO improve me
                 let ctx = Ctx {
                     block_contents_grammar: BlockContentsGrammar::DeclarationValue,

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -326,7 +326,7 @@ where
                 let mut is_legacy_syntax = true;
 
                 match cur!(self) {
-                    Token::Ident { value, .. } if &*value.to_lowercase() == "from" => {
+                    Token::Ident { value, .. } if &*value.to_ascii_lowercase() == "from" => {
                         is_legacy_syntax = false;
 
                         values.push(ComponentValue::Ident(self.parse()?));
@@ -664,7 +664,8 @@ where
 
                 match cur!(self) {
                     Token::Ident { value, .. }
-                        if &*value.to_lowercase() == "from" && function_name != "device-cmyk" =>
+                        if &*value.to_ascii_lowercase() == "from"
+                            && function_name != "device-cmyk" =>
                     {
                         values.push(ComponentValue::Ident(self.parse()?));
 
@@ -1011,7 +1012,7 @@ where
                 self.input.skip_ws()?;
 
                 match cur!(self) {
-                    Token::Ident { value, .. } if &*value.to_lowercase() == "from" => {
+                    Token::Ident { value, .. } if &*value.to_ascii_lowercase() == "from" => {
                         values.push(self.try_parse_variable_function(|parser| {
                             Ok(ComponentValue::Ident(parser.parse()?))
                         })?);


### PR DESCRIPTION
**Description:**

We don't need unicode handling in these cases.
