### PR TITLE
fix(node/types): correct type for jsc.paths

### DIFF
--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -664,7 +664,7 @@ export interface JscConfig {
   baseUrl?: string
 
   paths?: {
-    [from: string]: [string]
+    [from: string]: string[]
   }
 
   minify?: JsMinifyOptions;


### PR DESCRIPTION
**Description:**

Fix the type definition of `jsc.paths`.

**BREAKING CHANGE:**

**Related issue (if exists):**
