### PR TITLE
perf(es/minifier): Reduce edges of the graph for DCE

### DIFF
--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -233,13 +233,13 @@ enum ScopeKind {
 }
 
 impl Analyzer<'_> {
-    fn with_ast_path<F>(&mut self, ids: Vec<Id>, op: F)
+    fn with_ast_path<F>(&mut self, id: Id, op: F)
     where
         F: for<'aa> FnOnce(&mut Analyzer<'aa>),
     {
         let prev_len = self.scope.ast_path.len();
 
-        self.scope.ast_path.extend(ids);
+        self.scope.ast_path.push(id);
 
         op(self);
 
@@ -360,7 +360,7 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_class_decl(&mut self, n: &ClassDecl) {
-        self.with_ast_path(vec![n.ident.to_id()], |v| {
+        self.with_ast_path(n.ident.to_id(), |v| {
             let old = v.cur_class_id.take();
             v.cur_class_id = Some(n.ident.to_id());
             n.visit_children_with(v);
@@ -464,7 +464,7 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_fn_decl(&mut self, n: &FnDecl) {
-        self.with_ast_path(vec![n.ident.to_id()], |v| {
+        self.with_ast_path(n.ident.to_id(), |v| {
             let old = v.cur_fn_id.take();
             v.cur_fn_id = Some(n.ident.to_id());
             n.visit_children_with(v);

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1038,10 +1038,16 @@ impl Scope<'_> {
     }
 
     fn last_ast_path(&self) -> Option<Id> {
-        if let Some(v) = self.ast_path.last() {
-            return Some(v.clone());
+        let mut s = Some(self);
+
+        while let Some(scope) = s {
+            if let Some(v) = self.ast_path.last() {
+                return Some(v.clone());
+            }
+
+            s = scope.parent;
         }
 
-        self.parent?.last_ast_path()
+        None
     }
 }


### PR DESCRIPTION
**Description:**

We don't need to render the whole graph.

e.g.
`A -> B -> C` is better than `A -> B -> C && A -> C`

